### PR TITLE
Exposed `MRContoursStitch` to python

### DIFF
--- a/test_python/test_contourStitch.py
+++ b/test_python/test_contourStitch.py
@@ -1,0 +1,25 @@
+import pytest
+from helper import *
+
+def test_contour_stitch():
+    """
+    Stest exposing of `stitchContours` and `cutAlongEdgeLoop` functions.
+    """
+    
+    mesh = mrmesh.makeCube()
+    topology = mesh.topology
+    ueCntA = topology.computeNotLoneUndirectedEdges()
+
+    c0 = mrmesh.vectorEdges()
+    c0.append(mrmesh.EdgeId(0))
+    c0.append(mrmesh.EdgeId(2))
+    c0.append(mrmesh.EdgeId(4))
+    
+    c1 = mrmesh.cutAlongEdgeLoop( mesh.topology, c0 )
+    
+    ueCntB = topology.computeNotLoneUndirectedEdges()
+    assert ueCntB == ueCntA + 3
+
+    mrmesh.stitchContours( mesh.topology, c0, c1 )
+    ueCntC = topology.computeNotLoneUndirectedEdges()
+    assert ueCntC == ueCntA

--- a/test_python/test_positionVertsSmooth.py
+++ b/test_python/test_positionVertsSmooth.py
@@ -2,18 +2,30 @@ import pytest
 from helper import *
 
 
-def test_position_vers_smooth():
+def test_position_verts_smooth():
     R1 = 2
     R2_1 = 1
     R2_2 = 2.5
     torus = mrmesh.makeTorusWithSpikes(R1, R2_1, R2_2, 10, 12, None)
-    # torus = mrmesh.makeTorus(R1, R2_2, 10, 10, None)
 
-    # params = mrmesh.LaplacianEdgeWeightsParam.Unit
     params = mrmesh.LaplacianEdgeWeightsParam.Cotan
     verts = torus.topology.getValidVerts()
     verts.set(mrmesh.VertId(0), False)
     mrmesh.positionVertsSmoothly(torus, verts, params)
+
+    p = torus.points.vec[0]
+    for i in torus.points.vec:
+        assert i.x * i.x + i.y * i.y + i.z * i.z == p.x * p.x + p.y * p.y + p.z * p.z
+        
+def test_position_verts_smooth_sharpbd():
+    R1 = 2
+    R2_1 = 1
+    R2_2 = 2.5
+    torus = mrmesh.makeTorusWithSpikes(R1, R2_1, R2_2, 10, 12, None)
+
+    verts = torus.topology.getValidVerts()
+    verts.set(mrmesh.VertId(0), False)
+    mrmesh.positionVertsSmoothlySharpBd(torus, verts)
 
     p = torus.points.vec[0]
     for i in torus.points.vec:


### PR DESCRIPTION
Exposed:
- stitchContours
- cutAlongEdgeLoop

Also exposed `positionVertsSmoothlySharpBd` since it was not yet exposed from `MRPositionVertsSmoothly`

Added tests for:
- positionVertsSmoothlySharpBd
- stitchContours & cutAlongEdgeLoop by tr