### PR TITLE
Fixed cancelling worker threads in OpenVDB

### DIFF
--- a/source/MRMesh/MRVDBProgressInterrupter.h
+++ b/source/MRMesh/MRVDBProgressInterrupter.h
@@ -18,7 +18,8 @@ struct ProgressInterrupter : openvdb::util::NullInterrupter
         , progressThreadId_{ std::this_thread::get_id() } {}
     virtual bool wasInterrupted( int percent = -1 ) override
     {
-        wasInterrupted_ = false;
+        // OpenVdb uses worker threads from pool, in addition to the caller thread.
+        // It is assumed that the callback is periodically called in the caller thread.
         if ( cb_ && progressThreadId_ == std::this_thread::get_id() )
             wasInterrupted_ = !cb_( float( std::clamp( percent, 0, 100 ) ) / 100.0f );
         return wasInterrupted_;


### PR DESCRIPTION
Actual issue:
- OpenVDB creates worker threads.
- When callback is called from those threads (not from initial caller thread), `ProgressInterrupter` sets `wasInterrupted_` to false.
- As a result, the process is either not cancelled, or, in best case, cannot stop worker threads and waits them to finish.
- This can lead to out of memory error (https://github.com/MeshInspector/MeshInspectorCode/issues/2404)

Steps to reproduce:
- Create line object.
- Use Offset Lines tool.
- Adjust settings so that voxel count reaches 10-100M.

Note: cancelling still might take long because resource freeing takes lots of time.