### PR TITLE
Basic iteration exposing on Vector classes

### DIFF
--- a/source/mrmeshpy/MRPythonBaseExposing.cpp
+++ b/source/mrmeshpy/MRPythonBaseExposing.cpp
@@ -133,7 +133,10 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, name, [] ( pybind11::module_& m ) \
             std::stringstream ss;\
             ss << #name << "[" << data.x << ", " << data.y << "]";\
             return ss.str();\
-        } );\
+        } ).\
+         def( "__iter__", [](VectorType& data) {\
+            return pybind11::make_iterator<pybind11::return_value_policy::reference_internal>( begin( data ), end( data ) );\
+        }, pybind11::keep_alive<0, 1>() );\
     m.def( "dot", ( type( * )( const VectorType&, const VectorType& ) )& MR::dot<type>, pybind11::arg( "a" ), pybind11::arg( "b" ), "dot product" );\
     m.def( "cross", ( type( * )( const VectorType&, const VectorType& ) )& MR::cross<type>, pybind11::arg( "a" ), pybind11::arg( "b" ), "cross product" );\
 } )
@@ -182,7 +185,10 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, name, [] ( pybind11::module_& m )\
             std::stringstream ss;\
             ss << #name << "[" << data.x << ", " << data.y << ", " << data.z << "]";\
             return ss.str();\
-        } );\
+        } ).\
+        def( "__iter__", [](VectorType& data) {\
+            return pybind11::make_iterator<pybind11::return_value_policy::reference_internal>( begin( data ), end( data ) );\
+        }, pybind11::keep_alive<0, 1>() );\
     if constexpr ( !std::is_same_v<type, int> ) \
     {\
         MR_PYTHON_CUSTOM_CLASS( name ).\

--- a/test_python/test_iterators.py
+++ b/test_python/test_iterators.py
@@ -1,0 +1,36 @@
+from helper import *
+import pytest
+
+def test_Vector3():
+    double_vec = mrmesh.Vector3d(1, 2, 3)
+    int_vec = mrmesh.Vector3i(1, 2, 3)
+    float_vec = mrmesh.Vector3f(1, 2, 3)
+
+    doubles_list = list(double_vec)
+    ints_list = list(int_vec)
+    floats_list = list(float_vec)
+
+    assert len(doubles_list) == 3
+    assert len(ints_list) == 3
+    assert len(floats_list) == 3
+
+    assert type(doubles_list[0]) == float # Double is converted to float in python
+    assert type(ints_list[0]) == int
+    assert type(floats_list[0]) == float
+
+def test_Vector2():
+    double_vec = mrmesh.Vector2d(1, 2)
+    int_vec = mrmesh.Vector2i(1, 2)
+    float_vec = mrmesh.Vector2f(1, 2)
+
+    doubles_list = list(double_vec)
+    ints_list = list(int_vec)
+    floats_list = list(float_vec)
+
+    assert len(doubles_list) == 2
+    assert len(ints_list) == 2
+    assert len(floats_list) == 2
+
+    assert type(doubles_list[0]) == float # Double is converted to float in python
+    assert type(ints_list[0]) == int
+    assert type(floats_list[0]) == float

--- a/test_python/test_iterators.py
+++ b/test_python/test_iterators.py
@@ -12,6 +12,11 @@ def elementwise_comparison_2(a: List, b: Union[mrmesh.Vector2d,  mrmesh.Vector2i
     assert a[0] == b.x
     assert a[1] == b.y
 
+def iteration_check(a: Union[mrmesh.Vector3d,  mrmesh.Vector3i,  mrmesh.Vector3f, mrmesh.Vector2d,  mrmesh.Vector2i,  mrmesh.Vector2f]):
+    counter = 1
+    for el in a:
+        assert el == counter
+        counter = counter + 1
 
 def test_Vector3():
     double_vec = mrmesh.Vector3d(1, 2, 3)
@@ -34,6 +39,10 @@ def test_Vector3():
     elementwise_comparison_3(ints_list, int_vec)
     elementwise_comparison_3(floats_list, float_vec)
 
+    iteration_check(double_vec)
+    iteration_check(int_vec)
+    iteration_check(float_vec)
+
 def test_Vector2():
     double_vec = mrmesh.Vector2d(1, 2)
     int_vec = mrmesh.Vector2i(1, 2)
@@ -54,3 +63,7 @@ def test_Vector2():
     elementwise_comparison_2(doubles_list, double_vec)
     elementwise_comparison_2(ints_list, int_vec)
     elementwise_comparison_2(floats_list, float_vec)
+    
+    iteration_check(double_vec)
+    iteration_check(int_vec)
+    iteration_check(float_vec)

--- a/test_python/test_iterators.py
+++ b/test_python/test_iterators.py
@@ -1,5 +1,17 @@
+from typing import List, Union
 from helper import *
 import pytest
+
+def elementwise_comparison_3(a: List, b: Union[mrmesh.Vector3d,  mrmesh.Vector3i,  mrmesh.Vector3f]):
+    assert a[0] == b.x
+    assert a[1] == b.y
+    assert a[2] == b.z
+
+
+def elementwise_comparison_2(a: List, b: Union[mrmesh.Vector2d,  mrmesh.Vector2i,  mrmesh.Vector2f]):
+    assert a[0] == b.x
+    assert a[1] == b.y
+
 
 def test_Vector3():
     double_vec = mrmesh.Vector3d(1, 2, 3)
@@ -18,6 +30,10 @@ def test_Vector3():
     assert type(ints_list[0]) == int
     assert type(floats_list[0]) == float
 
+    elementwise_comparison_3(doubles_list, double_vec)
+    elementwise_comparison_3(ints_list, int_vec)
+    elementwise_comparison_3(floats_list, float_vec)
+
 def test_Vector2():
     double_vec = mrmesh.Vector2d(1, 2)
     int_vec = mrmesh.Vector2i(1, 2)
@@ -34,3 +50,7 @@ def test_Vector2():
     assert type(doubles_list[0]) == float # Double is converted to float in python
     assert type(ints_list[0]) == int
     assert type(floats_list[0]) == float
+
+    elementwise_comparison_2(doubles_list, double_vec)
+    elementwise_comparison_2(ints_list, int_vec)
+    elementwise_comparison_2(floats_list, float_vec)


### PR DESCRIPTION
- Exposed iterator on the `Vector3X` and `Vector2X` classes to be able to cast them to a python list using: `list(Vector3X())`

I guess in the future it might be nice to expose iterator on: `MR_ADD_PYTHON_VEC`
As far as I understand this is just the default `std::vector` but I wasn't able to make this work easily.
Might have another look at it later
