### PR TITLE
Drag and drop improvements

### DIFF
--- a/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
@@ -231,17 +231,17 @@ bool OpenFilesMenuItem::dragDrop_( const std::vector<std::filesystem::path>& pat
         return false;
     }
 
-    bool forceReplaceScene = false;
+    Viewer::LoadOptions options{ .undoPrefix = "Drop " };
     if ( menu )
     {
         auto sceneBoxSize = menu->getSceneSize();
         auto mousePos = viewerRef.mouseController().getMousePos();
         auto headerHeight = viewerRef.framebufferSize.y - sceneBoxSize.y;
         if ( mousePos.x > sceneBoxSize.x || mousePos.y < headerHeight )
-            forceReplaceScene = true;
+            options.forceReplaceScene = true;
     }
 
-    viewerRef.loadFiles( paths, "Drop ", forceReplaceScene );
+    viewerRef.loadFiles( paths, options );
     return true;
 }
 

--- a/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
@@ -231,24 +231,17 @@ bool OpenFilesMenuItem::dragDrop_( const std::vector<std::filesystem::path>& pat
         return false;
     }
 
-    SCOPED_HISTORY( "Drag and drop files" );
+    bool forceReplaceScene = false;
     if ( menu )
     {
         auto sceneBoxSize = menu->getSceneSize();
         auto mousePos = viewerRef.mouseController().getMousePos();
         auto headerHeight = viewerRef.framebufferSize.y - sceneBoxSize.y;
         if ( mousePos.x > sceneBoxSize.x || mousePos.y < headerHeight )
-        {
-            auto children = SceneRoot::get().children();
-            for ( auto child : children )
-            {
-                AppendHistory<ChangeSceneAction>( "Remove object", child, ChangeSceneAction::Type::RemoveObject );
-                child->detachFromParent();
-            }
-        }
+            forceReplaceScene = true;
     }
 
-    viewerRef.loadFiles( paths );
+    viewerRef.loadFiles( paths, "Drop ", forceReplaceScene );
     return true;
 }
 

--- a/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
@@ -231,7 +231,7 @@ bool OpenFilesMenuItem::dragDrop_( const std::vector<std::filesystem::path>& pat
         return false;
     }
 
-    Viewer::LoadOptions options{ .undoPrefix = "Drop " };
+    FileLoadOptions options{ .undoPrefix = "Drop " };
     if ( menu )
     {
         auto sceneBoxSize = menu->getSceneSize();

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -1183,22 +1183,22 @@ bool Viewer::isSupportedFormat( const std::filesystem::path& mesh_file_name )
     return false;
 }
 
-bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList, const char * undoPrefix, bool forceReplaceScene )
+bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList, const LoadOptions & options )
 {
     if ( filesList.empty() )
         return false;
 
-    const auto postProcess = [this, undoPrefix, forceReplaceScene] ( const SceneLoad::SceneLoadResult& result )
+    const auto postProcess = [this, options] ( const SceneLoad::SceneLoadResult& result )
     {
         if ( result.scene )
         {
             const bool wasEmptyScene = SceneRoot::get().children().empty();
             const bool wasEmptyUndo = globalHistoryStore_ && globalHistoryStore_->getStackPointer() == 0;
 
-            if ( forceReplaceScene || ( result.loadedFiles.size() == 1 && ( !result.isSceneConstructed || wasEmptyScene ) ) )
+            if ( options.forceReplaceScene || ( result.loadedFiles.size() == 1 && ( !result.isSceneConstructed || wasEmptyScene ) ) )
             {
                 // the scene is taken as is from a single file, replace the current scene with it
-                AppendHistory<SwapRootAction>( undoPrefix + commonFilesName( result.loadedFiles ) );
+                AppendHistory<SwapRootAction>( options.undoPrefix + commonFilesName( result.loadedFiles ) );
                 auto newRoot = result.scene;
                 std::swap( newRoot, SceneRoot::getSharedPtr() );
                 setSceneDirty();
@@ -1210,7 +1210,7 @@ bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList, con
                 for ( const auto& file : result.loadedFiles )
                     recentFilesStore().storeFile( file );
 
-                SCOPED_HISTORY( undoPrefix + commonFilesName( result.loadedFiles ) );
+                SCOPED_HISTORY( options.undoPrefix + commonFilesName( result.loadedFiles ) );
 
                 const auto children = result.scene->children();
                 result.scene->removeAllChildren();

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -1183,7 +1183,7 @@ bool Viewer::isSupportedFormat( const std::filesystem::path& mesh_file_name )
     return false;
 }
 
-bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList, const LoadOptions & options )
+bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList, const FileLoadOptions & options )
 {
     if ( filesList.empty() )
         return false;

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -1183,22 +1183,22 @@ bool Viewer::isSupportedFormat( const std::filesystem::path& mesh_file_name )
     return false;
 }
 
-bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList )
+bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList, const char * undoPrefix, bool forceReplaceScene )
 {
     if ( filesList.empty() )
         return false;
 
-    const auto postProcess = [this] ( const SceneLoad::SceneLoadResult& result )
+    const auto postProcess = [this, undoPrefix, forceReplaceScene] ( const SceneLoad::SceneLoadResult& result )
     {
         if ( result.scene )
         {
             const bool wasEmptyScene = SceneRoot::get().children().empty();
             const bool wasEmptyUndo = globalHistoryStore_ && globalHistoryStore_->getStackPointer() == 0;
 
-            if ( result.loadedFiles.size() == 1 && ( !result.isSceneConstructed || wasEmptyScene ) )
+            if ( forceReplaceScene || ( result.loadedFiles.size() == 1 && ( !result.isSceneConstructed || wasEmptyScene ) ) )
             {
                 // the scene is taken as is from a single file, replace the current scene with it
-                AppendHistory<SwapRootAction>( "Open " + commonFilesName( result.loadedFiles ) );
+                AppendHistory<SwapRootAction>( undoPrefix + commonFilesName( result.loadedFiles ) );
                 auto newRoot = result.scene;
                 std::swap( newRoot, SceneRoot::getSharedPtr() );
                 setSceneDirty();
@@ -1210,7 +1210,7 @@ bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList )
                 for ( const auto& file : result.loadedFiles )
                     recentFilesStore().storeFile( file );
 
-                SCOPED_HISTORY( "Open " + commonFilesName( result.loadedFiles ) );
+                SCOPED_HISTORY( undoPrefix + commonFilesName( result.loadedFiles ) );
 
                 const auto children = result.scene->children();
                 result.scene->removeAllChildren();

--- a/source/MRViewer/MRViewer.h
+++ b/source/MRViewer/MRViewer.h
@@ -110,9 +110,13 @@ public:
     // Mesh IO
     // Check the supported file format
     MRVIEWER_API bool isSupportedFormat( const std::filesystem::path& file_name );
+
     // Load objects / scenes from files
     // Note! load files with progress bar in next frame if it possible, otherwise load directly inside this function
-    MRVIEWER_API bool loadFiles( const std::vector< std::filesystem::path>& filesList );
+    // \param undoPrefix first part of undo name
+    // \param forceReplaceScene true here will replace existing scene even if more than one file is open
+    MRVIEWER_API bool loadFiles( const std::vector< std::filesystem::path>& filesList, const char * undoPrefix = "Open ", bool forceReplaceScene = false );
+
     // Save first selected objects to file
     MRVIEWER_API bool saveToFile( const std::filesystem::path & mesh_file_name );
 

--- a/source/MRViewer/MRViewer.h
+++ b/source/MRViewer/MRViewer.h
@@ -111,11 +111,18 @@ public:
     // Check the supported file format
     MRVIEWER_API bool isSupportedFormat( const std::filesystem::path& file_name );
 
+    struct LoadOptions
+    {
+        /// first part of undo name
+        const char * undoPrefix = "Open ";
+
+        // true here will replace existing scene even if more than one file is open
+        bool forceReplaceScene = false;
+    };
+
     // Load objects / scenes from files
     // Note! load files with progress bar in next frame if it possible, otherwise load directly inside this function
-    // \param undoPrefix first part of undo name
-    // \param forceReplaceScene true here will replace existing scene even if more than one file is open
-    MRVIEWER_API bool loadFiles( const std::vector< std::filesystem::path>& filesList, const char * undoPrefix = "Open ", bool forceReplaceScene = false );
+    MRVIEWER_API bool loadFiles( const std::vector< std::filesystem::path>& filesList, const LoadOptions & options = {} );
 
     // Save first selected objects to file
     MRVIEWER_API bool saveToFile( const std::filesystem::path & mesh_file_name );

--- a/source/MRViewer/MRViewer.h
+++ b/source/MRViewer/MRViewer.h
@@ -62,6 +62,15 @@ struct LaunchParams
     std::shared_ptr<SplashWindow> splashWindow; // if present will show this window while initializing plugins (after menu initialization)
 };
 
+struct FileLoadOptions
+{
+    /// first part of undo name
+    const char * undoPrefix = "Open ";
+
+    // true here will replace existing scene even if more than one file is open
+    bool forceReplaceScene = false;
+};
+
 // GLFW-based mesh viewer
 class MRVIEWER_CLASS Viewer
 {
@@ -111,18 +120,9 @@ public:
     // Check the supported file format
     MRVIEWER_API bool isSupportedFormat( const std::filesystem::path& file_name );
 
-    struct LoadOptions
-    {
-        /// first part of undo name
-        const char * undoPrefix = "Open ";
-
-        // true here will replace existing scene even if more than one file is open
-        bool forceReplaceScene = false;
-    };
-
     // Load objects / scenes from files
     // Note! load files with progress bar in next frame if it possible, otherwise load directly inside this function
-    MRVIEWER_API bool loadFiles( const std::vector< std::filesystem::path>& filesList, const LoadOptions & options = {} );
+    MRVIEWER_API bool loadFiles( const std::vector< std::filesystem::path>& filesList, const FileLoadOptions & options = {} );
 
     // Save first selected objects to file
     MRVIEWER_API bool saveToFile( const std::filesystem::path & mesh_file_name );


### PR DESCRIPTION
* Undo name in case of drag-and-drop will be "Drop .EXT" and not "Open .EXT"
* If drop happens in 3D scene, the only one undo action is created (not two as previously)