### PR TITLE
Point Cloud improvements

### DIFF
--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -68,8 +68,8 @@ void ObjectPointsHolder::setDirtyFlags( uint32_t mask, bool invalidateCaches )
     if ( mask & DIRTY_FACE )
     {
         numValidPoints_.reset();
-        const int validPointsCount = int( numValidPoints() );
-        setRenderDiscretization( validPointsCount > 2'000'000 ? validPointsCount / 1'000'000 : 1 );
+        const int validPointCount = int( numValidPoints() );
+        setRenderDiscretization( validPointCount > 2'000'000 ? validPointCount / 1'000'000 : 1 );
     }
 
     if ( mask & DIRTY_POSITION || mask & DIRTY_FACE )
@@ -250,8 +250,8 @@ VoidOrErrStr ObjectPointsHolder::deserializeModel_( const std::filesystem::path&
         setColoringType( ColoringType::VertsColorMap );
 
     points_ = std::make_shared<PointCloud>( std::move( res.value() ) );
-    if ( int pointCount = int( points_->validPoints.count() ); pointCount > 2'000'000 )
-        setRenderDiscretization( pointCount / 1'000'000 );
+    if ( int validPointCount = int( numValidPoints() ); validPointCount > 2'000'000 )
+        setRenderDiscretization( validPointCount / 1'000'000 );
     return {};
 }
 

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -312,4 +312,17 @@ int ObjectPointsHolder::chooseRenderDiscretization_()
     return std::max( 1, int( numValidPoints() ) / maxRenderingPoints_ );
 }
 
+int ObjectPointsHolder::getMaxAutoRenderingPoints() const
+{
+    return maxRenderingPoints_;
+}
+
+void ObjectPointsHolder::setMaxAutoRenderingPoints( int val )
+{
+    if ( maxRenderingPoints_ == val )
+        return;
+    maxRenderingPoints_ = val;
+    setRenderDiscretization( chooseRenderDiscretization_() );
+}
+
 }

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -12,6 +12,11 @@
 #include "MRPch/MRTBB.h"
 #include "MRPch/MRAsyncLaunchType.h"
 
+static int chooseRenderDiscretization( size_t numValidPoints )
+{
+    return std::max( 1, int ( numValidPoints / 1'000'000 ) );
+}
+
 namespace MR
 {
 
@@ -68,8 +73,7 @@ void ObjectPointsHolder::setDirtyFlags( uint32_t mask, bool invalidateCaches )
     if ( mask & DIRTY_FACE )
     {
         numValidPoints_.reset();
-        const int validPointCount = int( numValidPoints() );
-        setRenderDiscretization( validPointCount > 2'000'000 ? validPointCount / 1'000'000 : 1 );
+        setRenderDiscretization( chooseRenderDiscretization( numValidPoints() ) );
     }
 
     if ( mask & DIRTY_POSITION || mask & DIRTY_FACE )
@@ -250,8 +254,7 @@ VoidOrErrStr ObjectPointsHolder::deserializeModel_( const std::filesystem::path&
         setColoringType( ColoringType::VertsColorMap );
 
     points_ = std::make_shared<PointCloud>( std::move( res.value() ) );
-    if ( int validPointCount = int( numValidPoints() ); validPointCount > 2'000'000 )
-        setRenderDiscretization( validPointCount / 1'000'000 );
+    setRenderDiscretization( chooseRenderDiscretization( numValidPoints() ) );
     return {};
 }
 

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -12,11 +12,6 @@
 #include "MRPch/MRTBB.h"
 #include "MRPch/MRAsyncLaunchType.h"
 
-static int chooseRenderDiscretization( size_t numValidPoints )
-{
-    return std::max( 1, int ( numValidPoints / 1'000'000 ) );
-}
-
 namespace MR
 {
 
@@ -73,7 +68,7 @@ void ObjectPointsHolder::setDirtyFlags( uint32_t mask, bool invalidateCaches )
     if ( mask & DIRTY_FACE )
     {
         numValidPoints_.reset();
-        setRenderDiscretization( chooseRenderDiscretization( numValidPoints() ) );
+        setRenderDiscretization( chooseRenderDiscretization_() );
     }
 
     if ( mask & DIRTY_POSITION || mask & DIRTY_FACE )
@@ -254,7 +249,7 @@ VoidOrErrStr ObjectPointsHolder::deserializeModel_( const std::filesystem::path&
         setColoringType( ColoringType::VertsColorMap );
 
     points_ = std::make_shared<PointCloud>( std::move( res.value() ) );
-    setRenderDiscretization( chooseRenderDiscretization( numValidPoints() ) );
+    setRenderDiscretization( chooseRenderDiscretization_() );
     return {};
 }
 
@@ -310,6 +305,11 @@ void ObjectPointsHolder::setSelectedVerticesColorsForAllViewports( ViewportPrope
 void ObjectPointsHolder::setDefaultSceneProperties_()
 {
     setDefaultColors_();
+}
+
+int ObjectPointsHolder::chooseRenderDiscretization_()
+{
+    return std::max( 1, int( numValidPoints() ) / maxRenderingPoints_ );
 }
 
 }

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -66,7 +66,11 @@ void ObjectPointsHolder::setDirtyFlags( uint32_t mask, bool invalidateCaches )
     VisualObject::setDirtyFlags( mask, invalidateCaches );
 
     if ( mask & DIRTY_FACE )
+    {
         numValidPoints_.reset();
+        const int validPointsCount = int( numValidPoints() );
+        setRenderDiscretization( validPointsCount > 2'000'000 ? validPointsCount / 1'000'000 : 1 );
+    }
 
     if ( mask & DIRTY_POSITION || mask & DIRTY_FACE )
     {
@@ -246,7 +250,7 @@ VoidOrErrStr ObjectPointsHolder::deserializeModel_( const std::filesystem::path&
         setColoringType( ColoringType::VertsColorMap );
 
     points_ = std::make_shared<PointCloud>( std::move( res.value() ) );
-    if ( int pointCount = int( points_->points.size() ); pointCount > 2'000'000 )
+    if ( int pointCount = int( points_->validPoints.count() ); pointCount > 2'000'000 )
         setRenderDiscretization( pointCount / 1'000'000 );
     return {};
 }

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -93,6 +93,23 @@ public:
         return renderDiscretization_;
     }
 
+    /// returns maximal number of points that will be rendered
+    /// if actual count of valid points is greater then the points will be sampled
+    int getMaxRenderingPoints() const
+    {
+        return maxRenderingPoints_;
+    }
+
+    /// sets maximal number of points that will be rendered
+    /// INT_MAX means lack of limit
+    void setMaxRenderingPoints( int val )
+    {
+        if ( maxRenderingPoints_ == val )
+            return;
+        maxRenderingPoints_ = val;
+        needRedraw_ = true;
+    }
+
     /// returns file extension used to serialize the points
     [[nodiscard]] const char * savePointsFormat() const { return savePointsFormat_; }
 
@@ -138,7 +155,8 @@ protected:
     MRMESH_API virtual void setupRenderObject_() const override;
 
     int renderDiscretization_ = 1;
-
+    int maxRenderingPoints_ = 1'000'000;
+    int chooseRenderDiscretization_();
 
 private:
 

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -95,15 +95,15 @@ public:
 
     /// returns maximal number of points that will be rendered
     /// if actual count of valid points is greater then the points will be sampled
-    /// This value is used onl for automatic discretization
+    /// This value is used only for automatic discretization
     /// It can be changed manually by calling setRenderDiscretization
-    int getMaxAutoRenderingPoints() const;
+    MRMESH_API int getMaxAutoRenderingPoints() const;
 
     /// sets maximal number of points that will be rendered
     /// INT_MAX means lack of limit
-    /// This value is used onl for automatic discretization
+    /// This value is used only for automatic discretization
     /// It can be changed manually by calling setRenderDiscretization
-    void setMaxAutoRenderingPoints( int val );
+    MRMESH_API void setMaxAutoRenderingPoints( int val );
 
     /// returns file extension used to serialize the points
     [[nodiscard]] const char * savePointsFormat() const { return savePointsFormat_; }

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -95,20 +95,15 @@ public:
 
     /// returns maximal number of points that will be rendered
     /// if actual count of valid points is greater then the points will be sampled
-    int getMaxRenderingPoints() const
-    {
-        return maxRenderingPoints_;
-    }
+    /// This value is used onl for automatic discretization
+    /// It can be changed manually by calling setRenderDiscretization
+    int getMaxAutoRenderingPoints() const;
 
     /// sets maximal number of points that will be rendered
     /// INT_MAX means lack of limit
-    void setMaxRenderingPoints( int val )
-    {
-        if ( maxRenderingPoints_ == val )
-            return;
-        maxRenderingPoints_ = val;
-        needRedraw_ = true;
-    }
+    /// This value is used onl for automatic discretization
+    /// It can be changed manually by calling setRenderDiscretization
+    void setMaxAutoRenderingPoints( int val );
 
     /// returns file extension used to serialize the points
     [[nodiscard]] const char * savePointsFormat() const { return savePointsFormat_; }

--- a/source/MRViewer/ImGuiMenu.cpp
+++ b/source/MRViewer/ImGuiMenu.cpp
@@ -1672,7 +1672,7 @@ bool ImGuiMenu::drawAdvancedOptions_( const std::vector<std::shared_ptr<VisualOb
 
     if ( allIsObjPoints )
     {
-        make_points_discretization( selectedObjs, "Point Sampling", [&] ( const ObjectPointsHolder* data )
+        make_points_discretization( selectedObjs, "Visual Sampling", [&] ( const ObjectPointsHolder* data )
         {
             return data->getRenderDiscretization();
         }, [&] ( ObjectPointsHolder* data, const int val )


### PR DESCRIPTION
Rename Point Sampling in the rclick menu to Visual Sampling.
Adjust Visual sampling each time the number of points changes.