### PR TITLE
Apple: set rpath to @loader_path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ IF(APPLE)
  # Fix linking on 10.14+. See https://stackoverflow.com/questions/54068035
  LINK_DIRECTORIES(${HOMEBREW_PREFIX}/lib)
  LINK_DIRECTORIES(${HOMEBREW_PREFIX}/opt/python@3.10/Frameworks/Python.framework/Versions/3.10/lib/)
+ set(CMAKE_INSTALL_RPATH "@loader_path")
+ set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
  set(CPPFLAGS "-I${HOMEBREW_PREFIX}/opt/llvm/include -I${HOMEBREW_PREFIX}/include")
  set(LDFLAGS "-L${HOMEBREW_PREFIX}/opt/llvm/lib -Wl,-rpath,${HOMEBREW_PREFIX}/opt/llvm/lib")
  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -std=c++20-stdlib=libc++ -undefined dynamic_lookup -framework Cocoa -framework IOKit") # https://github.com/pybind/pybind11/issues/382


### PR DESCRIPTION
this change allows the python library to be run from everywhere on an apple computer, otherwise the build path is hardcoded in the library path.
This change makes the system try to find the dylib in the same folder as the loader library.

https://dev.my-gate.net/2021/08/04/understanding-rpath-with-cmake/