### PR TITLE
SurfaceContoursWidget: fix deletion of point being dragged

### DIFF
--- a/source/MRViewer/MRSurfaceContoursWidget.h
+++ b/source/MRViewer/MRSurfaceContoursWidget.h
@@ -139,7 +139,9 @@ private:
 
     // SurfaceContoursWidget internal variables
     bool moveClosedPoint_ = false;
-    bool activeChange_ = false;
+
+    // pick sphere currently dragged by mouse
+    const VisualObject * draggedPickSphere_ = nullptr;
 
     // active point
     int activeIndex_{ 0 };
@@ -148,8 +150,8 @@ private:
     // data storage
     SurfaceContours pickedPoints_;
 
-    // all objects created in createPickWidget_ to quickly differentiate them from other features
-    HashSet<const VisualObject*> myPickWidgets_;
+    // all spheres created in createPickWidget_ to quickly differentiate them from other features
+    HashSet<const VisualObject*> myPickSpheres_;
 
     // connection storage
     struct SurfaceConnectionHolder

--- a/source/MRViewer/MRSurfacePointPicker.cpp
+++ b/source/MRViewer/MRSurfacePointPicker.cpp
@@ -146,7 +146,7 @@ bool SurfacePointWidget::onMouseDown_( Viewer::MouseButton button, int mod )
     pickSphere_->setFrontColor( params_.activeColor, false );
     pickSphere_->setBackColor( pickSphere_->getFrontColor( false ) );
     if ( startMove_ )
-        startMove_( currentPos_ );
+        startMove_( *this, currentPos_ );
     return true;
 }
 
@@ -159,7 +159,7 @@ bool SurfacePointWidget::onMouseUp_( Viewer::MouseButton button, int )
     pickSphere_->setFrontColor( params_.baseColor, false );
     pickSphere_->setBackColor( pickSphere_->getFrontColor( false ) );
     if ( endMove_ )
-        endMove_( currentPos_ );
+        endMove_( *this, currentPos_ );
     return true;
 }
 
@@ -177,7 +177,7 @@ bool SurfacePointWidget::onMouseMove_( int, int )
         currentPos_ = pointOnObjectToPickedPoint( obj.get(), pick );
         updatePositionAndRadius_();
         if ( onMove_ )
-            onMove_( currentPos_ );
+            onMove_( *this, currentPos_ );
         return true;
     }
     else

--- a/source/MRViewer/MRSurfacePointPicker.h
+++ b/source/MRViewer/MRSurfacePointPicker.h
@@ -61,7 +61,7 @@ public:
     // resets whole widget
     MRVIEWER_API void reset();
     // returns object of control sphere
-    std::shared_ptr<SphereObject> getPickSphere() const
+    const std::shared_ptr<SphereObject>& getPickSphere() const
     {
         return pickSphere_;
     }
@@ -118,17 +118,17 @@ public:
     MRVIEWER_API void swapCurrentPosition( PickedPoint& pos );
 
     // this callback is called when modification starts if it is set
-    void setStartMoveCallback( std::function<void( const PickedPoint& )> startMove )
+    void setStartMoveCallback( std::function<void( SurfacePointWidget &, const PickedPoint& )> startMove )
     {
         startMove_ = startMove;
     }
     // this callback is called on modification if it is set
-    void setOnMoveCallback( std::function<void( const PickedPoint& )> onMove )
+    void setOnMoveCallback( std::function<void( SurfacePointWidget &, const PickedPoint& )> onMove )
     {
         onMove_ = onMove;
     }
     // this callback is called when modification ends if it is set
-    void setEndMoveCallback( std::function<void( const PickedPoint& )> endMove )
+    void setEndMoveCallback( std::function<void( SurfacePointWidget &, const PickedPoint& )> endMove )
     {
         endMove_ = endMove;
     }
@@ -168,9 +168,9 @@ private:
 
     boost::signals2::scoped_connection onBaseObjectWorldXfChanged_;
 
-    std::function<void( const PickedPoint& )> startMove_;
-    std::function<void( const PickedPoint& )> onMove_;
-    std::function<void( const PickedPoint& )> endMove_;
+    std::function<void( SurfacePointWidget &, const PickedPoint& )> startMove_;
+    std::function<void( SurfacePointWidget &, const PickedPoint& )> onMove_;
+    std::function<void( SurfacePointWidget &, const PickedPoint& )> endMove_;
 
     // Depending on the type of selected size, sets the point size
     void setPointRadius_();


### PR DESCRIPTION
Fix the scenario when a point being dragged is deleted by undo action. Previously it resulted in disabling the selection of active point under cursor and inability to move them.