### PR TITLE
RebuildMesh: control over sign detection mode inside

### DIFF
--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -561,6 +561,7 @@
     <ClCompile Include="MRSaveSettings.cpp" />
     <ClCompile Include="MRSceneLoad.cpp" />
     <ClCompile Include="MRSeparationPoint.cpp" />
+    <ClCompile Include="MRSignDetectionMode.cpp" />
     <ClCompile Include="MRSolarRadiation.cpp" />
     <ClCompile Include="MRStacktrace.cpp" />
     <ClCompile Include="MRSystemPath.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -756,9 +756,6 @@
     <ClInclude Include="MRChangeVertsColorMapAction.h">
       <Filter>Source Files\History</Filter>
     </ClInclude>
-    <ClInclude Include="MRSignDetectionMode.h">
-      <Filter>Source Files\Voxels</Filter>
-    </ClInclude>
     <ClInclude Include="MRGridSettings.h">
       <Filter>Source Files\Mesh</Filter>
     </ClInclude>
@@ -1232,6 +1229,9 @@
     </ClInclude>
     <ClInclude Include="MRMeshMeshDistance.h">
       <Filter>Source Files\AABBTree</Filter>
+    </ClInclude>
+    <ClInclude Include="MRSignDetectionMode.h">
+      <Filter>Source Files\Mesh</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -2026,6 +2026,9 @@
     </ClCompile>
     <ClCompile Include="MRMeshMeshDistance.cpp">
       <Filter>Source Files\AABBTree</Filter>
+    </ClCompile>
+    <ClCompile Include="MRSignDetectionMode.cpp">
+      <Filter>Source Files\Mesh</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/source/MRMesh/MRSignDetectionMode.cpp
+++ b/source/MRMesh/MRSignDetectionMode.cpp
@@ -1,4 +1,5 @@
 #include "MRSignDetectionMode.h"
+#include <cassert>
 
 namespace MR
 {

--- a/source/MRMesh/MRSignDetectionMode.cpp
+++ b/source/MRMesh/MRSignDetectionMode.cpp
@@ -1,0 +1,26 @@
+#include "MRSignDetectionMode.h"
+
+namespace MR
+{
+
+const char * asString( SignDetectionMode m )
+{
+    switch ( m )
+    {
+    case SignDetectionMode::Unsigned:
+        return "Unsigned";
+    case SignDetectionMode::OpenVDB:
+        return "OpenVDB";
+    case SignDetectionMode::ProjectionNormal:
+        return "ProjectionNormal";
+    case SignDetectionMode::WindingRule:
+        return "WindingRule";
+    case SignDetectionMode::HoleWindingRule:
+        return "HoleWindingRule";
+    default:
+        assert( false );
+        return "";
+    }
+}
+
+} //namespace MR

--- a/source/MRMesh/MRSignDetectionMode.h
+++ b/source/MRMesh/MRSignDetectionMode.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "MRMeshFwd.h"
+
 namespace MR
 {
 
@@ -11,6 +13,17 @@ enum class SignDetectionMode
     ProjectionNormal, ///< the sign is determined based on pseudonormal in closest mesh point (unsafe in case of self-intersections)
     WindingRule,      ///< ray intersection counter, significantly slower than ProjectionNormal and does not support holes in mesh
     HoleWindingRule   ///< computes winding number generalization with support of holes in mesh, slower than WindingRule
+};
+
+/// returns string representation of enum values
+[[nodiscard]] MRMESH_API const char * asString( SignDetectionMode m );
+
+/// how to determine the sign of distances from a mesh, short version including auto-detection
+enum class SignDetectionModeShort
+{
+    Auto,              ///< automatic selection of the fastest method among safe options for the current mesh
+    HoleWindingNumber, ///< detects sign from the winding number generalization with support for holes and self-intersections in mesh
+    ProjectionNormal   ///< detects sign from the pseudonormal in closest mesh point, which is fast but unsafe in the presence of holes and self-intersections in mesh
 };
 
 } //namespace MR

--- a/source/MRVoxels/MRRebuildMesh.h
+++ b/source/MRVoxels/MRRebuildMesh.h
@@ -4,6 +4,7 @@
 #include "MRMesh/MRMeshPart.h"
 #include "MRMesh/MRExpected.h"
 #include "MRMesh/MREnums.h"
+#include "MRMesh/MRSignDetectionMode.h"
 
 namespace MR
 {
@@ -13,6 +14,8 @@ struct RebuildMeshSettings
     /// Size of voxel in grid conversions;
     /// The user is responsible for setting some positive value here
     float voxelSize = 0;
+
+    SignDetectionModeShort signMode = SignDetectionModeShort::Auto;
 
     OffsetMode offsetMode = OffsetMode::Standard;
 
@@ -41,6 +44,10 @@ struct RebuildMeshSettings
 
     /// To report algorithm's progress and cancel it on user demand
     ProgressCallback progress;
+
+    /// this callback is invoked when SignDetectionMode is determined (useful if signMode = SignDetectionModeShort::Auto),
+    /// but before actual work begins
+    std::function<void(SignDetectionMode)> onSignDetectionModeSelected;
 };
 
 /// fixes all types of issues in input mesh (degenerations, holes, self-intersections, etc.)


### PR DESCRIPTION
Give the user control over sign detection mode inside `rebuidMesh`, this includes:
* New `enum class SignDetectionModeShort` introduced.
* New field `RebuildMeshSettings::signMode` introduced with default value corresponding to old behavior.
* Other values can force specific sign detection.