### PR TITLE
levelSetDoubleConvertion improvements

### DIFF
--- a/source/MRMesh/MROffset.cpp
+++ b/source/MRMesh/MROffset.cpp
@@ -101,7 +101,7 @@ Expected<Mesh> doubleOffsetMesh( const MeshPart& mp, float offsetA, float offset
     {
         spdlog::warn( "Cannot use shell for double offset, using offset mode instead." );
     }
-    return levelSetDoubleConvertion( mp, AffineXf3f(), params.voxelSize, offsetA, offsetB, 0, params.fwn, params.callBack );
+    return levelSetDoubleConvertion( mp, params.voxelSize, offsetA, offsetB, 0, params.fwn, params.callBack );
 }
 #endif
 

--- a/source/MRMesh/MRVDBConversions.h
+++ b/source/MRMesh/MRVDBConversions.h
@@ -107,7 +107,7 @@ MRMESH_API VoidOrErrStr makeSignedWithFastWinding( FloatGrid& grid, const Vector
 // adaptivity - [0.0;1.0] ratio of combining small triangles into bigger ones 
 //                       (curvature can be lost on high values)
 /// \param fwn defines particular implementation of IFastWindingNumber interface that will compute windings. If it is not specified, default FastWindingNumber is used
-MRMESH_API Expected<Mesh> levelSetDoubleConvertion( const MeshPart& mp, const AffineXf3f& xf,
+MRMESH_API Expected<Mesh> levelSetDoubleConvertion( const MeshPart& mp,
     float voxelSize, float offsetA, float offsetB, float adaptivity = 0.0f, std::shared_ptr<IFastWindingNumber> fwn = {}, ProgressCallback cb = {} );
 
 }


### PR DESCRIPTION
Improvements:
* `xf` parameter deleted, since not identity values of it were never supported
* `reportProgress` function is used for more clarity
* `findLeftBoundary` call is replaced with cheaper `topology.isClosed`