### PR TITLE
Fix Open Files

### DIFF
--- a/source/MRViewer/MRHistoryStore.cpp
+++ b/source/MRViewer/MRHistoryStore.cpp
@@ -54,6 +54,7 @@ void HistoryStore::clear()
 {
     if ( stack_.empty() )
         return;
+    spdlog::info( "History store clear" );
     stack_.clear();
     firstRedoIndex_ = 0;
     changedSignal( *this, ChangeType::Clear );

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -1192,9 +1192,9 @@ bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList )
     {
         if ( result.scene )
         {
-            // whether both the scene and undo/redo were empty
-            const auto wasCompletelyEmpty = globalHistoryStore_ && !globalHistoryStore_->isSceneModified()
-                && SceneRoot::get().children().empty();
+            const auto wasCompletelyEmpty =
+                globalHistoryStore_ && globalHistoryStore_->getStackPointer() == 0 // there are no undo actions
+                && SceneRoot::get().children().empty(); // and the scene is empty
 
             if ( !result.isSceneConstructed )
             {


### PR DESCRIPTION
* Always create an undo record, and clear it at the end if the scene was completely empty and there were no undo actions.
* Fix not-empty scene renaming after additional file opening.