### PR TITLE
Fix openvdb version condition

### DIFF
--- a/source/MRMesh/MRObjectVoxels.cpp
+++ b/source/MRMesh/MRObjectVoxels.cpp
@@ -59,7 +59,8 @@ void ObjectVoxels::updateHistogramAndSurface( const ProgressCallback& cb )
 
     float min{0.0f}, max{0.0f};
 
-#if OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER >= 9 && (OPENVDB_LIBRARY_MINOR_VERSION_NUMBER >= 1 || OPENVDB_LIBRARY_PATCH_VERSION_NUMBER >= 1)
+#if (OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER >= 9 && (OPENVDB_LIBRARY_MINOR_VERSION_NUMBER >= 1 || OPENVDB_LIBRARY_PATCH_VERSION_NUMBER >= 1)) || \
+    (OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER >= 10)
     auto minMax = openvdb::tools::minMax(grid_->tree());
     min = minMax.min();
     max = minMax.max();


### PR DESCRIPTION
`evalMinMax` was deprecated in [9.1.0](https://www.openvdb.org/documentation/doxygen/changes.html)