### PR TITLE
SurfaceContoursWidget::colorLast2Points_

### DIFF
--- a/source/MRViewer/MRSurfaceContoursWidget.h
+++ b/source/MRViewer/MRSurfaceContoursWidget.h
@@ -45,7 +45,7 @@ public:
 
         // Color for the last modified point in the contour
         // Parameters affect to future points only
-        MR::Color lastPoitColor = Color::green();
+        MR::Color lastPointColor = Color::green();
 
         // Color for the special point used to close a contour. Better do not change it.
         // Parameters affect to future points only
@@ -102,13 +102,9 @@ public:
     // check whether the contour is closed for a particular object.
     [[nodiscard]] MRVIEWER_API bool isClosedCountour( const std::shared_ptr<VisualObject>& obj ) const;
 
-    // Correctly selects the last point in the contours.
-    // If obj == nullptr then the check will be in all circuits.
-    // If specified, then only in the contour on specified object
-    MRVIEWER_API void highlightLastPoint( const std::shared_ptr<VisualObject>& obj );
-
     // shared variables. which need getters and setters.
-    [[nodiscard]] MRVIEWER_API std::pair <std::shared_ptr<MR::VisualObject>, int > getActivePoint() const;
+    [[nodiscard]] MRVIEWER_API std::pair<const std::shared_ptr<MR::VisualObject> &, int> getActivePoint() const { return { activeObject_, activeIndex_ }; }
+
     MRVIEWER_API void setActivePoint( std::shared_ptr<MR::VisualObject> obj, int index );
 
     /// Get the active (the latest picked/moved) surface point widget.
@@ -133,6 +129,10 @@ private:
     MRVIEWER_API bool onMouseMove_( int mouse_x, int mouse_y ) override;
 
     ObjAndPick pick_() const;
+
+    /// sets the color of last and pre-last pick spheres for given object;
+    /// the colors are taken from parameters
+    void colorLast2Points_( const std::shared_ptr<VisualObject>& obj );
 
     // creates point widget for add to contour.
     [[nodiscard]] std::shared_ptr<SurfacePointWidget> createPickWidget_( const std::shared_ptr<MR::VisualObject>& obj, const PickedPoint& pt );

--- a/source/MRViewer/MRSurfacePointPicker.cpp
+++ b/source/MRViewer/MRSurfacePointPicker.cpp
@@ -115,6 +115,18 @@ void SurfacePointWidget::setParameters( const Parameters& params )
     params_ = params;
 }
 
+void SurfacePointWidget::setBaseColor( const Color& color )
+{
+    if ( params_.baseColor == color )
+        return;
+    params_.baseColor = color;
+    if ( pickSphere_ )
+    {
+        pickSphere_->setFrontColor( color, false );
+        pickSphere_->setBackColor( color );
+    }
+}
+
 void SurfacePointWidget::updateParameters( const std::function<void( Parameters& )>& visitor )
 {
     auto params = params_;

--- a/source/MRViewer/MRSurfacePointPicker.h
+++ b/source/MRViewer/MRSurfacePointPicker.h
@@ -70,8 +70,13 @@ public:
     {
         return params_;
     }
+
     // set parameters for this widget
     MRVIEWER_API void setParameters( const Parameters& params );
+
+    // set baseColor parameter for this widget
+    MRVIEWER_API void setBaseColor( const Color& color );
+
     /// Update the widget parameters.
     /// \param visitor - the function that takes the widget parameters and modifies them. Then the parameters are applied by \ref setParameters.
     MRVIEWER_API void updateParameters( const std::function<void ( Parameters& )>& visitor );


### PR DESCRIPTION
* Public `highlightLastPoint` method made private with the name `colorLast2Points_`, comment updated
* The places of its usage were commented
* `getActivePoint` method become `inline` and without extra `shared_ptr` copy
* Spelling: `lastPoitColor` -> `lastPointColor`