### PR TITLE
fromSceneObjFile: use custom xf only if necessary

### DIFF
--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -376,8 +376,6 @@ namespace
             result.emplace( std::move( currentMaterialName ), std::move( currentMaterial ) );
         return result;
     }
-
-    constexpr Vector3d cInvalidColor = { -1., -1., -1. };
 }
 
 namespace MR

--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -566,6 +566,22 @@ Expected<std::vector<NamedMesh>> fromSceneObjFile( const char* data, size_t size
 
     auto parseVertices = [&] ( size_t begin, size_t end, std::string& parseError )
     {
+        if ( end > begin )
+        {
+            // detect presence of colors from the first vertex
+            Vector3d v;
+            constexpr Vector3d cInvalidColor = { -1., -1., -1. };
+            Vector3d c { cInvalidColor };
+            std::string_view line( data + newlines[begin], newlines[begin + 1] - newlines[begin] );
+            auto res = parseObjCoordinate( line, v, &c );
+            if ( !res.has_value() )
+            {
+                parseError = std::move( res.error() );
+                return;
+            }
+            hasColors = c != cInvalidColor;
+        }
+
         const auto offset = points.endId();
         originalPointCount += int( end - begin );
         const size_t newSize = points.size() + ( end - begin );

--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -566,17 +566,6 @@ Expected<std::vector<NamedMesh>> fromSceneObjFile( const char* data, size_t size
     if ( !reportProgress( settings.callback, 0.5f ) )
         return unexpected( "Loading canceled" );
 
-    auto parseVertex = [&] ( size_t li ) -> Expected<std::tuple<Vector3d, Vector3d>>
-    {
-        Vector3d v;
-        Vector3d c { cInvalidColor };
-        std::string_view line( data + newlines[li], newlines[li + 1] - newlines[li + 0] );
-        auto res = parseObjCoordinate( line, v, &c );
-        if ( !res.has_value() )
-            return unexpected( std::move( res.error() ) );
-        return std::make_tuple( v, c );
-    };
-
     auto parseVertices = [&] ( size_t begin, size_t end, std::string& parseError )
     {
         const auto offset = points.endId();

--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -566,7 +566,7 @@ Expected<std::vector<NamedMesh>> fromSceneObjFile( const char* data, size_t size
 
     auto parseVertices = [&] ( size_t begin, size_t end, std::string& parseError )
     {
-        if ( end > begin )
+        assert ( end > begin );
         {
             // detect presence of colors from the first vertex
             Vector3d v;


### PR DESCRIPTION
In function for .OBJ files opening:
1. use custom transformation only if it can really improve relative precision (only if bounding box of all points does not include the origin point (0,0,0)), otherwise automatically select identity transformation;
2. each object read from .OBJ can have its own custom transformation