### PR TITLE
IOFilter.isSupportedExtension: check full match of the extension

### DIFF
--- a/source/MRMesh/MRIOFilters.cpp
+++ b/source/MRMesh/MRIOFilters.cpp
@@ -1,0 +1,45 @@
+#include "MRIOFilters.h"
+#include <algorithm>
+#include <cassert>
+
+namespace MR
+{
+
+bool IOFilter::isSupportedExtension( const std::string& ext ) const
+{
+    const auto pos = extensions.find( ext );
+    if ( pos == std::string::npos )
+        return false;
+    // check full match of the extension
+    const auto epos = pos + ext.size();
+    assert( epos <= extensions.size() );
+    return epos == extensions.size() || extensions[epos] == ';';
+}
+
+IOFilters operator | ( const IOFilters& a, const IOFilters& b )
+{
+    IOFilters copy = a;
+    for ( const auto& bElem : b )
+    {
+        if ( std::find_if( a.begin(), a.end(), [&] ( const IOFilter& aF )
+        {
+            return aF.extensions == bElem.extensions;
+        } ) == a.end() )
+            copy.push_back( bElem );
+    }
+    return copy;
+}
+
+std::optional<IOFilter> findFilter( const IOFilters& filters, const std::string& extension )
+{
+    const auto it = std::find_if( filters.begin(), filters.end(), [&extension] ( auto&& filter )
+    {
+        return filter.isSupportedExtension( extension );
+    } );
+    if ( it != filters.end() )
+        return *it;
+    else
+        return std::nullopt;
+}
+
+} //namespace MR

--- a/source/MRMesh/MRIOFilters.h
+++ b/source/MRMesh/MRIOFilters.h
@@ -28,7 +28,13 @@ struct IOFilter
 
     [[nodiscard]] inline bool isSupportedExtension( const std::string& ext ) const
     {
-        return extensions.find( ext ) != std::string::npos;
+        const auto pos = extensions.find( ext );
+        if ( pos == std::string::npos )
+            return false;
+        // check full match of the extension
+        const auto epos = pos + ext.size();
+        assert( epos <= extensions.size() );
+        return epos == extensions.size() || extensions[epos] == ';';
     }
 };
 

--- a/source/MRMesh/MRIOFilters.h
+++ b/source/MRMesh/MRIOFilters.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <algorithm>
+#include "MRMeshFwd.h"
 #include <compare>
 #include <optional>
 #include <string>
@@ -26,46 +26,16 @@ struct IOFilter
 
     std::partial_ordering operator <=>( const IOFilter& ) const = default;
 
-    [[nodiscard]] inline bool isSupportedExtension( const std::string& ext ) const
-    {
-        const auto pos = extensions.find( ext );
-        if ( pos == std::string::npos )
-            return false;
-        // check full match of the extension
-        const auto epos = pos + ext.size();
-        assert( epos <= extensions.size() );
-        return epos == extensions.size() || extensions[epos] == ';';
-    }
+    [[nodiscard]] MRMESH_API bool isSupportedExtension( const std::string& ext ) const;
 };
 
 using IOFilters = std::vector<IOFilter>;
 
-inline IOFilters operator | ( const IOFilters& a, const IOFilters& b )
-{
-    IOFilters copy = a;
-    for ( const auto& bElem : b )
-    {
-        if ( std::find_if( a.begin(), a.end(), [&] ( const IOFilter& aF )
-        {
-            return aF.extensions == bElem.extensions;
-        } ) == a.end() )
-            copy.push_back( bElem );
-    }
-    return copy;
-}
+/// returns union of input filters
+[[nodiscard]] MRMESH_API IOFilters operator | ( const IOFilters& a, const IOFilters& b );
 
 /// find a corresponding filter for a given extension
-inline std::optional<IOFilter> findFilter( const IOFilters& filters, const std::string& extension )
-{
-    const auto it = std::find_if( filters.begin(), filters.end(), [&extension] ( auto&& filter )
-    {
-        return filter.isSupportedExtension( extension );
-    } );
-    if ( it != filters.end() )
-        return *it;
-    else
-        return std::nullopt;
-}
+[[nodiscard]] MRMESH_API std::optional<IOFilter> findFilter( const IOFilters& filters, const std::string& extension );
 
 /// \}
 

--- a/source/MRMesh/MRIOFormatsRegistry.h
+++ b/source/MRMesh/MRIOFormatsRegistry.h
@@ -74,13 +74,7 @@ public:
         auto it = std::find_if( processors.begin(), processors.end(), [&extension] ( auto&& item )
         {
             const auto& [filter, _] = item;
-            auto pos = filter.extensions.find( extension );
-            if ( pos == std::string::npos )
-                return false;
-            // check full match of the extension
-            auto epos = pos + extension.size();
-            assert( epos <= filter.extensions.size() );
-            return epos >= filter.extensions.size() || filter.extensions[epos] == ';';
+            return filter.isSupportedExtension( extension );
         } );
         if ( it != processors.end() )
             return it->second;

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -460,6 +460,7 @@
     <ClCompile Include="MRGcodeLoad.cpp" />
     <ClCompile Include="MRHistoryAction.cpp" />
     <ClCompile Include="MRImage.cpp" />
+    <ClCompile Include="MRIOFilters.cpp" />
     <ClCompile Include="MRIterativeSampling.cpp" />
     <ClCompile Include="MRLevelOfDetails.cpp" />
     <ClCompile Include="MRLocalTriangulations.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -2018,6 +2018,9 @@
     <ClCompile Include="MRSystemPath.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
+    <ClCompile Include="MRIOFilters.cpp">
+      <Filter>Source Files\IO</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />


### PR DESCRIPTION
and introduce `MRIOFilters.cpp` for not-trivial function implementations