### PR TITLE
Optimize generalized winding number computation

### DIFF
--- a/source/MRMesh/MRDipole.cpp
+++ b/source/MRMesh/MRDipole.cpp
@@ -37,7 +37,7 @@ void calcDipoles( Dipoles& dipoles, const AABBTree& tree_, const Mesh& mesh )
         const auto ap = a * mesh.triCenter( f );
         dipoles[i] = Dipole
         {
-            .areaPos = ap,
+            .pos = ap, // ( area * pos ) till for now
             .area = a,
             .dirArea = da
         };
@@ -53,18 +53,20 @@ void calcDipoles( Dipoles& dipoles, const AABBTree& tree_, const Mesh& mesh )
         const auto& dr = dipoles[node.r];
         dipoles[i] = Dipole
         {
-            .areaPos = dl.areaPos + dr.areaPos,
+            .pos = dl.pos + dr.pos, // ( area * pos ) till for now
             .area = dl.area + dr.area,
             .dirArea = dl.dirArea + dr.dirArea
         };
     }
 
-    // compute distance to farthest corner for all nodes
+    // compute 1) center mass 2) distance to farthest corner for all nodes
     ParallelFor( dipoles, [&]( NodeId i )
     {
         const auto& node = tree_[i];
         auto& d = dipoles[i];
-        d.rr = distToFarthestCornerSq( node.box, d.pos() );
+        if ( d.area > 0 )
+            d.pos /= d.area;
+        d.rr = distToFarthestCornerSq( node.box, d.pos );
     } );
 }
 

--- a/source/MRMesh/MRDipole.cpp
+++ b/source/MRMesh/MRDipole.cpp
@@ -102,14 +102,19 @@ float calcFastWindingNumber( const Dipoles& dipoles, const AABBTree& tree, const
 
     const float betaSq = sqr( beta );
     constexpr int MaxStackSize = 32; // to avoid allocations
-    NodeId subtasks[MaxStackSize];
+    struct SubTask
+    {
+        NodeId n;
+        SubTask() : n( noInit ) {}
+    };
+    SubTask subtasks[MaxStackSize];
     int stackSize = 0;
-    subtasks[stackSize++] = tree.rootNodeId();
+    subtasks[stackSize++].n = tree.rootNodeId();
 
     float res = 0;
     while( stackSize > 0 )
     {
-        const auto i = subtasks[--stackSize];
+        const auto i = subtasks[--stackSize].n;
         const auto & node = tree[i];
         const auto & d = dipoles[i];
         if ( d.addIfGoodApprox( q, betaSq, res ) )
@@ -117,8 +122,8 @@ float calcFastWindingNumber( const Dipoles& dipoles, const AABBTree& tree, const
         if ( !node.leaf() )
         {
             // recurse deeper
-            subtasks[stackSize++] = node.r; // to look later
-            subtasks[stackSize++] = node.l; // to look first
+            subtasks[stackSize++].n = node.r; // to look later
+            subtasks[stackSize++].n = node.l; // to look first
             continue;
         }
         if ( node.leafId() != skipFace )

--- a/source/MRMesh/MRDipole.cpp
+++ b/source/MRMesh/MRDipole.cpp
@@ -37,7 +37,7 @@ void calcDipoles( Dipoles& dipoles, const AABBTree& tree_, const Mesh& mesh )
         const auto ap = a * mesh.triCenter( f );
         dipoles[i] = Dipole
         {
-            .pos = ap, // ( area * pos ) till for now
+            .pos = ap, // ( area * pos ) for now
             .area = a,
             .dirArea = da
         };
@@ -53,7 +53,7 @@ void calcDipoles( Dipoles& dipoles, const AABBTree& tree_, const Mesh& mesh )
         const auto& dr = dipoles[node.r];
         dipoles[i] = Dipole
         {
-            .pos = dl.pos + dr.pos, // ( area * pos ) till for now
+            .pos = dl.pos + dr.pos, // ( area * pos ) for now
             .area = dl.area + dr.area,
             .dirArea = dl.dirArea + dr.dirArea
         };

--- a/source/MRMesh/MRDipole.h
+++ b/source/MRMesh/MRDipole.h
@@ -9,19 +9,15 @@ namespace MR
 /// https://www.dgp.toronto.edu/projects/fast-winding-numbers/fast-winding-numbers-for-soups-and-clouds-siggraph-2018-barill-et-al.pdf
 struct Dipole
 {
-    Vector3f areaPos;
+    Vector3f pos;
     float area = 0;
     Vector3f dirArea;
     float rr = 0; // maximum squared distance from pos to any corner of the bounding box
-    [[nodiscard]] Vector3f pos() const
-    {
-        return area > 0 ? areaPos / area : areaPos;
-    }
     /// returns true if this dipole is good approximation for a point \param q;
     /// and adds the contribution of this dipole to the winding number at point \param q to \param addTo
     [[nodiscard]] bool addIfGoodApprox( const Vector3f& q, float betaSq, float& addTo ) const
     {
-        const auto dp = pos() - q;
+        const auto dp = pos - q;
         const auto dd = dp.lengthSq();
         if ( dd <= betaSq * rr )
             return false;

--- a/source/MRMesh/MRDipole.h
+++ b/source/MRMesh/MRDipole.h
@@ -17,13 +17,9 @@ struct Dipole
     {
         return area > 0 ? areaPos / area : areaPos;
     }
-    /// returns true if this dipole is good approximation for a point \param q
-    [[nodiscard]] bool goodApprox( const Vector3f& q, float beta ) const
-    {
-        return ( q - pos() ).lengthSq() > sqr( beta ) * rr;
-    }
-    /// contribution of this dipole to the winding number at point \param q
-    [[nodiscard]] MRMESH_API float w( const Vector3f& q ) const;
+    /// returns true if this dipole is good approximation for a point \param q;
+    /// and adds the contribution of this dipole to the winding number at point \param q to \param addTo
+    [[nodiscard]] MRMESH_API bool addIfGoodApprox( const Vector3f& q, float betaSq, float& addTo ) const;
 };
 
 static_assert( sizeof( Dipole ) == 8 * sizeof( float ) );

--- a/source/MRMesh/MRDipole.h
+++ b/source/MRMesh/MRDipole.h
@@ -19,7 +19,16 @@ struct Dipole
     }
     /// returns true if this dipole is good approximation for a point \param q;
     /// and adds the contribution of this dipole to the winding number at point \param q to \param addTo
-    [[nodiscard]] MRMESH_API bool addIfGoodApprox( const Vector3f& q, float betaSq, float& addTo ) const;
+    [[nodiscard]] bool addIfGoodApprox( const Vector3f& q, float betaSq, float& addTo ) const
+    {
+        const auto dp = pos() - q;
+        const auto dd = dp.lengthSq();
+        if ( dd <= betaSq * rr )
+            return false;
+        if ( const auto d = std::sqrt( dd ); d > 0 )
+            addTo += dot( dp, dirArea ) / ( d * dd );
+        return true;
+    }
 };
 
 static_assert( sizeof( Dipole ) == 8 * sizeof( float ) );


### PR DESCRIPTION
Due to elimination of
* one division `areaPos / area` per node,
* one multiplication on `INV_4PI` per node,
* and combined and inlined `Dipole::goodApprox` with `Dipole::w`

it improves performance on 30% for complex meshes.