### PR TITLE
BitSet: prevent private access to m_bits

### DIFF
--- a/source/MRMesh/MRBitSet.cpp
+++ b/source/MRMesh/MRBitSet.cpp
@@ -54,11 +54,11 @@ bool operator == ( const BitSet & a, const BitSet & b )
     auto bBlocksNum = b.num_blocks();
     auto minBlocksNum = std::min( aBlocksNum, bBlocksNum );
     for ( size_t i = 0; i < std::min( aBlocksNum, bBlocksNum ); ++i )
-        if ( a.m_bits[i] != b.m_bits[i] )
+        if ( a.bits()[i] != b.bits()[i] )
             return false;
     const auto& maxBitSet = aBlocksNum > bBlocksNum ? a : b;
     for ( size_t i = minBlocksNum; i < maxBitSet.num_blocks(); ++i )
-        if ( maxBitSet.m_bits[i] != 0 )
+        if ( maxBitSet.bits()[i] != 0 )
             return false;
     return true;
 }

--- a/source/MRMesh/MRBitSet.h
+++ b/source/MRMesh/MRBitSet.h
@@ -133,6 +133,9 @@ public:
     /// copies all bits from another BitSet (or a descending class, e.g. TaggedBitSet<U>)
     explicit TaggedBitSet( const BitSet & src ) : BitSet( src ) {}
 
+    /// moves all bits from another BitSet (or a descending class, e.g. TaggedBitSet<U>)
+    explicit TaggedBitSet( BitSet && src ) : BitSet( std::move( src ) ) {}
+
     TaggedBitSet & set( IndexType n, size_type len, bool val ) { base::set( n, len, val ); return * this; }
     TaggedBitSet & set( IndexType n, bool val = true ) { base::set( n, val ); return * this; }
     TaggedBitSet & set() { base::set(); return * this; }

--- a/source/MRMesh/MRBitSet.h
+++ b/source/MRMesh/MRBitSet.h
@@ -131,7 +131,7 @@ public:
     using IndexType = Id<T>;
 
     /// copies all bits from another BitSet (or a descending class, e.g. TaggedBitSet<U>)
-    explicit TaggedBitSet( const BitSet & src ) { init_from_block_range( src.bits().begin(), src.bits().end() ); }
+    explicit TaggedBitSet( const BitSet & src ) : BitSet( src ) {}
 
     TaggedBitSet & set( IndexType n, size_type len, bool val ) { base::set( n, len, val ); return * this; }
     TaggedBitSet & set( IndexType n, bool val = true ) { base::set( n, val ); return * this; }

--- a/source/MRMesh/MRMultiwayICP.cpp
+++ b/source/MRMesh/MRMultiwayICP.cpp
@@ -167,12 +167,8 @@ public:
     {
         assert( l > 0 );
         if ( l == 1 )
-        {
-            const auto& leaves = leavesPerLayer_[l - 1][eId];
-            ICPElementBitSet els;
-            els.init_from_block_range( leaves.m_bits.begin(), leaves.m_bits.end() );
-            return els;
-        }
+            return ICPElementBitSet( leavesPerLayer_[l - 1][eId] );
+
         if ( l - 2 < nodesPerLayer_.size() )
             return nodesPerLayer_[l - 2][eId];
 

--- a/source/MRMesh/MRSerializer.cpp
+++ b/source/MRMesh/MRSerializer.cpp
@@ -156,7 +156,7 @@ void serializeToJson( const BitSet& bitset, Json::Value& root )
 {
     std::vector<std::uint8_t> data;
     root["size"] = Json::UInt( bitset.size() );
-    root["bits"] = encode64( (const std::uint8_t*) bitset.m_bits.data(), bitset.num_blocks() * sizeof( BitSet::block_type ) );
+    root["bits"] = encode64( (const std::uint8_t*) bitset.bits().data(), bitset.num_blocks() * sizeof( BitSet::block_type ) );
 }
 
 void serializeToJson( const MeshTexture& texture, Json::Value& root )
@@ -447,7 +447,7 @@ void deserializeFromJson( const Json::Value& root, BitSet& bitset )
         bitset.resize( root["size"].asInt() );
         auto bin = decode64( root["bits"].asString() );
         auto bytes = std::min( bin.size(), bitset.num_blocks() * sizeof( BitSet::block_type ) );
-        std::copy( bin.begin(), bin.begin() + bytes, (std::uint8_t*) bitset.m_bits.data() );
+        std::copy( bin.begin(), bin.begin() + bytes, (std::uint8_t*) bitset.bits().data() );
     }
 }
 

--- a/source/MRMeshC/MRBitSet.cpp
+++ b/source/MRMeshC/MRBitSet.cpp
@@ -21,13 +21,13 @@ MRBitSet* mrBitSetCopy( const MRBitSet* bs_ )
 const uint64_t* mrBitSetBlocks( const MRBitSet* bs_ )
 {
     ARG( bs );
-    return bs.m_bits.data();
+    return bs.bits().data();
 }
 
 size_t mrBitSetBlocksNum( const MRBitSet* bs_ )
 {
     ARG( bs );
-    return bs.m_bits.size();
+    return bs.bits().size();
 }
 
 size_t mrBitSetSize( const MRBitSet* bs_ )

--- a/source/MRViewer/MRRenderMeshObject.cpp
+++ b/source/MRViewer/MRRenderMeshObject.cpp
@@ -1052,7 +1052,7 @@ RenderBufferRef<unsigned> RenderMeshObject::loadFaceSelectionTextureBuffer_()
     assert( faceSelectionTextureSize_.x * faceSelectionTextureSize_.y >= size );
     auto buffer = glBuffer.prepareBuffer<unsigned>( faceSelectionTextureSize_.x * faceSelectionTextureSize_.y );
 
-    const auto& selection = objMesh_->getSelectedFaces().m_bits;
+    const auto& selection = objMesh_->getSelectedFaces().bits();
     const unsigned* selectionData = ( unsigned* )selection.data();
     tbb::parallel_for( tbb::blocked_range<int>( 0, (int)buffer.size() ), [&] ( const tbb::blocked_range<int>& range )
     {

--- a/source/MRViewer/MRRenderPointsObject.cpp
+++ b/source/MRViewer/MRRenderPointsObject.cpp
@@ -459,9 +459,9 @@ RenderBufferRef<unsigned> RenderPointsObject::loadVertSelectionTextureBuffer_()
     auto buffer = glBuffer.prepareBuffer<unsigned>( vertSelectionTextureSize_.x * vertSelectionTextureSize_.y );
 
     const auto& selectedPoints = objPoints_->getSelectedPoints();
-    const size_t selectionSize = selectedPoints.m_bits.size();
+    const size_t selectionSize = selectedPoints.bits().size();
     
-    const unsigned* selectionData = ( unsigned* )selectedPoints.m_bits.data();    
+    auto selectionData = ( const unsigned* )selectedPoints.bits().data();
 
     ParallelFor( 0, ( int )buffer.size(), [&]( int r )
     {

--- a/source/MRViewer/MRRenderVolumeObject.cpp
+++ b/source/MRViewer/MRRenderVolumeObject.cpp
@@ -88,7 +88,7 @@ RenderBufferRef<unsigned> RenderVolumeObject::loadActiveVoxelsTextureBuffer_()
         } );
         return buffer;
     }
-    const auto& activeVoxels = objVoxels_->getVolumeRenderActiveVoxels().m_bits;
+    const auto& activeVoxels = objVoxels_->getVolumeRenderActiveVoxels().bits();
     const unsigned* activeVoxelsData = ( unsigned* )activeVoxels.data();
     tbb::parallel_for( tbb::blocked_range<int>( 0, ( int )buffer.size() ), [&] ( const tbb::blocked_range<int>& range )
     {


### PR DESCRIPTION
In `BitSet` class:
* prevent public access to `m_bits` field
* use read-only `bits()` vector instead

In `TaggedBitSet` class:
* explicit initialization from differently typed descendant of `BitSet` 