### PR TITLE
Expose straighten boundary to python

### DIFF
--- a/source/mrmeshpy/MRPythonMeshExposing.cpp
+++ b/source/mrmeshpy/MRPythonMeshExposing.cpp
@@ -23,6 +23,7 @@
 #include "MRMesh/MRPartMapping.h"
 #include "MRMesh/MRBuffer.h"
 #include "MRMesh/MRMeshExtrude.h"
+#include "MRMesh/MRMeshBoundary.h"
 #include <pybind11/functional.h>
 
 using namespace MR;
@@ -609,3 +610,13 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, SimpleFunctions, [] ( pybind11::module_& m )
 } )
 
 MR_ADD_PYTHON_VEC( mrmeshpy, vectorFaceFace, FaceFace )
+
+MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, MeshBoundary, [] ( pybind11::module_& m )
+{
+    m.def( "straightenBoundary", &straightenBoundary,
+    pybind11::arg( "mesh" ), pybind11::arg( "bdEdge" ), pybind11::arg("minNeiNormalsDot"), pybind11::arg("maxTriAspectRatio"), pybind11::arg("newFaces") = nullptr,
+    "Adds triangles along the boundary to straighten it.\n"
+    "New triangle is added only if:\n"
+        "1) aspect ratio of the new triangle is at most maxTriAspectRatio\n"
+        "2) dot product of its normal with neighbor triangles is at least minNeiNormalsDot." );
+} )

--- a/test_python/test_relax.py
+++ b/test_python/test_relax.py
@@ -50,3 +50,14 @@ def test_smooth_region_boundary():
 
     # This just checks that the function exists and can be called.
     mrmesh.smoothRegionBoundary(keep_volume_torus, smooth_region)
+
+def test_straighten_boundary():
+    torus = mrmesh.makeTorus(2, 1, 10, 10, None)
+    faceBitSetToDelete = mrmesh.FaceBitSet()
+    faceBitSetToDelete.resize(5, False)
+    faceBitSetToDelete.set(mrmesh.FaceId(1), True)
+
+    torus.topology.deleteFaces(faceBitSetToDelete)
+
+    holes = torus.topology.findHoleRepresentiveEdges()
+    mrmesh.straightenBoundary(torus, holes[0], 13, 5)


### PR DESCRIPTION
Would it maybe make sense to put the `minNeiNormalsDot` and `maxTriAspectRatio` to the same default values used in the Meshlib App?
Same for the boundary edge? As now the user has to manually find the boundary edge?

While on the Meshlib App it goes automatically.