### PR TITLE
Add a canonical link for each page in documentation: added a parameter for post.sh to specify the output folder

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           scripts/pre.sh ${{ inputs.output_folder }}
           doxygen Doxyfile
-          scripts/post.sh
+          scripts/post.sh ${{ inputs.output_folder }} 
 
       - name: Commit and push changes
         working-directory: MeshInspector.github.io


### PR DESCRIPTION
More details in this PR:
- https://github.com/MeshInspector/MeshInspector.github.io/pull/6