### PR TITLE
Add option to close CommandLoop

### DIFF
--- a/source/MRTest/MRTestApp.cpp
+++ b/source/MRTest/MRTestApp.cpp
@@ -91,6 +91,6 @@ int main( int argc, char** argv )
 #endif
 
     ::testing::InitGoogleTest(&argc, argv);
-    MR::CommandLoop::removeCommands(); // that are added there by plugin constructors
+    MR::CommandLoop::removeCommands( false ); // that are added there by plugin constructors
     return RUN_ALL_TESTS();
 }

--- a/source/MRViewer/MRCommandLoop.h
+++ b/source/MRViewer/MRCommandLoop.h
@@ -44,7 +44,8 @@ public:
     MRVIEWER_API static void processCommands();
 
     // Clears the queue without executing the commands
-    MRVIEWER_API static void removeCommands();
+    // if closeLoop is true, does not accept any new commands
+    MRVIEWER_API static void removeCommands( bool closeLoop );
 
 private:
     CommandLoop() = default;
@@ -64,6 +65,8 @@ private:
 
     StartPosition state_{ StartPosition::AfterWindowInit };
 
+    // if set then cannot accept new commands
+    bool queueClosed_{ false }; // marked true in `removeCommands`
     std::thread::id mainThreadId_;
     std::queue<std::shared_ptr<Command>> commands_;
     std::mutex mutex_;

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -602,7 +602,7 @@ int Viewer::launch( const LaunchParams& params )
     }
     if ( params.close )
         launchShut();
-    CommandLoop::removeCommands();
+    CommandLoop::removeCommands( true );
     return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
WebRequests might add commands from detached threads after closing of application, so add `closing` option