### PR TITLE
AABBTreeBase: base class for most AABB-trees

### DIFF
--- a/source/MRMesh/MRAABBTree.cpp
+++ b/source/MRMesh/MRAABBTree.cpp
@@ -1,4 +1,5 @@
 #include "MRAABBTree.h"
+#include "MRAABBTreeBase.hpp"
 #include "MRAABBTreeMaker.h"
 #include "MRMesh.h"
 #include "MRTimer.h"
@@ -100,35 +101,6 @@ FaceBitSet AABBTree::getSubtreeFaces( NodeId subtreeRoot ) const
     return res;
 }
 
-auto AABBTree::getSubtrees( int minNum ) const -> std::vector<NodeId>
-{
-    MR_TIMER;
-    assert( minNum > 0 );
-    std::vector<NodeId> res;
-    if ( nodes_.empty() )
-        return res;
-    res.push_back( rootNodeId() );
-    std::vector<NodeId> tmp;
-    while ( res.size() < minNum )
-    {
-        for ( NodeId n : res )
-        {
-            if ( nodes_[n].leaf() )
-                tmp.push_back( n );
-            else
-            {
-                tmp.push_back( nodes_[n].l );
-                tmp.push_back( nodes_[n].r );
-            }
-        }
-        res.swap( tmp );
-        if ( res.size() == tmp.size() )
-            break;
-        tmp.clear();
-    }
-    return res;
-}
-
 void AABBTree::getLeafOrder( FaceBMap & faceMap ) const
 {
     MR_TIMER;
@@ -213,6 +185,8 @@ void AABBTree::refit( const Mesh & mesh, const VertBitSet & changedVerts )
         node.box.include( nodes_[node.r].box );
     }
 }
+
+template auto AABBTreeBase<FaceTreeTraits3>::getSubtrees( int minNum ) const -> std::vector<NodeId>;
 
 TEST(MRMesh, AABBTree)
 {

--- a/source/MRMesh/MRAABBTree.cpp
+++ b/source/MRMesh/MRAABBTree.cpp
@@ -71,36 +71,6 @@ AABBTree::AABBTree( const MeshPart & mp )
     nodes_ = makeAABBTreeNodeVec( std::move( boxedFaces ) );
 }
 
-FaceBitSet AABBTree::getSubtreeFaces( NodeId subtreeRoot ) const
-{
-    MR_TIMER;
-    FaceBitSet res;
-
-    constexpr int MaxStackSize = 32; // to avoid allocations
-    NodeId subtasks[MaxStackSize];
-    int stackSize = 0;
-    auto addSubTask = [&]( NodeId n )
-    {
-        if ( nodes_[n].leaf() )
-            res.autoResizeSet( nodes_[n].leafId() );
-        else
-        {
-            assert( stackSize < MaxStackSize );
-            subtasks[stackSize++] = n;
-        }
-    };
-    addSubTask( subtreeRoot );
-
-    while( stackSize > 0 )
-    {
-        NodeId n = subtasks[--stackSize];
-        addSubTask( nodes_[n].r );
-        addSubTask( nodes_[n].l );
-    }
-
-    return res;
-}
-
 void AABBTree::getLeafOrder( FaceBMap & faceMap ) const
 {
     MR_TIMER;
@@ -187,6 +157,7 @@ void AABBTree::refit( const Mesh & mesh, const VertBitSet & changedVerts )
 }
 
 template auto AABBTreeBase<FaceTreeTraits3>::getSubtrees( int minNum ) const -> std::vector<NodeId>;
+template auto AABBTreeBase<FaceTreeTraits3>::getSubtreeLeaves( NodeId subtreeRoot ) const -> LeafBitSet;
 
 TEST(MRMesh, AABBTree)
 {

--- a/source/MRMesh/MRAABBTree.cpp
+++ b/source/MRMesh/MRAABBTree.cpp
@@ -13,13 +13,6 @@ namespace MR
 
 using BoxedFace = BoxedLeaf<FaceTreeTraits3>;
 
-bool AABBTree::containsSameNumberOfTris( const Mesh & mesh ) const
-{
-    if ( mesh.topology.numValidFaces() <= 0 )
-        return nodes_.size() == 0;
-    return int(nodes_.size()) == getNumNodes( mesh.topology.numValidFaces() );
-}
-
 inline Box3f computeFaceBox( const Mesh & mesh, FaceId f )
 {
     Box3f box;

--- a/source/MRMesh/MRAABBTree.cpp
+++ b/source/MRMesh/MRAABBTree.cpp
@@ -62,33 +62,6 @@ AABBTree::AABBTree( const MeshPart & mp )
     nodes_ = makeAABBTreeNodeVec( std::move( boxedFaces ) );
 }
 
-void AABBTree::getLeafOrder( FaceBMap & faceMap ) const
-{
-    MR_TIMER;
-    FaceId f = 0_f;
-    for ( auto & n : nodes_ )
-    {
-        if ( !n.leaf() )
-            continue;
-        faceMap.b[n.leafId()] = f++;
-    }
-    faceMap.tsize = int( f );
-}
-
-void AABBTree::getLeafOrderAndReset( FaceBMap & faceMap )
-{
-    MR_TIMER;
-    FaceId f = 0_f;
-    for ( auto & n : nodes_ )
-    {
-        if ( !n.leaf() )
-            continue;
-        faceMap.b[n.leafId()] = f;
-        n.setLeafId( f++ );
-    }
-    faceMap.tsize = int( f );
-}
-
 void AABBTree::refit( const Mesh & mesh, const VertBitSet & changedVerts )
 {
     MR_TIMER
@@ -126,6 +99,8 @@ void AABBTree::refit( const Mesh & mesh, const VertBitSet & changedVerts )
 template auto AABBTreeBase<FaceTreeTraits3>::getSubtrees( int minNum ) const -> std::vector<NodeId>;
 template auto AABBTreeBase<FaceTreeTraits3>::getSubtreeLeaves( NodeId subtreeRoot ) const -> LeafBitSet;
 template NodeBitSet AABBTreeBase<FaceTreeTraits3>::getNodesFromLeaves( const LeafBitSet & leaves ) const;
+template void AABBTreeBase<FaceTreeTraits3>::getLeafOrder( LeafBMap & leafMap ) const;
+template void AABBTreeBase<FaceTreeTraits3>::getLeafOrderAndReset( LeafBMap & leafMap );
 
 TEST(MRMesh, AABBTree)
 {

--- a/source/MRMesh/MRAABBTree.h
+++ b/source/MRMesh/MRAABBTree.h
@@ -25,8 +25,7 @@ public:
 
     /// returns all faces in the subtree with given root
     [[nodiscard]] MRMESH_API FaceBitSet getSubtreeFaces( NodeId subtreeRoot ) const;
-    /// returns at least given number of top-level not-intersecting subtrees, union of which contain all tree leaves
-    [[nodiscard]] MRMESH_API std::vector<NodeId> getSubtrees( int minNum ) const;
+
     /// returns FaceId -> leaf#;
     /// buffer in faceMap must be resized before the call, and caller is responsible for filling missing face elements
     MRMESH_API void getLeafOrder( FaceBMap & faceMap ) const;

--- a/source/MRMesh/MRAABBTree.h
+++ b/source/MRMesh/MRAABBTree.h
@@ -17,15 +17,9 @@ class AABBTree : public AABBTreeBase<FaceTreeTraits3>
 {
 public:
     /// creates tree for given mesh or its part
-    [[nodiscard]] MRMESH_API AABBTree( const MeshPart & mp );
+    [[nodiscard]] MRMESH_API explicit AABBTree( const MeshPart & mp );
 
-    /// returns FaceId -> leaf#;
-    /// buffer in faceMap must be resized before the call, and caller is responsible for filling missing face elements
-    MRMESH_API void getLeafOrder( FaceBMap & faceMap ) const;
-    /// returns FaceId -> leaf#, then resets leaf order to 0,1,2,...;
-    /// buffer in faceMap must be resized before the call, and caller is responsible for filling missing face elements
-    MRMESH_API void getLeafOrderAndReset( FaceBMap & faceMap );
-
+    AABBTree() = default;
     AABBTree( AABBTree && ) noexcept = default;
     AABBTree & operator =( AABBTree && ) noexcept = default;
 

--- a/source/MRMesh/MRAABBTree.h
+++ b/source/MRMesh/MRAABBTree.h
@@ -16,10 +16,6 @@ namespace MR
 class AABBTree : public AABBTreeBase<FaceTreeTraits3>
 {
 public:
-    /// returns true if the tree contains exactly the same number of triangles as in given mesh;
-    /// this is fast validity check, but it is not comprehensive (tree can be outdated even if true is returned)
-    [[nodiscard]] MRMESH_API bool containsSameNumberOfTris( const Mesh & mesh ) const;
-
     /// creates tree for given mesh or its part
     [[nodiscard]] MRMESH_API AABBTree( const MeshPart & mp );
 

--- a/source/MRMesh/MRAABBTree.h
+++ b/source/MRMesh/MRAABBTree.h
@@ -30,9 +30,6 @@ public:
     /// buffer in faceMap must be resized before the call, and caller is responsible for filling missing face elements
     MRMESH_API void getLeafOrderAndReset( FaceBMap & faceMap );
 
-    /// returns set of nodes containing among direct or indirect children given faces
-    [[nodiscard]] MRMESH_API NodeBitSet getNodesFromFaces( const FaceBitSet & faces ) const;
-
     AABBTree( AABBTree && ) noexcept = default;
     AABBTree & operator =( AABBTree && ) noexcept = default;
 

--- a/source/MRMesh/MRAABBTree.h
+++ b/source/MRMesh/MRAABBTree.h
@@ -23,9 +23,6 @@ public:
     /// creates tree for given mesh or its part
     [[nodiscard]] MRMESH_API AABBTree( const MeshPart & mp );
 
-    /// returns all faces in the subtree with given root
-    [[nodiscard]] MRMESH_API FaceBitSet getSubtreeFaces( NodeId subtreeRoot ) const;
-
     /// returns FaceId -> leaf#;
     /// buffer in faceMap must be resized before the call, and caller is responsible for filling missing face elements
     MRMESH_API void getLeafOrder( FaceBMap & faceMap ) const;

--- a/source/MRMesh/MRAABBTree.h
+++ b/source/MRMesh/MRAABBTree.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MRAABBTreeNode.h"
+#include "MRAABBTreeBase.h"
 #include "MRVector.h"
 
 namespace MR
@@ -13,16 +13,9 @@ namespace MR
 
 /// bounding volume hierarchy
 /// \ingroup AABBTreeGroup
-class AABBTree
+class AABBTree : public AABBTreeBase<FaceTreeTraits3>
 {
 public:
-    using Node = AABBTreeNode<FaceTreeTraits3>;
-    using NodeVec = Vector<Node, NodeId>;
-    [[nodiscard]] const NodeVec & nodes() const { return nodes_; }
-    [[nodiscard]] const Node & operator[]( NodeId nid ) const { return nodes_[nid]; }
-    [[nodiscard]] static NodeId rootNodeId() { return NodeId{ 0 }; }
-    /// returns the root node bounding box
-    [[nodiscard]] Box3f getBoundingBox() const { return nodes_.empty() ? Box3f{} : nodes_[rootNodeId()].box; }
     /// returns true if the tree contains exactly the same number of triangles as in given mesh;
     /// this is fast validity check, but it is not comprehensive (tree can be outdated even if true is returned)
     [[nodiscard]] MRMESH_API bool containsSameNumberOfTris( const Mesh & mesh ) const;
@@ -47,9 +40,6 @@ public:
     AABBTree( AABBTree && ) noexcept = default;
     AABBTree & operator =( AABBTree && ) noexcept = default;
 
-    /// returns the amount of memory this object occupies on heap
-    [[nodiscard]] MRMESH_API size_t heapBytes() const { return nodes_.heapBytes(); }
-
     /// updates bounding boxes of the nodes containing changed vertices;
     /// this is a faster alternative to full tree rebuild (but the tree after refit might be less efficient)
     /// \param mesh same mesh for which this tree was constructed but with updated coordinates;
@@ -57,8 +47,6 @@ public:
     MRMESH_API void refit( const Mesh & mesh, const VertBitSet & changedVerts );
 
 private:
-    NodeVec nodes_;
-
     AABBTree( const AABBTree & ) = default;
     AABBTree & operator =( const AABBTree & ) = default;
     friend class UniqueThreadSafeOwner<AABBTree>;

--- a/source/MRMesh/MRAABBTreeBase.h
+++ b/source/MRMesh/MRAABBTreeBase.h
@@ -34,6 +34,9 @@ public:
     /// returns the amount of memory this object occupies on heap
     [[nodiscard]] MRMESH_API size_t heapBytes() const { return nodes_.heapBytes(); }
 
+    /// returns the number of leaves in whole tree
+    [[nodiscard]] size_t numLeaves() const { return nodes_.empty() ? 0 : ( nodes_.size() + 1 / 2 ); }
+
     /// returns at least given number of top-level not-intersecting subtrees, union of which contain all tree leaves
     [[nodiscard]] MRMESH_API std::vector<NodeId> getSubtrees( int minNum ) const;
 

--- a/source/MRMesh/MRAABBTreeBase.h
+++ b/source/MRMesh/MRAABBTreeBase.h
@@ -40,6 +40,9 @@ public:
     /// returns all leaves in the subtree with given root
     [[nodiscard]] MRMESH_API LeafBitSet getSubtreeLeaves( NodeId subtreeRoot ) const;
 
+    /// returns set of nodes containing among direct or indirect children given leaves
+    [[nodiscard]] MRMESH_API NodeBitSet getNodesFromLeaves( const LeafBitSet & leaves ) const;
+
 protected:
     NodeVec nodes_;
 };

--- a/source/MRMesh/MRAABBTreeBase.h
+++ b/source/MRMesh/MRAABBTreeBase.h
@@ -35,7 +35,7 @@ public:
     [[nodiscard]] MRMESH_API size_t heapBytes() const { return nodes_.heapBytes(); }
 
     /// returns the number of leaves in whole tree
-    [[nodiscard]] size_t numLeaves() const { return nodes_.empty() ? 0 : ( nodes_.size() + 1 / 2 ); }
+    [[nodiscard]] size_t numLeaves() const { return nodes_.empty() ? 0 : ( nodes_.size() + 1 ) / 2; }
 
     /// returns at least given number of top-level not-intersecting subtrees, union of which contain all tree leaves
     [[nodiscard]] MRMESH_API std::vector<NodeId> getSubtrees( int minNum ) const;

--- a/source/MRMesh/MRAABBTreeBase.h
+++ b/source/MRMesh/MRAABBTreeBase.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "MRAABBTreeNode.h"
+
+namespace MR
+{
+
+/// base class for most AABB-trees (except for AABBTreePoints)
+template <typename T>
+class AABBTreeBase
+{
+public:
+    using Traits = T;
+    using Node = AABBTreeNode<Traits>;
+    using NodeVec = Vector<Node, NodeId>;
+
+public:
+    /// const-access to all nodes
+    [[nodiscard]] const NodeVec & nodes() const { return nodes_; }
+
+    /// const-access to any node
+    [[nodiscard]] const Node & operator[]( NodeId nid ) const { return nodes_[nid]; }
+
+    /// returns root node id
+    [[nodiscard]] static NodeId rootNodeId() { return NodeId{ 0 }; }
+
+    /// returns the root node bounding box
+    [[nodiscard]] auto getBoundingBox() const { return nodes_.empty() ? typename Node::BoxT{} : nodes_[rootNodeId()].box; }
+
+    /// returns the amount of memory this object occupies on heap
+    [[nodiscard]] MRMESH_API size_t heapBytes() const { return nodes_.heapBytes(); }
+
+protected:
+    NodeVec nodes_;
+};
+
+} //namespace MR

--- a/source/MRMesh/MRAABBTreeBase.h
+++ b/source/MRMesh/MRAABBTreeBase.h
@@ -16,6 +16,7 @@ public:
     using LeafTag = typename T::LeafTag;
     using LeafId = typename T::LeafId;
     using LeafBitSet = TaggedBitSet<LeafTag>;
+    using LeafBMap = BMap<LeafId, LeafId>;
     using BoxT = typename T::BoxT;
 
 public:
@@ -45,6 +46,14 @@ public:
 
     /// returns set of nodes containing among direct or indirect children given leaves
     [[nodiscard]] MRMESH_API NodeBitSet getNodesFromLeaves( const LeafBitSet & leaves ) const;
+
+    /// fills map: LeafId -> leaf#;
+    /// buffer in leafMap must be resized before the call, and caller is responsible for filling missing leaf elements
+    MRMESH_API void getLeafOrder( LeafBMap & leafMap ) const;
+
+    /// fills map: LeafId -> leaf#, then resets leaf order to 0,1,2,...;
+    /// buffer in leafMap must be resized before the call, and caller is responsible for filling missing leaf elements
+    MRMESH_API void getLeafOrderAndReset( LeafBMap & leafMap );
 
 protected:
     NodeVec nodes_;

--- a/source/MRMesh/MRAABBTreeBase.h
+++ b/source/MRMesh/MRAABBTreeBase.h
@@ -30,6 +30,9 @@ public:
     /// returns the amount of memory this object occupies on heap
     [[nodiscard]] MRMESH_API size_t heapBytes() const { return nodes_.heapBytes(); }
 
+    /// returns at least given number of top-level not-intersecting subtrees, union of which contain all tree leaves
+    [[nodiscard]] MRMESH_API std::vector<NodeId> getSubtrees( int minNum ) const;
+
 protected:
     NodeVec nodes_;
 };

--- a/source/MRMesh/MRAABBTreeBase.h
+++ b/source/MRMesh/MRAABBTreeBase.h
@@ -13,6 +13,10 @@ public:
     using Traits = T;
     using Node = AABBTreeNode<Traits>;
     using NodeVec = Vector<Node, NodeId>;
+    using LeafTag = typename T::LeafTag;
+    using LeafId = typename T::LeafId;
+    using LeafBitSet = TaggedBitSet<LeafTag>;
+    using BoxT = typename T::BoxT;
 
 public:
     /// const-access to all nodes
@@ -25,13 +29,16 @@ public:
     [[nodiscard]] static NodeId rootNodeId() { return NodeId{ 0 }; }
 
     /// returns the root node bounding box
-    [[nodiscard]] auto getBoundingBox() const { return nodes_.empty() ? typename Node::BoxT{} : nodes_[rootNodeId()].box; }
+    [[nodiscard]] BoxT getBoundingBox() const { return nodes_.empty() ? BoxT{} : nodes_[rootNodeId()].box; }
 
     /// returns the amount of memory this object occupies on heap
     [[nodiscard]] MRMESH_API size_t heapBytes() const { return nodes_.heapBytes(); }
 
     /// returns at least given number of top-level not-intersecting subtrees, union of which contain all tree leaves
     [[nodiscard]] MRMESH_API std::vector<NodeId> getSubtrees( int minNum ) const;
+
+    /// returns all leaves in the subtree with given root
+    [[nodiscard]] MRMESH_API LeafBitSet getSubtreeLeaves( NodeId subtreeRoot ) const;
 
 protected:
     NodeVec nodes_;

--- a/source/MRMesh/MRAABBTreeBase.hpp
+++ b/source/MRMesh/MRAABBTreeBase.hpp
@@ -1,0 +1,37 @@
+#include "MRAABBTreeBase.h"
+#include "MRTimer.h"
+
+namespace MR
+{
+
+template <typename T>
+auto AABBTreeBase<T>::getSubtrees( int minNum ) const -> std::vector<NodeId>
+{
+    MR_TIMER
+    assert( minNum > 0 );
+    std::vector<NodeId> res;
+    if ( nodes_.empty() )
+        return res;
+    res.push_back( rootNodeId() );
+    std::vector<NodeId> tmp;
+    while ( res.size() < minNum )
+    {
+        for ( NodeId n : res )
+        {
+            if ( nodes_[n].leaf() )
+                tmp.push_back( n );
+            else
+            {
+                tmp.push_back( nodes_[n].l );
+                tmp.push_back( nodes_[n].r );
+            }
+        }
+        res.swap( tmp );
+        if ( res.size() == tmp.size() )
+            break;
+        tmp.clear();
+    }
+    return res;
+}
+
+} //namespace MR

--- a/source/MRMesh/MRAABBTreeBase.hpp
+++ b/source/MRMesh/MRAABBTreeBase.hpp
@@ -91,4 +91,33 @@ NodeBitSet AABBTreeBase<T>::getNodesFromLeaves( const LeafBitSet & leaves ) cons
     return res;
 }
 
+template <typename T>
+void AABBTreeBase<T>::getLeafOrder( LeafBMap & leafMap ) const
+{
+    MR_TIMER
+    LeafId l( 0 );
+    for ( auto & n : nodes_ )
+    {
+        if ( !n.leaf() )
+            continue;
+        leafMap.b[n.leafId()] = l++;
+    }
+    leafMap.tsize = int( l );
+}
+
+template <typename T>
+void AABBTreeBase<T>::getLeafOrderAndReset( LeafBMap & leafMap )
+{
+    MR_TIMER
+    LeafId l( 0 );
+    for ( auto & n : nodes_ )
+    {
+        if ( !n.leaf() )
+            continue;
+        leafMap.b[n.leafId()] = l;
+        n.setLeafId( l++ );
+    }
+    leafMap.tsize = int( l );
+}
+
 } //namespace MR

--- a/source/MRMesh/MRAABBTreeBase.hpp
+++ b/source/MRMesh/MRAABBTreeBase.hpp
@@ -34,4 +34,35 @@ auto AABBTreeBase<T>::getSubtrees( int minNum ) const -> std::vector<NodeId>
     return res;
 }
 
+template <typename T>
+auto AABBTreeBase<T>::getSubtreeLeaves( NodeId subtreeRoot ) const -> LeafBitSet
+{
+    MR_TIMER
+    LeafBitSet res;
+
+    constexpr int MaxStackSize = 32; // to avoid allocations
+    NodeId subtasks[MaxStackSize];
+    int stackSize = 0;
+    auto addSubTask = [&]( NodeId n )
+    {
+        if ( nodes_[n].leaf() )
+            res.autoResizeSet( nodes_[n].leafId() );
+        else
+        {
+            assert( stackSize < MaxStackSize );
+            subtasks[stackSize++] = n;
+        }
+    };
+    addSubTask( subtreeRoot );
+
+    while( stackSize > 0 )
+    {
+        NodeId n = subtasks[--stackSize];
+        addSubTask( nodes_[n].r );
+        addSubTask( nodes_[n].l );
+    }
+
+    return res;
+}
+
 } //namespace MR

--- a/source/MRMesh/MRAABBTreeNode.h
+++ b/source/MRMesh/MRAABBTreeNode.h
@@ -14,14 +14,15 @@ namespace MR
 template<typename L, typename B>
 struct AABBTreeTraits
 {
-    using LeafId = L;
+    using LeafTag = L;
+    using LeafId = Id<L>;
     using BoxT = B;
 };
 
-using FaceTreeTraits3 = AABBTreeTraits<FaceId, Box3f>;
+using FaceTreeTraits3 = AABBTreeTraits<FaceTag, Box3f>;
 
 template<typename V>
-using LineTreeTraits = AABBTreeTraits<UndirectedEdgeId, Box<V>>;
+using LineTreeTraits = AABBTreeTraits<UndirectedEdgeTag, Box<V>>;
 using LineTreeTraits2 = LineTreeTraits<Vector2f>;
 using LineTreeTraits3 = LineTreeTraits<Vector3f>;
 

--- a/source/MRMesh/MRAABBTreePolyline.cpp
+++ b/source/MRMesh/MRAABBTreePolyline.cpp
@@ -87,4 +87,7 @@ template AABBTreePolyline<Vector3f>::AABBTreePolyline( const Mesh &, const Undir
 template auto AABBTreeBase<LineTreeTraits<Vector2f>>::getSubtrees( int minNum ) const -> std::vector<NodeId>;
 template auto AABBTreeBase<LineTreeTraits<Vector3f>>::getSubtrees( int minNum ) const -> std::vector<NodeId>;
 
+template auto AABBTreeBase<LineTreeTraits<Vector2f>>::getSubtreeLeaves( NodeId subtreeRoot ) const -> LeafBitSet;
+template auto AABBTreeBase<LineTreeTraits<Vector3f>>::getSubtreeLeaves( NodeId subtreeRoot ) const -> LeafBitSet;
+
 } //namespace MR

--- a/source/MRMesh/MRAABBTreePolyline.cpp
+++ b/source/MRMesh/MRAABBTreePolyline.cpp
@@ -90,4 +90,7 @@ template auto AABBTreeBase<LineTreeTraits<Vector3f>>::getSubtrees( int minNum ) 
 template auto AABBTreeBase<LineTreeTraits<Vector2f>>::getSubtreeLeaves( NodeId subtreeRoot ) const -> LeafBitSet;
 template auto AABBTreeBase<LineTreeTraits<Vector3f>>::getSubtreeLeaves( NodeId subtreeRoot ) const -> LeafBitSet;
 
+template NodeBitSet AABBTreeBase<LineTreeTraits<Vector2f>>::getNodesFromLeaves( const LeafBitSet & leaves ) const;
+template NodeBitSet AABBTreeBase<LineTreeTraits<Vector3f>>::getNodesFromLeaves( const LeafBitSet & leaves ) const;
+
 } //namespace MR

--- a/source/MRMesh/MRAABBTreePolyline.cpp
+++ b/source/MRMesh/MRAABBTreePolyline.cpp
@@ -93,4 +93,10 @@ template auto AABBTreeBase<LineTreeTraits<Vector3f>>::getSubtreeLeaves( NodeId s
 template NodeBitSet AABBTreeBase<LineTreeTraits<Vector2f>>::getNodesFromLeaves( const LeafBitSet & leaves ) const;
 template NodeBitSet AABBTreeBase<LineTreeTraits<Vector3f>>::getNodesFromLeaves( const LeafBitSet & leaves ) const;
 
+template void AABBTreeBase<LineTreeTraits<Vector2f>>::getLeafOrder( LeafBMap & leafMap ) const;
+template void AABBTreeBase<LineTreeTraits<Vector3f>>::getLeafOrder( LeafBMap & leafMap ) const;
+
+template void AABBTreeBase<LineTreeTraits<Vector2f>>::getLeafOrderAndReset( LeafBMap & leafMap );
+template void AABBTreeBase<LineTreeTraits<Vector3f>>::getLeafOrderAndReset( LeafBMap & leafMap );
+
 } //namespace MR

--- a/source/MRMesh/MRAABBTreePolyline.cpp
+++ b/source/MRMesh/MRAABBTreePolyline.cpp
@@ -1,4 +1,5 @@
 #include "MRAABBTreePolyline.h"
+#include "MRAABBTreeBase.hpp"
 #include "MRAABBTreeMaker.h"
 #include "MRPolyline.h"
 #include "MRMesh.h"
@@ -82,5 +83,8 @@ AABBTreePolyline<V>::AABBTreePolyline( const Mesh& mesh, const UndirectedEdgeBit
 template AABBTreePolyline<Vector2f>::AABBTreePolyline( const Polyline2 & );
 template AABBTreePolyline<Vector3f>::AABBTreePolyline( const Polyline3 & );
 template AABBTreePolyline<Vector3f>::AABBTreePolyline( const Mesh &, const UndirectedEdgeBitSet & );
+
+template auto AABBTreeBase<LineTreeTraits<Vector2f>>::getSubtrees( int minNum ) const -> std::vector<NodeId>;
+template auto AABBTreeBase<LineTreeTraits<Vector3f>>::getSubtrees( int minNum ) const -> std::vector<NodeId>;
 
 } //namespace MR

--- a/source/MRMesh/MRAABBTreePolyline.h
+++ b/source/MRMesh/MRAABBTreePolyline.h
@@ -37,7 +37,7 @@ public:
 
 public:
     /// creates tree for given polyline
-    MRMESH_API AABBTreePolyline( const typename PolylineTraits<V>::Polyline & polyline );
+    MRMESH_API explicit AABBTreePolyline( const typename PolylineTraits<V>::Polyline & polyline );
 
     /// creates tree for selected edges on the mesh (only for 3d tree)
     MRMESH_API AABBTreePolyline( const Mesh& mesh, const UndirectedEdgeBitSet & edgeSet );

--- a/source/MRMesh/MRAABBTreePolyline.h
+++ b/source/MRMesh/MRAABBTreePolyline.h
@@ -31,13 +31,14 @@ class AABBTreePolyline : public AABBTreeBase<LineTreeTraits<V>>
     using Base = AABBTreeBase<LineTreeTraits<V>>;
 
 public:
-    using Base::Traits;
-    using Base::Node;
-    using Base::NodeVec;
+    using typename Base::Traits;
+    using typename Base::Node;
+    using typename Base::NodeVec;
 
 public:
     /// creates tree for given polyline
     MRMESH_API AABBTreePolyline( const typename PolylineTraits<V>::Polyline & polyline );
+
     /// creates tree for selected edges on the mesh (only for 3d tree)
     MRMESH_API AABBTreePolyline( const Mesh& mesh, const UndirectedEdgeBitSet & edgeSet );
 
@@ -48,8 +49,10 @@ public:
 private:
     /// make copy constructor unavailable for the public to avoid unnecessary copies
     AABBTreePolyline( const AABBTreePolyline & ) = default;
+
     /// make assign operator unavailable for the public to avoid unnecessary copies
     AABBTreePolyline & operator =( const AABBTreePolyline & ) = default;
+
     friend class UniqueThreadSafeOwner<AABBTreePolyline>;
 
     using Base::nodes_;

--- a/source/MRMesh/MRAABBTreePolyline.h
+++ b/source/MRMesh/MRAABBTreePolyline.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MRAABBTreeNode.h"
+#include "MRAABBTreeBase.h"
 #include "MRVector.h"
 
 namespace MR
@@ -26,31 +26,16 @@ struct PolylineTraits<Vector3f>
 
 /// bounding volume hierarchy for line segments
 template<typename V>
-class AABBTreePolyline
+class AABBTreePolyline : public AABBTreeBase<LineTreeTraits<V>>
 {
+    using Base = AABBTreeBase<LineTreeTraits<V>>;
+
 public:
-    using Traits = LineTreeTraits<V>;
-    using Node = AABBTreeNode<Traits>;
-    using NodeVec = Vector<Node, NodeId>;
+    using Base::Traits;
+    using Base::Node;
+    using Base::NodeVec;
 
-    [[nodiscard]] const NodeVec& nodes() const
-    {
-        return nodes_;
-    }
-    [[nodiscard]] const Node& operator[]( NodeId nid ) const
-    {
-        return nodes_[nid];
-    }
-    [[nodiscard]] static NodeId rootNodeId()
-    {
-        return NodeId{ 0 };
-    }
-    /// returns the root node bounding box
-    [[nodiscard]] Box<V> getBoundingBox() const
-    {
-        return nodes_.empty() ? Box<V>{} : nodes_[rootNodeId()].box;
-    }
-
+public:
     /// creates tree for given polyline
     MRMESH_API AABBTreePolyline( const typename PolylineTraits<V>::Polyline & polyline );
     /// creates tree for selected edges on the mesh (only for 3d tree)
@@ -60,9 +45,6 @@ public:
     AABBTreePolyline( AABBTreePolyline && ) noexcept = default;
     AABBTreePolyline & operator =( AABBTreePolyline && ) noexcept = default;
 
-    /// returns the amount of memory this object occupies on heap
-    [[nodiscard]] size_t heapBytes() const { return nodes_.heapBytes(); }
-
 private:
     /// make copy constructor unavailable for the public to avoid unnecessary copies
     AABBTreePolyline( const AABBTreePolyline & ) = default;
@@ -70,7 +52,7 @@ private:
     AABBTreePolyline & operator =( const AABBTreePolyline & ) = default;
     friend class UniqueThreadSafeOwner<AABBTreePolyline>;
 
-    NodeVec nodes_;
+    using Base::nodes_;
 };
 
 /// \}

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -1102,7 +1102,7 @@ std::optional<MeshProjectionResult> Mesh::projectPoint( const Vector3f& point, f
 const AABBTree & Mesh::getAABBTree() const 
 { 
     const auto & res = AABBTreeOwner_.getOrCreate( [this]{ return AABBTree( *this ); } );
-    assert( res.containsSameNumberOfTris( *this ) );
+    assert( res.numLeaves() == topology.numValidFaces() );
     return res;
 }
 
@@ -1124,7 +1124,7 @@ void Mesh::updateCaches( const VertBitSet & changedVerts )
 {
     AABBTreeOwner_.update( [&]( AABBTree & tree )
     {
-        assert( tree.containsSameNumberOfTris( *this ) );
+        assert( tree.numLeaves() == topology.numValidFaces() );
         tree.refit( *this, changedVerts ); 
     } );
     AABBTreePointsOwner_.update( [&]( AABBTreePoints & tree )

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -11,6 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="MRAABBTreeBase.h" />
     <ClInclude Include="MRAddNoise.h" />
     <ClInclude Include="MRAligningTransform.h" />
     <ClInclude Include="MRAlphaShape.h" />

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MRAABBTreeBase.h" />
+    <ClInclude Include="MRAABBTreeBase.hpp" />
     <ClInclude Include="MRAddNoise.h" />
     <ClInclude Include="MRAligningTransform.h" />
     <ClInclude Include="MRAlphaShape.h" />
@@ -396,7 +397,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MR2DContoursTriangulation.cpp" />
-    <ClCompile Include="MRAABBTreeBase.hpp" />
     <ClCompile Include="MRAABBTreeMaker.cpp" />
     <ClCompile Include="miniply.cpp" />
     <ClCompile Include="MRAABBTree.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -396,6 +396,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MR2DContoursTriangulation.cpp" />
+    <ClCompile Include="MRAABBTreeBase.hpp" />
     <ClCompile Include="MRAABBTreeMaker.cpp" />
     <ClCompile Include="miniply.cpp" />
     <ClCompile Include="MRAABBTree.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1266,6 +1266,9 @@
     <ClInclude Include="MRAABBTreeBase.h">
       <Filter>Source Files\AABBTree</Filter>
     </ClInclude>
+    <ClInclude Include="MRAABBTreeBase.hpp">
+      <Filter>Source Files\AABBTree</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRObject.cpp">
@@ -2110,9 +2113,6 @@
     </ClCompile>
     <ClCompile Include="MRDipole.cpp">
       <Filter>Source Files\Math</Filter>
-    </ClCompile>
-    <ClCompile Include="MRAABBTreeBase.hpp">
-      <Filter>Source Files\AABBTree</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -2111,6 +2111,9 @@
     <ClCompile Include="MRDipole.cpp">
       <Filter>Source Files\Math</Filter>
     </ClCompile>
+    <ClCompile Include="MRAABBTreeBase.hpp">
+      <Filter>Source Files\AABBTree</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1263,6 +1263,9 @@
     <ClInclude Include="MRDipole.h">
       <Filter>Source Files\Math</Filter>
     </ClInclude>
+    <ClInclude Include="MRAABBTreeBase.h">
+      <Filter>Source Files\AABBTree</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRObject.cpp">

--- a/source/MRMesh/MRMeshCollide.cpp
+++ b/source/MRMesh/MRMeshCollide.cpp
@@ -33,12 +33,12 @@ std::vector<FaceFace> findCollidingTriangles( const MeshPart & a, const MeshPart
     NodeBitSet* aNodesPtr{nullptr}, * bNodesPtr{nullptr};
     if ( a.region )
     {
-        aNodes = aTree.getNodesFromFaces( *a.region );
+        aNodes = aTree.getNodesFromLeaves( *a.region );
         aNodesPtr = &aNodes;
     }
     if ( b.region )
     {
-        bNodes = bTree.getNodesFromFaces( *b.region );
+        bNodes = bTree.getNodesFromLeaves( *b.region );
         bNodesPtr = &bNodes;
     }
 

--- a/source/MRMesh/MRMeshDecimateParallel.cpp
+++ b/source/MRMesh/MRMeshDecimateParallel.cpp
@@ -90,7 +90,7 @@ DecimateResult decimateParallelMesh( MR::Mesh & mesh, const DecimateParallelSett
             };
             if ( !reportThreadProgress( 0 ) )
                 break;
-            auto faces = tree.getSubtreeFaces( subroots[i] );
+            auto faces = tree.getSubtreeLeaves( subroots[i] );
             auto & submesh = submeshes[i];
             VertMap vertSubToFull;
             FaceHashMap faceFullToSub;

--- a/source/MRMesh/MRMeshDistance.cpp
+++ b/source/MRMesh/MRMeshDistance.cpp
@@ -33,12 +33,12 @@ MeshDistanceResult findDistance( const MeshPart& a, const MeshPart& b, const Aff
     NodeBitSet* aNodesPtr{nullptr}, *bNodesPtr{nullptr};
     if ( a.region )
     {
-        aNodes = aTree.getNodesFromFaces( *a.region );
+        aNodes = aTree.getNodesFromLeaves( *a.region );
         aNodesPtr = &aNodes;
     }
     if ( b.region )
     {
-        bNodes = bTree.getNodesFromFaces( *b.region );
+        bNodes = bTree.getNodesFromLeaves( *b.region );
         bNodesPtr = &bNodes;
     }
 


### PR DESCRIPTION
Move common methods for most AABB-trees in new class template `AABBTreeBase`.