### PR TITLE
getProcessor: check full match of the extension

### DIFF
--- a/source/MRMesh/MRIOFormatsRegistry.h
+++ b/source/MRMesh/MRIOFormatsRegistry.h
@@ -75,9 +75,12 @@ public:
         {
             const auto& [filter, _] = item;
             auto pos = filter.extensions.find( extension );
+            if ( pos == std::string::npos )
+                return false;
+            // check full match of the extension
             auto epos = pos + extension.size();
-            return pos != std::string::npos && 
-                ( epos >= filter.extensions.size() || filter.extensions[epos] == ';' ); // check full match of the extension
+            assert( epos <= filter.extensions.size() );
+            return epos >= filter.extensions.size() || filter.extensions[epos] == ';';
         } );
         if ( it != processors.end() )
             return it->second;

--- a/source/MRMesh/MRIOFormatsRegistry.h
+++ b/source/MRMesh/MRIOFormatsRegistry.h
@@ -74,7 +74,10 @@ public:
         auto it = std::find_if( processors.begin(), processors.end(), [&extension] ( auto&& item )
         {
             const auto& [filter, _] = item;
-            return filter.extensions.find( extension ) != std::string::npos;
+            auto pos = filter.extensions.find( extension );
+            auto epos = pos + extension.size();
+            return pos != std::string::npos && 
+                ( epos >= filter.extensions.size() || filter.extensions[epos] == ';' ); // check full match of the extension
         } );
         if ( it != processors.end() )
             return it->second;


### PR DESCRIPTION
Without this fix, the query for "*" extension, returns just the first processor.