### PR TITLE
Save in textual formats: keep single precision

### DIFF
--- a/.github/workflows/build-test-fedora.yml
+++ b/.github/workflows/build-test-fedora.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: boolean
       autotest_data_s3_url:
-        default: "s3://data-autotest/test_data_2024-sep-04"
+        default: "s3://data-autotest/test_data_2024-sep-06"
         required: false
         type: string
       UPLOAD_ARTIFACTS:

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       autotest_data_s3_url:
-        default: "s3://data-autotest/test_data_2024-sep-04"
+        default: "s3://data-autotest/test_data_2024-sep-06"
         required: false
         type: string
       UPLOAD_ARTIFACTS:

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: boolean
       autotest_data_s3_url:
-        default: "s3://data-autotest/test_data_2024-sep-04"
+        default: "s3://data-autotest/test_data_2024-sep-06"
         required: false
         type: string
       UPLOAD_ARTIFACTS:

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: boolean
       autotest_data_s3_url:
-        default: "s3://data-autotest/test_data_2024-sep-04"
+        default: "s3://data-autotest/test_data_2024-sep-06"
         required: false
         type: string
       UPLOAD_ARTIFACTS:

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: boolean
       autotest_data_s3_url:
-        default: "s3://data-autotest/test_data_2024-sep-04"
+        default: "s3://data-autotest/test_data_2024-sep-06"
         required: false
         type: string
       UPLOAD_ARTIFACTS:

--- a/source/MRMesh/MRLinesSave.cpp
+++ b/source/MRMesh/MRLinesSave.cpp
@@ -75,8 +75,14 @@ VoidOrErrStr toPts( const Polyline3& polyline, std::ostream& out, const SaveSett
         out << "BEGIN_Polyline\n";
         for ( auto v : contour )
         {
-            const auto p = applyDouble( settings.xf, v );
-            out << fmt::format( "{} {} {}\n", p.x, p.y, p.z );
+            auto saveVertex = [&]( auto && p )
+            {
+                out << fmt::format( "{} {} {}\n", p.x, p.y, p.z );
+            };
+            if ( settings.xf )
+                saveVertex( applyDouble( settings.xf, v ) );
+            else
+                saveVertex( v );
             ++pointIndex;
             if ( settings.progress && !( pointIndex & 0x3FF ) && !settings.progress( float( pointIndex ) / pointsNum ) )
                 return unexpected( std::string( "Saving canceled" ) );
@@ -122,15 +128,21 @@ VoidOrErrStr toDxf( const Polyline3& polyline, std::ostream& out, const SaveSett
         out << "70\n" << flags << "\n";
         for ( auto v : contour )
         {
-            const auto p = applyDouble( settings.xf, v );
-            out << fmt::format( 
-                "0\nVERTEX\n"
-                "8\n0\n"
-                "70\n32\n"
-                "10\n{}\n"
-                "20\n{}\n"
-                "30\n{}\n",
-                p.x, p.y, p.z );
+            auto saveVertex = [&]( auto && p )
+            {
+                out << fmt::format(
+                    "0\nVERTEX\n"
+                    "8\n0\n"
+                    "70\n32\n"
+                    "10\n{}\n"
+                    "20\n{}\n"
+                    "30\n{}\n",
+                    p.x, p.y, p.z );
+            };
+            if ( settings.xf )
+                saveVertex( applyDouble( settings.xf, v ) );
+            else
+                saveVertex( v );
             ++pointIndex;
             if ( settings.progress && !( pointIndex & 0x3FF ) && !settings.progress( float( pointIndex ) / pointsNum ) )
                 return unexpected( std::string( "Saving canceled" ) );

--- a/source/MRMesh/MRMeshSave.cpp
+++ b/source/MRMesh/MRMeshSave.cpp
@@ -86,8 +86,14 @@ VoidOrErrStr toOff( const Mesh& mesh, std::ostream& out, const SaveSettings & se
     {
         if ( settings.saveValidOnly && !mesh.topology.hasVert( i ) )
             continue;
-        auto p = applyDouble( settings.xf, mesh.points[i] );
-        out << fmt::format( "{} {} {}\n", p.x, p.y, p.z );
+        auto saveVertex = [&]( auto && p )
+        {
+            out << fmt::format( "{} {} {}\n", p.x, p.y, p.z );
+        };
+        if ( settings.xf )
+            saveVertex( applyDouble( settings.xf, mesh.points[i] ) );
+        else
+            saveVertex( mesh.points[i] );
         ++numSaved;
         if ( settings.progress && !( numSaved & 0x3FF ) && !settings.progress( float( numSaved ) / numPoints * 0.5f ) )
             return unexpected( std::string( "Saving canceled" ) );
@@ -159,16 +165,23 @@ VoidOrErrStr toObj( const Mesh & mesh, std::ostream & out, const SaveSettings & 
     {
         if ( settings.saveValidOnly && !mesh.topology.hasVert( i ) )
             continue;
-        auto p = applyDouble( settings.xf, mesh.points[i] );
-        if ( settings.colors )
+
+        auto saveVertex = [&]( auto && p )
         {
-            const auto c = (Vector4f)( *settings.colors )[i];
-            out << fmt::format( "v {} {} {} {} {} {}\n", p.x, p.y, p.z, c[0], c[1], c[2] );
-        }
+            if ( settings.colors )
+            {
+                const auto c = (Vector4f)( *settings.colors )[i];
+                out << fmt::format( "v {} {} {} {} {} {}\n", p.x, p.y, p.z, c[0], c[1], c[2] );
+            }
+            else
+            {
+                out << fmt::format( "v {} {} {}\n", p.x, p.y, p.z );
+            }
+        };
+        if ( settings.xf )
+            saveVertex( applyDouble( settings.xf, mesh.points[i] ) );
         else
-        {
-            out << fmt::format( "v {} {} {}\n", p.x, p.y, p.z );
-        }
+            saveVertex( mesh.points[i] );
         ++numSaved;
         if ( settings.progress && !( numSaved & 0x3FF ) && !sb( float( numSaved ) / numPoints ) )
             return unexpected( std::string( "Saving canceled" ) );
@@ -319,16 +332,20 @@ VoidOrErrStr toAsciiStl( const Mesh& mesh, std::ostream& out, const SaveSettings
         VertId a, b, c;
         mesh.topology.getTriVerts( f, a, b, c );
         assert( a.valid() && b.valid() && c.valid() );
-        const auto ap = applyDouble( settings.xf, mesh.points[a] );
-        const auto bp = applyDouble( settings.xf, mesh.points[b] );
-        const auto cp = applyDouble( settings.xf, mesh.points[c] );
-        const auto normal = cross( bp - ap, cp - ap ).normalized();
-        out << "" << fmt::format( "facet normal {} {} {}\n", normal.x, normal.y, normal.z );
-        out << "outer loop\n";
-        for ( const auto & p : { ap, bp, cp } )
+        auto saveVertex = [&]( auto && ap, auto && bp, auto && cp )
         {
-            out << fmt::format( "vertex {} {} {}\n", p.x, p.y, p.z );
-        }
+            const auto normal = cross( bp - ap, cp - ap ).normalized();
+            out << "" << fmt::format( "facet normal {} {} {}\n", normal.x, normal.y, normal.z );
+            out << "outer loop\n";
+            for ( const auto & p : { ap, bp, cp } )
+                out << fmt::format( "vertex {} {} {}\n", p.x, p.y, p.z );
+        };
+        if ( settings.xf )
+            saveVertex( applyDouble( settings.xf, mesh.points[a] ),
+                        applyDouble( settings.xf, mesh.points[b] ),
+                        applyDouble( settings.xf, mesh.points[c] ) );
+        else
+            saveVertex( mesh.points[a], mesh.points[b], mesh.points[c] );
         out << "endloop\n";
         out << "endfacet\n";
         if ( settings.progress && !( trisIndex & 0x3FF ) && !settings.progress( trisIndex / trisNum ) )

--- a/source/MRMesh/MRPointsSave.cpp
+++ b/source/MRMesh/MRPointsSave.cpp
@@ -71,12 +71,25 @@ VoidOrErrStr toAsc( const PointCloud& cloud, std::ostream& out, const SaveSettin
     {
         if ( settings.saveValidOnly && !cloud.validPoints.test( v ) )
             continue;
-        const auto p = applyDouble( settings.xf, cloud.points[v] );
-        out << fmt::format( "{} {} {}", p.x, p.y, p.z );
-        if ( saveNormals )
+        auto saveVertex = [&]( auto && p )
         {
-            const auto n = applyDouble( normXf, cloud.normals[v] );
+            out << fmt::format( "{} {} {}", p.x, p.y, p.z );
+        };
+        auto saveNormal = [&]( auto && n )
+        {
             out << fmt::format( " {} {} {}", n.x, n.y, n.z );
+        };
+        if ( settings.xf )
+        {
+            saveVertex( applyDouble( settings.xf, cloud.points[v] ) );
+            if ( saveNormals )
+                saveNormal( applyDouble( normXf, cloud.normals[v] ) );
+        }
+        else
+        {
+            saveVertex( cloud.points[v] );
+            if ( saveNormals )
+                saveNormal( cloud.normals[v] );
         }
         out << '\n';
         ++numSaved;


### PR DESCRIPTION
If `SaveSettings::xf` is not given, then do not convert coordinates in `double`s to keep short strings in file.