### PR TITLE
Fix mouse conflict warnings

### DIFF
--- a/source/MRViewer/MRMouseController.cpp
+++ b/source/MRViewer/MRMouseController.cpp
@@ -131,7 +131,9 @@ int MouseController::getMouseConflicts()
     for ( auto& [mode, key] : backMap_ )
         if ( keyToMouseAndMod( key ).btn == MouseButton::Left )
             // Return relevant connections number
-            return int( getViewerInstance().mouseDownSignal.num_slots() );
+            return
+                int( getViewerInstance().mouseDownSignal.num_slots() ) +
+                int( getViewerInstance().dragStartSignal.num_slots() );
     return 0;
 }
 

--- a/source/MRViewer/MRMouseController.cpp
+++ b/source/MRViewer/MRMouseController.cpp
@@ -125,24 +125,14 @@ void MouseController::cursorEntrance_( bool entered )
     isCursorInside_ = entered;
 }
 
-void MouseController::preCheckConflicts()
+int MouseController::getMouseConflicts()
 {
-    connectionsCounter_ = getViewerInstance().mouseDownSignal.num_slots();
-}
-bool MouseController::checkConflicts()
-{
-    // Check for new connections
-    if ( getViewerInstance().mouseDownSignal.num_slots() <= connectionsCounter_ )
-        return false;
     // Check if camera movement is set to use left mouse button, regardless of modifiers
-    bool usesLeftButton = false;
     for ( auto& [mode, key] : backMap_ )
         if ( keyToMouseAndMod( key ).btn == MouseButton::Left )
-        {
-            usesLeftButton = true;
-            break;
-        }
-    return usesLeftButton;
+            // Return relevant connections number
+            return int( getViewerInstance().mouseDownSignal.num_slots() );
+    return 0;
 }
 
 bool MouseController::preMouseDown_( MouseButton btn, int mod )

--- a/source/MRViewer/MRMouseController.h
+++ b/source/MRViewer/MRMouseController.h
@@ -67,11 +67,9 @@ public:
     // set callback to modify new field of view before it is applied to viewport
     void setFOVModifierCb( std::function<void( float& )> cb ) { fovModifierCb_ = cb; }
 
-    // check if an opened plugin can conflict with the camera controls:
-    // camera controls use LMB and current plugin listens for mouse events
-    // call preCheckConflicts() before plugin activation and checkConflicts() after
-    void preCheckConflicts();
-    bool checkConflicts();
+    // get number of potential conflicts between opened plugins and camera controls
+    // plugin is conflicting if it listens for mouseDown events, and camera control uses LMB
+    int getMouseConflicts();
 
 private:
     bool preMouseDown_( MouseButton button, int modifier );
@@ -113,8 +111,6 @@ private:
 
     std::function<void( AffineXf3f& )> transformModifierCb_;
     std::function<void( float& )> fovModifierCb_;
-
-    size_t connectionsCounter_{}; // for checkConflicts()
 };
 
 }

--- a/source/MRViewer/MRMouseController.h
+++ b/source/MRViewer/MRMouseController.h
@@ -68,7 +68,7 @@ public:
     void setFOVModifierCb( std::function<void( float& )> cb ) { fovModifierCb_ = cb; }
 
     // get number of potential conflicts between opened plugins and camera controls
-    // plugin is conflicting if it listens for mouseDown events, and camera control uses LMB
+    // plugin is conflicting if it listens for mouseDown or dragStart events, and camera control uses LMB
     int getMouseConflicts();
 
 private:

--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -1392,9 +1392,9 @@ void RibbonMenu::itemPressed_( const std::shared_ptr<RibbonMenuItem>& item, bool
     if ( !wasActive && !available )
         return;
     ImGui::CloseCurrentPopup();
-    getViewerInstance().mouseController().preCheckConflicts();
+    int conflicts = getViewerInstance().mouseController().getMouseConflicts();
     bool stateChanged = item->action();
-    bool hasConflicts = getViewerInstance().mouseController().checkConflicts();
+    bool hasConflicts = getViewerInstance().mouseController().getMouseConflicts() > conflicts;
     if ( !stateChanged )
         spdlog::info( "Action item: \"{}\"", name );
     else


### PR DESCRIPTION
MIC#4635
- Also show mouse conflict warning if a plugin listens for `dragStart`
- Refactor for clarity
 
![image](https://github.com/user-attachments/assets/33c20e22-1204-4481-941a-27ca392ad3d9)
