### PR TITLE
Use Alt modifier for camera control

### DIFF
--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
@@ -63,6 +63,8 @@ void MoveObjectByMouse::drawDialog( float menuScaling, ImGuiContext*)
 
 bool MoveObjectByMouse::onMouseDown_( MouseButton btn, int modifiers )
 {
+    if ( ( modifiers & ~( GLFW_MOD_SHIFT | GLFW_MOD_CONTROL ) ) != 0 )
+        return false;
     return moveByMouse_.onMouseDown( btn, modifiers );
 }
 

--- a/source/MRViewer/MRMouseController.cpp
+++ b/source/MRViewer/MRMouseController.cpp
@@ -164,6 +164,8 @@ bool MouseController::mouseDown_( MouseButton btn, int mod )
 
     auto modIt = map_.find( mouseAndModToKey( { btn,mod } ) );
     if ( modIt == map_.end() )
+        modIt = map_.find( mouseAndModToKey( { btn,mod & ~GLFW_MOD_ALT } ) );
+    if ( modIt == map_.end() )
         return false;
 
     currentMode_ = modIt->second;

--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -1403,7 +1403,8 @@ void RibbonMenu::itemPressed_( const std::shared_ptr<RibbonMenuItem>& item, bool
     if ( stateChanged && !wasActive && hasConflicts )
         pushNotification( {
             .text = "Camera operations that are controlled by left mouse button "
-                        "may not work while this tool is active",
+                    "may not work while this tool is active\n"
+                    "Hold Alt additionally to control camera",
             .type = NotificationType::Info,
             .lifeTimeSec = 3.0f } );
 


### PR DESCRIPTION
- Camera controls can be also used with the Alt modifier
![image](https://github.com/user-attachments/assets/3dc59495-fc64-4793-ac15-0875662d51e0)
- Fix modifiers usage in Move Object (addition to https://github.com/MeshInspector/MeshInspectorCode/issues/4520 )