### PR TITLE
MIC#4130 Add `IconType::Logos` to support only `Colored` icons in `RibbonIcons`

### DIFF
--- a/source/MRViewer/MRRibbonIcons.cpp
+++ b/source/MRViewer/MRRibbonIcons.cpp
@@ -141,7 +141,7 @@ void RibbonIcons::load_( IconType type )
             if ( !image.has_value() )
                 continue;
 
-            MeshTexture texture( std::move( *image ) );
+            MeshTexture texture{ std::move( *image ) };
             if ( loadedSizes[sz] == 0 )
                 loadedSizes[sz] = texture.resolution.x;
             if ( sz != int( Sizes::X0_5 ) )

--- a/source/MRViewer/MRRibbonIcons.cpp
+++ b/source/MRViewer/MRRibbonIcons.cpp
@@ -17,6 +17,7 @@ void RibbonIcons::load()
     instance.load_( IconType::RibbonItemIcon );
     instance.load_( IconType::ObjectTypeIcon );
     instance.load_( IconType::IndependentIcons );
+    instance.load_( IconType::Logos );
 }
 
 void RibbonIcons::free()
@@ -48,19 +49,25 @@ RibbonIcons::RibbonIcons()
     data_[size_t( IconType::RibbonItemIcon )] = {
         GetResourcesDirectory() / "resource" / "icons",
         std::make_pair( Sizes::X0_5, Sizes::X3 ),
-        true,
+        IconTypeData::AvailableColor::White | IconTypeData::AvailableColor::Colored,
     };
 
     data_[size_t( IconType::ObjectTypeIcon )] = {
         GetResourcesDirectory() / "resource" / "object_icons",
         std::make_pair( Sizes::X1, Sizes::X3 ),
-        false,
+        IconTypeData::AvailableColor::White,
     };
 
     data_[size_t( IconType::IndependentIcons )] = {
         GetResourcesDirectory() / "resource" / "independent_icons",
         std::make_pair( Sizes::X1, Sizes::X3 ),
-        false,
+        IconTypeData::AvailableColor::White,
+    };
+
+    data_[size_t( IconType::Logos )] = {
+        GetResourcesDirectory() / "resource" / "logos",
+        std::make_pair( Sizes::X1, Sizes::X3 ),
+        IconTypeData::AvailableColor::Colored,
     };
 }
 
@@ -98,16 +105,16 @@ RibbonIcons::Sizes RibbonIcons::findRequiredSize_( float width, IconType iconTyp
 
 void RibbonIcons::load_( IconType type )
 {
-    size_t num = static_cast<size_t>( type );
+    size_t num = static_cast< size_t >( type );
     auto& currentData = data_[num];
 
-    bool coloredIcons = currentData.needLoadColored;
+    bool coloredIcons = bool( currentData.availableColor & IconTypeData::AvailableColor::Colored );
+    bool whiteIcons = bool( currentData.availableColor & IconTypeData::AvailableColor::White );
 
     std::filesystem::path path = currentData.pathDirectory;
     int minSize = static_cast< int >( currentData.minMaxSizes.first );
     int maxSize = static_cast< int >( currentData.minMaxSizes.second );
 
-    //auto& map = currentData.map;
     auto& loadedSizes = currentData.loadSize;
 
     for ( int sz = minSize; sz <= maxSize; ++sz )
@@ -133,34 +140,34 @@ void RibbonIcons::load_( IconType type )
             auto image = ImageLoad::fromPng( entry.path() );
             if ( !image.has_value() )
                 continue;
-            Icons icons;
 
-            if ( coloredIcons )
-                icons.colored = std::make_unique<ImGuiImage>();
-
-            icons.white = std::make_unique<ImGuiImage>();
-            MeshTexture whiteTexture = { std::move( *image ) };
-            if ( sz != int( Sizes::X0_5 ) )
-                whiteTexture.filter = FilterType::Linear;
-
-            if ( coloredIcons )
-                icons.colored->update( whiteTexture );
-
-            tbb::parallel_for( tbb::blocked_range<int>( 0, int( whiteTexture.pixels.size() ) ),
-                               [&] ( const  tbb::blocked_range<int>& range )
-            {
-                for ( int i = range.begin(); i < range.end(); ++i )
-                {
-                    auto alpha = whiteTexture.pixels[i].a;
-                    whiteTexture.pixels[i] = Color::white();
-                    whiteTexture.pixels[i].a = alpha;
-                }
-            } );
-
+            MeshTexture texture( std::move( *image ) );
             if ( loadedSizes[sz] == 0 )
-                loadedSizes[sz] = whiteTexture.resolution.x;
+                loadedSizes[sz] = texture.resolution.x;
+            if ( sz != int( Sizes::X0_5 ) )
+                texture.filter = FilterType::Linear;
 
-            icons.white->update( std::move( whiteTexture ) );
+            Icons icons;
+            if ( coloredIcons )
+            {
+                icons.colored = std::make_unique<ImGuiImage>();
+                icons.colored->update( texture );
+            }
+            if ( whiteIcons )
+            {
+                icons.white = std::make_unique<ImGuiImage>();
+                tbb::parallel_for( tbb::blocked_range<int>( 0, int( texture.pixels.size() ) ),
+                                   [&] ( const  tbb::blocked_range<int>& range )
+                {
+                    for ( int i = range.begin(); i < range.end(); ++i )
+                    {
+                        auto alpha = texture.pixels[i].a;
+                        texture.pixels[i] = Color::white();
+                        texture.pixels[i].a = alpha;
+                    }
+                } );
+                icons.white->update( std::move( texture ) );
+            }
             currentData.map[utf8string( entry.path().stem() )][sz] = std::move( icons );
         }
     }

--- a/source/MRViewer/MRRibbonIcons.h
+++ b/source/MRViewer/MRRibbonIcons.h
@@ -1,6 +1,7 @@
 #pragma once
-#include "MRViewerFwd.h"
+#include "MRMesh/MRFlagOperators.h"
 #include "MRMesh/MRphmap.h"
+#include "MRViewerFwd.h"
 #include <array>
 #include <filesystem>
 
@@ -14,18 +15,19 @@ public:
     enum class ColorType
     {
         Colored,
-        White
+        White,
     };
     enum class IconType
     {
         RibbonItemIcon,   // have four sizes
         ObjectTypeIcon,   // have two sizes
         IndependentIcons, // have two sizes
-        Count
+        Logos,            // have two sizes
+        Count,
     };
-    // this should be called once on start of programm (called in RibbonMenu::init)
+    // this should be called once on start of program (called in RibbonMenu::init)
     MRVIEWER_API static void load();
-    // this should be called once before programm stops (called in RibbonMenu::shutdown)
+    // this should be called once before program stops (called in RibbonMenu::shutdown)
     MRVIEWER_API static void free();
     // finds icon with best fitting size, if there is no returns nullptr
     MRVIEWER_API static const ImGuiImage* findByName( const std::string& name, float width, 
@@ -61,12 +63,17 @@ private:
 
     struct IconTypeData
     {
+        enum class AvailableColor
+        {
+            White = 1 << 0,
+            Colored = 1 << 1,
+        };
+        MR_MAKE_FLAG_OPERATORS_IN_CLASS( AvailableColor )
+
         std::filesystem::path pathDirectory;
-        // first - min size, secon - max size
+        // first - min size, second - max size
         std::pair<Sizes, Sizes> minMaxSizes;
-        // true - Colored and White
-        // false - only White
-        bool needLoadColored = false;
+        AvailableColor availableColor = AvailableColor::White;
         HashMap<std::string, SizedIcons> map;
         std::array<int, size_t( Sizes::Count )> loadSize;
     };


### PR DESCRIPTION
Issue: MIC#4130

- Added ability to use only colored icons
- Some typos fixed