### PR TITLE
Close files from global context.

### DIFF
--- a/source/MRViewer/MRWebRequest.cpp
+++ b/source/MRViewer/MRWebRequest.cpp
@@ -315,21 +315,32 @@ void WebRequest::send( std::string urlP, const std::string & logName, ResponseCa
         if ( ctx->uploadCallback || ctx->downloadCallback )
             session.SetProgressCallback( { &progressCallback, ctxId } );
 
+        cpr::Response r;
         switch ( method )
         {
             case Method::Get:
-                return session.Get();
+                r = session.Get();
+                break;
             case Method::Post:
-                return session.Post();
+                r = session.Post();
+                break;
             case Method::Patch:
-                return session.Patch();
+                r = session.Patch();
+                break;
             case Method::Put:
-                return session.Put();
+                r = session.Put();
+                break;
             case Method::Delete:
-                return session.Delete();
+                r = session.Delete();
+                break;
         }
 
-        MR_UNREACHABLE
+        if ( ctx->output )
+            ctx->output->close();
+        if ( ctx->input )
+            ctx->input->close();
+
+        return r;
     };
     clear();
     if ( !async )


### PR DESCRIPTION
In Desktop version of `WebRequest`, output and input files are opened and then stored in global variable `sRequestContextMap` for eternity. This means that they are never closed and never explicitly flushed, which sometimes (especially for small files) may cause some data to not be written to disk.