### PR TITLE
quadraticForm: consider creases to keep collapsed positions on them

### DIFF
--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -698,12 +698,12 @@ float Mesh::leftCotan( EdgeId e ) const
     return nom / den;
 }
 
-QuadraticForm3f Mesh::quadraticForm( VertId v, const FaceBitSet * region ) const
+QuadraticForm3f Mesh::quadraticForm( VertId v, const FaceBitSet * region, const UndirectedEdgeBitSet * creases ) const
 {
     QuadraticForm3f qf;
     for ( EdgeId e : orgRing( topology, v ) )
     {
-        if ( topology.isBdEdge( e, region ) )
+        if ( topology.isBdEdge( e, region ) || ( creases && creases->test( e ) ) )
         {
             // zero-length boundary edge is treated as uniform stabilizer: all shift directions are equally penalized,
             // otherwise it penalizes the shift proportionally to the distance from the line containing the edge

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -301,8 +301,8 @@ struct [[nodiscard]] Mesh
 
     /// computes quadratic form in the vertex as the sum of squared distances from
     /// 1) planes of adjacent triangles
-    /// 2) lines of adjacent boundary edges
-    [[nodiscard]] MRMESH_API QuadraticForm3f quadraticForm( VertId v, const FaceBitSet * region = nullptr ) const;
+    /// 2) lines of adjacent boundary and crease edges
+    [[nodiscard]] MRMESH_API QuadraticForm3f quadraticForm( VertId v, const FaceBitSet * region = nullptr, const UndirectedEdgeBitSet * creases = nullptr ) const;
 
     /// passes through all valid vertices and finds the minimal bounding box containing all of them;
     /// if toWorld transformation is given then returns minimal bounding box in world space

--- a/source/MRMesh/MRMeshDecimate.cpp
+++ b/source/MRMesh/MRMeshDecimate.cpp
@@ -302,14 +302,14 @@ public:
     std::vector<QueueElement> elems_;
 };
 
-QuadraticForm3f computeFormAtVertex( const MR::MeshPart & mp, MR::VertId v, float stabilizer )
+QuadraticForm3f computeFormAtVertex( const MR::MeshPart & mp, MR::VertId v, float stabilizer, const UndirectedEdgeBitSet * creases )
 {
-    QuadraticForm3f qf = mp.mesh.quadraticForm( v, mp.region );
+    QuadraticForm3f qf = mp.mesh.quadraticForm( v, mp.region, creases );
     qf.addDistToOrigin( stabilizer );
     return qf;
 }
 
-Vector<QuadraticForm3f, VertId> computeFormsAtVertices( const MeshPart & mp, float stabilizer )
+Vector<QuadraticForm3f, VertId> computeFormsAtVertices( const MeshPart & mp, float stabilizer, const UndirectedEdgeBitSet * creases )
 {
     MR_TIMER;
 
@@ -319,7 +319,7 @@ Vector<QuadraticForm3f, VertId> computeFormsAtVertices( const MeshPart & mp, flo
     Vector<QuadraticForm3f, VertId> res( regionVertices.find_last() + 1 );
     BitSetParallelFor( regionVertices, [&]( VertId v )
     {
-        res[v] = computeFormAtVertex( mp, v, stabilizer );
+        res[v] = computeFormAtVertex( mp, v, stabilizer, creases );
     } );
 
     return res;
@@ -363,7 +363,7 @@ bool MeshDecimator::initializeQueue_()
         pVertForms_ = &myVertForms_;
 
     if ( pVertForms_->empty() )
-        *pVertForms_ = computeFormsAtVertices( MeshPart{ mesh_, settings_.region }, settings_.stabilizer );
+        *pVertForms_ = computeFormsAtVertices( MeshPart{ mesh_, settings_.region }, settings_.stabilizer, settings_.notFlippable );
 
     if ( settings_.progressCallback && !settings_.progressCallback( 0.1f ) )
         return false;
@@ -1033,7 +1033,7 @@ static DecimateResult decimateMeshParallelInplace( MR::Mesh & mesh, const Decima
     if ( settings.vertForms )
         mVertForms = std::move( *settings.vertForms );
     if ( mVertForms.empty() )
-        mVertForms = computeFormsAtVertices( MeshPart{ mesh, settings.region }, settings.stabilizer );
+        mVertForms = computeFormsAtVertices( MeshPart{ mesh, settings.region }, settings.stabilizer, settings.notFlippable );
     if ( settings.progressCallback && !settings.progressCallback( 0.2f ) )
         return res;
 

--- a/source/MRMesh/MRMeshDecimate.h
+++ b/source/MRMesh/MRMeshDecimate.h
@@ -193,13 +193,13 @@ MRMESH_API DecimateResult decimateMesh( Mesh & mesh, const DecimateSettings & se
  * \brief Computes quadratic form at given vertex of the initial surface before decimation
  * \ingroup DecimateGroup
  */
-[[nodiscard]] MRMESH_API QuadraticForm3f computeFormAtVertex( const MeshPart & mp, VertId v, float stabilizer );
+[[nodiscard]] MRMESH_API QuadraticForm3f computeFormAtVertex( const MeshPart & mp, VertId v, float stabilizer, const UndirectedEdgeBitSet * creases = nullptr );
 
 /**
  * \brief Computes quadratic forms at every vertex of mesh part before decimation
  * \ingroup DecimateGroup
  */
-[[nodiscard]] MRMESH_API Vector<QuadraticForm3f, VertId> computeFormsAtVertices( const MeshPart & mp, float stabilizer );
+[[nodiscard]] MRMESH_API Vector<QuadraticForm3f, VertId> computeFormsAtVertices( const MeshPart & mp, float stabilizer, const UndirectedEdgeBitSet * creases = nullptr );
 
 /**
  * \brief returns given subdivision part of all valid faces;


### PR DESCRIPTION
MeshDecimate now preserves not-flippable lines as much as possible while collapsing edges from them.