### PR TITLE
Remove outNewFaces argument in fillHole-like functions

### DIFF
--- a/source/MRMesh/MRContoursCut.cpp
+++ b/source/MRMesh/MRContoursCut.cpp
@@ -1302,11 +1302,14 @@ void executeTriangulateContourPlan( Mesh& mesh, EdgeId e, FillHolePlan & plan, F
 {
     MR_TIMER
     assert( oldFace.valid() );
-    FaceBitSet newFaces;
-    executeFillHolePlan( mesh, e, plan, new2OldMap ? &newFaces : nullptr );
+    const auto fsz0 = mesh.topology.faceSize();
+    executeFillHolePlan( mesh, e, plan );
     if ( new2OldMap )
-        for ( auto f : newFaces )
+    {
+        const auto fsz = mesh.topology.faceSize();
+        for ( FaceId f{ fsz0 }; f < fsz; ++f )
             new2OldMap->autoResizeAt( f ) = oldFace;
+    }
 }
 
 void triangulateContour( Mesh& mesh, EdgeId e, FaceId oldFace, FaceMap* new2OldMap )

--- a/source/MRMesh/MRFixUndercuts.cpp
+++ b/source/MRMesh/MRFixUndercuts.cpp
@@ -28,15 +28,14 @@ namespace FixUndercuts
 {
 constexpr float numVoxels = 1e7f;
 
-FloatGrid setupGridFromMesh( Mesh& mesh, const AffineXf3f& rot, float voxelSize, float holeExtension, Vector3f dir, FaceBitSet* outNewFaces = nullptr )
+FloatGrid setupGridFromMesh( Mesh& mesh, const AffineXf3f& rot, float voxelSize, float holeExtension, Vector3f dir )
 {
     MR_TIMER;
     auto borders = mesh.topology.findHoleRepresentiveEdges();
     
     for ( auto& border : borders )
-        border = buildBottom( mesh, border, dir, holeExtension, outNewFaces );
+        border = buildBottom( mesh, border, dir, holeExtension );
     FillHoleParams params;
-    params.outNewFaces = outNewFaces;
     for ( const auto& border : borders )
         fillHole( mesh, border, params );
 
@@ -142,7 +141,9 @@ void fixUndercuts( Mesh& mesh, const FaceBitSet& faceBitSet, const Vector3f& upD
 
     // add new triangles after hole filling to bitset
     FaceBitSet copyFBS = faceBitSet;
-    auto fullGrid = setupGridFromMesh( mesh, rot, voxelSize, bottomExtension, upDirectionMeshSpace, &copyFBS );
+    copyFBS.resize( mesh.topology.faceSize(), false );
+    auto fullGrid = setupGridFromMesh( mesh, rot, voxelSize, bottomExtension, upDirectionMeshSpace );
+    copyFBS.resize( mesh.topology.faceSize(), true );
 
     // create mesh and unclosed grid 
     Mesh selectedPartMesh;

--- a/source/MRMesh/MRMeshFillHole.h
+++ b/source/MRMesh/MRMeshFillHole.h
@@ -28,8 +28,6 @@ struct FillHoleParams
       * \sa \ref FillHoleMetric
       */
     FillHoleMetric metric;
-    /// If not nullptr accumulate new faces
-    FaceBitSet* outNewFaces{ nullptr };
     /** If Strong makes additional efforts to avoid creating multiple edges, 
       * in some rare cases it is not possible (cases with extremely bad topology), 
       * if you faced one try to use \ref MR::duplicateMultiHoleVertices before \ref MR::fillHole
@@ -77,8 +75,6 @@ struct StitchHolesParams
       * \sa \ref FillHoleMetric
       */
     FillHoleMetric metric;
-    /// If not nullptr accumulate new faces
-    FaceBitSet* outNewFaces{ nullptr };
 };
 
 /** \brief Stitches two holes in Mesh\n
@@ -143,7 +139,7 @@ using FillHolePlan = std::vector<FillHoleItem>;
 /// similar to fillHole function, but only gets the plan how to fill given hole, not filling it immediately
 MRMESH_API FillHolePlan getFillHolePlan( const Mesh& mesh, EdgeId a0, const FillHoleParams& params = {} );
 /// quickly fills the hole given the plan (quickly compared to fillHole function)
-MRMESH_API void executeFillHolePlan( Mesh & mesh, EdgeId a0, FillHolePlan & plan, FaceBitSet * outNewFaces = nullptr );
+MRMESH_API void executeFillHolePlan( Mesh & mesh, EdgeId a0, FillHolePlan & plan );
 
 /** \brief Fills hole in mesh trivially\n
   * \ingroup FillHoleGroup
@@ -161,36 +157,35 @@ MRMESH_API void executeFillHolePlan( Mesh & mesh, EdgeId a0, FillHolePlan & plan
   *
   * \param mesh mesh with hole
   * \param a EdgeId which represents hole
-  * \param outNewFaces optional output newly generated faces
   * \return new vertex
   * 
   * \sa \ref fillHole
   */
-MRMESH_API VertId fillHoleTrivially( Mesh& mesh, EdgeId a, FaceBitSet * outNewFaces = nullptr );
+MRMESH_API VertId fillHoleTrivially( Mesh& mesh, EdgeId a );
 
 /// adds cylindrical extension of given hole represented by one of its edges (having no valid left face)
 /// by adding new vertices located in given plane and 2 * number_of_hole_edge triangles;
 /// \return the edge of new hole opposite to input edge (a)
-MRMESH_API EdgeId extendHole( Mesh& mesh, EdgeId a, const Plane3f & plane, FaceBitSet * outNewFaces = nullptr );
+MRMESH_API EdgeId extendHole( Mesh& mesh, EdgeId a, const Plane3f & plane );
 
 /// adds extension of given hole represented by one of its edges (having no valid left face)
 /// by adding new vertices located at getVertPos( existing vertex position );
 /// \return the edge of new hole opposite to input edge (a)
-MRMESH_API EdgeId extendHole( Mesh& mesh, EdgeId a, std::function<Vector3f(const Vector3f &)> getVertPos, FaceBitSet * outNewFaces = nullptr );
+MRMESH_API EdgeId extendHole( Mesh& mesh, EdgeId a, std::function<Vector3f(const Vector3f &)> getVertPos );
 
 /// adds cylindrical extension of given hole represented by one of its edges (having no valid left face)
 /// by adding new vertices located in lowest point of the hole -dir*holeExtension and 2 * number_of_hole_edge triangles;
 /// \return the edge of new hole opposite to input edge (a)
-MRMESH_API EdgeId buildBottom( Mesh& mesh, EdgeId a, Vector3f dir, float holeExtension, FaceBitSet* outNewFaces = nullptr );
+MRMESH_API EdgeId buildBottom( Mesh& mesh, EdgeId a, Vector3f dir, float holeExtension );
 
 /// creates a band of degenerate triangles around given hole;
 /// \return the edge of new hole opposite to input edge (a)
-MRMESH_API EdgeId makeDegenerateBandAroundHole( Mesh& mesh, EdgeId a, FaceBitSet * outNewFaces = nullptr );
+MRMESH_API EdgeId makeDegenerateBandAroundHole( Mesh& mesh, EdgeId a );
 
 /// creates a bridge between two boundary edges a and b (both having no valid left face);
 /// bridge consists of two triangles in general or of one triangle if a and b are neighboring edges on the boundary;
 /// \return false if bridge cannot be created because otherwise multiple edges appear
-MRMESH_API bool makeBridge( MeshTopology & topology, EdgeId a, EdgeId b, FaceBitSet * outNewFaces = nullptr );
+MRMESH_API bool makeBridge( MeshTopology & topology, EdgeId a, EdgeId b );
 
 /// creates a new bridge edge between origins of two boundary edges a and b (both having no valid left face);
 /// \return invalid id if bridge cannot be created because otherwise multiple edges appear

--- a/source/mrmeshpy/MRPythonMeshExposing.cpp
+++ b/source/mrmeshpy/MRPythonMeshExposing.cpp
@@ -261,15 +261,13 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, FillHole, [] ( pybind11::module_& m )
         def_readwrite( "makeDegenerateBand", &MR::FillHoleParams::makeDegenerateBand,
             "If true creates degenerate faces band around hole to have sharp angle visualization\n"
             "warning: This flag bad for result topology, most likely you do not need it" ).
-        def_readwrite( "maxPolygonSubdivisions", &MR::FillHoleParams::maxPolygonSubdivisions, "The maximum number of polygon subdivisions on a triangle and two smaller polygons,\n""must be 2 or larger" ).
-        def_readwrite( "outNewFaces", &MR::FillHoleParams::outNewFaces, "If not nullptr accumulate new faces" );
+        def_readwrite( "maxPolygonSubdivisions", &MR::FillHoleParams::maxPolygonSubdivisions, "The maximum number of polygon subdivisions on a triangle and two smaller polygons,\n""must be 2 or larger" );
 
     pybind11::class_<MR::StitchHolesParams>( m, "StitchHolesParams", "Structure has some options to control buildCylinderBetweenTwoHoles" ).
         def( pybind11::init<>() ).
         def_readwrite( "metric", &StitchHolesParams::metric,
             "Specifies triangulation metric\n"
-            "default for buildCylinderBetweenTwoHoles: getComplexStitchMetric").
-        def_readwrite( "outNewFaces", &StitchHolesParams::outNewFaces, "If not nullptr accumulate new faces" );
+            "default for buildCylinderBetweenTwoHoles: getComplexStitchMetric");
 
     m.def( "fillHole", &MR::fillHole,
         pybind11::arg( "mesh" ), pybind11::arg( "a" ), pybind11::arg( "params" ) = MR::FillHoleParams{},
@@ -328,7 +326,7 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, SimpleFunctions, [] ( pybind11::module_& m )
     m.def( "computePerFaceNormals", &MR::computePerFaceNormals, pybind11::arg( "mesh" ), "returns a vector with face-normal in every element for valid mesh faces" );
     m.def( "mergeMehses", &pythonMergeMehses, pybind11::arg( "meshes" ), "merge python list of meshes to one mesh" );
     m.def( "getFacesByMinEdgeLength", &getFacesByMinEdgeLength, pybind11::arg( "mesh" ), pybind11::arg( "minLength" ), "return faces with at least one edge longer than min edge length" );
-    m.def( "buildBottom", &MR::buildBottom, pybind11::arg( "mesh" ), pybind11::arg( "a" ), pybind11::arg( "dir" ), pybind11::arg( "holeExtension" ), pybind11::arg( "outNewFaces" ) = nullptr,
+    m.def( "buildBottom", &MR::buildBottom, pybind11::arg( "mesh" ), pybind11::arg( "a" ), pybind11::arg( "dir" ), pybind11::arg( "holeExtension" ),
         "adds cylindrical extension of given hole represented by one of its edges (having no valid left face)\n"
         "by adding new vertices located in lowest point of the hole -dir*holeExtension and 2 * number_of_hole_edge triangles;\n"
         "return: the edge of new hole opposite to input edge (a)" );


### PR DESCRIPTION
because allocation of new FaceBitSet on every call is very expensive and new faces are always at the end