### PR TITLE
Delete move assignment&ctor in PluginUpdateOr for MAKE_SLOT to work

### DIFF
--- a/source/MRViewer/MRStatePluginUpdate.h
+++ b/source/MRViewer/MRStatePluginUpdate.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "MRMesh/MRMeshFwd.h"
+#include "MRViewerFwd.h"
 #include "exports.h"
 #include <boost/signals2/signal.hpp>
 #include <memory>
@@ -92,6 +92,7 @@ template<typename ...Updates>
 class PluginUpdateOr : virtual public Updates...
 {
 public:
+    MR_ADD_CTOR_DELETE_MOVE( PluginUpdateOr );
     virtual void preDrawUpdate() override
     {
         ( Updates::preDrawUpdate(), ... );


### PR DESCRIPTION
Problem:
```
class MyPlugin :
    public StateListenerPlugin<MouseDownListener, MouseUpListener, MouseMoveListener>,
    public PluginUpdateOr<PluginCloseOnSelectedObjectRemove, PluginCloseOnChangeMesh>,
    public AccessCheckMixin<SceneStateAtLeastCheck>
{
public:
    MR_DELETE_MOVE( MyPlugin  );
    MRPLUGINS_API MyPlugin();
```

Using `MAKE_SLOT` in this class still generates errors like `defaulted move assignment calls a non-trivial move assignment operator for virtual base 'MR::PluginCloseOnChangeMesh' [-Werror=virtual-move-assign]`