### PR TITLE
Move Object refactor and enhancements

### DIFF
--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
@@ -55,6 +55,7 @@ void MoveObjectByMouse::drawDialog( float menuScaling, ImGuiContext*)
 
     ImGui::Text( "%s", "Click and hold LMB on object to move" );
     ImGui::Text( "%s", "Click CTRL + LMB and hold LMB on object to rotate" );
+    ImGui::Text( "%s", "Click ALT + LMB and hold LMB on object to scale" );
     ImGui::Text( "%s", "Press Shift to move selected objects together" );
 
     moveByMouse_.onDrawDialog( menuScaling );
@@ -81,7 +82,8 @@ bool MoveObjectByMouse::onDragEnd_( MouseButton btn, int modifiers )
 MoveObjectByMouseImpl::TransformMode MoveObjectByMouse::MoveObjectByMouseWithSelected::pick_( MouseButton button, int modifiers,
     std::vector<std::shared_ptr<Object>>& objects, Vector3f& centerPoint, Vector3f& startPoint )
 {
-    if ( button != MouseButton::Left || ( modifiers & ~( GLFW_MOD_SHIFT | GLFW_MOD_CONTROL ) ) != 0 )
+    if ( button != MouseButton::Left || ( modifiers & ~( GLFW_MOD_SHIFT | GLFW_MOD_CONTROL | GLFW_MOD_ALT ) ) != 0 ||
+         ( modifiers & ( GLFW_MOD_CONTROL | GLFW_MOD_ALT ) ) == ( GLFW_MOD_CONTROL | GLFW_MOD_ALT ) )
         return TransformMode::None;
 
     Viewer& viewerInstance = getViewerInstance();
@@ -121,7 +123,8 @@ MoveObjectByMouseImpl::TransformMode MoveObjectByMouse::MoveObjectByMouseWithSel
     Box3f box = getBbox_( objects );
     centerPoint = box.valid() ? box.center() : Vector3f{};
 
-    return ( modifiers & GLFW_MOD_CONTROL ) == 0 ? TransformMode::Translation : TransformMode::Rotation;
+    return ( modifiers & GLFW_MOD_CONTROL ) != 0 ? TransformMode::Rotation : 
+        ( modifiers & GLFW_MOD_ALT ) != 0 ? TransformMode::Scale : TransformMode::Translation;
 }
 
 MR_REGISTER_RIBBON_ITEM( MoveObjectByMouse )

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
@@ -29,11 +29,12 @@ private:
     virtual bool onDrag_( int x, int y ) override;
     virtual bool onDragEnd_( MouseButton btn, int modifiers ) override;
 
+    // Same as basic implementation but allows to move selected objects together by holding Shift
     class MoveObjectByMouseWithSelected : public MoveObjectByMouseImpl
     {
     protected:
-        std::vector<std::shared_ptr<Object>> getObjects_( 
-            const std::shared_ptr<VisualObject>& obj, const PointOnObject& point, int modifiers ) override;
+        TransformMode pick_( MouseButton button, int modifiers,
+            std::vector<std::shared_ptr<Object>>& objects, Vector3f& centerPoint, Vector3f& startPoint ) override;
     } moveByMouse_;
 };
 

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "MRViewer/MRStatePlugin.h"
 #include "MRViewer/MRMoveObjectByMouseImpl.h"
+#include "MRViewer/MRUIStyle.h"
 #include "MRMesh/MRPlane3.h"
 #include "MRMesh/MRAffineXf3.h"
 #include "MRCommonPlugins/exports.h"
@@ -25,6 +26,11 @@ public:
     virtual bool blocking() const override { return false; };
 
 private:
+    // Transformation mode
+    enum class XfMode { Move, Rotate, Scale };
+    // Transformation target: pick an object or move selected object(s)
+    enum class XfTarget { Picked, Selected };
+
     virtual bool onDragStart_( MouseButton btn, int modifiers ) override;
     virtual bool onDrag_( int x, int y ) override;
     virtual bool onDragEnd_( MouseButton btn, int modifiers ) override;
@@ -35,6 +41,11 @@ private:
     protected:
         TransformMode pick_( MouseButton button, int modifiers,
             std::vector<std::shared_ptr<Object>>& objects, Vector3f& centerPoint, Vector3f& startPoint ) override;
+
+    public:
+        // Options are provided externally rather than directly from modifiers
+        UI::RadioButtonOrModifierState modXfMode_{};    // XfMode
+        UI::RadioButtonOrModifierState modXfTarget_{};  // XfTarget
     } moveByMouse_;
 };
 

--- a/source/MRViewer/MRMoveObjectByMouseImpl.cpp
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.cpp
@@ -128,7 +128,6 @@ bool MoveObjectByMouseImpl::onMouseMove( int x, int y )
 
     auto viewportEnd = viewer.screenToViewport( Vector3f( float( x ), float( y ), 0.f ), viewport.id );
     auto worldEndPoint = viewport.unprojectFromViewportSpace( { viewportEnd.x, viewportEnd.y, viewportStartPointZ_ } );
-    AffineXf3f newXf;
 
     if ( transformMode_ == TransformMode::Rotation )
     {

--- a/source/MRViewer/MRMoveObjectByMouseImpl.cpp
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.cpp
@@ -49,53 +49,43 @@ void MoveObjectByMouseImpl::onDrawDialog( float /* menuScaling */ ) const
 
 bool MoveObjectByMouseImpl::onMouseDown( MouseButton button, int modifiers )
 {
-    if ( button != Viewer::MouseButton::Left )
-        return false;
-
     Viewer& viewer = getViewerInstance();
     Viewport& viewport = viewer.viewport();
-    
-    screenStartPoint_ = minDistance() > 0 ? viewer.mouseController().getMousePos() : cNoPoint;
 
-    auto [obj, pick] = viewport.pick_render_object();
-
-    if ( !obj || !onPick_( obj, pick, modifiers ) || !obj )
+    cancel();
+    transformMode_ = pick_( button, modifiers, objects_, xfCenterPoint_, worldStartPoint_ );
+    if ( transformMode_ == TransformMode::None )
+    {
+        clear_();
         return false;
+    }
 
-    objects_ = getObjects_( obj, pick, modifiers );
-
-    visualizeVectors_.clear();
+    currentButton_ = button;
+    screenStartPoint_ = minDistance() > 0 ? viewer.mouseController().getMousePos() : cNoPoint;
     angle_ = 0.f;
     shift_ = 0.f;
-
-    obj_ = obj;
-    newWorldXf_ = objWorldXf_ = obj_->worldXf();
-    worldStartPoint_ = objWorldXf_( pick.point );
+    currentXf_ = {};
     viewportStartPointZ_ = viewport.projectToViewportSpace( worldStartPoint_ ).z;
-    objectsXfs_.clear();
-    for ( std::shared_ptr<Object>& f : objects_ )
-        objectsXfs_.push_back( f->worldXf() );
-
-    transformMode_ = ( modifiers & GLFW_MOD_CONTROL ) != 0 ? TransformMode::Rotation : TransformMode::Translation;
+    initialXfs_.clear();
+    for ( std::shared_ptr<Object>& obj : objects_ )
+        initialXfs_.push_back( obj->worldXf() );
 
     if ( transformMode_ == TransformMode::Rotation )
     {
-        bboxCenter_ = obj_->getBoundingBox().center();
-        worldBboxCenter_ = obj_->worldXf()( bboxCenter_ );
-        auto viewportBboxCenter = viewport.projectToViewportSpace( worldBboxCenter_ );
+        Vector3f viewportCenterPoint = viewport.projectToViewportSpace( xfCenterPoint_ );
 
-        auto bboxCenterAxis = viewport.unprojectPixelRay( Vector2f( viewportBboxCenter.x, viewportBboxCenter.y ) );
-        rotationPlane_ = Plane3f::fromDirAndPt( bboxCenterAxis.d.normalized(), worldBboxCenter_ );
+        Line3f centerAxis = viewport.unprojectPixelRay( Vector2f( viewportCenterPoint.x, viewportCenterPoint.y ) );
+        rotationPlane_ = Plane3f::fromDirAndPt( centerAxis.d.normalized(), xfCenterPoint_ );
 
-        auto viewportStartPoint = viewport.projectToViewportSpace( worldStartPoint_ );
-        auto startAxis = viewport.unprojectPixelRay( Vector2f( viewportStartPoint.x, viewportStartPoint.y ) );
+        Vector3f viewportStartPoint = viewport.projectToViewportSpace( worldStartPoint_ );
+        Line3f startAxis = viewport.unprojectPixelRay( Vector2f( viewportStartPoint.x, viewportStartPoint.y ) );
 
         if ( auto crossPL = intersection( rotationPlane_, startAxis ) )
             worldStartPoint_ = *crossPL;
         else
             spdlog::warn( "Bad cross start axis and rotation plane" );
 
-        setVisualizeVectors_( { worldBboxCenter_, worldStartPoint_, worldBboxCenter_, worldStartPoint_ } );
+        setVisualizeVectors_( { xfCenterPoint_, worldStartPoint_, xfCenterPoint_, worldStartPoint_ } );
     }
     else
         setVisualizeVectors_( { worldStartPoint_, worldStartPoint_ } );
@@ -105,7 +95,7 @@ bool MoveObjectByMouseImpl::onMouseDown( MouseButton button, int modifiers )
 
 bool MoveObjectByMouseImpl::onMouseMove( int x, int y )
 {
-    if ( !obj_ )
+    if ( transformMode_ == TransformMode::None )
         return false;
 
     Viewer& viewer = getViewerInstance();
@@ -119,7 +109,7 @@ bool MoveObjectByMouseImpl::onMouseMove( int x, int y )
 
     auto viewportEnd = viewer.screenToViewport( Vector3f( float( x ), float( y ), 0.f ), viewport.id );
     auto worldEndPoint = viewport.unprojectFromViewportSpace( { viewportEnd.x, viewportEnd.y, viewportStartPointZ_ } );
-    AffineXf3f worldXf;
+    AffineXf3f newXf;
 
     if ( transformMode_ == TransformMode::Rotation )
     {
@@ -129,8 +119,8 @@ bool MoveObjectByMouseImpl::onMouseMove( int x, int y )
         else
             spdlog::warn( "Bad cross end axis and rotation plane" );
 
-        const Vector3f vectorStart = worldStartPoint_ - worldBboxCenter_;
-        const Vector3f vectorEnd = worldEndPoint - worldBboxCenter_;
+        const Vector3f vectorStart = worldStartPoint_ - xfCenterPoint_;
+        const Vector3f vectorEnd = worldEndPoint - xfCenterPoint_;
         const float abSquare = vectorStart.length() * vectorEnd.length();
         if ( abSquare < 1.e-6 )
             angle_ = 0.f;
@@ -140,44 +130,41 @@ bool MoveObjectByMouseImpl::onMouseMove( int x, int y )
         if ( dot( rotationPlane_.n, cross( vectorStart, vectorEnd ) ) > 0.f )
             angle_ = 2.f * PI_F - angle_;
 
-        setVisualizeVectors_( { worldBboxCenter_, worldStartPoint_, worldBboxCenter_, worldEndPoint } );
+        setVisualizeVectors_( { xfCenterPoint_, worldStartPoint_, xfCenterPoint_, worldEndPoint } );
 
-        AffineXf3f rotation = AffineXf3f::linear( Matrix3f::rotation( vectorStart, worldEndPoint - worldBboxCenter_ ) );
-        AffineXf3f worldXfA = AffineXf3f::linear( objWorldXf_.A );
-        AffineXf3f toBboxCenter = AffineXf3f::translation( worldXfA( bboxCenter_ ) );
-        worldXf = AffineXf3f::translation( objWorldXf_.b ) * toBboxCenter * rotation * toBboxCenter.inverse() * worldXfA;
+        // Rotate around center point (e.g. bounding box center)
+        AffineXf3f rotation = AffineXf3f::linear( Matrix3f::rotation( vectorStart, worldEndPoint - xfCenterPoint_ ) );
+        AffineXf3f toCenterPoint = AffineXf3f::translation( xfCenterPoint_ );
+        currentXf_ = toCenterPoint * rotation * toCenterPoint.inverse();
     }
     else
     {
         shift_ = ( worldEndPoint - worldStartPoint_ ).length();
         setVisualizeVectors_( { worldStartPoint_, worldEndPoint } );
 
-        worldXf = AffineXf3f::translation( worldEndPoint - worldStartPoint_ ) * objWorldXf_;
+        currentXf_ = AffineXf3f::translation( worldEndPoint - worldStartPoint_ );
 
-        // Clamp movement.
-        float minSizeDim = 0;
-        if ( auto worldBox = transformed( obj_->getBoundingBox(), worldXf ); worldBox.valid() ) // Feature objects give an invalid box.
-        {
-            auto wbsize = worldBox.size();
-            minSizeDim = wbsize.length();
-        }
-
+        // Clamp movement
+        Box3f worldBox = getBbox_( objects_ );
+        float minSizeDim = worldBox.valid() ? worldBox.size().length() : 0;
         if ( minSizeDim == 0 )
             minSizeDim = 1.f;
-
-        for ( auto i = 0; i < 3; i++ )
-            worldXf.b[i] = std::clamp( worldXf.b[i], -cMaxTranslationMultiplier * minSizeDim, +cMaxTranslationMultiplier * minSizeDim );
+        for ( const AffineXf3f &xf : initialXfs_ )
+            for ( auto i = 0; i < 3; i++ )
+                // ( currentXf_ * initialXf_ ).b[i] must be in -/+ cMaxTranslationMultiplier * minSizeDim
+                currentXf_.b[i] = std::clamp( currentXf_.b[i],
+                     -xf.b[i] - cMaxTranslationMultiplier * minSizeDim,
+                     -xf.b[i] + cMaxTranslationMultiplier * minSizeDim );
     }
 
-    newWorldXf_ = worldXf;
-    setWorldXf_( worldXf, false );
+    applyCurrentXf_( false );
 
     return true;
 }
 
 bool MoveObjectByMouseImpl::onMouseUp( MouseButton button, int /*modifiers*/ )
 {
-    if ( !obj_ || button != Viewer::MouseButton::Left )
+    if ( transformMode_ == TransformMode::None || button != currentButton_ )
         return false;
 
     if ( screenStartPoint_ != cNoPoint )
@@ -186,9 +173,8 @@ bool MoveObjectByMouseImpl::onMouseUp( MouseButton button, int /*modifiers*/ )
         return false;
     }
 
-    resetWorldXf_();
-    setWorldXf_( newWorldXf_, true );
-
+    resetXfs_();
+    applyCurrentXf_( true );
     clear_();
 
     return true;
@@ -196,56 +182,79 @@ bool MoveObjectByMouseImpl::onMouseUp( MouseButton button, int /*modifiers*/ )
 
 bool MoveObjectByMouseImpl::isMoving() const
 {
-    return screenStartPoint_ == cNoPoint;
+    return transformMode_ != TransformMode::None && screenStartPoint_ == cNoPoint;
 }
 
 void MoveObjectByMouseImpl::cancel()
 {
-    if ( !obj_ )
+    if ( transformMode_ == TransformMode::None )
         return;
-    resetWorldXf_();
+    resetXfs_();
     clear_();
 }
 
-bool MoveObjectByMouseImpl::onPick_( std::shared_ptr<VisualObject>& obj, PointOnObject&, int )
+MRVIEWER_API MoveObjectByMouseImpl::TransformMode MoveObjectByMouseImpl::pick_( MouseButton button, int modifiers,
+    std::vector<std::shared_ptr<Object>>& objects, Vector3f& centerPoint, Vector3f& startPoint )
 {
-    return !obj->isAncillary();
+    // Use LMB for `Translation` and Ctrl+LMB for `Rotation`
+    if ( !( button == MouseButton::Left && ( modifiers == 0 || modifiers == GLFW_MOD_CONTROL ) ) )
+        return TransformMode::None;
+
+    Viewer& viewer = getViewerInstance();
+    Viewport& viewport = viewer.viewport();
+
+    // Pick a single object under cursor
+    auto [obj, pick] = viewport.pickRenderObject();
+
+    // Check if picked something, and is not an ancillary object
+    if ( !obj || obj->isAncillary() )
+        return TransformMode::None;
+
+    // Use bounding box center as transform center and the picked point as an initial position
+    objects = { obj };
+    Box3f box = getBbox_( objects );
+    centerPoint = box.valid() ? box.center() : Vector3f{};
+    startPoint = obj->worldXf()( pick.point );
+    // Sample code to calculate reasonable startPoint when pick is unavailable
+    // Vector2i mousePos = viewer.mouseController().getMousePos();
+    // Vector3f viewportPos = viewer.screenToViewport( Vector3f( float( mousePos.x ), float( mousePos.y ), 0.f ), viewport.id );
+    // startPoint = viewport.unprojectPixelRay( Vector2f( viewportPos.x, viewportPos.y ) ).project( startPoint );
+    return modifiers == 0 ? TransformMode::Translation : TransformMode::Rotation;
 }
 
-std::vector<std::shared_ptr<Object>> MoveObjectByMouseImpl::getObjects_( 
-    const std::shared_ptr<VisualObject>& obj, const PointOnObject &, int )
+Box3f MoveObjectByMouseImpl::getBbox_( const std::vector<std::shared_ptr<Object>>& objects )
 {
-    return { obj };
+    Box3f worldBbox;
+    for ( const std::shared_ptr<Object>& obj : objects )
+        if ( obj )
+            worldBbox.include( obj->getWorldBox() );
+    return worldBbox;
 }
 
 void MoveObjectByMouseImpl::clear_()
 {
-    obj_ = nullptr;
     transformMode_ = TransformMode::None;
     objects_.clear();
-    objectsXfs_.clear();
-    screenStartPoint_ = {};
+    initialXfs_.clear();
+    visualizeVectors_.clear();
+    currentButton_ = MouseButton::NoButton;
 }
 
-void MoveObjectByMouseImpl::setWorldXf_( AffineXf3f worldXf, bool history )
+void MoveObjectByMouseImpl::applyCurrentXf_( bool history )
 {
     std::unique_ptr<ScopeHistory> scope = history ? std::make_unique<ScopeHistory>( "Change Xf" ) : nullptr;
-    auto itXf = objectsXfs_.begin();
+    auto itXf = initialXfs_.begin();
     for ( std::shared_ptr<Object>& obj : objects_ )
     {
         if ( history )
             AppendHistory<ChangeXfAction>( "Change Xf", obj );
-        if ( obj == obj_ )
-            obj->setWorldXf( worldXf );
-        else
-            obj->setWorldXf( worldXf * objWorldXf_.inverse() * *itXf );
-        itXf++;
+        obj->setWorldXf( currentXf_ * *itXf++ );
     }
 }
 
-void MoveObjectByMouseImpl::resetWorldXf_()
+void MoveObjectByMouseImpl::resetXfs_()
 {
-    auto itXf = objectsXfs_.begin();
+    auto itXf = initialXfs_.begin();
     for ( std::shared_ptr<Object>& f : objects_ )
         f->setWorldXf( *itXf++ );
 }

--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -9,7 +9,7 @@ namespace MR
 {
 
 /// Helper class to incorporate basic object transformation feature into plugins
-/// User can move objects by dragging them, rotate by dragging with Ctrl key
+/// User can move objects by dragging them, rotate by dragging with Ctrl key; scaling is disabled by default
 /// To use, create class instance and call its event handlers
 /// For extra features, override the `pick_` method
 class MRVIEWER_CLASS MoveObjectByMouseImpl
@@ -53,7 +53,8 @@ protected:
     {
         None,
         Translation,
-        Rotation
+        Rotation,
+        Scale
     };
 
     /// Called from `onMouseDown`
@@ -91,9 +92,10 @@ private:
     Vector3f worldStartPoint_;  // World point corresponding to cursor, for transform calculation
     Vector3f xfCenterPoint_;
     float viewportStartPointZ_;
-    Plane3f rotationPlane_;
+    Plane3f referencePlane_;
     float angle_ = 0.f;
     float shift_ = 0.f;
+    float scale_ = 1.f;
 
     std::vector<ImVec2> visualizeVectors_;
 };


### PR DESCRIPTION
- Implementation: picking object refactoring for more flexibility
- Add Scale transform mode [#4630](https://github.com/MeshInspector/MeshInspectorCode/issues/4630)
- Plugin window: add radio buttons with modifiers
- Enhance multiple objects mode: transform selected objects without picking (e.g. when objects are obscured), center calculation

![image](https://github.com/user-attachments/assets/e345e4a5-a479-4c71-b59a-84885de2ae49)