### PR TITLE
Fix imgui mouse down event

### DIFF
--- a/source/MRViewer/ImGuiMenu.cpp
+++ b/source/MRViewer/ImGuiMenu.cpp
@@ -516,10 +516,7 @@ bool ImGuiMenu::onMouseDown_( Viewer::MouseButton button, int modifier)
     capturedMouse_ = ImGui::GetIO().WantCaptureMouse
         || bool( uiRenderManager_->consumedInteractions & BasicUiRenderTask::InteractionMask::mouseHover );
 
-    // If a plugin opens some UI in its `onMouseDown_()`,
-    // this condition prevents that UI from immediately getting clicked in the same frame.
-    if ( capturedMouse_ )
-        ImGui_ImplGlfw_MouseButtonCallback( viewer->window, int( button ), GLFW_PRESS, modifier );
+    ImGui_ImplGlfw_MouseButtonCallback( viewer->window, int( button ), GLFW_PRESS, modifier );
 
     if ( !capturedMouse_ )
     {

--- a/source/MRViewer/MRRenderNameObject.cpp
+++ b/source/MRViewer/MRRenderNameObject.cpp
@@ -29,10 +29,10 @@ void RenderNameObject::Task::earlyBackwardPass( const BackwardPassParams& backPa
             {
                 isHovered = true;
 
-                if ( ImGui::IsMouseDown( ImGuiMouseButton_Left ) )
+                if ( prevFrameHovered && ImGui::IsMouseDown( ImGuiMouseButton_Left ) )
                     isActive = true;
 
-                if ( ImGui::IsMouseClicked( ImGuiMouseButton_Left ) )
+                if ( prevFrameHovered && ImGui::IsMouseClicked( ImGuiMouseButton_Left ) )
                 {
                     RibbonMenu::instance()->simulateNameTagClick(
                         // Yes, a dumb cast. We could find the same object in the scene, but it's a waste of time.
@@ -44,6 +44,7 @@ void RenderNameObject::Task::earlyBackwardPass( const BackwardPassParams& backPa
             }
         }
     }
+    prevFrameHovered = isHovered;
 }
 
 void RenderNameObject::Task::renderPass()


### PR DESCRIPTION
Old code leads to incorrect mouse state inside ImGui:
 rotating scene could highlight hovered ImGui items.