### PR TITLE
Optimize mesh on voxels correction, voxels interpolation fixes

### DIFF
--- a/source/MRMesh/MRMoveMeshToVoxelMaxDeriv.cpp
+++ b/source/MRMesh/MRMoveMeshToVoxelMaxDeriv.cpp
@@ -21,6 +21,15 @@ MeshOnVoxelsT<MeshType>::MeshOnVoxelsT( MeshType& mesh, const AffineXf3f& meshXf
     numVerts_( mesh_.topology.numValidVerts() )
 {}
 
+template <typename MeshType>
+MeshOnVoxelsT<MeshType>::MeshOnVoxelsT( const MeshOnVoxelsT& other ) :
+    mesh_( other.mesh_ ), volume_( other.volume_ ),
+    voxelSize_( other.voxelSize_ ),
+    accessor_( other.accessor_ ), interpolator_( volume_, accessor_ ), // Note: accessor copy is created here
+    xf_( other.xf_ ), xfInv_( other.xfInv_ ), xfNormal_( other.xfNormal_ ), noXf_( other.noXf_ ),
+    numVerts_( other.numVerts_ )
+{}
+
 
 template <typename MeshType>
 MeshType& MeshOnVoxelsT<MeshType>::mesh() const

--- a/source/MRMesh/MRMoveMeshToVoxelMaxDeriv.h
+++ b/source/MRMesh/MRMoveMeshToVoxelMaxDeriv.h
@@ -41,11 +41,13 @@ MRMESH_API VertBitSet moveMeshToVoxelMaxDeriv(
 
 
 // Helper class to organize mesh and voxels volume access and build point sequences
+// Note: this class is not thread-safe but accessing same volume from different instances is ok
 template <typename MeshType>
 class MeshOnVoxelsT
 {
 public:
     MRMESH_API MeshOnVoxelsT( MeshType& mesh, const AffineXf3f& meshXf, const VdbVolume& volume, const AffineXf3f& volumeXf );
+    MRMESH_API MeshOnVoxelsT( const MeshOnVoxelsT& other );
 
     // Access to base data
     MRMESH_API MeshType& mesh() const;


### PR DESCRIPTION
- Change `VoxelsVolumeInterpolatedAccessor` and `VoxelsVolumeInterpolatedAccessor` constructors to avoid non-thread-safe objects, add comments
- Parallelize and optimize moveMeshToVoxelMaxDeriv