### PR TITLE
MIC#4130 Load `RibbonIcons` only for Windows

### DIFF
--- a/source/MRViewer/MRRibbonIcons.cpp
+++ b/source/MRViewer/MRRibbonIcons.cpp
@@ -17,7 +17,9 @@ void RibbonIcons::load()
     instance.load_( IconType::RibbonItemIcon );
     instance.load_( IconType::ObjectTypeIcon );
     instance.load_( IconType::IndependentIcons );
+#ifdef _WIN32
     instance.load_( IconType::Logos );
+#endif // _WIN32
 }
 
 void RibbonIcons::free()


### PR DESCRIPTION
Issue MIC#4130

- This fixes error message for platforms where Logos is not used (all except Windows)
https://github.com/MeshInspector/MeshLib/blob/23011b3385c5ee54e3ca2ce4aadb9a0d780ab96f/source/MRViewer/MRRibbonIcons.cpp#L127

Probably this is temporary solution.