### PR TITLE
Pack point clouds

### DIFF
--- a/source/MRMesh/MRObjectPoints.h
+++ b/source/MRMesh/MRObjectPoints.h
@@ -61,4 +61,9 @@ protected:
 /// does not copy selection
 [[nodiscard]] MRMESH_API std::shared_ptr<ObjectPoints> cloneRegion( const std::shared_ptr<ObjectPoints>& objPoints, const VertBitSet& region );
 
+/// constructs new ObjectPoints containing the packed version of input points,
+/// \param newValidVerts if given, then use them instead of valid points from pts
+/// \return nullptr if the operation was cancelled
+[[nodiscard]] MRMESH_API std::shared_ptr<ObjectPoints> pack( const ObjectPoints& pts, Reorder reorder, VertBitSet* newValidVerts = nullptr, const ProgressCallback & cb = {} );
+
 } //namespace MR

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -93,9 +93,9 @@ void ObjectPointsHolder::swapSignals_( Object& other )
         assert( false );
 }
 
-void ObjectPointsHolder::selectPoints( VertBitSet newSelection )
+void ObjectPointsHolder::updateSelectedPoints( VertBitSet& selection )
 {
-    selectedPoints_ = std::move( newSelection );
+    std::swap( selectedPoints_, selection );
     numSelectedPoints_.reset();
     pointsSelectionChangedSignal();
     dirty_ |= DIRTY_SELECTION;

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -39,8 +39,14 @@ public:
 
     MRMESH_API virtual void setDirtyFlags( uint32_t mask, bool invalidateCaches = true ) override;
 
+    /// gets current selected points
     const VertBitSet& getSelectedPoints() const { return selectedPoints_; }
-    MRMESH_API virtual void selectPoints( VertBitSet newSelection );
+
+    /// sets current selected points
+    void selectPoints( VertBitSet newSelection ) { updateSelectedPoints( newSelection ); }
+
+    /// swaps current selected points with the argument
+    MRMESH_API virtual void updateSelectedPoints( VertBitSet& selection );
 
     /// returns selected points if any, otherwise returns all valid points
     MRMESH_API const VertBitSet& getSelectedPointsOrAll() const;

--- a/source/MRViewer/MRObjectPointsHistory.cpp
+++ b/source/MRViewer/MRObjectPointsHistory.cpp
@@ -6,9 +6,6 @@
 #include <MRMesh/MRObjectPoints.h>
 #include <MRMesh/MRPointCloud.h>
 #include <MRMesh/MRTimer.h>
-#include <MRMesh/MRParallelFor.h>
-#include <MRMesh/MRBitSetParallelFor.h>
-#include <MRMesh/MRBuffer.h>
 
 namespace MR
 {
@@ -20,42 +17,27 @@ static void packPointsWithHistoryCore( const std::shared_ptr<ObjectPoints>& objP
     if ( !objPoints || !objPoints->pointCloud() )
         return;
 
-    Historian<ChangePointCloudAction> h( "set cloud", objPoints );
+    auto packed = pack( *objPoints, reorder, newValidVerts );
 
-    if ( newValidVerts )
     {
-        objPoints->varPointCloud()->validPoints = std::move( *newValidVerts );
-        objPoints->varPointCloud()->invalidateCaches();
+        Historian<ChangePointCloudAction> h( "set cloud", objPoints );
+        std::shared_ptr<PointCloud> tmp;
+        packed->swapPointCloud( tmp );    // tmp := packed
+        objPoints->swapPointCloud( tmp ); // objPoints := tmp
     }
 
-    const auto map = objPoints->varPointCloud()->pack( reorder );
-
-    if ( !objPoints->getVertsColorMap().empty() )
     {
         Historian<ChangeVertsColorMapAction> hCM( "color map update", objPoints );
-        VertColors newColors;
-        newColors.resizeNoInit( map.tsize );
-        const auto & oldColors = objPoints->getVertsColorMap();
-        ParallelFor( 0_v, map.b.endId(), [&] ( VertId oldv )
-        {
-            auto newv = map.b[oldv];
-            if ( !newv )
-                return;
-            newColors[newv] = oldColors[oldv];
-        } );
-        objPoints->setVertsColorMap( std::move( newColors ) );
+        VertColors tmp;
+        packed->updateVertsColorMap( tmp );    // tmp := packed
+        objPoints->updateVertsColorMap( tmp ); // objPoints := tmp
     }
 
-    // update points in the selection
-    const auto & oldSel = objPoints->getSelectedPoints();
-    if ( oldSel.any() )
     {
         Historian<ChangePointPointSelectionAction> hs( "selection", objPoints );
-        VertBitSet newSel( map.tsize );
-        for ( auto oldv : oldSel )
-            if ( auto newv = map.b[ oldv ] )
-                newSel.set( newv );
-        objPoints->selectPoints( std::move( newSel ) );
+        VertBitSet tmp;
+        packed->updateSelectedPoints( tmp );    // tmp := packed
+        objPoints->updateSelectedPoints( tmp ); // objPoints := tmp
     }
 }
 


### PR DESCRIPTION
1. New function
```
[[nodiscard]] MRMESH_API std::shared_ptr<ObjectPoints> pack( const ObjectPoints& pts, Reorder reorder, VertBitSet* newValidVerts = nullptr, const ProgressCallback & cb = {} );
```
2. `packPointsWithHistoryCore` implemented via it.

3. `ObjectPointsHolder::updateSelectedPoints` method added to support 2.