### PR TITLE
Allocate buffers for zlib in heap

### DIFF
--- a/source/MRMesh/MRZlib.cpp
+++ b/source/MRMesh/MRZlib.cpp
@@ -1,4 +1,5 @@
 #include "MRZlib.h"
+#include "MRBuffer.h"
 #include "MRFinally.h"
 
 #include <zlib.h>
@@ -44,7 +45,7 @@ namespace MR
 
 VoidOrErrStr zlibCompressStream( std::istream& in, std::ostream& out, int level )
 {
-    std::array<char, cChunkSize> inChunk, outChunk;
+    Buffer<char> inChunk( cChunkSize ), outChunk( cChunkSize );
     z_stream stream {
         .zalloc = Z_NULL,
         .zfree = Z_NULL,
@@ -89,7 +90,7 @@ VoidOrErrStr zlibCompressStream( std::istream& in, std::ostream& out, int level 
 
 VoidOrErrStr zlibDecompressStream( std::istream& in, std::ostream& out )
 {
-    std::array<char, cChunkSize> inChunk, outChunk;
+    Buffer<char> inChunk( cChunkSize ), outChunk( cChunkSize );
     z_stream stream {
         .zalloc = Z_NULL,
         .zfree = Z_NULL,


### PR DESCRIPTION
On Wasm the default stack size is very small and the zlib buffers don't fit in it. Reducing the buffer size would decrease the (de-)compression performance. Allocating the buffers in the heap will be more efficient.