### PR TITLE
ObjectVoxels::construct: all overloads behave similarly

### DIFF
--- a/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
@@ -343,7 +343,7 @@ void sOpenDICOMs( const std::filesystem::path & directory, const std::string & s
                     std::shared_ptr<ObjectVoxels> obj = std::make_shared<ObjectVoxels>();
                     obj->setName( res->name );
                     ProgressBar::nextTask( "Construct ObjectVoxels" );
-                    obj->construct( res->vdbVolume, ProgressBar::callBackSetProgress );
+                    obj->construct( res->vdbVolume );
                     if ( ProgressBar::isCanceled() )
                     {
                         errors = getCancelMessage( directory );

--- a/source/MRCommonPlugins/Voxels/MROpenRawVoxelsPlugin.cpp
+++ b/source/MRCommonPlugins/Voxels/MROpenRawVoxelsPlugin.cpp
@@ -104,7 +104,7 @@ void OpenRawVoxelsPlugin::drawDialog( float menuScaling, ImGuiContext* )
                     ProgressBar::nextTask( "Create object" );
                     std::shared_ptr<ObjectVoxels> object = std::make_shared<ObjectVoxels>();
                     object->setName( utf8string( path.stem() ) );
-                    object->construct( *res, ProgressBar::callBackSetProgress );
+                    object->construct( *res );
                     auto bins = object->histogram().getBins();
                     auto minMax = object->histogram().getBinMinMax( bins.size() / 3 );
 

--- a/source/MRCommonPlugins/Voxels/MROpenRawVoxelsPlugin.cpp
+++ b/source/MRCommonPlugins/Voxels/MROpenRawVoxelsPlugin.cpp
@@ -104,7 +104,7 @@ void OpenRawVoxelsPlugin::drawDialog( float menuScaling, ImGuiContext* )
                     ProgressBar::nextTask( "Create object" );
                     std::shared_ptr<ObjectVoxels> object = std::make_shared<ObjectVoxels>();
                     object->setName( utf8string( path.stem() ) );
-                    object->construct( res->data, res->voxelSize, ProgressBar::callBackSetProgress );
+                    object->construct( *res, ProgressBar::callBackSetProgress );
                     auto bins = object->histogram().getBins();
                     auto minMax = object->histogram().getBinMinMax( bins.size() / 3 );
 

--- a/source/MRCommonPlugins/Voxels/MROpenVoxelsFromTiffPlugin.cpp
+++ b/source/MRCommonPlugins/Voxels/MROpenVoxelsFromTiffPlugin.cpp
@@ -94,7 +94,7 @@ void OpenVoxelsFromTiffPlugin::drawDialog( float menuScaling, ImGuiContext* )
             voxelsObject->setName( std::move( name ) );
             ProgressBar::setTaskCount( 2 );
             ProgressBar::nextTask( "Construct ObjectVoxels" );
-            voxelsObject->construct( *loadRes, ProgressBar::callBackSetProgress );
+            voxelsObject->construct( *loadRes );
             if ( ProgressBar::isCanceled() || !loadRes.has_value() )
                 return returnError;
 

--- a/source/MRVoxels/MRObjectVoxels.cpp
+++ b/source/MRVoxels/MRObjectVoxels.cpp
@@ -62,7 +62,7 @@ void ObjectVoxels::construct( const SimpleVolumeMinMax& simpleVolumeMinMax, Prog
     construct( simpleVolumeMinMax, Vector2f( simpleVolumeMinMax.min, simpleVolumeMinMax.max ), cb, normalPlusGrad );
 }
 
-void ObjectVoxels::construct( const FloatGrid& grid, const Vector3f& voxelSize, const std::optional<Vector2f> & minmax, ProgressCallback cb )
+void ObjectVoxels::construct( const FloatGrid& grid, const Vector3f& voxelSize, const std::optional<Vector2f> & minmax )
 {
     assert( grid );
     if ( !grid )
@@ -89,9 +89,9 @@ void ObjectVoxels::construct( const FloatGrid& grid, const Vector3f& voxelSize, 
         dirty_ |= ( DIRTY_PRIMITIVES | DIRTY_TEXTURE | DIRTY_SELECTION );
 }
 
-void ObjectVoxels::construct( const VdbVolume& volume, ProgressCallback cb )
+void ObjectVoxels::construct( const VdbVolume& volume )
 {
-    construct( volume.data, volume.voxelSize, Vector2f( volume.min, volume.max ), cb );
+    construct( volume.data, volume.voxelSize, Vector2f( volume.min, volume.max ) );
 }
 
 void ObjectVoxels::updateHistogramAndSurface( ProgressCallback cb )

--- a/source/MRVoxels/MRObjectVoxels.cpp
+++ b/source/MRVoxels/MRObjectVoxels.cpp
@@ -29,7 +29,7 @@ MR_ADD_CLASS_FACTORY( ObjectVoxels )
 
 constexpr size_t cVoxelsHistogramBinsNumber = 256;
 
-void ObjectVoxels::construct( const SimpleVolume& simpleVolume, ProgressCallback cb, bool normalPlusGrad )
+void ObjectVoxels::construct( const SimpleVolume& simpleVolume, const std::optional<Vector2f> & minmax, ProgressCallback cb, bool normalPlusGrad )
 {
     mesh_.reset();
     activeVoxels_.reset();
@@ -37,7 +37,13 @@ void ObjectVoxels::construct( const SimpleVolume& simpleVolume, ProgressCallback
     vdbVolume_.data = simpleVolumeToDenseGrid( simpleVolume, cb );
     vdbVolume_.dims = simpleVolume.dims;
     vdbVolume_.voxelSize = simpleVolume.voxelSize;
-    std::tie( vdbVolume_.min, vdbVolume_.max ) = parallelMinMax( simpleVolume.data );
+    if ( minmax )
+    {
+        vdbVolume_.min = minmax->x;
+        vdbVolume_.max = minmax->y;
+    }
+    else
+        std::tie( vdbVolume_.min, vdbVolume_.max ) = parallelMinMax( simpleVolume.data );
     indexer_ = VolumeIndexer( vdbVolume_.dims );
     reverseVoxelSize_ = { 1 / vdbVolume_.voxelSize.x,1 / vdbVolume_.voxelSize.y,1 / vdbVolume_.voxelSize.z };
 
@@ -53,19 +59,28 @@ void ObjectVoxels::construct( const SimpleVolume& simpleVolume, ProgressCallback
 
 void ObjectVoxels::construct( const SimpleVolumeMinMax& simpleVolumeMinMax, ProgressCallback cb, bool normalPlusGrad )
 {
-    mesh_.reset();
+    construct( simpleVolumeMinMax, Vector2f( simpleVolumeMinMax.min, simpleVolumeMinMax.max ), cb, normalPlusGrad );
+}
+
+void ObjectVoxels::construct( const FloatGrid& grid, const Vector3f& voxelSize, const std::optional<Vector2f> & minmax, ProgressCallback cb )
+{
+    assert( grid );
+    if ( !grid )
+        return;
     activeVoxels_.reset();
     activeBounds_.reset();
-    vdbVolume_.data = simpleVolumeToDenseGrid( simpleVolumeMinMax, cb );
-    vdbVolume_.dims = simpleVolumeMinMax.dims;
-    vdbVolume_.voxelSize = simpleVolumeMinMax.voxelSize;
-    vdbVolume_.min = simpleVolumeMinMax.min;
-    vdbVolume_.max = simpleVolumeMinMax.max;
+    vdbVolume_.data = grid;
+    vdbVolume_.dims = fromVdb( vdbVolume_.data->evalActiveVoxelDim() );
     indexer_ = VolumeIndexer( vdbVolume_.dims );
+    vdbVolume_.voxelSize = voxelSize;
+    if ( minmax )
+    {
+        vdbVolume_.min = minmax->x;
+        vdbVolume_.max = minmax->y;
+    }
+    else
+        evalGridMinMax( vdbVolume_.data, vdbVolume_.min, vdbVolume_.max );
     reverseVoxelSize_ = { 1 / vdbVolume_.voxelSize.x,1 / vdbVolume_.voxelSize.y,1 / vdbVolume_.voxelSize.z };
-
-    if ( normalPlusGrad )
-        vdbVolume_.data->setGridClass( openvdb::GRID_LEVEL_SET );
 
     volumeRenderActiveVoxels_.clear();
 
@@ -74,29 +89,9 @@ void ObjectVoxels::construct( const SimpleVolumeMinMax& simpleVolumeMinMax, Prog
         dirty_ |= ( DIRTY_PRIMITIVES | DIRTY_TEXTURE | DIRTY_SELECTION );
 }
 
-void ObjectVoxels::construct( const FloatGrid& grid, const Vector3f& voxelSize, ProgressCallback cb )
-{
-    if ( !grid )
-        return;
-    activeVoxels_.reset();
-    activeBounds_.reset();
-    vdbVolume_.data = grid;
-
-    vdbVolume_.dims = fromVdb( vdbVolume_.data->evalActiveVoxelDim() );
-    indexer_ = VolumeIndexer( vdbVolume_.dims );
-    vdbVolume_.voxelSize = voxelSize;
-    reverseVoxelSize_ = { 1 / vdbVolume_.voxelSize.x,1 / vdbVolume_.voxelSize.y,1 / vdbVolume_.voxelSize.z };
-
-    volumeRenderActiveVoxels_.clear();
-
-    updateHistogramAndSurface( cb );
-    if ( volumeRendering_ )
-        dirty_ |= ( DIRTY_PRIMITIVES | DIRTY_TEXTURE | DIRTY_SELECTION );
-}
-
 void ObjectVoxels::construct( const VdbVolume& volume, ProgressCallback cb )
 {
-    construct( volume.data, volume.voxelSize, cb );
+    construct( volume.data, volume.voxelSize, Vector2f( volume.min, volume.max ), cb );
 }
 
 void ObjectVoxels::updateHistogramAndSurface( ProgressCallback cb )
@@ -687,7 +682,7 @@ VoidOrErrStr ObjectVoxels::deserializeModel_( const std::filesystem::path& path,
         return unexpected( "No voxels found in file: " + utf8string( modelPath ) );
     assert( res->size() == 1 );
 
-    construct( (*res).front().data, (*res).front().voxelSize );
+    construct( (*res).front() );
     if ( !vdbVolume_.data )
         return unexpected( "No grid loaded" );
 

--- a/source/MRVoxels/MRObjectVoxels.h
+++ b/source/MRVoxels/MRObjectVoxels.h
@@ -65,10 +65,10 @@ public:
 
     /// Clears all internal data and then remembers grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface)
     /// \param minmax optional data about known min and max values
-    MRVOXELS_API void construct( const FloatGrid& grid, const Vector3f& voxelSize, const std::optional<Vector2f> & minmax = {}, ProgressCallback cb = {} );
+    MRVOXELS_API void construct( const FloatGrid& grid, const Vector3f& voxelSize, const std::optional<Vector2f> & minmax = {} );
 
     /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface)
-    MRVOXELS_API void construct( const VdbVolume& vdbVolume, ProgressCallback cb = {} );
+    MRVOXELS_API void construct( const VdbVolume& vdbVolume );
 
     /// Updates histogram, by stored grid (evals min and max values from grid)
     /// rebuild iso surface if it is present

--- a/source/MRVoxels/MRObjectVoxels.h
+++ b/source/MRVoxels/MRObjectVoxels.h
@@ -54,18 +54,20 @@ public:
     MRVOXELS_API virtual std::vector<std::string> getInfoLines() const override;
     virtual std::string getClassName() const override { return "Voxels"; }
 
-    /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface);
+    /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface)
     /// \param normalPlusGrad true means that iso-surface normals will be along gradient, false means opposite direction
-    MRVOXELS_API void construct( const SimpleVolume& simpleVolume, ProgressCallback cb = {}, bool normalPlusGrad = false );
+    /// \param minmax optional data about known min and max values
+    MRVOXELS_API void construct( const SimpleVolume& simpleVolume, const std::optional<Vector2f> & minmax = {}, ProgressCallback cb = {}, bool normalPlusGrad = false );
 
-    /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface);
+    /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface)
     /// \param normalPlusGrad true means that iso-surface normals will be along gradient, false means opposite direction
     MRVOXELS_API void construct( const SimpleVolumeMinMax& simpleVolumeMinMax, ProgressCallback cb = {}, bool normalPlusGrad = false );
 
-    /// Clears all internal data and calculates histogram
-    MRVOXELS_API void construct( const FloatGrid& grid, const Vector3f& voxelSize, ProgressCallback cb = {} );
+    /// Clears all internal data and then remembers grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface)
+    /// \param minmax optional data about known min and max values
+    MRVOXELS_API void construct( const FloatGrid& grid, const Vector3f& voxelSize, const std::optional<Vector2f> & minmax = {}, ProgressCallback cb = {} );
 
-    /// Clears all internal data and calculates histogram
+    /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface)
     MRVOXELS_API void construct( const VdbVolume& vdbVolume, ProgressCallback cb = {} );
 
     /// Updates histogram, by stored grid (evals min and max values from grid)

--- a/source/MRVoxels/MRVoxelsLoad.cpp
+++ b/source/MRVoxels/MRVoxelsLoad.cpp
@@ -1062,23 +1062,9 @@ Expected<std::vector<std::shared_ptr<ObjectVoxels>>> toObjectVoxels( const std::
         const std::string name = i > 1 ? fmt::format( "{} {}", utf8string( file.stem() ), (int)i ) : utf8string( file.stem() );
         obj->setName( name );
 
-        bool callbackRes = true;
-        auto redirectProgress = [] ( const ProgressCallback& cb, bool& result ) -> ProgressCallback
-        {
-            return [cb, &result] ( float v )
-            {
-                return ( result = cb( v ) );
-            };
-        };
-
-        auto cb1 = redirectProgress( subprogress( cb, 0.00f, 0.50f ), callbackRes );
-        obj->construct( volume, cb1 );
-        if ( !callbackRes )
-            return unexpected( getCancelMessage( file ) );
-
-        auto cb2 = redirectProgress( subprogress( cb, 0.50f, 1.00f ), callbackRes );
-        obj->setIsoValue( ( volume.min + volume.max ) / 2.f, cb2 );
-        if ( !callbackRes )
+        obj->construct( volume );
+        obj->setIsoValue( ( volume.min + volume.max ) / 2.f, cb );
+        if ( !reportProgress( cb, 1.0f ) )
             return unexpected( getCancelMessage( file ) );
 
         res.emplace_back( obj );


### PR DESCRIPTION
* all `constuct` methods do not create the surface (previously some created and some not).
* `construct( const SimpleVolume& )` and `construct( const SimpleVolumeMinMax& )` share the same implementation.
* `construct( const SimpleVolume& )` and `construct( const FloatGrid& grid )` take optional min/max to save time on their recomputation.
* replace some `construct( const FloatGrid& grid )` with more efficient `construct( const VdbVolume& vdbVolume )`.
* `construct( const FloatGrid& grid )` and `construct( const VdbVolume& vdbVolume )` perform only fast operations and do not take progress callback.