### PR TITLE
DenseBox: consider an option with axis-aligned box

### DIFF
--- a/source/MRMesh/MRDenseBox.cpp
+++ b/source/MRMesh/MRDenseBox.cpp
@@ -1,32 +1,33 @@
 #include "MRDenseBox.h"
 #include "MRMesh.h"
+#include "MRTimer.h"
 
 namespace MR
 {
 
 DenseBox::DenseBox( const std::vector<Vector3f>& points, const AffineXf3f* xf )
 {
-    include_( points, nullptr, xf );
+    init_( points, nullptr, xf );
 }
 
 DenseBox::DenseBox( const std::vector<Vector3f>& points, const std::vector<float>& weights, const AffineXf3f* xf )
 {
-    include_( points, &weights, xf );
+    init_( points, &weights, xf );
 }
 
 DenseBox::DenseBox( const MeshPart& meshPart, const AffineXf3f* xf /*= nullptr*/ )
 {
-    include_( meshPart, xf );
+    init_( meshPart, xf );
 }
 
 DenseBox::DenseBox( const PointCloud& points, const AffineXf3f* xf /*= nullptr*/ )
 {
-    include_( points, xf );
+    init_( points, xf );
 }
 
 DenseBox::DenseBox( const Polyline3& line, const AffineXf3f* xf /*= nullptr*/ )
 {
-    include_( line, xf );
+    init_( line, xf );
 }
 
 Vector3f DenseBox::center() const
@@ -47,8 +48,17 @@ bool DenseBox::contains( const Vector3f& pt ) const
     return box_.contains( basisXfInv_( pt ) );
 }
 
-void DenseBox::include_( const std::vector<Vector3f>& points, const std::vector<float>* weights, const AffineXf3f* xf )
+void DenseBox::init_( const std::vector<Vector3f>& points, const std::vector<float>* weights, const AffineXf3f* xf )
 {
+    MR_TIMER
+    for ( const auto& p : points )
+        box_.include( xf ? (*xf)( p ) : p );
+    if ( xf )
+    {
+        basisXf_ = *xf;
+        basisXfInv_ = basisXf_.inverse();
+    }
+
     assert( !weights || points.size() == weights->size() );
     PointAccumulator accum;
     if ( weights )
@@ -57,59 +67,100 @@ void DenseBox::include_( const std::vector<Vector3f>& points, const std::vector<
         accumulatePoints( accum, points, xf );
     if ( !accum.valid() )
         return;
-    basisXf_ = AffineXf3f( accum.getBasicXf() );
-    basisXfInv_ = basisXf_.inverse();
-    auto tempXf = basisXfInv_;
-    if ( xf )
-        tempXf = basisXfInv_ * ( *xf );
 
+    const auto aXf = AffineXf3f( accum.getBasicXf() );
+    const auto aInvXf = aXf.inverse();
+    const auto tempXf = xf ? aInvXf * ( *xf ) : aInvXf;
+    Box3f abox;
     for ( const auto& p : points )
-        box_.include( tempXf( p ) );
+        abox.include( tempXf( p ) );
+    if ( abox.volume() < box_.volume() )
+    {
+        box_ = abox;
+        basisXf_ = aXf;
+        basisXfInv_ = aInvXf;
+    }
 }
 
-void DenseBox::include_( const MeshPart& meshPart, const AffineXf3f* xf /*= nullptr */ )
+void DenseBox::init_( const MeshPart& meshPart, const AffineXf3f* xf )
 {
+    MR_TIMER
+    box_ = meshPart.mesh.computeBoundingBox( meshPart.region, xf );
+    if ( xf )
+    {
+        basisXf_ = *xf;
+        basisXfInv_ = basisXf_.inverse();
+    }
+
     PointAccumulator accum;
     accumulateFaceCenters( accum, meshPart, xf );
     if ( !accum.valid() )
         return;
-    basisXf_ = AffineXf3f( accum.getBasicXf() );
-    basisXfInv_ = basisXf_.inverse();
-    auto tempXf = basisXfInv_;
-    if ( xf )
-        tempXf = basisXfInv_ * ( *xf );
 
-    box_.include( meshPart.mesh.computeBoundingBox( &tempXf ) );
+    const auto aXf = AffineXf3f( accum.getBasicXf() );
+    const auto aInvXf = aXf.inverse();
+    const auto tempXf = xf ? aInvXf * ( *xf ) : aInvXf;
+    const auto abox = meshPart.mesh.computeBoundingBox( meshPart.region, &tempXf );
+    if ( abox.volume() < box_.volume() )
+    {
+        box_ = abox;
+        basisXf_ = aXf;
+        basisXfInv_ = aInvXf;
+    }
 }
 
-void DenseBox::include_( const PointCloud& points, const AffineXf3f* xf )
+void DenseBox::init_( const PointCloud& points, const AffineXf3f* xf )
 {
+    MR_TIMER
+    box_ = points.computeBoundingBox( xf );
+    if ( xf )
+    {
+        basisXf_ = *xf;
+        basisXfInv_ = basisXf_.inverse();
+    }
+
     PointAccumulator accum;
     accumulatePoints( accum, points, xf );
     if ( !accum.valid() )
         return;
-    basisXf_ = AffineXf3f( accum.getBasicXf() );
-    basisXfInv_ = basisXf_.inverse();
-    auto tempXf = basisXfInv_;
-    if ( xf )
-        tempXf = basisXfInv_ * ( *xf );
 
-    box_.include( points.computeBoundingBox( &tempXf ) );
+    const auto aXf = AffineXf3f( accum.getBasicXf() );
+    const auto aInvXf = aXf.inverse();
+    const auto tempXf = xf ? aInvXf * ( *xf ) : aInvXf;
+    const auto abox = points.computeBoundingBox( &tempXf );
+    if ( abox.volume() < box_.volume() )
+    {
+        box_ = abox;
+        basisXf_ = aXf;
+        basisXfInv_ = aInvXf;
+    }
 }
 
-void DenseBox::include_( const Polyline3& line, const AffineXf3f* xf )
+void DenseBox::init_( const Polyline3& line, const AffineXf3f* xf )
 {
+    MR_TIMER
+    box_ = line.computeBoundingBox( xf );
+    if ( xf )
+    {
+        basisXf_ = *xf;
+        basisXfInv_ = basisXf_.inverse();
+    }
+
     PointAccumulator accum;
     accumulateLineCenters( accum, line, xf );
     if ( !accum.valid() )
         return;
-    basisXf_ = AffineXf3f( accum.getBasicXf() );
-    basisXfInv_ = basisXf_.inverse();
-    auto tempXf = basisXfInv_;
-    if ( xf )
-        tempXf = basisXfInv_ * ( *xf );
 
-    box_.include( line.computeBoundingBox( &tempXf ) );
+    const auto aXf = AffineXf3f( accum.getBasicXf() );
+    const auto aInvXf = aXf.inverse();
+    const auto tempXf = xf ? aInvXf * ( *xf ) : aInvXf;
+    const auto abox = line.computeBoundingBox( &tempXf );
+    if ( abox.volume() < box_.volume() )
+    {
+        box_ = abox;
+        basisXf_ = aXf;
+        basisXfInv_ = aInvXf;
+    }
 }
 
-}
+} //namespace MR

--- a/source/MRMesh/MRDenseBox.h
+++ b/source/MRMesh/MRDenseBox.h
@@ -43,13 +43,13 @@ struct DenseBox
 
 private:
     /// Include given points into this dense box
-    void include_( const std::vector<Vector3f>& points, const std::vector<float>* weights = nullptr, const AffineXf3f* xf = nullptr );
+    void init_( const std::vector<Vector3f>& points, const std::vector<float>* weights = nullptr, const AffineXf3f* xf = nullptr );
     /// Include mesh part into this dense box
-    void include_( const MeshPart& meshPart, const AffineXf3f* xf = nullptr );
+    void init_( const MeshPart& meshPart, const AffineXf3f* xf = nullptr );
     /// Include point into this dense box
-    void include_( const PointCloud& points, const AffineXf3f* xf = nullptr );
+    void init_( const PointCloud& points, const AffineXf3f* xf = nullptr );
     /// Include line into this dense box
-    void include_( const Polyline3& line, const AffineXf3f* xf = nullptr );
+    void init_( const Polyline3& line, const AffineXf3f* xf = nullptr );
 
     Box3f box_;
     AffineXf3f basisXf_;


### PR DESCRIPTION
Select the box with minimal volume among two options:
1) the smallest box from `PointAccumulator` basis (as before),
2) the smallest box from user-provided basis (e.g. global-basis).