### PR TITLE
OffsetParameters: memoryEfficient = true by default

### DIFF
--- a/source/MRMesh/MROffset.cpp
+++ b/source/MRMesh/MROffset.cpp
@@ -161,7 +161,7 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
         vmParams.lessInside = true;
         vmParams.outVoxelPerFaceMap = outMap;
 
-        if ( params.memoryEfficient )
+        if ( !params.fwn && params.memoryEfficient )
         {
             return marchingCubes( meshToDistanceFunctionVolume( mp, msParams ), vmParams );
         }

--- a/source/MRMesh/MROffset.cpp
+++ b/source/MRMesh/MROffset.cpp
@@ -141,8 +141,10 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
     }
     else
     {
+        const bool funcVolume = !params.fwn && params.memoryEfficient;
         MeshToDistanceVolumeParams msParams;
-        msParams.vol.cb = meshToLSCb;
+        if ( !funcVolume )
+            msParams.vol.cb = meshToLSCb;
         auto box = mp.mesh.computeBoundingBox( mp.region );
         auto absOffset = std::abs( offset );
         auto expansion = Vector3f::diagonal( 2 * params.voxelSize + absOffset );
@@ -157,11 +159,11 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
         MarchingCubesParams vmParams;
         vmParams.origin = msParams.vol.origin;
         vmParams.iso = offset;
-        vmParams.cb = subprogress( params.callBack, 0.4f, 1.0f );
+        vmParams.cb = funcVolume ? params.callBack : subprogress( params.callBack, 0.4f, 1.0f );
         vmParams.lessInside = true;
         vmParams.outVoxelPerFaceMap = outMap;
 
-        if ( !params.fwn && params.memoryEfficient )
+        if ( funcVolume )
         {
             return marchingCubes( meshToDistanceFunctionVolume( mp, msParams ), vmParams );
         }

--- a/source/MRMesh/MROffset.h
+++ b/source/MRMesh/MROffset.h
@@ -32,11 +32,13 @@ struct OffsetParameters : BaseShellParameters
     std::shared_ptr<IFastWindingNumber> fwn;
 
     /// use FunctionVolume for voxel grid representation:
-    ///  - memory consumption is approx. (z / (2 * thread_count)) lesser
-    ///  - computation is about 2-3 times slower
-    ///  - custom IFastWindingNumber interface \ref fwn is ignored (CPU-only computation, no CUDA support)
+    ///  - memory consumption for voxel storage is approx. (dims.z / (2 * thread_count)) lesser
+    ///  - computations are about 15% slower (because some z-layers are computed twice)
+    /// this setting is ignored (as if memoryEfficient == false) if
+    ///  a) signDetectionMode = SignDetectionMode::OpenVDB, or
+    ///  b) \ref fwn is provided (CUDA computations require full memory storage)
     /// used only by \ref mcOffsetMesh and \ref sharpOffsetMesh methods
-    bool memoryEfficient = false;
+    bool memoryEfficient = true;
 };
 
 struct SharpOffsetParameters : OffsetParameters


### PR DESCRIPTION
Memory efficient mode is the main benefit of MeshLib library compared to other implementations.

After several recent improvements, it shall same fast as `memoryEfficient=false` from the previous MeshLib release.