### PR TITLE
SurfaceContoursWidget: remove "active point"

### DIFF
--- a/source/MRViewer/MRSurfaceContoursWidget.cpp
+++ b/source/MRViewer/MRSurfaceContoursWidget.cpp
@@ -259,6 +259,7 @@ std::shared_ptr<SurfacePointWidget> SurfaceContoursWidget::getPointWidget( const
     if ( it != pickedPoints_.end() )
     {
         const auto& contour = it->second;
+        assert( index < contour.size() );
         if ( index < contour.size() )
             res = contour[index];
     }
@@ -450,6 +451,8 @@ bool SurfaceContoursWidget::onMouseMove_( int, int )
             widget->setHovered( hovered );
             if ( hovered )
             {
+                // setting callback is very cheap operation (in comparison to pick_ above),
+                // and we do it here because here we know up-today index of the point
                 widget->setStartMoveCallback( [this, obj = obj, index] ( SurfacePointWidget & pointWidget, const PickedPoint& point )
                 {
                     const bool closedPath = isClosedCountour( obj );

--- a/source/MRViewer/MRSurfaceContoursWidget.cpp
+++ b/source/MRViewer/MRSurfaceContoursWidget.cpp
@@ -144,8 +144,13 @@ void SurfaceContoursWidget::ChangePointActionPickerPoint::action( Type )
     MR_SCOPED_VALUE( widget_.undoRedoMode_, true );
     MR_SCOPED_VALUE( widget_.params.writeHistory, false );
 
-    widget_.pickedPoints_[obj_][index_]->swapCurrentPosition( point_ );
-    widget_.onPointMoveFinish_( obj_, index_ );
+    if ( auto w = widget_.getPointWidget( obj_, index_ ) )
+    {
+        w->swapCurrentPosition( point_ );
+        widget_.onPointMoveFinish_( obj_, index_ );
+    }
+    else
+        assert( false );
 }
 
 size_t SurfaceContoursWidget::ChangePointActionPickerPoint::heapBytes() const

--- a/source/MRViewer/MRSurfaceContoursWidget.cpp
+++ b/source/MRViewer/MRSurfaceContoursWidget.cpp
@@ -430,22 +430,22 @@ bool SurfaceContoursWidget::onMouseMove_( int, int )
     if ( pickedPoints_.empty() || draggedPointWidget_ )
         return false;
 
-    auto [obj, pick] = pick_();
-    if ( !obj )
+    auto [pickObj, pick] = pick_();
+    if ( !pickObj )
         return false;
 
-    if ( ( params.surfacePointParams.pickInBackFaceObject == false ) && ( SurfacePointWidget::isPickIntoBackFace( obj, pick, getViewerInstance().viewport().getCameraPoint() ) ) )
+    if ( ( params.surfacePointParams.pickInBackFaceObject == false ) && ( SurfacePointWidget::isPickIntoBackFace( pickObj, pick, getViewerInstance().viewport().getCameraPoint() ) ) )
         return false;
 
-    for ( auto contour : pickedPoints_ )
-        for ( int index = 0; index < contour.second.size(); ++index )
+    for ( const auto & [obj, widgets] : pickedPoints_ )
+        for ( int index = 0; index < widgets.size(); ++index )
         {
-            const auto& point = contour.second[index];
-            bool hovered = obj == point->getPickSphere();
-            point->setHovered( hovered );
+            const auto& widget = widgets[index];
+            bool hovered = pickObj == widget->getPickSphere();
+            widget->setHovered( hovered );
             if ( hovered )
             {
-                point->setStartMoveCallback( [this, obj, index] ( SurfacePointWidget & pointWidget, const PickedPoint& point )
+                widget->setStartMoveCallback( [this, obj = obj, index] ( SurfacePointWidget & pointWidget, const PickedPoint& point )
                 {
                     const bool closedPath = isClosedCountour( obj );
 
@@ -477,7 +477,7 @@ bool SurfaceContoursWidget::onMouseMove_( int, int )
                     onPointMove_( obj, index );
 
                 } );
-                point->setEndMoveCallback( [this, obj, index] ( SurfacePointWidget & pointWidget, const PickedPoint& point )
+                widget->setEndMoveCallback( [this, obj = obj, index] ( SurfacePointWidget & pointWidget, const PickedPoint& point )
                 {
                     if ( moveClosedPoint_ )
                     {

--- a/source/MRViewer/MRSurfaceContoursWidget.h
+++ b/source/MRViewer/MRSurfaceContoursWidget.h
@@ -140,10 +140,6 @@ private:
     // point widget currently dragged by mouse
     SurfacePointWidget* draggedPointWidget_ = nullptr;
 
-    // active point
-    int activeIndex_{ 0 };
-    std::shared_ptr<MR::VisualObject> activeObject_ = nullptr;
-
     // data storage
     SurfaceContours pickedPoints_;
 

--- a/source/MRViewer/MRSurfaceContoursWidget.h
+++ b/source/MRViewer/MRSurfaceContoursWidget.h
@@ -101,8 +101,11 @@ public:
     // check whether the contour is closed for a particular object.
     [[nodiscard]] MRVIEWER_API bool isClosedCountour( const std::shared_ptr<VisualObject>& obj ) const;
 
-    /// Get the active (the latest picked/moved) surface point widget.
-    [[nodiscard]] MRVIEWER_API std::shared_ptr<SurfacePointWidget> getActiveSurfacePoint() const;
+    /// returns point widget by index from given object or nullptr if no such widget exists
+    [[nodiscard]] MRVIEWER_API std::shared_ptr<SurfacePointWidget> getPointWidget( const std::shared_ptr<VisualObject>& obj, int index ) const;
+
+    /// returns point widget currently dragged by mouse
+    [[nodiscard]] SurfacePointWidget* draggedPointWidget() const { return draggedPointWidget_; }
 
     // Add a point to the end of non closed contour connected with obj.
     MRVIEWER_API bool appendPoint( const std::shared_ptr<VisualObject>& obj, const PickedPoint& triPoint );
@@ -134,8 +137,8 @@ private:
     // SurfaceContoursWidget internal variables
     bool moveClosedPoint_ = false;
 
-    // pick sphere currently dragged by mouse
-    const VisualObject * draggedPickSphere_ = nullptr;
+    // point widget currently dragged by mouse
+    SurfacePointWidget* draggedPointWidget_ = nullptr;
 
     // active point
     int activeIndex_{ 0 };

--- a/source/MRViewer/MRSurfaceContoursWidget.h
+++ b/source/MRViewer/MRSurfaceContoursWidget.h
@@ -58,19 +58,18 @@ public:
     // A common base class for all history actions of this widget.
     struct WidgetHistoryAction : HistoryAction {};
 
-    using PickerPointCallBack = std::function<void( std::shared_ptr<MR::VisualObject> )>;
+    using PickerPointCallBack = std::function<void( std::shared_ptr<MR::VisualObject> obj, int index )>;
     using PickerPointObjectChecker = std::function<bool( std::shared_ptr<MR::VisualObject> )>;
 
     using SurfaceContour = std::vector<std::shared_ptr<SurfacePointWidget>>;
     using SurfaceContours = std::unordered_map <std::shared_ptr<MR::VisualObject>, SurfaceContour>;
 
-    // create a widget and connect it.
     // To create a widget, you need to provide 4 callbacks and one function that determines whether this object can be used to place points.
     // All callback takes a shared pointer to an MR::VisualObject as an argument.
-    // onPointAdd: This callback is invoked when a point is added.
-    // onPointMove : This callback is triggered when a point is being start  moved or dragged.
-    // onPointMoveFinish : This callback is called when the movement of a point is completed.
-    // onPointRemove : This callback is executed when a point is removed.
+    // onPointAdd: This callback is invoked after a point is added with its index.
+    // onPointMove : This callback is invoked when a point starts being dragged.
+    // onPointMoveFinish : This callback is invoked when point's dragging is completed.
+    // onPointRemove : This callback is invoked when a point is removed with its index before deletion.
     // isObjectValidToPick : Must return true or false. This callback is used to determine whether an object is valid for picking.
     MRVIEWER_API SurfaceContoursWidget(
             PickerPointCallBack onPointAdd,
@@ -101,11 +100,6 @@ public:
 
     // check whether the contour is closed for a particular object.
     [[nodiscard]] MRVIEWER_API bool isClosedCountour( const std::shared_ptr<VisualObject>& obj ) const;
-
-    // shared variables. which need getters and setters.
-    [[nodiscard]] MRVIEWER_API std::pair<const std::shared_ptr<MR::VisualObject> &, int> getActivePoint() const { return { activeObject_, activeIndex_ }; }
-
-    MRVIEWER_API void setActivePoint( std::shared_ptr<MR::VisualObject> obj, int index );
 
     /// Get the active (the latest picked/moved) surface point widget.
     [[nodiscard]] MRVIEWER_API std::shared_ptr<SurfacePointWidget> getActiveSurfacePoint() const;


### PR DESCRIPTION
The class does not store "active point" any more, instead:
* `PickerPointCallBack` passes additionally point index
* `getPointWidget` function added to convert object and index into widget
* `draggedPointWidget` function added