### PR TITLE
Pip wheels for Python 3.13

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -82,8 +82,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Checkout third-party submodules
         # Some of those safe.directory rules could be redudant.
@@ -101,7 +99,7 @@ jobs:
         if: ${{ matrix.py-version != '3.8' }}
         run: |
           apt -y update && apt -y upgrade && apt -y install software-properties-common
-          add-apt-repository -y ppa:deadsnakes/ppa && apt -y install ${{ matrix.py-cmd }}-dev ${{ matrix.py-cmd }}-distutils
+          add-apt-repository -y ppa:deadsnakes/ppa && apt -y install ${{ matrix.py-cmd }}-dev
 
       - name: Pip setup
         run: |
@@ -167,13 +165,13 @@ jobs:
           path: ./scripts/wheel/meshlib/wheelhouse/meshlib-*.whl
           retention-days: 1
 
-  update-documentation:
-    needs:
-      - manylinux-pip-build
-    uses: ./.github/workflows/update-docs.yml
-    with:
-      output_folder: MeshLib
-    secrets: inherit
+#  update-documentation:
+#    needs:
+#      - manylinux-pip-build
+#    uses: ./.github/workflows/update-docs.yml
+#    with:
+#      output_folder: MeshLib
+#    secrets: inherit
 
   windows-pip-build:
     needs: setup
@@ -228,7 +226,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Checkout Vcpkg ${{env.VCPKG-VERSION}}
         working-directory: C:\vcpkg
@@ -405,7 +402,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Fix links x86
         if: ${{ matrix.platform == 'x86' }}
@@ -521,12 +517,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Ubuntu system setup
         if: ${{ matrix.os == 'ubuntu:20.04' || matrix.os == 'ubuntu:22.04' || matrix.os == 'debian:11-slim' }}
-        run: apt -y update && apt -y upgrade && apt -y install curl libssl-dev python3-distutils python3-pip
+        run: apt -y update && apt -y upgrade && apt -y install curl libssl-dev python3-pip
 
       - name: Fedora 37 system setup
         if: ${{matrix.os == 'fedora:37' || matrix.os == 'fedora:39'}}
@@ -563,8 +557,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Download Meshlib wheel from Artifact
         uses: actions/download-artifact@v4
@@ -627,8 +619,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Python setup
         if: ${{ !(matrix.platform == 'x86' && ( matrix.py-version == '3.11' || matrix.py-version == '3.12' || matrix.py-version == '3.13' ) ) }}

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ["x86_64", "aarch64"]
-        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - platform: "x86_64"
             docker-image: "meshlib/meshlib-ubuntu20:latest"
@@ -66,6 +66,9 @@ jobs:
           - py-version: "3.12"
             py-tag: "cp312"
             py-cmd: "python3.12"
+          - py-version: "3.13"
+            py-tag: "cp313"
+            py-cmd: "python3.13"
     steps:
       - name: Work-around possible permission issues
         shell: bash
@@ -179,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - py-version: "3.8"
             py-tag: "cp38"
@@ -211,6 +214,12 @@ jobs:
             py-dir: "Python312"
             py-file: "python312"
             embed-version: "3.12.0"
+          - py-version: "3.13"
+            py-tag: "cp313"
+            py-short-version: "313"
+            py-dir: "Python313"
+            py-file: "python313"
+            embed-version: "3.13.0"
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
@@ -359,7 +368,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ["x86", "arm64"]
-        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude: # python 3.8 disabled on x86 macOS since 2024-10-14
           - platform: "x86"
             py-version: "3.8"
@@ -388,6 +397,9 @@ jobs:
           - py-version: "3.12"
             py-tag: "cp312"
             py-cmd: "python3.12"
+          - py-version: "3.13"
+            py-tag: "cp313"
+            py-cmd: "python3.13"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -547,7 +559,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -588,7 +600,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ["arm64", "x86"]
-        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude: # python 3.8 disabled on x86 macOS since 2024-10-14
           - platform: "x86"
             py-version: "3.8"
@@ -610,6 +622,8 @@ jobs:
             py-cmd: "python3.11"
           - py-version: "3.12"
             py-cmd: "python3.12"
+          - py-version: "3.13"
+            py-cmd: "python3.13"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -617,7 +631,7 @@ jobs:
           ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Python setup
-        if: ${{ !(matrix.platform == 'x86' && ( matrix.py-version == '3.11' || matrix.py-version == '3.12' ) ) }}
+        if: ${{ !(matrix.platform == 'x86' && ( matrix.py-version == '3.11' || matrix.py-version == '3.12' || matrix.py-version == '3.13' ) ) }}
         run: brew install python@${{matrix.py-version}}
 
       - name: Create virtualenv
@@ -675,8 +689,8 @@ jobs:
       - name: Install twine
         run: python3 -m pip install --upgrade pip twine
 
-      - name: Upload to Production PyPi
-        run: twine upload ./meshlib-*.whl -u __token__ -p ${{ secrets.PYPI_MESHINSPECTOR_TOKEN }} --skip-existing
+#      - name: Upload to Production PyPi
+#        run: twine upload ./meshlib-*.whl -u __token__ -p ${{ secrets.PYPI_MESHINSPECTOR_TOKEN }} --skip-existing
 
   post-release-test:
     needs: upload-to-release

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Checkout third-party submodules
         # Some of those safe.directory rules could be redudant.
@@ -165,13 +167,13 @@ jobs:
           path: ./scripts/wheel/meshlib/wheelhouse/meshlib-*.whl
           retention-days: 1
 
-#  update-documentation:
-#    needs:
-#      - manylinux-pip-build
-#    uses: ./.github/workflows/update-docs.yml
-#    with:
-#      output_folder: MeshLib
-#    secrets: inherit
+  update-documentation:
+    needs:
+      - manylinux-pip-build
+    uses: ./.github/workflows/update-docs.yml
+    with:
+      output_folder: MeshLib
+    secrets: inherit
 
   windows-pip-build:
     needs: setup
@@ -226,6 +228,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Checkout Vcpkg ${{env.VCPKG-VERSION}}
         working-directory: C:\vcpkg
@@ -402,6 +405,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Fix links x86
         if: ${{ matrix.platform == 'x86' }}
@@ -517,6 +521,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Ubuntu system setup
         if: ${{ matrix.os == 'ubuntu:20.04' || matrix.os == 'ubuntu:22.04' || matrix.os == 'debian:11-slim' }}
@@ -557,6 +563,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Download Meshlib wheel from Artifact
         uses: actions/download-artifact@v4
@@ -619,6 +627,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Python setup
         if: ${{ !(matrix.platform == 'x86' && ( matrix.py-version == '3.11' || matrix.py-version == '3.12' || matrix.py-version == '3.13' ) ) }}
@@ -679,8 +689,8 @@ jobs:
       - name: Install twine
         run: python3 -m pip install --upgrade pip twine
 
-#      - name: Upload to Production PyPi
-#        run: twine upload ./meshlib-*.whl -u __token__ -p ${{ secrets.PYPI_MESHINSPECTOR_TOKEN }} --skip-existing
+      - name: Upload to Production PyPi
+        run: twine upload ./meshlib-*.whl -u __token__ -p ${{ secrets.PYPI_MESHINSPECTOR_TOKEN }} --skip-existing
 
   post-release-test:
     needs: upload-to-release


### PR DESCRIPTION
And remove unnecessary dependency from `python3-distutils` package, which is unavailable since python 3.12