### PR TITLE
makeSignedByWindingNumber: change only sign not magnitude of distances

### DIFF
--- a/.github/workflows/build-test-fedora.yml
+++ b/.github/workflows/build-test-fedora.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: boolean
       autotest_data_s3_url:
-        default: "s3://data-autotest/test_data_2023-jun-14"
+        default: "s3://data-autotest/test_data_2024-sep-04"
         required: false
         type: string
       UPLOAD_ARTIFACTS:

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       autotest_data_s3_url:
-        default: "s3://data-autotest/test_data_2023-jun-14"
+        default: "s3://data-autotest/test_data_2024-sep-04"
         required: false
         type: string
       UPLOAD_ARTIFACTS:

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: boolean
       autotest_data_s3_url:
-        default: "s3://data-autotest/test_data_2023-jun-14"
+        default: "s3://data-autotest/test_data_2024-sep-04"
         required: false
         type: string
       UPLOAD_ARTIFACTS:

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: boolean
       autotest_data_s3_url:
-        default: "s3://data-autotest/test_data_2023-jun-14"
+        default: "s3://data-autotest/test_data_2024-sep-04"
         required: false
         type: string
       UPLOAD_ARTIFACTS:

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: boolean
       autotest_data_s3_url:
-        default: "s3://data-autotest/test_data_2023-jun-14"
+        default: "s3://data-autotest/test_data_2024-sep-04"
         required: false
         type: string
       UPLOAD_ARTIFACTS:

--- a/source/MRMesh/MRVDBConversions.cpp
+++ b/source/MRMesh/MRVDBConversions.cpp
@@ -448,15 +448,13 @@ VoidOrErrStr makeSignedByWindingNumber( FloatGrid& grid, const Vector3f& voxelSi
             for ( int j = 0; j < 3; ++j )
                 coord[j] += pos[j];
 
-            auto windVal = std::clamp( 2 * ( settings.windingNumberThreshold - windVals[i] ), -1.0f, 1.0f );
-            if ( windVal < 0.0f )
-                windVal *= -windVal;
-            else
-                windVal *= windVal;
-            accessor.modifyValue( coord, [windVal] ( float& val )
+            if ( windVals[i] > settings.windingNumberThreshold )
             {
-                val *= windVal;
-            } );
+                accessor.modifyValue( coord, [] ( float& val )
+                {
+                    val = -val;
+                } );
+            }
         }, subprogress( settings.progress, 0.8f, 1.0f ) ) )
     {
         return unexpectedOperationCanceled();

--- a/source/MRMesh/MRVDBConversions.h
+++ b/source/MRMesh/MRVDBConversions.h
@@ -115,8 +115,7 @@ struct MakeSignedByWindingNumberSettings
     ProgressCallback progress;
 };
 
-/// set signs for unsigned distance field grid using refMesh FastWindingNumber;
-/// not only the sign but the magnitudes of distances in the grid are changed to make smooth transition from positive to negative
+/// set signs for unsigned distance field grid using generalized winding number computed at voxel grid point from refMesh
 MRMESH_API VoidOrErrStr makeSignedByWindingNumber( FloatGrid& grid, const Vector3f& voxelSize, const Mesh& refMesh,
     const MakeSignedByWindingNumberSettings & settings );
 


### PR DESCRIPTION
For an input mesh with hole:
![image](https://github.com/user-attachments/assets/8c2efdd5-af78-4186-a582-0cdfc4a94fac)

Current result of signed VDB offset 0:
![image](https://github.com/user-attachments/assets/dd65ce4d-f3af-49c1-ab8f-3842b774def0)
(note waves over existed triangles)

The result of signed VDB offset 0 after the fix:
![image](https://github.com/user-attachments/assets/52bd46da-088f-41e5-a016-16008dce0bd4)
(the mesh over holes is more aliased, but it is not that important)