### PR TITLE
PointCloudTriangulator: compute local triangulations only once (even if no normals were present)

### DIFF
--- a/source/MRMesh/MRLocalTriangulations.h
+++ b/source/MRMesh/MRLocalTriangulations.h
@@ -52,4 +52,7 @@ struct AllLocalTriangulations
 /// into one AllLocalTriangulations with records for all points
 [[nodiscard]] MRMESH_API std::optional<AllLocalTriangulations> uniteLocalTriangulations( const std::vector<SomeLocalTriangulations> & in, const ProgressCallback & progress = {} );
 
+/// orient neighbors around each point so they will be in clockwise order if look from the top of target normal
+MRMESH_API void orientLocalTriangulations( AllLocalTriangulations & triangs, const VertCoords & coords, const VertNormals & normals );
+
 } //namespace MR


### PR DESCRIPTION
Previous triangulation:
![image](https://github.com/MeshInspector/MeshLib/assets/3136125/b5645e93-a0e6-4a62-8448-ff46cafc72d3)

New triangulation:
![image](https://github.com/MeshInspector/MeshLib/assets/3136125/5196ada7-f335-4a56-9d66-fdb169018dc4)

And new is faster.
