### PR TITLE
PickPointManager: getting and setting full state

### DIFF
--- a/source/MRViewer/MRPickPointManager.cpp
+++ b/source/MRViewer/MRPickPointManager.cpp
@@ -186,7 +186,8 @@ public:
 
     virtual std::string name() const override;
     virtual void action( Type ) override;
-    [[nodiscard]] virtual size_t heapBytes() const override;
+    [[nodiscard]] virtual size_t heapBytes() const override { return 0; } //this undo action will be deleted in widget disable
+
 private:
     PickPointManager& widget_;
     const std::shared_ptr<MR::VisualObject> obj_;
@@ -196,7 +197,7 @@ private:
 
 std::string PickPointManager::MovePointHistoryAction::name() const
 {
-    return "Move point" + widget_.params.historyNameSuffix;
+    return "Move Point" + widget_.params.historyNameSuffix;
 }
 
 void PickPointManager::MovePointHistoryAction::action( Type )
@@ -209,11 +210,6 @@ void PickPointManager::MovePointHistoryAction::action( Type )
     }
     else
         assert( false );
-}
-
-size_t PickPointManager::MovePointHistoryAction::heapBytes() const
-{
-    return 0; //this undo action will be deleted in widget disable
 }
 
 std::shared_ptr<SurfacePointWidget> PickPointManager::createPickWidget_( const std::shared_ptr<MR::VisualObject>& obj, const PickedPoint& pt )
@@ -326,14 +322,12 @@ std::shared_ptr<SurfacePointWidget> PickPointManager::getPointWidget( const std:
 
 bool PickPointManager::appendPoint( const std::shared_ptr<VisualObject>& obj, const PickedPoint& triPoint )
 {
-    SCOPED_HISTORY( "Append Point" + params.historyNameSuffix );
     AppendHistory( AddRemovePointHistoryAction::appendAndGetUndo( *this, obj, triPoint ) );
     return true;
 }
 
 bool PickPointManager::removePoint( const std::shared_ptr<VisualObject>& obj, int pickedIndex )
 {
-    SCOPED_HISTORY( "Remove Point" + params.historyNameSuffix );
     AppendHistory( AddRemovePointHistoryAction::removeAndGetUndo( *this, obj, pickedIndex ) );
     return true;
 }
@@ -497,7 +491,7 @@ bool PickPointManager::onMouseMove_( int, int )
                         const auto& contour = pickedPoints_[obj];
                         if ( &pointWidget == contour[0].get() )
                         {
-                            SCOPED_HISTORY( "Move point" + params.historyNameSuffix );
+                            SCOPED_HISTORY( "Move Point" + params.historyNameSuffix );
                             AppendHistory<MovePointHistoryAction>( *this, obj, point, index );
                             AppendHistory<MovePointHistoryAction>( *this, obj, point, int( contour.size() ) - 1 );
                             moveClosedPoint_ = true;

--- a/source/MRViewer/MRPickPointManager.h
+++ b/source/MRViewer/MRPickPointManager.h
@@ -29,9 +29,6 @@ public:
         /// Modifier key for deleting a point using the widget
         int widgetDeletePointMod = GLFW_MOD_SHIFT;
 
-        /// Indicates whether to write history of the contours
-        bool writeHistory = true;
-
         /// This is appended to the names of all undo/redo actions.
         std::string historyNameSuffix;
 
@@ -122,9 +119,8 @@ public:
     /// returns the state of this
     MRVIEWER_API FullState getFullState() const;
 
-    /// remove all points from all objects
-    /// \param writeHistory - add history action (item in undo/redo). Set to false if you call the method as a part of another action.
-    MRVIEWER_API void clear( bool writeHistory = true );
+    /// remove all points from all objects, adding undo action for reverting
+    MRVIEWER_API void clear();
 
 private:
     MRVIEWER_API bool onMouseDown_( MouseButton button, int modifier ) override;

--- a/source/MRViewer/MRPickPointManager.h
+++ b/source/MRViewer/MRPickPointManager.h
@@ -13,7 +13,8 @@
 namespace MR
 {
 
-/// this object allows the user to pick/move/delete several ordered points on one or more visual objects
+/// PickPointManager allows the user to pick/move/delete several ordered points on one or more visual objects;
+/// mouse events and public methods automatically add history actions for reverting
 class MRVIEWER_CLASS PickPointManager : public MultiListener<
     MouseDownListener,
     MouseMoveListener>
@@ -65,7 +66,7 @@ public:
     };
     Params params;
 
-    // A common base class for all history actions of this widget.
+    /// A common base class for all history actions of this widget.
     struct WidgetHistoryAction : HistoryAction {};
 
     using SurfaceContour = std::vector<std::shared_ptr<SurfacePointWidget>>;
@@ -74,22 +75,16 @@ public:
     /// create an object and starts listening for mouse events
     MRVIEWER_API PickPointManager();
 
-    /// destroy this and remove the undo/redo actions from the history.
+    /// destroy this and remove the undo/redo actions referring this from the history.
     MRVIEWER_API ~PickPointManager();
 
-    // return contour for specific object (creating new one if necessary)
-    [[nodiscard]] const SurfaceContour& getSurfaceContour( const std::shared_ptr<MR::VisualObject>& obj )
-    {
-        return pickedPoints_[obj];
-    }
+    /// return contour for specific object (creating new one if necessary)
+    [[nodiscard]] const SurfaceContour& getSurfaceContour( const std::shared_ptr<MR::VisualObject>& obj ) { return pickedPoints_[obj]; }
 
-    // return all contours, i.e. per object unorderd_map of ordered surface points [vector].
-    [[nodiscard]] const SurfaceContours& getSurfaceContours() const
-    {
-        return pickedPoints_;
-    }
+    /// return all contours, i.e. per object unorderd_map of ordered surface points [vector].
+    [[nodiscard]] const SurfaceContours& getSurfaceContours() const { return pickedPoints_; }
 
-    // check whether the contour is closed for a particular object.
+    /// check whether the contour is closed for a particular object.
     [[nodiscard]] MRVIEWER_API bool isClosedCountour( const std::shared_ptr<VisualObject>& obj ) const;
 
     /// returns point widget by index from given object or nullptr if no such widget exists
@@ -98,10 +93,10 @@ public:
     /// returns point widget currently dragged by mouse
     [[nodiscard]] SurfacePointWidget* draggedPointWidget() const { return draggedPointWidget_; }
 
-    // Add a point to the end of non closed contour connected with obj.
+    /// Add a point to the end of non closed contour connected with obj.
     MRVIEWER_API bool appendPoint( const std::shared_ptr<VisualObject>& obj, const PickedPoint& triPoint );
 
-    // Remove point with pickedIndex index from contour connected with obj.
+    /// Remove point with pickedIndex index from contour connected with obj.
     MRVIEWER_API bool removePoint( const std::shared_ptr<VisualObject>& obj, int pickedIndex );
 
     // if ( makeClosed ), and the contour is open add a special transparent point contour to the end of contour connected with given object.
@@ -119,7 +114,7 @@ public:
     /// returns the state of this
     MRVIEWER_API FullState getFullState() const;
 
-    /// remove all points from all objects, adding undo action for reverting
+    /// removes all points from all objects
     MRVIEWER_API void clear();
 
     /// removes all current points, then adds pick points on all objects as prescribed by given state

--- a/source/MRViewer/MRPickPointManager.h
+++ b/source/MRViewer/MRPickPointManager.h
@@ -122,6 +122,9 @@ public:
     /// remove all points from all objects, adding undo action for reverting
     MRVIEWER_API void clear();
 
+    /// removes all current points, then adds pick points on all objects as prescribed by given state
+    MRVIEWER_API void setFullState( FullState s );
+
 private:
     MRVIEWER_API bool onMouseDown_( MouseButton button, int modifier ) override;
     MRVIEWER_API bool onMouseMove_( int mouse_x, int mouse_y ) override;


### PR DESCRIPTION
* Public methods for getting full state of the object and setting it with undo
* `clear` is implemented via `setState( empty )`
* `writeHistory` flags eliminated