### PR TITLE
Extract code from MoveObjectByMouse, add new features

### DIFF
--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
@@ -19,9 +19,17 @@
 namespace MR
 {
 
+MoveObjectByMouse* MoveObjectByMouse::instance_;
+
 MoveObjectByMouse::MoveObjectByMouse() :
     PluginParent( "Move object", StatePluginTabs::Basic )
 {
+    instance_ = this;
+}
+
+MoveObjectByMouse::~MoveObjectByMouse()
+{
+    instance_ = nullptr;
 }
 
 bool MoveObjectByMouse::onDisable_()

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
@@ -14,13 +14,6 @@
 #include "MRPch/MRSpdlog.h"
 #include "MRViewer/ImGuiHelpers.h"
 
-namespace
-{
-// translation multiplier that limits its maximum value depending on object size
-// the constant duplicates value defined in ImGuiMenu implementation
-constexpr float cMaxTranslationMultiplier = 0xC00;
-}
-
 namespace MR
 {
 
@@ -38,153 +31,24 @@ void MoveObjectByMouse::drawDialog( float menuScaling, ImGuiContext*)
     ImGui::Text( "%s", "Click and hold LMB on object to move" );
     ImGui::Text( "%s", "Click CTRL + LMB and hold LMB on object to rotate" );
 
-    if ( transformMode_ != TransformMode::None )
-    {
-        auto drawList = ImGui::GetBackgroundDrawList();
-        drawList->AddPolyline( visualizeVectors_.data(), int( visualizeVectors_.size() ),
-                               SceneColors::get( SceneColors::Labels ).getUInt32(), ImDrawFlags_None, 1.f );
-    }
-    if ( transformMode_ == TransformMode::Translation )
-        ImGui::SetTooltip( "Distance : %.3f", shift_ );
-    if ( transformMode_ == TransformMode::Rotation )
-        ImGui::SetTooltip( "Angle : %.3f", angle_ );
+    moveByMouse_.onDrawDialog( menuScaling );
 
     ImGui::EndCustomStatePlugin();
 }
 
-bool MoveObjectByMouse::onMouseDown_( MouseButton button, int modifier )
+bool MoveObjectByMouse::onMouseDown_( MouseButton btn, int modifiers )
 {
-    if ( button != Viewer::MouseButton::Left )
-        return false;
-
-    const auto [obj, pick] = viewer->viewport().pick_render_object();
-
-    if ( !obj || obj->isAncillary() )
-        return false;
-
-    visualizeVectors_.clear();
-    angle_ = 0.f;
-    shift_ = 0.f;
-
-    obj_ = obj;
-    objWorldXf_ = obj_->worldXf();
-    worldStartPoint_ = objWorldXf_( pick.point );
-    viewportStartPointZ_ = viewer->viewport().projectToViewportSpace( worldStartPoint_ ).z;
-
-    transformMode_ = ( modifier == GLFW_MOD_CONTROL ) ? TransformMode::Rotation : TransformMode::Translation;
-
-    if ( transformMode_ == TransformMode::Rotation )
-    {
-        bboxCenter_ = obj_->getBoundingBox().center();
-        worldBboxCenter_ = obj_->worldXf()( bboxCenter_ );
-        auto viewportBboxCenter = viewer->viewport().projectToViewportSpace( worldBboxCenter_ );
-
-        auto bboxCenterAxis = viewer->viewport().unprojectPixelRay( Vector2f( viewportBboxCenter.x, viewportBboxCenter.y ) );
-        rotationPlane_ = Plane3f::fromDirAndPt( bboxCenterAxis.d.normalized(), worldBboxCenter_ );
-
-        auto viewportStartPoint = viewer->viewport().projectToViewportSpace( worldStartPoint_ );
-        auto startAxis = viewer->viewport().unprojectPixelRay( Vector2f( viewportStartPoint.x, viewportStartPoint.y ) );
-
-        if ( auto crossPL = intersection( rotationPlane_, startAxis ) )
-            worldStartPoint_ = *crossPL;
-        else
-            spdlog::warn( "Bad cross start axis and rotation plane" );
-
-        setVisualizeVectors_( { worldBboxCenter_, worldStartPoint_, worldBboxCenter_, worldStartPoint_ } );
-    }
-    else
-        setVisualizeVectors_( { worldStartPoint_, worldStartPoint_ } );
-
-    return true;
+    return moveByMouse_.onMouseDown( btn, modifiers );
 }
 
 bool MoveObjectByMouse::onMouseMove_( int x, int y )
 {
-    if ( !obj_ )
-        return false;
-
-    auto viewportEnd = viewer->screenToViewport( Vector3f( float( x ), float( y ), 0.f ), viewer->viewport().id );
-    auto worldEndPoint = viewer->viewport().unprojectFromViewportSpace( { viewportEnd.x, viewportEnd.y, viewportStartPointZ_ } );
-
-    if ( transformMode_ == TransformMode::Rotation )
-    {
-        auto endAxis = viewer->viewport().unprojectPixelRay( Vector2f( viewportEnd.x, viewportEnd.y ) );
-        if ( auto crossPL = intersection( rotationPlane_, endAxis ) )
-            worldEndPoint = *crossPL;
-        else
-            spdlog::warn( "Bad cross end axis and rotation plane" );
-
-        const Vector3f vectorStart = worldStartPoint_ - worldBboxCenter_;
-        const Vector3f vectorEnd = worldEndPoint - worldBboxCenter_;
-        const float abSquare = vectorStart.length() * vectorEnd.length();
-        if ( abSquare < 1.e-6 )
-            angle_ = 0.f;
-        else
-            angle_ = angle( vectorStart, vectorEnd );
-
-        if ( dot( rotationPlane_.n, cross( vectorStart, vectorEnd ) ) > 0.f )
-            angle_ = 2.f * PI_F - angle_;
-
-        angle_ = angle_ / PI_F * 180.f;
-
-        setVisualizeVectors_( { worldBboxCenter_, worldStartPoint_, worldBboxCenter_, worldEndPoint } );
-
-        AffineXf3f rotation = AffineXf3f::linear( Matrix3f::rotation( vectorStart, worldEndPoint - worldBboxCenter_ ) );
-        AffineXf3f worldXfA = AffineXf3f::linear( objWorldXf_.A );
-        AffineXf3f toBboxCenter = AffineXf3f::translation( worldXfA( bboxCenter_ ) );
-        obj_->setWorldXf( AffineXf3f::translation( objWorldXf_.b ) * toBboxCenter * rotation * toBboxCenter.inverse() * worldXfA );
-    }
-    else
-    {
-        shift_ = ( worldEndPoint - worldStartPoint_ ).length();
-        setVisualizeVectors_( { worldStartPoint_, worldEndPoint } );
-
-        auto worldXf = AffineXf3f::translation( worldEndPoint - worldStartPoint_ ) * objWorldXf_;
-
-        // Clamp movement.
-        float minSizeDim = 0;
-        if ( auto worldBox = transformed( obj_->getBoundingBox(), worldXf ); worldBox.valid() ) // Feature objects give an invalid box.
-        {
-            auto wbsize = worldBox.size();
-            minSizeDim = wbsize.length();
-        }
-
-        if ( minSizeDim == 0 )
-            minSizeDim = 1.f;
-
-        for ( auto i = 0; i < 3; i++ )
-            worldXf.b[i] = std::clamp( worldXf.b[i], -cMaxTranslationMultiplier * minSizeDim, +cMaxTranslationMultiplier * minSizeDim );
-
-        obj_->setWorldXf( worldXf );
-    }
-
-    return true;
+    return moveByMouse_.onMouseMove( x, y );
 }
 
-bool MoveObjectByMouse::onMouseUp_( MouseButton btn, int /*modifiers*/ )
+bool MoveObjectByMouse::onMouseUp_( MouseButton btn, int modifiers )
 {
-    if ( !obj_ || btn != Viewer::MouseButton::Left )
-        return false;
-
-    auto newWorldXf = obj_->worldXf();
-    obj_->setWorldXf( objWorldXf_ );
-    AppendHistory<ChangeXfAction>( "Change Xf", obj_ );
-    obj_->setWorldXf( newWorldXf );
-
-    obj_ = nullptr;
-    transformMode_ = TransformMode::None;
-
-    return true;
-}
-
-void MoveObjectByMouse::setVisualizeVectors_( std::vector<Vector3f> worldPoints )
-{
-    visualizeVectors_.clear();
-    for ( const auto& p : worldPoints )
-    {
-        const Vector3f screenPoint = viewer->viewportToScreen( viewer->viewport().projectToViewportSpace( p ), viewer->viewport().id );
-        visualizeVectors_.push_back( ImVec2( screenPoint.x, screenPoint.y ) );
-    }
+    return moveByMouse_.onMouseUp( btn, modifiers );
 }
 
 MR_REGISTER_RIBBON_ITEM( MoveObjectByMouse )

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
@@ -69,7 +69,7 @@ bool MoveObjectByMouse::onMouseUp_( MouseButton btn, int modifiers )
     return moveByMouse_.onMouseUp( btn, modifiers );
 }
 
-std::vector<std::shared_ptr<Object>> MoveObjectByMouse::MoveObjectByMouseWithSelected::getObjects(
+std::vector<std::shared_ptr<Object>> MoveObjectByMouse::MoveObjectByMouseWithSelected::getObjects_(
     const std::shared_ptr<VisualObject>& obj, const PointOnObject&, int modifiers )
 {
     if ( ( modifiers & GLFW_MOD_SHIFT ) != 0 && obj->isSelected() )

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
@@ -60,6 +60,7 @@ bool MoveObjectByMouse::onMouseDown_( MouseButton btn, int modifiers )
 
 bool MoveObjectByMouse::onMouseMove_( int x, int y )
 {
+    viewer->select_hovered_viewport();
     return moveByMouse_.onMouseMove( x, y );
 }
 

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
@@ -16,25 +16,28 @@
 #include "MRMesh/MRSceneColors.h"
 #include "MRPch/MRSpdlog.h"
 
+namespace
+{
+MR::MoveObjectByMouse* sInstance{ nullptr };
+}
+
 namespace MR
 {
-
-MoveObjectByMouse* MoveObjectByMouse::instance_ = nullptr;
 
 MoveObjectByMouse::MoveObjectByMouse() :
     PluginParent( "Move object", StatePluginTabs::Basic )
 {
-    instance_ = this;
+    sInstance = this;
 }
 
 MoveObjectByMouse::~MoveObjectByMouse()
 {
-    instance_ = nullptr;
+    sInstance = nullptr;
 }
 
 MoveObjectByMouse* MoveObjectByMouse::instance()
 {
-    return instance_;
+    return sInstance;
 }
 
 bool MoveObjectByMouse::onDisable_()

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
@@ -19,7 +19,7 @@
 namespace MR
 {
 
-MoveObjectByMouse* MoveObjectByMouse::instance_;
+MoveObjectByMouse* MoveObjectByMouse::instance_ = nullptr;
 
 MoveObjectByMouse::MoveObjectByMouse() :
     PluginParent( "Move object", StatePluginTabs::Basic )
@@ -30,6 +30,11 @@ MoveObjectByMouse::MoveObjectByMouse() :
 MoveObjectByMouse::~MoveObjectByMouse()
 {
     instance_ = nullptr;
+}
+
+MoveObjectByMouse* MoveObjectByMouse::instance()
+{
+    return instance_;
 }
 
 bool MoveObjectByMouse::onDisable_()

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
@@ -15,6 +15,7 @@ class MoveObjectByMouse : public StateListenerPlugin<MouseDownListener, MouseMov
 public:
     MoveObjectByMouse();
 
+    virtual bool onDisable_() override;
     virtual void drawDialog( float menuScaling, ImGuiContext* ) override;
 
     virtual bool blocking() const override { return false; };
@@ -24,7 +25,12 @@ private:
     virtual bool onMouseMove_( int x, int y ) override;
     virtual bool onMouseUp_( MouseButton btn, int modifiers ) override;
 
-    MoveObjectByMouseImpl moveByMouse_;
+    class MoveObjectByMouseWithSelected : public MoveObjectByMouseImpl
+    {
+    protected:
+        std::vector<std::shared_ptr<Object>> getObjects( 
+            const std::shared_ptr<VisualObject>& obj, const PointOnObject& point, int modifiers ) override;
+    } moveByMouse_;
 };
 
 }

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
@@ -17,7 +17,7 @@ public:
     MoveObjectByMouse();
     ~MoveObjectByMouse();
 
-    static MoveObjectByMouse* instance() { return instance_; }
+    MRCOMMONPLUGINS_API static MoveObjectByMouse* instance();
 
     virtual bool onDisable_() override;
     virtual void drawDialog( float menuScaling, ImGuiContext* ) override;
@@ -29,7 +29,7 @@ private:
     virtual bool onMouseMove_( int x, int y ) override;
     virtual bool onMouseUp_( MouseButton btn, int modifiers ) override;
 
-    MRCOMMONPLUGINS_API static MoveObjectByMouse* instance_;
+    static MoveObjectByMouse* instance_;
 
     class MoveObjectByMouseWithSelected : public MoveObjectByMouseImpl
     {

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
@@ -29,8 +29,6 @@ private:
     virtual bool onMouseMove_( int x, int y ) override;
     virtual bool onMouseUp_( MouseButton btn, int modifiers ) override;
 
-    static MoveObjectByMouse* instance_;
-
     class MoveObjectByMouseWithSelected : public MoveObjectByMouseImpl
     {
     protected:

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "MRViewer/MRStatePlugin.h"
+#include "MRViewer/MRMoveObjectByMouseImpl.h"
 #include "MRMesh/MRPlane3.h"
 #include "MRMesh/MRAffineXf3.h"
 #include "imgui.h"
@@ -19,31 +20,11 @@ public:
     virtual bool blocking() const override { return false; };
 
 private:
-    virtual bool onMouseDown_( MouseButton button, int modifier ) override;
+    virtual bool onMouseDown_( MouseButton btn, int modifiers ) override;
     virtual bool onMouseMove_( int x, int y ) override;
     virtual bool onMouseUp_( MouseButton btn, int modifiers ) override;
 
-    void setVisualizeVectors_( std::vector<Vector3f> worldPoints );
-
-    std::shared_ptr<VisualObject> obj_;
-
-    Vector3f worldStartPoint_;
-    Vector3f worldBboxCenter_;
-    Vector3f bboxCenter_;
-    AffineXf3f objWorldXf_;
-    float viewportStartPointZ_;
-    Plane3f rotationPlane_;
-
-    std::vector<ImVec2> visualizeVectors_;
-    float angle_ = 0.f;
-    float shift_ = 0.f;
-
-    enum class TransformMode
-    {
-        Translation,
-        Rotation,
-        None
-    } transformMode_ = TransformMode::None;
+    MoveObjectByMouseImpl moveByMouse_;
 };
 
 }

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
@@ -3,6 +3,7 @@
 #include "MRViewer/MRMoveObjectByMouseImpl.h"
 #include "MRMesh/MRPlane3.h"
 #include "MRMesh/MRAffineXf3.h"
+#include "MRCommonPlugins/exports.h"
 #include "imgui.h"
 
 namespace MR
@@ -14,6 +15,9 @@ class MoveObjectByMouse : public StateListenerPlugin<MouseDownListener, MouseMov
 {
 public:
     MoveObjectByMouse();
+    ~MoveObjectByMouse();
+
+    static MoveObjectByMouse* instance() { return instance_; }
 
     virtual bool onDisable_() override;
     virtual void drawDialog( float menuScaling, ImGuiContext* ) override;
@@ -24,6 +28,8 @@ private:
     virtual bool onMouseDown_( MouseButton btn, int modifiers ) override;
     virtual bool onMouseMove_( int x, int y ) override;
     virtual bool onMouseUp_( MouseButton btn, int modifiers ) override;
+
+    MRCOMMONPLUGINS_API static MoveObjectByMouse* instance_;
 
     class MoveObjectByMouseWithSelected : public MoveObjectByMouseImpl
     {

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
@@ -34,7 +34,7 @@ private:
     class MoveObjectByMouseWithSelected : public MoveObjectByMouseImpl
     {
     protected:
-        std::vector<std::shared_ptr<Object>> getObjects( 
+        std::vector<std::shared_ptr<Object>> getObjects_( 
             const std::shared_ptr<VisualObject>& obj, const PointOnObject& point, int modifiers ) override;
     } moveByMouse_;
 };

--- a/source/MRViewer/MRMoveObjectByMouseImpl.cpp
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.cpp
@@ -140,8 +140,6 @@ bool MoveObjectByMouseImpl::onMouseMove( int x, int y )
         if ( dot( rotationPlane_.n, cross( vectorStart, vectorEnd ) ) > 0.f )
             angle_ = 2.f * PI_F - angle_;
 
-        angle_ = angle_ / PI_F * 180.f;
-
         setVisualizeVectors_( { worldBboxCenter_, worldStartPoint_, worldBboxCenter_, worldEndPoint } );
 
         AffineXf3f rotation = AffineXf3f::linear( Matrix3f::rotation( vectorStart, worldEndPoint - worldBboxCenter_ ) );

--- a/source/MRViewer/MRMoveObjectByMouseImpl.cpp
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.cpp
@@ -1,0 +1,190 @@
+#include "MRMoveObjectByMouseImpl.h"
+#include "MRViewer/MRMouse.h"
+#include "MRViewer/MRViewer.h"
+#include "MRViewer/MRRibbonMenu.h"
+#include "MRViewer/MRViewport.h"
+#include "MRViewer/MRGladGlfw.h"
+#include "MRViewer/MRAppendHistory.h"
+#include "MRMesh/MRSceneColors.h"
+#include "MRMesh/MRChangeXfAction.h"
+#include "MRMesh/MRConstants.h"
+#include "MRMesh/MRIntersection.h"
+#include "MRMesh/MRVisualObject.h"
+#include "MRPch/MRSpdlog.h"
+
+namespace
+{
+// translation multiplier that limits its maximum value depending on object size
+// the constant duplicates value defined in ImGuiMenu implementation
+constexpr float cMaxTranslationMultiplier = 0xC00;
+}
+
+namespace MR
+{
+
+void MoveObjectByMouseImpl::onDrawDialog( float /* menuScaling */ )
+{
+    if ( transformMode_ != TransformMode::None )
+    {
+        auto drawList = ImGui::GetBackgroundDrawList();
+        drawList->AddPolyline( visualizeVectors_.data(), int( visualizeVectors_.size() ),
+                               SceneColors::get( SceneColors::Labels ).getUInt32(), ImDrawFlags_None, 1.f );
+    }
+    if ( transformMode_ == TransformMode::Translation )
+        ImGui::SetTooltip( "Distance : %.3f", shift_ );
+    if ( transformMode_ == TransformMode::Rotation )
+        ImGui::SetTooltip( "Angle : %.3f", angle_ );
+}
+
+bool MoveObjectByMouseImpl::onMouseDown( MouseButton button, int modifier )
+{
+    if ( button != Viewer::MouseButton::Left )
+        return false;
+
+    viewer->select_hovered_viewport();
+
+    auto [obj, pick] = viewer->viewport().pick_render_object();
+
+    if ( !obj || !onPick( obj, pick ) || !obj )
+        return false;
+
+    visualizeVectors_.clear();
+    angle_ = 0.f;
+    shift_ = 0.f;
+
+    obj_ = obj;
+    objWorldXf_ = obj_->worldXf();
+    worldStartPoint_ = objWorldXf_( pick.point );
+    viewportStartPointZ_ = viewer->viewport().projectToViewportSpace( worldStartPoint_ ).z;
+
+    transformMode_ = ( modifier == GLFW_MOD_CONTROL ) ? TransformMode::Rotation : TransformMode::Translation;
+
+    if ( transformMode_ == TransformMode::Rotation )
+    {
+        bboxCenter_ = obj_->getBoundingBox().center();
+        worldBboxCenter_ = obj_->worldXf()( bboxCenter_ );
+        auto viewportBboxCenter = viewer->viewport().projectToViewportSpace( worldBboxCenter_ );
+
+        auto bboxCenterAxis = viewer->viewport().unprojectPixelRay( Vector2f( viewportBboxCenter.x, viewportBboxCenter.y ) );
+        rotationPlane_ = Plane3f::fromDirAndPt( bboxCenterAxis.d.normalized(), worldBboxCenter_ );
+
+        auto viewportStartPoint = viewer->viewport().projectToViewportSpace( worldStartPoint_ );
+        auto startAxis = viewer->viewport().unprojectPixelRay( Vector2f( viewportStartPoint.x, viewportStartPoint.y ) );
+
+        if ( auto crossPL = intersection( rotationPlane_, startAxis ) )
+            worldStartPoint_ = *crossPL;
+        else
+            spdlog::warn( "Bad cross start axis and rotation plane" );
+
+        setVisualizeVectors_( { worldBboxCenter_, worldStartPoint_, worldBboxCenter_, worldStartPoint_ } );
+    }
+    else
+        setVisualizeVectors_( { worldStartPoint_, worldStartPoint_ } );
+
+    return true;
+}
+
+bool MoveObjectByMouseImpl::onMouseMove( int x, int y )
+{
+    if ( !obj_ )
+        return false;
+
+    auto viewportEnd = viewer->screenToViewport( Vector3f( float( x ), float( y ), 0.f ), viewer->viewport().id );
+    auto worldEndPoint = viewer->viewport().unprojectFromViewportSpace( { viewportEnd.x, viewportEnd.y, viewportStartPointZ_ } );
+
+    if ( transformMode_ == TransformMode::Rotation )
+    {
+        auto endAxis = viewer->viewport().unprojectPixelRay( Vector2f( viewportEnd.x, viewportEnd.y ) );
+        if ( auto crossPL = intersection( rotationPlane_, endAxis ) )
+            worldEndPoint = *crossPL;
+        else
+            spdlog::warn( "Bad cross end axis and rotation plane" );
+
+        const Vector3f vectorStart = worldStartPoint_ - worldBboxCenter_;
+        const Vector3f vectorEnd = worldEndPoint - worldBboxCenter_;
+        const float abSquare = vectorStart.length() * vectorEnd.length();
+        if ( abSquare < 1.e-6 )
+            angle_ = 0.f;
+        else
+            angle_ = angle( vectorStart, vectorEnd );
+
+        if ( dot( rotationPlane_.n, cross( vectorStart, vectorEnd ) ) > 0.f )
+            angle_ = 2.f * PI_F - angle_;
+
+        angle_ = angle_ / PI_F * 180.f;
+
+        setVisualizeVectors_( { worldBboxCenter_, worldStartPoint_, worldBboxCenter_, worldEndPoint } );
+
+        AffineXf3f rotation = AffineXf3f::linear( Matrix3f::rotation( vectorStart, worldEndPoint - worldBboxCenter_ ) );
+        AffineXf3f worldXfA = AffineXf3f::linear( objWorldXf_.A );
+        AffineXf3f toBboxCenter = AffineXf3f::translation( worldXfA( bboxCenter_ ) );
+        obj_->setWorldXf( AffineXf3f::translation( objWorldXf_.b ) * toBboxCenter * rotation * toBboxCenter.inverse() * worldXfA );
+    }
+    else
+    {
+        shift_ = ( worldEndPoint - worldStartPoint_ ).length();
+        setVisualizeVectors_( { worldStartPoint_, worldEndPoint } );
+
+        auto worldXf = AffineXf3f::translation( worldEndPoint - worldStartPoint_ ) * objWorldXf_;
+
+        // Clamp movement.
+        float minSizeDim = 0;
+        if ( auto worldBox = transformed( obj_->getBoundingBox(), worldXf ); worldBox.valid() ) // Feature objects give an invalid box.
+        {
+            auto wbsize = worldBox.size();
+            minSizeDim = wbsize.length();
+        }
+
+        if ( minSizeDim == 0 )
+            minSizeDim = 1.f;
+
+        for ( auto i = 0; i < 3; i++ )
+            worldXf.b[i] = std::clamp( worldXf.b[i], -cMaxTranslationMultiplier * minSizeDim, +cMaxTranslationMultiplier * minSizeDim );
+
+        obj_->setWorldXf( worldXf );
+    }
+
+    return true;
+}
+
+bool MoveObjectByMouseImpl::onMouseUp( MouseButton btn, int /*modifiers*/ )
+{
+    if ( !obj_ || btn != Viewer::MouseButton::Left )
+        return false;
+
+    auto newWorldXf = obj_->worldXf();
+    obj_->setWorldXf( objWorldXf_ );
+    AppendHistory<ChangeXfAction>( "Change Xf", obj_ );
+    obj_->setWorldXf( newWorldXf );
+
+    obj_ = nullptr;
+    transformMode_ = TransformMode::None;
+
+    return true;
+}
+
+void MoveObjectByMouseImpl::cancel()
+{
+    if ( !obj_ )
+        return;
+    obj_->setWorldXf( objWorldXf_ );
+    obj_ = nullptr;
+    transformMode_ = TransformMode::None;
+}
+
+bool MoveObjectByMouseImpl::onPick( std::shared_ptr<VisualObject>& obj, PointOnObject& )
+{
+    return !obj->isAncillary();
+}
+
+void MoveObjectByMouseImpl::setVisualizeVectors_( std::vector<Vector3f> worldPoints )
+{
+    visualizeVectors_.clear();
+    for ( const auto& p : worldPoints )
+    {
+        const Vector3f screenPoint = viewer->viewportToScreen( viewer->viewport().projectToViewportSpace( p ), viewer->viewport().id );
+        visualizeVectors_.push_back( ImVec2( screenPoint.x, screenPoint.y ) );
+    }
+}
+
+}

--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -1,0 +1,68 @@
+#pragma once
+#include "MRMesh/MRPlane3.h"
+#include "MRMesh/MRAffineXf3.h"
+#include "MRViewer/MRViewerInstance.h"
+#include "imgui.h"
+
+namespace MR
+{
+
+class Object;
+class Viewer;
+
+class MRVIEWER_CLASS MoveObjectByMouseImpl
+{
+public:
+    MoveObjectByMouseImpl() = default;
+    virtual ~MoveObjectByMouseImpl() = default;
+
+    // Drawing callback to draw lines and tooltips
+    // Should be called from drawDialog
+    MRVIEWER_API void onDrawDialog( float menuScaling );
+
+    // These functions should be called from corresponding mouse handlers
+    // Return true if handled (picked/moved/released)
+    MRVIEWER_API bool onMouseDown( MouseButton button, int modifier );
+    MRVIEWER_API bool onMouseMove( int x, int y );
+    MRVIEWER_API bool onMouseUp( MouseButton btn, int modifiers );
+
+    // Current object being moved; null if no object is being moved right now
+    std::shared_ptr<VisualObject> currentObject() { return obj_; }
+
+    // Reset transformation and stop moving the object. Does nothing if not moving anything
+    // Calling onMouseUp is not necessary after this
+    MRVIEWER_API void cancel();
+
+protected:
+    // Called when onMouseDown_ picks an object
+    // Return true to start transformation, false to skip; modify the arguments if necessary
+    // Default implementation returns true for all non-ancillary objects
+    MRVIEWER_API virtual bool onPick( std::shared_ptr<VisualObject> &obj, PointOnObject &point );
+
+private:
+    Viewer* viewer = &getViewerInstance();
+
+    void setVisualizeVectors_( std::vector<Vector3f> worldPoints );
+
+    std::shared_ptr<VisualObject> obj_;
+
+    Vector3f worldStartPoint_;
+    Vector3f worldBboxCenter_;
+    Vector3f bboxCenter_;
+    AffineXf3f objWorldXf_;
+    float viewportStartPointZ_;
+    Plane3f rotationPlane_;
+
+    std::vector<ImVec2> visualizeVectors_;
+    float angle_ = 0.f;
+    float shift_ = 0.f;
+
+    enum class TransformMode
+    {
+        Translation,
+        Rotation,
+        None
+    } transformMode_ = TransformMode::None;
+};
+
+}

--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -1,66 +1,69 @@
 #pragma once
 #include "MRMesh/MRPlane3.h"
 #include "MRMesh/MRAffineXf3.h"
-#include "MRViewer/MRViewerInstance.h"
+#include "MRViewer/MRViewerFwd.h"
 #include "imgui.h"
 
 namespace MR
 {
 
-class Object;
-class Viewer;
-
+/// Helper class to incorporate basic object transformation feature into plugins
+/// User can move objects by dragging them, rotate by dragging with Ctrl key
+/// To use, create class instance and call its event handlers
+/// For extra features, override the pick and object selection functions
 class MRVIEWER_CLASS MoveObjectByMouseImpl
 {
 public:
     MoveObjectByMouseImpl() = default;
     virtual ~MoveObjectByMouseImpl() = default;
 
-    // Minimum drag distance in screen pixels
-    // If cursor moved less than this value, no transform is done
-    // Default value 0 (set transformation even if mouse did not move)
-    int minDistance() { return minDistance_; }
+    /// Minimum drag distance in screen pixels
+    /// If cursor moved less than this value, no transform is done
+    /// Default value 0 (set transformation even if mouse did not move)
+    int minDistance() const { return minDistance_; }
     void setMinDistance( int minDistance ) { minDistance_ = minDistance; }
 
-    // Drawing callback to draw lines and tooltips
-    // Should be called from drawDialog
-    MRVIEWER_API void onDrawDialog( float menuScaling );
+    /// Drawing callback to draw lines and tooltips
+    /// Should be called from `drawDialog`
+    MRVIEWER_API void onDrawDialog( float menuScaling ) const;
 
-    // These functions should be called from corresponding mouse handlers
-    // Return true if handled (picked/moved/released)
-    // It is recommended to call viewer->select_hovered_viewport() before onMouseDown
+    /// These functions should be called from corresponding mouse handlers
+    /// Return true if handled (picked/moved/released)
+    /// It is recommended to call `viewer->select_hovered_viewport()` before `onMouseDown`
+    /// The object is transformed temporarily in `onMouseMove`
+    /// `onMouseUp` finalizes the transformation and writes to undo/redo history (unless cancelled)
     MRVIEWER_API bool onMouseDown( MouseButton button, int modifiers );
     MRVIEWER_API bool onMouseMove( int x, int y );
     MRVIEWER_API bool onMouseUp( MouseButton button, int modifiers );
 
-    // Object currently picked for moving; null if not currently moving
-    std::shared_ptr<VisualObject> currentObject() { return obj_; }
+    /// Object currently picked for moving (if any, otherwise null)
+    /// The current object is set in `onMouseDown` and set to null in `onMouseUp`
+    std::shared_ptr<VisualObject> currentObject() const { return obj_; }
 
-    // Currently moving objects, and actually started transforming (considering minDistance)
-    MRVIEWER_API bool isMoving();
+    /// Returns true if has a picked object, and actually started moving it
+    /// Return false if no object, or `minDistance` has not yet reached
+    MRVIEWER_API bool isMoving() const;
 
-    // Reset transformation and stop moving the object(s). Does nothing if not moving anything
-    // Calling onMouseUp is not necessary after this
-    // Should be called when closing plugin etc.
+    /// Reset transformation and stop moving the object(s). Does nothing if not moving anything
+    /// Calling `onMouseUp` is not necessary after this
+    /// Should be called when closing plugin etc.
     MRVIEWER_API void cancel();
 
 protected:
-    // Called when onMouseDown_ picks an object
-    // Return true to start transformation, false to skip
-    // `obj` and `point` can be modified if necessary (in `point`, only `point` member is used)
-    // Default implementation returns true for all non-ancillary objects;
-    MRVIEWER_API virtual bool onPick(
+    /// Called when `onMouseDown` picks an object
+    /// Return true to start transformation, false to skip
+    /// `obj` and `point` can be modified if necessary (in `point`, only `point` member is used)
+    /// Default implementation returns true for all non-ancillary objects
+    MRVIEWER_API virtual bool onPick_(
         std::shared_ptr<VisualObject>& obj, PointOnObject& point, int modifiers );
 
     // Returns a list of objects that will be moved
     // Default implementation returns `{ obj }`
     // Regardless of the list, `obj` is used as a reference object in transformation
-    MRVIEWER_API virtual std::vector<std::shared_ptr<Object>> getObjects(
+    MRVIEWER_API virtual std::vector<std::shared_ptr<Object>> getObjects_(
         const std::shared_ptr<VisualObject>& obj, const PointOnObject& point, int modifiers );
 
 private:
-    Viewer* viewer = &getViewerInstance();
-
     int minDistance_ = 0;
 
     void clear_();

--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -22,34 +22,52 @@ public:
 
     // These functions should be called from corresponding mouse handlers
     // Return true if handled (picked/moved/released)
-    MRVIEWER_API bool onMouseDown( MouseButton button, int modifier );
+    MRVIEWER_API bool onMouseDown( MouseButton button, int modifiers );
     MRVIEWER_API bool onMouseMove( int x, int y );
-    MRVIEWER_API bool onMouseUp( MouseButton btn, int modifiers );
+    MRVIEWER_API bool onMouseUp( MouseButton button, int modifiers );
 
     // Current object being moved; null if no object is being moved right now
     std::shared_ptr<VisualObject> currentObject() { return obj_; }
 
     // Reset transformation and stop moving the object. Does nothing if not moving anything
     // Calling onMouseUp is not necessary after this
+    // Should be called when closing plugin etc.
     MRVIEWER_API void cancel();
 
 protected:
     // Called when onMouseDown_ picks an object
-    // Return true to start transformation, false to skip; modify the arguments if necessary
-    // Default implementation returns true for all non-ancillary objects
-    MRVIEWER_API virtual bool onPick( std::shared_ptr<VisualObject> &obj, PointOnObject &point );
+    // Return true to start transformation, false to skip
+    // `obj` and `point` can be modified if necessary (in `point`, only `point` member is used)
+    // Default implementation returns true for all non-ancillary objects;
+    MRVIEWER_API virtual bool onPick( 
+        std::shared_ptr<VisualObject>& obj, PointOnObject& point, int modifiers );
+
+    // Returns a list of objects that will be moved
+    // Default implementation returns `{ obj }`
+    // Regardless of the list, `obj` is used as a reference object in transformation
+    MRVIEWER_API virtual std::vector<std::shared_ptr<Object>> getObjects(
+        const std::shared_ptr<VisualObject>& obj, const PointOnObject& point, int modifiers );
 
 private:
     Viewer* viewer = &getViewerInstance();
+
+    void clear_();
+
+    void setWorldXf_( AffineXf3f worldXf, bool history );
+    void resetWorldXf_();
 
     void setVisualizeVectors_( std::vector<Vector3f> worldPoints );
 
     std::shared_ptr<VisualObject> obj_;
 
+    std::vector<std::shared_ptr<Object>> objects_;
+    std::vector<AffineXf3f> objectsXfs_;
+
     Vector3f worldStartPoint_;
     Vector3f worldBboxCenter_;
     Vector3f bboxCenter_;
     AffineXf3f objWorldXf_;
+    AffineXf3f newWorldXf_;
     float viewportStartPointZ_;
     Plane3f rotationPlane_;
 

--- a/source/MRViewer/MRViewer.vcxproj
+++ b/source/MRViewer/MRViewer.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="MRHistoryStore.cpp" />
     <ClCompile Include="MRMeshBoundarySelectionWidget.cpp" />
     <ClCompile Include="MRFrameCounter.cpp" />
+    <ClCompile Include="MRMoveObjectByMouseImpl.cpp" />
     <ClCompile Include="MRRenderDefaultObjects.cpp" />
     <ClCompile Include="MRRibbonNotification.cpp" />
     <ClCompile Include="MRSelectCurvaturePreference.cpp" />
@@ -132,6 +133,7 @@
     <ClInclude Include="MRLambdaRibbonItem.h" />
     <ClInclude Include="MRMeshBoundarySelectionWidget.h" />
     <ClInclude Include="MRFrameCounter.h" />
+    <ClInclude Include="MRMoveObjectByMouseImpl.h" />
     <ClInclude Include="MRNotificationType.h" />
     <ClInclude Include="MRRibbonNotification.h" />
     <ClInclude Include="MRSelectCurvaturePreference.h" />

--- a/source/MRViewer/MRViewer.vcxproj.filters
+++ b/source/MRViewer/MRViewer.vcxproj.filters
@@ -367,6 +367,9 @@
     <ClCompile Include="MRNameTagClickListener.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
+    <ClCompile Include="MRMoveObjectByMouseImpl.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ImGuiHelpers.h">
@@ -723,6 +726,9 @@
       <Filter>Helpers</Filter>
     </ClInclude>
     <ClInclude Include="MRNameTagClickListener.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="MRMoveObjectByMouseImpl.h">
       <Filter>Helpers</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Code:
- Extract code from `MoveObjectByMouse` into separate class `MoveObjectByMouseImpl` to use in other plugins (currently Align Manually)
- Add support for transforming mutiple objects
- Add minimum distance (small movements ignored)
- Other features

Move object plugin:
![image](https://github.com/MeshInspector/MeshLib/assets/120382683/04a6fdaf-41e4-485f-819f-b7027dba9013)
- Add support for moving several selected objects
- Fix for multiple viewports etc.
