### PR TITLE
MeshTopology::collapseEdge(...)

### DIFF
--- a/source/MRMesh/MRMeshDecimate.cpp
+++ b/source/MRMesh/MRMeshDecimate.cpp
@@ -18,110 +18,6 @@
 namespace MR
 {
 
-/// collapses given edge and deletes
-/// 1) faces: left( e ) and right( e );
-/// 2) vertex org( e )/dest( e ) if given edge was their only edge, otherwise only dest( e );
-/// 3) edges: e, next( e.sym() ), prev( e.sym() ), and optionally next( e ), prev( e ) if their left and right triangles are deleted;
-/// calls onEdgeDel for every deleted edge;
-/// returns prev( e ) if it is valid
-EdgeId collapseEdge( MeshTopology & topology, const EdgeId e, const std::function<void( EdgeId del, EdgeId rem )> & onEdgeDel )
-{
-    auto delEdge = [&]( EdgeId del )
-    {
-        assert( del );
-        if ( onEdgeDel )
-            onEdgeDel( del, {} );
-    };
-    auto replaceEdge = [&]( EdgeId del, EdgeId rem )
-    {
-        assert( del && rem );
-        if ( onEdgeDel )
-            onEdgeDel( del, rem );
-    };
-
-    topology.setLeft( e, FaceId() );
-    topology.setLeft( e.sym(), FaceId() );
-
-    delEdge( e );
-
-    if ( topology.next( e ) == e )
-    {
-        topology.setOrg( e, VertId() );
-        const EdgeId b = topology.prev( e.sym() );
-        if ( b == e.sym() )
-            topology.setOrg( e.sym(), VertId() );
-        else
-            topology.splice( b, e.sym() );
-
-        assert( topology.isLoneEdge( e ) );
-        return EdgeId();
-    }
-
-    topology.setOrg( e.sym(), VertId() );
-
-    const EdgeId ePrev = topology.prev( e );
-    const EdgeId eNext = topology.next( e );
-    if ( ePrev != e )
-        topology.splice( ePrev, e );
-
-    const EdgeId a = topology.next( e.sym() );
-    if ( a == e.sym() )
-    {
-        assert( topology.isLoneEdge( e ) );
-        return ePrev != e ? ePrev : EdgeId();
-    }
-    const EdgeId b = topology.prev( e.sym() );
-
-    topology.splice( b, e.sym() );
-    assert( topology.isLoneEdge( e ) );
-
-    assert( topology.next( b ) == a );
-    assert( topology.next( ePrev ) == eNext );
-    topology.splice( b, ePrev );
-    assert( topology.next( b ) == eNext );
-    assert( topology.next( ePrev ) == a );
-
-    if ( topology.next( a.sym() ) == ePrev.sym() )
-    {
-        topology.splice( ePrev, a );
-        topology.splice( topology.prev( a.sym() ), a.sym() );
-        assert( topology.isLoneEdge( a ) );
-        if ( !topology.left( ePrev ) && !topology.right( ePrev ) )
-        {
-            topology.splice( topology.prev( ePrev ), ePrev );
-            topology.splice( topology.prev( ePrev.sym() ), ePrev.sym() );
-            topology.setOrg( ePrev, {} );
-            topology.setOrg( ePrev.sym(), {} );
-            assert( topology.isLoneEdge( ePrev ) );
-            delEdge( a );
-            delEdge( ePrev );
-        }
-        else
-            replaceEdge( a, ePrev );
-    }
-
-    if ( topology.next( eNext.sym() ) == b.sym() )
-    {
-        topology.splice( eNext.sym(), b.sym() );
-        topology.splice( topology.prev( b ), b );
-        assert( topology.isLoneEdge( b ) );
-        if ( !topology.left( eNext ) && !topology.right( eNext ) )
-        {
-            topology.splice( topology.prev( eNext ), eNext );
-            topology.splice( topology.prev( eNext.sym() ), eNext.sym() );
-            topology.setOrg( eNext, {} );
-            topology.setOrg( eNext.sym(), {} );
-            assert( topology.isLoneEdge( eNext ) );
-            delEdge( b );
-            delEdge( eNext );
-        }
-        else
-            replaceEdge( b, eNext );
-    }
-
-    return ePrev != e ? ePrev : EdgeId();
-}
-
 class MeshDecimator
 {
 public:
@@ -755,7 +651,7 @@ VertId MeshDecimator::forceCollapse_( EdgeId edgeToCollapse, const Vector3f & co
         if ( r )
             settings_.region->reset( r );
     }
-    auto eo = collapseEdge( topology, edgeToCollapse, onEdgeDel_ );
+    auto eo = topology.collapseEdge( edgeToCollapse, onEdgeDel_ );
     if ( !eo )
         return {};
 

--- a/source/MRMesh/MRMeshDecimate.h
+++ b/source/MRMesh/MRMeshDecimate.h
@@ -78,8 +78,9 @@ struct DecimateSettings
     /// which can move vertices of notFlippable edges unless they are fixed
     bool collapseNearNotFlippable = false;
 
-    /// If pointer is not null, then only edges from here can be collapsed (and some nearby edges can disappear)
-    const UndirectedEdgeBitSet * edgesToCollapse = nullptr;
+    /// If pointer is not null, then only edges from here can be collapsed (and some nearby edges can disappear);
+    /// the algorithm updates this map during collapses, removing or replacing elements
+    UndirectedEdgeBitSet * edgesToCollapse = nullptr;
 
     /// if an edge present as a key in this map is flipped or collapsed, then same happens to the value-edge (with same collapse position);
     /// the algorithm updates this map during collapses, removing or replacing elements

--- a/source/MRMesh/MRMeshDecimate.h
+++ b/source/MRMesh/MRMeshDecimate.h
@@ -119,9 +119,9 @@ struct DecimateSettings
      */
     std::function<void( UndirectedEdgeId ue, float & collapseErrorSq, Vector3f & collapsePos )> adjustCollapse;
 
-    /// this function is called each time edge (e) is deleted;
-    /// if valid (e1) is given then dest(e) = dest(e1) and their origins are in different ends of collapsing edge, e1 shall take the place of e
-    std::function<void(EdgeId e, EdgeId e1)> onEdgeDel;
+    /// this function is called each time edge (del) is deleted;
+    /// if valid (rem) is given then dest(del) = dest(rem) and their origins are in different ends of collapsing edge, (rem) shall take the place of (del)
+    std::function<void( EdgeId del, EdgeId rem )> onEdgeDel;
 
     /**
      * \brief  If not null, then vertex quadratic forms are stored there;

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -66,6 +66,15 @@ public:
     /// the cut in rings in both cases is made after a and b
     MRMESH_API void splice( EdgeId a, EdgeId b );
 
+    /// collapses given edge in a vertex and deletes
+    /// 1) faces: left( e ) and right( e );
+    /// 2) vertex org( e )/dest( e ) if given edge was their only edge, otherwise only dest( e );
+    /// 3) edges: e, next( e.sym() ), prev( e.sym() ), and optionally next( e ), prev( e ) if their left and right triangles are deleted;
+    /// calls onEdgeDel for every deleted edge (del);
+    /// if valid (rem) is given then dest(del) = dest(rem) and their origins are in different ends of collapsing edge, (rem) shall take the place of (del)
+    /// \return prev( e ) if it is still valid
+    MRMESH_API EdgeId collapseEdge( EdgeId e, const std::function<void( EdgeId del, EdgeId rem )> & onEdgeDel );
+
 
     /// next (counter clock wise) half-edge in the origin ring
     [[nodiscard]] EdgeId next( EdgeId he ) const { assert(he.valid()); return edges_[he].next; }

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -68,10 +68,10 @@ public:
 
     /// collapses given edge in a vertex and deletes
     /// 1) faces: left( e ) and right( e );
-    /// 2) vertex org( e )/dest( e ) if given edge was their only edge, otherwise only dest( e );
-    /// 3) edges: e, next( e.sym() ), prev( e.sym() ), and optionally next( e ), prev( e ) if their left and right triangles are deleted;
-    /// calls onEdgeDel for every deleted edge (del);
-    /// if valid (rem) is given then dest(del) = dest(rem) and their origins are in different ends of collapsing edge, (rem) shall take the place of (del)
+    /// 2) edges: e, next( e.sym() ), prev( e.sym() ), and optionally next( e ), prev( e ) if their left and right triangles are deleted;
+    /// 3) all vertices that lost their last edge;
+    /// calls onEdgeDel for every deleted edge (del) including given (e);
+    /// if valid (rem) is given then dest( del ) = dest( rem ) and their origins are in different ends of collapsing edge, (rem) shall take the place of (del)
     /// \return prev( e ) if it is still valid
     MRMESH_API EdgeId collapseEdge( EdgeId e, const std::function<void( EdgeId del, EdgeId rem )> & onEdgeDel );
 


### PR DESCRIPTION
* Hidden `collapseEdge` function in `MRMeshDecimate.cpp` becomes public method of `MeshTopology`
* The function takes only one `std::function` optional parameter, all other updates can be implemented via it
* `DecimateSettings::edgesToCollapse` is updated during decimation.