### PR TITLE
Add mouseClick signal

### DIFF
--- a/source/MRViewer/MRMouseController.cpp
+++ b/source/MRViewer/MRMouseController.cpp
@@ -31,6 +31,10 @@ EMSCRIPTEN_KEEPALIVE void emsDropEvents()
 namespace MR
 {
 
+// Maximum delay and offset for mouseClick
+static constexpr long long cMouseClickNs = 300'000'000; // 0.3s
+static constexpr int cMouseClickDist = 5;
+
 void MouseController::setMouseControl( const MouseControlKey& key, MouseMode mode )
 {
     auto newMapKey = mouseAndModToKey( key );
@@ -141,11 +145,20 @@ bool MouseController::checkConflicts()
     return usesLeftButton;
 }
 
-bool MouseController::preMouseDown_( MouseButton btn, int )
+bool MouseController::preMouseDown_( MouseButton btn, int mod )
 {
     resetAllIfNeeded_();
     if ( !downState_.any() )
         downMousePos_ = currentMousePos_;
+
+    // Click behavior is enabled only if it has listeners
+    if ( getViewerInstance().mouseClickSignal.num_slots() > 0 )
+    {
+        clickButton_ = btn; // Support click by one button only
+        clickPendingDown_ = NoButton;
+        clickModifiers_ = mod;
+        clickTime_ = std::chrono::steady_clock::now();
+    }
 
     downState_.set( int( btn ) );
     return false;
@@ -158,6 +171,13 @@ bool MouseController::mouseDown_( MouseButton btn, int mod )
 
     if ( downState_.count() > 1 )
         return false;
+
+    if ( clickButton_ != NoButton )
+    {
+        // Mouse down pending to be handled if mouse is actually moved
+        clickPendingDown_ = btn;
+        return false;
+    }
 
     auto& viewer = getViewerInstance();
     viewer.select_hovered_viewport();
@@ -176,9 +196,17 @@ bool MouseController::mouseDown_( MouseButton btn, int mod )
     return true;
 }
 
-bool MouseController::preMouseUp_( MouseButton btn, int )
+bool MouseController::preMouseUp_( MouseButton btn, int mod )
 {
     downState_.set( int( btn ), false );
+
+    if ( clickButton_ == btn )
+    {
+        if ( ( std::chrono::steady_clock::now() - clickTime_ ).count() < cMouseClickNs )
+            getViewerInstance().mouseClick( btn, mod );
+    }
+    clickButton_ = NoButton;
+
     if ( currentMode_ == MouseMode::None )
         return false;
 
@@ -196,8 +224,25 @@ bool MouseController::preMouseUp_( MouseButton btn, int )
     return false; // so others can override mouse up even if scene control was active
 }
 
-bool MouseController::preMouseMove_( int x, int y)
+bool MouseController::preMouseMove_( int x, int y )
 {
+    if ( clickButton_ != NoButton )
+    {
+        if ( std::abs( x - downMousePos_.x ) + std::abs( y - downMousePos_.y ) > cMouseClickDist ||
+             ( std::chrono::steady_clock::now() - clickTime_ ).count() > cMouseClickNs )
+        {
+            MouseButton btn = clickButton_;
+            clickButton_ = NoButton;
+            // Moved the mouse far/long enough - replay mouse down in original position
+            currentMousePos_ = downMousePos_;
+            if ( clickPendingDown_ == btn )
+                mouseDown_( btn, clickModifiers_ );
+            // Continue handling mouse move as if it was a single event from downMousePos_
+        }
+    }
+    if ( clickButton_ != NoButton )
+        return false;
+
     prevMousePos_ = currentMousePos_;
     currentMousePos_ = { x,y };
 

--- a/source/MRViewer/MRMouseController.h
+++ b/source/MRViewer/MRMouseController.h
@@ -94,6 +94,13 @@ private:
     BitSet downState_;
     MouseMode currentMode_{ MouseMode::None };
 
+    // Variables related to mouseClick signal
+    MouseButton clickButton_{ NoButton };
+    MouseButton clickPendingDown_{ NoButton };
+    int clickModifiers_{};
+    std::chrono::steady_clock::time_point clickTime_{};
+    static constexpr MouseButton NoButton = MouseButton::Count;
+
     using MouseModeMap = HashMap<int, MouseMode>;
     using MouseModeBackMap = HashMap<MouseMode, int>;
 

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -962,6 +962,7 @@ void Viewer::launchShut()
     mouseUpSignal = {};
     mouseMoveSignal = {};
     mouseScrollSignal = {};
+    mouseClickSignal = {};
     cursorEntranceSignal = {};
     charPressedSignal = {};
     keyUpSignal = {};
@@ -1418,6 +1419,11 @@ bool Viewer::mouseScroll( float delta_y )
         return true;
 
     return true;
+}
+
+bool Viewer::mouseClick( MouseButton button, int modifier )
+{
+    return mouseClickSignal( button, modifier );
 }
 
 bool Viewer::spaceMouseMove( const Vector3f& translate, const Vector3f& rotate )

--- a/source/MRViewer/MRViewer.h
+++ b/source/MRViewer/MRViewer.h
@@ -138,6 +138,7 @@ public:
     MRVIEWER_API bool mouseUp( MouseButton button, int modifier );
     MRVIEWER_API bool mouseMove( int mouse_x, int mouse_y );
     MRVIEWER_API bool mouseScroll( float delta_y );
+    MRVIEWER_API bool mouseClick( MouseButton button, int modifier );
     MRVIEWER_API bool spaceMouseMove( const Vector3f& translate, const Vector3f& rotate );
     MRVIEWER_API bool spaceMouseDown( int key );
     MRVIEWER_API bool spaceMouseUp( int key );
@@ -480,6 +481,7 @@ public:
     MouseUpDownSignal mouseUpSignal; // signal is called on mouse up
     MouseMoveSignal mouseMoveSignal; // signal is called on mouse move, note that input x and y are in screen space
     MouseScrollSignal mouseScrollSignal; // signal is called on mouse is scrolled
+    MouseUpDownSignal mouseClickSignal; // signal is called when mouse button is pressed and immediately released
     // Cursor enters/leaves
     using CursorEntranceSignal = boost::signals2::signal<void(bool)>;
     CursorEntranceSignal cursorEntranceSignal;

--- a/source/MRViewer/MRViewerEventsListener.cpp
+++ b/source/MRViewer/MRViewerEventsListener.cpp
@@ -32,6 +32,13 @@ void MouseScrollListener::connect( Viewer* viewer, int group, boost::signals2::c
     connection_ = viewer->mouseScrollSignal.connect( group, MAKE_SLOT( &MouseScrollListener::onMouseScroll_ ), pos );
 }
 
+void MouseClickListener::connect( Viewer* viewer, int group, boost::signals2::connect_position pos )
+{
+    if ( !viewer )
+        return;
+    connection_ = viewer->mouseClickSignal.connect( group, MAKE_SLOT( &MouseClickListener::onMouseClick_ ), pos );
+}
+
 void CharPressedListener::connect( Viewer* viewer, int group, boost::signals2::connect_position pos )
 {
     if ( !viewer )

--- a/source/MRViewer/MRViewerEventsListener.h
+++ b/source/MRViewer/MRViewerEventsListener.h
@@ -83,6 +83,15 @@ protected:
     virtual bool onMouseScroll_( float delta ) = 0;
 };
 
+struct MRVIEWER_CLASS MouseClickListener : ConnectionHolder
+{
+    MR_ADD_CTOR_DELETE_MOVE( MouseClickListener );
+    virtual ~MouseClickListener() = default;
+    MRVIEWER_API virtual void connect( Viewer* viewer, int group, boost::signals2::connect_position pos ) override;
+protected:
+    virtual bool onMouseClick_( MouseButton btn, int modifiers ) = 0;
+};
+
 struct MRVIEWER_CLASS CharPressedListener : ConnectionHolder
 {
     MR_ADD_CTOR_DELETE_MOVE( CharPressedListener );


### PR DESCRIPTION
A new signal is ``mouseClickSignal`` is added to the ``Viewer``. It is emitted if a mouse button is pressed then immediately released.
Camera control is deferred a little to distinguish between clicks and click-and-drag operations. But this behavior is enabled only if clicks are expected by a current tool (i.e. ``mouseClickSignal`` has connections).