### PR TITLE
Organize controls in Viewer Settings to separate tabs

### DIFF
--- a/source/MRCommonPlugins/ViewerButtons/MRViewerSettingsPlugin.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRViewerSettingsPlugin.cpp
@@ -59,54 +59,124 @@ void ViewerSettingsPlugin::drawDialog( float menuScaling, ImGuiContext* )
     auto menuWidth = 380.0f * menuScaling;
     if ( !ImGuiBeginWindow_( { .width = menuWidth, .menuScaling = menuScaling } ) )
         return;
-
-
     ImGui::PushStyleVar( ImGuiStyleVar_ItemSpacing, MR::StyleConsts::pluginItemSpacing );
 
+    if ( ImGui::BeginTabBar( "##MainTabs" ) )
+    {
+        if ( ImGui::BeginTabItem( "Settings" ) )
+        {
+            activeTab_ = TabType::Settings;
+            drawSettingsTab_( menuWidth, menuScaling );
+            ImGui::EndTabItem();
+        }
+        if ( ImGui::BeginTabItem( "Viewport" ) )
+        {
+            activeTab_ = TabType::Viewport;
+            drawViewportTab_( menuWidth, menuScaling );
+            ImGui::EndTabItem();
+        }
+        if ( ImGui::BeginTabItem( "View" ) )
+        {
+            activeTab_ = TabType::View;
+            drawViewTab_( menuWidth, menuScaling );
+            ImGui::EndTabItem();
+        }
+        if ( ImGui::BeginTabItem( "Control" ) )
+        {
+            activeTab_ = TabType::Control;
+            drawControlTab_( menuWidth, menuScaling );
+            ImGui::EndTabItem();
+        }
+        ImGui::EndTabBar();
+    }
+
+    ImGui::PopStyleVar();
+
+    ImGui::EndCustomStatePlugin();
+}
+
+bool ViewerSettingsPlugin::onEnable_()
+{
+    backgroundColor_.w = -1.0f;
+
+    ribbonMenu_ = getViewerInstance().getMenuPluginAs<RibbonMenu>().get();
+    updateThemes();
+
+    auto& viewerRef = getViewerInstance();
+    spaceMouseParams_ = viewerRef.getSpaceMouseParameters();
+#if defined(_WIN32) || defined(__APPLE__)
+    if ( auto spaceMouseHandler = viewerRef.getSpaceMouseHandler() )
+    {
+        auto hidapiHandler = std::dynamic_pointer_cast< MR::SpaceMouseHandlerHidapi >( spaceMouseHandler );
+        if ( hidapiHandler )
+            activeMouseScrollZoom_ = hidapiHandler->isMouseScrollZoomActive();
+    }
+#endif
+
+    return true;
+}
+
+bool ViewerSettingsPlugin::onDisable_()
+{
+    userThemesPresets_.clear();
+    ribbonMenu_ = nullptr;
+    return true;
+}
+
+void ViewerSettingsPlugin::drawSettingsTab_( float menuWidth, float menuScaling )
+{
     auto& style = ImGui::GetStyle();
     const float btnHalfSizeX = ( menuWidth - style.WindowPadding.x * 2 - style.ItemSpacing.x ) / 2.f;
 
     if ( UI::button( "Toolbar Customize", Vector2f( btnHalfSizeX, 0 ) ) && ribbonMenu_ )
         ribbonMenu_->openToolbarCustomize();
-
-    ImGui::SameLine();
-    if ( UI::button( "Scene Mouse Controls", Vector2f( btnHalfSizeX, 0 ) ) )
-        ImGui::OpenPopup( "Scene Mouse Controls" );
-    drawMouseSceneControlsSettings_( menuScaling );
-
-    if ( UI::button( "Show Hotkeys", Vector2f( btnHalfSizeX, 0 ) ) && ribbonMenu_ )
-        ribbonMenu_->setShowShortcuts( true );
-
-    ImGui::SameLine();
-    if ( UI::button( "Spacemouse Settings", Vector2f( btnHalfSizeX, 0 ) ) )
+    if ( RibbonButtonDrawer::CustomCollapsingHeader( "Behavior", ImGuiTreeNodeFlags_DefaultOpen ) )
     {
-        auto& viewerRef = getViewerInstance();
-        spaceMouseParams_ = viewerRef.getSpaceMouseParameters();
-#if defined(_WIN32) || defined(__APPLE__)
-        if ( auto spaceMouseHandler = viewerRef.getSpaceMouseHandler() )
+        ImGui::SetNextItemWidth( menuWidth * 0.5f );
+        if ( ribbonMenu_ )
         {
-            auto hidapiHandler = std::dynamic_pointer_cast<MR::SpaceMouseHandlerHidapi>( spaceMouseHandler );
-            if ( hidapiHandler )
-                activeMouseScrollZoom_ = hidapiHandler->isMouseScrollZoomActive();
+            UI::checkbox( "Make Visible on Select",
+                                                  std::bind( &RibbonMenu::getShowNewSelectedObjects, ribbonMenu_ ),
+                                                  std::bind( &RibbonMenu::setShowNewSelectedObjects, ribbonMenu_, std::placeholders::_1 ) );
+            UI::checkbox( "Deselect on Hide",
+                                                  std::bind( &RibbonMenu::getDeselectNewHiddenObjects, ribbonMenu_ ),
+                                                  std::bind( &RibbonMenu::setDeselectNewHiddenObjects, ribbonMenu_, std::placeholders::_1 ) );
+            UI::checkbox( "Close Context Menu on Change",
+                                                  std::bind( &RibbonMenu::getCloseContextOnChange, ribbonMenu_ ),
+                                                  std::bind( &RibbonMenu::setCloseContextOnChange, ribbonMenu_, std::placeholders::_1 ) );
+            UI::setTooltipIfHovered( "Close scene context menu on any change", menuScaling );
         }
-#endif
-        ImGui::OpenPopup( "Spacemouse Settings" );
-    }
-    drawSpaceMouseSettings_( menuScaling );
 
-    if ( UI::button( "Touchpad Settings", Vector2f( btnHalfSizeX, 0 ) ) )
-    {
-        touchpadParameters_ = viewer->getTouchpadParameters();
-        ImGui::OpenPopup( "Touchpad Settings" );
-    }
-    drawTouchpadSettings_( menuScaling );
+        bool flatShading = SceneSettings::get( SceneSettings::Type::MeshFlatShading );
+        bool flatShadingBackup = flatShading;
+        UI::checkbox( "Default Shading Flat", &flatShading );
+        if ( flatShadingBackup != flatShading )
+            SceneSettings::set( SceneSettings::Type::MeshFlatShading, flatShading );
 
+        ImGui::SetNextItemWidth( 100.0f * menuScaling );
+        int pickRadius = int( getViewerInstance().glPickRadius );
+        ImGui::DragInputInt( "Picker Radius", &pickRadius, 1, 0, 10 );
+        getViewerInstance().glPickRadius = uint16_t( pickRadius );
+        UI::setTooltipIfHovered( "Radius of area under cursor to pick objects in scene.", menuScaling );
+
+        bool savedDialogsBackUp = viewer->getMenuPlugin()->isSavedDialogPositionsEnabled();
+        bool savedDialogsVal = savedDialogsBackUp;
+        UI::checkbox( "Save Tool Window Positions", &savedDialogsVal );
+        UI::setTooltipIfHovered( "If checked then enables using of saved positions of tool windows in the config file", menuScaling );
+        if ( savedDialogsVal != savedDialogsBackUp )
+            viewer->getMenuPlugin()->enableSavedDialogPositions( savedDialogsVal );
+    }
+}
+
+void ViewerSettingsPlugin::drawViewportTab_( float menuWidth, float menuScaling )
+{
+    if ( viewer->viewport_list.size() > 1 )
+        ImGui::Text( "Current viewport: %d", viewer->viewport().id.value() );
     const auto& viewportParameters = viewer->viewport().getParameters();
-    // Viewing options
-    if ( RibbonButtonDrawer::CustomCollapsingHeader( "Current Viewport Options", ImGuiTreeNodeFlags_DefaultOpen ) )
-    {
-        //ImGui::Text( "Current viewport: %d", viewer->viewport().id.value() );
 
+    // Viewing options
+    if ( RibbonButtonDrawer::CustomCollapsingHeader( "Options", ImGuiTreeNodeFlags_DefaultOpen ) )
+    {
         ImGui::SetNextItemWidth( 140.0f * menuScaling );
         auto rotMode = viewportParameters.rotationMode;
         UI::combo( "Rotation Mode", ( int* )&rotMode, { "Scene Center", "Pick / Scene Center", "Pick" } );
@@ -128,7 +198,7 @@ void ViewerSettingsPlugin::drawDialog( float menuScaling, ImGuiContext* )
 
         ImGui::PopItemWidth();
 
-        
+
         bool needUpdateBackup = backgroundColor_.w == -1.0f;
         if ( needUpdateBackup )
             backgroundColor_ = Vector4f( viewportParameters.backgroundColor );
@@ -160,76 +230,53 @@ void ViewerSettingsPlugin::drawDialog( float menuScaling, ImGuiContext* )
             viewer->viewport().showClippingPlane( showPlane );
         }
     }
-    ImGui::Separator();
-    if ( RibbonButtonDrawer::CustomCollapsingHeader( "Viewer Options", ImGuiTreeNodeFlags_DefaultOpen ) )
+}
+
+void ViewerSettingsPlugin::drawViewTab_( float menuWidth, float menuScaling )
+{
+    auto& style = ImGui::GetStyle();
+
+    ImGui::SetNextItemWidth( menuWidth * 0.5f );
+    int selectedUserIdxBackup = selectedUserPreset_;
+    UI::combo( "Color theme", &selectedUserPreset_, userThemesPresets_ );
+    if ( selectedUserPreset_ != selectedUserIdxBackup )
     {
-        ImGui::SetNextItemWidth( menuWidth * 0.5f );
-        int selectedUserIdxBackup = selectedUserPreset_;
-        UI::combo( "Color theme", &selectedUserPreset_, userThemesPresets_ );
-        if ( selectedUserPreset_ != selectedUserIdxBackup )
+        if ( selectedUserPreset_ == 0 )
+            ColorTheme::setupDefaultDark();
+        else if ( selectedUserPreset_ == 1 )
+            ColorTheme::setupDefaultLight();
+        else
+            ColorTheme::setupUserTheme( userThemesPresets_[selectedUserPreset_] );
+        if ( !ColorTheme::isInitialized() )
         {
-            if ( selectedUserPreset_ == 0 )
+            if ( selectedUserIdxBackup == 0 )
                 ColorTheme::setupDefaultDark();
-            else if ( selectedUserPreset_ == 1 )
+            else if ( selectedUserIdxBackup == 1 )
                 ColorTheme::setupDefaultLight();
             else
-                ColorTheme::setupUserTheme( userThemesPresets_[selectedUserPreset_] );
-            if ( !ColorTheme::isInitialized() )
-            {
-                if ( selectedUserIdxBackup == 0 )
-                    ColorTheme::setupDefaultDark();
-                else if ( selectedUserIdxBackup == 1 )
-                    ColorTheme::setupDefaultLight();
-                else
-                    ColorTheme::setupUserTheme( userThemesPresets_[selectedUserIdxBackup] );
-                selectedUserPreset_ = selectedUserIdxBackup;
+                ColorTheme::setupUserTheme( userThemesPresets_[selectedUserIdxBackup] );
+            selectedUserPreset_ = selectedUserIdxBackup;
 
-                showError( "This theme is not valid." );
-            }
-            backgroundColor_ = Vector4f( ColorTheme::getViewportColor( ColorTheme::ViewportColorsType::Background ) );
-            ColorTheme::apply();
+            showError( "This theme is not valid." );
         }
-        auto item = RibbonSchemaHolder::schema().items.find( "Add custom theme" );
-        if ( item != RibbonSchemaHolder::schema().items.end() )
+        backgroundColor_ = Vector4f( ColorTheme::getViewportColor( ColorTheme::ViewportColorsType::Background ) );
+        ColorTheme::apply();
+    }
+    auto item = RibbonSchemaHolder::schema().items.find( "Add custom theme" );
+    if ( item != RibbonSchemaHolder::schema().items.end() )
+    {
+        ImGui::SameLine( menuWidth * 0.75f );
+        if ( UI::button( "Add",
+            item->second.item->isAvailable( getAllObjectsInTree<const Object>( &SceneRoot::get(), ObjectSelectivityType::Selected ) ).empty(),
+            Vector2f( menuWidth * 0.20f, 0 ) ) )
         {
-            ImGui::SameLine( menuWidth * 0.75f );
-            if ( UI::button( "Add",
-                item->second.item->isAvailable( getAllObjectsInTree<const Object>( &SceneRoot::get(), ObjectSelectivityType::Selected ) ).empty(),
-                Vector2f( menuWidth * 0.20f, 0 ) ) )
-            {
-                item->second.item->action();
-            }
-            UI::setTooltipIfHovered( item->second.tooltip, menuScaling );
+            item->second.item->action();
         }
+        UI::setTooltipIfHovered( item->second.tooltip, menuScaling );
+    }
 
-        ImGui::Separator();
-
-        if ( ribbonMenu_ )
-        {
-            UI::checkbox( "Make Visible on Select",
-                                                  std::bind( &RibbonMenu::getShowNewSelectedObjects, ribbonMenu_ ),
-                                                  std::bind( &RibbonMenu::setShowNewSelectedObjects, ribbonMenu_, std::placeholders::_1 ) );
-            UI::checkbox( "Deselect on Hide",
-                                                  std::bind( &RibbonMenu::getDeselectNewHiddenObjects, ribbonMenu_ ),
-                                                  std::bind( &RibbonMenu::setDeselectNewHiddenObjects, ribbonMenu_, std::placeholders::_1 ) );
-            UI::checkbox( "Close Context on Change",
-                                                  std::bind( &RibbonMenu::getCloseContextOnChange, ribbonMenu_ ),
-                                                  std::bind( &RibbonMenu::setCloseContextOnChange, ribbonMenu_, std::placeholders::_1 ) );
-            UI::setTooltipIfHovered( "Close scene context menu on any change", menuScaling );
-        }
-
-        bool flatShading = SceneSettings::get( SceneSettings::Type::MeshFlatShading );
-        bool flatShadingBackup = flatShading;
-        UI::checkbox( "Default Shading Flat", &flatShading );
-        if ( flatShadingBackup != flatShading )
-            SceneSettings::set( SceneSettings::Type::MeshFlatShading, flatShading );
-
-        ImGui::SetNextItemWidth( 100.0f * menuScaling );
-        int pickRadius = int( getViewerInstance().glPickRadius );
-        ImGui::DragInputInt( "Picker Radius", &pickRadius, 1, 0, 10 );
-        getViewerInstance().glPickRadius = uint16_t( pickRadius );
-        UI::setTooltipIfHovered( "Radius of area under cursor to pick objects in scene.", menuScaling );
-
+    if ( RibbonButtonDrawer::CustomCollapsingHeader( "Render Options", ImGuiTreeNodeFlags_DefaultOpen ) )
+    {
         if ( viewer->isAlphaSortAvailable() )
         {
             bool alphaSortBackUp = viewer->isAlphaSortEnabled();
@@ -239,20 +286,11 @@ void ViewerSettingsPlugin::drawDialog( float menuScaling, ImGuiContext* )
                 viewer->enableAlphaSort( alphaBoxVal );
         }
 
-        bool savedDialogsBackUp = viewer->getMenuPlugin()->isSavedDialogPositionsEnabled();
-        bool savedDialogsVal = savedDialogsBackUp;
-        UI::checkbox( "Save Tool Window Positions", &savedDialogsVal );
-        UI::setTooltipIfHovered( "If checked then enables using of saved positions of tool windows in the config file", menuScaling );
-
-        if ( savedDialogsVal != savedDialogsBackUp )
-            viewer->getMenuPlugin()->enableSavedDialogPositions( savedDialogsVal );
-
         if ( viewer->isGLInitialized() )
         {
             if ( maxSamples_ > 1 )
             {
                 auto backUpSamples = storedSamples_;
-                ImGui::Separator();
                 ImGui::Text( "Multisample anti-aliasing (MSAA):" );
                 UI::setTooltipIfHovered( "The number of samples per pixel: more samples - better render quality but worse performance.", menuScaling );
                 int counter = 0;
@@ -275,7 +313,7 @@ void ViewerSettingsPlugin::drawDialog( float menuScaling, ImGuiContext* )
                 {
                     if ( auto& settingsManager = viewer->getViewportSettingsManager() )
                         settingsManager->saveInt( "multisampleAntiAliasing", storedSamples_ );
-                    
+
                     needReset_ = storedSamples_ != curSamples_;
                 }
                 if ( gpuOverridesMSAA_ )
@@ -284,62 +322,54 @@ void ViewerSettingsPlugin::drawDialog( float menuScaling, ImGuiContext* )
                     UI::transparentTextWrapped( "Application requires restart to apply this change" );
             }
         }
-        if ( shadowGl_ && RibbonButtonDrawer::CustomCollapsingHeader( "Shadows" ) )
-        {
-            bool isEnableShadows = shadowGl_->isEnabled();
-            UI::checkbox( "Enabled", &isEnableShadows );
-            if ( isEnableShadows != shadowGl_->isEnabled() )
-            {
-                CommandLoop::appendCommand( [shadowGl = shadowGl_.get(), isEnableShadows] ()
-                {
-                    shadowGl->enable( isEnableShadows );
-                } );
-            }
-            ImGui::SameLine( menuWidth * 0.25f + style.WindowPadding.x + 2 * menuScaling );
-            auto color = shadowGl_->getShadowColor();
-            UI::colorEdit4( "Shadow Color", color,
-                ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_PickerHueWheel );
-            shadowGl_->setShadowColor( color );
-
-            const char* tooltipsShift[2] = {
-                "Shift along Ox-axis to the left",
-                "Shift along Oy-axis to the top"
-            };
-            ImGui::PushItemWidth( menuWidth * 0.5f );
-            auto shfit = shadowGl_->getShadowShift();
-            auto radius = shadowGl_->getBlurRadius();
-            auto quality = shadowGl_->getQuality();
-            ImGui::DragFloatValid2( "Shift", &shfit.x, 0.4f, -200.0f, 200.0f, "%.3f px", 0, &tooltipsShift );
-            ImGui::DragFloatValid( "Blur Radius", &radius, 0.2f, 0, 200, "%.3f px" );
-            ImGui::DragFloatValid( "Quality", &quality, 0.001f, 0.0625f, 1.0f );
-            ImGui::PopItemWidth();
-            UI::setTooltipIfHovered( "Blur texture downscaling coefficient", menuScaling );
-            shadowGl_->setShadowShift( shfit );
-            shadowGl_->setBlurRadius( radius );
-            shadowGl_->setQuality( quality );
-        }
     }
+    if ( shadowGl_ && RibbonButtonDrawer::CustomCollapsingHeader( "Shadows" ) )
+    {
+        bool isEnableShadows = shadowGl_->isEnabled();
+        UI::checkbox( "Enabled", &isEnableShadows );
+        if ( isEnableShadows != shadowGl_->isEnabled() )
+        {
+            CommandLoop::appendCommand( [shadowGl = shadowGl_.get(), isEnableShadows]()
+            {
+                shadowGl->enable( isEnableShadows );
+            } );
+        }
+        ImGui::SameLine( menuWidth * 0.25f + style.WindowPadding.x + 2 * menuScaling );
+        auto color = shadowGl_->getShadowColor();
+        UI::colorEdit4( "Shadow Color", color,
+            ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_PickerHueWheel );
+        shadowGl_->setShadowColor( color );
 
-    ImGui::PopStyleVar();
-
-    ImGui::EndCustomStatePlugin();
+        const char* tooltipsShift[2] = {
+            "Shift along Ox-axis to the left",
+            "Shift along Oy-axis to the top"
+        };
+        ImGui::PushItemWidth( menuWidth * 0.5f );
+        auto shfit = shadowGl_->getShadowShift();
+        auto radius = shadowGl_->getBlurRadius();
+        auto quality = shadowGl_->getQuality();
+        ImGui::DragFloatValid2( "Shift", &shfit.x, 0.4f, -200.0f, 200.0f, "%.3f px", 0, &tooltipsShift );
+        ImGui::DragFloatValid( "Blur Radius", &radius, 0.2f, 0, 200, "%.3f px" );
+        ImGui::DragFloatValid( "Quality", &quality, 0.001f, 0.0625f, 1.0f );
+        ImGui::PopItemWidth();
+        UI::setTooltipIfHovered( "Blur texture downscaling coefficient", menuScaling );
+        shadowGl_->setShadowShift( shfit );
+        shadowGl_->setBlurRadius( radius );
+        shadowGl_->setQuality( quality );
+    }
 }
 
-bool ViewerSettingsPlugin::onEnable_()
+void ViewerSettingsPlugin::drawControlTab_( float menuWidth, float menuScaling )
 {
-    backgroundColor_.w = -1.0f;
+    auto& style = ImGui::GetStyle();
+    const float btnHalfSizeX = ( menuWidth - style.WindowPadding.x * 2 - style.ItemSpacing.x ) / 2.f;
 
-    ribbonMenu_ = getViewerInstance().getMenuPluginAs<RibbonMenu>().get();
-    updateThemes();
+    if ( UI::button( "Show Hotkeys", Vector2f( btnHalfSizeX, 0 ) ) && ribbonMenu_ )
+        ribbonMenu_->setShowShortcuts( true );
 
-    return true;
-}
-
-bool ViewerSettingsPlugin::onDisable_()
-{
-    userThemesPresets_.clear();
-    ribbonMenu_ = nullptr;
-    return true;
+    drawMouseSceneControlsSettings_( menuWidth, menuScaling );
+    drawTouchpadSettings_();
+    drawSpaceMouseSettings_( menuWidth, menuScaling );
 }
 
 void ViewerSettingsPlugin::updateThemes()
@@ -383,29 +413,12 @@ void ViewerSettingsPlugin::updateThemes()
     }
 }
 
-void ViewerSettingsPlugin::drawMouseSceneControlsSettings_( float scaling )
+void ViewerSettingsPlugin::drawMouseSceneControlsSettings_( float menuWidth, float scaling )
 {
-    ImVec2 windowSize = ImVec2( 500 * scaling, 0 );
-    ImGui::SetNextWindowSize( windowSize, ImGuiCond_Always );
-
-    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-    ImGui::SetNextWindowPos( center, ImGuiCond_Appearing, ImVec2( 0.5f, 0.5f ) );
-    ImGui::SetNextWindowSizeConstraints( ImVec2( windowSize.x, -1 ), ImVec2( windowSize.x, 0 ) );
-
-    ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 3 * MR::cDefaultItemSpacing * scaling, 3 * MR::cDefaultItemSpacing * scaling ) );
-    if ( !ImGui::BeginModalNoAnimation( "Scene Mouse Controls", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar ) )
-    {
-        ImGui::PopStyleVar();
+    if ( !ImGui::CollapsingHeader( "Mouse Control", ImGuiTreeNodeFlags_DefaultOpen ) )
         return;
-    }
-    ImGui::PopStyleVar();
 
-    if ( ImGui::ModalBigTitle( "Scene Mouse Controls", scaling ) )
-    {
-        ImGui::CloseCurrentPopup();
-    }
-
-	const float buttonHeight = cGradientButtonFramePadding * scaling + ImGui::CalcTextSize( "Set other" ).y;
+    const float buttonHeight = cGradientButtonFramePadding * scaling + ImGui::CalcTextSize( "Set other" ).y;
     for ( int i = 0; i < int( MouseMode::Count ); ++i )
     {
         MouseMode mode = MouseMode( i );
@@ -421,10 +434,10 @@ void ViewerSettingsPlugin::drawMouseSceneControlsSettings_( float scaling )
         ImGui::SetCursorPosY( posY + cGradientButtonFramePadding * scaling / 2.f );
         ImGui::Text( "%s", modeName.c_str() );
         ImGui::SameLine();
-        ImGui::SetCursorPosX( windowSize.x * 0.5f - 50.0f * scaling );
+        ImGui::SetCursorPosX( menuWidth * 0.5f - 50.0f * scaling );
         ImGui::Text( "%s", ctrlStr.c_str() );
         ImGui::SameLine();
-        ImGui::SetCursorPosX( windowSize.x - 150.0f * scaling );
+        ImGui::SetCursorPosX( menuWidth - 150.0f * scaling );
 
 		ImGui::SetCursorPosY( posY );
         UI::button( "Set other", Vector2f( -1, buttonHeight ) );
@@ -457,45 +470,21 @@ void ViewerSettingsPlugin::drawMouseSceneControlsSettings_( float scaling )
 
     ImGui::SetNextItemWidth( 100 * scaling );
     ImGui::DragFloatValid( "Scroll modifier", &viewer->scrollForce, 0.01f, 0.2f, 3.0f );
-
-    ImGui::EndPopup();
 }
 
-void ViewerSettingsPlugin::drawSpaceMouseSettings_( float scaling )
+void ViewerSettingsPlugin::drawSpaceMouseSettings_( float menuWidth, float scaling )
 {
-    ImVec2 windowSize = ImVec2( 450 * scaling, 0);
-    ImGui::SetNextWindowSize( windowSize, ImGuiCond_Always );
-    ImGui::SetNextWindowSizeConstraints( ImVec2( windowSize.x, -1 ), ImVec2( windowSize.x, 0 ) );
-
-    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-    ImGui::SetNextWindowPos( center, ImGuiCond_Appearing, ImVec2( 0.5f, 0.5f ) );
-
-    ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 3 * MR::cDefaultItemSpacing * scaling, 3 * MR::cDefaultItemSpacing * scaling ) );
-    if ( !ImGui::BeginModalNoAnimation( "Spacemouse Settings", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar ) )
-    {
-        ImGui::PopStyleVar();
+    if ( !ImGui::CollapsingHeader( "Spacemouse Settings" ) )
         return;
-    }
-
-    if ( ImGui::ModalBigTitle( "Spacemouse Settings", scaling ) )
-        ImGui::CloseCurrentPopup();
-
-
-    auto font = RibbonFontManager::getFontByTypeStatic( MR::RibbonFontManager::FontType::BigSemiBold );
-    if ( font )
-        ImGui::PushFont( font );
-    ImGui::Text( "%s", "Translation scales" );
-    if ( font )
-        ImGui::PopFont();
 
     bool anyChanged = false;
-    auto drawSlider = [&anyChanged, &windowSize] ( const char* label, float& value )
+    auto drawSlider = [&anyChanged, menuWidth] ( const char* label, float& value )
     {
         int valueAbs = int( std::fabs( value ) );
         bool inverse = value < 0.f;
-        ImGui::SetNextItemWidth( windowSize.x * 0.6f );
+        ImGui::SetNextItemWidth( menuWidth * 0.6f );
         bool changed = ImGui::SliderInt( label, &valueAbs, 1, 100 );
-        ImGui::SameLine( windowSize.x * 0.78f );
+        ImGui::SameLine( menuWidth * 0.78f );
         const float cursorPosY = ImGui::GetCursorPosY();
         ImGui::SetCursorPosY( cursorPosY + 3 );
         changed = UI::checkbox( ( std::string( "Inverse##" ) + label ).c_str(), &inverse ) || changed;
@@ -504,21 +493,16 @@ void ViewerSettingsPlugin::drawSpaceMouseSettings_( float scaling )
         anyChanged = anyChanged || changed;
     };
 
+    ImGui::Text( "%s", "Translation scales" );
     drawSlider( "X##translate", spaceMouseParams_.translateScale[0] );
     drawSlider( "Y##translate", spaceMouseParams_.translateScale[2] );
     drawSlider( "Zoom##translate", spaceMouseParams_.translateScale[1] );
 
-    ImGui::NewLine();
-    if ( font )
-        ImGui::PushFont( font );
     ImGui::Text( "%s", "Rotation scales" );
-    if ( font )
-        ImGui::PopFont();
     drawSlider( "Ox##rotate", spaceMouseParams_.rotateScale[0] );
     drawSlider( "Oy##rotate", spaceMouseParams_.rotateScale[1] );
     drawSlider( "Oz##rotate", spaceMouseParams_.rotateScale[2] );
 #if defined(_WIN32) || defined(__APPLE__)
-    ImGui::NewLine();
     if ( UI::checkbox( "Zoom by mouse wheel", &activeMouseScrollZoom_ ) )
     {
         if ( auto spaceMouseHandler = getViewerInstance().getSpaceMouseHandler() )
@@ -534,32 +518,12 @@ void ViewerSettingsPlugin::drawSpaceMouseSettings_( float scaling )
 #endif
     if ( anyChanged )
         getViewerInstance().setSpaceMouseParameters( spaceMouseParams_ );
-
-    ImGui::PopStyleVar();
-    ImGui::EndPopup();
 }
 
-void ViewerSettingsPlugin::drawTouchpadSettings_( float menuScaling )
+void ViewerSettingsPlugin::drawTouchpadSettings_()
 {
-    ImVec2 windowSize = ImVec2( 500 * menuScaling, 0 );
-    ImGui::SetNextWindowSize( windowSize, ImGuiCond_Always );
-
-    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-    ImGui::SetNextWindowPos( center, ImGuiCond_Appearing, ImVec2( 0.5f, 0.5f ) );
-    ImGui::SetNextWindowSizeConstraints( ImVec2( windowSize.x, -1 ), ImVec2( windowSize.x, 0 ) );
-
-    ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 3 * MR::cDefaultItemSpacing * menuScaling, 3 * MR::cDefaultItemSpacing * menuScaling ) );
-    if ( !ImGui::BeginModalNoAnimation( "Touchpad Settings", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar ) )
-    {
-        ImGui::PopStyleVar();
+    if ( !ImGui::CollapsingHeader( "Touchpad Settings" ) )
         return;
-    }
-    ImGui::PopStyleVar();
-
-    if ( ImGui::ModalBigTitle( "Touchpad Settings", menuScaling ) )
-    {
-        ImGui::CloseCurrentPopup();
-    }
 
     const std::vector<std::string> swipeModeList = { "Swipe Rotates Camera", "Swipe Moves Camera" };
     assert( swipeModeList.size() == (size_t)TouchpadParameters::SwipeMode::Count );
@@ -573,26 +537,6 @@ void ViewerSettingsPlugin::drawTouchpadSettings_( float menuScaling )
         updateSettings = true;
     if ( updateSettings )
         viewer->setTouchpadParameters( touchpadParameters_ );
-
-    ImGui::EndPopup();
-}
-
-void ViewerSettingsPlugin::drawModalExitButton_( float scaling )
-{
-    ImVec2 oldCursorPos = ImGui::GetCursorPos();
-    ImVec2 windowSize = ImGui::GetWindowSize();
-    ImVec2 btnPos = ImVec2( windowSize.x - 30 * scaling, 10 * scaling );
-    ImGui::SetCursorPos( btnPos );
-    auto font = RibbonFontManager::getFontByTypeStatic( MR::RibbonFontManager::FontType::Icons );
-    if ( !font )
-        return;
-    font->Scale = 0.6f;
-    ImGui::PushFont( font );
-    const float btnSize = 20 * scaling;
-    if ( UI::button( "\xef\x80\x8d", Vector2f( btnSize , btnSize ) ) )
-        ImGui::CloseCurrentPopup();
-    ImGui::PopFont();
-    ImGui::SetCursorPos( oldCursorPos );
 }
 
 MR_REGISTER_RIBBON_ITEM( ViewerSettingsPlugin )

--- a/source/MRCommonPlugins/ViewerButtons/MRViewerSettingsPlugin.h
+++ b/source/MRCommonPlugins/ViewerButtons/MRViewerSettingsPlugin.h
@@ -25,13 +25,23 @@ private:
     virtual bool onEnable_() override;
     virtual bool onDisable_() override;
 
-    void drawMouseSceneControlsSettings_( float menuScaling );
+    void drawSettingsTab_( float menuWidth, float menuScaling );
+    void drawViewportTab_( float menuWidth, float menuScaling );
+    void drawViewTab_( float menuWidth, float menuScaling );
+    void drawControlTab_( float menuWidth, float menuScaling );
 
-    void drawSpaceMouseSettings_( float menuScaling );
-
-    void drawTouchpadSettings_( float menuScaling );
-
-    void drawModalExitButton_( float menuScaling );
+    void drawMouseSceneControlsSettings_( float menuWidth, float menuScaling );
+    void drawSpaceMouseSettings_( float menuWidth, float menuScaling );
+    void drawTouchpadSettings_();
+   
+    enum class TabType
+    {
+        Settings,
+        Viewport,
+        View,
+        Control,
+        Count
+    } activeTab_{ TabType::Settings };
 
     int curSamples_{ 0 };
     int storedSamples_{ 0 };


### PR DESCRIPTION
- Split settings to 4 tabs (to the right: `Control` tab with all areas expanded)
- Parameters from `Viewer Options` are moved to `Behavior` and `Render Options` groups
![settings-window](https://github.com/MeshInspector/MeshLib/assets/120382683/6701a057-84e3-4975-9ed5-34d6c087e528)
