### PR TITLE
delete SelectScreenLasso class

### DIFF
--- a/source/MRViewer/MRSelectScreenLasso.cpp
+++ b/source/MRViewer/MRSelectScreenLasso.cpp
@@ -20,19 +20,9 @@
 namespace MR
 {
 
-void SelectScreenLasso::addPoint( int mouseX, int mouseY )
+BitSet calculateSelectedPixelsInsidePolygon( const Contour2f & screenPoints )
 {
-    float mx = float( mouseX );
-    float my = float( mouseY );
-    if ( screenPoints_.empty() || screenPoints_.back().x != mx || screenPoints_.back().y != my )
-    {
-        screenPoints_.push_back( { mx, my } );
-    }
-}
-
-BitSet SelectScreenLasso::calculateSelectedPixelsInsidePolygon()
-{
-    if ( screenPoints_.empty() )
+    if ( screenPoints.empty() )
         return {};
 
     Viewer& viewer = getViewerInstance();
@@ -40,11 +30,11 @@ BitSet SelectScreenLasso::calculateSelectedPixelsInsidePolygon()
     const auto& vpRect = viewer.viewport().getViewportRect();
 
     // convert polygon
-    Contour2f contour( screenPoints_.size() + 1 );
+    Contour2f contour( screenPoints.size() + 1 );
     
     auto viewportId = viewer.viewport().id;
-    for ( int i = 0; i < screenPoints_.size(); i++ )
-        contour[i] = to2dim( viewer.screenToViewport( { screenPoints_[i].x, screenPoints_[i].y,0.f }, viewportId ) );
+    for ( int i = 0; i < screenPoints.size(); i++ )
+        contour[i] = to2dim( viewer.screenToViewport( { screenPoints[i].x, screenPoints[i].y, 0.f }, viewportId ) );
     contour.back() = contour.front();
 
     Polyline2 polygon( { std::move( contour ) } );
@@ -76,9 +66,9 @@ BitSet SelectScreenLasso::calculateSelectedPixelsInsidePolygon()
     return resBS;
 }
 
-BitSet SelectScreenLasso::calculateSelectedPixelsNearPolygon( float radiusPix )
+BitSet calculateSelectedPixelsNearPolygon( const Contour2f & screenPoints, float radiusPix )
 {
-    if ( screenPoints_.empty() )
+    if ( screenPoints.empty() )
         return {};
 
     Viewer& viewer = getViewerInstance();
@@ -86,11 +76,11 @@ BitSet SelectScreenLasso::calculateSelectedPixelsNearPolygon( float radiusPix )
     const auto& vpRect = viewer.viewport().getViewportRect();
 
     // convert polygon
-    Contour2f contour( screenPoints_.size() );
+    Contour2f contour( screenPoints.size() );
 
     auto viewportId = viewer.viewport().id;
-    for ( int i = 0; i < screenPoints_.size(); i++ )
-        contour[i] = to2dim( viewer.screenToViewport( { screenPoints_[i].x, screenPoints_[i].y,0.f }, viewportId ) );
+    for ( int i = 0; i < screenPoints.size(); i++ )
+        contour[i] = to2dim( viewer.screenToViewport( { screenPoints[i].x, screenPoints[i].y,0.f }, viewportId ) );
     if ( contour.size() == 1 )
         contour.emplace_back( contour.front() );
 

--- a/source/MRViewer/MRSelectScreenLasso.h
+++ b/source/MRViewer/MRSelectScreenLasso.h
@@ -7,37 +7,18 @@ namespace MR
 {
 
 /**
- * Class for selection area on screen
- */
-class MRVIEWER_CLASS SelectScreenLasso
-{
-public:
-    /// add point to contour
-    MRVIEWER_API void addPoint( int mouseX, int mouseY );
+    * calculate area on screen that is inside of closed contour given by screen points.
+    * 
+    * return the matrix of pixels (in local space of active viewport) belonging selected area
+    */
+MRVIEWER_API BitSet calculateSelectedPixelsInsidePolygon( const Contour2f & screenPoints );
 
-    /// get current points in contour
-    const Contour2f& getScreenPoints() const { return screenPoints_; };
-    
-    /// clean contour
-    void cleanScreenPoints() { screenPoints_.clear(); };
-
-    /**
-     * calculate area on screen that are inside of closed contour.
-     * 
-     * return the matrix of pixels (in local space of active viewport) belonging selected area
-     */
-    MRVIEWER_API BitSet calculateSelectedPixelsInsidePolygon();
-
-    /**
-     * calculate area on screen that near open contour.
-     *
-     * return the matrix of pixels (in local space of active viewport) belonging selected area
-     */
-    MRVIEWER_API BitSet calculateSelectedPixelsNearPolygon( float radiusPix );
-
-private:
-    Contour2f screenPoints_;
-};
+/**
+    * calculate area on screen that is near to open contour given by screen points.
+    *
+    * return the matrix of pixels (in local space of active viewport) belonging selected area
+    */
+MRVIEWER_API BitSet calculateSelectedPixelsNearPolygon( const Contour2f & screenPoints, float radiusPix );
 
 /**
  * get faces ids of object located in selected area on viewport


### PR DESCRIPTION
The class `SelectScreenLasso`, which was just a wrapper around `Contour2f` deleted. It allows us to perform any operations with `Contour2f` to implement new tools, like Screen Polyline.

The methods `calculateSelectedPixelsInsidePolygon` and `calculateSelectedPixelsNearPolygon` becomes free standing functions.