### PR TITLE
Display shortcuts with 'Super' modifier, fix Mac shortcut

### DIFF
--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -2095,7 +2095,7 @@ void RibbonMenu::drawShortcutsWindow_()
 {
     const auto& style = ImGui::GetStyle();
     const auto scaling = menu_scaling();
-    float windowWidth = 920.0f * scaling;
+    float windowWidth = 1000.0f * scaling;
 
     const auto& shortcutList = shortcutManager_->getShortcutList();
     // header size
@@ -2125,6 +2125,7 @@ void RibbonMenu::drawShortcutsWindow_()
         rightNumKeys * ( fontManager_.getFontSizeByType( RibbonFontManager::FontType::Default ) + cButtonPadding + 2 * cDefaultItemSpacing ) ) * scaling;
     // calc window size for better positioning
     windowHeight += std::max( leftSize, rightSize );
+    windowHeight += 40.0f * scaling; // Reserve a bit more space
 
     const float minHeight = 200.0f * scaling;
     windowHeight = std::clamp( windowHeight, minHeight, float( getViewerInstance().framebufferSize.y ) - 100.0f * scaling );

--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -56,6 +56,14 @@
 #pragma clang diagnostic pop
 #endif
 
+// Modifier for shortcuts
+// Some shortcuts still use GLFW_MOD_CONTROL on Mac to avoid conflict with system shortcuts
+#if !defined( __APPLE__ )
+#define CONTROL_OR_SUPER GLFW_MOD_CONTROL
+#else
+#define CONTROL_OR_SUPER GLFW_MOD_SUPER
+#endif
+
 namespace MR
 {
 
@@ -2019,7 +2027,7 @@ void RibbonMenu::setupShortcuts_()
         for ( const auto& sel : selected )
             sel->toggleVisualizeProperty( MeshVisualizePropertyType::FlatShading, viewportid );
     } } );
-    shortcutManager_->setShortcut( { GLFW_KEY_F, GLFW_MOD_CONTROL }, { ShortcutManager::Category::Info, "Search plugin by name or description",[this] ()
+    shortcutManager_->setShortcut( { GLFW_KEY_F, CONTROL_OR_SUPER }, { ShortcutManager::Category::Info, "Search plugin by name or description",[this] ()
     {
         searcher_.activate();
     } } );
@@ -2069,22 +2077,18 @@ void RibbonMenu::setupShortcuts_()
         changeSelection( false,GLFW_MOD_SHIFT );
     } }  );
 
-    addRibbonItemShortcut_( "Ribbon Scene Select all", { GLFW_KEY_A, GLFW_MOD_CONTROL }, ShortcutManager::Category::Objects );
+    addRibbonItemShortcut_( "Ribbon Scene Select all", { GLFW_KEY_A, CONTROL_OR_SUPER }, ShortcutManager::Category::Objects );
     addRibbonItemShortcut_( "Fit data", { GLFW_KEY_F, GLFW_MOD_CONTROL | GLFW_MOD_ALT }, ShortcutManager::Category::View );
     addRibbonItemShortcut_( "Select objects", { GLFW_KEY_Q, GLFW_MOD_CONTROL }, ShortcutManager::Category::Objects );
-    addRibbonItemShortcut_( "Open files", { GLFW_KEY_O, GLFW_MOD_CONTROL }, ShortcutManager::Category::Scene );
-    addRibbonItemShortcut_( "Save Scene", { GLFW_KEY_S, GLFW_MOD_CONTROL }, ShortcutManager::Category::Scene );
-    addRibbonItemShortcut_( "Save Scene As", { GLFW_KEY_S, GLFW_MOD_CONTROL | GLFW_MOD_SHIFT }, ShortcutManager::Category::Scene );
-    addRibbonItemShortcut_( "New", { GLFW_KEY_N, GLFW_MOD_CONTROL }, ShortcutManager::Category::Scene );
+    addRibbonItemShortcut_( "Open files", { GLFW_KEY_O, CONTROL_OR_SUPER }, ShortcutManager::Category::Scene );
+    addRibbonItemShortcut_( "Save Scene", { GLFW_KEY_S, CONTROL_OR_SUPER }, ShortcutManager::Category::Scene );
+    addRibbonItemShortcut_( "Save Scene As", { GLFW_KEY_S, CONTROL_OR_SUPER | GLFW_MOD_SHIFT }, ShortcutManager::Category::Scene );
+    addRibbonItemShortcut_( "New", { GLFW_KEY_N, CONTROL_OR_SUPER }, ShortcutManager::Category::Scene );
     addRibbonItemShortcut_( "Ribbon Scene Show only previous", { GLFW_KEY_F3, 0 }, ShortcutManager::Category::View );
     addRibbonItemShortcut_( "Ribbon Scene Show only next", { GLFW_KEY_F4, 0 }, ShortcutManager::Category::View );
     addRibbonItemShortcut_( "Ribbon Scene Rename", { GLFW_KEY_F2, 0 }, ShortcutManager::Category::Objects );
     addRibbonItemShortcut_( "Ribbon Scene Remove selected objects", { GLFW_KEY_R, GLFW_MOD_SHIFT }, ShortcutManager::Category::Objects );
-#if defined( __APPLE__ )
-    addRibbonItemShortcut_( "Viewer settings", { GLFW_KEY_COMMA, GLFW_MOD_SUPER }, ShortcutManager::Category::Info );
-#else
-    addRibbonItemShortcut_( "Viewer settings", { GLFW_KEY_COMMA, GLFW_MOD_CONTROL }, ShortcutManager::Category::Info );
-#endif
+    addRibbonItemShortcut_( "Viewer settings", { GLFW_KEY_COMMA, CONTROL_OR_SUPER }, ShortcutManager::Category::Info );
 }
 
 void RibbonMenu::drawShortcutsWindow_()

--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -2080,7 +2080,11 @@ void RibbonMenu::setupShortcuts_()
     addRibbonItemShortcut_( "Ribbon Scene Show only next", { GLFW_KEY_F4, 0 }, ShortcutManager::Category::View );
     addRibbonItemShortcut_( "Ribbon Scene Rename", { GLFW_KEY_F2, 0 }, ShortcutManager::Category::Objects );
     addRibbonItemShortcut_( "Ribbon Scene Remove selected objects", { GLFW_KEY_R, GLFW_MOD_SHIFT }, ShortcutManager::Category::Objects );
+#if defined( __APPLE__ )
+    addRibbonItemShortcut_( "Viewer settings", { GLFW_KEY_COMMA, GLFW_MOD_SUPER }, ShortcutManager::Category::Info );
+#else
     addRibbonItemShortcut_( "Viewer settings", { GLFW_KEY_COMMA, GLFW_MOD_CONTROL }, ShortcutManager::Category::Info );
+#endif
 }
 
 void RibbonMenu::drawShortcutsWindow_()
@@ -2228,6 +2232,16 @@ void RibbonMenu::drawShortcutsWindow_()
             {
                 ImGui::SetCursorPosY( ImGui::GetCursorPosY() - cButtonPadding * scaling );
                 addReadOnlyLine( ShortcutManager::getModifierString( GLFW_MOD_SHIFT ) );
+                ImGui::SameLine( 0, style.ItemInnerSpacing.x );
+                ImGui::SetCursorPosY( ImGui::GetCursorPosY() - cButtonPadding * scaling );
+                ImGui::Text( "+" );
+                ImGui::SameLine( 0, style.ItemInnerSpacing.x );
+            }
+
+            if ( key.mod & GLFW_MOD_SUPER )
+            {
+                ImGui::SetCursorPosY( ImGui::GetCursorPosY() - cButtonPadding * scaling );
+                addReadOnlyLine( ShortcutManager::getModifierString( GLFW_MOD_SUPER ) );
                 ImGui::SameLine( 0, style.ItemInnerSpacing.x );
                 ImGui::SetCursorPosY( ImGui::GetCursorPosY() - cButtonPadding * scaling );
                 ImGui::Text( "+" );

--- a/source/MRViewer/MRShortcutManager.cpp
+++ b/source/MRViewer/MRShortcutManager.cpp
@@ -73,6 +73,8 @@ std::string ShortcutManager::getModifierString( int mod )
         return "Alt";
     case GLFW_MOD_SHIFT:
         return "Shift";
+    case GLFW_MOD_SUPER:
+        return "Command";
     default:
         return "";
     }
@@ -124,6 +126,8 @@ std::string ShortcutManager::getKeyFullString( const ShortcutKey& key, bool resp
         res += getModifierString( GLFW_MOD_CONTROL ) + "+";
     if ( key.mod & GLFW_MOD_SHIFT )
         res += getModifierString( GLFW_MOD_SHIFT ) + "+";
+    if ( key.mod & GLFW_MOD_SUPER )
+        res += getModifierString( GLFW_MOD_SUPER ) + "+";
     if ( respectKey )
         res += getKeyString( key.key );
     return res;


### PR DESCRIPTION
MacOS fixes:
- Shortcut for Settings is now correctly Command+`,` (Ctrl+`,` for other platforms)
- Display shortcuts with Command modifier in help screen

![image](https://github.com/MeshInspector/MeshLib/assets/120382683/3757f4fe-b2ff-4c85-846c-077a7823ae54)

https://github.com/MeshInspector/MeshInspectorCode/issues/3352