### PR TITLE
subdivideLoneContours( ... FaceHashMap* new2oldMap = ... );

### DIFF
--- a/source/MRMesh/MRContoursCut.cpp
+++ b/source/MRMesh/MRContoursCut.cpp
@@ -456,7 +456,7 @@ std::function<bool( const EdgeIntersectionData&, const EdgeIntersectionData& )> 
     };
 }
 
-void subdivideLoneContours( Mesh& mesh, const OneMeshContours& contours, FaceMap* new2oldMap /*= nullptr */ )
+void subdivideLoneContours( Mesh& mesh, const OneMeshContours& contours, FaceHashMap* new2oldMap /*= nullptr */ )
 {
     MR_TIMER;
     MR_WRITER( mesh );
@@ -504,10 +504,7 @@ void subdivideLoneContours( Mesh& mesh, const OneMeshContours& contours, FaceMap
         mesh.topology.setLeft( en1, nf1 );
         mesh.topology.setLeft( en2, nf2 );
         if ( new2oldMap )
-        {
-            new2oldMap->autoResizeAt( nf2 ) = f;
-            ( *new2oldMap )[nf1] = ( *new2oldMap )[nf0] = f;
-        }
+            ( *new2oldMap )[nf2] = ( *new2oldMap )[nf1] = ( *new2oldMap )[nf0] = f;
     }
 }
 

--- a/source/MRMesh/MRContoursCut.h
+++ b/source/MRMesh/MRContoursCut.h
@@ -49,7 +49,7 @@ using OneMeshContours = std::vector<OneMeshContour>;
 
 // Divides faces that fully own contours into 3 parts with center in center mass of one of the face contours
 // if there is more than one contour on face it guarantee to subdivide at least one lone contour on this face
-MRMESH_API void subdivideLoneContours( Mesh& mesh, const OneMeshContours& contours, FaceMap* new2oldMap = nullptr );
+MRMESH_API void subdivideLoneContours( Mesh& mesh, const OneMeshContours& contours, FaceHashMap* new2oldMap = nullptr );
 
 // Converts ordered continuous contours of two meshes to OneMeshContours
 // converters is required for better precision in case of degenerations

--- a/source/MRMesh/MRMeshBoolean.cpp
+++ b/source/MRMesh/MRMeshBoolean.cpp
@@ -219,20 +219,17 @@ BooleanResult booleanImpl( Mesh&& meshA, Mesh&& meshB, BooleanOperation operatio
             auto loneIntsA = getOneMeshIntersectionContours( meshA, meshB, loneA, true, converters, params.rigidB2A );
             auto loneIntsAonB = getOneMeshIntersectionContours( meshA, meshB, loneA, false, converters, params.rigidB2A );
             removeLoneDegeneratedContours( meshB.topology, loneIntsA, loneIntsAonB );
-            FaceMap new2orgLocalMap;
-            FaceMap* mapPointer = params.mapper ? &new2orgLocalMap : nullptr;
+            FaceHashMap new2orgLocalMap;
+            FaceHashMap* mapPointer = params.mapper ? &new2orgLocalMap : nullptr;
             subdivideLoneContours( meshA, loneIntsA, mapPointer );
             if ( new2orgSubdivideMapA.size() < new2orgLocalMap.size() )
                 new2orgSubdivideMapA.resize( new2orgLocalMap.size() );
-            ParallelFor( new2orgLocalMap, [&] ( FaceId i )
+            for ( auto [i, refFace] : new2orgLocalMap )
             {
-                if ( !new2orgLocalMap[i] )
-                    return;
-                FaceId refFace = new2orgLocalMap[i];
                 if ( new2orgSubdivideMapA[refFace] )
                     refFace = new2orgSubdivideMapA[refFace];
                 new2orgSubdivideMapA[i] = refFace;
-            } );
+            }
         }
         if ( !loneB.empty() && needCutMeshB )
         {
@@ -240,20 +237,17 @@ BooleanResult booleanImpl( Mesh&& meshA, Mesh&& meshB, BooleanOperation operatio
             auto loneIntsB = getOneMeshIntersectionContours( meshA, meshB, loneB, false, converters, params.rigidB2A );
             auto loneIntsBonA = getOneMeshIntersectionContours( meshA, meshB, loneB, true, converters, params.rigidB2A );
             removeLoneDegeneratedContours( meshA.topology, loneIntsB, loneIntsBonA );
-            FaceMap new2orgLocalMap;
-            FaceMap* mapPointer = params.mapper ? &new2orgLocalMap : nullptr;
+            FaceHashMap new2orgLocalMap;
+            FaceHashMap* mapPointer = params.mapper ? &new2orgLocalMap : nullptr;
             subdivideLoneContours( meshB, loneIntsB, mapPointer );
             if ( new2orgSubdivideMapB.size() < new2orgLocalMap.size() )
                 new2orgSubdivideMapB.resize( new2orgLocalMap.size() );
-            ParallelFor( new2orgLocalMap, [&] ( FaceId i )
+            for ( auto [i, refFace] : new2orgLocalMap )
             {
-                if ( !new2orgLocalMap[i] )
-                    return;
-                FaceId refFace = new2orgLocalMap[i];
                 if ( new2orgSubdivideMapB[refFace] )
                     refFace = new2orgSubdivideMapB[refFace];
                 new2orgSubdivideMapB[i] = refFace;
-            } );
+            }
         }
     }
     if ( iters == cMaxFixLoneIterations )


### PR DESCRIPTION
`subdivideLoneContours` function takes optional parameter as `FaceHashMap` instead of `FaceMap`. This will allow us to switch the implementation to `mesh.splitFace` later.