### PR TITLE
MouseControlChecker plugin for camera and plugins confilcts

### DIFF
--- a/source/MRCommonPlugins/Basic/MRMouseControlChecker.cpp
+++ b/source/MRCommonPlugins/Basic/MRMouseControlChecker.cpp
@@ -1,4 +1,3 @@
-#include "exports.h"
 #include "MRViewer/MRViewerPlugin.h"
 #include "MRViewer/MRViewer.h"
 #include "MRViewer/MRRibbonMenu.h"

--- a/source/MRCommonPlugins/Basic/MRMouseControlChecker.cpp
+++ b/source/MRCommonPlugins/Basic/MRMouseControlChecker.cpp
@@ -26,10 +26,12 @@ private:
 void MouseControlChecker::init( Viewer* _viewer )
 {
     viewer = _viewer;
-    connection_ = viewer->pluginEnabledChangedSignal.connect( 0, [this] ( StateBasePlugin*, bool enabled )
-    {
-        pluginEnabledChanged_( enabled );
-    } );
+    RibbonMenu* menu = getViewerInstance().getMenuPluginAs<RibbonMenu>().get();
+    if ( menu )
+        connection_ = menu->pluginEnabledChangedSignal.connect( 0, [this] ( StateBasePlugin*, bool enabled )
+        {
+            pluginEnabledChanged_( enabled );
+        } );
 
     mouseDownConnections_ = viewer->mouseDownSignal.num_slots();
 }

--- a/source/MRCommonPlugins/Basic/MRMouseControlChecker.cpp
+++ b/source/MRCommonPlugins/Basic/MRMouseControlChecker.cpp
@@ -1,0 +1,77 @@
+#include "exports.h"
+#include "MRViewer/MRViewerPlugin.h"
+#include "MRViewer/MRViewer.h"
+#include "MRViewer/MRRibbonMenu.h"
+#include "MRViewer/MRMouseController.h"
+
+namespace MR
+{
+
+// Plugin that checks mouse usage conflicts between camera operations and current plugin
+class MouseControlChecker : public ViewerPlugin
+{
+public:
+    MouseControlChecker()
+    {}
+    virtual void init( Viewer* _viewer ) override;
+    virtual void shutdown() override;
+
+private:
+    boost::signals2::connection connection_;
+    size_t mouseDownConnections_{};
+
+    bool checkUseLeftButton_();
+    void pluginEnabledChanged_( bool enabled );
+};
+
+void MouseControlChecker::init( Viewer* _viewer )
+{
+    viewer = _viewer;
+    connection_ = viewer->pluginEnabledChangedSignal.connect( 0, [this] ( StateBasePlugin*, bool enabled )
+    {
+        pluginEnabledChanged_( enabled );
+    } );
+
+    mouseDownConnections_ = viewer->mouseDownSignal.num_slots();
+}
+void MouseControlChecker::shutdown()
+{
+    connection_.disconnect();
+}
+
+bool MouseControlChecker::checkUseLeftButton_()
+{
+    // Check if camera movement is set to use left mouse button, regardless of modifiers
+    for ( int i = 0; i < int( MouseMode::Count ); ++i )
+    {
+        MouseMode mode = MouseMode( i );
+        if ( mode == MouseMode::None )
+            continue;
+        auto ctrl = viewer->mouseController().findControlByMode( mode );
+        if ( ctrl && ctrl->btn == MouseButton::Left )
+            return true;
+    }
+    return false;
+}
+
+void MouseControlChecker::pluginEnabledChanged_( bool enabled )
+{
+    size_t connections = viewer->mouseDownSignal.num_slots();
+    if ( enabled &&
+         connections > mouseDownConnections_ &&
+         checkUseLeftButton_() )
+    {
+        RibbonMenu* menu = viewer->getMenuPluginAs<RibbonMenu>().get();
+        if ( menu )
+            menu->pushNotification( {
+                .text = "Camera operations that are controlled by left mouse button "
+                        "may not work while this tool is active",
+                .lifeTimeSec = 3.0f
+            } );
+    }
+    mouseDownConnections_ = connections;
+}
+
+MRVIEWER_PLUGIN_REGISTRATION( MouseControlChecker )
+
+}

--- a/source/MRCommonPlugins/MRCommonPlugins.vcxproj
+++ b/source/MRCommonPlugins/MRCommonPlugins.vcxproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Basic\MRCameraOrientationPlugin.cpp" />
+    <ClCompile Include="Basic\MRMouseControlChecker.cpp" />
     <ClCompile Include="Basic\MRMoveObjectByMouse.cpp" />
     <ClCompile Include="Basic\MRShowGlobalBasis.cpp" />
     <ClCompile Include="Selectors\MRSelectObjectByClick.cpp" />

--- a/source/MRCommonPlugins/MRCommonPlugins.vcxproj.filters
+++ b/source/MRCommonPlugins/MRCommonPlugins.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="Basic\MRShowGlobalBasis.cpp">
       <Filter>Basic</Filter>
     </ClCompile>
+    <ClCompile Include="Basic\MRMouseControlChecker.cpp">
+      <Filter>Basic</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="exports.h" />

--- a/source/MRViewer/MRRibbonMenu.h
+++ b/source/MRViewer/MRRibbonMenu.h
@@ -88,6 +88,10 @@ public:
     /// updates status of item if it was changed outside of menu
     MRVIEWER_API void updateItemStatus( const std::string& itemName );
 
+    using PluginEnabledChangedSignal = boost::signals2::signal<void( StateBasePlugin*, bool )>;
+    /// this signal is called when a plugin gets enabled or disabled
+    PluginEnabledChangedSignal pluginEnabledChangedSignal;
+
     /// returns index of active tab in RibbonSchemaHolder::schema().tabsOrder
     int getActiveTabIndex() const { return activeTabIndex_; }
 

--- a/source/MRViewer/MRStatePlugin.cpp
+++ b/source/MRViewer/MRStatePlugin.cpp
@@ -84,6 +84,11 @@ bool StateBasePlugin::enable( bool on )
     }
     if ( res )
     {
+        // Need to make sure initialization is finished when signal is emitted
+        CommandLoop::appendCommand( [this] ()
+        {
+            viewer->pluginEnabledChangedSignal( this, isEnabled_ );
+        } );
         auto ribbonMenu = getViewerInstance().getMenuPluginAs<RibbonMenu>();
         if ( ribbonMenu )
             ribbonMenu->updateItemStatus( name() );

--- a/source/MRViewer/MRStatePlugin.cpp
+++ b/source/MRViewer/MRStatePlugin.cpp
@@ -84,14 +84,16 @@ bool StateBasePlugin::enable( bool on )
     }
     if ( res )
     {
-        // Need to make sure initialization is finished when signal is emitted
-        CommandLoop::appendCommand( [this] ()
-        {
-            viewer->pluginEnabledChangedSignal( this, isEnabled_ );
-        } );
         auto ribbonMenu = getViewerInstance().getMenuPluginAs<RibbonMenu>();
         if ( ribbonMenu )
+        {
             ribbonMenu->updateItemStatus( name() );
+            // Need to make sure initialization is finished when signal is emitted
+            CommandLoop::appendCommand( [this, ribbonMenu = ribbonMenu.get()] ()
+            {
+                ribbonMenu->pluginEnabledChangedSignal( this, isEnabled_ );
+            } );
+        }
     }
     return res;
 }

--- a/source/MRViewer/MRViewer.h
+++ b/source/MRViewer/MRViewer.h
@@ -532,6 +532,9 @@ public:
     // Window focus signal
     using PostFocusSignal = boost::signals2::signal<void( bool )>;
     PostFocusSignal postFocusSignal;
+    // Plugin enabled/disabled signal
+    using PluginEnabledChangedSignal = boost::signals2::signal<void( StateBasePlugin *, bool )>;
+    PluginEnabledChangedSignal pluginEnabledChangedSignal;
 
     /// emplace event at the end of the queue
     /// replace last skipable with new skipable

--- a/source/MRViewer/MRViewer.h
+++ b/source/MRViewer/MRViewer.h
@@ -532,9 +532,6 @@ public:
     // Window focus signal
     using PostFocusSignal = boost::signals2::signal<void( bool )>;
     PostFocusSignal postFocusSignal;
-    // Plugin enabled/disabled signal
-    using PluginEnabledChangedSignal = boost::signals2::signal<void( StateBasePlugin *, bool )>;
-    PluginEnabledChangedSignal pluginEnabledChangedSignal;
 
     /// emplace event at the end of the queue
     /// replace last skipable with new skipable


### PR DESCRIPTION
If left mouse button is configured to perform any camera operation
![image](https://github.com/user-attachments/assets/3736ded7-83ef-4cf5-b1b5-e07a4689ab88)

When a plugin is opened that accepts mouse operations on viewport, a warning is shown
![image](https://github.com/user-attachments/assets/bba9b9bb-b153-4f2d-92ac-41e133bc563a)

