### PR TITLE
Improve active voxels support.

### DIFF
--- a/source/MRMesh/MRChangeVoxelsAction.h
+++ b/source/MRMesh/MRChangeVoxelsAction.h
@@ -227,7 +227,6 @@ public:
         {
             vdbVolume_ = obj->vdbVolume();
             histogram_ = obj->histogram();
-            activeBox_ = obj->getActiveBounds();
         }
     }
 
@@ -243,7 +242,6 @@ public:
 
         vdbVolume_ = objVoxels_->updateVdbVolume( std::move( vdbVolume_ ) );
         histogram_ = objVoxels_->updateHistogram( std::move( histogram_ ) );
-        activeBox_ = objVoxels_->updateActiveBounds( activeBox_ );
         changeIsoAction_.action( obj );
         changeSurfaceAction_.action( obj );
     }
@@ -265,7 +263,6 @@ private:
     Histogram histogram_;
     ChangeIsoAction changeIsoAction_;
     ChangeSurfaceAction changeSurfaceAction_;
-    Box3i activeBox_;
 
     std::string name_;
 };

--- a/source/MRMesh/MRObjectVoxels.cpp
+++ b/source/MRMesh/MRObjectVoxels.cpp
@@ -33,11 +33,11 @@ void ObjectVoxels::construct( const SimpleVolume& volume, ProgressCallback cb )
 {
     mesh_.reset();
     activeVoxels_.reset();
+    activeVoxelsBox_.reset();
     vdbVolume_.data = simpleVolumeToDenseGrid( volume, cb );
     vdbVolume_.dims = volume.dims;
     vdbVolume_.voxelSize = volume.voxelSize;
     indexer_ = VolumeIndexer( vdbVolume_.dims );
-    activeBox_ = Box3i( Vector3i(), vdbVolume_.dims );
     reverseVoxelSize_ = { 1 / vdbVolume_.voxelSize.x,1 / vdbVolume_.voxelSize.y,1 / vdbVolume_.voxelSize.z };
 
     volumeRenderActiveVoxels_.clear();
@@ -52,12 +52,12 @@ void ObjectVoxels::construct( const FloatGrid& grid, const Vector3f& voxelSize, 
     if ( !grid )
         return;
     activeVoxels_.reset();
+    activeVoxelsBox_.reset();
     vdbVolume_.data = grid;
 
     auto vdbDims = vdbVolume_.data->evalActiveVoxelDim();
     vdbVolume_.dims = {vdbDims.x(),vdbDims.y(),vdbDims.z()};
     indexer_ = VolumeIndexer( vdbVolume_.dims );
-    activeBox_ = Box3i( Vector3i(), vdbVolume_.dims );
     vdbVolume_.voxelSize = voxelSize;
     reverseVoxelSize_ = { 1 / vdbVolume_.voxelSize.x,1 / vdbVolume_.voxelSize.y,1 / vdbVolume_.voxelSize.z };
 
@@ -131,6 +131,7 @@ VdbVolume ObjectVoxels::updateVdbVolume( VdbVolume vdbVolume )
 {
     auto oldVdbVolume = std::move( vdbVolume_ );
     activeVoxels_.reset();
+    activeVoxelsBox_.reset();
     vdbVolume_ = std::move( vdbVolume );
     indexer_ = VolumeIndexer( vdbVolume_.dims );
     reverseVoxelSize_ = { 1 / vdbVolume_.voxelSize.x, 1 / vdbVolume_.voxelSize.y, 1 / vdbVolume_.voxelSize.z };
@@ -146,13 +147,6 @@ Histogram ObjectVoxels::updateHistogram( Histogram histogram )
     auto oldHistogram = std::move( histogram_ );
     histogram_ = std::move( histogram );
     return oldHistogram;
-}
-
-Box3i ObjectVoxels::updateActiveBounds( const Box3i& box )
-{
-    Box3i oldBox = activeBox_;
-    activeBox_ = box;
-    return oldBox;
 }
 
 Expected<std::shared_ptr<Mesh>> ObjectVoxels::recalculateIsoSurface( float iso, MR::ProgressCallback cb ) const
@@ -319,7 +313,7 @@ void ObjectVoxels::setActiveBounds( const Box3i& activeBox, ProgressCallback cb,
         return;
 
     activeVoxels_.reset();
-    activeBox_ = activeBox;
+    activeVoxelsBox_.reset();
 
     float cbModifier = 1.0f;
     if ( updateSurface && volumeRendering_ )
@@ -329,8 +323,8 @@ void ObjectVoxels::setActiveBounds( const Box3i& activeBox, ProgressCallback cb,
     float lastProgress = 0.0f;
 
     openvdb::CoordBBox activeVdbBox;
-    activeVdbBox.min() = openvdb::Coord( activeBox_.min.x, activeBox_.min.y, activeBox_.min.z );
-    activeVdbBox.max() = openvdb::Coord( activeBox_.max.x - 1, activeBox_.max.y - 1, activeBox_.max.z - 1 );
+    activeVdbBox.min() = openvdb::Coord( activeBox.min.x, activeBox.min.y, activeBox.min.z );
+    activeVdbBox.max() = openvdb::Coord( activeBox.max.x - 1, activeBox.max.y - 1, activeBox.max.z - 1 );
 
     // create active mask tree
     openvdb::TopologyTree topologyTree;
@@ -384,9 +378,20 @@ void ObjectVoxels::setActiveBounds( const Box3i& activeBox, ProgressCallback cb,
     }
 }
 
+const Box3i& ObjectVoxels::getActiveBounds() const
+{
+    if ( !activeVoxelsBox_ )
+    {
+        auto activeBox = vdbVolume_.data->evalActiveVoxelBoundingBox();
+        activeVoxelsBox_.emplace( Vector3i{ activeBox.min().x(), activeBox.min().y(), activeBox.min().z() },
+                                  Vector3i{ activeBox.max().x(), activeBox.max().y(), activeBox.max().z() } );
+    }
+    return *activeVoxelsBox_;
+}
+
 void ObjectVoxels::setVolumeRenderActiveVoxels( const VoxelBitSet& activeVoxels )
 {
-    auto box = activeBox_.size();
+    auto box = getActiveBounds().size();
     const bool valid = activeVoxels.empty() || activeVoxels.size() == box.x * box.y * box.z;
     assert( valid );
     if ( !valid )
@@ -575,8 +580,6 @@ void ObjectVoxels::serializeFields_( Json::Value& root ) const
     serializeToJson( vdbVolume_.voxelSize, root["VoxelSize"] );
 
     serializeToJson( vdbVolume_.dims, root["Dimensions"] );
-    serializeToJson( activeBox_.min, root["MinCorner"] );
-    serializeToJson( activeBox_.max, root["MaxCorner"] );
     serializeToJson( selectedVoxels_, root["SelectionVoxels"] );
 
     root["IsoValue"] = isoValue_;
@@ -606,10 +609,6 @@ void ObjectVoxels::deserializeFields_( const Json::Value& root )
 
     deserializeFromJson( root["Dimensions"], vdbVolume_.dims );
 
-    deserializeFromJson( root["MinCorner"], activeBox_.min );
-
-    deserializeFromJson( root["MaxCorner"], activeBox_.max );
-
     deserializeFromJson( root["SelectionVoxels"], selectedVoxels_ );
 
     if ( root["IsoValue"].isNumeric() )
@@ -618,13 +617,7 @@ void ObjectVoxels::deserializeFields_( const Json::Value& root )
     if ( root["DualMarchingCubes"].isBool() )
         dualMarchingCubes_ = root["DualMarchingCubes"].asBool();
 
-    if ( !activeBox_.valid() )
-        activeBox_ = Box3i( Vector3i(), vdbVolume_.dims );
-
-    if ( activeBox_.min != Vector3i() || activeBox_.max != vdbVolume_.dims )
-        setActiveBounds( activeBox_ );
-    else 
-        setIsoValue( isoValue_ );
+    setIsoValue( isoValue_ );
 
     if ( root["UseDefaultSceneProperties"].isBool() && root["UseDefaultSceneProperties"].asBool() )
         setDefaultSceneProperties_();
@@ -658,6 +651,7 @@ VoidOrErrStr ObjectVoxels::deserializeModel_( const std::filesystem::path& path,
 
 std::vector<std::string> ObjectVoxels::getInfoLines() const
 {
+    auto activeBox = getActiveBounds();
     std::vector<std::string> res = ObjectMeshHolder::getInfoLines();
     res.push_back( fmt::format( "dims: ({}, {}, {})", vdbVolume_.dims.x, vdbVolume_.dims.y, vdbVolume_.dims.z ) );
     res.push_back( fmt::format( "voxel size: ({:.3}, {:.3}, {:.3})", vdbVolume_.voxelSize.x, vdbVolume_.voxelSize.y, vdbVolume_.voxelSize.z ) );
@@ -665,6 +659,9 @@ std::vector<std::string> ObjectVoxels::getInfoLines() const
         vdbVolume_.dims.x * vdbVolume_.voxelSize.x,
         vdbVolume_.dims.y * vdbVolume_.voxelSize.y,
         vdbVolume_.dims.z * vdbVolume_.voxelSize.z ) );
+    res.push_back( fmt::format( "active box: ({}, {}, {}; {}, {}, {})",
+        activeBox.min.x, activeBox.min.y, activeBox.min.z,
+        activeBox.max.x, activeBox.max.y, activeBox.max.z ) );
     res.push_back( fmt::format( "min-value: {:.3}", vdbVolume_.min ) );
     res.push_back( fmt::format( "iso-value: {:.3}", isoValue_ ) );
     res.push_back( fmt::format( "max-value: {:.3}", vdbVolume_.max ) );

--- a/source/MRMesh/MRObjectVoxels.cpp
+++ b/source/MRMesh/MRObjectVoxels.cpp
@@ -33,7 +33,7 @@ void ObjectVoxels::construct( const SimpleVolume& volume, ProgressCallback cb )
 {
     mesh_.reset();
     activeVoxels_.reset();
-    activeVoxelsBox_.reset();
+    activeBounds_.reset();
     vdbVolume_.data = simpleVolumeToDenseGrid( volume, cb );
     vdbVolume_.dims = volume.dims;
     vdbVolume_.voxelSize = volume.voxelSize;
@@ -52,7 +52,7 @@ void ObjectVoxels::construct( const FloatGrid& grid, const Vector3f& voxelSize, 
     if ( !grid )
         return;
     activeVoxels_.reset();
-    activeVoxelsBox_.reset();
+    activeBounds_.reset();
     vdbVolume_.data = grid;
 
     auto vdbDims = vdbVolume_.data->evalActiveVoxelDim();
@@ -131,7 +131,7 @@ VdbVolume ObjectVoxels::updateVdbVolume( VdbVolume vdbVolume )
 {
     auto oldVdbVolume = std::move( vdbVolume_ );
     activeVoxels_.reset();
-    activeVoxelsBox_.reset();
+    activeBounds_.reset();
     vdbVolume_ = std::move( vdbVolume );
     indexer_ = VolumeIndexer( vdbVolume_.dims );
     reverseVoxelSize_ = { 1 / vdbVolume_.voxelSize.x, 1 / vdbVolume_.voxelSize.y, 1 / vdbVolume_.voxelSize.z };
@@ -313,7 +313,7 @@ void ObjectVoxels::setActiveBounds( const Box3i& activeBox, ProgressCallback cb,
         return;
 
     activeVoxels_.reset();
-    activeVoxelsBox_.reset();
+    activeBounds_.reset();
 
     float cbModifier = 1.0f;
     if ( updateSurface && volumeRendering_ )
@@ -380,13 +380,13 @@ void ObjectVoxels::setActiveBounds( const Box3i& activeBox, ProgressCallback cb,
 
 const Box3i& ObjectVoxels::getActiveBounds() const
 {
-    if ( !activeVoxelsBox_ )
+    if ( !activeBounds_ )
     {
         auto activeBox = vdbVolume_.data->evalActiveVoxelBoundingBox();
-        activeVoxelsBox_.emplace( Vector3i{ activeBox.min().x(), activeBox.min().y(), activeBox.min().z() },
-                                  Vector3i{ activeBox.max().x(), activeBox.max().y(), activeBox.max().z() } );
+        activeBounds_.emplace( Vector3i{ activeBox.min().x(), activeBox.min().y(), activeBox.min().z() },
+                               Vector3i{ activeBox.max().x(), activeBox.max().y(), activeBox.max().z() } );
     }
-    return *activeVoxelsBox_;
+    return *activeBounds_;
 }
 
 void ObjectVoxels::setVolumeRenderActiveVoxels( const VoxelBitSet& activeVoxels )

--- a/source/MRMesh/MRObjectVoxels.cpp
+++ b/source/MRMesh/MRObjectVoxels.cpp
@@ -631,8 +631,8 @@ void ObjectVoxels::deserializeFields_( const Json::Value& root )
 
     if ( activeBox.valid() && ( activeBox.min != Vector3i() || activeBox.max != vdbVolume_.dims ) )
         setActiveBounds( activeBox );
-
-    setIsoValue( isoValue_ );
+    else
+        setIsoValue( isoValue_ ); // is called automatically in `setActiveBounds`
 
     if ( root["UseDefaultSceneProperties"].isBool() && root["UseDefaultSceneProperties"].asBool() )
         setDefaultSceneProperties_();

--- a/source/MRMesh/MRObjectVoxels.cpp
+++ b/source/MRMesh/MRObjectVoxels.cpp
@@ -613,7 +613,13 @@ void ObjectVoxels::deserializeFields_( const Json::Value& root )
     else
         deserializeFromJson( root["VoxelSize"], vdbVolume_.voxelSize );
 
+    Box3i activeBox;
+
     deserializeFromJson( root["Dimensions"], vdbVolume_.dims );
+
+    deserializeFromJson( root["MinCorner"], activeBox.min );
+
+    deserializeFromJson( root["MaxCorner"], activeBox.max );
 
     deserializeFromJson( root["SelectionVoxels"], selectedVoxels_ );
 
@@ -622,6 +628,9 @@ void ObjectVoxels::deserializeFields_( const Json::Value& root )
 
     if ( root["DualMarchingCubes"].isBool() )
         dualMarchingCubes_ = root["DualMarchingCubes"].asBool();
+
+    if ( activeBox.valid() && ( activeBox.min != Vector3i() || activeBox.max != vdbVolume_.dims ) )
+        setActiveBounds( activeBox );
 
     setIsoValue( isoValue_ );
 

--- a/source/MRMesh/MRObjectVoxels.cpp
+++ b/source/MRMesh/MRObjectVoxels.cpp
@@ -579,7 +579,13 @@ void ObjectVoxels::serializeFields_( Json::Value& root ) const
     VisualObject::serializeFields_( root );
     serializeToJson( vdbVolume_.voxelSize, root["VoxelSize"] );
 
+    const auto activeBounds = getActiveBounds();
+
     serializeToJson( vdbVolume_.dims, root["Dimensions"] );
+    // Min and Max corners are serialized for backward-compatibility
+    serializeToJson( activeBounds.min, root["MinCorner"] );
+    serializeToJson( activeBounds.max, root["MaxCorner"] );
+    //
     serializeToJson( selectedVoxels_, root["SelectionVoxels"] );
 
     root["IsoValue"] = isoValue_;

--- a/source/MRMesh/MRObjectVoxels.h
+++ b/source/MRMesh/MRObjectVoxels.h
@@ -209,7 +209,7 @@ private:
     bool dualMarchingCubes_{true};
     VoxelPointPositioner positioner_ = {};
     Histogram histogram_;
-    mutable std::optional<Box3i> activeVoxelsBox_;
+    mutable std::optional<Box3i> activeBounds_;
     mutable std::optional<size_t> activeVoxels_;
 
     const char * serializeFormat_ = ".raw";

--- a/source/MRMesh/MRObjectVoxels.h
+++ b/source/MRMesh/MRObjectVoxels.h
@@ -77,9 +77,6 @@ public:
     /// Sets external histogram for this object
     /// and returns back previous histogram of this
     MRMESH_API Histogram updateHistogram( Histogram histogram );
-    /// Sets active bounds for this object
-    /// and returns back previous active bounds of this
-    MRMESH_API Box3i updateActiveBounds( const Box3i &box );
 
     /// Calculates and return new mesh or error message
     MRMESH_API Expected<std::shared_ptr<Mesh>> recalculateIsoSurface( float iso, ProgressCallback cb = {} ) const;
@@ -101,8 +98,7 @@ public:
     MRMESH_API virtual void setActiveBounds( const Box3i& activeBox, ProgressCallback cb = {}, bool updateSurface = true );
     /// Returns active bounds (max excluded)
     /// active bounds is box in voxel coordinates, note that voxels under (0,0,0) and voxels over (dimensions) are empty 
-    const Box3i& getActiveBounds() const
-    { return activeBox_; }
+    MRMESH_API const Box3i& getActiveBounds() const;
 
     const VoxelBitSet& getSelectedVoxels() const { return selectedVoxels_; }
     void selectVoxels( const VoxelBitSet& selectedVoxels ) { selectedVoxels_ = selectedVoxels; }
@@ -213,7 +209,7 @@ private:
     bool dualMarchingCubes_{true};
     VoxelPointPositioner positioner_ = {};
     Histogram histogram_;
-    Box3i activeBox_;
+    mutable std::optional<Box3i> activeVoxelsBox_;
     mutable std::optional<size_t> activeVoxels_;
 
     const char * serializeFormat_ = ".raw";


### PR DESCRIPTION
Instead of storing the active box manually (separate from the active voxels representation in OpenVDB), get it from the underlying OpenVdb-volume and cache it when possible.