### PR TITLE
Add Volume interpolation functions, helper accessors

### DIFF
--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -325,6 +325,7 @@
     <ClInclude Include="MRViewportId.h" />
     <ClInclude Include="MRViewportProperty.h" />
     <ClInclude Include="MRVolumeIndexer.h" />
+    <ClInclude Include="MRVolumeInterpolation.h" />
     <ClInclude Include="MRVoxelGraphCut.h" />
     <ClInclude Include="MRVoxelPath.h" />
     <ClInclude Include="MRVisualObject.h" />
@@ -627,6 +628,7 @@
     <ClCompile Include="MRVertexAttributeGradient.cpp" />
     <ClCompile Include="MRViewportId.cpp" />
     <ClCompile Include="MRVolumeIndexer.cpp" />
+    <ClCompile Include="MRVolumeInterpolation.cpp" />
     <ClCompile Include="MRVoxelGraphCut.cpp" />
     <ClCompile Include="MRObjectLines.cpp" />
     <ClCompile Include="MRVoxelPath.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -628,7 +628,6 @@
     <ClCompile Include="MRVertexAttributeGradient.cpp" />
     <ClCompile Include="MRViewportId.cpp" />
     <ClCompile Include="MRVolumeIndexer.cpp" />
-    <ClCompile Include="MRVolumeInterpolation.cpp" />
     <ClCompile Include="MRVoxelGraphCut.cpp" />
     <ClCompile Include="MRObjectLines.cpp" />
     <ClCompile Include="MRVoxelPath.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1287,6 +1287,9 @@
     <ClInclude Include="MRFeatureHelpers.h">
       <Filter>Source Files\DataModel\Features</Filter>
     </ClInclude>
+    <ClInclude Include="MRVolumeInterpolation.h">
+      <Filter>Source Files\Voxels</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRObject.cpp">
@@ -2134,6 +2137,15 @@
     </ClCompile>
     <ClCompile Include="MRAABBTreeObjects.cpp">
       <Filter>Source Files\AABBTree</Filter>
+    </ClCompile>
+    <ClCompile Include="MRFeatureRefine.cpp">
+      <Filter>Source Files\DataModel\Features</Filter>
+    </ClCompile>
+    <ClCompile Include="MRFeatureHelpers.cpp">
+      <Filter>Source Files\DataModel\Features</Filter>
+    </ClCompile>
+    <ClCompile Include="MRVolumeInterpolation.cpp">
+      <Filter>Source Files\Voxels</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -2144,9 +2144,6 @@
     <ClCompile Include="MRFeatureHelpers.cpp">
       <Filter>Source Files\DataModel\Features</Filter>
     </ClCompile>
-    <ClCompile Include="MRVolumeInterpolation.cpp">
-      <Filter>Source Files\Voxels</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />

--- a/source/MRMesh/MRObjectVoxels.h
+++ b/source/MRMesh/MRObjectVoxels.h
@@ -53,7 +53,7 @@ public:
     MRMESH_API virtual std::vector<std::string> getInfoLines() const override;
     virtual std::string getClassName() const override { return "Voxels"; }
 
-    /// Clears all internal data and then creates grid and calculates histogram
+    /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface)
     MRMESH_API void construct( const SimpleVolume& simpleVolume, ProgressCallback cb = {} );
     /// Clears all internal data and calculates histogram
     MRMESH_API void construct( const FloatGrid& grid, const Vector3f& voxelSize, ProgressCallback cb = {} );

--- a/source/MRMesh/MRVolumeIndexer.h
+++ b/source/MRMesh/MRVolumeIndexer.h
@@ -50,6 +50,8 @@ public:
     size_t sizeXY() const { return sizeXY_; }
     Vector3i toPos( VoxelId id ) const;
     VoxelId toVoxelId( const Vector3i & pos ) const;
+    /// returns true if this voxel is within dimensions
+    bool isInDims( const Vector3i& pos ) const { return pos.x >= 0 && pos.x < dims_.x && pos.y >= 0 && pos.y < dims_.y && pos.z >= 0 && pos.z < dims_.z; }
     /// returns true if this voxel is on the boundary of the volume
     bool isBdVoxel( const Vector3i & pos ) const { return pos.x == 0 || pos.x + 1 == dims_.x || pos.y == 0 || pos.y + 1 == dims_.y || pos.z == 0 || pos.z + 1 == dims_.z; }
     /// returns true if v1 is within at most 6 neighbors of v0

--- a/source/MRMesh/MRVolumeInterpolation.cpp
+++ b/source/MRMesh/MRVolumeInterpolation.cpp
@@ -1,0 +1,7 @@
+#include "MRPch\MRPch.h"
+
+#include "MRVolumeInterpolation.h"
+
+namespace MR
+{
+} // namespace MR

--- a/source/MRMesh/MRVolumeInterpolation.cpp
+++ b/source/MRMesh/MRVolumeInterpolation.cpp
@@ -1,7 +1,0 @@
-#include "MRPch/MRPch.h"
-
-#include "MRVolumeInterpolation.h"
-
-namespace MR
-{
-} // namespace MR

--- a/source/MRMesh/MRVolumeInterpolation.cpp
+++ b/source/MRMesh/MRVolumeInterpolation.cpp
@@ -1,4 +1,4 @@
-#include "MRPch\MRPch.h"
+#include "MRPch/MRPch.h"
 
 #include "MRVolumeInterpolation.h"
 

--- a/source/MRMesh/MRVolumeInterpolation.h
+++ b/source/MRMesh/MRVolumeInterpolation.h
@@ -8,11 +8,10 @@ namespace MR
 /// helper class for generalized access to voxel volume data with trilinear interpolation
 /// coordinate: 0       voxelSize
 ///             |       |
-///             I---*---I---*---I--
-///             |   |   |   |
-/// value:     [0]  |  [1]  |  ...      (!centerAligned)
-/// value:         [0]     [1] ...      (centerAligned)
-template <typename Accessor, bool centerAligned>
+///             I---*---I---*---I---
+///             |       |       |
+/// value:     [0]     [1]     [2] ...
+template <typename Accessor>
 class VoxelsVolumeInterpolatedAccessor
 {
 public:
@@ -63,10 +62,9 @@ private:
     IndexAndPos getIndexAndPos( Vector3f pos ) const
     {
         IndexAndPos res;
-        constexpr float shift = centerAligned ? 0.5f : 0.0f;
-        res.pos.x = pos.x / volume_.voxelSize.x - shift;
-        res.pos.y = pos.y / volume_.voxelSize.y - shift;
-        res.pos.z = pos.z / volume_.voxelSize.z - shift;
+        res.pos.x = pos.x / volume_.voxelSize.x;
+        res.pos.y = pos.y / volume_.voxelSize.y;
+        res.pos.z = pos.z / volume_.voxelSize.z;
         pos.x = floor( res.pos.x );
         pos.y = floor( res.pos.y );
         pos.z = floor( res.pos.z );
@@ -85,9 +83,9 @@ private:
 };
 
 /// sample function that resamples the voxel volume using interpolating accessor
-template <typename Accessor, bool centerAligned>
-SimpleVolume resampleVolumeByInterpolation( 
-    const typename Accessor::VolumeType &volume, 
+template <typename Accessor>
+SimpleVolume resampleVolumeByInterpolation(
+    const typename Accessor::VolumeType &volume,
     const typename Accessor &accessor,
     const Vector3f &newVoxelSize )
 {
@@ -102,7 +100,7 @@ SimpleVolume resampleVolumeByInterpolation(
     res.data.resize( res.dims.x * res.dims.y * res.dims.z );
     VolumeIndexer indexer( res.dims );
 
-    VoxelsVolumeInterpolatedAccessor<Accessor, centerAligned> interpolator( volume, accessor );
+    VoxelsVolumeInterpolatedAccessor<Accessor> interpolator( volume, accessor );
     for ( int k = 0; k < res.dims.z; k++ )
     for ( int j = 0; j < res.dims.y; j++ )
     for ( int i = 0; i < res.dims.x; i++ )

--- a/source/MRMesh/MRVolumeInterpolation.h
+++ b/source/MRMesh/MRVolumeInterpolation.h
@@ -55,8 +55,8 @@ private:
 
     struct IndexAndPos
     {
-        Vector3i index;
-        Vector3f pos;
+        Vector3i index; // Zero-based voxel index in the volume
+        Vector3f pos;   // [0;1) position of a point in the voxel: 0 corresponds to index and 1 to next voxel
     };
 
     IndexAndPos getIndexAndPos( Vector3f pos ) const
@@ -94,9 +94,9 @@ SimpleVolume resampleVolumeByInterpolation(
         .min{ volume.min },
         .max{ volume.max }
     };
-    res.dims.x = int( volume.dims.x * volume.voxelSize.x / res.voxelSize.x + 1e-6f );
-    res.dims.y = int( volume.dims.y * volume.voxelSize.y / res.voxelSize.y + 1e-6f );
-    res.dims.z = int( volume.dims.z * volume.voxelSize.z / res.voxelSize.z + 1e-6f );
+    res.dims.x = int( volume.dims.x * volume.voxelSize.x / res.voxelSize.x );
+    res.dims.y = int( volume.dims.y * volume.voxelSize.y / res.voxelSize.y );
+    res.dims.z = int( volume.dims.z * volume.voxelSize.z / res.voxelSize.z );
     res.data.resize( res.dims.x * res.dims.y * res.dims.z );
     VolumeIndexer indexer( res.dims );
 

--- a/source/MRMesh/MRVolumeInterpolation.h
+++ b/source/MRMesh/MRVolumeInterpolation.h
@@ -15,7 +15,7 @@ template <typename Accessor>
 class VoxelsVolumeInterpolatedAccessor
 {
 public:
-    using VolumeType = Accessor::VolumeType;
+    using VolumeType = typename Accessor::VolumeType;
     using ValueType = typename Accessor::ValueType;
 
     explicit VoxelsVolumeInterpolatedAccessor( const VolumeType& volume, const Accessor &accessor )
@@ -86,7 +86,7 @@ private:
 template <typename Accessor>
 SimpleVolume resampleVolumeByInterpolation(
     const typename Accessor::VolumeType &volume,
-    const typename Accessor &accessor,
+    const Accessor &accessor,
     const Vector3f &newVoxelSize )
 {
     SimpleVolume res{

--- a/source/MRMesh/MRVolumeInterpolation.h
+++ b/source/MRMesh/MRVolumeInterpolation.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "MRVoxelsVolumeAccess.h"
+
+namespace MR
+{
+
+/// helper class for generalized access to voxel volume data with trilinear interpolation
+/// coordinate: 0       voxelSize
+///             |       |
+///             I---*---I---*---I--
+///             |   |   |   |
+/// value:     [0]  |  [1]  |  ...      (!centerAligned)
+/// value:         [0]     [1] ...      (centerAligned)
+template <typename Accessor, bool centerAligned>
+class VoxelsVolumeInterpolatedAccessor
+{
+public:
+    using VolumeType = Accessor::VolumeType;
+    using ValueType = typename Accessor::ValueType;
+
+    explicit VoxelsVolumeInterpolatedAccessor( const VolumeType& volume, const Accessor &accessor )
+        : volume_( volume ), accessor_( accessor )
+    {}
+
+    /// get value at specified coordinates
+    ValueType get( const Vector3f& pos ) const
+    {
+        IndexAndPos index = getIndexAndPos(pos);
+        ValueType value{};
+        float cx[2] = { 1.0f - index.pos.x, index.pos.x };
+        float cy[2] = { 1.0f - index.pos.y, index.pos.y };
+        float cz[2] = { 1.0f - index.pos.z, index.pos.z };
+        for ( int i = 0; i < 8; i++ )
+        {
+            Vector3i d{ i & 1, ( i >> 1 ) & 1, i >> 2 };
+            value += accessor_.safeGet( index.index + d ) * ( cx[d.x] * cy[d.y] * cz[d.z] );
+        }
+        return value;
+    }
+
+private:
+    const VolumeType& volume_;
+    const Accessor& accessor_;
+
+    struct IndexAndPos
+    {
+        Vector3i index;
+        Vector3f pos;
+    };
+
+    IndexAndPos getIndexAndPos( Vector3f pos ) const
+    {
+        IndexAndPos res;
+        constexpr float shift = centerAligned ? 0.5f : 0.0f;
+        res.pos.x = pos.x / volume_.voxelSize.x - shift;
+        res.pos.y = pos.y / volume_.voxelSize.y - shift;
+        res.pos.z = pos.z / volume_.voxelSize.z - shift;
+        pos.x = floor( res.pos.x );
+        pos.y = floor( res.pos.y );
+        pos.z = floor( res.pos.z );
+        res.index.x = int( pos.x );
+        res.index.y = int( pos.y );
+        res.index.z = int( pos.z );
+        res.pos.x -= pos.x;
+        res.pos.y -= pos.y;
+        res.pos.z -= pos.z;
+        return res;
+    }
+};
+
+/// sample function that resamples the voxel volume using interpolating accessor
+template <typename Accessor, bool centerAligned>
+SimpleVolume resampleVolumeByInterpolation( 
+    const typename Accessor::VolumeType &volume, 
+    const typename Accessor &accessor,
+    const Vector3f &newVoxelSize )
+{
+    SimpleVolume res{
+        .voxelSize{ newVoxelSize },
+        .min{ volume.min },
+        .max{ volume.max }
+    };
+    res.dims.x = int( volume.dims.x * volume.voxelSize.x / res.voxelSize.x + 1e-6f );
+    res.dims.y = int( volume.dims.y * volume.voxelSize.y / res.voxelSize.y + 1e-6f );
+    res.dims.z = int( volume.dims.z * volume.voxelSize.z / res.voxelSize.z + 1e-6f );
+    res.data.resize( res.dims.x * res.dims.y * res.dims.z );
+    VolumeIndexer indexer( res.dims );
+
+    VoxelsVolumeInterpolatedAccessor<Accessor, centerAligned> interpolator( volume, accessor );
+    for ( int k = 0; k < res.dims.z; k++ )
+    for ( int j = 0; j < res.dims.y; j++ )
+    for ( int i = 0; i < res.dims.x; i++ )
+        res.data[indexer.toVoxelId( { i, j, k } )] = interpolator.get(
+            { i * res.voxelSize.x, j * res.voxelSize.y, k * res.voxelSize.z } );
+
+    return res;
+}
+
+} // namespace MR

--- a/source/MRMesh/MRVoxelsVolumeAccess.h
+++ b/source/MRMesh/MRVoxelsVolumeAccess.h
@@ -130,15 +130,15 @@ private:
     ValueType bgValue_;
 };
 
-/// accessor override with repeating edge values for out-of-bound indexes
+/// accessor override with clamping coordinates to volume bounds (for out-of-bounds indexes, edge values are repeated)
 template <typename Accessor>
-class VoxelsVolumeAccessorWithRepeat : public Accessor
+class VoxelsVolumeAccessorWithClamp : public Accessor
 {
 public:
     using VolumeType = typename Accessor::VolumeType;
     using ValueType = typename VolumeType::ValueType;
 
-    explicit VoxelsVolumeAccessorWithRepeat( const VolumeType& volume )
+    explicit VoxelsVolumeAccessorWithClamp( const VolumeType& volume )
         : Accessor( volume ), dims_( volume.dims )
     {}
 


### PR DESCRIPTION
- Add `VoxelsVolumeInterpolatedAccessor` template class to access volume data using trilinear interpolation
- Add example function to resample volume data
- Add `safeGet` functions to `VoxelsVolumeAccessor` and its specializations to safely access data outside the grid
- Add its overridden implementations:
  - `VoxelsVolumeAccessorWithBackground` to set specific background value
  - `VoxelsVolumeAccessorWithRepeat` to repeat edge values
