### PR TITLE
SurfaceContoursWidget::AddRemovePointHistoryAction

### DIFF
--- a/source/MRViewer/MRSurfaceContoursWidget.h
+++ b/source/MRViewer/MRSurfaceContoursWidget.h
@@ -175,8 +175,7 @@ private:
     bool undoRedoMode_{ false };
 
     // History classes:
-    class AddPointActionPickerPoint;
-    class RemovePointActionPickerPoint;
+    class AddRemovePointHistoryAction;
     class ChangePointActionPickerPoint;
     class SurfaceContoursWidgetClearAction;
 };


### PR DESCRIPTION
* One `AddRemovePointHistoryAction` instead of two `AddPointActionPickerPoint` and `RemovePointActionPickerPoint`
* Also remove all places where points are added/deleted except for `AddRemovePointHistoryAction`