### PR TITLE
Points clouds sampling fixes and refactoring

### DIFF
--- a/source/MRMesh/MRObjectPoints.cpp
+++ b/source/MRMesh/MRObjectPoints.cpp
@@ -57,7 +57,9 @@ std::vector<std::string> ObjectPoints::getInfoLines() const
                 res.back() += " / " + std::to_string( vertsColorMap_.capacity() ) + " capacity";
         }
 
-        res.push_back( "max rendered points: " + std::to_string( getMaxRenderingPoints() ) );
+        res.push_back( "max rendered points: " +
+            ( getMaxRenderingPoints() == ObjectPoints::MaxRenderingPointsUnlimited ?
+              "unlimited" : std::to_string( getMaxRenderingPoints() ) ) );
 
         boundingBoxToInfoLines_( res );
     }

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -198,17 +198,6 @@ size_t ObjectPointsHolder::heapBytes() const
         + MR::heapBytes( points_ );
 }
 
-void ObjectPointsHolder::setRenderDiscretization( int val )
-{
-    if ( val == renderDiscretization_ )
-        return;
-
-    assert( val > 0 );
-    val = val < 1 ? 1 : val;
-    maxRenderingPoints_ = std::max( ( int( numValidPoints() ) + val - 1 ) / val, 1 ); // Avoid rounding errors
-    updateRenderDiscretization_();
-}
-
 void ObjectPointsHolder::setMaxRenderingPoints( int val )
 {
     if ( maxRenderingPoints_ == val )
@@ -362,12 +351,9 @@ void ObjectPointsHolder::setDefaultSceneProperties_()
 
 void ObjectPointsHolder::updateRenderDiscretization_()
 {
-    int numPoints = int( numValidPoints() );
     int newRenderDiscretization = maxRenderingPoints_ <= 0 ? 1 :
-        ( numPoints + maxRenderingPoints_ - 1 ) / maxRenderingPoints_;
+        int( numValidPoints() + maxRenderingPoints_ - 1 ) / maxRenderingPoints_;
     newRenderDiscretization = std::max( 1, newRenderDiscretization );
-    if ( newRenderDiscretization == 1 )
-        maxRenderingPoints_ = std::max( numPoints, MaxRenderingPointsDefault );
     if ( newRenderDiscretization == renderDiscretization_ )
         return;
     renderDiscretization_ = newRenderDiscretization;

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -205,8 +205,8 @@ void ObjectPointsHolder::setRenderDiscretization( int val )
 
     assert( val > 0 );
     val = val < 1 ? 1 : val;
-    int newMax = std::max(int( numValidPoints() + val - 1 ) / val, 1); // Avoid rounding errors
-    setMaxRenderingPoints( newMax );
+    maxRenderingPoints_ = std::max( ( int( numValidPoints() ) + val - 1 ) / val, 1 ); // Avoid rounding errors
+    updateRenderDiscretization_();
 }
 
 void ObjectPointsHolder::setMaxRenderingPoints( int val )
@@ -362,9 +362,12 @@ void ObjectPointsHolder::setDefaultSceneProperties_()
 
 void ObjectPointsHolder::updateRenderDiscretization_()
 {
+    int numPoints = int( numValidPoints() );
     int newRenderDiscretization = maxRenderingPoints_ <= 0 ? 1 :
-        int( numValidPoints() + maxRenderingPoints_ - 1 ) / maxRenderingPoints_;
+        ( numPoints + maxRenderingPoints_ - 1 ) / maxRenderingPoints_;
     newRenderDiscretization = std::max( 1, newRenderDiscretization );
+    if ( newRenderDiscretization == 1 )
+        maxRenderingPoints_ = std::max( numPoints, MaxRenderingPointsDefault );
     if ( newRenderDiscretization == renderDiscretization_ )
         return;
     renderDiscretization_ = newRenderDiscretization;

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -85,12 +85,17 @@ public:
 
     /// sets maxRenderingPoints from rendering discretization, each \param val -th point will be displayed on screen
     /// \detail convenient way to set maxRenderingPoints
-    /// maxRenderingPoints is set so: validPointsCount / val
+    /// maxRenderingPoints is set so: validPointsCount / val (rounded up)
+    /// (for small meshes and discretization of 1, to \ref MaxRenderingPointsDefault)
+    /// note: changing the cloud (setting DIRTY_FACE) recalculates the sampling to match maxRenderingPoints
     MRMESH_API void setRenderDiscretization( int val );
 
     /// returns rendering discretization, each N-th point will be displayed on screen
     /// \detail used for rendering
     int getRenderDiscretization() const { return renderDiscretization_; }
+
+    /// default value for maximum rendered points number
+    static constexpr int MaxRenderingPointsDefault = 1'000'000;
 
     /// returns maximal number of points that will be rendered
     /// if actual count of valid points is greater then the points will be sampled
@@ -150,7 +155,7 @@ protected:
     /// set all visualize properties masks
     MRMESH_API void setAllVisualizeProperties_( const AllVisualizeProperties& properties, std::size_t& pos ) override;
 
-    int maxRenderingPoints_ = 1'000'000;
+    int maxRenderingPoints_ = MaxRenderingPointsDefault;
 
 private:
 
@@ -160,7 +165,7 @@ private:
     /// set default scene-related properties
     void setDefaultSceneProperties_();
 
-    // update renderDiscretization_ as numValidPoints_ / maxRenderingPoints_
+    // update renderDiscretization_ as numValidPoints_ / maxRenderingPoints_ (rounded up)
     void updateRenderDiscretization_();
 
     int renderDiscretization_ = 1; // auxiliary parameter to avoid recalculation in every frame

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -83,26 +83,24 @@ public:
     /// returns the amount of memory this object occupies on heap
     [[nodiscard]] MRMESH_API virtual size_t heapBytes() const override;
 
-    /// sets maxRenderingPoints from rendering discretization, each \param val -th point will be displayed on screen
-    /// \detail convenient way to set maxRenderingPoints
-    /// maxRenderingPoints is set so: validPointsCount / val (rounded up)
-    /// (for small meshes and discretization of 1, to \ref MaxRenderingPointsDefault)
-    /// note: changing the cloud (setting DIRTY_FACE) recalculates the sampling to match maxRenderingPoints
-    MRMESH_API void setRenderDiscretization( int val );
-
-    /// returns rendering discretization, each N-th point will be displayed on screen
-    /// \detail used for rendering
+    /// returns rendering discretization
+    /// display each `renderDiscretization`-th point only (TODO: elaborate)
+    /// \detail defined by maximum rendered points number as:
+    /// \ref numValidPoints() / \ref getMaxRenderingPoints() (rounded up)
+    /// updated when setting `maxRenderingPoints` or changing the cloud (setting `DIRTY_FACE` flag)
     int getRenderDiscretization() const { return renderDiscretization_; }
 
     /// default value for maximum rendered points number
     static constexpr int MaxRenderingPointsDefault = 1'000'000;
+    /// recommended value for maximum rendered points number to disable discretization
+    static constexpr int MaxRenderingPointsUnlimited = std::numeric_limits<int>::max();
 
     /// returns maximal number of points that will be rendered
     /// if actual count of valid points is greater then the points will be sampled
     MRMESH_API int getMaxRenderingPoints() const { return maxRenderingPoints_; }
 
     /// sets maximal number of points that will be rendered
-    /// INT_MAX means lack of limit
+    /// \sa \ref getRenderDiscretization, \ref MaxRenderingPointsDefault, \ref MaxRenderingPointsUnlimited
     MRMESH_API void setMaxRenderingPoints( int val );
 
     /// returns file extension used to serialize the points

--- a/source/MRViewer/ImGuiMenu.cpp
+++ b/source/MRViewer/ImGuiMenu.cpp
@@ -1551,7 +1551,9 @@ bool ImGuiMenu::drawAdvancedOptions( const std::vector<std::shared_ptr<VisualObj
             return data->getRenderDiscretization();
         }, [&] ( ObjectPointsHolder* data, const int val )
         {
-            data->setRenderDiscretization( val );
+            data->setMaxRenderingPoints( val == 1 ?
+                std::max( ObjectPointsHolder::MaxRenderingPointsDefault, int( data->numValidPoints() ) ) :
+                int( data->numValidPoints() + val - 1 ) / val );
         } );
     }
 


### PR DESCRIPTION
https://github.com/MeshInspector/MeshInspectorCode/issues/4161

- Refactor sampling API: remove `setRenderDiscretization` function as confusing, add constants
- Enhance comments