### PR TITLE
ObjectVoxels::construct( const SimpleVolume& )

### DIFF
--- a/source/MRVoxels/MRObjectVoxels.h
+++ b/source/MRVoxels/MRObjectVoxels.h
@@ -54,12 +54,20 @@ public:
     MRVOXELS_API virtual std::vector<std::string> getInfoLines() const override;
     virtual std::string getClassName() const override { return "Voxels"; }
 
-    /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface)
-    MRVOXELS_API void construct( const SimpleVolumeMinMax& simpleVolume, ProgressCallback cb = {} );
+    /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface);
+    /// \param normalPlusGrad true means that iso-surface normals will be along gradient, false means opposite direction
+    MRVOXELS_API void construct( const SimpleVolume& simpleVolume, ProgressCallback cb = {}, bool normalPlusGrad = false );
+
+    /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface);
+    /// \param normalPlusGrad true means that iso-surface normals will be along gradient, false means opposite direction
+    MRVOXELS_API void construct( const SimpleVolumeMinMax& simpleVolumeMinMax, ProgressCallback cb = {}, bool normalPlusGrad = false );
+
     /// Clears all internal data and calculates histogram
     MRVOXELS_API void construct( const FloatGrid& grid, const Vector3f& voxelSize, ProgressCallback cb = {} );
+
     /// Clears all internal data and calculates histogram
     MRVOXELS_API void construct( const VdbVolume& vdbVolume, ProgressCallback cb = {} );
+
     /// Updates histogram, by stored grid (evals min and max values from grid)
     /// rebuild iso surface if it is present
     MRVOXELS_API void updateHistogramAndSurface( ProgressCallback cb = {} );


### PR DESCRIPTION
1. `ObjectVoxel::construct` can take `SimpleVolume` on input in addition to `SimpleVolumeMinMax`
2. Fix the issue that `vdbVolume_.min` and `vdbVolume_.max` were not initialized
3. An option to direct surface normal along minus gradient (default) and along plus gradient