### PR TITLE
Fix getZoomFOVtoScreen_ for orthogonal views

### DIFF
--- a/source/MRViewer/MRViewport.h
+++ b/source/MRViewer/MRViewport.h
@@ -399,12 +399,13 @@ public:
     //   overlay basis
     void postDraw() const;
 
-    // fill = 1.0 parameter means that scene will 0.5 of screen
+    // fit camera to the scene box (note: scene box does not include ancillary objects)
+    // fill = 1.0 parameter means that scene will be approximately 0.5 of screen
     // snapView - to snap camera angle to closest canonical quaternion
     MRVIEWER_API void fitData( float fill = 1.0f, bool snapView = true );
 
     // set scene box by given one and fit camera to it
-    // fill = 1.0 parameter means that box diagonal will 0.5 of screen
+    // fill = 1.0 parameter means that box diagonal will be approximately 0.5 of the viewport
     // snapView - to snap camera angle to closest canonical quaternion
     MRVIEWER_API void fitBox( const Box3f& newSceneBox, float fill = 1.0f, bool snapView = true );
 

--- a/source/MRViewer/MRViewport.h
+++ b/source/MRViewer/MRViewport.h
@@ -399,12 +399,12 @@ public:
     //   overlay basis
     void postDraw() const;
 
-    // fill = 0.5 parameter means that scene will 0.5 of screen
+    // fill = 1.0 parameter means that scene will 0.5 of screen
     // snapView - to snap camera angle to closest canonical quaternion
     MRVIEWER_API void fitData( float fill = 1.0f, bool snapView = true );
 
     // set scene box by given one and fit camera to it
-    // fill = 0.5 parameter means that scene will 0.5 of screen
+    // fill = 1.0 parameter means that box diagonal will 0.5 of screen
     // snapView - to snap camera angle to closest canonical quaternion
     MRVIEWER_API void fitBox( const Box3f& newSceneBox, float fill = 1.0f, bool snapView = true );
 
@@ -534,8 +534,10 @@ private:
     Box3f calcBox_( const std::vector<std::shared_ptr<VisualObject>>& objs, Space space, bool selectedPrimitives = false ) const;
 
     /**
-     * @brief find maximum FOV angle allows to keep box (space of box depends of viewport params)
-     * given by getBoxFn visible inside the screen
+     * @brief find minimum FOV angle allows to keep box given by getBoxFn visible inside the screen
+     * The box is either in CameraOrthographic or CameraPerspective, depending on viewport setting
+     * If cameraShift is not null, calculate angle assuming the camera can be moved, and fills the shift value
+     * (orthogonal only; for perspective mode, must be null)
      * @returns true if all models are inside the projection volume
      */
     std::pair<float, bool> getZoomFOVtoScreen_( std::function<Box3f()> getBoxFn, Vector3f* cameraShift = nullptr ) const;

--- a/source/MRViewer/MRViewportCamera.cpp
+++ b/source/MRViewer/MRViewportCamera.cpp
@@ -700,6 +700,7 @@ std::pair<float, bool> Viewport::getZoomFOVtoScreen_( std::function<Box3f()> get
     }
     else
     {
+        assert( cameraShift == nullptr );
         auto maxX = std::max( box.max.x, -box.min.x ) / winRatio;
         auto maxY = std::max( box.max.y, -box.min.y );
         return std::make_pair( (2.f * atan( std::max( maxX, maxY ) ) ) / PI_F * 180.f, allInside );

--- a/source/MRViewer/MRViewportCamera.cpp
+++ b/source/MRViewer/MRViewportCamera.cpp
@@ -683,9 +683,8 @@ std::pair<float, bool> Viewport::getZoomFOVtoScreen_( std::function<Box3f()> get
     const auto winRatio = getRatio();
     if( params_.orthographic )
     {
-        auto dX = (box.max.x - box.min.x) / 2.f / winRatio;
-        auto dY = (box.max.y - box.min.y) / 2.f;
-        float maxD = std::max(dX, dY);
+        auto maxX = std::max( box.max.x, -box.min.x ) / winRatio;
+        auto maxY = std::max( box.max.y, -box.min.y );
         if( cameraShift )
         {
             auto meanX = (box.max.x + box.min.x) / 2.f;
@@ -693,7 +692,7 @@ std::pair<float, bool> Viewport::getZoomFOVtoScreen_( std::function<Box3f()> get
             const AffineXf3f xfV = getViewXf_();
             *cameraShift = -xfV.A.x.normalized() * (meanX / params_.cameraZoom) - xfV.A.y.normalized() * (meanY / params_.cameraZoom);
         }
-        return std::make_pair( (2.f * atan2( maxD, params_.cameraDnear )) / PI_F * 180.f, allInside );
+        return std::make_pair( (2.f * atan( std::max( maxX, maxY ) ) ) / PI_F * 180.f, allInside );
     }
     else
     {

--- a/source/MRViewer/MRViewportCamera.cpp
+++ b/source/MRViewer/MRViewportCamera.cpp
@@ -9,6 +9,7 @@
 #include "MRMesh/MRObjectMesh.h"
 #include "MRMesh/MRObjectLinesHolder.h"
 #include "MRMesh/MRObjectLabel.h"
+#include "MRMesh/MRObjectImGuiLabel.h"
 #include "MRMesh/MRObjectPoints.h"
 #include "MRMesh/MRObjectVoxels.h"
 #include "MRMesh/MRLine3.h"
@@ -614,7 +615,7 @@ Box3f Viewport::calcBox_( const std::vector<std::shared_ptr<VisualObject>>& objs
                 coords = &pointCloud.points;
                 selectedVerts = &pointCloud.validPoints;
             }
-            else if ( obj->asType<ObjectLabel>() )
+            else if ( obj->asType<ObjectLabel>() || obj->asType<ObjectImGuiLabel>() )
             {
                 // do nothing
             }


### PR DESCRIPTION
https://github.com/MeshInspector/MeshInspectorCode/issues/4502
- Fix `getZoomFOVtoScreen_` to work as `allModelsInsideViewportRectangle` expects (`allModelsInsideViewportRectangle` did not work for orthogonal views).
- Update comments