### PR TITLE
Fix CPR 1.11 compatibility

### DIFF
--- a/source/MRViewer/MRWebRequest.cpp
+++ b/source/MRViewer/MRWebRequest.cpp
@@ -118,7 +118,11 @@ EMSCRIPTEN_KEEPALIVE int emsCallDownloadCallback( double v, int ctxId )
 namespace
 {
 
+#if CPR_VERSION_MAJOR >= 2 || ( CPR_VERSION_MAJOR == 1 && CPR_VERSION_MINOR >= 11 )
+bool downloadFileCallback( const std::string_view& data, intptr_t userdata )
+#else
 bool downloadFileCallback( std::string data, intptr_t userdata )
+#endif
 {
     const auto ctxId = (int)userdata;
     auto& ctx = sRequestContextMap.at( ctxId );


### PR DESCRIPTION
CPR 1.11 has a backward-incompatible change of some callbacks' signature. This pull request adds support of both old and new callback API.