### PR TITLE
deprecate VoidOrErrStr alias

### DIFF
--- a/source/MRCuda/MRCudaFastWindingNumber.cpp
+++ b/source/MRCuda/MRCudaFastWindingNumber.cpp
@@ -106,7 +106,7 @@ bool FastWindingNumber::calcSelfIntersections( FaceBitSet& res, float beta, Prog
     }, subprogress( cb, 0.9f, 1.0f ) );
 }
 
-VoidOrErrStr FastWindingNumber::calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb )
+Expected<void> FastWindingNumber::calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb )
 {
     MR_TIMER
     prepareData_( {} );
@@ -145,7 +145,7 @@ VoidOrErrStr FastWindingNumber::calcFromGrid( std::vector<float>& res, const Vec
     return {};
 }
 
-VoidOrErrStr FastWindingNumber::calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb )
+Expected<void> FastWindingNumber::calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb )
 {
     MR_TIMER
     prepareData_( {} );

--- a/source/MRCuda/MRCudaFastWindingNumber.h
+++ b/source/MRCuda/MRCudaFastWindingNumber.h
@@ -25,9 +25,9 @@ public:
     // see methods' descriptions in IFastWindingNumber
     MRCUDA_API void calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace = {} ) override;
     MRCUDA_API bool calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb ) override;
-    MRCUDA_API VoidOrErrStr calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
+    MRCUDA_API Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
     MRCUDA_API float calcWithDistances( const Vector3f& p, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq );
-    MRCUDA_API VoidOrErrStr calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) override;
+    MRCUDA_API Expected<void> calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) override;
 
 private:
     bool prepareData_( ProgressCallback cb );

--- a/source/MRIOExtras/MRCtm.cpp
+++ b/source/MRIOExtras/MRCtm.cpp
@@ -157,7 +157,7 @@ MR_ADD_MESH_LOADER( IOFilter( "Compact triangle-based mesh (.ctm)", "*.ctm" ), f
 namespace MeshSave
 {
 
-VoidOrErrStr toCtm( const Mesh & mesh, const std::filesystem::path & file, const CtmSaveOptions& options )
+Expected<void> toCtm( const Mesh & mesh, const std::filesystem::path & file, const CtmSaveOptions& options )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -166,7 +166,7 @@ VoidOrErrStr toCtm( const Mesh & mesh, const std::filesystem::path & file, const
     return toCtm( mesh, out, options );
 }
 
-VoidOrErrStr toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOptions& options )
+Expected<void> toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOptions& options )
 {
     MR_TIMER
 
@@ -326,12 +326,12 @@ VoidOrErrStr toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOptions&
     return {};
 }
 
-VoidOrErrStr toCtm( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings& settings )
+Expected<void> toCtm( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings& settings )
 {
     return toCtm( mesh, file, CtmSaveOptions { settings } );
 }
 
-VoidOrErrStr toCtm( const Mesh& mesh, std::ostream& out, const SaveSettings& settings )
+Expected<void> toCtm( const Mesh& mesh, std::ostream& out, const SaveSettings& settings )
 {
     return toCtm( mesh, out, CtmSaveOptions { settings } );
 }
@@ -436,7 +436,7 @@ MR_ADD_POINTS_LOADER( IOFilter( "CTM (.ctm)", "*.ctm" ), fromCtm )
 namespace PointsSave
 {
 
-VoidOrErrStr toCtm( const PointCloud& points, const std::filesystem::path& file, const CtmSavePointsOptions& options )
+Expected<void> toCtm( const PointCloud& points, const std::filesystem::path& file, const CtmSavePointsOptions& options )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -445,7 +445,7 @@ VoidOrErrStr toCtm( const PointCloud& points, const std::filesystem::path& file,
     return toCtm( points, out, options );
 }
 
-VoidOrErrStr toCtm( const PointCloud& cloud, std::ostream& out, const CtmSavePointsOptions& options )
+Expected<void> toCtm( const PointCloud& cloud, std::ostream& out, const CtmSavePointsOptions& options )
 {
     MR_TIMER
 
@@ -590,12 +590,12 @@ VoidOrErrStr toCtm( const PointCloud& cloud, std::ostream& out, const CtmSavePoi
     return {};
 }
 
-VoidOrErrStr toCtm( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
+Expected<void> toCtm( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
 {
     return toCtm( points, file, CtmSavePointsOptions{ settings } );
 }
 
-VoidOrErrStr toCtm( const PointCloud& points, std::ostream& out, const SaveSettings& settings )
+Expected<void> toCtm( const PointCloud& points, std::ostream& out, const SaveSettings& settings )
 {
     return toCtm( points, out, CtmSavePointsOptions{ settings } );
 }

--- a/source/MRIOExtras/MRCtm.h
+++ b/source/MRIOExtras/MRCtm.h
@@ -45,10 +45,10 @@ struct CtmSaveOptions : SaveSettings
 };
 
 /// saves in .ctm file
-MRIOEXTRAS_API VoidOrErrStr toCtm( const Mesh & mesh, const std::filesystem::path & file, const CtmSaveOptions & options );
-MRIOEXTRAS_API VoidOrErrStr toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOptions & options );
-MRIOEXTRAS_API VoidOrErrStr toCtm( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings = {} );
-MRIOEXTRAS_API VoidOrErrStr toCtm( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
+MRIOEXTRAS_API Expected<void> toCtm( const Mesh & mesh, const std::filesystem::path & file, const CtmSaveOptions & options );
+MRIOEXTRAS_API Expected<void> toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOptions & options );
+MRIOEXTRAS_API Expected<void> toCtm( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings = {} );
+MRIOEXTRAS_API Expected<void> toCtm( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
 
 } // namespace MeshSave
 
@@ -73,10 +73,10 @@ struct CtmSavePointsOptions : SaveSettings
 };
 
 /// saves in .ctm file
-MRIOEXTRAS_API VoidOrErrStr toCtm( const PointCloud& points, const std::filesystem::path& file, const CtmSavePointsOptions& options );
-MRIOEXTRAS_API VoidOrErrStr toCtm( const PointCloud& points, std::ostream& out, const CtmSavePointsOptions& options );
-MRIOEXTRAS_API VoidOrErrStr toCtm( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
-MRIOEXTRAS_API VoidOrErrStr toCtm( const PointCloud& points, std::ostream& out, const SaveSettings& settings = {} );
+MRIOEXTRAS_API Expected<void> toCtm( const PointCloud& points, const std::filesystem::path& file, const CtmSavePointsOptions& options );
+MRIOEXTRAS_API Expected<void> toCtm( const PointCloud& points, std::ostream& out, const CtmSavePointsOptions& options );
+MRIOEXTRAS_API Expected<void> toCtm( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
+MRIOEXTRAS_API Expected<void> toCtm( const PointCloud& points, std::ostream& out, const SaveSettings& settings = {} );
 
 } // namespace PointsSave
 

--- a/source/MRIOExtras/MRGltf.cpp
+++ b/source/MRIOExtras/MRGltf.cpp
@@ -168,7 +168,7 @@ constexpr float channelMax()
         return float( std::numeric_limits<ChannelType>::max() );
 }
 
-VoidOrErrStr fillVertsColorMap( VertColors& vertsColorMap, int vertexCount, const std::vector<Material>& materials, int materialIndex, const tinygltf::Model& model, const tinygltf::Primitive& primitive )
+Expected<void> fillVertsColorMap( VertColors& vertsColorMap, int vertexCount, const std::vector<Material>& materials, int materialIndex, const tinygltf::Model& model, const tinygltf::Primitive& primitive )
 {
     const VertId startPos = VertId( vertsColorMap.size() );
     vertsColorMap.resize( vertsColorMap.size() + vertexCount );
@@ -555,7 +555,7 @@ Expected<std::shared_ptr<Object>> deserializeObjectTreeFromGltf( const std::file
     return scene;
 }
 
-VoidOrErrStr serializeObjectTreeToGltf( const Object& root, const std::filesystem::path& file, ProgressCallback callback )
+Expected<void> serializeObjectTreeToGltf( const Object& root, const std::filesystem::path& file, ProgressCallback callback )
 {
     tinygltf::Model model;
     model.asset.generator = "MeshLib";

--- a/source/MRIOExtras/MRGltf.h
+++ b/source/MRIOExtras/MRGltf.h
@@ -13,7 +13,7 @@ namespace MR
 // loads scene from glTF file in a new container object
 MRIOEXTRAS_API Expected<std::shared_ptr<Object>> deserializeObjectTreeFromGltf( const std::filesystem::path& file, ProgressCallback callback = {} );
 // saves scene to a glTF file
-MRIOEXTRAS_API VoidOrErrStr serializeObjectTreeToGltf( const Object& root, const std::filesystem::path& file, ProgressCallback callback = {} );
+MRIOEXTRAS_API Expected<void> serializeObjectTreeToGltf( const Object& root, const std::filesystem::path& file, ProgressCallback callback = {} );
 
 } // namespace MR
 #endif

--- a/source/MRIOExtras/MRJpeg.cpp
+++ b/source/MRIOExtras/MRJpeg.cpp
@@ -98,7 +98,7 @@ MR_ADD_IMAGE_LOADER_WITH_PRIORITY( IOFilter( "JPEG (.jpg,.jpeg)", "*.jpg;*.jpeg"
 namespace ImageSave
 {
 
-VoidOrErrStr toJpeg( const Image& image, const std::filesystem::path& path )
+Expected<void> toJpeg( const Image& image, const std::filesystem::path& path )
 {
     unsigned long jpegSize = 0;
     JpegWriter writer;

--- a/source/MRIOExtras/MRPng.cpp
+++ b/source/MRIOExtras/MRPng.cpp
@@ -194,7 +194,7 @@ MR_ADD_IMAGE_LOADER_WITH_PRIORITY( IOFilter( "Portable Network Graphics (.png)",
 namespace ImageSave
 {
 
-VoidOrErrStr toPng( const Image& image, const std::filesystem::path& file )
+Expected<void> toPng( const Image& image, const std::filesystem::path& file )
 {
     std::ofstream fp( file, std::ios::binary );
     if ( !fp )
@@ -203,7 +203,7 @@ VoidOrErrStr toPng( const Image& image, const std::filesystem::path& file )
     return toPng( image, fp );
 }
 
-VoidOrErrStr toPng( const Image& image, std::ostream& os )
+Expected<void> toPng( const Image& image, std::ostream& os )
 {
     WritePng png;
     if ( !png.pngPtr )

--- a/source/MRIOExtras/MRStep.cpp
+++ b/source/MRIOExtras/MRStep.cpp
@@ -652,7 +652,7 @@ std::filesystem::path getStepTemporaryDirectory()
 std::mutex cOpenCascadeTempFileMutex = {};
 #endif
 
-VoidOrErrStr readFromFile( STEPControl_Reader& reader, const std::filesystem::path& path )
+Expected<void> readFromFile( STEPControl_Reader& reader, const std::filesystem::path& path )
 {
     MR_TIMER
 
@@ -662,7 +662,7 @@ VoidOrErrStr readFromFile( STEPControl_Reader& reader, const std::filesystem::pa
     return {};
 }
 
-VoidOrErrStr readFromStream( STEPControl_Reader& reader, std::istream& in )
+Expected<void> readFromStream( STEPControl_Reader& reader, std::istream& in )
 {
     MR_TIMER
 
@@ -692,7 +692,7 @@ VoidOrErrStr readFromStream( STEPControl_Reader& reader, std::istream& in )
 }
 
 #if !STEP_READER_FIXED
-VoidOrErrStr repairStepFile( STEPControl_Reader& reader )
+Expected<void> repairStepFile( STEPControl_Reader& reader )
 {
     const auto model = reader.StepModel();
     const auto protocol = Handle( StepData_Protocol )::DownCast( model->Protocol() );
@@ -736,7 +736,7 @@ VoidOrErrStr repairStepFile( STEPControl_Reader& reader )
 
 std::mutex cOpenCascadeMutex = {};
 
-Expected<Mesh> fromStepImpl( const std::function<VoidOrErrStr ( STEPControl_Reader& )>& readFunc, const MeshLoadSettings& settings )
+Expected<Mesh> fromStepImpl( const std::function<Expected<void> ( STEPControl_Reader& )>& readFunc, const MeshLoadSettings& settings )
 {
     MR_TIMER
 
@@ -767,7 +767,7 @@ Expected<Mesh> fromStepImpl( const std::function<VoidOrErrStr ( STEPControl_Read
 }
 
 #ifndef MRIOEXTRAS_OPENCASCADE_USE_XDE
-Expected<std::shared_ptr<Object>> fromSceneStepFileImpl( const std::function<VoidOrErrStr ( STEPControl_Reader& )>& readFunc, const MeshLoadSettings& settings )
+Expected<std::shared_ptr<Object>> fromSceneStepFileImpl( const std::function<Expected<void> ( STEPControl_Reader& )>& readFunc, const MeshLoadSettings& settings )
 {
     MR_TIMER
 
@@ -792,7 +792,7 @@ Expected<std::shared_ptr<Object>> fromSceneStepFileImpl( const std::function<Voi
 #endif
 
 #ifdef MRIOEXTRAS_OPENCASCADE_USE_XDE
-Expected<std::shared_ptr<Object>> fromSceneStepFileImpl( const std::function<VoidOrErrStr ( STEPControl_Reader& )>& readFunc, const MeshLoadSettings& settings )
+Expected<std::shared_ptr<Object>> fromSceneStepFileImpl( const std::function<Expected<void> ( STEPControl_Reader& )>& readFunc, const MeshLoadSettings& settings )
 {
     MR_TIMER
 

--- a/source/MRIOExtras/MRZlib.cpp
+++ b/source/MRIOExtras/MRZlib.cpp
@@ -44,7 +44,7 @@ std::string zlibToString( int code )
 namespace MR
 {
 
-VoidOrErrStr zlibCompressStream( std::istream& in, std::ostream& out, int level )
+Expected<void> zlibCompressStream( std::istream& in, std::ostream& out, int level )
 {
     Buffer<char> inChunk( cChunkSize ), outChunk( cChunkSize );
     z_stream stream {
@@ -89,7 +89,7 @@ VoidOrErrStr zlibCompressStream( std::istream& in, std::ostream& out, int level 
     return {};
 }
 
-VoidOrErrStr zlibDecompressStream( std::istream& in, std::ostream& out )
+Expected<void> zlibDecompressStream( std::istream& in, std::ostream& out )
 {
     Buffer<char> inChunk( cChunkSize ), outChunk( cChunkSize );
     z_stream stream {

--- a/source/MRIOExtras/MRZlib.h
+++ b/source/MRIOExtras/MRZlib.h
@@ -18,7 +18,7 @@ namespace MR
  * @param level - compression level (0 - no compression, 1 - the fastest but the most inefficient compression, 9 - the most efficient but the slowest compression)
  * @return nothing or error string
  */
-MRIOEXTRAS_API VoidOrErrStr zlibCompressStream( std::istream& in, std::ostream& out, int level = -1 );
+MRIOEXTRAS_API Expected<void> zlibCompressStream( std::istream& in, std::ostream& out, int level = -1 );
 
 /**
  * /brief decompress the input data compressed using the Deflate algorithm
@@ -26,7 +26,7 @@ MRIOEXTRAS_API VoidOrErrStr zlibCompressStream( std::istream& in, std::ostream& 
  * @param out - output data stream
  * @return nothing or error string
  */
-MRIOEXTRAS_API VoidOrErrStr zlibDecompressStream( std::istream& in, std::ostream& out );
+MRIOEXTRAS_API Expected<void> zlibDecompressStream( std::istream& in, std::ostream& out );
 
 } // namespace MR
 #endif

--- a/source/MRMesh/MRAddNoise.cpp
+++ b/source/MRMesh/MRAddNoise.cpp
@@ -8,7 +8,7 @@
 namespace MR
 {
 
-VoidOrErrStr addNoise( VertCoords& points, const VertBitSet& validVerts, NoiseSettings settings )
+Expected<void> addNoise( VertCoords& points, const VertBitSet& validVerts, NoiseSettings settings )
 {
     if ( validVerts.count() > 1000 )
     {

--- a/source/MRMesh/MRAddNoise.h
+++ b/source/MRMesh/MRAddNoise.h
@@ -17,6 +17,6 @@ struct NoiseSettings
 };
 
 // Adds noise to the points, using a normal distribution
-MRMESH_API VoidOrErrStr addNoise( VertCoords& points, const VertBitSet& validVerts, NoiseSettings settings );
+MRMESH_API Expected<void> addNoise( VertCoords& points, const VertBitSet& validVerts, NoiseSettings settings );
 
 }

--- a/source/MRMesh/MRCircleObject.h
+++ b/source/MRMesh/MRCircleObject.h
@@ -70,12 +70,12 @@ protected:
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 
-    virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& ) const override
+    virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& ) const override
     {
         return {};
     }
 
-    virtual VoidOrErrStr deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
+    virtual Expected<void> deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
     {
         return {};
     }

--- a/source/MRMesh/MRConeObject.h
+++ b/source/MRMesh/MRConeObject.h
@@ -83,12 +83,12 @@ protected:
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 
-    virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& ) const override
+    virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& ) const override
     {
         return {};
     }
 
-    virtual VoidOrErrStr deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
+    virtual Expected<void> deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
     {
         return {};
     }

--- a/source/MRMesh/MRCylinderObject.h
+++ b/source/MRMesh/MRCylinderObject.h
@@ -78,12 +78,12 @@ protected:
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 
-    virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& ) const override
+    virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& ) const override
     {
         return {};
     }
 
-    virtual VoidOrErrStr deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
+    virtual Expected<void> deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
     {
         return {};
     }

--- a/source/MRMesh/MRDistanceMapSave.cpp
+++ b/source/MRMesh/MRDistanceMapSave.cpp
@@ -17,7 +17,7 @@ const IOFilters Filters =
     {"MRDistanceMap (.mrdistancemap)","*.mrdistancemap"}
 };
 
-VoidOrErrStr toRAW( const std::filesystem::path& path, const DistanceMap& dmap )
+Expected<void> toRAW( const std::filesystem::path& path, const DistanceMap& dmap )
 {
     if ( path.empty() )
         return unexpected( "Path is empty" );
@@ -57,7 +57,7 @@ VoidOrErrStr toRAW( const std::filesystem::path& path, const DistanceMap& dmap )
     return {};
 }
 
-VoidOrErrStr toMrDistanceMap( const std::filesystem::path& path, const DistanceMap& dmap, const DistanceMapToWorld& params )
+Expected<void> toMrDistanceMap( const std::filesystem::path& path, const DistanceMap& dmap, const DistanceMapToWorld& params )
 {
     if ( path.empty() )
         return unexpected( "Path is empty" );
@@ -100,7 +100,7 @@ VoidOrErrStr toMrDistanceMap( const std::filesystem::path& path, const DistanceM
     return {};
 }
 
-VoidOrErrStr toAnySupportedFormat( const std::filesystem::path& path, const DistanceMap& dmap, const AffineXf3f * xf )
+Expected<void> toAnySupportedFormat( const std::filesystem::path& path, const DistanceMap& dmap, const AffineXf3f * xf )
 {
     auto ext = utf8string( path.extension() );
     for ( auto& c : ext )

--- a/source/MRMesh/MRDistanceMapSave.h
+++ b/source/MRMesh/MRDistanceMapSave.h
@@ -23,9 +23,9 @@ MRMESH_API extern const IOFilters Filters;
  * 2 integer - DistanceMap.resX & DistanceMap.resY
  * [resX * resY] float - matrix of values
  */
-MRMESH_API VoidOrErrStr toRAW( const std::filesystem::path& path, const DistanceMap& dmap );
-MRMESH_API VoidOrErrStr toMrDistanceMap( const std::filesystem::path& path, const DistanceMap& dmapObject, const DistanceMapToWorld& params );
-MRMESH_API VoidOrErrStr toAnySupportedFormat( const std::filesystem::path& path, const DistanceMap& dmapObject, const AffineXf3f * xf = nullptr );
+MRMESH_API Expected<void> toRAW( const std::filesystem::path& path, const DistanceMap& dmap );
+MRMESH_API Expected<void> toMrDistanceMap( const std::filesystem::path& path, const DistanceMap& dmapObject, const DistanceMapToWorld& params );
+MRMESH_API Expected<void> toAnySupportedFormat( const std::filesystem::path& path, const DistanceMap& dmapObject, const AffineXf3f * xf = nullptr );
 
 /// \}
 

--- a/source/MRMesh/MRExpected.h
+++ b/source/MRMesh/MRExpected.h
@@ -66,7 +66,7 @@ MR_BIND_IGNORE inline auto unexpected( E &&e )
 #endif
 
 /// return type for a void function that can produce an error string
-using VoidOrErrStr = Expected<void>;
+using VoidOrErrStr [[deprecated]] = Expected<void>;
 
 /// Common operation canceled line for all
 MR_BIND_IGNORE inline std::string stringOperationCanceled()

--- a/source/MRMesh/MRFastWindingNumber.cpp
+++ b/source/MRMesh/MRFastWindingNumber.cpp
@@ -43,7 +43,7 @@ bool FastWindingNumber::calcSelfIntersections( FaceBitSet& res, float beta, Prog
     }, cb );
 }
 
-VoidOrErrStr FastWindingNumber::calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb )
+Expected<void> FastWindingNumber::calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb )
 {
     MR_TIMER
 
@@ -64,7 +64,7 @@ float FastWindingNumber::calcWithDistances( const Vector3f& p, float windingNumb
     return sign * std::sqrt( findProjection( p, mesh_, maxDistSq, nullptr, minDistSq ).distSq );
 }
 
-VoidOrErrStr FastWindingNumber::calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb )
+Expected<void> FastWindingNumber::calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb )
 {
     MR_TIMER
 

--- a/source/MRMesh/MRFastWindingNumber.h
+++ b/source/MRMesh/MRFastWindingNumber.h
@@ -37,7 +37,7 @@ public:
     /// <param name="dims">dimensions of the grid</param>
     /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
     /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    virtual VoidOrErrStr calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb = {} ) = 0;
+    virtual Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb = {} ) = 0;
 
     /// <summary>
     /// calculates distances with the sign obtained from winding number in each point from a three-dimensional grid
@@ -47,7 +47,7 @@ public:
     /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
     /// <param name="windingNumberThreshold">positive distance if winding number below or equal this threshold</param>
     /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    virtual VoidOrErrStr calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) = 0;
+    virtual Expected<void> calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) = 0;
 };
 
 /// the class for fast approximate computation of winding number for a mesh (using its AABB tree)
@@ -64,9 +64,9 @@ public:
     // see methods' descriptions in IFastWindingNumber
     MRMESH_API void calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace = {} ) override;
     MRMESH_API bool calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb ) override;
-    MRMESH_API VoidOrErrStr calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
+    MRMESH_API Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
     MRMESH_API float calcWithDistances( const Vector3f& p, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq );
-    MRMESH_API VoidOrErrStr calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) override;
+    MRMESH_API Expected<void> calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float windingNumberThreshold, float beta, float maxDistSq, float minDistSq, ProgressCallback cb ) override;
 
 private:
     [[nodiscard]] float calc_( const Vector3f & q, float beta, FaceId skipFace = {} ) const;

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -69,7 +69,7 @@ AffineXf3f getXfFromOxyPlane( const Contours3f& contours )
     return AffineXf3f( c.getXf() );
 }
 
-VoidOrErrStr fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges )
+Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges )
 {
     MR_TIMER
     // check input

--- a/source/MRMesh/MRFillContours2D.h
+++ b/source/MRMesh/MRFillContours2D.h
@@ -13,7 +13,7 @@ namespace MR
  * edges should have invalid left face (FaceId == -1)
  * @return Expected with has_value()=true if holes filled, otherwise - string error
  */
-MRMESH_API VoidOrErrStr fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges );
+MRMESH_API Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges );
 
 /// computes the transformation that maps
 /// O into center mass of contours' points

--- a/source/MRMesh/MRFixSelfIntersections.cpp
+++ b/source/MRMesh/MRFixSelfIntersections.cpp
@@ -26,13 +26,13 @@ Expected<FaceBitSet> getFaces( const Mesh& mesh, ProgressCallback cb )
 }
 
 // Helper function to fix self-intersections on part of mesh
-static VoidOrErrStr doFix( Mesh& mesh, FaceBitSet& part, const Settings& settings,
+static Expected<void> doFix( Mesh& mesh, FaceBitSet& part, const Settings& settings,
     int expandSize,
     FaceBitSet& accumBadFaces,
     ProgressCallback cb );
 
 // TODO: finish implementation
-VoidOrErrStr fixOld( Mesh& mesh, const Settings& settings )
+Expected<void> fixOld( Mesh& mesh, const Settings& settings )
 {
     Settings currentSettings = settings;
     if ( currentSettings.subdivideEdgeLen <= 0.0f )
@@ -104,7 +104,7 @@ VoidOrErrStr fixOld( Mesh& mesh, const Settings& settings )
     return {};
 }
 
-VoidOrErrStr fix( Mesh& mesh, const Settings& settings )
+Expected<void> fix( Mesh& mesh, const Settings& settings )
 {
     MR_TIMER;
 
@@ -237,7 +237,7 @@ static Expected<FaceBitSet> findSelfCollidingTrianglesBSForPart( Mesh& mesh, con
     return result;
 }
 
-static VoidOrErrStr doFix( Mesh &mesh, FaceBitSet &part, const Settings & settings,
+static Expected<void> doFix( Mesh &mesh, FaceBitSet &part, const Settings & settings,
     int expandSize,
     FaceBitSet& accumBadFaces,
     ProgressCallback cb )

--- a/source/MRMesh/MRFixSelfIntersections.h
+++ b/source/MRMesh/MRFixSelfIntersections.h
@@ -36,7 +36,7 @@ struct Settings
 MRMESH_API Expected<FaceBitSet> getFaces( const Mesh& mesh, ProgressCallback cb = {} );
 
 /// Finds and fixes self-intersections per component:
-MRMESH_API VoidOrErrStr fix( Mesh& mesh, const Settings& settings );
+MRMESH_API Expected<void> fix( Mesh& mesh, const Settings& settings );
 }
 
 }

--- a/source/MRMesh/MRIOParsing.cpp
+++ b/source/MRMesh/MRIOParsing.cpp
@@ -122,7 +122,7 @@ Expected<Buffer<char>> readCharBuffer( std::istream& in )
 }
 
 template <typename T>
-VoidOrErrStr parseTextCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* n, Color* c )
+Expected<void> parseTextCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* n, Color* c )
 {
     using namespace boost::spirit::x3;
 
@@ -177,7 +177,7 @@ VoidOrErrStr parseTextCoordinate( const std::string_view& str, Vector3<T>& v, Ve
 }
 
 template <typename T>
-VoidOrErrStr parseObjCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* c )
+Expected<void> parseObjCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* c )
 {
     using namespace boost::spirit::x3;
 
@@ -212,7 +212,7 @@ VoidOrErrStr parseObjCoordinate( const std::string_view& str, Vector3<T>& v, Vec
 }
 
 template<typename T>
-VoidOrErrStr parsePtsCoordinate( const std::string_view& str, Vector3<T>& v, Color& c )
+Expected<void> parsePtsCoordinate( const std::string_view& str, Vector3<T>& v, Color& c )
 {
     using namespace boost::spirit::x3;
 
@@ -239,7 +239,7 @@ VoidOrErrStr parsePtsCoordinate( const std::string_view& str, Vector3<T>& v, Col
 }
 
 template<typename T>
-VoidOrErrStr parseSingleNumber( const std::string_view& str, T& num )
+Expected<void> parseSingleNumber( const std::string_view& str, T& num )
 {
     using namespace boost::spirit::x3;
 
@@ -272,7 +272,7 @@ VoidOrErrStr parseSingleNumber( const std::string_view& str, T& num )
     return {};
 }
 
-VoidOrErrStr parseFirstNum( const std::string_view& str, int& num )
+Expected<void> parseFirstNum( const std::string_view& str, int& num )
 {
     using namespace boost::spirit::x3;
 
@@ -294,7 +294,7 @@ VoidOrErrStr parseFirstNum( const std::string_view& str, int& num )
     return {};
 }
 
-VoidOrErrStr parsePolygon( const std::string_view& str, VertId* vertId, int* numPoints)
+Expected<void> parsePolygon( const std::string_view& str, VertId* vertId, int* numPoints)
 {
     using namespace boost::spirit::x3;
 
@@ -329,24 +329,24 @@ VoidOrErrStr parsePolygon( const std::string_view& str, VertId* vertId, int* num
 }
 
 template <typename T>
-VoidOrErrStr parseAscCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* n, Color* c )
+Expected<void> parseAscCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* n, Color* c )
 {
     return parseTextCoordinate( str, v, n, c );
 }
 
-template VoidOrErrStr parseSingleNumber<float>( const std::string_view& str, float& num );
-template VoidOrErrStr parseSingleNumber<int>( const std::string_view& str, int& num );
+template Expected<void> parseSingleNumber<float>( const std::string_view& str, float& num );
+template Expected<void> parseSingleNumber<int>( const std::string_view& str, int& num );
 
-template VoidOrErrStr parsePtsCoordinate<float>( const std::string_view& str, Vector3f& v, Color& c );
-template VoidOrErrStr parsePtsCoordinate<double>( const std::string_view& str, Vector3d& v, Color& c );
+template Expected<void> parsePtsCoordinate<float>( const std::string_view& str, Vector3f& v, Color& c );
+template Expected<void> parsePtsCoordinate<double>( const std::string_view& str, Vector3d& v, Color& c );
 
-template VoidOrErrStr parseTextCoordinate<float>( const std::string_view& str, Vector3f& v, Vector3f* n, Color* c );
-template VoidOrErrStr parseTextCoordinate<double>( const std::string_view& str, Vector3d& v, Vector3d* n, Color* c );
+template Expected<void> parseTextCoordinate<float>( const std::string_view& str, Vector3f& v, Vector3f* n, Color* c );
+template Expected<void> parseTextCoordinate<double>( const std::string_view& str, Vector3d& v, Vector3d* n, Color* c );
 
-template VoidOrErrStr parseObjCoordinate<float>( const std::string_view& str, Vector3f& v, Vector3f* c );
-template VoidOrErrStr parseObjCoordinate<double>( const std::string_view& str, Vector3d& v, Vector3d* c );
+template Expected<void> parseObjCoordinate<float>( const std::string_view& str, Vector3f& v, Vector3f* c );
+template Expected<void> parseObjCoordinate<double>( const std::string_view& str, Vector3d& v, Vector3d* c );
 
-template VoidOrErrStr parseAscCoordinate<float>( const std::string_view& str, Vector3f& v, Vector3f* n, Color* c );
-template VoidOrErrStr parseAscCoordinate<double>( const std::string_view& str, Vector3d& v, Vector3d* n, Color* c );
+template Expected<void> parseAscCoordinate<float>( const std::string_view& str, Vector3f& v, Vector3f* n, Color* c );
+template Expected<void> parseAscCoordinate<double>( const std::string_view& str, Vector3d& v, Vector3d* n, Color* c );
 
 }

--- a/source/MRMesh/MRIOParsing.h
+++ b/source/MRMesh/MRIOParsing.h
@@ -21,26 +21,26 @@ MRMESH_API Expected<Buffer<char>> readCharBuffer( std::istream& in );
 
 // read coordinates to `v` separated by space
 template<typename T>
-VoidOrErrStr parseTextCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* n = nullptr, Color* c = nullptr );
+Expected<void> parseTextCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* n = nullptr, Color* c = nullptr );
 template<typename T>
-VoidOrErrStr parseObjCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* c = nullptr );
+Expected<void> parseObjCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* c = nullptr );
 template<typename T>
-VoidOrErrStr parsePtsCoordinate( const std::string_view& str, Vector3<T>& v, Color& c );
+Expected<void> parsePtsCoordinate( const std::string_view& str, Vector3<T>& v, Color& c );
 
 // reads the first integer number in the line
-MRMESH_API VoidOrErrStr parseFirstNum( const std::string_view& str, int& num );
+MRMESH_API Expected<void> parseFirstNum( const std::string_view& str, int& num );
 // reads the polygon points and optional number of polygon points
 // example
 // N vertex0 vertex1 ... vertexN
-MRMESH_API VoidOrErrStr parsePolygon( const std::string_view& str, VertId* vertId, int* numPoints );
+MRMESH_API Expected<void> parsePolygon( const std::string_view& str, VertId* vertId, int* numPoints );
 
 template<typename T>
 [[deprecated( "use parseTextCoordinate() instead")]]
-VoidOrErrStr parseAscCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* n = nullptr, Color* c = nullptr );
+Expected<void> parseAscCoordinate( const std::string_view& str, Vector3<T>& v, Vector3<T>* n = nullptr, Color* c = nullptr );
 
 
 
 template<typename T>
-VoidOrErrStr parseSingleNumber( const std::string_view& str, T& num );
+Expected<void> parseSingleNumber( const std::string_view& str, T& num );
 
 }

--- a/source/MRMesh/MRImageSave.cpp
+++ b/source/MRMesh/MRImageSave.cpp
@@ -38,7 +38,7 @@ struct BMPHeader
 };
 #pragma pack(pop)
 
-VoidOrErrStr toBmp( const Image& image, const std::filesystem::path& file )
+Expected<void> toBmp( const Image& image, const std::filesystem::path& file )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -68,7 +68,7 @@ VoidOrErrStr toBmp( const Image& image, const std::filesystem::path& file )
 #ifndef __EMSCRIPTEN__
 
 #ifndef MRMESH_NO_TIFF
-VoidOrErrStr toTiff( const Image& image, const std::filesystem::path& path )
+Expected<void> toTiff( const Image& image, const std::filesystem::path& path )
 {
     BaseTiffParameters btParams;
     btParams.bytesPerSample = 1;
@@ -81,7 +81,7 @@ VoidOrErrStr toTiff( const Image& image, const std::filesystem::path& path )
 
 #endif
 
-VoidOrErrStr toAnySupportedFormat( const Image& image, const std::filesystem::path& file )
+Expected<void> toAnySupportedFormat( const Image& image, const std::filesystem::path& file )
 {
     auto ext = utf8string( file.extension() );
     for ( auto& c : ext )

--- a/source/MRMesh/MRImageSave.h
+++ b/source/MRMesh/MRImageSave.h
@@ -18,18 +18,18 @@ namespace ImageSave
 /// \{
 
 /// saves in .bmp format
-MRMESH_API VoidOrErrStr toBmp( const Image& image, const std::filesystem::path& path );
+MRMESH_API Expected<void> toBmp( const Image& image, const std::filesystem::path& path );
 
 #ifndef __EMSCRIPTEN__
 
 #ifndef MRMESH_NO_TIFF
-MRMESH_API VoidOrErrStr toTiff( const Image& image, const std::filesystem::path& path );
+MRMESH_API Expected<void> toTiff( const Image& image, const std::filesystem::path& path );
 #endif
 
 #endif
 
 /// detects the format from file extension and save image to it  
-MRMESH_API VoidOrErrStr toAnySupportedFormat( const Image& image, const std::filesystem::path& path );
+MRMESH_API Expected<void> toAnySupportedFormat( const Image& image, const std::filesystem::path& path );
 
 /// \}
 

--- a/source/MRMesh/MRLineObject.h
+++ b/source/MRMesh/MRLineObject.h
@@ -69,10 +69,10 @@ protected:
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 
-    virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& ) const override
+    virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& ) const override
         { return {}; }
 
-    virtual VoidOrErrStr deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
+    virtual Expected<void> deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
         { return {}; }
 
     MRMESH_API void setupRenderObject_() const override;

--- a/source/MRMesh/MRLinesSave.cpp
+++ b/source/MRMesh/MRLinesSave.cpp
@@ -15,7 +15,7 @@ namespace MR
 namespace LinesSave
 {
 
-VoidOrErrStr toMrLines( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings )
+Expected<void> toMrLines( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -24,7 +24,7 @@ VoidOrErrStr toMrLines( const Polyline3& polyline, const std::filesystem::path& 
     return toMrLines( polyline, out, settings );
 }
 
-VoidOrErrStr toMrLines( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings )
+Expected<void> toMrLines( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings )
 {
     MR_TIMER;
     polyline.topology.write( out );
@@ -47,7 +47,7 @@ VoidOrErrStr toMrLines( const Polyline3& polyline, std::ostream& out, const Save
     return {};
 }
 
-VoidOrErrStr toPts( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings )
+Expected<void> toPts( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -56,7 +56,7 @@ VoidOrErrStr toPts( const Polyline3& polyline, const std::filesystem::path& file
     return toPts( polyline, out, settings );
 }
 
-VoidOrErrStr toPts( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings )
+Expected<void> toPts( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings )
 {
     float pointsNum{ 0.f };
     auto contours = polyline.contours();
@@ -91,7 +91,7 @@ VoidOrErrStr toPts( const Polyline3& polyline, std::ostream& out, const SaveSett
     return {};
 }
 
-VoidOrErrStr toDxf( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings )
+Expected<void> toDxf( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -100,7 +100,7 @@ VoidOrErrStr toDxf( const Polyline3& polyline, const std::filesystem::path& file
     return toDxf( polyline, out, settings );
 }
 
-VoidOrErrStr toDxf( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings )
+Expected<void> toDxf( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings )
 {
     out << "0\nSECTION\n";
     out << "2\nENTITIES\n";
@@ -154,7 +154,7 @@ VoidOrErrStr toDxf( const Polyline3& polyline, std::ostream& out, const SaveSett
     return {};
 }
 
-VoidOrErrStr toAnySupportedFormat( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings )
+Expected<void> toAnySupportedFormat( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings )
 {
     auto ext = utf8string( file.extension() );
     for ( auto& c : ext )
@@ -168,7 +168,7 @@ VoidOrErrStr toAnySupportedFormat( const Polyline3& polyline, const std::filesys
     return saver.fileSave( polyline, file, settings );
 }
 
-VoidOrErrStr toAnySupportedFormat( const Polyline3& polyline, const std::string& extension, std::ostream& out, const SaveSettings & settings )
+Expected<void> toAnySupportedFormat( const Polyline3& polyline, const std::string& extension, std::ostream& out, const SaveSettings & settings )
 {
     auto ext = extension;
     for ( auto& c : ext )

--- a/source/MRMesh/MRLinesSave.h
+++ b/source/MRMesh/MRLinesSave.h
@@ -18,23 +18,23 @@ namespace LinesSave
 
 /// saves in .mrlines file;
 /// SaveSettings::saveValidOnly = true is ignored
-MRMESH_API VoidOrErrStr toMrLines( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings = {} );
-MRMESH_API VoidOrErrStr toMrLines( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toMrLines( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toMrLines( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings = {} );
 
 /// saves in .pts file;
 /// SaveSettings::saveValidOnly = false is ignored
-MRMESH_API VoidOrErrStr toPts( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings = {} );
-MRMESH_API VoidOrErrStr toPts( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toPts( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toPts( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings = {} );
 
 /// saves in .dxf file;
 /// SaveSettings::saveValidOnly = false is ignored
-MRMESH_API VoidOrErrStr toDxf( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings = {} );
-MRMESH_API VoidOrErrStr toDxf( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toDxf( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toDxf( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings = {} );
 
 /// detects the format from file extension and saves polyline in it
-MRMESH_API VoidOrErrStr toAnySupportedFormat( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toAnySupportedFormat( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings = {} );
 /// extension in `*.ext` format
-MRMESH_API VoidOrErrStr toAnySupportedFormat( const Polyline3& polyline, const std::string& extension, std::ostream& out, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toAnySupportedFormat( const Polyline3& polyline, const std::string& extension, std::ostream& out, const SaveSettings & settings = {} );
 
 } // namespace LinesSave
 

--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -179,7 +179,7 @@ namespace
         return groups;
     }
 
-    VoidOrErrStr parseObjTextureVertex( const std::string_view& str, UVCoord& vt )
+    Expected<void> parseObjTextureVertex( const std::string_view& str, UVCoord& vt )
     {
         using namespace boost::spirit::x3;
 
@@ -209,7 +209,7 @@ namespace
         std::vector<int> normals;
     };
 
-    VoidOrErrStr parseObjFace( const std::string_view& str, ObjFace& f )
+    Expected<void> parseObjFace( const std::string_view& str, ObjFace& f )
     {
         using namespace boost::spirit::x3;
 
@@ -237,7 +237,7 @@ namespace
         return {};
     }
 
-    VoidOrErrStr parseMtlColor( const std::string_view& str, Vector3f& color )
+    Expected<void> parseMtlColor( const std::string_view& str, Vector3f& color )
     {
         using namespace boost::spirit::x3;
 
@@ -264,7 +264,7 @@ namespace
         return {};
     }
 
-    VoidOrErrStr parseMtlTexture( const std::string_view& str, std::string& textureFile )
+    Expected<void> parseMtlTexture( const std::string_view& str, std::string& textureFile )
     {
         using namespace boost::spirit::x3;
 

--- a/source/MRMesh/MRMeshSave.cpp
+++ b/source/MRMesh/MRMeshSave.cpp
@@ -16,7 +16,7 @@ namespace MR
 namespace MeshSave
 {
 
-VoidOrErrStr toMrmesh( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings )
+Expected<void> toMrmesh( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -25,7 +25,7 @@ VoidOrErrStr toMrmesh( const Mesh & mesh, const std::filesystem::path & file, co
     return toMrmesh( mesh, out, settings );
 }
 
-VoidOrErrStr toMrmesh( const Mesh & mesh, std::ostream & out, const SaveSettings & settings )
+Expected<void> toMrmesh( const Mesh & mesh, std::ostream & out, const SaveSettings & settings )
 {
     MR_TIMER
     mesh.topology.write( out );
@@ -46,7 +46,7 @@ VoidOrErrStr toMrmesh( const Mesh & mesh, std::ostream & out, const SaveSettings
     return {};
 }
 
-VoidOrErrStr toOff( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings )
+Expected<void> toOff( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings )
 {
     // although .off is a textual format, we open the file in binary mode to get exactly the same result on Windows and Linux
     std::ofstream out( file, std::ofstream::binary );
@@ -56,7 +56,7 @@ VoidOrErrStr toOff( const Mesh & mesh, const std::filesystem::path & file, const
     return toOff( mesh, out, settings );
 }
 
-VoidOrErrStr toOff( const Mesh& mesh, std::ostream& out, const SaveSettings & settings )
+Expected<void> toOff( const Mesh& mesh, std::ostream& out, const SaveSettings & settings )
 {
     MR_TIMER
 
@@ -108,7 +108,7 @@ VoidOrErrStr toOff( const Mesh& mesh, std::ostream& out, const SaveSettings & se
 }
 
 
-VoidOrErrStr toObj( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings, int firstVertId )
+Expected<void> toObj( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings, int firstVertId )
 {
     // although .obj is a textual format, we open the file in binary mode to get exactly the same result on Windows and Linux
     std::ofstream out( file, std::ofstream::binary );
@@ -136,7 +136,7 @@ VoidOrErrStr toObj( const Mesh & mesh, const std::filesystem::path & file, const
     return toObj( mesh, out, settings, firstVertId );
 }
 
-VoidOrErrStr toObj( const Mesh & mesh, std::ostream & out, const SaveSettings & settings, int firstVertId )
+Expected<void> toObj( const Mesh & mesh, std::ostream & out, const SaveSettings & settings, int firstVertId )
 {
     MR_TIMER
     out << "# MeshInspector.com\n";
@@ -223,12 +223,12 @@ VoidOrErrStr toObj( const Mesh & mesh, std::ostream & out, const SaveSettings & 
     return {};
 }
 
-VoidOrErrStr toObj( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings& settings )
+Expected<void> toObj( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings& settings )
 {
     return toObj( mesh, file, settings, 1 );
 }
 
-VoidOrErrStr toObj( const Mesh& mesh, std::ostream& out, const SaveSettings& settings )
+Expected<void> toObj( const Mesh& mesh, std::ostream& out, const SaveSettings& settings )
 {
     return toObj( mesh, out, settings, 1 );
 }
@@ -252,7 +252,7 @@ static FaceBitSet getNotDegenTris( const Mesh &mesh )
     return notDegenTris;
 }
 
-VoidOrErrStr toBinaryStl( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings )
+Expected<void> toBinaryStl( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -261,7 +261,7 @@ VoidOrErrStr toBinaryStl( const Mesh & mesh, const std::filesystem::path & file,
     return toBinaryStl( mesh, out, settings );
 }
 
-VoidOrErrStr toBinaryStl( const Mesh & mesh, std::ostream & out, const SaveSettings & settings )
+Expected<void> toBinaryStl( const Mesh & mesh, std::ostream & out, const SaveSettings & settings )
 {
     MR_TIMER
 
@@ -307,7 +307,7 @@ VoidOrErrStr toBinaryStl( const Mesh & mesh, std::ostream & out, const SaveSetti
     return {};
 }
 
-VoidOrErrStr toAsciiStl( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings & settings )
+Expected<void> toAsciiStl( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings & settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -316,7 +316,7 @@ VoidOrErrStr toAsciiStl( const Mesh& mesh, const std::filesystem::path& file, co
     return toAsciiStl( mesh, out, settings );
 }
 
-VoidOrErrStr toAsciiStl( const Mesh& mesh, std::ostream& out, const SaveSettings & settings )
+Expected<void> toAsciiStl( const Mesh& mesh, std::ostream& out, const SaveSettings & settings )
 {
     MR_TIMER;
 
@@ -359,7 +359,7 @@ VoidOrErrStr toAsciiStl( const Mesh& mesh, std::ostream& out, const SaveSettings
     return {};
 }
 
-VoidOrErrStr toPly( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings )
+Expected<void> toPly( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -368,7 +368,7 @@ VoidOrErrStr toPly( const Mesh & mesh, const std::filesystem::path & file, const
     return toPly( mesh, out, settings );
 }
 
-VoidOrErrStr toPly( const Mesh & mesh, std::ostream & out, const SaveSettings & settings )
+Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings & settings )
 {
     MR_TIMER
 
@@ -444,7 +444,7 @@ VoidOrErrStr toPly( const Mesh & mesh, std::ostream & out, const SaveSettings & 
     return {};
 }
 
-VoidOrErrStr toAnySupportedFormat( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings & settings )
+Expected<void> toAnySupportedFormat( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings & settings )
 {
     auto ext = utf8string( file.extension() );
     for ( auto & c : ext )
@@ -458,7 +458,7 @@ VoidOrErrStr toAnySupportedFormat( const Mesh& mesh, const std::filesystem::path
     return saver.fileSave( mesh, file, settings );
 }
 
-VoidOrErrStr toAnySupportedFormat( const Mesh& mesh, const std::string& extension, std::ostream& out, const SaveSettings & settings )
+Expected<void> toAnySupportedFormat( const Mesh& mesh, const std::string& extension, std::ostream& out, const SaveSettings & settings )
 {
     auto ext = extension;
     for ( auto& c : ext )

--- a/source/MRMesh/MRMeshSave.h
+++ b/source/MRMesh/MRMeshSave.h
@@ -19,44 +19,44 @@ namespace MeshSave
 
 /// saves in internal file format;
 /// SaveSettings::saveValidOnly = true is ignored
-MRMESH_API VoidOrErrStr toMrmesh( const Mesh & mesh, const std::filesystem::path & file,
+MRMESH_API Expected<void> toMrmesh( const Mesh & mesh, const std::filesystem::path & file,
                                                      const SaveSettings & settings = {} );
-MRMESH_API VoidOrErrStr toMrmesh( const Mesh & mesh, std::ostream & out,
+MRMESH_API Expected<void> toMrmesh( const Mesh & mesh, std::ostream & out,
                                                      const SaveSettings & settings = {} );
 
 /// saves in .off file
-MRMESH_API VoidOrErrStr toOff( const Mesh & mesh, const std::filesystem::path & file,
+MRMESH_API Expected<void> toOff( const Mesh & mesh, const std::filesystem::path & file,
                                                   const SaveSettings & settings = {} );
-MRMESH_API VoidOrErrStr toOff( const Mesh & mesh, std::ostream & out,
+MRMESH_API Expected<void> toOff( const Mesh & mesh, std::ostream & out,
                                                   const SaveSettings & settings = {} );
 
 /// saves in .obj file
 /// \param firstVertId is the index of first mesh vertex in the output file (if this object is not the first there)
-MRMESH_API VoidOrErrStr toObj( const Mesh & mesh, const std::filesystem::path & file,
+MRMESH_API Expected<void> toObj( const Mesh & mesh, const std::filesystem::path & file,
                                                   const SaveSettings & settings, int firstVertId );
-MRMESH_API VoidOrErrStr toObj( const Mesh & mesh, std::ostream & out,
+MRMESH_API Expected<void> toObj( const Mesh & mesh, std::ostream & out,
                                                   const SaveSettings & settings, int firstVertId );
-MRMESH_API VoidOrErrStr toObj( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings = {} );
-MRMESH_API VoidOrErrStr toObj( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toObj( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toObj( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
 
 /// saves in binary .stl file;
 /// SaveSettings::saveValidOnly = false is ignored
-MRMESH_API VoidOrErrStr toBinaryStl( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings = {} );
-MRMESH_API VoidOrErrStr toBinaryStl( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toBinaryStl( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toBinaryStl( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
 
 /// saves in textual .stl file;
 /// SaveSettings::saveValidOnly = false is ignored
-MRMESH_API VoidOrErrStr toAsciiStl( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings & settings = {} );
-MRMESH_API VoidOrErrStr toAsciiStl( const Mesh& mesh, std::ostream& out, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toAsciiStl( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toAsciiStl( const Mesh& mesh, std::ostream& out, const SaveSettings & settings = {} );
 
 /// saves in .ply file
-MRMESH_API VoidOrErrStr toPly( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings & settings = {} );
-MRMESH_API VoidOrErrStr toPly( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toPly( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
 
 /// detects the format from file extension and save mesh to it
-MRMESH_API VoidOrErrStr toAnySupportedFormat( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toAnySupportedFormat( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings = {} );
 /// extension in `*.ext` format
-MRMESH_API VoidOrErrStr toAnySupportedFormat( const Mesh& mesh, const std::string& extension, std::ostream& out, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toAnySupportedFormat( const Mesh& mesh, const std::string& extension, std::ostream& out, const SaveSettings & settings = {} );
 
 /// \}
 

--- a/source/MRMesh/MRMeshSaveObj.cpp
+++ b/source/MRMesh/MRMeshSaveObj.cpp
@@ -9,7 +9,7 @@ namespace MR
 namespace MeshSave
 {
 
-VoidOrErrStr sceneToObj( const std::vector<NamedXfMesh> & objects, const std::filesystem::path & file,
+Expected<void> sceneToObj( const std::vector<NamedXfMesh> & objects, const std::filesystem::path & file,
                          VertColors* colors )
 {
     // although .obj is a textual format, we open the file in binary mode to get exactly the same result on Windows and Linux
@@ -20,7 +20,7 @@ VoidOrErrStr sceneToObj( const std::vector<NamedXfMesh> & objects, const std::fi
     return sceneToObj( objects, out, colors );
 }
 
-VoidOrErrStr sceneToObj( const std::vector<NamedXfMesh> & objects, std::ostream & out, VertColors* colors )
+Expected<void> sceneToObj( const std::vector<NamedXfMesh> & objects, std::ostream & out, VertColors* colors )
 {
     out << "# MeshInspector.com\n";
     int firstVertId = 1;

--- a/source/MRMesh/MRMeshSaveObj.h
+++ b/source/MRMesh/MRMeshSaveObj.h
@@ -24,9 +24,9 @@ struct NamedXfMesh
     AffineXf3f toWorld;
     std::shared_ptr<const Mesh> mesh;
 };
-MRMESH_API VoidOrErrStr sceneToObj( const std::vector<NamedXfMesh> & objects, const std::filesystem::path & file,
+MRMESH_API Expected<void> sceneToObj( const std::vector<NamedXfMesh> & objects, const std::filesystem::path & file,
                                     VertColors* colors = nullptr );
-MRMESH_API VoidOrErrStr sceneToObj( const std::vector<NamedXfMesh> & objects, std::ostream & out,
+MRMESH_API Expected<void> sceneToObj( const std::vector<NamedXfMesh> & objects, std::ostream & out,
                                     VertColors* colors = nullptr );
 
 /// \}

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -2104,7 +2104,7 @@ void MeshTopology::write( std::ostream & s ) const
     s.write( (const char*)edgePerFace_.data(), edgePerFace_.size() * sizeof(EdgeId) );
 }
 
-VoidOrErrStr MeshTopology::read( std::istream & s, ProgressCallback callback )
+Expected<void> MeshTopology::read( std::istream & s, ProgressCallback callback )
 {
     updateValids_ = false;
 

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -463,7 +463,7 @@ public:
 
     /// loads from binary stream
     /// \return text of error if any
-    MRMESH_API VoidOrErrStr read( std::istream& s, ProgressCallback callback = {} );
+    MRMESH_API Expected<void> read( std::istream& s, ProgressCallback callback = {} );
 
     /// compare that two topologies are exactly the same
     [[nodiscard]] MRMESH_API bool operator ==( const MeshTopology & b ) const;

--- a/source/MRMesh/MRNormalDenoising.cpp
+++ b/source/MRMesh/MRNormalDenoising.cpp
@@ -207,7 +207,7 @@ void updateIndicatorFast( const MeshTopology & topology, Vector<float, Undirecte
     } );
 }
 
-VoidOrErrStr meshDenoiseViaNormals( Mesh & mesh, const DenoiseViaNormalsSettings & settings )
+Expected<void> meshDenoiseViaNormals( Mesh & mesh, const DenoiseViaNormalsSettings & settings )
 {
     MR_TIMER
     if ( settings.normalIters <= 0 || settings.pointIters <= 0 )

--- a/source/MRMesh/MRNormalDenoising.h
+++ b/source/MRMesh/MRNormalDenoising.h
@@ -65,6 +65,6 @@ struct DenoiseViaNormalsSettings
 
 /// Reduces noise in given mesh,
 /// see the article "Mesh Denoising via a Novel Mumford-Shah Framework"
-MRMESH_API VoidOrErrStr meshDenoiseViaNormals( Mesh & mesh, const DenoiseViaNormalsSettings & settings = {} );
+MRMESH_API Expected<void> meshDenoiseViaNormals( Mesh & mesh, const DenoiseViaNormalsSettings & settings = {} );
 
 } //namespace MR

--- a/source/MRMesh/MRObject.cpp
+++ b/source/MRMesh/MRObject.cpp
@@ -417,7 +417,7 @@ void Object::swapSignals_( Object& other )
     std::swap( worldXfChangedSignal, other.worldXfChangedSignal );
 }
 
-Expected<std::future<VoidOrErrStr>> Object::serializeModel_( const std::filesystem::path& ) const
+Expected<std::future<Expected<void>>> Object::serializeModel_( const std::filesystem::path& ) const
 {
     return {};
 }
@@ -437,7 +437,7 @@ void Object::serializeFields_( Json::Value& root ) const
     root["Type"].append( Object::TypeName() ); // will be appended in derived calls
 }
 
-VoidOrErrStr Object::deserializeModel_( const std::filesystem::path&, ProgressCallback progressCb )
+Expected<void> Object::deserializeModel_( const std::filesystem::path&, ProgressCallback progressCb )
 {
     if ( progressCb && !progressCb( 1.f ) )
         return unexpected( std::string( "Loading canceled" ) );
@@ -518,14 +518,14 @@ std::vector<std::string> Object::getInfoLines() const
     return res;
 }
 
-Expected<std::vector<std::future<VoidOrErrStr>>> Object::serializeRecursive( const std::filesystem::path& path, Json::Value& root, int childId ) const
+Expected<std::vector<std::future<Expected<void>>>> Object::serializeRecursive( const std::filesystem::path& path, Json::Value& root, int childId ) const
 {
     std::error_code ec;
     if ( !std::filesystem::is_directory( path, ec ) )
         if ( !std::filesystem::create_directories( path, ec ) )
             return unexpected( "Cannot create directories " + utf8string( path ) );
 
-    std::vector<std::future<VoidOrErrStr>> res;
+    std::vector<std::future<Expected<void>>> res;
 
     // the key must be unique among all children of same parent
     std::string key = std::to_string( childId ) + "_" + replaceProhibitedChars( name_ );
@@ -561,7 +561,7 @@ Expected<std::vector<std::future<VoidOrErrStr>>> Object::serializeRecursive( con
     return res;
 }
 
-VoidOrErrStr Object::deserializeRecursive( const std::filesystem::path& path, const Json::Value& root,
+Expected<void> Object::deserializeRecursive( const std::filesystem::path& path, const Json::Value& root,
         ProgressCallback progressCb, int* objCounter )
 {
     std::string key = root["Key"].isString() ? root["Key"].asString() : root["Name"].asString();

--- a/source/MRMesh/MRObject.h
+++ b/source/MRMesh/MRObject.h
@@ -209,12 +209,12 @@ public:
     ///   models in the folder by given path and
     ///   fields in given JSON
     /// \param childId is its ordinal number within the parent
-    MRMESH_API Expected<std::vector<std::future<VoidOrErrStr>>> serializeRecursive( const std::filesystem::path& path, Json::Value& root, int childId ) const;
+    MRMESH_API Expected<std::vector<std::future<Expected<void>>>> serializeRecursive( const std::filesystem::path& path, Json::Value& root, int childId ) const;
 
     /// loads subtree into this Object
     ///   models from the folder by given path and
     ///   fields from given JSON
-    MRMESH_API VoidOrErrStr deserializeRecursive( const std::filesystem::path& path, const Json::Value& root,
+    MRMESH_API Expected<void> deserializeRecursive( const std::filesystem::path& path, const Json::Value& root,
         ProgressCallback progressCb = {}, int* objCounter = nullptr );
 
     /// swaps this object with other
@@ -260,14 +260,14 @@ protected:
 
     /// Creates future to save object model (e.g. mesh) in given file
     /// path is full filename without extension
-    MRMESH_API virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& path ) const;
+    MRMESH_API virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& path ) const;
 
     /// Write parameters to given Json::Value,
     /// \note if you override this method, please call Base::serializeFields_(root) in the beginning
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const;
 
     /// Reads model from file
-    MRMESH_API virtual VoidOrErrStr deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb = {} );
+    MRMESH_API virtual Expected<void> deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb = {} );
 
     /// Reads parameters from json value
     /// \note if you override this method, please call Base::deserializeFields_(root) in the beginning

--- a/source/MRMesh/MRObjectDistanceMap.cpp
+++ b/source/MRMesh/MRObjectDistanceMap.cpp
@@ -148,7 +148,7 @@ void ObjectDistanceMap::deserializeFields_( const Json::Value& root )
     construct_( dmap_, dmap2local_ );
 }
 
-VoidOrErrStr ObjectDistanceMap::deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb )
+Expected<void> ObjectDistanceMap::deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb )
 {
     auto modelPath = pathFromUtf8( utf8string( path ) + saveDistanceMapFormat_ );
     std::error_code ec;
@@ -167,7 +167,7 @@ VoidOrErrStr ObjectDistanceMap::deserializeModel_( const std::filesystem::path& 
     return {};
 }
 
-Expected<std::future<VoidOrErrStr>> ObjectDistanceMap::serializeModel_( const std::filesystem::path& path ) const
+Expected<std::future<Expected<void>>> ObjectDistanceMap::serializeModel_( const std::filesystem::path& path ) const
 {
     if ( !dmap_ )
         return {};

--- a/source/MRMesh/MRObjectDistanceMap.h
+++ b/source/MRMesh/MRObjectDistanceMap.h
@@ -66,9 +66,9 @@ protected:
 
     MRMESH_API void deserializeFields_( const Json::Value& root ) override;
 
-    MRMESH_API VoidOrErrStr deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb = {} ) override;
+    MRMESH_API Expected<void> deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb = {} ) override;
 
-    MRMESH_API virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& path ) const override;
+    MRMESH_API virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& path ) const override;
 
 private:
     std::shared_ptr<DistanceMap> dmap_;

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -49,7 +49,7 @@ void ObjectMeshHolder::setSelectedEdgesColor( const Color& color, ViewportId id 
     needRedraw_ = true;
 }
 
-Expected<std::future<VoidOrErrStr>> ObjectMeshHolder::serializeModel_( const std::filesystem::path& path ) const
+Expected<std::future<Expected<void>>> ObjectMeshHolder::serializeModel_( const std::filesystem::path& path ) const
 {
     if ( ancillary_ || !mesh_ )
         return {};
@@ -242,7 +242,7 @@ void ObjectMeshHolder::deserializeFields_( const Json::Value& root )
         setDefaultSceneProperties_();
 }
 
-VoidOrErrStr ObjectMeshHolder::deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb )
+Expected<void> ObjectMeshHolder::deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb )
 {
     vertsColorMap_.clear();
     auto modelPath = pathFromUtf8( utf8string( path ) + ".ctm" ); //quick path for most used format

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -257,13 +257,13 @@ protected:
     /// pls call Parent::swapSignals_ first when overriding this function
     MRMESH_API virtual void swapSignals_( Object& other ) override;
 
-    MRMESH_API virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& path ) const override;
+    MRMESH_API virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& path ) const override;
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 
     MRMESH_API void deserializeFields_( const Json::Value& root ) override;
 
-    MRMESH_API VoidOrErrStr deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb = {} ) override;
+    MRMESH_API Expected<void> deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb = {} ) override;
 
     /// set all visualize properties masks
     MRMESH_API void setAllVisualizeProperties_( const AllVisualizeProperties& properties, std::size_t& pos ) override;

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -248,13 +248,13 @@ Box3f ObjectPointsHolder::computeBoundingBox_() const
     return bb;
 }
 
-Expected<std::future<VoidOrErrStr>> ObjectPointsHolder::serializeModel_( const std::filesystem::path& path ) const
+Expected<std::future<Expected<void>>> ObjectPointsHolder::serializeModel_( const std::filesystem::path& path ) const
 {
     if ( ancillary_ || !points_ )
         return {};
 
     if ( points_->points.empty() ) // some formats (e.g. .ctm) require at least one point in the vector
-        return std::async( getAsyncLaunchType(), []{ return VoidOrErrStr{}; } );
+        return std::async( getAsyncLaunchType(), []{ return Expected<void>{}; } );
 
     SaveSettings saveSettings;
     saveSettings.saveValidOnly = false;
@@ -279,7 +279,7 @@ Expected<std::future<VoidOrErrStr>> ObjectPointsHolder::serializeModel_( const s
     return std::async( getAsyncLaunchType(), save );
 }
 
-VoidOrErrStr ObjectPointsHolder::deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb )
+Expected<void> ObjectPointsHolder::deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb )
 {
     auto modelPath = pathFromUtf8( utf8string( path ) + ".ctm" ); //quick path for most used format
     std::error_code ec;

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -144,9 +144,9 @@ protected:
 
     MRMESH_API virtual Box3f computeBoundingBox_() const override;
 
-    MRMESH_API virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& path ) const override;
+    MRMESH_API virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& path ) const override;
 
-    MRMESH_API virtual VoidOrErrStr deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb = {} ) override;
+    MRMESH_API virtual Expected<void> deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb = {} ) override;
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 

--- a/source/MRMesh/MRObjectSave.cpp
+++ b/source/MRMesh/MRObjectSave.cpp
@@ -187,7 +187,7 @@ Expected<void> toAnySupportedFormat( const Object& object, const std::filesystem
 
 } // namespace ObjectSave
 
-VoidOrErrStr serializeObjectTree( const Object& object, const std::filesystem::path& path,
+Expected<void> serializeObjectTree( const Object& object, const std::filesystem::path& path,
                                   ProgressCallback progressCb, FolderCallback preCompress )
 {
     MR_TIMER;
@@ -250,7 +250,7 @@ VoidOrErrStr serializeObjectTree( const Object& object, const std::filesystem::p
     return compressZip( path, scenePath, {}, nullptr, subprogress( progressCb, 0.9f, 1.0f ) );
 }
 
-VoidOrErrStr serializeObjectTree( const Object& object, const std::filesystem::path& path, ProgressCallback progress )
+Expected<void> serializeObjectTree( const Object& object, const std::filesystem::path& path, ProgressCallback progress )
 {
     return serializeObjectTree( object, path, std::move( progress ), {} );
 }

--- a/source/MRMesh/MRObjectSave.h
+++ b/source/MRMesh/MRObjectSave.h
@@ -35,9 +35,9 @@ MRMESH_API Expected<void> toAnySupportedFormat( const Object& object, const std:
  * if preCompress is set, it is called before compression
  * saving is controlled with Object::serializeModel_ and Object::serializeFields_
  */
-MRMESH_API VoidOrErrStr serializeObjectTree( const Object& object, const std::filesystem::path& path,
+MRMESH_API Expected<void> serializeObjectTree( const Object& object, const std::filesystem::path& path,
                                              ProgressCallback progress, FolderCallback preCompress );
-MRMESH_API VoidOrErrStr serializeObjectTree( const Object& object, const std::filesystem::path& path,
+MRMESH_API Expected<void> serializeObjectTree( const Object& object, const std::filesystem::path& path,
                                              ProgressCallback progress = {} );
 
 } // namespace MR

--- a/source/MRMesh/MRPlaneObject.h
+++ b/source/MRMesh/MRPlaneObject.h
@@ -76,12 +76,12 @@ protected:
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 
-    virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& ) const override
+    virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& ) const override
     {
         return {};
     }
 
-    virtual VoidOrErrStr deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
+    virtual Expected<void> deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
     {
         return {};
     }

--- a/source/MRMesh/MRPointObject.h
+++ b/source/MRMesh/MRPointObject.h
@@ -49,10 +49,10 @@ protected:
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 
-    virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& ) const override
+    virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& ) const override
         { return {}; }
 
-    virtual VoidOrErrStr deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
+    virtual Expected<void> deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
         { return {}; }
 
     MRMESH_API void setupRenderObject_() const override;

--- a/source/MRMesh/MRPointsSave.cpp
+++ b/source/MRMesh/MRPointsSave.cpp
@@ -39,7 +39,7 @@ private:
 
 } //anonymous namespace
 
-VoidOrErrStr toXyz( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
+Expected<void> toXyz( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -48,7 +48,7 @@ VoidOrErrStr toXyz( const PointCloud& points, const std::filesystem::path& file,
     return toXyz( points, out, settings );
 }
 
-VoidOrErrStr toXyz( const PointCloud& cloud, std::ostream& out, const SaveSettings& settings )
+Expected<void> toXyz( const PointCloud& cloud, std::ostream& out, const SaveSettings& settings )
 {
     MR_TIMER
     const size_t totalPoints = settings.saveValidOnly ? cloud.validPoints.count() : cloud.points.size();
@@ -79,7 +79,7 @@ VoidOrErrStr toXyz( const PointCloud& cloud, std::ostream& out, const SaveSettin
     return {};
 }
 
-VoidOrErrStr toXyzn( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
+Expected<void> toXyzn( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -88,7 +88,7 @@ VoidOrErrStr toXyzn( const PointCloud& points, const std::filesystem::path& file
     return toXyzn( points, out, settings );
 }
 
-VoidOrErrStr toXyzn( const PointCloud& cloud, std::ostream& out, const SaveSettings& settings )
+Expected<void> toXyzn( const PointCloud& cloud, std::ostream& out, const SaveSettings& settings )
 {
     MR_TIMER
     if ( !cloud.hasNormals() )
@@ -121,7 +121,7 @@ VoidOrErrStr toXyzn( const PointCloud& cloud, std::ostream& out, const SaveSetti
     return {};
 }
 
-VoidOrErrStr toAsc( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
+Expected<void> toAsc( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -130,7 +130,7 @@ VoidOrErrStr toAsc( const PointCloud& points, const std::filesystem::path& file,
     return toAsc( points, out, settings );
 }
 
-VoidOrErrStr toAsc( const PointCloud& cloud, std::ostream& out, const SaveSettings& settings )
+Expected<void> toAsc( const PointCloud& cloud, std::ostream& out, const SaveSettings& settings )
 {
     if ( cloud.hasNormals() )
         return toXyzn( cloud, out, settings );
@@ -138,7 +138,7 @@ VoidOrErrStr toAsc( const PointCloud& cloud, std::ostream& out, const SaveSettin
         return toXyz( cloud, out, settings );
 }
 
-VoidOrErrStr toPly( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
+Expected<void> toPly( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -147,7 +147,7 @@ VoidOrErrStr toPly( const PointCloud& points, const std::filesystem::path& file,
     return toPly( points, out, settings );
 }
 
-VoidOrErrStr toPly( const PointCloud& cloud, std::ostream& out, const SaveSettings& settings )
+Expected<void> toPly( const PointCloud& cloud, std::ostream& out, const SaveSettings& settings )
 {
     MR_TIMER
     const size_t totalPoints = settings.saveValidOnly ? cloud.validPoints.count() : cloud.points.size();
@@ -203,7 +203,7 @@ VoidOrErrStr toPly( const PointCloud& cloud, std::ostream& out, const SaveSettin
     return {};
 }
 
-VoidOrErrStr toAnySupportedFormat( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
+Expected<void> toAnySupportedFormat( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
 {
     auto ext = utf8string( file.extension() );
     for ( auto& c : ext )
@@ -216,7 +216,7 @@ VoidOrErrStr toAnySupportedFormat( const PointCloud& points, const std::filesyst
 
     return saver.fileSave( points, file, settings );
 }
-VoidOrErrStr toAnySupportedFormat( const PointCloud& points, const std::string& extension, std::ostream& out, const SaveSettings& settings )
+Expected<void> toAnySupportedFormat( const PointCloud& points, const std::string& extension, std::ostream& out, const SaveSettings& settings )
 {
     auto ext = extension;
     for ( auto& c : ext )

--- a/source/MRMesh/MRPointsSave.h
+++ b/source/MRMesh/MRPointsSave.h
@@ -20,26 +20,26 @@ namespace PointsSave
 
 /// save points without normals in textual .xyz file;
 /// each output line contains [x, y, z], where x, y, z are point coordinates
-MRMESH_API VoidOrErrStr toXyz( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
-MRMESH_API VoidOrErrStr toXyz( const PointCloud& points, std::ostream& out, const SaveSettings& settings = {} );
+MRMESH_API Expected<void> toXyz( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
+MRMESH_API Expected<void> toXyz( const PointCloud& points, std::ostream& out, const SaveSettings& settings = {} );
 
 /// save points with normals in textual .xyzn file;
 /// each output line contains [x, y, z, nx, ny, nz], where x, y, z are point coordinates and nx, ny, nz are the components of point normal
-MRMESH_API VoidOrErrStr toXyzn( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
-MRMESH_API VoidOrErrStr toXyzn( const PointCloud& points, std::ostream& out, const SaveSettings& settings = {} );
+MRMESH_API Expected<void> toXyzn( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
+MRMESH_API Expected<void> toXyzn( const PointCloud& points, std::ostream& out, const SaveSettings& settings = {} );
 
 /// save points with normals in .xyzn format, and save points without normals in .xyz format
-MRMESH_API VoidOrErrStr toAsc( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
-MRMESH_API VoidOrErrStr toAsc( const PointCloud& points, std::ostream& out, const SaveSettings& settings = {} );
+MRMESH_API Expected<void> toAsc( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
+MRMESH_API Expected<void> toAsc( const PointCloud& points, std::ostream& out, const SaveSettings& settings = {} );
 
 /// saves in .ply file
-MRMESH_API VoidOrErrStr toPly( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
-MRMESH_API VoidOrErrStr toPly( const PointCloud& points, std::ostream& out, const SaveSettings& settings = {} );
+MRMESH_API Expected<void> toPly( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
+MRMESH_API Expected<void> toPly( const PointCloud& points, std::ostream& out, const SaveSettings& settings = {} );
 
 /// detects the format from file extension and save points to it
-MRMESH_API VoidOrErrStr toAnySupportedFormat( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
+MRMESH_API Expected<void> toAnySupportedFormat( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings = {} );
 /// extension in `*.ext` format
-MRMESH_API VoidOrErrStr toAnySupportedFormat( const PointCloud& points, const std::string& extension, std::ostream& out, const SaveSettings& settings = {} );
+MRMESH_API Expected<void> toAnySupportedFormat( const PointCloud& points, const std::string& extension, std::ostream& out, const SaveSettings& settings = {} );
 
 /// \}
 

--- a/source/MRMesh/MRRegularMapMesher.cpp
+++ b/source/MRMesh/MRRegularMapMesher.cpp
@@ -14,7 +14,7 @@ void RegularMapMesher::setDirectionsPC( const std::shared_ptr<PointCloud>& direc
     directionsPC_ = directionsPC;
 }
 
-VoidOrErrStr RegularMapMesher::loadDistances( int width, int height, const std::filesystem::path& path )
+Expected<void> RegularMapMesher::loadDistances( int width, int height, const std::filesystem::path& path )
 {
     width_ = width;
     height_ = height;

--- a/source/MRMesh/MRRegularMapMesher.h
+++ b/source/MRMesh/MRRegularMapMesher.h
@@ -24,7 +24,7 @@ public:
     /// Sets directions Point Cloud
     MRMESH_API void setDirectionsPC( const std::shared_ptr<PointCloud>& directionsPC );
     /// Loads distances form distances file (1/distance)
-    MRMESH_API VoidOrErrStr loadDistances( int width, int height, const std::filesystem::path& path );
+    MRMESH_API Expected<void> loadDistances( int width, int height, const std::filesystem::path& path );
     /// Sets distances
     MRMESH_API void setDistances( int width, int height, const std::vector<float>& distances );
 

--- a/source/MRMesh/MRSphereObject.h
+++ b/source/MRMesh/MRSphereObject.h
@@ -54,10 +54,10 @@ protected:
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 
-    virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& ) const override
+    virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& ) const override
         { return {}; }
 
-    virtual VoidOrErrStr deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
+    virtual Expected<void> deserializeModel_( const std::filesystem::path&, ProgressCallback ) override
         { return {}; }
 
     MRMESH_API void setupRenderObject_() const override;

--- a/source/MRMesh/MRTiffIO.cpp
+++ b/source/MRMesh/MRTiffIO.cpp
@@ -129,7 +129,7 @@ void readRawTiff( TIFF* tiff, uint8_t* bytes, size_t size, const TiffParameters&
     }
 }
 
-VoidOrErrStr writeRawTiff( const uint8_t* bytes, const std::filesystem::path& path, const BaseTiffParameters& params )
+Expected<void> writeRawTiff( const uint8_t* bytes, const std::filesystem::path& path, const BaseTiffParameters& params )
 {
     TIFF* tif = TIFFOpen( MR::utf8string( path ).c_str(), "w" );
     if ( !tif )
@@ -279,7 +279,7 @@ Expected<TiffParameters> readTiffParameters( const std::filesystem::path& path )
     return addFileNameInError( readTifParameters( tif ), path );
 }
 
-VoidOrErrStr readRawTiff( const std::filesystem::path& path, RawTiffOutput& output )
+Expected<void> readRawTiff( const std::filesystem::path& path, RawTiffOutput& output )
 {
     assert( output.size != 0 );
     if ( output.size == 0 )

--- a/source/MRMesh/MRTiffIO.h
+++ b/source/MRMesh/MRTiffIO.h
@@ -72,10 +72,10 @@ struct RawTiffOutput
 };
 
 // load values from tiff to ouput.data
-MRMESH_API VoidOrErrStr readRawTiff( const std::filesystem::path& path, RawTiffOutput& output );
+MRMESH_API Expected<void> readRawTiff( const std::filesystem::path& path, RawTiffOutput& output );
 
 // writes bytes to tiff file
-MRMESH_API VoidOrErrStr writeRawTiff( const uint8_t* bytes, const std::filesystem::path& path,
+MRMESH_API Expected<void> writeRawTiff( const uint8_t* bytes, const std::filesystem::path& path,
     const BaseTiffParameters& params );
 
 }

--- a/source/MRMesh/MRTunnelDetector.cpp
+++ b/source/MRMesh/MRTunnelDetector.cpp
@@ -27,7 +27,7 @@ class BasisTunnelsDetector
 {
 public:
     BasisTunnelsDetector( const MeshPart & mp, EdgeMetric metric );
-    VoidOrErrStr prepare( ProgressCallback cb );
+    Expected<void> prepare( ProgressCallback cb );
     // after prepare(...) region can only shrink, not become larger
     Expected<std::vector<EdgeLoop>> detect( ProgressCallback cb );
 
@@ -48,7 +48,7 @@ BasisTunnelsDetector::BasisTunnelsDetector( const MeshPart & mp, EdgeMetric metr
     assert( metric_ );
 }
 
-VoidOrErrStr BasisTunnelsDetector::prepare( ProgressCallback cb )
+Expected<void> BasisTunnelsDetector::prepare( ProgressCallback cb )
 {
     MR_TIMER
 

--- a/source/MRMesh/MRZip.cpp
+++ b/source/MRMesh/MRZip.cpp
@@ -162,7 +162,7 @@ zip_int64_t istreamZipSourceCallback( void *istream, void *data, zip_uint64_t le
     return -1;
 }
 
-VoidOrErrStr decompressZip_( zip_t * zip, const std::filesystem::path& targetFolder, const char * password )
+Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetFolder, const char * password )
 {
     assert( zip );
 
@@ -224,7 +224,7 @@ VoidOrErrStr decompressZip_( zip_t * zip, const std::filesystem::path& targetFol
 
 } // anonymous namespace
 
-VoidOrErrStr compressZip( const std::filesystem::path& zipFile, const std::filesystem::path& sourceFolder,
+Expected<void> compressZip( const std::filesystem::path& zipFile, const std::filesystem::path& sourceFolder,
     const std::vector<std::filesystem::path>& excludeFiles, const char * password, ProgressCallback cb )
 {
     MR_TIMER
@@ -316,7 +316,7 @@ VoidOrErrStr compressZip( const std::filesystem::path& zipFile, const std::files
     return {};
 }
 
-VoidOrErrStr decompressZip( const std::filesystem::path& zipFile, const std::filesystem::path& targetFolder, const char * password )
+Expected<void> decompressZip( const std::filesystem::path& zipFile, const std::filesystem::path& targetFolder, const char * password )
 {
     MR_TIMER
     int err;
@@ -327,7 +327,7 @@ VoidOrErrStr decompressZip( const std::filesystem::path& zipFile, const std::fil
     return decompressZip_( zip, targetFolder, password );
 }
 
-VoidOrErrStr decompressZip( std::istream& zipStream, const std::filesystem::path& targetFolder, const char * password )
+Expected<void> decompressZip( std::istream& zipStream, const std::filesystem::path& targetFolder, const char * password )
 {
     MR_TIMER
 

--- a/source/MRMesh/MRZip.h
+++ b/source/MRMesh/MRZip.h
@@ -17,14 +17,14 @@ namespace MR
  * \brief decompresses given zip-file into given folder
  * \param password if password is given then it will be used to decipher encrypted archive
  */
-MRMESH_API VoidOrErrStr decompressZip( const std::filesystem::path& zipFile, const std::filesystem::path& targetFolder,
+MRMESH_API Expected<void> decompressZip( const std::filesystem::path& zipFile, const std::filesystem::path& targetFolder,
     const char * password = nullptr );
 
 /**
  * \brief decompresses given binary stream (containing the data of a zip file only) into given folder
  * \param password if password is given then it will be used to decipher encrypted archive
  */
-MRMESH_API VoidOrErrStr decompressZip( std::istream& zipStream, const std::filesystem::path& targetFolder, const char * password = nullptr );
+MRMESH_API Expected<void> decompressZip( std::istream& zipStream, const std::filesystem::path& targetFolder, const char * password = nullptr );
 
 /**
  * \brief compresses given folder in given zip-file
@@ -32,7 +32,7 @@ MRMESH_API VoidOrErrStr decompressZip( std::istream& zipStream, const std::files
  * \param password if password is given then the archive will be encrypted
  * \param cb an option to get progress notifications and cancel the operation
  */
-MRMESH_API VoidOrErrStr compressZip( const std::filesystem::path& zipFile, const std::filesystem::path& sourceFolder, 
+MRMESH_API Expected<void> compressZip( const std::filesystem::path& zipFile, const std::filesystem::path& sourceFolder, 
     const std::vector<std::filesystem::path>& excludeFiles = {}, const char * password = nullptr, ProgressCallback cb = {} );
 
 /// \}

--- a/source/MRViewer/MRPalette.cpp
+++ b/source/MRViewer/MRPalette.cpp
@@ -691,7 +691,7 @@ bool PalettePresets::loadPreset( const std::string& name, Palette& palette )
     return palette.loadFromJson( res.value() );
 }
 
-VoidOrErrStr PalettePresets::savePreset( const std::string& name, const Palette& palette )
+Expected<void> PalettePresets::savePreset( const std::string& name, const Palette& palette )
 {
     Json::Value root;
     palette.saveCurrentToJson( root );

--- a/source/MRViewer/MRPalette.h
+++ b/source/MRViewer/MRPalette.h
@@ -191,7 +191,7 @@ public:
     /// returns true if load was succeed
     MRVIEWER_API static bool loadPreset( const std::string& name, Palette& palette );
     /// saves given palette to preset with given name
-    MRVIEWER_API static VoidOrErrStr savePreset( const std::string& name, const Palette& palette );
+    MRVIEWER_API static Expected<void> savePreset( const std::string& name, const Palette& palette );
     /// returns path to presets folder
     MRVIEWER_API static std::filesystem::path getPalettePresetsFolder();
 private:

--- a/source/MRViewer/MRViewerIO.cpp
+++ b/source/MRViewer/MRViewerIO.cpp
@@ -30,7 +30,7 @@
 namespace MR
 {
 
-VoidOrErrStr saveObjectToFile( const Object& obj, const std::filesystem::path& filename, const SaveObjectSettings & settings )
+Expected<void> saveObjectToFile( const Object& obj, const std::filesystem::path& filename, const SaveObjectSettings & settings )
 {
     MR_TIMER
     if ( !reportProgress( settings.callback, 0.f ) )
@@ -55,7 +55,7 @@ VoidOrErrStr saveObjectToFile( const Object& obj, const std::filesystem::path& f
         .xf = ( xf == AffineXf3d() ) ? nullptr : &xf,
         .progress = settings.callback
     };
-    VoidOrErrStr result;
+    Expected<void> result;
 
     if ( auto objPoints = obj.asType<ObjectPoints>() )
     {

--- a/source/MRViewer/MRViewerIO.h
+++ b/source/MRViewer/MRViewerIO.h
@@ -23,7 +23,7 @@ struct SaveObjectSettings
  * \brief save visual object (mesh, lines, points or voxels) to file
  * \return empty string if no error or error text
  */
-MRVIEWER_API VoidOrErrStr saveObjectToFile( const Object& obj, const std::filesystem::path& filename,
+MRVIEWER_API Expected<void> saveObjectToFile( const Object& obj, const std::filesystem::path& filename,
     const SaveObjectSettings & settings = {} );
 
 } //namespace MR

--- a/source/MRVoxels/MRDicom.cpp
+++ b/source/MRVoxels/MRDicom.cpp
@@ -725,7 +725,7 @@ Expected<DicomVolume> loadDicomFile( const std::filesystem::path& path, const Pr
 namespace VoxelsSave
 {
 
-VoidOrErrStr toDCM( const VdbVolume& vdbVolume, const std::filesystem::path& path, ProgressCallback cb )
+Expected<void> toDCM( const VdbVolume& vdbVolume, const std::filesystem::path& path, ProgressCallback cb )
 {
     auto simpleVolume = vdbVolumeToSimpleVolumeU16( vdbVolume, {}, subprogress( cb, 0.f, 0.5f ) );
     if ( simpleVolume )
@@ -735,7 +735,7 @@ VoidOrErrStr toDCM( const VdbVolume& vdbVolume, const std::filesystem::path& pat
 }
 
 template <typename T>
-VoidOrErrStr toDCM( const VoxelsVolume<std::vector<T>>& volume, const std::filesystem::path& path, ProgressCallback cb )
+Expected<void> toDCM( const VoxelsVolume<std::vector<T>>& volume, const std::filesystem::path& path, ProgressCallback cb )
 {
     if ( !reportProgress( cb, 0.0f ) )
         return unexpected( "Loading canceled" );
@@ -771,7 +771,7 @@ VoidOrErrStr toDCM( const VoxelsVolume<std::vector<T>>& volume, const std::files
     return {};
 }
 
-template VoidOrErrStr toDCM<uint16_t>( const SimpleVolumeU16& volume, const std::filesystem::path& path, ProgressCallback cb );
+template Expected<void> toDCM<uint16_t>( const SimpleVolumeU16& volume, const std::filesystem::path& path, ProgressCallback cb );
 
 MR_ON_INIT
 {

--- a/source/MRVoxels/MRDicom.h
+++ b/source/MRVoxels/MRDicom.h
@@ -63,9 +63,9 @@ namespace VoxelsSave
 {
 
 /// Save voxels objet to a single 3d DICOM file
-MRVOXELS_API VoidOrErrStr toDCM( const VdbVolume& vdbVolume, const std::filesystem::path& path, ProgressCallback cb = {} );
+MRVOXELS_API Expected<void> toDCM( const VdbVolume& vdbVolume, const std::filesystem::path& path, ProgressCallback cb = {} );
 template <typename T>
-MRVOXELS_API VoidOrErrStr toDCM( const VoxelsVolume<std::vector<T>>& volume, const std::filesystem::path& path, ProgressCallback cb = {} );
+MRVOXELS_API Expected<void> toDCM( const VoxelsVolume<std::vector<T>>& volume, const std::filesystem::path& path, ProgressCallback cb = {} );
 
 } // namespace VoxelsSave
 

--- a/source/MRVoxels/MRObjectVoxels.cpp
+++ b/source/MRVoxels/MRObjectVoxels.cpp
@@ -618,7 +618,7 @@ void ObjectVoxels::serializeFields_( Json::Value& root ) const
     root["Type"].append( ObjectVoxels::TypeName() );
 }
 
-Expected<std::future<VoidOrErrStr>> ObjectVoxels::serializeModel_( const std::filesystem::path& path ) const
+Expected<std::future<Expected<void>>> ObjectVoxels::serializeModel_( const std::filesystem::path& path ) const
 {
     if ( ancillary_ || !vdbVolume_.data )
         return {};
@@ -663,7 +663,7 @@ void ObjectVoxels::deserializeFields_( const Json::Value& root )
         setDefaultSceneProperties_();
 }
 
-VoidOrErrStr ObjectVoxels::deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb )
+Expected<void> ObjectVoxels::deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb )
 {
     // in case of raw file, we need to find its full name with suffix
     auto modelPath = pathFromUtf8( utf8string( path ) + ".raw" );

--- a/source/MRVoxels/MRObjectVoxels.h
+++ b/source/MRVoxels/MRObjectVoxels.h
@@ -257,9 +257,9 @@ protected:
 
     MRVOXELS_API void deserializeFields_( const Json::Value& root ) override;
 
-    MRVOXELS_API VoidOrErrStr deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb = {} ) override;
+    MRVOXELS_API Expected<void> deserializeModel_( const std::filesystem::path& path, ProgressCallback progressCb = {} ) override;
 
-    MRVOXELS_API virtual Expected<std::future<VoidOrErrStr>> serializeModel_( const std::filesystem::path& path ) const override;
+    MRVOXELS_API virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& path ) const override;
 };
 
 

--- a/source/MRVoxels/MRToolPath.cpp
+++ b/source/MRVoxels/MRToolPath.cpp
@@ -1341,7 +1341,7 @@ std::vector<GCommand> replaceLineSegmentsWithCircularArcs( const std::span<GComm
     return res;
 }
 
-VoidOrErrStr interpolateArcs( std::vector<GCommand>& commands, const ArcInterpolationParams& params, Axis axis )
+Expected<void> interpolateArcs( std::vector<GCommand>& commands, const ArcInterpolationParams& params, Axis axis )
 {
     const ArcPlane arcPlane = ( axis == Axis::X ) ? ArcPlane::YZ :
         ( axis == Axis::Y ) ? ArcPlane::XZ :
@@ -1500,7 +1500,7 @@ std::vector<GCommand> replaceStraightSegmentsWithOneLine( const std::span<GComma
     return res;
 }
 
-VoidOrErrStr interpolateLines( std::vector<GCommand>& commands, const LineInterpolationParams& params, Axis axis )
+Expected<void> interpolateLines( std::vector<GCommand>& commands, const LineInterpolationParams& params, Axis axis )
 {
     size_t startIndex = 0u;
 

--- a/source/MRVoxels/MRToolPath.h
+++ b/source/MRVoxels/MRToolPath.h
@@ -149,9 +149,9 @@ MRVOXELS_API Expected<ToolPathResult> constantCuspToolPath( const MeshPart& mp, 
 MRVOXELS_API std::shared_ptr<ObjectGcode> exportToolPathToGCode( const std::vector<GCommand>& commands );
 
 // interpolates several points lying on the same straight line with one move
-MRVOXELS_API VoidOrErrStr interpolateLines( std::vector<GCommand>& commands, const LineInterpolationParams& params, Axis axis );
+MRVOXELS_API Expected<void> interpolateLines( std::vector<GCommand>& commands, const LineInterpolationParams& params, Axis axis );
 // interpolates given path with arcs
-MRVOXELS_API VoidOrErrStr interpolateArcs( std::vector<GCommand>& commands, const ArcInterpolationParams& params, Axis axis );
+MRVOXELS_API Expected<void> interpolateArcs( std::vector<GCommand>& commands, const ArcInterpolationParams& params, Axis axis );
 
 // makes the given selection more smooth with shifthing a boundary of the selection outside and back. Input mesh is changed because we have to cut new edges along the new boundaries
 // \param expandOffset defines how much the boundary is expanded

--- a/source/MRVoxels/MRVDBConversions.cpp
+++ b/source/MRVoxels/MRVDBConversions.cpp
@@ -406,7 +406,7 @@ Expected<Mesh> gridToMesh( FloatGrid&& grid, const GridToMeshSettings & settings
     return res;
 }
 
-VoidOrErrStr makeSignedByWindingNumber( FloatGrid& grid, const Vector3f& voxelSize, const Mesh& refMesh, const MakeSignedByWindingNumberSettings & settings )
+Expected<void> makeSignedByWindingNumber( FloatGrid& grid, const Vector3f& voxelSize, const Mesh& refMesh, const MakeSignedByWindingNumberSettings & settings )
 {
     MR_TIMER
 

--- a/source/MRVoxels/MRVDBConversions.h
+++ b/source/MRVoxels/MRVDBConversions.h
@@ -116,7 +116,7 @@ struct MakeSignedByWindingNumberSettings
 };
 
 /// set signs for unsigned distance field grid using generalized winding number computed at voxel grid point from refMesh
-MRVOXELS_API VoidOrErrStr makeSignedByWindingNumber( FloatGrid& grid, const Vector3f& voxelSize, const Mesh& refMesh,
+MRVOXELS_API Expected<void> makeSignedByWindingNumber( FloatGrid& grid, const Vector3f& voxelSize, const Mesh& refMesh,
     const MakeSignedByWindingNumberSettings & settings );
 
 struct DoubleOffsetSettings

--- a/source/MRVoxels/MRVoxelGraphCut.cpp
+++ b/source/MRVoxels/MRVoxelGraphCut.cpp
@@ -120,7 +120,7 @@ public:
     /// constructs forest of paths reaching all voxels in the span
     void buildForest( Context & context, bool initial );
     /// performs min-cut segmentation in given span
-    VoidOrErrStr segment( Context & context );
+    Expected<void> segment( Context & context );
     /// obtain result of segmentation
     VoxelBitSet getResult( const VoxelBitSet & sourceSeeds ) const;
     /// visits all sources/sinks to find the amount of flow
@@ -616,7 +616,7 @@ void VoxelGraphCut::buildForest( Context & context, bool initial )
     //spdlog::info( "VoxelGraphCut: {} initial layers", layers );
 }
 
-VoidOrErrStr VoxelGraphCut::segment( Context & context )
+Expected<void> VoxelGraphCut::segment( Context & context )
 {
     MR_TIMER
     

--- a/source/MRVoxels/MRVoxelsConversionsByParts.cpp
+++ b/source/MRVoxels/MRVoxelsConversionsByParts.cpp
@@ -59,7 +59,7 @@ namespace MR
 {
 
 template <typename Volume>
-VoidOrErrStr
+Expected<void>
 mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume,
                float leftCutPosition, float rightCutPosition, const MergeVolumePartSettings &settings )
 {
@@ -383,9 +383,9 @@ TEST( MRMesh, volumeToMeshByParts )
     EXPECT_NEAR( expectedVolume, mesh.volume(), 0.001f );
 }
 
-template MRVOXELS_API VoidOrErrStr mergeVolumePart<SimpleVolumeMinMax>( Mesh&, std::vector<EdgePath>&, SimpleVolumeMinMax&&, float, float, const MergeVolumePartSettings& );
-template MRVOXELS_API VoidOrErrStr mergeVolumePart<VdbVolume>( Mesh&, std::vector<EdgePath>&, VdbVolume&&, float, float, const MergeVolumePartSettings& );
-template MRVOXELS_API VoidOrErrStr mergeVolumePart<FunctionVolume>( Mesh&, std::vector<EdgePath>&, FunctionVolume&&, float, float, const MergeVolumePartSettings& );
+template MRVOXELS_API Expected<void> mergeVolumePart<SimpleVolumeMinMax>( Mesh&, std::vector<EdgePath>&, SimpleVolumeMinMax&&, float, float, const MergeVolumePartSettings& );
+template MRVOXELS_API Expected<void> mergeVolumePart<VdbVolume>( Mesh&, std::vector<EdgePath>&, VdbVolume&&, float, float, const MergeVolumePartSettings& );
+template MRVOXELS_API Expected<void> mergeVolumePart<FunctionVolume>( Mesh&, std::vector<EdgePath>&, FunctionVolume&&, float, float, const MergeVolumePartSettings& );
 
 template MRVOXELS_API Expected<Mesh> volumeToMeshByParts<SimpleVolumeMinMax>( const VolumePartBuilder<SimpleVolumeMinMax>&, const Vector3i&, const Vector3f&, const VolumeToMeshByPartsSettings&, const MergeVolumePartSettings& );
 template MRVOXELS_API Expected<Mesh> volumeToMeshByParts<VdbVolume>( const VolumePartBuilder<VdbVolume>&, const Vector3i&, const Vector3f&, const VolumeToMeshByPartsSettings&, const MergeVolumePartSettings& );

--- a/source/MRVoxels/MRVoxelsConversionsByParts.h
+++ b/source/MRVoxels/MRVoxelsConversionsByParts.h
@@ -55,7 +55,7 @@ struct MergeVolumePartSettings
  * @return nothing if succeeds, an error string otherwise
  */
 template <typename Volume>
-VoidOrErrStr
+Expected<void>
 mergeVolumePart( Mesh& mesh, std::vector<EdgePath>& cutContours, Volume&& volume, float leftCutPosition, float rightCutPosition,
                  const MergeVolumePartSettings& settings = {} );
 

--- a/source/MRVoxels/MRVoxelsSave.cpp
+++ b/source/MRVoxels/MRVoxelsSave.cpp
@@ -26,7 +26,7 @@ namespace MR
 namespace VoxelsSave
 {
 
-VoidOrErrStr toRawFloat( const VdbVolume& vdbVolume, std::ostream & out, ProgressCallback callback )
+Expected<void> toRawFloat( const VdbVolume& vdbVolume, std::ostream & out, ProgressCallback callback )
 {
     MR_TIMER
     const auto& grid = vdbVolume.data;
@@ -56,7 +56,7 @@ VoidOrErrStr toRawFloat( const VdbVolume& vdbVolume, std::ostream & out, Progres
     return {};
 }
 
-VoidOrErrStr toRawAutoname( const VdbVolume& vdbVolume, const std::filesystem::path& file, ProgressCallback callback )
+Expected<void> toRawAutoname( const VdbVolume& vdbVolume, const std::filesystem::path& file, ProgressCallback callback )
 {
     MR_TIMER
     if ( file.empty() )
@@ -98,7 +98,7 @@ VoidOrErrStr toRawAutoname( const VdbVolume& vdbVolume, const std::filesystem::p
     return addFileNameInError( toRawFloat( vdbVolume, out, callback ), outPath );
 }
 
-VoidOrErrStr toGav( const VdbVolume& vdbVolume, const std::filesystem::path& file, ProgressCallback callback )
+Expected<void> toGav( const VdbVolume& vdbVolume, const std::filesystem::path& file, ProgressCallback callback )
 {
     MR_TIMER
     std::ofstream out( file, std::ofstream::binary );
@@ -108,7 +108,7 @@ VoidOrErrStr toGav( const VdbVolume& vdbVolume, const std::filesystem::path& fil
     return addFileNameInError( toGav( vdbVolume, out, callback ), file );
 }
 
-VoidOrErrStr toGav( const VdbVolume& vdbVolume, std::ostream & out, ProgressCallback callback )
+Expected<void> toGav( const VdbVolume& vdbVolume, std::ostream & out, ProgressCallback callback )
 {
     MR_TIMER
     Json::Value headerJson;
@@ -147,7 +147,7 @@ VoidOrErrStr toGav( const VdbVolume& vdbVolume, std::ostream & out, ProgressCall
     return toRawFloat( vdbVolume, out, callback );
 }
 
-VoidOrErrStr toVdb( const VdbVolume& vdbVolume, const std::filesystem::path& filename, ProgressCallback /*callback*/ )
+Expected<void> toVdb( const VdbVolume& vdbVolume, const std::filesystem::path& filename, ProgressCallback /*callback*/ )
 {
     MR_TIMER
     openvdb::FloatGrid::Ptr gridPtr = std::make_shared<openvdb::FloatGrid>();
@@ -173,7 +173,7 @@ VoidOrErrStr toVdb( const VdbVolume& vdbVolume, const std::filesystem::path& fil
 
 MR_FORMAT_REGISTRY_IMPL( VoxelsSaver )
 
-VoidOrErrStr toAnySupportedFormat( const VdbVolume& vdbVolume, const std::filesystem::path& file,
+Expected<void> toAnySupportedFormat( const VdbVolume& vdbVolume, const std::filesystem::path& file,
                                    ProgressCallback callback /*= {} */ )
 {
     auto ext = utf8string( file.extension() );
@@ -215,7 +215,7 @@ MR_ADD_VOXELS_SAVER( IOFilter( "Raw (.raw)", "*.raw" ), toRawAutoname )
 MR_ADD_VOXELS_SAVER( IOFilter( "Micro CT (.gav)", "*.gav" ), toGav )
 MR_ADD_VOXELS_SAVER( IOFilter( "OpenVDB (.vdb)", "*.vdb" ), toVdb )
 
-VoidOrErrStr saveSliceToImage( const std::filesystem::path& path, const VdbVolume& vdbVolume, const SlicePlane& slicePlain, int sliceNumber, ProgressCallback callback )
+Expected<void> saveSliceToImage( const std::filesystem::path& path, const VdbVolume& vdbVolume, const SlicePlane& slicePlain, int sliceNumber, ProgressCallback callback )
 {
     const auto& dims = vdbVolume.dims;
     const int textureWidth = dims[( slicePlain + 1 ) % 3];
@@ -276,7 +276,7 @@ VoidOrErrStr saveSliceToImage( const std::filesystem::path& path, const VdbVolum
     return {};
 }
 
-VoidOrErrStr saveAllSlicesToImage( const VdbVolume& vdbVolume, const SavingSettings& settings )
+Expected<void> saveAllSlicesToImage( const VdbVolume& vdbVolume, const SavingSettings& settings )
 {
     int numSlices{ 0 };
     switch ( settings.slicePlane )

--- a/source/MRVoxels/MRVoxelsSave.h
+++ b/source/MRVoxels/MRVoxelsSave.h
@@ -17,27 +17,27 @@ namespace VoxelsSave
 /// \{
 
 /// Save raw voxels file, writing parameters in file name
-MRVOXELS_API VoidOrErrStr toRawAutoname( const VdbVolume& vdbVolume, const std::filesystem::path& file,
+MRVOXELS_API Expected<void> toRawAutoname( const VdbVolume& vdbVolume, const std::filesystem::path& file,
                                        ProgressCallback callback = {} );
 
 /// Save voxels in raw format with each value as 32-bit float in given binary stream
-MRVOXELS_API VoidOrErrStr toRawFloat( const VdbVolume& vdbVolume, std::ostream & out, ProgressCallback callback = {} );
+MRVOXELS_API Expected<void> toRawFloat( const VdbVolume& vdbVolume, std::ostream & out, ProgressCallback callback = {} );
 
 /// Save voxels in Gav-format in given file
-MRVOXELS_API VoidOrErrStr toGav( const VdbVolume& vdbVolume, const std::filesystem::path& file, ProgressCallback callback = {} );
+MRVOXELS_API Expected<void> toGav( const VdbVolume& vdbVolume, const std::filesystem::path& file, ProgressCallback callback = {} );
 /// Save voxels in Gav-format in given binary stream
-MRVOXELS_API VoidOrErrStr toGav( const VdbVolume& vdbVolume, std::ostream & out, ProgressCallback callback = {} );
+MRVOXELS_API Expected<void> toGav( const VdbVolume& vdbVolume, std::ostream & out, ProgressCallback callback = {} );
 
 /// Save voxels file in OpenVDB format
-MRVOXELS_API VoidOrErrStr toVdb( const VdbVolume& vdbVolume, const std::filesystem::path& file,
+MRVOXELS_API Expected<void> toVdb( const VdbVolume& vdbVolume, const std::filesystem::path& file,
                                ProgressCallback callback = {} );
 
 /// Saves voxels in a file, detecting the format from file extension
-MRVOXELS_API VoidOrErrStr toAnySupportedFormat( const VdbVolume& vdbVolume, const std::filesystem::path& file,
+MRVOXELS_API Expected<void> toAnySupportedFormat( const VdbVolume& vdbVolume, const std::filesystem::path& file,
                                               ProgressCallback callback = {} );
 
 /// save the slice by the active plane through the sliceNumber to an image file
-MRVOXELS_API VoidOrErrStr saveSliceToImage( const std::filesystem::path& path, const VdbVolume& vdbVolume, const SlicePlane& slicePlain, int sliceNumber, ProgressCallback callback = {} );
+MRVOXELS_API Expected<void> saveSliceToImage( const std::filesystem::path& path, const VdbVolume& vdbVolume, const SlicePlane& slicePlain, int sliceNumber, ProgressCallback callback = {} );
 
 // stores together all data for save voxel object as a group of images
 struct SavingSettings
@@ -53,7 +53,7 @@ struct SavingSettings
 };
 
 /// save all slices by the active plane through all voxel planes along the active axis to an image file
-MRVOXELS_API VoidOrErrStr saveAllSlicesToImage( const VdbVolume& vdbVolume, const SavingSettings& settings );
+MRVOXELS_API Expected<void> saveAllSlicesToImage( const VdbVolume& vdbVolume, const SavingSettings& settings );
 
 /// \}
 

--- a/source/mrmeshpy/MRPythonBaseExposing.cpp
+++ b/source/mrmeshpy/MRPythonBaseExposing.cpp
@@ -35,10 +35,10 @@ MR_INIT_PYTHON_MODULE( mrmeshpy )
 
 MR_ADD_PYTHON_VEC( mrmeshpy, vectorFloat, float )
 
-MR_ADD_PYTHON_CUSTOM_CLASS( mrmeshpy, ExpectedVoid, MR::VoidOrErrStr )
+MR_ADD_PYTHON_CUSTOM_CLASS( mrmeshpy, ExpectedVoid, MR::Expected<void> )
 MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, ExpectedVoid, [] ( pybind11::module_& )
 {
-    using expectedType = MR::VoidOrErrStr;
+    using expectedType = MR::Expected<void>;
     MR_PYTHON_CUSTOM_CLASS( ExpectedVoid ).
         def( "has_value", &expectedType::has_value ).
         def( "error", ( const std::string& ( expectedType::* )( )const& )& expectedType::error );

--- a/source/mrmeshpy/MRPythonDistanceMap.cpp
+++ b/source/mrmeshpy/MRPythonDistanceMap.cpp
@@ -15,7 +15,7 @@ namespace
 
 using namespace MR;
 
-VoidOrErrStr saveDistanceMapToImage( const DistanceMap& dm, const std::filesystem::path& filename, float threshold /*= 1.f / 255*/ )
+Expected<void> saveDistanceMapToImage( const DistanceMap& dm, const std::filesystem::path& filename, float threshold /*= 1.f / 255*/ )
 {
     const auto image = convertDistanceMapToImage( dm, threshold );
     return ImageSave::toAnySupportedFormat( image, filename );

--- a/source/mrmeshpy/MRPythonVoxels.cpp
+++ b/source/mrmeshpy/MRPythonVoxels.cpp
@@ -169,7 +169,7 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Voxels, []( pybind11::module_& m )
         value( "None", MR::SlicePlane::None, "None" );
 
     m.def( "saveSliceToImage",
-        MR::decorateExpected( ( MR::VoidOrErrStr( * )( const std::filesystem::path&, const MR::VdbVolume&, const MR::SlicePlane&, int, MR::ProgressCallback ) )& MR::VoxelsSave::saveSliceToImage ),
+        MR::decorateExpected( ( MR::Expected<void>( * )( const std::filesystem::path&, const MR::VdbVolume&, const MR::SlicePlane&, int, MR::ProgressCallback ) )& MR::VoxelsSave::saveSliceToImage ),
         pybind11::arg( "path" ), pybind11::arg( "vdbVolume" ), pybind11::arg( "slicePlane" ), pybind11::arg( "sliceNumber" ), pybind11::arg( "cb" ) = MR::ProgressCallback{},
         "Save the slice by the active plane through the sliceNumber to an image file.\n" );
 


### PR DESCRIPTION
Use `Expected<void>` instead of `VoidOrErrStr`.