### PR TITLE
SimpleVolumeMinMax

### DIFF
--- a/source/MRCuda/MRCudaPointsToDistanceVolume.cpp
+++ b/source/MRCuda/MRCudaPointsToDistanceVolume.cpp
@@ -6,53 +6,57 @@
 
 namespace MR
 {
+
 namespace Cuda
 {
-    Expected<MR::SimpleVolume> pointsToDistanceVolume( const PointCloud& cloud, const MR::PointsToDistanceVolumeParams& params )
-    {
-        const auto& tree = cloud.getAABBTree();
-        const auto& nodes = tree.nodes();
 
-        DynamicArray<Node3> cudaNodes;
-        cudaNodes.fromVector( nodes.vec_ );
+Expected<MR::SimpleVolumeMinMax> pointsToDistanceVolume( const PointCloud& cloud, const MR::PointsToDistanceVolumeParams& params )
+{
+    const auto& tree = cloud.getAABBTree();
+    const auto& nodes = tree.nodes();
+
+    DynamicArray<Node3> cudaNodes;
+    cudaNodes.fromVector( nodes.vec_ );
         
-        DynamicArray<OrderedPoint> cudaPoints;
-        cudaPoints.fromVector( tree.orderedPoints() );
+    DynamicArray<OrderedPoint> cudaPoints;
+    cudaPoints.fromVector( tree.orderedPoints() );
 
-        DynamicArray<float3> cudaNormals;
-        cudaNormals.fromVector( params.ptNormals ? params.ptNormals->vec_ : cloud.normals.vec_ );
+    DynamicArray<float3> cudaNormals;
+    cudaNormals.fromVector( params.ptNormals ? params.ptNormals->vec_ : cloud.normals.vec_ );
 
-        PointsToDistanceVolumeParams cudaParams
-        {
-            .sigma = params.sigma,
-            .minWeight = params.minWeight
-        };
+    PointsToDistanceVolumeParams cudaParams
+    {
+        .sigma = params.sigma,
+        .minWeight = params.minWeight
+    };
 
-        cudaParams.origin.x = params.origin.x;
-        cudaParams.origin.y = params.origin.y;
-        cudaParams.origin.z = params.origin.z;
+    cudaParams.origin.x = params.origin.x;
+    cudaParams.origin.y = params.origin.y;
+    cudaParams.origin.z = params.origin.z;
 
-        cudaParams.voxelSize.x = params.voxelSize.x;
-        cudaParams.voxelSize.y = params.voxelSize.y;
-        cudaParams.voxelSize.z = params.voxelSize.z;
+    cudaParams.voxelSize.x = params.voxelSize.x;
+    cudaParams.voxelSize.y = params.voxelSize.y;
+    cudaParams.voxelSize.z = params.voxelSize.z;
 
-        cudaParams.dimensions.x = params.dimensions.x;
-        cudaParams.dimensions.y = params.dimensions.y;
-        cudaParams.dimensions.z = params.dimensions.z;
+    cudaParams.dimensions.x = params.dimensions.x;
+    cudaParams.dimensions.y = params.dimensions.y;
+    cudaParams.dimensions.z = params.dimensions.z;
        
-        DynamicArray<float> cudaVolume;
-        cudaVolume.resize( params.dimensions.x * params.dimensions.y * params.dimensions.z );
-        if ( !pointsToDistanceVolumeKernel( cudaNodes.data(), cudaPoints.data(), cudaNormals.data(), cudaVolume.data(), cudaParams ) )
-            return unexpected( "CUDA error occured" );
+    DynamicArray<float> cudaVolume;
+    cudaVolume.resize( params.dimensions.x * params.dimensions.y * params.dimensions.z );
+    if ( !pointsToDistanceVolumeKernel( cudaNodes.data(), cudaPoints.data(), cudaNormals.data(), cudaVolume.data(), cudaParams ) )
+        return unexpected( "CUDA error occurred" );
 
-        MR::SimpleVolume res;
-        res.dims = params.dimensions;
-        res.voxelSize = params.voxelSize;
-        res.max = params.sigma * std::exp( -0.5f );
-        res.min = -res.max;
-        cudaVolume.toVector( res.data );
-        return res;
-    }
+    MR::SimpleVolumeMinMax res;
+    res.dims = params.dimensions;
+    res.voxelSize = params.voxelSize;
+    res.max = params.sigma * std::exp( -0.5f );
+    res.min = -res.max;
+    cudaVolume.toVector( res.data );
+    return res;
 }
-}
+
+} //namespace Cuda
+
+} //namespace MR
 #endif

--- a/source/MRCuda/MRCudaPointsToDistanceVolume.h
+++ b/source/MRCuda/MRCudaPointsToDistanceVolume.h
@@ -10,7 +10,7 @@ namespace MR
 namespace Cuda
 {
 /// makes SimpleVolume filled with signed distances to points with normals
-MRCUDA_API Expected<MR::SimpleVolume> pointsToDistanceVolume( const PointCloud& cloud, const MR::PointsToDistanceVolumeParams& params );
+MRCUDA_API Expected<MR::SimpleVolumeMinMax> pointsToDistanceVolume( const PointCloud& cloud, const MR::PointsToDistanceVolumeParams& params );
 
 }
 }

--- a/source/MRViewer/MRCudaAccessor.h
+++ b/source/MRViewer/MRCudaAccessor.h
@@ -26,7 +26,7 @@ public:
     using CudaMeshProjectorConstructor = std::function<std::unique_ptr<IPointsToMeshProjector>()>;
 
 #ifndef MRVIEWER_NO_VOXELS
-    using CudaPointsToDistanceVolumeCallback = std::function<Expected<SimpleVolume>( const PointCloud& cloud, const PointsToDistanceVolumeParams& params )>;
+    using CudaPointsToDistanceVolumeCallback = std::function<Expected<SimpleVolumeMinMax>( const PointCloud& cloud, const PointsToDistanceVolumeParams& params )>;
 #endif
 
     // setup functions

--- a/source/MRVoxels/MRMarchingCubes.cpp
+++ b/source/MRVoxels/MRMarchingCubes.cpp
@@ -813,14 +813,14 @@ Expected<TriMesh> volumeToMeshHelper1( const V& volume, const MarchingCubesParam
         } );
 }
 
-Expected<TriMesh> marchingCubesAsTriMesh( const SimpleVolume& volume, const MarchingCubesParams& params /*= {} */ )
+Expected<TriMesh> marchingCubesAsTriMesh( const SimpleVolumeMinMax& volume, const MarchingCubesParams& params /*= {} */ )
 {
     if ( params.iso <= volume.min || params.iso >= volume.max )
         return TriMesh{};
     return volumeToMeshHelper1( volume, params );
 }
 
-Expected<Mesh> marchingCubes( const SimpleVolume& volume, const MarchingCubesParams& params )
+Expected<Mesh> marchingCubes( const SimpleVolumeMinMax& volume, const MarchingCubesParams& params )
 {
     MR_TIMER
     auto p = params;

--- a/source/MRVoxels/MRMarchingCubes.h
+++ b/source/MRVoxels/MRMarchingCubes.h
@@ -57,9 +57,9 @@ struct MarchingCubesParams
     std::function<void()> freeVolume;
 };
 
-// makes Mesh from SimpleVolume with given settings using Marching Cubes algorithm
-MRVOXELS_API Expected<Mesh> marchingCubes( const SimpleVolume& volume, const MarchingCubesParams& params = {} );
-MRVOXELS_API Expected<TriMesh> marchingCubesAsTriMesh( const SimpleVolume& volume, const MarchingCubesParams& params = {} );
+// makes Mesh from SimpleVolumeMinMax with given settings using Marching Cubes algorithm
+MRVOXELS_API Expected<Mesh> marchingCubes( const SimpleVolumeMinMax& volume, const MarchingCubesParams& params = {} );
+MRVOXELS_API Expected<TriMesh> marchingCubesAsTriMesh( const SimpleVolumeMinMax& volume, const MarchingCubesParams& params = {} );
 
 // makes Mesh from VdbVolume with given settings using Marching Cubes algorithm
 MRVOXELS_API Expected<Mesh> marchingCubes( const VdbVolume& volume, const MarchingCubesParams& params = {} );

--- a/source/MRVoxels/MRMeshToDistanceVolume.cpp
+++ b/source/MRVoxels/MRMeshToDistanceVolume.cpp
@@ -51,7 +51,7 @@ std::optional<float> signedDistanceToMesh( const MeshPart& mp, const Vector3f& p
     return dist;
 }
 
-Expected<SimpleVolume> meshToDistanceVolume( const MeshPart& mp, const MeshToDistanceVolumeParams& cParams /*= {} */ )
+Expected<SimpleVolumeMinMax> meshToDistanceVolume( const MeshPart& mp, const MeshToDistanceVolumeParams& cParams /*= {} */ )
 {
     MR_TIMER
     auto params = cParams;
@@ -59,7 +59,7 @@ Expected<SimpleVolume> meshToDistanceVolume( const MeshPart& mp, const MeshToDis
 
     if ( params.dist.signMode == SignDetectionMode::HoleWindingRule )
     {
-        SimpleVolume res;
+        SimpleVolumeMinMax res;
         res.voxelSize = params.vol.voxelSize;
         res.dims = params.vol.dimensions;
         VolumeIndexer indexer( res.dims );
@@ -102,7 +102,7 @@ FunctionVolume meshToDistanceFunctionVolume( const MeshPart& mp, const MeshToDis
     };
 }
 
-Expected<SimpleVolume> meshRegionToIndicatorVolume( const Mesh& mesh, const FaceBitSet& region,
+Expected<SimpleVolumeMinMax> meshRegionToIndicatorVolume( const Mesh& mesh, const FaceBitSet& region,
     float offset, const DistanceVolumeParams& params )
 {
     MR_TIMER
@@ -112,7 +112,7 @@ Expected<SimpleVolume> meshRegionToIndicatorVolume( const Mesh& mesh, const Face
         return unexpected( "empty region" );
     }
 
-    SimpleVolume res;
+    SimpleVolumeMinMax res;
     res.voxelSize = params.voxelSize;
     res.dims = params.dimensions;
     VolumeIndexer indexer( res.dims );
@@ -146,9 +146,7 @@ Expected<SimpleVolume> meshRegionToIndicatorVolume( const Mesh& mesh, const Face
     return res;
 }
 
-
-
-Expected<std::array<SimpleVolume, 3>> meshToDirectionVolume( const MeshToDirectionVolumeParams& params )
+Expected<std::array<SimpleVolumeMinMax, 3>> meshToDirectionVolume( const MeshToDirectionVolumeParams& params )
 {
     MR_TIMER
     VolumeIndexer indexer( params.vol.dimensions );
@@ -169,7 +167,7 @@ Expected<std::array<SimpleVolume, 3>> meshToDirectionVolume( const MeshToDirecti
         params.projector->findProjections( projs, points );
     }
 
-    std::array<SimpleVolume, 3> res;
+    std::array<SimpleVolumeMinMax, 3> res;
     for ( auto& v : res )
     {
         v.voxelSize = params.vol.voxelSize;

--- a/source/MRVoxels/MRMeshToDistanceVolume.h
+++ b/source/MRVoxels/MRMeshToDistanceVolume.h
@@ -45,14 +45,14 @@ struct MeshToDistanceVolumeParams
 };
 
 /// makes SimpleVolume filled with (signed or unsigned) distances from Mesh with given settings
-MRVOXELS_API Expected<SimpleVolume> meshToDistanceVolume( const MeshPart& mp, const MeshToDistanceVolumeParams& params = {} );
+MRVOXELS_API Expected<SimpleVolumeMinMax> meshToDistanceVolume( const MeshPart& mp, const MeshToDistanceVolumeParams& params = {} );
 
 /// makes FunctionVolume representing (signed or unsigned) distances from Mesh with given settings
 MRVOXELS_API FunctionVolume meshToDistanceFunctionVolume( const MeshPart& mp, const MeshToDistanceVolumeParams& params = {} );
 
 /// returns a volume filled with the values:
 /// v < 0: this point is within offset distance to region-part of mesh and it is closer to region-part than to not-region-part
-MRVOXELS_API Expected<SimpleVolume> meshRegionToIndicatorVolume( const Mesh& mesh, const FaceBitSet& region,
+MRVOXELS_API Expected<SimpleVolumeMinMax> meshRegionToIndicatorVolume( const Mesh& mesh, const FaceBitSet& region,
     float offset, const DistanceVolumeParams& params );
 
 
@@ -66,6 +66,6 @@ struct MeshToDirectionVolumeParams
 /// Converts mesh into 4d voxels, so that each cell in 3d space holds the direction from the closest point on mesh to the cell position.
 /// Resulting volume is encoded by 3 separate 3d volumes, corresponding to `x`, `y` and `z` components of vectors respectively.
 /// \param params Expected to have valid (not null) projector, with invoked method \ref IPointsToMeshProjector::updateMeshData
-MRVOXELS_API Expected<std::array<SimpleVolume, 3>> meshToDirectionVolume( const MeshToDirectionVolumeParams& params );
+MRVOXELS_API Expected<std::array<SimpleVolumeMinMax, 3>> meshToDirectionVolume( const MeshToDirectionVolumeParams& params );
 
 } //namespace MR

--- a/source/MRVoxels/MRObjectVoxels.cpp
+++ b/source/MRVoxels/MRObjectVoxels.cpp
@@ -29,7 +29,7 @@ MR_ADD_CLASS_FACTORY( ObjectVoxels )
 
 constexpr size_t cVoxelsHistogramBinsNumber = 256;
 
-void ObjectVoxels::construct( const SimpleVolume& volume, ProgressCallback cb )
+void ObjectVoxels::construct( const SimpleVolumeMinMax& volume, ProgressCallback cb )
 {
     mesh_.reset();
     activeVoxels_.reset();

--- a/source/MRVoxels/MRObjectVoxels.h
+++ b/source/MRVoxels/MRObjectVoxels.h
@@ -55,7 +55,7 @@ public:
     virtual std::string getClassName() const override { return "Voxels"; }
 
     /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface)
-    MRVOXELS_API void construct( const SimpleVolume& simpleVolume, ProgressCallback cb = {} );
+    MRVOXELS_API void construct( const SimpleVolumeMinMax& simpleVolume, ProgressCallback cb = {} );
     /// Clears all internal data and calculates histogram
     MRVOXELS_API void construct( const FloatGrid& grid, const Vector3f& voxelSize, ProgressCallback cb = {} );
     /// Clears all internal data and calculates histogram

--- a/source/MRVoxels/MROffset.cpp
+++ b/source/MRVoxels/MROffset.cpp
@@ -173,7 +173,7 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
         }
         else
         {
-            return meshToDistanceVolume( mp, msParams ).and_then( [&vmParams] ( SimpleVolume&& volume )
+            return meshToDistanceVolume( mp, msParams ).and_then( [&vmParams] ( SimpleVolumeMinMax&& volume )
             {
                 vmParams.freeVolume = [&volume]
                 {

--- a/source/MRVoxels/MRPointsToMeshFusion.cpp
+++ b/source/MRVoxels/MRPointsToMeshFusion.cpp
@@ -54,7 +54,7 @@ Expected<Mesh> pointsToMeshFusion( const PointCloud & cloud, const PointsToMeshP
     Expected<Mesh> res;
     if ( params.createVolumeCallback )
     {
-        res = params.createVolumeCallback( cloud, p2vParams ).and_then( [&vmParams] ( SimpleVolume&& volume )
+        res = params.createVolumeCallback( cloud, p2vParams ).and_then( [&vmParams] ( SimpleVolumeMinMax&& volume )
         {
             vmParams.freeVolume = [&volume]
             {

--- a/source/MRVoxels/MRPointsToMeshFusion.h
+++ b/source/MRVoxels/MRPointsToMeshFusion.h
@@ -33,7 +33,7 @@ struct PointsToMeshParameters
     ProgressCallback progress;
 
     /// Callback for volume creation. If null - volume will be created with memory efficient pointsToDistanceFunctionVolume function
-    std::function<Expected<SimpleVolume>( const PointCloud& cloud, const PointsToDistanceVolumeParams& params )> createVolumeCallback;
+    std::function<Expected<SimpleVolumeMinMax>( const PointCloud& cloud, const PointsToDistanceVolumeParams& params )> createVolumeCallback;
 };
 
 /// makes mesh from points with normals by constructing intermediate volume with signed distances

--- a/source/MRVoxels/MRTeethMaskToDirectionVolume.cpp
+++ b/source/MRVoxels/MRTeethMaskToDirectionVolume.cpp
@@ -113,7 +113,7 @@ Expected<TeethMaskToDirectionVolumeConvertor::ProcessResult> TeethMaskToDirectio
 
     const VolumeIndexer maskIndexer( mask_.dims );
 
-    SimpleVolume toothMask;
+    SimpleVolumeMinMax toothMask;
     toothMask.dims = box.size();
     toothMask.voxelSize = mask_.voxelSize;
     toothMask.data.resize( box.volume() );
@@ -190,7 +190,7 @@ Expected<TeethMaskToDirectionVolumeConvertor::ProcessResult> TeethMaskToDirectio
             return unexpected( std::move( maybeRes.error() ) );
     }
 
-    std::array<SimpleVolume, 3> res;
+    std::array<SimpleVolumeMinMax, 3> res;
     for ( int i = 0; i < 3; ++i )
     {
         auto& r = res[i];
@@ -219,7 +219,7 @@ Expected<TeethMaskToDirectionVolumeConvertor::ProcessResult> TeethMaskToDirectio
     };
 }
 
-Expected<std::array<SimpleVolume, 3>> teethMaskToDirectionVolume( const VdbVolume& volume, const std::vector<int>& additionalIds )
+Expected<std::array<SimpleVolumeMinMax, 3>> teethMaskToDirectionVolume( const VdbVolume& volume, const std::vector<int>& additionalIds )
 {
     return TeethMaskToDirectionVolumeConvertor::create( volume, additionalIds )
             .and_then( &TeethMaskToDirectionVolumeConvertor::convertAll )

--- a/source/MRVoxels/MRTeethMaskToDirectionVolume.h
+++ b/source/MRVoxels/MRTeethMaskToDirectionVolume.h
@@ -73,7 +73,7 @@ public:
     MRVOXELS_API const HashMap<int, Box3i>& getObjectBounds() const;
 
     /// See \ref meshToDirectionVolume for details
-    using DirectionVolume = std::array<SimpleVolume, 3>;
+    using DirectionVolume = std::array<SimpleVolumeMinMax, 3>;
     struct ProcessResult
     {
         DirectionVolume volume;
@@ -95,7 +95,7 @@ private:
 
 
 /// A shortcut for \ref TeethMaskToDirectionVolumeConvertor::create and \ref TeethMaskToDirectionVolumeConvertor::convertAll
-MRVOXELS_API Expected<std::array<SimpleVolume, 3>> teethMaskToDirectionVolume( const VdbVolume& volume, const std::vector<int>& additionalIds = {} );
+MRVOXELS_API Expected<std::array<SimpleVolumeMinMax, 3>> teethMaskToDirectionVolume( const VdbVolume& volume, const std::vector<int>& additionalIds = {} );
 
 
 }

--- a/source/MRVoxels/MRVDBConversions.cpp
+++ b/source/MRVoxels/MRVDBConversions.cpp
@@ -276,7 +276,7 @@ FloatGrid simpleVolumeToDenseGrid( const SimpleVolume& simpleVolume,
     return MakeFloatGrid( std::move( grid ) );
 }
 
-VdbVolume simpleVolumeToVdbVolume( const SimpleVolume& simpleVolume, ProgressCallback cb /*= {} */ )
+VdbVolume simpleVolumeToVdbVolume( const SimpleVolumeMinMax& simpleVolume, ProgressCallback cb /*= {} */ )
 {
     VdbVolume res;
     res.data = simpleVolumeToDenseGrid( simpleVolume, cb );
@@ -348,17 +348,17 @@ Expected<VoxelsVolumeMinMax<std::vector<T>>> vdbVolumeToSimpleVolumeImpl(
     return res;
 }
 
-Expected<SimpleVolume> vdbVolumeToSimpleVolume( const VdbVolume& vdbVolume, const Box3i& activeBox, ProgressCallback cb )
+Expected<SimpleVolumeMinMax> vdbVolumeToSimpleVolume( const VdbVolume& vdbVolume, const Box3i& activeBox, ProgressCallback cb )
 {
     return vdbVolumeToSimpleVolumeImpl<float, false>( vdbVolume, activeBox, cb );
 }
 
-Expected<MR::SimpleVolume> vdbVolumeToSimpleVolumeNorm( const VdbVolume& vdbVolume, const Box3i& activeBox /*= Box3i()*/, ProgressCallback cb /*= {} */ )
+Expected<SimpleVolumeMinMax> vdbVolumeToSimpleVolumeNorm( const VdbVolume& vdbVolume, const Box3i& activeBox /*= Box3i()*/, ProgressCallback cb /*= {} */ )
 {
     return vdbVolumeToSimpleVolumeImpl<float, true>( vdbVolume, activeBox, cb );
 }
 
-Expected<SimpleVolumeU16> vdbVolumeToSimpleVolumeU16( const VdbVolume& vdbVolume, const Box3i& activeBox, ProgressCallback cb )
+Expected<SimpleVolumeMinMaxU16> vdbVolumeToSimpleVolumeU16( const VdbVolume& vdbVolume, const Box3i& activeBox, ProgressCallback cb )
 {
     return vdbVolumeToSimpleVolumeImpl<uint16_t, true>( vdbVolume, activeBox, cb );
 }

--- a/source/MRVoxels/MRVDBConversions.h
+++ b/source/MRVoxels/MRVDBConversions.h
@@ -56,19 +56,19 @@ MRVOXELS_API VdbVolume floatGridToVdbVolume( FloatGrid grid );
 // make copy of data
 // grid can be used to make iso-surface later with gridToMesh function
 MRVOXELS_API FloatGrid simpleVolumeToDenseGrid( const SimpleVolume& simpleVolume, ProgressCallback cb = {} );
-MRVOXELS_API VdbVolume simpleVolumeToVdbVolume( const SimpleVolume& simpleVolume, ProgressCallback cb = {} );
+MRVOXELS_API VdbVolume simpleVolumeToVdbVolume( const SimpleVolumeMinMax& simpleVolume, ProgressCallback cb = {} );
 
 // make SimpleVolume from VdbVolume
 // make copy of data
-MRVOXELS_API Expected<SimpleVolume> vdbVolumeToSimpleVolume(
+MRVOXELS_API Expected<SimpleVolumeMinMax> vdbVolumeToSimpleVolume(
     const VdbVolume& vdbVolume, const Box3i& activeBox = Box3i(), ProgressCallback cb = {} );
 // make normalized SimpleVolume from VdbVolume
 // make copy of data
-MRVOXELS_API Expected<SimpleVolume> vdbVolumeToSimpleVolumeNorm(
+MRVOXELS_API Expected<SimpleVolumeMinMax> vdbVolumeToSimpleVolumeNorm(
     const VdbVolume& vdbVolume, const Box3i& activeBox = Box3i(), ProgressCallback cb = {} );
 // make SimpleVolumeU16 from VdbVolume
 // performs mapping from [vdbVolume.min, vdbVolume.max] to nonnegative range of uint16_t
-MRVOXELS_API Expected<SimpleVolumeU16> vdbVolumeToSimpleVolumeU16(
+MRVOXELS_API Expected<SimpleVolumeMinMaxU16> vdbVolumeToSimpleVolumeU16(
     const VdbVolume& vdbVolume, const Box3i& activeBox = Box3i(), ProgressCallback cb = {} );
 
 /// parameters of OpenVDB Grid to Mesh conversion using Dual Marching Cubes algorithm

--- a/source/MRVoxels/MRVolumeInterpolation.h
+++ b/source/MRVoxels/MRVolumeInterpolation.h
@@ -95,12 +95,12 @@ private:
 
 /// sample function that resamples the voxel volume using interpolating accessor
 template <typename Accessor>
-SimpleVolume resampleVolumeByInterpolation(
+SimpleVolumeMinMax resampleVolumeByInterpolation(
     const typename Accessor::VolumeType &volume,
     const Accessor &accessor,
     const Vector3f &newVoxelSize )
 {
-    SimpleVolume res{
+    SimpleVolumeMinMax res{
         { .voxelSize{ newVoxelSize } },
         volume.min,
         volume.max

--- a/source/MRVoxels/MRVolumeSegment.h
+++ b/source/MRVoxels/MRVolumeSegment.h
@@ -100,7 +100,7 @@ public:
 private:
     const VdbVolume& volume_;
 
-    SimpleVolume volumePart_;
+    SimpleVolumeMinMax volumePart_;
 
     Vector3i minVoxel_;
     Vector3i maxVoxel_;

--- a/source/MRVoxels/MRVoxelsConversionsByParts.cpp
+++ b/source/MRVoxels/MRVoxelsConversionsByParts.cpp
@@ -72,14 +72,14 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
             .isoValue = 0.f,
         } );
     }
-    else if constexpr ( std::is_same_v<Volume, SimpleVolume> )
+    else if constexpr ( std::is_same_v<Volume, SimpleVolumeMinMax> )
     {
         res = marchingCubes( volume, {
             .iso = 0.f,
             .lessInside = true,
             .freeVolume = [&volume]
             {
-                Timer t( "~SimpleVolume" );
+                Timer t( "~SimpleVolumeMinMax" );
                 volume = {};
             }
         } );
@@ -277,9 +277,9 @@ TEST( MRMesh, volumeToMeshByParts )
         };
     };
 
-    VolumePartBuilder<SimpleVolume> simpleBuilder = [&] ( int begin, int end, std::optional<Vector3i>& offset )
+    VolumePartBuilder<SimpleVolumeMinMax> simpleBuilder = [&] ( int begin, int end, std::optional<Vector3i>& offset )
     {
-        SimpleVolume result {
+        SimpleVolumeMinMax result {
             {
                 .dims = { end - begin, dimensions.y, dimensions.z },
                 .voxelSize = Vector3f::diagonal( voxelSize )
@@ -354,11 +354,11 @@ TEST( MRMesh, volumeToMeshByParts )
     EXPECT_NEAR( expectedVolume, functionMesh->volume(), 0.001f );
 }
 
-template MRVOXELS_API VoidOrErrStr mergeVolumePart<SimpleVolume>( Mesh&, std::vector<EdgePath>&, SimpleVolume&&, float, float, const MergeVolumePartSettings& );
+template MRVOXELS_API VoidOrErrStr mergeVolumePart<SimpleVolumeMinMax>( Mesh&, std::vector<EdgePath>&, SimpleVolumeMinMax&&, float, float, const MergeVolumePartSettings& );
 template MRVOXELS_API VoidOrErrStr mergeVolumePart<VdbVolume>( Mesh&, std::vector<EdgePath>&, VdbVolume&&, float, float, const MergeVolumePartSettings& );
 template MRVOXELS_API VoidOrErrStr mergeVolumePart<FunctionVolume>( Mesh&, std::vector<EdgePath>&, FunctionVolume&&, float, float, const MergeVolumePartSettings& );
 
-template MRVOXELS_API Expected<Mesh> volumeToMeshByParts<SimpleVolume>( const VolumePartBuilder<SimpleVolume>&, const Vector3i&, const Vector3f&, const VolumeToMeshByPartsSettings&, const MergeVolumePartSettings& );
+template MRVOXELS_API Expected<Mesh> volumeToMeshByParts<SimpleVolumeMinMax>( const VolumePartBuilder<SimpleVolumeMinMax>&, const Vector3i&, const Vector3f&, const VolumeToMeshByPartsSettings&, const MergeVolumePartSettings& );
 template MRVOXELS_API Expected<Mesh> volumeToMeshByParts<VdbVolume>( const VolumePartBuilder<VdbVolume>&, const Vector3i&, const Vector3f&, const VolumeToMeshByPartsSettings&, const MergeVolumePartSettings& );
 template MRVOXELS_API Expected<Mesh> volumeToMeshByParts<FunctionVolume>( const VolumePartBuilder<FunctionVolume>&, const Vector3i&, const Vector3f&, const VolumeToMeshByPartsSettings&, const MergeVolumePartSettings& );
 

--- a/source/MRVoxels/MRVoxelsFwd.h
+++ b/source/MRVoxels/MRVoxelsFwd.h
@@ -25,8 +25,8 @@ struct OpenVdbFloatGrid;
 using FloatGrid = std::shared_ptr<OpenVdbFloatGrid>;
 
 MR_CANONICAL_TYPEDEFS( (template <typename T> struct), VoxelsVolumeMinMax,
-    ( SimpleVolume, VoxelsVolumeMinMax<std::vector<float>> )
-    ( SimpleVolumeU16, VoxelsVolumeMinMax<std::vector<uint16_t>> )
+    ( SimpleVolumeMinMax, VoxelsVolumeMinMax<std::vector<float>> )
+    ( SimpleVolumeMinMaxU16, VoxelsVolumeMinMax<std::vector<uint16_t>> )
     ( VdbVolume, VoxelsVolumeMinMax<FloatGrid> )
 )
 
@@ -36,6 +36,8 @@ using VoxelValueGetter = std::function<T ( const Vector3i& )>;
 MR_CANONICAL_TYPEDEFS( (template <typename T> struct), VoxelsVolume,
     ( FunctionVolume, VoxelsVolume<VoxelValueGetter<float>> )
     ( FunctionVolumeU8, VoxelsVolume<VoxelValueGetter<uint8_t>> )
+    ( SimpleVolume, VoxelsVolume<std::vector<float>> )
+    ( SimpleVolumeU16, VoxelsVolume<std::vector<uint16_t>> )
 )
 
 } // namespace MR

--- a/source/MRVoxels/MRVoxelsLoad.cpp
+++ b/source/MRVoxels/MRVoxelsLoad.cpp
@@ -571,7 +571,7 @@ Expected<DicomVolume> loadSingleDicomFolder( std::vector<std::filesystem::path>&
     if ( files.empty() )
         return unexpected( "loadDCMFolder: there is no dcm file" );
 
-    SimpleVolume data;
+    SimpleVolumeMinMax data;
     data.voxelSize = Vector3f();
     data.dims = Vector3i::diagonal( 0 );
 
@@ -812,7 +812,7 @@ Expected<DicomVolume> loadDicomFile( const std::filesystem::path& path, const Pr
     if ( !reportProgress( cb, 0.0f ) )
         return unexpected( "Loading canceled" );
 
-    SimpleVolume simpleVolume;
+    SimpleVolumeMinMax simpleVolume;
     simpleVolume.voxelSize = Vector3f();
     simpleVolume.dims.z = 1;
     auto fileRes = loadSingleFile( path, simpleVolume, 0 );
@@ -1171,7 +1171,7 @@ Expected<VdbVolume> loadTiffDir( const LoadingTiffSettings& settings )
 
     auto& tp = *tpExp;
 
-    SimpleVolume outVolume;
+    SimpleVolumeMinMax outVolume;
     outVolume.dims = { tp.imageSize.x, tp.imageSize.y, int( files.size() ) };
     outVolume.min = FLT_MAX;
     outVolume.max = FLT_MIN;
@@ -1290,7 +1290,7 @@ Expected<VdbVolume> fromRaw( std::istream& in, const RawParameters& params,  con
         return unexpected( "Wrong scalar type parameter value" );
     }
 
-    SimpleVolume outVolume;
+    SimpleVolumeMinMax outVolume;
     outVolume.dims = params.dimensions;
     outVolume.voxelSize = params.voxelSize;
     outVolume.data.resize( size_t( outVolume.dims.x ) * outVolume.dims.y * outVolume.dims.z );

--- a/source/MRVoxels/MRVoxelsLoad.h
+++ b/source/MRVoxels/MRVoxelsLoad.h
@@ -24,7 +24,7 @@ MRVOXELS_API void sortFilesByName( std::vector<std::filesystem::path>& scans );
 #ifndef MRVOXELS_NO_DICOM
 struct DicomVolume
 {
-    SimpleVolume vol;
+    SimpleVolumeMinMax vol;
     std::string name;
     AffineXf3f xf;
 };

--- a/source/MRVoxels/MRVoxelsVolume.cpp
+++ b/source/MRVoxels/MRVoxelsVolume.cpp
@@ -4,15 +4,13 @@
 #include "MRMesh/MRVolumeIndexer.h"
 #include "MRMesh/MRParallelFor.h"
 
-
-
 namespace MR
 {
 
-Expected<SimpleVolume> functionVolumeToSimpleVolume( const FunctionVolume& volume, const ProgressCallback& cb )
+Expected<SimpleVolumeMinMax> functionVolumeToSimpleVolume( const FunctionVolume& volume, const ProgressCallback& cb )
 {
     MR_TIMER
-    SimpleVolume res;
+    SimpleVolumeMinMax res;
     res.voxelSize = volume.voxelSize;
     res.dims = volume.dims;
     VolumeIndexer indexer( res.dims );

--- a/source/MRVoxels/MRVoxelsVolume.h
+++ b/source/MRVoxels/MRVoxelsVolume.h
@@ -62,6 +62,6 @@ struct VoxelsVolumeMinMax : VoxelsVolume<T>
 
 
 /// converts function volume into simple volume
-MRVOXELS_API Expected<SimpleVolume> functionVolumeToSimpleVolume( const FunctionVolume& volume, const ProgressCallback& callback = {} );
+MRVOXELS_API Expected<SimpleVolumeMinMax> functionVolumeToSimpleVolume( const FunctionVolume& volume, const ProgressCallback& callback = {} );
 
 } //namespace MR

--- a/source/MRVoxels/MRVoxelsVolume.h
+++ b/source/MRVoxels/MRVoxelsVolume.h
@@ -50,12 +50,11 @@ struct VoxelsVolume
 template <typename T>
 struct VoxelsVolumeMinMax : VoxelsVolume<T>
 {
-    using VoxelsVolume = VoxelsVolume<T>;
-    using typename VoxelsVolume::ValueType;
-    using VoxelsVolume::data;
-    using VoxelsVolume::dims;
-    using VoxelsVolume::voxelSize;
-    using VoxelsVolume::heapBytes;
+    using typename VoxelsVolume<T>::ValueType;
+    using VoxelsVolume<T>::data;
+    using VoxelsVolume<T>::dims;
+    using VoxelsVolume<T>::voxelSize;
+    using VoxelsVolume<T>::heapBytes;
 
     ValueType min = std::numeric_limits<ValueType>::max();
     ValueType max = std::numeric_limits<ValueType>::lowest();

--- a/source/MRVoxels/MRVoxelsVolume.h
+++ b/source/MRVoxels/MRVoxelsVolume.h
@@ -50,11 +50,12 @@ struct VoxelsVolume
 template <typename T>
 struct VoxelsVolumeMinMax : VoxelsVolume<T>
 {
-    using typename VoxelsVolume<T>::ValueType;
-    using VoxelsVolume<T>::data;
-    using VoxelsVolume<T>::dims;
-    using VoxelsVolume<T>::voxelSize;
-    using VoxelsVolume<T>::heapBytes;
+    using VoxelsVolume = VoxelsVolume<T>;
+    using typename VoxelsVolume::ValueType;
+    using VoxelsVolume::data;
+    using VoxelsVolume::dims;
+    using VoxelsVolume::voxelSize;
+    using VoxelsVolume::heapBytes;
 
     ValueType min = std::numeric_limits<ValueType>::max();
     ValueType max = std::numeric_limits<ValueType>::lowest();

--- a/source/mrmeshnumpy/MRPythonNumpyVoxels.cpp
+++ b/source/mrmeshnumpy/MRPythonNumpyVoxels.cpp
@@ -77,18 +77,11 @@ pybind11::array_t<double> getNumpy3Darray( const MR::SimpleVolume& simpleVolume 
         freeWhenDone ); // numpy array references this parent
 }
 
-pybind11::array_t<double> getNumpy3DarrayMinMax( const MR::SimpleVolumeMinMax& simpleVolumeMinMax )
-{
-    return getNumpy3Darray( simpleVolumeMinMax );
-}
-
 MR_ADD_PYTHON_CUSTOM_DEF( mrmeshnumpy, VoxelsVolumeNumpyConvert, [] ( pybind11::module_& m )
 {
     m.def( "simpleVolumeFrom3Darray", &simpleVolumeFrom3Darray, pybind11::arg( "3DvoxelsArray" ),
         "Convert numpy 3D array to SimpleVolume" );
     m.def( "getNumpy3Darray", &getNumpy3Darray, pybind11::arg( "simpleVolume" ),
         "Convert SimpleVolume to numpy 3D array" );
-    m.def( "getNumpy3Darray", &getNumpy3DarrayMinMax, pybind11::arg( "simpleVolumeMinMax" ),
-        "Convert SimpleVolumeMinMax to numpy 3D array" );
 } )
 #endif

--- a/source/mrmeshnumpy/MRPythonNumpyVoxels.cpp
+++ b/source/mrmeshnumpy/MRPythonNumpyVoxels.cpp
@@ -75,11 +75,18 @@ pybind11::array_t<double> getNumpy3Darray( const MR::SimpleVolume& simpleVolume 
         freeWhenDone ); // numpy array references this parent
 }
 
+pybind11::array_t<double> getNumpy3DarrayMinMax( const MR::SimpleVolumeMinMax& simpleVolumeMinMax )
+{
+    return getNumpy3Darray( simpleVolumeMinMax );
+}
+
 MR_ADD_PYTHON_CUSTOM_DEF( mrmeshnumpy, VoxelsVolumeNumpyConvert, [] ( pybind11::module_& m )
 {
     m.def( "simpleVolumeFrom3Darray", &simpleVolumeFrom3Darray, pybind11::arg( "3DvoxelsArray" ),
         "Convert numpy 3D array to SimpleVolume" );
     m.def( "getNumpy3Darray", &getNumpy3Darray, pybind11::arg( "simpleVolume" ),
         "Convert SimpleVolume to numpy 3D array" );
+    m.def( "getNumpy3Darray", &getNumpy3DarrayMinMax, pybind11::arg( "simpleVolumeMinMax" ),
+        "Convert SimpleVolumeMinMax to numpy 3D array" );
 } )
 #endif

--- a/source/mrmeshnumpy/MRPythonNumpyVoxels.cpp
+++ b/source/mrmeshnumpy/MRPythonNumpyVoxels.cpp
@@ -1,15 +1,16 @@
 #ifndef MESHLIB_NO_VOXELS
 #include "MRPython/MRPython.h"
-#include "MRVoxels/MRVoxelsVolume.h"
 #include "MRMesh/MRVector3.h"
+#include "MRMesh/MRParallelFor.h"
+#include "MRVoxels/MRVoxelsVolume.h"
 
-MR::SimpleVolume simpleVolumeFrom3Darray( const pybind11::buffer& voxelsArray )
+MR::SimpleVolumeMinMax simpleVolumeFrom3Darray( const pybind11::buffer& voxelsArray )
 {
     pybind11::buffer_info info = voxelsArray.request();
     if ( info.ndim != 3 )
         throw std::runtime_error( "shape of input python vector 'voxelsArray' should be (x,y,z)" );
 
-    MR::SimpleVolume res;
+    MR::SimpleVolumeMinMax res;
     res.dims = MR::Vector3i( int( info.shape[0] ), int( info.shape[1] ), int( info.shape[2] ) );
     size_t countPoints = res.dims.x * res.dims.y * res.dims.z;
     res.data.resize( countPoints );
@@ -40,6 +41,7 @@ MR::SimpleVolume simpleVolumeFrom3Darray( const pybind11::buffer& voxelsArray )
     else
         throw std::runtime_error( "dtype of input python vector should be float32 or float64" );
 
+    std::tie( res.min, res.max ) = MR::parallelMinMax( res.data );
     return res;
 }
 

--- a/source/mrmeshpy/MRPythonVoxels.cpp
+++ b/source/mrmeshpy/MRPythonVoxels.cpp
@@ -35,7 +35,6 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Type, [] ( pybind11::module_& ) \
 MR_ADD_PYTHON_VOXELS_VOLUME( SimpleVolume, "vector of float" )
 
 #define MR_ADD_PYTHON_VOXELS_VOLUME_MINMAX( Type, TypeText ) \
-MR_ADD_PYTHON_CUSTOM_CLASS( mrmeshpy, Type, MR::Type, MR::Type::VoxelsVolume ) \
 MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Type, [] ( pybind11::module_& ) \
 {                                                     \
     MR_PYTHON_CUSTOM_CLASS( Type ).doc() =                                       \
@@ -49,7 +48,10 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Type, [] ( pybind11::module_& ) \
         def_readwrite( "max", &MR::Type::max, "Maximum value from all voxels" );\
 } )
 
+MR_ADD_PYTHON_CUSTOM_CLASS( mrmeshpy, VdbVolume, MR::VdbVolume )
 MR_ADD_PYTHON_VOXELS_VOLUME_MINMAX( VdbVolume, "VDB FloatGrid" )
+
+MR_ADD_PYTHON_CUSTOM_CLASS( mrmeshpy, SimpleVolumeMinMax, MR::SimpleVolumeMinMax, MR::SimpleVolume )
 MR_ADD_PYTHON_VOXELS_VOLUME_MINMAX( SimpleVolumeMinMax, "vector of float" )
 
 MR_ADD_PYTHON_CUSTOM_CLASS_DECL( mrmeshpy, FloatGrid, MR::OpenVdbFloatGrid, MR::FloatGrid )

--- a/source/mrmeshpy/MRPythonVoxels.cpp
+++ b/source/mrmeshpy/MRPythonVoxels.cpp
@@ -59,8 +59,7 @@ MR_ADD_PYTHON_VEC( mrmeshpy, vectorVdbVolume, MR::VdbVolume )
 
 MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Voxels, []( pybind11::module_& m )
 {
-    pybind11::implicitly_convertible< MR::SimpleVolumeMinMax, MR::SimpleVolume >();
-    pybind11::implicitly_convertible< const MR::SimpleVolumeMinMax&, const MR::SimpleVolume& >();
+    pybind11::implicitly_convertible< const MR::SimpleVolumeMinMax&, MR::SimpleVolume >();
 
     MR_PYTHON_CUSTOM_CLASS( FloatGrid ).doc() =
         "Smart pointer to OpenVdbFloatGrid";

--- a/source/mrmeshpy/MRPythonVoxels.cpp
+++ b/source/mrmeshpy/MRPythonVoxels.cpp
@@ -35,7 +35,7 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Type, [] ( pybind11::module_& ) \
 MR_ADD_PYTHON_VOXELS_VOLUME( SimpleVolume, "vector of float" )
 
 #define MR_ADD_PYTHON_VOXELS_VOLUME_MINMAX( Type, TypeText ) \
-MR_ADD_PYTHON_CUSTOM_CLASS( mrmeshpy, Type, MR::Type ) \
+MR_ADD_PYTHON_CUSTOM_CLASS( mrmeshpy, Type, MR::Type, MR::Type::VoxelsVolume ) \
 MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Type, [] ( pybind11::module_& ) \
 {                                                     \
     MR_PYTHON_CUSTOM_CLASS( Type ).doc() =                                       \
@@ -59,8 +59,6 @@ MR_ADD_PYTHON_VEC( mrmeshpy, vectorVdbVolume, MR::VdbVolume )
 
 MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Voxels, []( pybind11::module_& m )
 {
-    pybind11::implicitly_convertible< const MR::SimpleVolumeMinMax&, MR::SimpleVolume >();
-
     MR_PYTHON_CUSTOM_CLASS( FloatGrid ).doc() =
         "Smart pointer to OpenVdbFloatGrid";
     MR_PYTHON_CUSTOM_CLASS( FloatGrid ).

--- a/source/mrmeshpy/MRPythonVoxels.cpp
+++ b/source/mrmeshpy/MRPythonVoxels.cpp
@@ -78,9 +78,9 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Voxels, []( pybind11::module_& m )
         pybind11::arg( "simpleVolume" ), pybind11::arg( "cb" ) = MR::ProgressCallback{},
         "Make FloatGrid from SimpleVolume. Make copy of data.\n"
         "Grid can be used to make iso-surface later with gridToMesh function." );
-    m.def( "simpleVolumeToVdbVolume", ( MR::VdbVolume( * )( const MR::SimpleVolume&, MR::ProgressCallback ) )& MR::simpleVolumeToVdbVolume,
-        pybind11::arg( "simpleVolume" ), pybind11::arg( "cb" ) = MR::ProgressCallback{},
-        "Make VdbVolume from SimpleVolume. Make copy of data.\n"
+    m.def( "simpleVolumeToVdbVolume", &MR::simpleVolumeToVdbVolume,
+        pybind11::arg( "simpleVolumeMinMax" ), pybind11::arg( "cb" ) = MR::ProgressCallback{},
+        "Make VdbVolume from SimpleVolumeMinMax. Make copy of data.\n"
         "Grid can be used to make iso-surface later with gridToMesh function." );
     m.def( "vdbVolumeToSimpleVolume",
         MR::decorateExpected(

--- a/source/mrmeshpy/MRPythonVoxels.cpp
+++ b/source/mrmeshpy/MRPythonVoxels.cpp
@@ -59,6 +59,8 @@ MR_ADD_PYTHON_VEC( mrmeshpy, vectorVdbVolume, MR::VdbVolume )
 
 MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Voxels, []( pybind11::module_& m )
 {
+    pybind11::implicitly_convertible< MR::SimpleVolumeMinMax, MR::SimpleVolume >();
+
     MR_PYTHON_CUSTOM_CLASS( FloatGrid ).doc() =
         "Smart pointer to OpenVdbFloatGrid";
     MR_PYTHON_CUSTOM_CLASS( FloatGrid ).
@@ -74,7 +76,7 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Voxels, []( pybind11::module_& m )
         "Does not require closed surface, resulting grid cannot be used for boolean operations.\n"
         "SurfaceOffset - the number voxels around surface to calculate distance in (should be positive)." );
 
-    m.def( "simpleVolumeToDenseGrid", ( MR::FloatGrid( * )( const MR::SimpleVolume&, MR::ProgressCallback ) )& MR::simpleVolumeToDenseGrid,
+    m.def( "simpleVolumeToDenseGrid", &MR::simpleVolumeToDenseGrid,
         pybind11::arg( "simpleVolume" ), pybind11::arg( "cb" ) = MR::ProgressCallback{},
         "Make FloatGrid from SimpleVolume. Make copy of data.\n"
         "Grid can be used to make iso-surface later with gridToMesh function." );

--- a/source/mrmeshpy/MRPythonVoxels.cpp
+++ b/source/mrmeshpy/MRPythonVoxels.cpp
@@ -29,13 +29,28 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Type, [] ( pybind11::module_& ) \
         def( pybind11::init<>() ).\
         def_readwrite( "data", &MR::Type::data ).\
         def_readwrite( "dims", &MR::Type::dims, "Size of voxels space" ).\
+        def_readwrite( "voxelSize", &MR::Type::voxelSize );\
+} )
+
+MR_ADD_PYTHON_VOXELS_VOLUME( SimpleVolume, "vector of float" )
+
+#define MR_ADD_PYTHON_VOXELS_VOLUME_MINMAX( Type, TypeText ) \
+MR_ADD_PYTHON_CUSTOM_CLASS( mrmeshpy, Type, MR::Type ) \
+MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Type, [] ( pybind11::module_& ) \
+{                                                     \
+    MR_PYTHON_CUSTOM_CLASS( Type ).doc() =                                       \
+        "Voxels representation as " #TypeText;        \
+    MR_PYTHON_CUSTOM_CLASS( Type ).                                              \
+        def( pybind11::init<>() ).\
+        def_readwrite( "data", &MR::Type::data ).\
+        def_readwrite( "dims", &MR::Type::dims, "Size of voxels space" ).\
         def_readwrite( "voxelSize", &MR::Type::voxelSize ).\
         def_readwrite( "min", &MR::Type::min, "Minimum value from all voxels" ).\
         def_readwrite( "max", &MR::Type::max, "Maximum value from all voxels" );\
 } )
 
-MR_ADD_PYTHON_VOXELS_VOLUME( VdbVolume, "VDB FloatGrid" )
-MR_ADD_PYTHON_VOXELS_VOLUME( SimpleVolume, "vector of float" )
+MR_ADD_PYTHON_VOXELS_VOLUME_MINMAX( VdbVolume, "VDB FloatGrid" )
+MR_ADD_PYTHON_VOXELS_VOLUME_MINMAX( SimpleVolumeMinMax, "vector of float" )
 
 MR_ADD_PYTHON_CUSTOM_CLASS_DECL( mrmeshpy, FloatGrid, MR::OpenVdbFloatGrid, MR::FloatGrid )
 MR_ADD_PYTHON_CUSTOM_CLASS_INST( mrmeshpy, FloatGrid )

--- a/source/mrmeshpy/MRPythonVoxels.cpp
+++ b/source/mrmeshpy/MRPythonVoxels.cpp
@@ -60,6 +60,7 @@ MR_ADD_PYTHON_VEC( mrmeshpy, vectorVdbVolume, MR::VdbVolume )
 MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Voxels, []( pybind11::module_& m )
 {
     pybind11::implicitly_convertible< MR::SimpleVolumeMinMax, MR::SimpleVolume >();
+    pybind11::implicitly_convertible< const MR::SimpleVolumeMinMax&, const MR::SimpleVolume& >();
 
     MR_PYTHON_CUSTOM_CLASS( FloatGrid ).doc() =
         "Smart pointer to OpenVdbFloatGrid";


### PR DESCRIPTION
* Rename `VoxelsVolumeMinMax<std::vector<float>>` from `SimpleVolume` into `SimpleVolumeMinMax`.
* And give name `SimpleVolume` to `VoxelsVolume<std::vector<float>>` instead.

Motivation:
* most voxel-processing algorithm do not need min/max, and their computation only complicates development.