### PR TITLE
MRViewer: Add option to build without GTK

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -119,6 +119,7 @@ jobs:
           # FIXME: OpenGL libraries are included to wheel packages when the XDE module is used
           MR_CMAKE_OPTIONS: >
             -DMRIOEXTRAS_OPENCASCADE_USE_XDE=OFF
+            -DMRVIEWER_NO_GTK=ON
           # not realy needed
           CMAKE_C_COMPILER: /usr/bin/clang-11
 

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -407,6 +407,8 @@ jobs:
           MESHLIB_BUILD_RELEASE: "ON"
           MESHLIB_BUILD_DEBUG: "OFF"
           CMAKE_CXX_COMPILER: /usr/bin/clang++
+          MR_CMAKE_OPTIONS: >
+            -DMRVIEWER_NO_GTK=ON
           # not realy needed
           CMAKE_C_COMPILER: /usr/bin/clang
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,6 @@ ENDIF()
 IF(MESHLIB_BUILD_MRVIEWER)
   IF(NOT MR_EMSCRIPTEN)
     find_package(glfw3 CONFIG REQUIRED)
-    pkg_check_modules(GTKMM gtkmm-3.0)
   ENDIF()
 
   IF(MR_EMSCRIPTEN)

--- a/source/MRViewer/CMakeLists.txt
+++ b/source/MRViewer/CMakeLists.txt
@@ -4,10 +4,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(MRViewer CXX)
 
+option(MRVIEWER_NO_GTK "Disable GTK support (affects file dialog support on Linux and macOS)" OFF)
 option(MRVIEWER_NO_VOXELS "Disable voxels support" OFF)
 
 IF(NOT MESHLIB_BUILD_VOXELS)
   set(MRVIEWER_NO_VOXELS ON)
+ENDIF()
+
+IF(WIN32 OR MR_EMSCRIPTEN)
+  set(MRVIEWER_NO_GTK ON)
 ENDIF()
 
 file(GLOB HEADERS "*.h")
@@ -36,9 +41,10 @@ IF(NOT MRVIEWER_NO_VOXELS)
   ENDIF()
 ENDIF()
 
-IF(NOT MR_EMSCRIPTEN)
+IF(NOT MRVIEWER_NO_GTK)
   pkg_check_modules(gtkmm REQUIRED IMPORTED_TARGET gtkmm-3.0)
-ENDIF() # NOT MR_EMSCRIPTEN
+  list(APPEND MRVIEWER_OPTIONAL_DEPENDENCIES PkgConfig::gtkmm)
+ENDIF()
 
 file(GLOB JSONS "*.json")
 IF(MR_EMSCRIPTEN)
@@ -78,7 +84,6 @@ ELSE() # NOT MR_EMSCRIPTEN
       spdlog
       jsoncpp
       cpr
-      PkgConfig::gtkmm
       imgui
       glad
       glfw
@@ -100,7 +105,6 @@ ELSE() # NOT MR_EMSCRIPTEN
       imgui
       glad
       glfw
-      PkgConfig::gtkmm
       hidapi-hidraw
       jsoncpp
       spdlog

--- a/source/MRViewer/config_cmake.h.in
+++ b/source/MRViewer/config_cmake.h.in
@@ -1,3 +1,4 @@
 #pragma once
 
+#cmakedefine MRVIEWER_NO_GTK
 #cmakedefine MRVIEWER_NO_VOXELS


### PR DESCRIPTION
- Make GTK support optional
- Build Python modules without GTK support to minimize the packages' size