### PR TITLE
RibbonMenu::instance()

### DIFF
--- a/source/MRCommonPlugins/ViewerButtons/MRActiveListPlugin.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRActiveListPlugin.cpp
@@ -2,7 +2,6 @@
 #include "MRViewer/MRRibbonConstants.h"
 #include "MRViewer/ImGuiHelpers.h"
 #include "MRViewer/MRCommandLoop.h"
-#include "MRViewer/MRViewer.h"
 
 namespace MR
 {
@@ -16,7 +15,7 @@ public:
     }
     virtual std::string isAvailable( const std::vector<std::shared_ptr<const Object>>& ) const override
     {
-        auto menu = getViewerInstance().getMenuPluginAs<RibbonMenu>();
+        auto menu = RibbonMenu::instance();
         if ( !menu )
             return "No menu present";
         if ( !menu->hasAnyActiveItem() )
@@ -26,7 +25,7 @@ public:
 
     virtual bool action() override
     {
-        auto menu = getViewerInstance().getMenuPluginAs<RibbonMenu>();
+        auto menu = RibbonMenu::instance();
         if ( !menu )
             return false;
         menu->showActiveList();

--- a/source/MRCommonPlugins/ViewerButtons/MRRibbonSceneButtons.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRRibbonSceneButtons.cpp
@@ -58,7 +58,7 @@ std::string RibbonSceneSelectAll::isAvailable( const std::vector<std::shared_ptr
 
 bool RibbonSceneSelectAll::action()
 {
-    if ( auto menu = RibbonMenu::instance() )
+    if ( auto menu = ImGuiMenu::instance() )
     {
         if ( auto sceneList = menu->getSceneObjectsList() )
             sceneList->selectAllObjects();
@@ -92,7 +92,7 @@ std::string RibbonSceneShowAll::isAvailable( const std::vector<std::shared_ptr<c
 
 bool RibbonSceneShowAll::action()
 {
-    if ( auto menu = RibbonMenu::instance() )
+    if ( auto menu = ImGuiMenu::instance() )
     {
         if ( auto sceneList = menu->getSceneObjectsList() )
             sceneList->setLeavesVisibility( true );
@@ -113,7 +113,7 @@ std::string RibbonSceneHideAll::isAvailable( const std::vector<std::shared_ptr<c
 
 bool RibbonSceneHideAll::action()
 {
-    if ( auto menu = RibbonMenu::instance() )
+    if ( auto menu = ImGuiMenu::instance() )
     {
         if ( auto sceneList = menu->getSceneObjectsList() )
             sceneList->setLeavesVisibility( false );
@@ -135,7 +135,7 @@ std::string RibbonSceneShowOnlyPrev::isAvailable( const std::vector<std::shared_
 
 bool RibbonSceneShowOnlyPrev::action()
 {
-    auto menu = RibbonMenu::instance();
+    auto menu = ImGuiMenu::instance();
     if ( menu )
     {
         if ( auto sceneList = menu->getSceneObjectsList() )
@@ -158,7 +158,7 @@ std::string RibbonSceneShowOnlyNext::isAvailable( const std::vector<std::shared_
 
 bool RibbonSceneShowOnlyNext::action()
 {
-    auto menu = RibbonMenu::instance();
+    auto menu = ImGuiMenu::instance();
     if ( menu )
     {
         if ( auto sceneList = menu->getSceneObjectsList() )
@@ -174,7 +174,7 @@ RibbonSceneRename::RibbonSceneRename() :
 
 bool RibbonSceneRename::action()
 {
-    RibbonMenu::instance()->tryRenameSelectedObject();
+    ImGuiMenu::instance()->tryRenameSelectedObject();
     return false;
 }
 
@@ -186,7 +186,7 @@ RibbonSceneRemoveSelected::RibbonSceneRemoveSelected() :
 std::string RibbonSceneRemoveSelected::isAvailable( const std::vector<std::shared_ptr<const Object>>& objs ) const
 {
     auto res = SceneStateAtLeastCheck<1, Object, NoModelCheck>::isAvailable( objs );
-    auto allowRemoval = RibbonMenu::instance()->checkPossibilityObjectRemoval();
+    auto allowRemoval = ImGuiMenu::instance()->checkPossibilityObjectRemoval();
     if ( !allowRemoval )
     {
         if ( !res.empty() )
@@ -198,7 +198,7 @@ std::string RibbonSceneRemoveSelected::isAvailable( const std::vector<std::share
 
 bool RibbonSceneRemoveSelected::action()
 {
-    if ( auto menu = RibbonMenu::instance() )
+    if ( auto menu = ImGuiMenu::instance() )
         if ( !menu->checkPossibilityObjectRemoval() )
             return false;
 

--- a/source/MRCommonPlugins/ViewerButtons/MRRibbonSceneButtons.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRRibbonSceneButtons.cpp
@@ -7,7 +7,6 @@
 #include "MRViewer/ImGuiMenu.h"
 #include "MRViewer/MRSceneCache.h"
 #include "MRViewer/MRAppendHistory.h"
-#include "MRViewer/MRViewer.h"
 #include "MRMesh/MRChangeSceneObjectsOrder.h"
 #include "MRMesh/MRVisualObject.h"
 #include "MRMesh/MRChangeSceneAction.h"
@@ -59,7 +58,7 @@ std::string RibbonSceneSelectAll::isAvailable( const std::vector<std::shared_ptr
 
 bool RibbonSceneSelectAll::action()
 {
-    if ( auto menu = getViewerInstance().getMenuPlugin() )
+    if ( auto menu = RibbonMenu::instance() )
     {
         if ( auto sceneList = menu->getSceneObjectsList() )
             sceneList->selectAllObjects();
@@ -93,7 +92,7 @@ std::string RibbonSceneShowAll::isAvailable( const std::vector<std::shared_ptr<c
 
 bool RibbonSceneShowAll::action()
 {
-    if ( auto menu = getViewerInstance().getMenuPlugin() )
+    if ( auto menu = RibbonMenu::instance() )
     {
         if ( auto sceneList = menu->getSceneObjectsList() )
             sceneList->setLeavesVisibility( true );
@@ -114,7 +113,7 @@ std::string RibbonSceneHideAll::isAvailable( const std::vector<std::shared_ptr<c
 
 bool RibbonSceneHideAll::action()
 {
-    if ( auto menu = getViewerInstance().getMenuPlugin() )
+    if ( auto menu = RibbonMenu::instance() )
     {
         if ( auto sceneList = menu->getSceneObjectsList() )
             sceneList->setLeavesVisibility( false );
@@ -136,7 +135,7 @@ std::string RibbonSceneShowOnlyPrev::isAvailable( const std::vector<std::shared_
 
 bool RibbonSceneShowOnlyPrev::action()
 {
-    auto menu = getViewerInstance().getMenuPlugin();
+    auto menu = RibbonMenu::instance();
     if ( menu )
     {
         if ( auto sceneList = menu->getSceneObjectsList() )
@@ -159,7 +158,7 @@ std::string RibbonSceneShowOnlyNext::isAvailable( const std::vector<std::shared_
 
 bool RibbonSceneShowOnlyNext::action()
 {
-    auto menu = getViewerInstance().getMenuPlugin();
+    auto menu = RibbonMenu::instance();
     if ( menu )
     {
         if ( auto sceneList = menu->getSceneObjectsList() )
@@ -175,7 +174,7 @@ RibbonSceneRename::RibbonSceneRename() :
 
 bool RibbonSceneRename::action()
 {
-    getViewerInstance().getMenuPlugin()->tryRenameSelectedObject();
+    RibbonMenu::instance()->tryRenameSelectedObject();
     return false;
 }
 
@@ -187,7 +186,7 @@ RibbonSceneRemoveSelected::RibbonSceneRemoveSelected() :
 std::string RibbonSceneRemoveSelected::isAvailable( const std::vector<std::shared_ptr<const Object>>& objs ) const
 {
     auto res = SceneStateAtLeastCheck<1, Object, NoModelCheck>::isAvailable( objs );
-    auto allowRemoval = getViewerInstance().getMenuPlugin()->checkPossibilityObjectRemoval();
+    auto allowRemoval = RibbonMenu::instance()->checkPossibilityObjectRemoval();
     if ( !allowRemoval )
     {
         if ( !res.empty() )
@@ -199,7 +198,7 @@ std::string RibbonSceneRemoveSelected::isAvailable( const std::vector<std::share
 
 bool RibbonSceneRemoveSelected::action()
 {
-    if ( auto menu = getViewerInstance().getMenuPlugin() )
+    if ( auto menu = RibbonMenu::instance() )
         if ( !menu->checkPossibilityObjectRemoval() )
             return false;
 

--- a/source/MRViewer/ImGuiHelpers.cpp
+++ b/source/MRViewer/ImGuiHelpers.cpp
@@ -1,28 +1,26 @@
 #include "ImGuiHelpers.h"
-#include "MRViewer/MRUIRectAllocator.h"
-#include "MRViewer/MRUITestEngine.h"
-#include "MRViewer/MRImGuiVectorOperators.h"
+#include "MRUIRectAllocator.h"
+#include "MRUITestEngine.h"
+#include "MRImGuiVectorOperators.h"
 #include "imgui_internal.h"
 #include "MRMesh/MRBitSet.h"
-#include "MRPch/MRSpdlog.h"
 #include "MRRibbonButtonDrawer.h"
 #include "MRPalette.h"
 #include "MRViewerInstance.h"
-#include "MRViewer.h"
 #include "MRRibbonConstants.h"
 #include "MRRibbonMenu.h"
 #include "MRImGuiImage.h"
 #include "MRRenderLinesObject.h"
 #include "MRShowModal.h"
-#include "MRViewer/MRRibbonFontManager.h"
-#include "MRViewer/MRPlaneWidget.h"
-#include "MRViewer/MRViewer.h"
+#include "MRRibbonFontManager.h"
+#include "MRPlaneWidget.h"
 #include "MRColorTheme.h"
 #include "MRMesh/MRColor.h"
 #include "MRMesh/MRStringConvert.h"
 #include "MRMesh/MRConfig.h"
 #include "MRMesh/MRObjectMesh.h"
 #include "MRUIStyle.h"
+#include "MRPch/MRSpdlog.h"
 
 namespace ImGui
 {
@@ -37,7 +35,7 @@ void drawCursorArrow()
     auto mousePos = ImGui::GetMousePos();
     mousePos.x += 5.f;
 
-    const auto menuPlugin = MR::getViewerInstance().getMenuPlugin();
+    const auto menuPlugin = ImGuiMenu::instance();
     const float scale = menuPlugin ? menuPlugin->menu_scaling() : 1.f;
 
     const float spaceX = 10 * scale;
@@ -530,8 +528,7 @@ bool BeginStatePlugin( const char* label, bool* open, float width )
     if ( !window )
     {
         float yPos = 0.0f;
-        auto menu = MR::getViewerInstance().getMenuPluginAs<MR::RibbonMenu>();
-        if ( menu )
+        if ( auto menu = RibbonMenu::instance() )
             yPos = menu->getTopPanelOpenedHeight() * menu->menu_scaling();
         SetNextWindowPos( ImVec2( GetIO().DisplaySize.x - width, yPos ), ImGuiCond_FirstUseEver );
         SetNextWindowSize( ImVec2( width, 0 ), ImGuiCond_FirstUseEver );
@@ -565,7 +562,7 @@ bool BeginCustomStatePlugin( const char* label, bool* open, const CustomStatePlu
     ImGui::PushStyleVar( ImGuiStyleVar_ItemSpacing, ImVec2( 12 * params.menuScaling, 8 * params.menuScaling ) );
 
     ImGuiWindow* window = FindWindowByName( label );
-    auto menu = MR::getViewerInstance().getMenuPlugin();
+    auto menu = ImGuiMenu::instance();
     ImVec2 initialWindowPos;
     bool haveSavedWindowPos = false;
     bool windowIsInactive = window && !window->WasActive;
@@ -958,7 +955,7 @@ bool BeginModalNoAnimation( const char* label, bool* open /*= nullptr*/, ImGuiWi
     const auto backupPos = ImGui::GetCursorPos();
 
     float menuScaling = 1.0f;
-    if ( auto menu = MR::getViewerInstance().getMenuPlugin() )
+    if ( auto menu = ImGuiMenu::instance() )
         menuScaling = menu->menu_scaling();
 
     ImGui::PushClipRect( { window->Pos.x, window->Pos.y }, { window->Pos.x + window->Size.x, window->Pos.y + window->Size.y }, false );
@@ -1579,7 +1576,7 @@ void Spinner( float radius, float scaling )
 
     SetCursorPosY( GetCursorPosY() + radius );
     ImGui::Dummy( ImVec2( 0, 0 ) );
-    MR::getViewerInstance().incrementForceRedrawFrames();
+    incrementForceRedrawFrames();
 }
 
 bool ModalBigTitle( const char* title, float scaling )

--- a/source/MRViewer/MRImGuiMenuListeners.cpp
+++ b/source/MRViewer/MRImGuiMenuListeners.cpp
@@ -1,6 +1,5 @@
 #include "MRImGuiMenuListeners.h"
-
-#include "MRViewer/MRViewer.h"
+#include "MRMakeSlot.h"
 
 namespace MR
 {
@@ -9,7 +8,7 @@ void NameTagClickListener::connect( Viewer* viewer, int group, boost::signals2::
 {
     if ( !viewer )
         return;
-    auto menu = viewer->getMenuPlugin();
+    auto menu = ImGuiMenu::instance();
     assert( menu );
     if ( menu )
         connection_ = menu->nameTagClickSignal.connect( group, MAKE_SLOT( &NameTagClickListener::onNameTagClicked_ ), pos );
@@ -19,7 +18,7 @@ void DrawSceneUiListener::connect( Viewer* viewer, int group, boost::signals2::c
 {
     if ( !viewer )
         return;
-    auto menu = viewer->getMenuPlugin();
+    auto menu = ImGuiMenu::instance();
     assert( menu );
     if ( menu )
         connection_ = menu->drawSceneUiSignal.connect( group, MAKE_SLOT( &DrawSceneUiListener::onDrawSceneUi_ ), pos );

--- a/source/MRViewer/MRMakeSlot.h
+++ b/source/MRViewer/MRMakeSlot.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <type_traits>
+
+template<typename MemberFuncPtr, typename BaseClass>
+auto bindSlotCallback( BaseClass* base, MemberFuncPtr func )
+{
+    static_assert( !( std::is_move_assignable_v<BaseClass> || std::is_move_constructible_v<BaseClass> ),
+                   "MAKE_SLOT requires a non-movable type" );
+    return[base, func] ( auto&&... args )
+    {
+        return ( base->*func )( std::forward<decltype( args )>( args )... );
+    };
+}
+
+// you will not be able to move your struct after using this macro
+#define MAKE_SLOT(func) bindSlotCallback(this,func)

--- a/source/MRViewer/MRPalette.cpp
+++ b/source/MRViewer/MRPalette.cpp
@@ -1,5 +1,4 @@
 #include "MRPalette.h"
-#include "MRViewer.h"
 #include "ImGuiMenu.h"
 #include "imgui_internal.h"
 #include "MRViewport.h"
@@ -362,9 +361,8 @@ void Palette::draw( const std::string& windowName, const ImVec2& pose, const ImV
     }
 
     const auto& style = ImGui::GetStyle();
-    const auto& viewer = getViewerInstance();
-    const auto menu = viewer.getMenuPlugin();
-    const auto& windowSize = viewer.viewport().getViewportRect();
+    const auto menu = ImGuiMenu::instance();
+    const auto& windowSize = MR::viewport().getViewportRect();
 
     ImGui::SetNextWindowPos( pose, ImGuiCond_Appearing );
     ImGui::SetNextWindowSize( size, ImGuiCond_Appearing );

--- a/source/MRViewer/MRRenderNameObject.cpp
+++ b/source/MRViewer/MRRenderNameObject.cpp
@@ -1,14 +1,13 @@
 #include "MRRenderNameObject.h"
+#include "MRColorTheme.h"
+#include "MRImGuiVectorOperators.h"
+#include "MRRibbonMenu.h"
+#include "MRViewport.h"
 
 #include "MRMesh/MRFinally.h"
 #include "MRMesh/MRSceneRoot.h"
 #include "MRMesh/MRString.h"
 #include "MRMesh/MRVisualObject.h"
-#include "MRViewer/MRColorTheme.h"
-#include "MRViewer/MRImGuiVectorOperators.h"
-#include "MRViewer/MRRibbonMenu.h"
-#include "MRViewer/MRViewer.h"
-#include "MRViewer/MRViewport.h"
 
 #include <imgui.h>
 
@@ -35,7 +34,7 @@ void RenderNameObject::Task::earlyBackwardPass( const BackwardPassParams& backPa
 
                 if ( ImGui::IsMouseClicked( ImGuiMouseButton_Left ) )
                 {
-                    getViewerInstance().getMenuPluginAs<RibbonMenu>()->simulateNameTagClick(
+                    RibbonMenu::instance()->simulateNameTagClick(
                         // Yes, a dumb cast. We could find the same object in the scene, but it's a waste of time.
                         // Changing the `RenderObject` constructor parameter to accept a non-const reference requires changing a lot of stuff.
                         *const_cast<VisualObject*>( object ),
@@ -158,7 +157,7 @@ void RenderNameObject::renderUi( const UiRenderParams& params )
     task_.text = getObjectNameString( *task_.object, params.viewportId );
     task_.textSize = ImGui::CalcTextSize( task_.text.c_str() );
 
-    Viewport& viewportRef = getViewerInstance().viewport( params.viewportId );
+    Viewport& viewportRef = MR::viewport( params.viewportId );
 
     ImVec2 viewportCornerA( float( params.viewport.x ), float( ImGui::GetIO().DisplaySize.y - params.viewport.y - params.viewport.w ) );
     ImVec2 viewportCornerB( float( params.viewport.x + params.viewport.z ), float( ImGui::GetIO().DisplaySize.y - params.viewport.y ) );

--- a/source/MRViewer/MRRibbonFontManager.cpp
+++ b/source/MRViewer/MRRibbonFontManager.cpp
@@ -4,8 +4,6 @@
 #include "MRMesh/MRSystemPath.h"
 #include "MRRibbonConstants.h"
 #include "imgui_fonts_droid_sans.h"
-#include "MRViewerInstance.h"
-#include "MRViewer.h"
 #include "MRRibbonMenu.h"
 #include "MRPch/MRSpdlog.h"
 #include "MRCommandLoop.h"
@@ -116,7 +114,7 @@ std::filesystem::path RibbonFontManager::getMenuFontPath() const
 void RibbonFontManager::setNewFontPaths( const FontFilePaths& paths )
 {
     fontPaths_ = paths;
-    if ( auto menu = getViewerInstance().getMenuPlugin() )
+    if ( auto menu = ImGuiMenu::instance() )
     {
         CommandLoop::appendCommand( [menu] ()
         {

--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -72,6 +72,11 @@ constexpr auto cTransformContextName = "TransformContextWindow";
 namespace MR
 {
 
+std::shared_ptr<RibbonMenu> RibbonMenu::instance()
+{
+    return getViewerInstance().getRibbonMenu();
+}
+
 void RibbonMenu::setCustomContextCheckbox(
     const std::string& name,
     CustomContextMenuCheckbox customContextMenuCheckbox )

--- a/source/MRViewer/MRRibbonMenu.h
+++ b/source/MRViewer/MRRibbonMenu.h
@@ -42,6 +42,9 @@ class MRVIEWER_CLASS RibbonMenu : public ImGuiMenu
     };
 
 public:
+    // returns RibonMenu from ViewerInstance()
+    MRVIEWER_API static std::shared_ptr<RibbonMenu> instance();
+
     // adds a custom checkBox to the context menu
     // it is applied to the selected objects
     MRVIEWER_API void setCustomContextCheckbox(

--- a/source/MRViewer/MRShowModal.cpp
+++ b/source/MRViewer/MRShowModal.cpp
@@ -1,5 +1,4 @@
 #include "MRShowModal.h"
-#include "MRViewer.h"
 #include "ImGuiMenu.h"
 #include <MRPch/MRSpdlog.h>
 
@@ -8,7 +7,7 @@ namespace MR
 
 void showModal( const std::string& msg, NotificationType type )
 {
-    if ( auto menu = getViewerInstance().getMenuPlugin() )
+    if ( auto menu = ImGuiMenu::instance() )
         menu->showModalMessage( msg, type );
     else
     {

--- a/source/MRViewer/MRStatePlugin.cpp
+++ b/source/MRViewer/MRStatePlugin.cpp
@@ -2,7 +2,6 @@
 #include "MRMesh/MRString.h"
 #include "MRRibbonMenu.h"
 #include "MRMesh/MRSystem.h"
-#include "MRViewer.h"
 #include "MRCommandLoop.h"
 #include "MRMesh/MRConfig.h"
 #include "imgui/imgui.h"
@@ -76,8 +75,7 @@ bool StateBasePlugin::enable( bool on )
     }
     if ( res )
     {
-        auto ribbonMenu = getViewerInstance().getMenuPluginAs<RibbonMenu>();
-        if ( ribbonMenu )
+        if ( auto ribbonMenu = RibbonMenu::instance() )
             ribbonMenu->updateItemStatus( name() );
     }
     return res;

--- a/source/MRViewer/MRStatePluginUpdate.cpp
+++ b/source/MRViewer/MRStatePluginUpdate.cpp
@@ -1,6 +1,5 @@
 #include "MRStatePluginUpdate.h"
 #include "ImGuiMenu.h"
-#include "MRViewer.h"
 
 #include "MRMesh/MRObjectMesh.h"
 #include "MRMesh/MRObjectPoints.h"
@@ -106,7 +105,7 @@ bool PluginCloseOnChangePointCloud::shouldClose_() const
 bool PluginCloseOnEscPressed::shouldClose_() const
 {
     // ignore if there are opened dialogs
-    if ( const auto& menu = Viewer::constInstanceRef().getMenuPlugin() )
+    if ( const auto& menu = ImGuiMenu::instance() )
         if ( menu->getLastFocusedPlugin() )
             return false;
 

--- a/source/MRViewer/MRUIStyle.cpp
+++ b/source/MRViewer/MRUIStyle.cpp
@@ -4,9 +4,7 @@
 #include "MRColorTheme.h"
 #include "MRRibbonConstants.h"
 #include "MRViewer/MRUITestEngine.h"
-#include "MRViewerInstance.h"
 #include "MRRibbonFontManager.h"
-#include "MRViewer.h"
 #include "ImGuiHelpers.h"
 #include "ImGuiMenu.h"
 #include "imgui_internal.h"
@@ -241,7 +239,7 @@ bool buttonEx( const char* label, bool active, const Vector2f& size_arg /*= Vect
 bool button( const char* label, bool active, const Vector2f& size /*= Vector2f( 0, 0 )*/, ImGuiKey key /*= ImGuiKey_None */ )
 {
     const ImGuiStyle& style = ImGui::GetStyle();
-    const auto menu = getViewerInstance().getMenuPlugin();
+    const auto menu = ImGuiMenu::instance();
     const float scaling = menu ? menu->menu_scaling() : 1.f;
     StyleParamHolder sh;
     sh.addVar( ImGuiStyleVar_FramePadding, ImVec2( style.FramePadding.x, cGradientButtonFramePadding * scaling ) );
@@ -258,7 +256,7 @@ bool buttonCommonSize( const char* label, const Vector2f& size /*= Vector2f( 0, 
 
 bool buttonUnique( const char* label, int* value, int ownValue, const Vector2f& size /*= Vector2f( 0, 0 )*/, ImGuiKey key /*= ImGuiKey_None*/ )
 {
-    const auto menu = getViewerInstance().getMenuPlugin();
+    const auto menu = ImGuiMenu::instance();
     const float scaling = menu ? menu->menu_scaling() : 1.f;
 
     Color clearBlue = ColorTheme::getRibbonColor( ColorTheme::RibbonColorsType::SelectedObjectFrame );
@@ -551,7 +549,7 @@ static bool checkboxWithoutTestEngine( const char* label, bool* value )
 {
     const ImGuiStyle& style = ImGui::GetStyle();
 
-    const auto menu = getViewerInstance().getMenuPlugin();
+    const auto menu = ImGuiMenu::instance();
     const float scaling = menu ? menu->menu_scaling() : 1.f;
 
     StyleParamHolder sh;
@@ -773,8 +771,8 @@ bool checkboxOrModifier( const char* label, CheckboxOrModifierState& value, int 
     { // Modifiers hint.
         std::string modsText = modifiersToString( modifiers );
         ImGui::SameLine();
-        // ImGui::SetCursorPosY( ImGui::GetCursorPosY() + cCheckboxPadding * getViewerInstance().getMenuPlugin()->menu_scaling() );
-        // alignTextToCheckBox( getViewerInstance().getMenuPlugin()->menu_scaling() );
+        // ImGui::SetCursorPosY( ImGui::GetCursorPosY() + cCheckboxPadding * ImGuiMenu::instance()->menu_scaling() );
+        // alignTextToCheckBox( ImGuiMenu::instance()->menu_scaling() );
         // Neither of above is needed, the UI::checkbox... functions align the following text automatically
         ImGui::TextDisabled( "[%s]", modsText.c_str() );
     }
@@ -794,7 +792,7 @@ bool radioButton( const char* label, int* value, int valButton )
 {
     const ImGuiStyle& style = ImGui::GetStyle();
 
-    const auto menu = getViewerInstance().getMenuPlugin();
+    const auto menu = ImGuiMenu::instance();
     const float scaling = menu ? menu->menu_scaling() : 1.f;
 
     StyleParamHolder sh;
@@ -839,7 +837,7 @@ bool radioButton( const char* label, int* value, int valButton )
         const ImGuiID id = window->GetID( label );
         const ImVec2 label_size = ImGui::CalcTextSize( label, NULL, true );
 
-        const auto menu = getViewerInstance().getMenuPlugin();
+        const auto menu = ImGuiMenu::instance();
         const ImVec2 pos = window->DC.CursorPos;
         const ImRect check_bb( pos, ImVec2( pos.x + clickSize, pos.y + clickSize ) );
         const ImRect total_bb( pos, ImVec2( pos.x + clickSize + ( label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f ), pos.y + label_size.y + style.FramePadding.y * 2.0f ) );
@@ -1266,7 +1264,7 @@ bool combo( const char* label, int* v, const std::vector<std::string>& options, 
     }
 
     StyleParamHolder sh;
-    const float menuScaling = Viewer::instanceRef().getMenuPlugin()->menu_scaling();
+    const float menuScaling = ImGuiMenu::instance()->menu_scaling();
     sh.addVar( ImGuiStyleVar_FramePadding, menuScaling * StyleConsts::CustomCombo::framePadding );
 
     auto context = ImGui::GetCurrentContext();
@@ -1489,7 +1487,7 @@ static void drawDragCursor()
     auto mousePos = ImGui::GetMousePos();
     mousePos.x += 5.f;
 
-    const auto menuPlugin = MR::getViewerInstance().getMenuPlugin();
+    const auto menuPlugin = MR::ImGuiMenu::instance();
     const float scale = menuPlugin ? menuPlugin->menu_scaling() : 1.f;
 
     const float spaceX = 10 * scale;
@@ -1672,9 +1670,9 @@ bool inputTextCentered( const char* label, std::string& str, float width /*= 0.0
     ImGuiInputTextFlags flags /*= 0*/, ImGuiInputTextCallback callback /*= nullptr*/, void* user_data /*= nullptr */ )
 {
     const auto& style = ImGui::GetStyle();
-    const auto& viewer = MR::Viewer::instanceRef();
+    const auto& menu = ImGuiMenu::instance();
     const auto estimatedSize = ImGui::CalcTextSize( str.c_str() );
-    const float scaling = viewer.getMenuPlugin() ? viewer.getMenuPlugin()->menu_scaling() : 1.0f;
+    const float scaling = menu ? menu->menu_scaling() : 1.0f;
     const ImVec2 padding{ 2 * style.FramePadding.x * scaling , 2 * style.FramePadding.y * scaling };
     const auto actualWidth = ( width == 0.0f ) ? estimatedSize.x + padding.x : width;
 

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -2594,6 +2594,11 @@ const std::shared_ptr<ImGuiMenu>& Viewer::getMenuPlugin() const
     return menuPlugin_;
 }
 
+std::shared_ptr<RibbonMenu> Viewer::getRibbonMenu() const
+{
+    return std::dynamic_pointer_cast<RibbonMenu>( getMenuPlugin() );
+}
+
 void Viewer::setMenuPlugin( std::shared_ptr<ImGuiMenu> menu )
 {
     assert( !menuPlugin_ );

--- a/source/MRViewer/MRViewer.h
+++ b/source/MRViewer/MRViewer.h
@@ -401,6 +401,9 @@ public:
     MRVIEWER_API const std::shared_ptr<ImGuiMenu>& getMenuPlugin() const;
     MRVIEWER_API void setMenuPlugin( std::shared_ptr<ImGuiMenu> menu );
 
+    // get menu plugin casted in RibbonMenu
+    MRVIEWER_API std::shared_ptr<RibbonMenu> getRibbonMenu() const;
+
     // Get the menu plugin casted in given type
     template <typename T>
     std::shared_ptr<T> getMenuPluginAs() const { return std::dynamic_pointer_cast<T>( getMenuPlugin() ); }

--- a/source/MRViewer/MRViewer.h
+++ b/source/MRViewer/MRViewer.h
@@ -1,30 +1,17 @@
 #pragma once
 
-#include "MRMesh/MRRenderModelParameters.h"
 #include "MRViewerInstance.h"
 #include "MRMouse.h"
+#include "MRSignalCombiners.h"
+#include "MRMakeSlot.h"
 #include <MRMesh/MRVector2.h>
 #include <MRMesh/MRViewportId.h>
 #include "MRMesh/MRSignal.h"
-#include "MRViewer/MRSignalCombiners.h"
+#include "MRMesh/MRRenderModelParameters.h"
 #include <cstdint>
 #include <filesystem>
 
 struct GLFWwindow;
-
-template<typename MemberFuncPtr, typename BaseClass>
-auto bindSlotCallback( BaseClass* base, MemberFuncPtr func )
-{
-    static_assert( !( std::is_move_assignable_v<BaseClass> || std::is_move_constructible_v<BaseClass> ),
-                   "MAKE_SLOT requires a non-movable type" );
-    return[base, func] ( auto&&... args )
-    {
-        return ( base->*func )( std::forward<decltype( args )>( args )... );
-    };
-}
-
-// you will not be able to move your struct after using this macro
-#define MAKE_SLOT(func) bindSlotCallback(this,func)
 
 /// helper macros to add an `MR::Viewer` method call to the event queue
 #define ENQUEUE_VIEWER_METHOD( NAME, METHOD ) MR::getViewerInstance().emplaceEvent( NAME, [] { \

--- a/source/MRViewer/MRViewer.vcxproj
+++ b/source/MRViewer/MRViewer.vcxproj
@@ -161,6 +161,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="MRMakeSlot.h" />
     <ClInclude Include="MRMarkedVoxelSlice.h" />
     <ClInclude Include="MRMeshBoundarySelectionWidget.h" />
     <ClInclude Include="MRFrameCounter.h" />

--- a/source/MRViewer/MRViewer.vcxproj.filters
+++ b/source/MRViewer/MRViewer.vcxproj.filters
@@ -857,6 +857,9 @@
     <ClInclude Include="MRShowModal.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="MRMakeSlot.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\MeshLib\source\.editorconfig" />


### PR DESCRIPTION
Use `ImGuiMenu::instance()` and `RibbonMenu::instance()` and avoid `MRViewer.h` inclusion to reduce compilation times.