### PR TITLE
Manually validate png signature

### DIFF
--- a/source/MRMesh/MRImageLoad.cpp
+++ b/source/MRMesh/MRImageLoad.cpp
@@ -91,6 +91,14 @@ Expected<MR::Image> fromPng( std::istream& in )
 
     Image result;
 
+    char sign[8];
+    if ( !in.read( sign, 8 ) )
+        return unexpected( "Cannot read png signature" );
+    in.seekg( 0 );
+
+    if ( png_sig_cmp( ( png_const_bytep )sign, 0, 8 ) != 0 )
+        return unexpected( "Invalid png signature" );
+
     unsigned w{ 0 }, h{ 0 };
     int depth{ 0 }; // 8
     int colorType{ 0 }; // PNG_COLOR_TYPE_RGBA


### PR DESCRIPTION
There is `png_set_error_fn` function but according to documentation:
```c++
/* This function is called when the application wants to use another method
 * of handling errors and warnings.  Note that the error function MUST NOT
 * return to the calling routine or serious problems will occur.  The return
 * method used in the default routine calls longjmp(png_ptr->jmp_buf_ptr, 1)
 */
```
it still requires to `longjmp` to abort function. So easiest way is to manually check signature