### PR TITLE
Show message on camera/plugins conflict

### DIFF
--- a/source/MRViewer/MRMouseController.cpp
+++ b/source/MRViewer/MRMouseController.cpp
@@ -114,11 +114,32 @@ void MouseController::connect()
     viewer.mouseMoveSignal.connect( MAKE_SLOT( &MouseController::preMouseMove_ ), boost::signals2::at_front );
     viewer.mouseScrollSignal.connect( MAKE_SLOT( &MouseController::mouseScroll_ ) );
     viewer.cursorEntranceSignal.connect( MAKE_SLOT( &MouseController::cursorEntrance_ ) );
+
+    connectionsCounter_ = viewer.mouseDownSignal.num_slots();
 }
 
 void MouseController::cursorEntrance_( bool entered )
 {
     isCursorInside_ = entered;
+}
+
+bool MouseController::checkConflicts()
+{
+    // Check for new connections
+    size_t connectionsCounter = getViewerInstance().mouseDownSignal.num_slots();
+    bool newConnections = connectionsCounter > connectionsCounter_;
+    connectionsCounter_ = connectionsCounter;
+    if ( !newConnections )
+        return false;
+    // Check if camera movement is set to use left mouse button, regardless of modifiers
+    bool usesLeftButton = false;
+    for ( auto& [mode, key] : backMap_ )
+        if ( keyToMouseAndMod( key ).btn == MouseButton::Left )
+        {
+            usesLeftButton = true;
+            break;
+        }
+    return usesLeftButton;
 }
 
 bool MouseController::preMouseDown_( MouseButton btn, int )

--- a/source/MRViewer/MRMouseController.h
+++ b/source/MRViewer/MRMouseController.h
@@ -65,6 +65,11 @@ public:
     
     // set callback to modify new field of view before it is applied to viewport
     void setFOVModifierCb( std::function<void( float& )> cb ) { fovModifierCb_ = cb; }
+
+    // check if newly opened plugin (since last call) can conflict with the camera controls:
+    // camera controls use LMB and current plugin listens for mouse events
+    bool checkConflicts();
+
 private:
     bool preMouseDown_( MouseButton button, int modifier );
     bool mouseDown_( MouseButton button, int modifier );
@@ -97,6 +102,8 @@ private:
 
     std::function<void( AffineXf3f& )> transformModifierCb_;
     std::function<void( float& )> fovModifierCb_;
+
+    size_t connectionsCounter_{}; // for checkConflicts()
 };
 
 }


### PR DESCRIPTION
[#4456](https://github.com/MeshInspector/MeshInspectorCode/issues/4456)

If left mouse button is configured to perform any camera operation
![image](https://github.com/user-attachments/assets/3736ded7-83ef-4cf5-b1b5-e07a4689ab88)

When a plugin is opened that accepts mouse operations on viewport, a warning is shown
![image](https://github.com/user-attachments/assets/bba9b9bb-b153-4f2d-92ac-41e133bc563a)

