### PR TITLE
WindingNumber: expose all options to the user

### DIFF
--- a/source/MRCuda/MRCudaFastWindingNumber.cpp
+++ b/source/MRCuda/MRCudaFastWindingNumber.cpp
@@ -145,7 +145,7 @@ VoidOrErrStr FastWindingNumber::calcFromGrid( std::vector<float>& res, const Vec
     return {};
 }
 
-VoidOrErrStr FastWindingNumber::calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, float maxDistSq, float minDistSq, ProgressCallback cb )
+VoidOrErrStr FastWindingNumber::calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb )
 {
     MR_TIMER
     prepareData_( {} );
@@ -171,7 +171,7 @@ VoidOrErrStr FastWindingNumber::calcFromGridWithDistances( std::vector<float>& r
         int3{ dims.x, dims.y, dims.z },
         cudaGridToMeshXf,
         data_->dipoles.data(), data_->cudaNodes.data(), data_->cudaMeshPoints.data(), data_->cudaFaces.data(),
-        cudaResult.data(), beta, maxDistSq, minDistSq );
+        cudaResult.data(), windingNumberThreshold, beta, maxDistSq, minDistSq );
 
     if ( auto code = CUDA_EXEC( cudaGetLastError() ) )
         return unexpected( Cuda::getError( code ) );
@@ -182,7 +182,6 @@ VoidOrErrStr FastWindingNumber::calcFromGridWithDistances( std::vector<float>& r
     if ( !reportProgress( cb, 1.0f ) )
         return unexpectedOperationCanceled();
     return {};
-
 }
 
 } //namespace Cuda

--- a/source/MRCuda/MRCudaFastWindingNumber.cu
+++ b/source/MRCuda/MRCudaFastWindingNumber.cu
@@ -197,7 +197,7 @@ __global__ void fastWindingNumberFromGridKernel( int3 dims, Matrix4 gridToMeshXf
 
 __global__ void signedDistanceKernel( int3 dims, Matrix4 gridToMeshXf,
     const Dipole* __restrict__ dipoles, const Node3* __restrict__ nodes, const float3* __restrict__ meshPoints, const FaceToThreeVerts* __restrict__ faces,
-    float* resVec, float beta, float maxDistSq, float minDistSq, size_t size )
+    float* resVec, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, size_t size )
 {
     if ( size == 0 )
     {
@@ -220,7 +220,7 @@ __global__ void signedDistanceKernel( int3 dims, Matrix4 gridToMeshXf,
 
     float fwn{ 0 };
     processPoint( transformedPoint, fwn, dipoles, nodes, meshPoints, faces, beta, index );
-    if ( fwn > 0.5f )
+    if ( fwn > windingNumberThreshold )
         res = -res;
 }
 
@@ -251,11 +251,11 @@ void fastWindingNumberFromGrid( int3 dims, Matrix4 gridToMeshXf,
 
 void signedDistance( int3 dims, Matrix4 gridToMeshXf,
                                         const Dipole* dipoles, const Node3* nodes, const float3* meshPoints, const FaceToThreeVerts* faces,
-                                        float* resVec, float beta, float maxDistSq, float minDistSq )
+                                        float* resVec, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq )
 {
     const size_t size = size_t( dims.x ) * dims.y * dims.z;
     int numBlocks = ( int( size ) + maxThreadsPerBlock - 1 ) / maxThreadsPerBlock;
-    signedDistanceKernel<<< numBlocks, maxThreadsPerBlock >>>( dims, gridToMeshXf, dipoles, nodes, meshPoints, faces, resVec, beta, maxDistSq, minDistSq, size );
+    signedDistanceKernel<<< numBlocks, maxThreadsPerBlock >>>( dims, gridToMeshXf, dipoles, nodes, meshPoints, faces, resVec, windingNumberThreshold, beta, maxDistSq, minDistSq, size );
 }
 
 } //namespece Cuda

--- a/source/MRCuda/MRCudaFastWindingNumber.cuh
+++ b/source/MRCuda/MRCudaFastWindingNumber.cuh
@@ -48,7 +48,7 @@ void fastWindingNumberFromGrid( int3 gridSize, Matrix4 gridToMeshXf,
 /// calls fast winding number for each point in three-dimensional grid to get sign
 void signedDistance( int3 gridSize, Matrix4 gridToMeshXf,
                                       const Dipole* dipoles, const Node3* nodes, const float3* meshPoints, const FaceToThreeVerts* faces,
-                                      float* resVec, float beta, float maxDistSq, float minDistSq );
+                                      float* resVec, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq );
 
 
 } //namespece Cuda

--- a/source/MRCuda/MRCudaFastWindingNumber.h
+++ b/source/MRCuda/MRCudaFastWindingNumber.h
@@ -2,11 +2,15 @@
 #include "exports.h"
 #include "MRMesh/MRFastWindingNumber.h"
 #include "MRMesh/MRMesh.h"
+
 namespace MR
 {
+
 namespace Cuda
 {
+
 struct FastWindingNumberData;
+
 /// the class for fast approximate computation of winding number for a mesh (using its AABB tree)
 /// \ingroup AABBTreeGroup
 class FastWindingNumber : public IFastWindingNumber
@@ -17,39 +21,17 @@ class FastWindingNumber : public IFastWindingNumber
 public:
     /// constructs this from AABB tree of given mesh;
     MRCUDA_API FastWindingNumber( const Mesh& mesh );
-    /// <summary>
-    /// calculates winding numbers for a vector of points
-    /// </summary>
-    /// <param name="res">resulting winding numbers, will be resized automatically</param>
-    /// <param name="points">incoming points</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    /// <param name="skipFace">this triangle (if it is close to \param q) will be skipped from summation</param>
+
+    // see methods' descriptions in IFastWindingNumber
     MRCUDA_API void calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace = {} ) override;
-    /// <summary>
-    /// calculates winding numbers for all centers of mesh's triangles. if winding number is less than 0 or greater then 1, that face is marked as self-intersected
-    /// </summary>
-    /// <param name="res">resulting bit set</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
     MRCUDA_API bool calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb ) override;
-    /// <summary>
-    /// calculates winding numbers for each point in a three-dimensional grid
-    /// </summary>
-    /// <param name="res">resulting winding numbers, will be resized automatically</param>
-    /// <param name="dims">dimensions of the grid</param>
-    /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
     MRCUDA_API VoidOrErrStr calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
-    /// <summary>
-    /// calculates winding numbers for each point in a three-dimensional grid
-    /// </summary>
-    /// <param name="res">resulting winding numbers, will be resized automatically</param>
-    /// <param name="dims">dimensions of the grid</param>
-    /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    MRCUDA_API VoidOrErrStr calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) override;
+    MRCUDA_API float calcWithDistances( const Vector3f& p, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq );
+    MRCUDA_API VoidOrErrStr calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) override;
+
 private:
     bool prepareData_( ProgressCallback cb );
 };
 
-}
-}
+} // namespace Cuda
+} // namespace MR

--- a/source/MRMesh/MRFastWindingNumber.cpp
+++ b/source/MRMesh/MRFastWindingNumber.cpp
@@ -58,13 +58,13 @@ VoidOrErrStr FastWindingNumber::calcFromGrid( std::vector<float>& res, const Vec
     return {};
 }
 
-float FastWindingNumber::calcWithDistances( const Vector3f& p, float beta, float maxDistSq, float minDistSq )
+float FastWindingNumber::calcWithDistances( const Vector3f& p, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq )
 {
-    const auto sign = calc_( p, beta ) > 0.5f ? -1.f : +1.f;
+    const auto sign = calc_( p, beta ) > windingNumberThreshold ? -1.f : +1.f;
     return sign * std::sqrt( findProjection( p, mesh_, maxDistSq, nullptr, minDistSq ).distSq );
 }
 
-VoidOrErrStr FastWindingNumber::calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, float maxDistSq, float minDistSq, ProgressCallback cb )
+VoidOrErrStr FastWindingNumber::calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb )
 {
     MR_TIMER
 
@@ -76,7 +76,7 @@ VoidOrErrStr FastWindingNumber::calcFromGridWithDistances( std::vector<float>& r
     if ( !ParallelFor( 0_vox, indexer.endId(), [&]( VoxelId i )
         {
             const auto transformedPoint = gridToMeshXf( Vector3f( indexer.toPos( i ) ) );
-            res[i] = calcWithDistances( transformedPoint, beta, maxDistSq, minDistSq );
+            res[i] = calcWithDistances( transformedPoint, windingNumberThreshold, beta, maxDistSq, minDistSq );
         }, cb ) )
         return unexpectedOperationCanceled();
     return {};

--- a/source/MRMesh/MRFastWindingNumber.h
+++ b/source/MRMesh/MRFastWindingNumber.h
@@ -7,19 +7,21 @@
 namespace MR
 {
 
-/// Abstract class for fast approximate computation of winding number for a mesh (using its AABB tree)
+/// Abstract class for fast approximate computation of generalized winding number for a mesh (using its AABB tree)
 class IFastWindingNumber
 {
 public:
     virtual ~IFastWindingNumber() = default;
+
     /// <summary>
-    /// calculates winding numbers for a vector of points
+    /// calculates winding numbers in the points from given vector
     /// </summary>
     /// <param name="res">resulting winding numbers, will be resized automatically</param>
     /// <param name="points">incoming points</param>
     /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
     /// <param name="skipFace">this triangle (if it is close to `q`) will be skipped from summation</param>
     virtual void calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace = {} ) = 0;
+
     /// <summary>
     /// calculates winding numbers for all centers of mesh's triangles. if winding number is less than 0 or greater then 1, that face is marked as self-intersected
     /// </summary>
@@ -27,8 +29,9 @@ public:
     /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
     /// <returns>false if the operation was canceled by the user</returns>
     virtual bool calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb = {} ) = 0;
+
     /// <summary>
-    /// calculates winding numbers for each point in a three-dimensional grid
+    /// calculates winding numbers in each point from a three-dimensional grid
     /// </summary>
     /// <param name="res">resulting winding numbers, will be resized automatically</param>
     /// <param name="dims">dimensions of the grid</param>
@@ -37,13 +40,14 @@ public:
     virtual VoidOrErrStr calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb = {} ) = 0;
 
     /// <summary>
-    /// calculates distances and winding numbers for each point in a three-dimensional grid
+    /// calculates distances with the sign obtained from winding number in each point from a three-dimensional grid
     /// </summary>
     /// <param name="res">resulting signed distances, will be resized automatically</param>
     /// <param name="dims">dimensions of the grid</param>
     /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
+    /// <param name="windingNumberThreshold">positive distance if winding number below or equal this threshold</param>
     /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    virtual VoidOrErrStr calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) = 0;
+    virtual VoidOrErrStr calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) = 0;
 };
 
 /// the class for fast approximate computation of winding number for a mesh (using its AABB tree)
@@ -57,46 +61,12 @@ public:
     /// this remains valid only if tree is valid
     [[nodiscard]] MRMESH_API FastWindingNumber( const Mesh & mesh );
 
-    /// <summary>
-    /// calculates winding numbers for a vector of points
-    /// </summary>
-    /// <param name="res">resulting winding numbers, will be resized automatically</param>
-    /// <param name="points">incoming points</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    /// <param name="skipFace">this triangle (if it is close to `q`) will be skipped from summation</param>
+    // see methods' descriptions in IFastWindingNumber
     MRMESH_API void calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace = {} ) override;
-
-    /// <summary>
-    /// calculates winding numbers for all centers of mesh's triangles. if winding number is less than 0 or greater then 1, that face is marked as self-intersected
-    /// </summary>
-    /// <param name="res">resulting bit set</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
     MRMESH_API bool calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb ) override;
-
-    /// <summary>
-    /// calculates winding numbers for each point in a three-dimensional grid
-    /// </summary>
-    /// <param name="res">resulting winding numbers, will be resized automatically</param>
-    /// <param name="dims">dimensions of the grid</param>
-    /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
     MRMESH_API VoidOrErrStr calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
-
-    /// calculates distances and winding numbers at \param p
-    /// \param beta determines the precision of the approximation: the more the better, recommended value 2 or more;
-    /// if distance from p to the center of some triangle group is more than beta times the distance from the center to most distance triangle in the group then we use approximate formula
-    /// \param maxDistSq - maximum possible distance
-    /// \param minDistSq - minimum possible distance
-    MRMESH_API float calcWithDistances( const Vector3f& p, float beta, float maxDistSq, float minDistSq );
-
-    /// <summary>
-    /// calculates distances and winding numbers for each point in a three-dimensional grid
-    /// </summary>
-    /// <param name="res">resulting signed distances, will be resized automatically</param>
-    /// <param name="dims">dimensions of the grid</param>
-    /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    MRMESH_API VoidOrErrStr calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) override;
+    MRMESH_API float calcWithDistances( const Vector3f& p, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq );
+    MRMESH_API VoidOrErrStr calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) override;
 
 private:
     [[nodiscard]] float calc_( const Vector3f & q, float beta, FaceId skipFace = {} ) const;

--- a/source/MRMesh/MRMeshToDistanceVolume.cpp
+++ b/source/MRMesh/MRMeshToDistanceVolume.cpp
@@ -42,7 +42,7 @@ std::optional<float> signedDistanceToMesh( const MeshPart& mp, const Vector3f& p
 
     case SignDetectionMode::HoleWindingRule:
         assert( !mp.region );
-        if ( !mp.mesh.isOutside( p ) )
+        if ( !mp.mesh.isOutside( p, op.windingNumberThreshold, op.windingNumberBeta ) )
             dist = -dist;
         break;
 
@@ -69,8 +69,8 @@ Expected<SimpleVolume> meshToDistanceVolume( const MeshPart& mp, const MeshToDis
             params.fwn = std::make_shared<FastWindingNumber>( mp.mesh );
         assert( !mp.region ); // only whole mesh is supported for now
         auto basis = AffineXf3f( Matrix3f::scale( params.vol.voxelSize ), params.vol.origin + 0.5f * params.vol.voxelSize );
-        constexpr float beta = 2;
-        if ( auto d = params.fwn->calcFromGridWithDistances( res.data, res.dims, basis, beta,
+        if ( auto d = params.fwn->calcFromGridWithDistances( res.data, res.dims, basis,
+            params.dist.windingNumberThreshold, params.dist.windingNumberBeta,
             params.dist.maxDistSq, params.dist.minDistSq, params.vol.cb ); !d )
         {
             return unexpected( std::move( d.error() ) );

--- a/source/MRMesh/MRMeshToDistanceVolume.h
+++ b/source/MRMesh/MRMeshToDistanceVolume.h
@@ -21,6 +21,15 @@ struct DistanceToMeshOptions
 
     /// the method to compute distance sign
     SignDetectionMode signMode{ SignDetectionMode::ProjectionNormal };
+
+    /// only for SignDetectionMode::HoleWindingRule:
+    /// positive distance if winding number below or equal this threshold;
+    /// ideal threshold: 0.5 for closed meshes; 0.0 for planar meshes
+    float windingNumberThreshold = 0.5f;
+
+    /// only for SignDetectionMode::HoleWindingRule:
+    /// determines the precision of fast approximation: the more the better, minimum value is 1
+    float windingNumberBeta = 2;
 };
 
 /// computes signed distance from point (p) to mesh part (mp) following options (op)

--- a/source/MRMesh/MROffset.cpp
+++ b/source/MRMesh/MROffset.cpp
@@ -151,9 +151,11 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
         msParams.vol.origin = box.min - expansion;
         msParams.vol.voxelSize = Vector3f::diagonal( params.voxelSize );
         msParams.vol.dimensions = Vector3i( ( box.max + expansion - msParams.vol.origin ) / params.voxelSize ) + Vector3i::diagonal( 1 );
-        msParams.dist.signMode = params.signDetectionMode;
         msParams.dist.maxDistSq = sqr( absOffset + params.voxelSize );
         msParams.dist.minDistSq = sqr( std::max( absOffset - params.voxelSize, 0.0f ) );
+        msParams.dist.signMode = params.signDetectionMode;
+        msParams.dist.windingNumberThreshold = params.windingNumberThreshold;
+        msParams.dist.windingNumberBeta = params.windingNumberBeta;
         msParams.fwn = params.fwn;
 
         MarchingCubesParams vmParams;

--- a/source/MRMesh/MROffset.h
+++ b/source/MRMesh/MROffset.h
@@ -28,6 +28,15 @@ struct OffsetParameters : BaseShellParameters
     /// determines the method to compute distance sign
     SignDetectionMode signDetectionMode = SignDetectionMode::OpenVDB;
 
+    /// only for SignDetectionMode::HoleWindingRule:
+    /// positive distance if winding number below or equal this threshold;
+    /// ideal threshold: 0.5 for closed meshes; 0.0 for planar meshes
+    float windingNumberThreshold = 0.5f;
+
+    /// only for SignDetectionMode::HoleWindingRule:
+    /// determines the precision of fast approximation: the more the better, minimum value is 1
+    float windingNumberBeta = 2;
+
     /// defines particular implementation of IFastWindingNumber interface that will compute windings. If it is not specified, default FastWindingNumber is used
     std::shared_ptr<IFastWindingNumber> fwn;
 


### PR DESCRIPTION
Generalized winding number computation now exposes all parameter:

* threshold
* beta (to control the precision)

to the user, both for CPU and CUDA implementations.