### PR TITLE
Exclude full components from natural smooth

### DIFF
--- a/source/MRMesh/MRFillHoleNicely.cpp
+++ b/source/MRMesh/MRFillHoleNicely.cpp
@@ -7,6 +7,7 @@
 #include "MRTimer.h"
 #include "MRRegionBoundary.h"
 #include "MRExpandShrink.h"
+#include "MRMeshComponents.h"
 
 namespace MR
 {
@@ -69,7 +70,9 @@ FaceBitSet fillHoleNicely( Mesh & mesh,
                 auto undirectedEdgeBitSet = findRegionBoundaryUndirectedEdgesInsideMesh( mesh.topology, newFaces );
                 auto incidentVerts = getIncidentVerts( mesh.topology, undirectedEdgeBitSet );
                 expand( mesh.topology, incidentVerts, 3 );
-                positionVertsSmoothly( mesh, incidentVerts, settings.edgeWeights );
+                MeshComponents::excludeFullySelectedComponents( mesh, incidentVerts );
+                if ( incidentVerts.any() )
+                    positionVertsSmoothly( mesh, incidentVerts, settings.edgeWeights );
             }
         }
 

--- a/source/MRMesh/MRMeshComponents.h
+++ b/source/MRMesh/MRMeshComponents.h
@@ -139,7 +139,7 @@ struct LargeByAreaComponentsSettings
 /// returns true if all vertices of a mesh connected component are present in selection
 [[nodiscard]] MRMESH_API bool hasFullySelectedComponent( const Mesh& mesh, const VertBitSet & selection );
 
-/// excludes vertices from VertBitSet if it is present with all connected component
+/// if all vertices of a mesh connected component are present in selection exludes these vertices
 MRMESH_API void excludeFullySelectedComponents( const Mesh& mesh, VertBitSet& selection );
 
 /// gets union-find structure for faces with different options of face-connectivity

--- a/source/MRMesh/MRMeshComponents.h
+++ b/source/MRMesh/MRMeshComponents.h
@@ -136,10 +136,11 @@ struct LargeByAreaComponentsSettings
 /// gets all connected components where difference between the highest and the lowest point is less than \param zTolerance
 [[nodiscard]] MRMESH_API std::vector<FaceBitSet> getAllFlatComponents( const MeshPart& meshPart, float zTolerance );
 
-
 /// returns true if all vertices of a mesh connected component are present in selection
 [[nodiscard]] MRMESH_API bool hasFullySelectedComponent( const Mesh& mesh, const VertBitSet & selection );
 
+/// excludes vertices from VertBitSet if it is present with all connected component
+MRMESH_API void excludeFullySelectedComponents( const Mesh& mesh, VertBitSet& selection );
 
 /// gets union-find structure for faces with different options of face-connectivity
 [[nodiscard]] MRMESH_API UnionFind<FaceId> getUnionFindStructureFaces( const MeshPart& meshPart, FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgePredicate & isCompBd = {} );


### PR DESCRIPTION
1) simplify full components check
2) introduce excludeFullySelectedComponents function 
3) excludeFullySelectedComponents in fillHoleNicely for naturalSmooth