### PR TITLE
LoadedObjectMesh

### DIFF
--- a/source/MRMesh/MRLoadedObjects.h
+++ b/source/MRMesh/MRLoadedObjects.h
@@ -15,6 +15,13 @@ struct LoadedObject
     std::string warnings; //either empty or ends with '\n'
 };
 
+/// result of mesh loading (e.g. from a file) as one object
+struct LoadedObjectMesh
+{
+    std::shared_ptr<ObjectMesh> obj;
+    std::string warnings; //either empty or ends with '\n'
+};
+
 /// result of loading (e.g. from a file) as a number of objects
 struct LoadedObjects
 {

--- a/source/MRMesh/MRObjectLoad.h
+++ b/source/MRMesh/MRObjectLoad.h
@@ -16,18 +16,11 @@ namespace MR
 /// \ingroup DataModelGroup
 /// \{
 
-/// information about loading process and mesh construction from primitives
-struct MeshLoadInfo
-{
-    std::string* warnings = nullptr; ///< any warnings during loading will be appended here, each warning is ended with '\n'
-    ProgressCallback callback;       ///< callback for set progress and stop process
-};
-
 /// loads mesh from given file in new object
-MRMESH_API Expected<ObjectMesh> makeObjectMeshFromFile( const std::filesystem::path& file, const MeshLoadInfo& info = {} );
+MRMESH_API Expected<LoadedObjectMesh> makeObjectMeshFromFile( const std::filesystem::path& file, const ProgressCallback& cb = {} );
 
-/// loads mesh from given file and makes either ObjectMesh or ObjectPoints (if the file has points but not faces)
-MRMESH_API Expected<std::shared_ptr<Object>> makeObjectFromMeshFile( const std::filesystem::path& file, const MeshLoadInfo& info = {},
+/// loads data from given file and makes either ObjectMesh or ObjectPoints (if the file has points but not faces)
+MRMESH_API Expected<LoadedObject> makeObjectFromMeshFile( const std::filesystem::path& file, const ProgressCallback& cb = {},
     bool returnOnlyMesh = false ); ///< if true the function can return only ObjectMesh and never ObjectPoints
 
 /// loads lines from given file in new object


### PR DESCRIPTION
Switch to common warnings output in `makeObjectMeshFromFile` and `makeObjectFromMeshFile` functions.