### PR TITLE
Smooth sign from winding number for distance fields

### DIFF
--- a/source/MRCuda/MRCudaFastWindingNumber.cu
+++ b/source/MRCuda/MRCudaFastWindingNumber.cu
@@ -220,8 +220,8 @@ __global__ void signedDistanceKernel( int3 dims, Matrix4 gridToMeshXf,
 
     float fwn{ 0 };
     processPoint( transformedPoint, fwn, dipoles, nodes, meshPoints, faces, beta, index );
-    if ( fwn > windingNumberThreshold )
-        res = -res;
+    const auto w = clamp( 2 * ( windingNumberThreshold - fwn ), -1.0f, 1.0f );
+    res *= ( 1.5f - 0.5f * w * w ) * w;
 }
 
 void fastWindingNumberFromVector( const float3* points, const Dipole* dipoles,

--- a/source/MRMesh/MRFastWindingNumber.cpp
+++ b/source/MRMesh/MRFastWindingNumber.cpp
@@ -60,8 +60,10 @@ VoidOrErrStr FastWindingNumber::calcFromGrid( std::vector<float>& res, const Vec
 
 float FastWindingNumber::calcWithDistances( const Vector3f& p, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq )
 {
-    const auto sign = calc_( p, beta ) > windingNumberThreshold ? -1.f : +1.f;
-    return sign * std::sqrt( findProjection( p, mesh_, maxDistSq, nullptr, minDistSq ).distSq );
+    const auto dist = std::sqrt( findProjection( p, mesh_, maxDistSq, nullptr, minDistSq ).distSq );
+    const auto fwn = calc_( p, beta );
+    const auto w = std::clamp( 2 * ( windingNumberThreshold - fwn ), -1.0f, 1.0f );
+    return dist * ( 1.5f - 0.5f * w * w ) * w;
 }
 
 VoidOrErrStr FastWindingNumber::calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb )

--- a/source/MRMesh/MRMeshToDistanceVolume.cpp
+++ b/source/MRMesh/MRMeshToDistanceVolume.cpp
@@ -43,14 +43,9 @@ std::optional<float> signedDistanceToMesh( const MeshPart& mp, const Vector3f& p
     case SignDetectionMode::HoleWindingRule:
     {
         assert( !mp.region );
-            auto windNum = mp.mesh.calcFastWindingNumber( p, op.windingNumberBeta );
-
-            auto k = std::clamp( 2 * ( op.windingNumberThreshold - windNum ), -1.0f, 1.0f );
-            if ( k < 0.0f )
-                k *= -k;
-            else
-                k *= k;
-            dist *= k;
+        auto fwn = mp.mesh.calcFastWindingNumber( p, op.windingNumberBeta );
+        const auto w = std::clamp( 2 * ( op.windingNumberThreshold - fwn ), -1.0f, 1.0f );
+        dist *= ( 1.5f - 0.5f * w * w ) * w;
         break;
     }
     default: ; //nothing

--- a/source/MRMesh/MRMeshToDistanceVolume.cpp
+++ b/source/MRMesh/MRMeshToDistanceVolume.cpp
@@ -41,11 +41,18 @@ std::optional<float> signedDistanceToMesh( const MeshPart& mp, const Vector3f& p
     }
 
     case SignDetectionMode::HoleWindingRule:
+    {
         assert( !mp.region );
-        if ( !mp.mesh.isOutside( p, op.windingNumberThreshold, op.windingNumberBeta ) )
-            dist = -dist;
-        break;
+            auto windNum = mp.mesh.calcFastWindingNumber( p, op.windingNumberBeta );
 
+            auto k = std::clamp( 2 * ( op.windingNumberThreshold - windNum ), -1.0f, 1.0f );
+            if ( k < 0.0f )
+                k *= -k;
+            else
+                k *= k;
+            dist *= k;
+        break;
+    }
     default: ; //nothing
     }
     return dist;

--- a/source/MRMesh/MRVDBConversions.cpp
+++ b/source/MRMesh/MRVDBConversions.cpp
@@ -448,14 +448,10 @@ VoidOrErrStr makeSignedByWindingNumber( FloatGrid& grid, const Vector3f& voxelSi
             for ( int j = 0; j < 3; ++j )
                 coord[j] += pos[j];
 
-            auto windVal = std::clamp( 2 * ( settings.windingNumberThreshold - windVals[i] ), -1.0f, 1.0f );
-            if ( windVal < 0.0f )
-                windVal *= -windVal;
-            else
-                windVal *= windVal;
-            accessor.modifyValue( coord, [windVal] ( float& val )
+            const auto w = std::clamp( 2 * ( settings.windingNumberThreshold - windVals[i] ), -1.0f, 1.0f );
+            accessor.modifyValue( coord, [k = ( 1.5f - 0.5f * w * w ) * w] ( float& val )
             {
-                val *= windVal;
+                val *= k;
             } );
         }, subprogress( settings.progress, 0.8f, 1.0f ) ) )
     {


### PR DESCRIPTION
Here we introduce similar setting of sign from Winding Number for unsigned distance fields.

Example of input mesh:
![image](https://github.com/user-attachments/assets/615b1f22-2c1f-4a2c-8440-7df33b98229a)

And we are trying to get offset=0 below.

Current `signedDistanceToMesh`:
![image](https://github.com/user-attachments/assets/5ac23323-6546-4d4c-b87a-172d4daa68cc)

Current `makeSignedByWindingNumber`:
![image](https://github.com/user-attachments/assets/73ed7f35-7122-4723-ad9e-b750557114ba)

New cubic formula:
![image](https://github.com/user-attachments/assets/5768bbff-5445-420c-8fda-32d5bca99890)


