### PR TITLE
Improve MeshLib documentation pages for SEO: remove BOM for specific files

### DIFF
--- a/examples/c--sharp-example/GlobalRegistration.dox.cs
+++ b/examples/c--sharp-example/GlobalRegistration.dox.cs
@@ -1,4 +1,4 @@
-﻿/// \page ExampleCSharpGlobalRegistration Global Registration
+/// \page ExampleCSharpGlobalRegistration Global Registration
 ///
 /// Example of Global Registration
 ///

--- a/examples/c--sharp-example/MeshBoolean.dox.cs
+++ b/examples/c--sharp-example/MeshBoolean.dox.cs
@@ -1,4 +1,4 @@
-﻿/// \page ExampleCSharpMeshBoolean Mesh boolean
+/// \page ExampleCSharpMeshBoolean Mesh boolean
 ///
 /// Example of Boolean operation
 ///


### PR DESCRIPTION
These files contain a [BOM](https://en.wikipedia.org/wiki/Byte_order_mark), which disrupts local Doxygen documentation builds in certain environments (specifically, macOS filesystems that are case-sensitive, using Dev Containers in Visual Studio Code with an Alpine Linux Docker image 3.20 and Doxygen 1.11.0).

Here is how it is looks like with BOM:
<img width="973" alt="bom-issue" src="https://github.com/user-attachments/assets/718ddf6a-fcb9-4704-901d-fda3b7ce3211">

This PR removes BOM.