### PR TITLE
fix: instal thirdparty with vcpkg on windows

### DIFF
--- a/thirdparty/install.bat
+++ b/thirdparty/install.bat
@@ -4,4 +4,4 @@ for /f "delims=" %%i in ('where vcpkg') do set vcpkg_path=%%i
 if not exist %vcpkg_path%\..\downloads mkdir %vcpkg_path%\..\downloads
 copy "%~dp0vcpkg\downloads" %vcpkg_path%\..\downloads
 
-vcpkg install "@%~dp0\..\requirements\windows.txt" --recurse --binarysource=clear
+vcpkg install "@%~dp0\..\requirements\windows.txt" --recurse --binarysource=clear --overlay-triplets %~dp0vcpkg\triplets


### PR DESCRIPTION
use custom triplets with --overlay-triplets option