### PR TITLE
Radio buttons controlled by modifier keys

### DIFF
--- a/source/MRViewer/MRUIStyle.cpp
+++ b/source/MRViewer/MRUIStyle.cpp
@@ -878,7 +878,7 @@ bool radioButtonOrFixedValue( const char* label, int* value, int valButton, std:
     return false;
 }
 
-MRVIEWER_API bool radioButtonOrModifier( const char* label, RadioButtonOrModifierState& value, int valButton, int modifiers, int checkedModifiers, std::optional<int> valueOverride )
+bool radioButtonOrModifier( const char* label, RadioButtonOrModifierState& value, int valButton, int modifiers, int checkedModifiers, std::optional<int> valueOverride )
 {
     // See `checkboxOrModifier` for detailed comments
     if ( checkedModifiers == -1 )

--- a/source/MRViewer/MRUIStyle.cpp
+++ b/source/MRViewer/MRUIStyle.cpp
@@ -815,7 +815,7 @@ bool radioButton( const char* label, int* value, int valButton )
         const ImVec2 pos = window->DC.CursorPos;
         const ImRect check_bb( pos, ImVec2( pos.x + clickSize, pos.y + clickSize ) );
         const ImRect total_bb( pos, ImVec2( pos.x + clickSize + ( label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f ), pos.y + label_size.y + style.FramePadding.y * 2.0f ) );
-        ImGui::ItemSize( total_bb, style.FramePadding.y );
+        ImGui::ItemSize( total_bb, std::ceil( ( clickSize - label_size.y ) * 0.5f ) );
         if ( !ImGui::ItemAdd( total_bb, id ) )
             return false;
 

--- a/source/MRViewer/MRUIStyle.cpp
+++ b/source/MRViewer/MRUIStyle.cpp
@@ -907,9 +907,6 @@ MRVIEWER_API bool radioButtonOrModifier( const char* label, RadioButtonOrModifie
     if ( modActivated )
         detail::markItemEdited( ImGui::GetID( label ) );
 
-    if ( buttonActivated || modActivated )
-        spdlog::info( "Activated {}", valButton );
-
     return buttonActivated || modActivated;
 }
 

--- a/source/MRViewer/MRUIStyle.h
+++ b/source/MRViewer/MRUIStyle.h
@@ -201,6 +201,30 @@ MRVIEWER_API bool checkboxOrModifier( const char* label, CheckboxOrModifierState
 
 /// draw gradient radio button
 MRVIEWER_API bool radioButton( const char* label, int* value, int valButton );
+/// If `valueOverride` is specified, then the radio button is disabled and that value is displayed instead of `value`.
+MRVIEWER_API bool radioButtonOrFixedValue( const char* label, int* value, int valButton, std::optional<int> valueOverride );
+
+struct RadioButtonOrModifierState
+{
+    // The permanent value of this setting, as set by the user by clicking the radio button.
+    int value{};
+    // The value that is displayed, and to be used - can differ from `value` if modifiers are pressed.
+    int effectiveValue{};
+
+    // The effective value, affected by modifiers.
+    [[nodiscard]] explicit operator int() const
+    {
+        return effectiveValue;
+    }
+};
+
+/// Draws a radio button, that can be affected by modifier keys.
+/// `modifiers` must be one or more of `ImGuiMod_{Shift,Alt,Ctrl}`.
+/// By default ignores all modifiers not in `modifiers`. But if `checkedModifiers` is specified, then only ignores modifiers not included in it.
+/// `checkedModifiers` must be a superset of `modifiers`. `-1` has special meaning, making it same as `modifiers` (which makes it have no effect).
+/// If `valueOverride` is specified, then acts as `radioButtonOrFixedValue`: disables the radio button and displays that value instead of the real one,
+///   and also pretends that the modifier isn't held.
+MRVIEWER_API bool radioButtonOrModifier( const char* label, RadioButtonOrModifierState& value, int valButton, int modifiers, int checkedModifiers = -1, std::optional<int> valueOverride = {} );
 
 /// draw gradient color edit 4
 MRVIEWER_API bool colorEdit4( const char* label, Vector4f& color, ImGuiColorEditFlags flags = ImGuiColorEditFlags_None );


### PR DESCRIPTION
https://github.com/MeshInspector/MeshInspectorCode/issues/4726
Similar to, and based on existing checkboxes with similar function: https://github.com/MeshInspector/MeshLib/commit/c5f39f55e62e7650797c27791a1e97519faa504d

Also, fix text alignment after radio buttons, e.g.:
```
UI::radioButton(...);
ImGui::SameLine();
ImGui::DisabledText( "[Ctrl]" );
```
does not need `alignTextToRadioButton`.