### PR TITLE
LoadedObjects

### DIFF
--- a/source/MRIOExtras/MRE57.cpp
+++ b/source/MRIOExtras/MRE57.cpp
@@ -269,13 +269,14 @@ Expected<PointCloud> fromE57( std::istream&, const PointsLoadSettings& )
 
 MR_ADD_POINTS_LOADER( IOFilter( "E57 (.e57)", "*.e57" ), fromE57 )
 
-Expected<std::vector<std::shared_ptr<Object>>> loadObjectFromE57( const std::filesystem::path& path, std::string*, ProgressCallback cb )
+Expected<LoadedObjects> loadObjectFromE57( const std::filesystem::path& path, const ProgressCallback& cb )
 {
     return fromSceneE57File( path, { .progress = std::move( cb ) } )
     .transform( [&path] ( std::vector<NamedCloud>&& nclouds )
     {
-        std::vector<std::shared_ptr<Object>> objects( nclouds.size() );
-        for ( int i = 0; i < objects.size(); ++i )
+        LoadedObjects res;
+        res.objs.resize( nclouds.size() );
+        for ( int i = 0; i < res.objs.size(); ++i )
         {
             auto objectPoints = std::make_shared<ObjectPoints>();
             if ( nclouds[i].name.empty() || nclouds.size() <= 1 ) // if only one cloud in file, then take name from file
@@ -290,9 +291,9 @@ Expected<std::vector<std::shared_ptr<Object>>> loadObjectFromE57( const std::fil
                 objectPoints->setVertsColorMap( std::move( nclouds[i].colors ) );
                 objectPoints->setColoringType( ColoringType::VertsColorMap );
             }
-            objects[i] = std::dynamic_pointer_cast< Object >( std::move( objectPoints ) );
+            res.objs[i] = std::dynamic_pointer_cast< Object >( std::move( objectPoints ) );
         }
-        return objects;
+        return res;
     } );
 }
 

--- a/source/MRIOExtras/MRE57.h
+++ b/source/MRIOExtras/MRE57.h
@@ -45,9 +45,7 @@ MRIOEXTRAS_API Expected<PointCloud> fromE57( const std::filesystem::path& file,
                                              const PointsLoadSettings& settings = {} );
 MRIOEXTRAS_API Expected<PointCloud> fromE57( std::istream& in, const PointsLoadSettings& settings = {} );
 
-MRIOEXTRAS_API Expected<std::vector<std::shared_ptr<Object>>> loadObjectFromE57( const std::filesystem::path& path,
-                                                                                 std::string* warnings = nullptr,
-                                                                                 ProgressCallback cb = {} );
+MRIOEXTRAS_API Expected<LoadedObjects> loadObjectFromE57( const std::filesystem::path& path, const ProgressCallback& cb = {} );
 
 } // namespace MR::PointsLoad
 #endif

--- a/source/MRIOExtras/MRE57.h
+++ b/source/MRIOExtras/MRE57.h
@@ -9,6 +9,7 @@
 #include <MRMesh/MRExpected.h>
 #include <MRMesh/MRPointCloud.h>
 #include <MRMesh/MRPointsLoadSettings.h>
+#include <MRMesh/MRLoadedObjects.h>
 
 #include <filesystem>
 #include <string>

--- a/source/MRMesh/MRIOFormatsRegistry.h
+++ b/source/MRMesh/MRIOFormatsRegistry.h
@@ -321,7 +321,7 @@ namespace AsyncObjectLoad
 {
 
 using PostLoadCallback = std::function<void ( Expected<LoadedObjects> )>;
-using ObjectLoader = void( * )( const std::filesystem::path&, PostLoadCallback, ProgressCallback );
+using ObjectLoader = void( * )( const std::filesystem::path&, PostLoadCallback, const ProgressCallback& );
 
 MR_FORMAT_REGISTRY_DECL( ObjectLoader )
 

--- a/source/MRMesh/MRIOFormatsRegistry.h
+++ b/source/MRMesh/MRIOFormatsRegistry.h
@@ -7,6 +7,7 @@
 #include "MROnInit.h"
 #include "MRPointsLoadSettings.h"
 #include "MRSaveSettings.h"
+#include "MRLoadedObjects.h"
 
 #include <filesystem>
 #include <map>

--- a/source/MRMesh/MRIOFormatsRegistry.h
+++ b/source/MRMesh/MRIOFormatsRegistry.h
@@ -292,12 +292,10 @@ MR_ON_INIT { using namespace MR::ImageSave; setImageSaver( filter, saver, priori
 
 } // namespace ImageSave
 
-using ObjectPtr = std::shared_ptr<Object>;
-
 namespace ObjectLoad
 {
 
-using ObjectLoader = Expected<std::vector<ObjectPtr>>( * )( const std::filesystem::path&, std::string*, ProgressCallback );
+using ObjectLoader = Expected<LoadedObjects>( * )( const std::filesystem::path&, const ProgressCallback& );
 
 MR_FORMAT_REGISTRY_DECL( ObjectLoader )
 
@@ -321,8 +319,8 @@ MR_ON_INIT { using namespace MR::ObjectSave; setObjectSaver( filter, saver ); };
 namespace AsyncObjectLoad
 {
 
-using PostLoadCallback = std::function<void ( Expected<std::vector<ObjectPtr>> )>;
-using ObjectLoader = void( * )( const std::filesystem::path&, std::string*, PostLoadCallback, ProgressCallback );
+using PostLoadCallback = std::function<void ( Expected<LoadedObjects> )>;
+using ObjectLoader = void( * )( const std::filesystem::path&, PostLoadCallback, ProgressCallback );
 
 MR_FORMAT_REGISTRY_DECL( ObjectLoader )
 

--- a/source/MRMesh/MRLoadedObjects.h
+++ b/source/MRMesh/MRLoadedObjects.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "MRMeshFwd.h"
+#include <memory>
+
+namespace MR
+{
+
+using ObjectPtr = std::shared_ptr<Object>;
+
+/// results of loading e.g. from a file
+struct LoadedObjects
+{
+    std::vector<ObjectPtr> objs;
+    std::string warnings;
+};
+
+} //namespace MR

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -44,6 +44,7 @@
     <ClInclude Include="MRImproveSampling.h" />
     <ClInclude Include="MRIterativeSampling.h" />
     <ClInclude Include="MRLevelOfDetails.h" />
+    <ClInclude Include="MRLoadedObjects.h" />
     <ClInclude Include="MRLocalTriangulations.h" />
     <ClInclude Include="MRMapping.h" />
     <ClInclude Include="MRMeshAttributesToUpdate.h" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1230,6 +1230,9 @@
     <ClInclude Include="MRSignDetectionMode.h">
       <Filter>Source Files\Mesh</Filter>
     </ClInclude>
+    <ClInclude Include="MRLoadedObjects.h">
+      <Filter>Source Files\IO</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRObject.cpp">

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -51,6 +51,7 @@
 
 
 #include <array>
+#include <memory>
 #include <vector>
 #include <string>
 #include <parallel_hashmap/phmap_fwd_decl.h>
@@ -561,6 +562,15 @@ class PlaneObject;
 class SphereObject;
 class CylinderObject;
 class ConeObject;
+
+using ObjectPtr = std::shared_ptr<Object>;
+
+/// results of loading from a file
+struct LoadedObjects
+{
+    std::vector<ObjectPtr> objs;
+    std::string warnings;
+};
 
 struct Image;
 class AnyVisualizeMaskEnum;

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -51,7 +51,6 @@
 
 
 #include <array>
-#include <memory>
 #include <vector>
 #include <string>
 #include <parallel_hashmap/phmap_fwd_decl.h>
@@ -563,14 +562,7 @@ class SphereObject;
 class CylinderObject;
 class ConeObject;
 
-using ObjectPtr = std::shared_ptr<Object>;
-
-/// results of loading from a file
-struct LoadedObjects
-{
-    std::vector<ObjectPtr> objs;
-    std::string warnings;
-};
+struct LoadedObjects;
 
 struct Image;
 class AnyVisualizeMaskEnum;

--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -960,26 +960,24 @@ Expected<LoadedObjects> loadObjectFromObj( const std::filesystem::path& file, co
             totalDuplicatedVertexCount += result.duplicatedVertexCount;
         }
 
-        const auto makeWarningString = [] ( int skippedFaceCount, int duplicatedVertexCount, int holesCount )
+        if ( totalSkippedFaceCount )
         {
-            std::string res;
-            if ( skippedFaceCount )
-                res = fmt::format( "{} triangles were skipped as inconsistent with others.", skippedFaceCount );
-            if ( duplicatedVertexCount )
-            {
-                if ( !res.empty() )
-                    res += '\n';
-                res += fmt::format( "{} vertices were duplicated to make them manifold.", duplicatedVertexCount );
-            }
-            if ( holesCount )
-            {
-                if ( !res.empty() )
-                    res += '\n';
-                res += fmt::format( "The objects contains {} holes. Please consider using Fill Holes tool.", holesCount );
-            }
-            return res;
-        };
-        res.warnings = makeWarningString( totalSkippedFaceCount, totalDuplicatedVertexCount, holesCount );
+            if ( !res.warnings.empty() )
+                res.warnings += '\n';
+            res.warnings = fmt::format( "{} triangles were skipped as inconsistent with others.", totalSkippedFaceCount );
+        }
+        if ( totalDuplicatedVertexCount )
+        {
+            if ( !res.warnings.empty() )
+                res.warnings += '\n';
+            res.warnings += fmt::format( "{} vertices were duplicated to make them manifold.", totalDuplicatedVertexCount );
+        }
+        if ( holesCount )
+        {
+            if ( !res.warnings.empty() )
+                res.warnings += '\n';
+            res.warnings += fmt::format( "The objects contain {} holes. Please consider using Fill Holes tool.", holesCount );
+        }
         return res;
     } );
 }

--- a/source/MRMesh/MRMeshLoadObj.h
+++ b/source/MRMesh/MRMeshLoadObj.h
@@ -6,6 +6,7 @@
 #include "MRExpected.h"
 #include "MRMeshLoadSettings.h"
 #include "MRAffineXf3.h"
+#include "MRLoadedObjects.h"
 #include <filesystem>
 #include <istream>
 #include <string>

--- a/source/MRMesh/MRMeshLoadObj.h
+++ b/source/MRMesh/MRMeshLoadObj.h
@@ -67,9 +67,8 @@ MRMESH_API Expected<std::vector<NamedMesh>> fromSceneObjFile( std::istream& in, 
 MRMESH_API Expected<std::vector<NamedMesh>> fromSceneObjFile( const char* data, size_t size, bool combineAllObjects, const std::filesystem::path& dir,
                                                                            const ObjLoadSettings& settings = {} );
 
-MRMESH_API Expected<std::vector<std::shared_ptr<Object>>> loadObjectFromObj( const std::filesystem::path& results,
-                                                                             std::string* warnings = nullptr,
-                                                                             ProgressCallback cb = {} );
+/// reads all objects from .OBJ file
+MRMESH_API Expected<LoadedObjects> loadObjectFromObj( const std::filesystem::path& file, const ProgressCallback& cb = {} );
 
 } // namespace MeshLoad
 

--- a/source/MRMesh/MRObjectLoad.cpp
+++ b/source/MRMesh/MRObjectLoad.cpp
@@ -317,46 +317,47 @@ Expected<ObjectGcode> makeObjectGcodeFromFile( const std::filesystem::path& file
     return objectGcode;
 }
 
-Expected<std::vector<std::shared_ptr<MR::Object>>> loadObjectFromFile( const std::filesystem::path& filename,
-                                                                       std::string* loadWarn, ProgressCallback callback )
+Expected<LoadedObjects> loadObjectFromFile( const std::filesystem::path& filename, const ProgressCallback& callback )
 {
     if ( callback && !callback( 0.f ) )
         return unexpected( std::string( "Loading canceled" ) );
 
-    Expected<std::vector<std::shared_ptr<Object>>> result;
+    Expected<LoadedObjects> result;
     bool loadedFromSceneFile = false;
 
     auto ext = std::string( "*" ) + utf8string( filename.extension().u8string() );
     for ( auto& c : ext )
-        c = ( char )tolower( c );   
+        c = ( char )tolower( c );
     
     if ( findFilter( SceneLoad::getFilters(), ext ) )
     {
-        const auto objTree = loadSceneFromAnySupportedFormat( filename, loadWarn, callback );
+        std::string loadWarn;
+        const auto objTree = loadSceneFromAnySupportedFormat( filename, &loadWarn, callback );
         if ( !objTree.has_value() )
             return unexpected( objTree.error() );
-        
-        result = std::vector( { *objTree } );
-        ( *result )[0]->setName( utf8string( filename.stem() ) );
+
+        ( *objTree )->setName( utf8string( filename.stem() ) );
+        result = LoadedObjects{ .objs = { *objTree }, .warnings = std::move( loadWarn ) };
         loadedFromSceneFile = true;
     }
     else if ( const auto filter = findFilter( ObjectLoad::getFilters(), ext ) )
     {
         const auto loader = ObjectLoad::getObjectLoader( *filter );
-        result = loader( filename, loadWarn, std::move( callback ) );
+        result = loader( filename, callback );
     }
     else
     {
+        std::string loadWarn;
         MeshLoadInfo info
         {
-            .warnings = loadWarn,
+            .warnings = &loadWarn,
             .callback = callback
         };
         auto object = makeObjectFromMeshFile( filename, info );
         if ( object && *object )
         {
             (*object)->select( true );
-            result = { *object };
+            result = LoadedObjects{ .objs = { *object }, .warnings = std::move( loadWarn ) };
         }
         else if ( object.error() == "Loading canceled" )
         {
@@ -371,7 +372,7 @@ Expected<std::vector<std::shared_ptr<MR::Object>>> loadObjectFromFile( const std
             {
                 objectPoints->select( true );
                 auto obj = std::make_shared<ObjectPoints>( std::move( objectPoints.value() ) );
-                result = { obj };
+                result = LoadedObjects{ .objs = { obj }, .warnings = std::move( loadWarn ) };
             }
             else if ( result.error() == "unsupported file extension" )
             {
@@ -382,7 +383,7 @@ Expected<std::vector<std::shared_ptr<MR::Object>>> loadObjectFromFile( const std
                 {
                     objectLines->select( true );
                     auto obj = std::make_shared<ObjectLines>( std::move( objectLines.value() ) );
-                    result = { obj };
+                    result = LoadedObjects{ .objs = { obj }, .warnings = std::move( loadWarn ) };
                 }
                 else if ( result.error() == "unsupported file extension" )
                 {
@@ -393,7 +394,7 @@ Expected<std::vector<std::shared_ptr<MR::Object>>> loadObjectFromFile( const std
                     {
                         objectDistanceMap->select( true );
                         auto obj = std::make_shared<ObjectDistanceMap>( std::move( objectDistanceMap.value() ) );
-                        result = { obj };
+                        result = LoadedObjects{ .objs = { obj }, .warnings = std::move( loadWarn ) };
                     }
                     else if ( result.error() == "unsupported file extension" )
                     {
@@ -404,7 +405,7 @@ Expected<std::vector<std::shared_ptr<MR::Object>>> loadObjectFromFile( const std
                         {
                             objectGcode->select( true );
                             auto obj = std::make_shared<ObjectGcode>( std::move( objectGcode.value() ) );
-                            result = { obj };
+                            result = LoadedObjects{ .objs = { obj }, .warnings = std::move( loadWarn ) };
                         }
                         else
                         {
@@ -417,15 +418,15 @@ Expected<std::vector<std::shared_ptr<MR::Object>>> loadObjectFromFile( const std
     }
 
     if ( result.has_value() && !loadedFromSceneFile )
-        for ( const std::shared_ptr<Object>& o : result.value() )
+        for ( const std::shared_ptr<Object>& o : result->objs )
         {
             postImportObject( o, filename );
-            if ( auto objectPoints = o->asType<ObjectPoints>(); objectPoints && loadWarn )
+            if ( auto objectPoints = o->asType<ObjectPoints>(); objectPoints )
             {
                 if ( !objectPoints->pointCloud()->hasNormals() )
-                    *loadWarn += "Point cloud " + o->name() + " has no normals.\n";
+                    result->warnings += "Point cloud " + o->name() + " has no normals.\n";
                 if ( objectPoints->getRenderDiscretization() > 1 )
-                    *loadWarn += "Point cloud " + o->name() + " has too many points in PointCloud:\n"
+                    result->warnings += "Point cloud " + o->name() + " has too many points in PointCloud:\n"
                     "Visualization is simplified (only part of the points is drawn)\n";
             }
         }
@@ -535,7 +536,7 @@ Expected<Object> makeObjectTreeFromFolder( const std::filesystem::path & folder,
         return unexpected( std::string( "Error: folder is empty." ) );
 
 
-    using loadObjResultType = Expected<std::vector<std::shared_ptr<MR::Object>>>;
+    using loadObjResultType = Expected<LoadedObjects>;
     // create folders objects
     struct LoadTask
     {
@@ -560,9 +561,9 @@ Expected<Object> makeObjectTreeFromFolder( const std::filesystem::path & folder,
         }
         for ( const FilePathNode& file : node.files )
         {
-            loadTasks.emplace_back( std::async( std::launch::async, [&] ()
+            loadTasks.emplace_back( std::async( std::launch::async, [filepath = file.path, &loadingCanceled] ()
             {
-                return loadObjectFromFile( file.path, loadWarn, [&]( float ){ return !loadingCanceled; } );
+                return loadObjectFromFile( filepath, [&loadingCanceled]( float ){ return !loadingCanceled; } );
             } ), objPtr );
         }
     };
@@ -589,9 +590,14 @@ Expected<Object> makeObjectTreeFromFolder( const std::filesystem::path & folder,
             auto res = t.future.get();
             if ( res.has_value() )
             {
-                for ( const auto& objPtr : *res )
-                {
+                for ( const auto& objPtr : res->objs )
                     t.parent->addChild( objPtr );
+                if ( loadWarn && !res->warnings.empty() )
+                {
+                    if ( loadWarn->empty() )
+                        *loadWarn = res->warnings;
+                    else
+                        *loadWarn += '\n' + res->warnings;
                 }
                 if ( !atLeastOneLoaded )
                     atLeastOneLoaded = true;

--- a/source/MRMesh/MRObjectLoad.h
+++ b/source/MRMesh/MRObjectLoad.h
@@ -42,13 +42,10 @@ MRMESH_API Expected<ObjectDistanceMap> makeObjectDistanceMapFromFile( const std:
 MRMESH_API Expected<ObjectGcode> makeObjectGcodeFromFile( const std::filesystem::path& file, ProgressCallback callback = {} );
 
 /**
- * \brief load object (mesh, lines, points, voxels or scene) from file
- * \param loadWarn - string that collect warning messages
+ * \brief load all objects (or any type: mesh, lines, points, voxels or scene) from file
  * \param callback - callback function to set progress (for progress bar)
- * \return empty string if no error or error text
  */
-MRMESH_API Expected<std::vector<std::shared_ptr<Object>>> loadObjectFromFile( const std::filesystem::path& filename,
-                                                                                           std::string* loadWarn = nullptr, ProgressCallback callback = {} );
+MRMESH_API Expected<LoadedObjects> loadObjectFromFile( const std::filesystem::path& filename, const ProgressCallback& callback = {} );
 
 // check if there are any supported files folder and subfolders
 MRMESH_API bool isSupportedFileInSubfolders( const std::filesystem::path& folder );

--- a/source/MRMesh/MRObjectLoad.h
+++ b/source/MRMesh/MRObjectLoad.h
@@ -6,6 +6,7 @@
 #include "MRExpected.h"
 #include "MRMeshLoadSettings.h"
 #include "MRUniqueTemporaryFolder.h"
+#include "MRLoadedObjects.h"
 
 #include <filesystem>
 

--- a/source/MRVoxels/MRVoxelsLoad.cpp
+++ b/source/MRVoxels/MRVoxelsLoad.cpp
@@ -586,8 +586,7 @@ Expected<std::vector<std::shared_ptr<ObjectVoxels>>> makeObjectVoxelsFromFile( c
 
 Expected<LoadedObjects> makeObjectFromVoxelsFile( const std::filesystem::path& file, const ProgressCallback& callback )
 {
-    return makeObjectVoxelsFromFile( file, std::move( callback ) )
-        .transform( VoxelsLoad::toObjects );
+    return makeObjectVoxelsFromFile( file, callback ).transform( VoxelsLoad::toObjects );
 }
 
 } // namespace MR

--- a/source/MRVoxels/MRVoxelsLoad.cpp
+++ b/source/MRVoxels/MRVoxelsLoad.cpp
@@ -277,20 +277,20 @@ Expected<std::vector<std::shared_ptr<ObjectVoxels>>> toObjectVoxels( const std::
     return res;
 }
 
-std::vector<std::shared_ptr<Object>> toObjects( std::vector<std::shared_ptr<ObjectVoxels>>&& voxels )
+LoadedObjects toObjects( std::vector<std::shared_ptr<ObjectVoxels>>&& voxels )
 {
-    std::vector<std::shared_ptr<Object>> results;
-    results.reserve( voxels.size() );
+    LoadedObjects res;
+    res.objs.reserve( voxels.size() );
     for ( auto&& objVoxels : voxels )
     {
         objVoxels->select( true );
-        results.emplace_back( std::move( objVoxels ) );
+        res.objs.emplace_back( std::move( objVoxels ) );
     }
-    return results;
+    return res;
 }
 
 template <VoxelsLoader voxelsLoader>
-Expected<std::vector<std::shared_ptr<Object>>> toObjectLoader( const std::filesystem::path& path, std::string*, ProgressCallback cb )
+Expected<LoadedObjects> toObjectLoader( const std::filesystem::path& path, const ProgressCallback& cb )
 {
     return voxelsLoader( path, subprogress( cb, 0.f, 1.f / 3.f ) )
         .and_then( [&] ( auto&& volumes ) { return toObjectVoxels( volumes, path, subprogress( cb, 1.f / 3.f, 1.f ) ); } )
@@ -584,7 +584,7 @@ Expected<std::vector<std::shared_ptr<ObjectVoxels>>> makeObjectVoxelsFromFile( c
         .and_then( [&] ( auto&& volumes ) { return VoxelsLoad::toObjectVoxels( volumes, file, subprogress( callback, 1.f / 3.f, 1.f ) ); } );
 }
 
-Expected<std::vector<std::shared_ptr<Object>>> makeObjectFromVoxelsFile( const std::filesystem::path& file, std::string*, ProgressCallback callback )
+Expected<LoadedObjects> makeObjectFromVoxelsFile( const std::filesystem::path& file, const ProgressCallback& callback )
 {
     return makeObjectVoxelsFromFile( file, std::move( callback ) )
         .transform( VoxelsLoad::toObjects );

--- a/source/MRVoxels/MRVoxelsLoad.h
+++ b/source/MRVoxels/MRVoxelsLoad.h
@@ -90,6 +90,6 @@ MR_FORMAT_REGISTRY_EXTERNAL_DECL( MRVOXELS_API, VoxelsLoader )
 /// loads voxels from given file in new object
 MRVOXELS_API Expected<std::vector<std::shared_ptr<ObjectVoxels>>> makeObjectVoxelsFromFile( const std::filesystem::path& file, ProgressCallback callback = {} );
 
-MRVOXELS_API Expected<std::vector<std::shared_ptr<Object>>> makeObjectFromVoxelsFile( const std::filesystem::path& file, std::string* warnings = nullptr, ProgressCallback callback = {} );
+MRVOXELS_API Expected<LoadedObjects> makeObjectFromVoxelsFile( const std::filesystem::path& file, const ProgressCallback& callback = {} );
 
 }

--- a/source/MRVoxels/MRVoxelsLoad.h
+++ b/source/MRVoxels/MRVoxelsLoad.h
@@ -5,6 +5,7 @@
 
 #include "MRMesh/MRIOFormatsRegistry.h"
 #include "MRMesh/MRObject.h"
+#include <MRMesh/MRLoadedObjects.h>
 
 #include <filesystem>
 


### PR DESCRIPTION
* `struct LoadedObjects` in `MRLoadedObjects.h`.
* all loading functions return `Expected<LoadedObjects>` and do not get optional parameter `warnings`, which is inside `LoadedObjects` now.
* Fix unsafe access to `loadWarn` from many `async`'s in `makeObjectTreeFromFolder` function.