### PR TITLE
Fix mesh attributes in brash patch

### DIFF
--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -473,7 +473,6 @@ template <typename T, typename I, typename P> class Heap;
 
 class MRMESH_CLASS MeshTopology;
 struct MRMESH_CLASS Mesh;
-struct MRMESH_CLASS MeshPart;
 class MRMESH_CLASS MeshOrPoints;
 struct MRMESH_CLASS PointCloud;
 class MRMESH_CLASS AABBTree;
@@ -485,6 +484,11 @@ struct MeshOrPointsXf;
 struct MeshTexture;
 struct GridSettings;
 struct TriMesh;
+
+MR_CANONICAL_TYPEDEFS( ( template <typename T> struct ), MRMESH_CLASS MeshRegion,
+    ( MeshPart, MeshRegion<FaceTag> )
+    ( MeshVertPart, MeshRegion<VertTag> )
+)
 
 template<typename T> class UniqueThreadSafeOwner;
 

--- a/source/MRMesh/MRMeshPart.h
+++ b/source/MRMesh/MRMeshPart.h
@@ -23,8 +23,8 @@ struct MeshRegion
         if ( this != &other )
         {
             // In modern C++ the result doesn't need to be `std::launder`ed, right?
-            this->~MeshPart();
-            ::new( ( void* )this ) MeshPart( other );
+            this->~MeshRegion();
+            ::new( ( void* )this ) MeshRegion( other );
         }
         return *this;
     }

--- a/source/MRMesh/MRMeshPart.h
+++ b/source/MRMesh/MRMeshPart.h
@@ -7,22 +7,24 @@ namespace MR
 
 /// stores reference on whole mesh (if region is nullptr) or on its part (if region pointer is valid)
 /// \ingroup MeshAlgorithmGroup
-struct MeshPart
+template<typename RegionTag>
+struct MeshRegion
 {
-    const Mesh & mesh;
-    const FaceBitSet * region = nullptr; // nullptr here means whole mesh
+    const Mesh& mesh;
+    const TaggedBitSet<RegionTag>* region = nullptr; // nullptr here means whole mesh
 
-    MeshPart( const Mesh & m, const FaceBitSet * bs = nullptr ) noexcept : mesh( m ), region( bs ) { }
+    MeshRegion( const Mesh& m, const TaggedBitSet<RegionTag>* bs = nullptr ) noexcept : mesh( m ), region( bs )
+    {}
 
     // Make this assignable. A better idea would be to rewrite the class to not use references, but doing this instead preserves API compatibility.
-    MeshPart(const MeshPart &other) noexcept = default;
-    MeshPart &operator=(const MeshPart &other) noexcept
+    MeshRegion( const MeshRegion& other ) noexcept = default;
+    MeshRegion& operator=( const MeshRegion& other ) noexcept
     {
-        if (this != &other)
+        if ( this != &other )
         {
             // In modern C++ the result doesn't need to be `std::launder`ed, right?
             this->~MeshPart();
-            ::new((void *)this) MeshPart(other);
+            ::new( ( void* )this ) MeshPart( other );
         }
         return *this;
     }

--- a/source/MRMesh/MRProjectionMeshAttribute.h
+++ b/source/MRMesh/MRProjectionMeshAttribute.h
@@ -11,20 +11,20 @@ namespace MR
 // projecting the vertex attributes of the old onto the new one
 // returns false if canceled by progress bar
 template<typename F>
-bool projectVertAttribute( const Mesh& newMesh, const Mesh& oldMesh, F&& func, ProgressCallback progressCb );
+bool projectVertAttribute( const MeshVertPart& mp, const Mesh& oldMesh, F&& func, ProgressCallback progressCb );
 
 // projecting the face attributes of the old onto the new one
 // returns false if canceled by progress bar
 template<typename F>
-bool projectFaceAttribute( const Mesh& newMesh, const Mesh& oldMesh, F&& func, ProgressCallback progressCb );
+bool projectFaceAttribute( const MeshPart& mp, const Mesh& oldMesh, F&& func, ProgressCallback progressCb );
 
 
 template<typename F>
-bool projectVertAttribute( const Mesh& newMesh, const Mesh& oldMesh, F&& func, ProgressCallback progressCb )
+bool projectVertAttribute( const MeshVertPart& mp, const Mesh& oldMesh, F&& func, ProgressCallback progressCb )
 {
-    return BitSetParallelFor( newMesh.topology.getValidVerts(), [&] ( VertId id )
+    return BitSetParallelFor( mp.mesh.topology.getVertIds( mp.region ), [&] ( VertId id )
         {
-            auto projectionResult = findProjection( newMesh.points[id], oldMesh );
+            auto projectionResult = findProjection( mp.mesh.points[id], oldMesh );
             auto res = projectionResult.mtp;
             VertId v1 = oldMesh.topology.org( res.e );
             VertId v2 = oldMesh.topology.dest( res.e );
@@ -35,11 +35,11 @@ bool projectVertAttribute( const Mesh& newMesh, const Mesh& oldMesh, F&& func, P
 }
 
 template<typename F>
-bool projectFaceAttribute( const Mesh& newMesh, const Mesh& oldMesh, F&& func, ProgressCallback progressCb )
+bool projectFaceAttribute( const MeshPart& mp, const Mesh& oldMesh, F&& func, ProgressCallback progressCb )
 {
-    return BitSetParallelFor( newMesh.topology.getValidFaces(), [&] ( FaceId newFaceId )
+    return BitSetParallelFor( mp.mesh.topology.getFaceIds( mp.region ), [&] ( FaceId newFaceId )
     {
-        auto projectionResult = findProjection( newMesh.triCenter( newFaceId ), oldMesh );
+        auto projectionResult = findProjection( mp.mesh.triCenter( newFaceId ), oldMesh );
         func( newFaceId, projectionResult );
     },
     progressCb );

--- a/source/MRViewer/MRProjectMeshAttributes.cpp
+++ b/source/MRViewer/MRProjectMeshAttributes.cpp
@@ -31,22 +31,22 @@ std::optional<MeshAttributes> projectMeshAttributes(
     if ( !oldUVCoords.empty() )
     {
         newAttribute.uvCoords = oldUVCoords;
-        newAttribute.uvCoords.resize( size_t( newMesh.topology.lastValidVert() + 1 ) );
+        newAttribute.uvCoords.vec_.resize( size_t( newMesh.topology.lastValidVert() + 1 ) );
     }
     if ( !oldVertColors.empty() )
     {
         newAttribute.colorMap = oldVertColors;
-        newAttribute.colorMap.resize( size_t( newMesh.topology.lastValidVert() + 1 ) );
+        newAttribute.colorMap.vec_.resize( size_t( newMesh.topology.lastValidVert() + 1 ) );
     }
     if ( !oldFaceColorMap.empty() )
     {
         newAttribute.faceColors = oldFaceColorMap;
-        newAttribute.faceColors.resize( size_t( newMesh.topology.lastValidFace() + 1 ) );
+        newAttribute.faceColors.vec_.resize( size_t( newMesh.topology.lastValidFace() + 1 ) );
     }
     if ( !oldTexturePerFace.empty() )
     {
         newAttribute.texturePerFace = oldTexturePerFace;
-        newAttribute.texturePerFace.resize( size_t( newMesh.topology.lastValidFace() + 1 ) );
+        newAttribute.texturePerFace.vec_.resize( size_t( newMesh.topology.lastValidFace() + 1 ) );
     }
 
     const bool hasFaceAttribs = !oldFaceColorMap.empty() || !oldTexturePerFace.empty();

--- a/source/MRViewer/MRProjectMeshAttributes.cpp
+++ b/source/MRViewer/MRProjectMeshAttributes.cpp
@@ -1,0 +1,110 @@
+#include "MRProjectMeshAttributes.h"
+
+#include <MRMesh/MRMesh.h>
+#include <MRMesh/MRObjectMesh.h>
+#include <MRMesh/MRMeshAttributesToUpdate.h>
+#include <MRMesh/MRProjectionMeshAttribute.h>
+#include <MRMesh/MRChangeMeshAction.h>
+#include <MRMesh/MRChangeVertsColorMapAction.h>
+#include <MRMesh/MRChangeColoringActions.h>
+#include <MRViewer/MRAppendHistory.h>
+#include "MRMesh/MRRegionBoundary.h"
+#include "MRMesh/MRVector.h"
+#include "MRMesh/MRColor.h"
+#include "MRMesh/MRId.h"
+
+namespace MR
+{
+
+std::optional<MeshAttributes> projectMeshAttributes(
+    const ObjectMesh& objectMesh,
+    const MeshPart& mp,
+    ProgressCallback cb )
+{
+    const auto& newMesh = mp.mesh;
+    const auto& oldVertColors = objectMesh.getVertsColorMap();
+    const auto& oldUVCoords = objectMesh.getUVCoords();
+    const auto& oldFaceColorMap = objectMesh.getFacesColorMap();
+    const auto& oldTexturePerFace = objectMesh.getTexturePerFace();
+
+    MeshAttributes newAttribute;
+    if ( !oldUVCoords.empty() )
+    {
+        newAttribute.uvCoords = oldUVCoords;
+        newAttribute.uvCoords.resize( size_t( newMesh.topology.lastValidVert() + 1 ) );
+    }
+    if ( !oldVertColors.empty() )
+    {
+        newAttribute.colorMap = oldVertColors;
+        newAttribute.colorMap.resize( size_t( newMesh.topology.lastValidVert() + 1 ) );
+    }
+    if ( !oldFaceColorMap.empty() )
+    {
+        newAttribute.faceColors = oldFaceColorMap;
+        newAttribute.faceColors.resize( size_t( newMesh.topology.lastValidFace() + 1 ) );
+    }
+    if ( !oldTexturePerFace.empty() )
+    {
+        newAttribute.texturePerFace = oldTexturePerFace;
+        newAttribute.texturePerFace.resize( size_t( newMesh.topology.lastValidFace() + 1 ) );
+    }
+
+    const bool hasFaceAttribs = !oldFaceColorMap.empty() || !oldTexturePerFace.empty();
+    const bool hasVertAttribs = !oldVertColors.empty() || !oldUVCoords.empty();
+
+    auto vertFunc = [&] ( VertId id, const MeshProjectionResult& res, VertId v1, VertId v2, VertId v3 )
+    {
+        if ( !oldVertColors.empty() )
+            newAttribute.colorMap[id] = res.mtp.bary.interpolate( oldVertColors[v1], oldVertColors[v2], oldVertColors[v3] );
+        if ( !oldUVCoords.empty() )
+            newAttribute.uvCoords[id] = res.mtp.bary.interpolate( oldUVCoords[v1], oldUVCoords[v2], oldUVCoords[v3] );
+    };
+
+    auto faceFunc = [&] ( FaceId id, const MeshProjectionResult& res )
+    {
+        if ( !oldFaceColorMap.empty() )
+            newAttribute.faceColors[id] = oldFaceColorMap[res.proj.face];
+        if ( !oldTexturePerFace.empty() )
+            newAttribute.texturePerFace[id] = oldTexturePerFace[res.proj.face];
+    };
+
+    VertBitSet vertRegion;
+    MeshVertPart mvp( newMesh );
+    if ( mp.region )
+    {
+        vertRegion = getIncidentVerts( newMesh.topology, *mp.region );
+        mvp.region = &vertRegion;
+    }
+
+    if ( hasVertAttribs && !projectVertAttribute( mvp, *objectMesh.mesh(), vertFunc, subprogress(cb, 0.0f, hasVertAttribs ? 0.5f : 1.0f)) )
+        return {};
+
+    if ( hasFaceAttribs && !projectFaceAttribute( mp, *objectMesh.mesh(), faceFunc, subprogress( cb, hasVertAttribs ? 0.0f : 0.5f, 1.0f ) ) )
+        return {};
+
+    return newAttribute;
+}
+
+void emplaceMeshAttributes(
+    std::shared_ptr<ObjectMesh> objectMesh,
+    MeshAttributes&& newAttribute )
+{
+    if ( !newAttribute.uvCoords.empty() )
+    {
+        Historian<ChangeMeshUVCoordsAction> htpf( "setUVCoords", objectMesh, std::move( newAttribute.uvCoords ) );
+    }
+    if ( !newAttribute.texturePerFace.empty() )
+    {
+        Historian<ChangeMeshTexturePerFaceAction> htpf( "setTexturePerFace", objectMesh, std::move( newAttribute.texturePerFace ) );
+    }
+    if ( !newAttribute.colorMap.empty() )
+    {
+        Historian<ChangeVertsColorMapAction> htpf( "setVertsColorMap", objectMesh, std::move( newAttribute.colorMap ) );
+    }
+    if ( !newAttribute.faceColors.empty() )
+    {
+        Historian<ChangeFacesColorMapAction> htpf( "setFacesColorMap", objectMesh, std::move( newAttribute.faceColors ) );
+    }
+}
+
+}

--- a/source/MRViewer/MRProjectMeshAttributes.h
+++ b/source/MRViewer/MRProjectMeshAttributes.h
@@ -17,14 +17,14 @@ struct MeshAttributes
     FaceColors faceColors;
 };
 
-// projecting the attributes of the old mesh onto the new
-// returns nullopt if canceled by progress bar
+/// finds attributes of new mesh part by projecting region's faces/vertices on old mesh
+/// returns nullopt if canceled by progress bar
 [[nodiscard]] MRVIEWER_API std::optional<MeshAttributes> projectMeshAttributes(
-    const ObjectMesh& oldMesh,
-    const MeshPart& mp,
+    const ObjectMesh& oldMeshObj,
+    const MeshPart& newMeshPart,
     ProgressCallback cb = {} );
 
-// set new mesh attributes and saving the history of changing mesh attributes
+/// set new mesh attributes and saving the history of changing mesh attributes
 MRVIEWER_API void emplaceMeshAttributes(
     std::shared_ptr<ObjectMesh> objectMesh,
     MeshAttributes&& newAttribute );

--- a/source/MRViewer/MRProjectMeshAttributes.h
+++ b/source/MRViewer/MRProjectMeshAttributes.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "MRViewerFwd.h"
+#include <MRMesh/MRMeshFwd.h>
+#include "MRMesh/MRVector.h"
+
+#include <optional>
+
+namespace MR
+{
+
+struct MeshAttributes
+{
+    VertUVCoords uvCoords;
+    VertColors colorMap;
+
+    TexturePerFace texturePerFace;
+    FaceColors faceColors;
+};
+
+// projecting the attributes of the old mesh onto the new
+// returns nullopt if canceled by progress bar
+[[nodiscard]] MRVIEWER_API std::optional<MeshAttributes> projectMeshAttributes(
+    const ObjectMesh& oldMesh,
+    const MeshPart& mp,
+    ProgressCallback cb = {} );
+
+// set new mesh attributes and saving the history of changing mesh attributes
+MRVIEWER_API void emplaceMeshAttributes(
+    std::shared_ptr<ObjectMesh> objectMesh,
+    MeshAttributes&& newAttribute );
+
+}

--- a/source/MRViewer/MRSurfaceManipulationWidget.cpp
+++ b/source/MRViewer/MRSurfaceManipulationWidget.cpp
@@ -23,6 +23,7 @@
 #include "MRMesh/MRPointsToMeshProjector.h"
 #include "MRMesh/MRRingIterator.h"
 #include "MRMesh/MRParallelFor.h"
+#include "MRProjectMeshAttributes.h"
 
 namespace MR
 {
@@ -226,16 +227,17 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
     pointsShift_.clear();
     pointsShift_.resize( numV, 0.f );
 
-    auto & mesh = *obj_->varMesh();
+    const auto & oldMesh = *obj_->varMesh();
     if ( settings_.workMode == WorkMode::Patch )
     {
-        auto faces = getIncidentFaces( mesh.topology, generalEditingRegion_ );
+        auto faces = getIncidentFaces( oldMesh.topology, generalEditingRegion_ );
         if ( faces.any() )
         {
+            SCOPED_HISTORY( "Brush: Patch" );
             ownMeshChangedSignal_ = true;
-            AppendHistory<ChangeMeshAction>( "Brush: Patch", obj_ );
-            auto bds = delRegionKeepBd( mesh, faces );
-            VertBitSet stableVerts = mesh.topology.getValidVerts();
+            std::shared_ptr<Mesh> newMesh = std::make_shared<Mesh>( oldMesh );
+            auto bds = delRegionKeepBd( *newMesh, faces );
+            VertBitSet stableVerts = newMesh->topology.getValidVerts();
             stableVerts -= generalEditingRegion_;
             for ( const auto & bd : bds )
             {
@@ -243,26 +245,34 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
                     continue;
                 // assert( isHoleBd( mesh.topology, bd ) ) can probably fail due to different construction of loops,
                 // so we check every edge of every loop below
-                const auto len = calcPathLength( bd, mesh );
+                const auto len = calcPathLength( bd, *newMesh );
                 const auto avgLen = len / bd.size();
                 FillHoleNicelySettings settings
                 {
                     .triangulateParams =
                     {
-                        .metric = getUniversalMetric( mesh ),
+                        .metric = getUniversalMetric( *newMesh ),
                         .multipleEdgesResolveMode = FillHoleParams::MultipleEdgesResolveMode::Strong
                     },
                     .maxEdgeLen = 2 * (float)avgLen,
                     .edgeWeights = settings_.edgeWeights
                 };
                 for ( auto e : bd )
-                    if ( !mesh.topology.left( e ) )
-                        fillHoleNicely( mesh, e, settings );
+                    if ( !newMesh->topology.left( e ) )
+                        fillHoleNicely( *newMesh, e, settings );
             }
 
-            VertBitSet newVerts = mesh.topology.getValidVerts();
+            VertBitSet newVerts = newMesh->topology.getValidVerts();
             newVerts -= stableVerts;
-            reallocData_( mesh.topology.lastValidVert() + 1 );
+
+            FaceBitSet newFaces = getInnerFaces( newMesh->topology, newVerts );
+            auto meshAttribs = projectMeshAttributes( *obj_, MeshPart( *newMesh, &newFaces ) );
+
+            Historian<ChangeMeshAction>( "mesh", obj_, newMesh );
+            if ( meshAttribs )
+                emplaceMeshAttributes( obj_, std::move( *meshAttribs ) );
+
+            reallocData_( obj_->mesh()->topology.lastValidVert() + 1);
             updateValueChangesByDistance_( newVerts );
             obj_->setDirtyFlags( DIRTY_ALL );
 
@@ -279,7 +289,7 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
         params.region = &generalEditingRegion_;
         params.force = settings_.relaxForceAfterEdit;
         params.iterations = 5;
-        relax( mesh, params );
+        relax( *obj_->varMesh(), params );
         updateValueChangesByDistance_( generalEditingRegion_ );
         obj_->setDirtyFlags( DIRTY_POSITION );
     }

--- a/source/MRViewer/MRViewer.vcxproj
+++ b/source/MRViewer/MRViewer.vcxproj
@@ -39,6 +39,7 @@
     <ClCompile Include="MRMoveObjectByMouseImpl.cpp" />
     <ClCompile Include="MRObjectImGuiLabel.cpp" />
     <ClCompile Include="MRPointsShader.cpp" />
+    <ClCompile Include="MRProjectMeshAttributes.cpp" />
     <ClCompile Include="MRRenderDefaultObjects.cpp" />
     <ClCompile Include="MRRibbonNotification.cpp" />
     <ClCompile Include="MRRibbonSceneObjectsListDrawer.cpp" />
@@ -171,6 +172,7 @@
     <ClInclude Include="MRNotificationType.h" />
     <ClInclude Include="MRObjectImGuiLabel.h" />
     <ClInclude Include="MRPointsShader.h" />
+    <ClInclude Include="MRProjectMeshAttributes.h" />
     <ClInclude Include="MRRibbonNotification.h" />
     <ClInclude Include="MRRibbonSceneObjectsListDrawer.h" />
     <ClInclude Include="MRUISaveChangesPopup.h" />

--- a/source/MRViewer/MRViewer.vcxproj.filters
+++ b/source/MRViewer/MRViewer.vcxproj.filters
@@ -445,6 +445,9 @@
     <ClCompile Include="SceneReorder.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRProjectMeshAttributes.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ImGuiHelpers.h">
@@ -871,6 +874,9 @@
     </ClInclude>
     <ClInclude Include="SceneReorder.h">
       <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MRProjectMeshAttributes.h">
+      <Filter>Helpers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
1. Introduce `MeshRegion<T>` and unify `MeshPart` and `MeshVertPart`
2. Support `MeshRegion` in attributes projection function
3. Project new vertices attributes after Patch