### PR TITLE
Optimize building of MRUIStyle.ipp

### DIFF
--- a/source/MRCommonPlugins/ViewerButtons/MRAddCustomTheme.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRAddCustomTheme.cpp
@@ -2,7 +2,7 @@
 #include "MRViewer/MRRibbonSchema.h"
 #include "MRViewer/ImGuiMenu.h"
 #include "MRViewer/MRRibbonFontManager.h"
-#include "MRViewer/MRViewer.h"
+#include "MRViewer/MRViewerInstance.h"
 #include "MRMesh/MRSceneColors.h"
 #include "MRViewer/ImGuiHelpers.h"
 #include "MRMesh/MRSerializer.h"
@@ -86,7 +86,7 @@ void AddCustomThemePlugin::drawDialog( float menuScaling, ImGuiContext* )
         if ( std::filesystem::is_regular_file( saveDir, ec ) )
         {
             ImGui::OpenPopup( "File already exists" );
-            getViewerInstance().incrementForceRedrawFrames();
+            incrementForceRedrawFrames();
         }
         else
         {

--- a/source/MRCommonPlugins/ViewerButtons/MRRotatorPlugin.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRRotatorPlugin.cpp
@@ -2,7 +2,7 @@
 #include "MRViewer/ImGuiHelpers.h"
 #include "MRViewer/MRRibbonMenu.h"
 #include "MRViewer/MRUIStyle.h"
-#include "MRViewer/MRViewer.h"
+#include "MRViewer/MRViewerInstance.h"
 #include "MRViewer/MRViewport.h"
 #include "MRMesh/MRLine3.h"
 #include <chrono>
@@ -63,7 +63,7 @@ void RotatorPlugin::preDraw_()
     if ( lastDrawTime_ )
     {
         auto timePassed = std::chrono::duration<float>( *lastDrawTime_ - now ).count();
-        auto & viewport = getViewerInstance().viewport();
+        auto & viewport = MR::viewport();
         Vector3f sceneCenter;
         if ( auto sceneBox = viewport.getSceneBox(); sceneBox.valid() )
             sceneCenter = sceneBox.center();
@@ -73,7 +73,7 @@ void RotatorPlugin::preDraw_()
             timePassed * rotationSpeed_ );
     }
     lastDrawTime_ = now;
-    getViewerInstance().incrementForceRedrawFrames();
+    incrementForceRedrawFrames();
 }
 
 MR_REGISTER_RIBBON_ITEM( RotatorPlugin )

--- a/source/MRViewer/MRUIStyle.ipp
+++ b/source/MRViewer/MRUIStyle.ipp
@@ -3,8 +3,8 @@
 // A template implementation file for `MRUIStyle.h`. Include that file.
 
 #include "MRUIStyle.h" // To help intellisense.
-#include "MRViewer/MRUITestEngine.h"
-#include "MRViewer.h"
+#include "MRUITestEngine.h"
+#include "MRViewerInstance.h"
 
 namespace MR::UI
 {
@@ -255,7 +255,7 @@ bool slider( const char* label, T& v, const U& vMin, const U& vMax, UnitToString
             );
 
             if ( ret ) // it is needed if we in drag mode to update frame with changed value after moving mouse
-                getViewerInstance().incrementForceRedrawFrames();
+                incrementForceRedrawFrames();
 
             // Test engine stuff:
             if ( auto opt = TestEngine::createValue( detail::Scalar<T> ? label : detail::getTestEngineLabelForVecElem( i ), elemVal, *elemMin, *elemMax ) )
@@ -364,7 +364,7 @@ bool drag( const char* label, T& v, SpeedType vSpeed, const U& vMin, const U& vM
                     elemVal = std::clamp( elemVal, *elemMin, *elemMax );
 
                 // it is needed if we in drag mode to update frame with changed value after moving mouse
-                getViewerInstance().incrementForceRedrawFrames();
+                incrementForceRedrawFrames();
             }
             auto dragId = ImGui::GetItemID();
 

--- a/source/MRViewer/MRViewerInstance.cpp
+++ b/source/MRViewer/MRViewerInstance.cpp
@@ -10,4 +10,14 @@ Viewer& getViewerInstance()
     return viewer;
 }
 
+void incrementForceRedrawFrames( int i, bool swapOnLastOnly )
+{
+    getViewerInstance().incrementForceRedrawFrames( i, swapOnLastOnly );
+}
+
+Viewport& viewport( ViewportId viewportId )
+{
+    return getViewerInstance().viewport( viewportId );
+}
+
 } //namespace MR

--- a/source/MRViewer/MRViewerInstance.h
+++ b/source/MRViewer/MRViewerInstance.h
@@ -1,11 +1,22 @@
 #pragma once
 
 #include "MRViewerFwd.h"
+#include <MRMesh/MRViewportId.h>
+
+// This is lightweight header, pleas include it instead of "MRViewer.h" whenever possible
 
 namespace MR
 {
 
-// returns global instance of Viewer class
-MRVIEWER_API Viewer& getViewerInstance();
+/// returns global instance of Viewer class
+[[nodiscard]] MRVIEWER_API Viewer& getViewerInstance();
+
+/// Increment number of forced frames to redraw in event loop
+/// if `swapOnLastOnly` only last forced frame will be present on screen and all previous will not
+MRVIEWER_API void incrementForceRedrawFrames( int i = 1, bool swapOnLastOnly = false );
+
+/// Return the current viewport, or the viewport corresponding to a given unique identifier
+/// \param viewportId unique identifier corresponding to the desired viewport (current viewport if 0)
+[[nodiscard]] MRVIEWER_API Viewport& viewport( ViewportId viewportId = {} );
 
 } //namespace MR


### PR DESCRIPTION
This decreases the number of `MRViewer.h` includes, and `Release` configuration on my machine takes 1 minute less to rebuild.