### PR TITLE
clang: use v13

### DIFF
--- a/requirements/macos.txt
+++ b/requirements/macos.txt
@@ -8,8 +8,7 @@ gdcm
 ilmbase
 jpeg-turbo
 jsoncpp
-eigen
-llvm
+llvm@13
 openblas
 openexr
 openvdb

--- a/scripts/install_brew_requirements.sh
+++ b/scripts/install_brew_requirements.sh
@@ -8,10 +8,8 @@
 requirements_file=requirements/macos.txt
 for req in `cat $requirements_file`
 do
-  echo "brew \"${req}\"" >> requirements/Brewfile
+  brew install $req
 done
-
-brew bundle install --file=requirements/Brewfile
 
 brew install pybind11
 


### PR DESCRIPTION
Over the past three months, v14 and v15 have been added to brew
https://github.com/Homebrew/homebrew-core/commits/master/Formula/llvm.rb

v13 is default for Xcode13 - https://trac.macports.org/wiki/XcodeVersionInfo#macOS13