### PR TITLE
Fix crashes and inconsistencies in points clouds sampling

### DIFF
--- a/source/MRMesh/MRObjectLoad.cpp
+++ b/source/MRMesh/MRObjectLoad.cpp
@@ -182,7 +182,8 @@ Expected<std::shared_ptr<Object>, std::string> makeObjectFromMeshFile( const std
         auto objectPoints = std::make_unique<ObjectPoints>();
         objectPoints->setName( utf8string( file.stem() ) );
         objectPoints->setPointCloud( pointCloud );
-        objectPoints->setRenderDiscretization( chooseRenderDiscretization(pointCloud->points.size() ) );
+        objectPoints->setMaxRenderingPoints( int( objectPoints->numValidPoints() ) ); // For exact calculations
+        objectPoints->setRenderDiscretization( chooseRenderDiscretization( pointCloud->points.size() ) );
 
         if ( !colors.empty() )
         {
@@ -238,8 +239,9 @@ Expected<ObjectPoints, std::string> makeObjectPointsFromFile( const std::filesys
 
     ObjectPoints objectPoints;
     objectPoints.setName( utf8string( file.stem() ) );
-    objectPoints.setRenderDiscretization( chooseRenderDiscretization( pointsCloud->points.size() ) );
     objectPoints.setPointCloud( std::make_shared<MR::PointCloud>( std::move( pointsCloud.value() ) ) );
+    objectPoints.setMaxRenderingPoints( int( objectPoints.numValidPoints() ) ); // For exact calculations
+    objectPoints.setRenderDiscretization( chooseRenderDiscretization( objectPoints.pointCloud()->points.size() ) );
     objectPoints.setXf( xf );
     if ( !colors.empty() )
     {
@@ -554,6 +556,7 @@ Expected<std::vector<std::shared_ptr<MR::Object>>, std::string> loadObjectFromFi
             postImportObject( o, filename );
             if ( auto objectPoints = o->asType<ObjectPoints>(); objectPoints && !objectPoints->pointCloud()->hasNormals() && loadWarn )
             {
+                objectPoints->setMaxRenderingPoints( int( objectPoints->numValidPoints() ) ); // For exact calculations
                 objectPoints->setRenderDiscretization( chooseRenderDiscretization( objectPoints->pointCloud()->points.size() ) );
                 *loadWarn += "Point cloud " + o->name() + " has no normals.\n";
                 if ( objectPoints->getRenderDiscretization() > 1 )

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -205,9 +205,7 @@ void ObjectPointsHolder::setRenderDiscretization( int val )
 
     assert( val > 0 );
     val = val < 1 ? 1 : val;
-    int newMax = int( numValidPoints() + val - 1 ) / val; // Avoid rounding errors
-    if ( newMax == 0 && numValidPoints() != 0 )
-        newMax = 1; // At least one point
+    int newMax = std::max(int( numValidPoints() + val - 1 ) / val, 1); // Avoid rounding errors
     setMaxRenderingPoints( newMax );
 }
 

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -205,7 +205,7 @@ void ObjectPointsHolder::setRenderDiscretization( int val )
 
     assert( val > 0 );
     val = val < 1 ? 1 : val;
-    int newMax = int( numValidPoints() ) / val;
+    int newMax = int( numValidPoints() + val - 1 ) / val; // Avoid rounding errors
     if ( newMax == 0 && numValidPoints() != 0 )
         newMax = 1; // At least one point
     setMaxRenderingPoints( newMax );
@@ -365,7 +365,8 @@ void ObjectPointsHolder::setDefaultSceneProperties_()
 void ObjectPointsHolder::updateRenderDiscretization_()
 {
     int newRenderDiscretization = maxRenderingPoints_ <= 0 ? 1 :
-        std::max( 1, int( numValidPoints() ) / maxRenderingPoints_ );
+        int( numValidPoints() + maxRenderingPoints_ - 1 ) / maxRenderingPoints_;
+    newRenderDiscretization = std::max( 1, newRenderDiscretization );
     if ( newRenderDiscretization == renderDiscretization_ )
         return;
     renderDiscretization_ = newRenderDiscretization;

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -206,6 +206,8 @@ void ObjectPointsHolder::setRenderDiscretization( int val )
     assert( val > 0 );
     val = val < 1 ? 1 : val;
     int newMax = int( numValidPoints() ) / val;
+    if ( newMax == 0 && numValidPoints() != 0 )
+        newMax = 1; // At least one point
     setMaxRenderingPoints( newMax );
 }
 
@@ -362,7 +364,8 @@ void ObjectPointsHolder::setDefaultSceneProperties_()
 
 void ObjectPointsHolder::updateRenderDiscretization_()
 {
-    int newRenderDiscretization = std::max( 1, int( numValidPoints() ) / maxRenderingPoints_ );
+    int newRenderDiscretization = maxRenderingPoints_ <= 0 ? 1 :
+        std::max( 1, int( numValidPoints() ) / maxRenderingPoints_ );
     if ( newRenderDiscretization == renderDiscretization_ )
         return;
     renderDiscretization_ = newRenderDiscretization;


### PR DESCRIPTION
- Fix crash when loading ASC with > 2 000 000 points [#4151](https://github.com/MeshInspector/MeshInspectorCode/issues/4151)
- Fix visual inconsistencies in sampling of imported clouds:
![image](https://github.com/MeshInspector/MeshLib/assets/120382683/481853e6-9d8c-45ad-adba-b11c60badb27)
![image](https://github.com/MeshInspector/MeshLib/assets/120382683/1d830419-7a8f-4f59-b03f-0208ef05005d)
- Round up when calculating discretization
- Simplify discretization calculation when loading
- Fix message not showing when sampling is enabled for a loaded cloud

Some test data: [millions_of_points.zip](https://github.com/MeshInspector/MeshLib/files/15393104/millions_of_points.zip)
