### PR TITLE
Add mouse drag signals

### DIFF
--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
@@ -61,20 +61,20 @@ void MoveObjectByMouse::drawDialog( float menuScaling, ImGuiContext*)
     ImGui::EndCustomStatePlugin();
 }
 
-bool MoveObjectByMouse::onMouseDown_( MouseButton btn, int modifiers )
+bool MoveObjectByMouse::onDragStart_( MouseButton btn, int modifiers )
 {
     if ( ( modifiers & ~( GLFW_MOD_SHIFT | GLFW_MOD_CONTROL ) ) != 0 )
         return false;
     return moveByMouse_.onMouseDown( btn, modifiers );
 }
 
-bool MoveObjectByMouse::onMouseMove_( int x, int y )
+bool MoveObjectByMouse::onDrag_( int x, int y )
 {
     viewer->select_hovered_viewport();
     return moveByMouse_.onMouseMove( x, y );
 }
 
-bool MoveObjectByMouse::onMouseUp_( MouseButton btn, int modifiers )
+bool MoveObjectByMouse::onDragEnd_( MouseButton btn, int modifiers )
 {
     return moveByMouse_.onMouseUp( btn, modifiers );
 }

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
@@ -11,7 +11,7 @@ namespace MR
 
 class Object;
 
-class MoveObjectByMouse : public StateListenerPlugin<MouseDownListener, MouseMoveListener, MouseUpListener>
+class MoveObjectByMouse : public StateListenerPlugin<DragStartListener, DragListener, DragEndListener>
 {
 public:
     MoveObjectByMouse();
@@ -25,9 +25,9 @@ public:
     virtual bool blocking() const override { return false; };
 
 private:
-    virtual bool onMouseDown_( MouseButton btn, int modifiers ) override;
-    virtual bool onMouseMove_( int x, int y ) override;
-    virtual bool onMouseUp_( MouseButton btn, int modifiers ) override;
+    virtual bool onDragStart_( MouseButton btn, int modifiers ) override;
+    virtual bool onDrag_( int x, int y ) override;
+    virtual bool onDragEnd_( MouseButton btn, int modifiers ) override;
 
     class MoveObjectByMouseWithSelected : public MoveObjectByMouseImpl
     {

--- a/source/MRViewer/MRMouseController.h
+++ b/source/MRViewer/MRMouseController.h
@@ -96,10 +96,12 @@ private:
     MouseMode currentMode_{ MouseMode::None };
 
     // Variables related to mouseClick signal
-    MouseButton clickButton_{ MouseButton::NoButton }; // Current candidate for mouseClick
-    int clickModifiers_{}; // Modifiers state at the moment of button press
-    Time clickTime_{}; // Time point of button press
+    MouseButton clickButton_{ MouseButton::NoButton };  // Current candidate for mouseClick
+    int clickModifiers_{};                              // Modifiers state at the moment of button press
+    Time clickTime_{};                                  // Time point of button press
     MouseButton clickPendingDown_{ MouseButton::NoButton }; // Button for deterred camera operation
+    MouseButton dragButton_{ MouseButton::NoButton };   // Current candidate for dragging
+    bool dragActive_{};                                 // Dragging currently active
 
     using MouseModeMap = HashMap<int, MouseMode>;
     using MouseModeBackMap = HashMap<MouseMode, int>;

--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -27,7 +27,7 @@ public:
     /// Should be called from `drawDialog`
     MRVIEWER_API void onDrawDialog( float menuScaling ) const;
 
-    /// These functions should be called from corresponding mouse handlers
+    /// These functions should be called from corresponding mouse handlers (or better drag handlers)
     /// Return true if handled (picked/moved/released)
     /// It is recommended to call `viewer->select_hovered_viewport()` before `onMouseDown`
     /// The object is transformed temporarily in `onMouseMove`

--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -27,7 +27,8 @@ public:
     /// Should be called from `drawDialog`
     MRVIEWER_API void onDrawDialog( float menuScaling ) const;
 
-    /// These functions should be called from corresponding mouse handlers (or better drag handlers)
+    /// These functions should be called from corresponding mouse handlers
+    /// Or mouse drag handlers, making it work together with mouseClick signal
     /// Return true if handled (picked/moved/released)
     /// It is recommended to call `viewer->select_hovered_viewport()` before `onMouseDown`
     /// The object is transformed temporarily in `onMouseMove`

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -963,6 +963,9 @@ void Viewer::launchShut()
     mouseMoveSignal = {};
     mouseScrollSignal = {};
     mouseClickSignal = {};
+    dragStartSignal = {};
+    dragEndSignal = {};
+    dragSignal = {};
     cursorEntranceSignal = {};
     charPressedSignal = {};
     keyUpSignal = {};
@@ -1424,6 +1427,21 @@ bool Viewer::mouseScroll( float delta_y )
 bool Viewer::mouseClick( MouseButton button, int modifier )
 {
     return mouseClickSignal( button, modifier );
+}
+
+bool Viewer::dragStart( MouseButton button, int modifier )
+{
+    return dragStartSignal( button, modifier );
+}
+
+bool Viewer::dragEnd( MouseButton button, int modifier )
+{
+    return dragEndSignal( button, modifier );
+}
+
+bool Viewer::drag( int mouse_x, int mouse_y )
+{
+    return dragSignal( mouse_x, mouse_y );
 }
 
 bool Viewer::spaceMouseMove( const Vector3f& translate, const Vector3f& rotate )

--- a/source/MRViewer/MRViewer.h
+++ b/source/MRViewer/MRViewer.h
@@ -139,6 +139,9 @@ public:
     MRVIEWER_API bool mouseMove( int mouse_x, int mouse_y );
     MRVIEWER_API bool mouseScroll( float delta_y );
     MRVIEWER_API bool mouseClick( MouseButton button, int modifier );
+    MRVIEWER_API bool dragStart( MouseButton button, int modifier );
+    MRVIEWER_API bool dragEnd( MouseButton button, int modifier );
+    MRVIEWER_API bool drag( int mouse_x, int mouse_y );
     MRVIEWER_API bool spaceMouseMove( const Vector3f& translate, const Vector3f& rotate );
     MRVIEWER_API bool spaceMouseDown( int key );
     MRVIEWER_API bool spaceMouseUp( int key );
@@ -481,9 +484,15 @@ public:
     MouseUpDownSignal mouseUpSignal; // signal is called on mouse up
     MouseMoveSignal mouseMoveSignal; // signal is called on mouse move, note that input x and y are in screen space
     MouseScrollSignal mouseScrollSignal; // signal is called on mouse is scrolled
-    // High-level mouse event, emitted by MouseController
-    // When mouseClickSignal has connections, a small delay for click detection is introduced into camera operations
+    // High-level mouse events for clicks and dragging, emitted by MouseController
+    // When mouseClickSignal has connections, a small delay for click detection is introduced into camera operations and dragging
+    // Dragging starts if dragStartSignal is handled (returns true), and ends on button release
+    // When dragging is active, dragSignal and dragEndSignal are emitted instead of mouseMove and mouseUp
+    // mouseDown handler have priority over dragStart
     MouseUpDownSignal mouseClickSignal; // signal is called when mouse button is pressed and immediately released
+    MouseUpDownSignal dragStartSignal; // signal is called when mouse button is pressed (deterred if click behavior is on)
+    MouseUpDownSignal dragEndSignal; // signal is called when mouse button used to start drag is released
+    MouseMoveSignal dragSignal; // signal is called when mouse is being dragged with button down
     // Cursor enters/leaves
     using CursorEntranceSignal = boost::signals2::signal<void(bool)>;
     CursorEntranceSignal cursorEntranceSignal;

--- a/source/MRViewer/MRViewerEventsListener.cpp
+++ b/source/MRViewer/MRViewerEventsListener.cpp
@@ -39,6 +39,27 @@ void MouseClickListener::connect( Viewer* viewer, int group, boost::signals2::co
     connection_ = viewer->mouseClickSignal.connect( group, MAKE_SLOT( &MouseClickListener::onMouseClick_ ), pos );
 }
 
+void DragStartListener::connect( Viewer* viewer, int group, boost::signals2::connect_position pos )
+{
+    if ( !viewer )
+        return;
+    connection_ = viewer->dragStartSignal.connect( group, MAKE_SLOT( &DragStartListener::onDragStart_ ), pos );
+}
+
+void DragEndListener::connect( Viewer* viewer, int group, boost::signals2::connect_position pos )
+{
+    if ( !viewer )
+        return;
+    connection_ = viewer->dragEndSignal.connect( group, MAKE_SLOT( &DragEndListener::onDragEnd_ ), pos );
+}
+
+void DragListener::connect( Viewer* viewer, int group, boost::signals2::connect_position pos )
+{
+    if ( !viewer )
+        return;
+    connection_ = viewer->dragSignal.connect( group, MAKE_SLOT( &DragListener::onDrag_ ), pos );
+}
+
 void CharPressedListener::connect( Viewer* viewer, int group, boost::signals2::connect_position pos )
 {
     if ( !viewer )

--- a/source/MRViewer/MRViewerEventsListener.h
+++ b/source/MRViewer/MRViewerEventsListener.h
@@ -92,6 +92,33 @@ protected:
     virtual bool onMouseClick_( MouseButton btn, int modifiers ) = 0;
 };
 
+struct MRVIEWER_CLASS DragStartListener : ConnectionHolder
+{
+    MR_ADD_CTOR_DELETE_MOVE( DragStartListener );
+    virtual ~DragStartListener() = default;
+    MRVIEWER_API virtual void connect( Viewer* viewer, int group, boost::signals2::connect_position pos ) override;
+protected:
+    virtual bool onDragStart_( MouseButton btn, int modifiers ) = 0;
+};
+
+struct MRVIEWER_CLASS DragEndListener : ConnectionHolder
+{
+    MR_ADD_CTOR_DELETE_MOVE( DragEndListener );
+    virtual ~DragEndListener() = default;
+    MRVIEWER_API virtual void connect( Viewer* viewer, int group, boost::signals2::connect_position pos ) override;
+protected:
+    virtual bool onDragEnd_( MouseButton btn, int modifiers ) = 0;
+};
+
+struct MRVIEWER_CLASS DragListener : ConnectionHolder
+{
+    MR_ADD_CTOR_DELETE_MOVE( DragListener );
+    virtual ~DragListener() = default;
+    MRVIEWER_API virtual void connect( Viewer* viewer, int group, boost::signals2::connect_position pos ) override;
+protected:
+    virtual bool onDrag_( int x, int y ) = 0;
+};
+
 struct MRVIEWER_CLASS CharPressedListener : ConnectionHolder
 {
     MR_ADD_CTOR_DELETE_MOVE( CharPressedListener );


### PR DESCRIPTION
https://github.com/MeshInspector/MeshInspectorCode/issues/4635

Three new signals are added:
- `dragStart( MouseButton button, int modifier )`
- `drag( int mouse_x, int mouse_y )`
- `dragEnd( MouseButton button, int modifier )`

  - `dragStart` is called when a mouse button is pressed (only if `mouseDown` has not been accepted).
  - If `dragStart` has been accepted, `drag` and `dragEnd` are subsequently called instead of `mouseMove` and `mouseUp`.
  - `dragStart` can be deferred if `mouseClick` behavior is active.

This can simplify creation of user-friendly plugins, allowing to:
- Reduce conflicts of plugin functions and camera controls
- Create plugins that accept both clicks and press-and-drag operations
- Simultaneous function of plugins that use different type of operations

Existing plugins can be refactored to utilize new signals, often by just changing the handlers:
- `mouseDown` to `mouseClick`
- `mouseDown`, `mouseMove`, `mouseUp` to `dragStart`, `drag`, `dragEnd`  

Move Object plugin now uses drag signals.