### PR TITLE
rebuildMesh

### DIFF
--- a/source/MRMesh/MRMeshToDistanceVolume.h
+++ b/source/MRMesh/MRMeshToDistanceVolume.h
@@ -41,18 +41,38 @@ struct MeshToDistanceVolumeParams
 
     DistanceToMeshOptions dist;
 
+    /// defines particular implementation of IFastWindingNumber interface that will compute windings. If it is not specified, default FastWindingNumber is used
     std::shared_ptr<IFastWindingNumber> fwn;
 };
 
 /// makes SimpleVolume filled with (signed or unsigned) distances from Mesh with given settings
-MRMESH_API Expected<SimpleVolume> meshToDistanceVolume( const MeshPart& mp, const MeshToDistanceVolumeParams& params = {} );
+[[nodiscard]] MRMESH_API Expected<SimpleVolume> meshToDistanceVolume( const MeshPart& mp, const MeshToDistanceVolumeParams& params = {} );
 
 /// makes FunctionVolume representing (signed or unsigned) distances from Mesh with given settings
-MRMESH_API FunctionVolume meshToDistanceFunctionVolume( const MeshPart& mp, const MeshToDistanceVolumeParams& params = {} );
+[[nodiscard]] MRMESH_API FunctionVolume meshToDistanceFunctionVolume( const MeshPart& mp, const MeshToDistanceVolumeParams& params = {} );
+
+
+struct MeshToWindingNumberVolumeParams
+{
+    DistanceVolumeParams vol;
+
+    /// defines particular implementation of IFastWindingNumber interface that will compute windings. If it is not specified, default FastWindingNumber is used
+    std::shared_ptr<IFastWindingNumber> fwn;
+
+    /// determines the precision of fast approximation: the more the better, minimum value is 1
+    float windingNumberBeta = 2;
+};
+
+/// makes SimpleVolume filled in grid points with generalized winding number induced by given mesh
+[[nodiscard]] MRMESH_API Expected<SimpleVolume> meshToWindingNumberVolume( const MeshPart& mp, const MeshToWindingNumberVolumeParams& params );
+
+/// makes FunctionVolume representing grid points with generalized winding number induced by given mesh
+[[nodiscard]] MRMESH_API FunctionVolume meshToWindingNumberFunctionVolume( const MeshPart& mp, const MeshToWindingNumberVolumeParams& params );
+
 
 /// returns a volume filled with the values:
 /// v < 0: this point is within offset distance to region-part of mesh and it is closer to region-part than to not-region-part
-MRMESH_API Expected<SimpleVolume> meshRegionToIndicatorVolume( const Mesh& mesh, const FaceBitSet& region,
+[[nodiscard]] MRMESH_API Expected<SimpleVolume> meshRegionToIndicatorVolume( const Mesh& mesh, const FaceBitSet& region,
     float offset, const DistanceVolumeParams& params );
 
 
@@ -66,6 +86,6 @@ struct MeshToDirectionVolumeParams
 /// Converts mesh into 4d voxels, so that each cell in 3d space holds the direction from the closest point on mesh to the cell position.
 /// Resulting volume is encoded by 3 separate 3d volumes, corresponding to `x`, `y` and `z` components of vectors respectively.
 /// \param params Expected to have valid (not null) projector, with invoked method \ref IPointsToMeshProjector::updateMeshData
-MRMESH_API Expected<std::array<SimpleVolume, 3>> meshToDirectionVolume( const MeshToDirectionVolumeParams& params );
+[[nodiscard]] MRMESH_API Expected<std::array<SimpleVolume, 3>> meshToDirectionVolume( const MeshToDirectionVolumeParams& params );
 
 } //namespace MR

--- a/source/MRMesh/MROffset.h
+++ b/source/MRMesh/MROffset.h
@@ -80,7 +80,13 @@ struct SharpOffsetParameters : OffsetParameters
 
 /// Offsets mesh by converting it to distance field in voxels (using OpenVDB library if SignDetectionMode::OpenVDB or our implementation otherwise)
 /// and back using standard Marching Cubes, as opposed to Dual Marching Cubes in offsetMesh(...)
-[[nodiscard]] MRMESH_API Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset, 
+[[nodiscard]] MRMESH_API Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
+    const OffsetParameters& params = {}, Vector<VoxelId, FaceId>* outMap = nullptr );
+
+/// Converts the mesh into volume with generalized winding number function values in grid points,
+/// then constructs resulting mesh as an iso-value of that volume using marching cubes algorithm;
+/// signDetectionMode must be SignDetectionMode::HoleWindingRule
+[[nodiscard]] MRMESH_API Expected<Mesh> rebuildMesh( const MeshPart& mp,
     const OffsetParameters& params = {}, Vector<VoxelId, FaceId>* outMap = nullptr );
 
 /// Constructs a shell around selected mesh region with the properties that every point on the shall must


### PR DESCRIPTION
`rebuildMesh` function to convert a mesh with self-intersections and holes in another closed and simple mesh. It is implemented via new functions `meshToWindingNumberVolume` and `meshToWindingNumberFunctionVolume`.