### PR TITLE
   Make public addPoint, removePoint and closeContour  methods for Contours Widget 

### DIFF
--- a/source/MRViewer/MRSurfaceContoursWidget.cpp
+++ b/source/MRViewer/MRSurfaceContoursWidget.cpp
@@ -248,7 +248,8 @@ void SurfaceContoursWidget::setActivePoint( std::shared_ptr<MR::VisualObject> ob
     activeIndex_ = index;
     activeObject_ = obj;
 }
-bool SurfaceContoursWidget::addPoint( const std::shared_ptr<VisualObject>& obj, const PickedPoint& triPoint )
+
+bool SurfaceContoursWidget::appendPoint( const std::shared_ptr<VisualObject>& obj, const PickedPoint& triPoint )
 {
 
     if ( !isObjectValidToPick_( obj ) )
@@ -281,7 +282,7 @@ bool SurfaceContoursWidget::addPoint( const std::shared_ptr<VisualObject>& obj, 
         onAddPointAction();
 
     return true;
-};
+}
 
 bool SurfaceContoursWidget::removePoint( const std::shared_ptr<VisualObject>& obj, int pickedIndex )
 {
@@ -312,8 +313,7 @@ bool SurfaceContoursWidget::removePoint( const std::shared_ptr<VisualObject>& ob
         onRemovePointAction();
 
     return true;
-};
-
+}
 
 bool SurfaceContoursWidget::closeContour( const std::shared_ptr<VisualObject>& objectToCloseCoutour )
 {
@@ -322,7 +322,7 @@ bool SurfaceContoursWidget::closeContour( const std::shared_ptr<VisualObject>& o
 
     assert( objectToCloseCoutour != nullptr );
     auto triPoint = pickedPoints_[objectToCloseCoutour][0]->getCurrentPosition();
-    addPoint( objectToCloseCoutour, triPoint );
+    appendPoint( objectToCloseCoutour, triPoint );
     activeIndex_ = 0;
     return true;
 }
@@ -351,7 +351,7 @@ bool SurfaceContoursWidget::onMouseDown_( Viewer::MouseButton button, int mod )
 
         assert( objVisual != nullptr ); // contoursWidget_ can join for mesh objects only
 
-        addPoint( objVisual, pointOnObjectToPickedPoint( objVisual.get(), pick ) );
+        appendPoint( objVisual, pointOnObjectToPickedPoint( objVisual.get(), pick ) );
         return true;
     }
     else if ( mod == params.widgetContourCloseMod ) // close contour case 
@@ -421,7 +421,7 @@ bool SurfaceContoursWidget::onMouseDown_( Viewer::MouseButton button, int mod )
 
             // Restore close countour. 
             if ( contour.size() > 2 && pickedIndex == 0 )
-                addPoint( pickedObj, contour[0]->getCurrentPosition() );
+                appendPoint( pickedObj, contour[0]->getCurrentPosition() );
         }
         else
             removePoint( pickedObj, pickedIndex );

--- a/source/MRViewer/MRSurfaceContoursWidget.h
+++ b/source/MRViewer/MRSurfaceContoursWidget.h
@@ -110,9 +110,11 @@ public:
     MRVIEWER_API void setActivePoint( std::shared_ptr<MR::VisualObject> obj, int index );
 
     // Add a point to the end of non closed contour connected with obj.
+    // With carefull it is possile to use it in CallBack.
     MRVIEWER_API bool addPoint( const std::shared_ptr<VisualObject>& obj, const PickedPoint& triPoint );
 
     // Remove point with pickedIndex index from contour connected with obj.
+    // With carefull it is possile to use it in CallBack.
     MRVIEWER_API bool removePoint( const std::shared_ptr<VisualObject>& obj, int pickedIndex );
 
     // Add a special transperent point contour to the end of contour connected with objectToCloseCoutour.

--- a/source/MRViewer/MRSurfaceContoursWidget.h
+++ b/source/MRViewer/MRSurfaceContoursWidget.h
@@ -111,7 +111,7 @@ public:
 
     // Add a point to the end of non closed contour connected with obj.
     // With carefull it is possile to use it in CallBack.
-    MRVIEWER_API bool addPoint( const std::shared_ptr<VisualObject>& obj, const PickedPoint& triPoint );
+    MRVIEWER_API bool appendPoint( const std::shared_ptr<VisualObject>& obj, const PickedPoint& triPoint );
 
     // Remove point with pickedIndex index from contour connected with obj.
     // With carefull it is possile to use it in CallBack.

--- a/source/MRViewer/MRSurfaceContoursWidget.h
+++ b/source/MRViewer/MRSurfaceContoursWidget.h
@@ -109,6 +109,17 @@ public:
     MRVIEWER_API std::pair <std::shared_ptr<MR::VisualObject>, int > getActivePoint();
     MRVIEWER_API void setActivePoint( std::shared_ptr<MR::VisualObject> obj, int index );
 
+    // Add a point to the end of non closed contour connected with obj.
+    MRVIEWER_API bool addPoint( const std::shared_ptr<VisualObject>& obj, const PickedPoint& triPoint );
+
+    // Remove point with pickedIndex index from contour connected with obj.
+    MRVIEWER_API bool removePoint( const std::shared_ptr<VisualObject>& obj, int pickedIndex );
+
+    // Add a special transperent point contour to the end of contour connected with objectToCloseCoutour.
+    // A coordinated of this special transperent point will be equal to the firs point in contour, 
+    // which will means that contour is closed.
+    MRVIEWER_API bool closeContour( const std::shared_ptr<VisualObject>& objectToCloseCoutour );
+
     // configuration params
     SurfaceContoursWidgetParams params;
 private:


### PR DESCRIPTION
     // Add a point to the end of non closed contour connected with obj.
    MRVIEWER_API bool addPoint( const std::shared_ptr<VisualObject>& obj, const PickedPoint& triPoint );

    // Remove point with pickedIndex index from contour connected with obj.
    MRVIEWER_API bool removePoint( const std::shared_ptr<VisualObject>& obj, int pickedIndex );

    // Add a special transperent point contour to the end of contour connected with objectToCloseCoutour.
    // A coordinated of this special transperent point will be equal to the firs point in contour,
    // which will means that contour is closed.
    MRVIEWER_API bool closeContour( const std::shared_ptr<VisualObject>& objectToCloseCoutour );