### PR TITLE
heapBytes( HashMap<...> )

### DIFF
--- a/source/MRMesh/MRHeapBytes.h
+++ b/source/MRMesh/MRHeapBytes.h
@@ -70,6 +70,20 @@ template<typename T>
     return 0;
 }
 
+/// returns the amount of memory given HashMap occupies on heap
+template<typename ...Ts>
+[[nodiscard]] inline size_t heapBytes( const phmap::flat_hash_map<Ts...>& hashMap )
+{
+    // from parallel_hashmap/phmap.h:
+    // The control state and slot array are stored contiguously in a shared heap
+    // allocation. The layout of this allocation is: `capacity()` control bytes,
+    // one sentinel control byte, `Group::kWidth - 1` cloned control bytes,
+    // <possible padding>, `capacity()` slots
+    const auto cap = hashMap.capacity();
+    constexpr size_t kWidth = 16; // the usage of phmap::priv::Group::kWidth here will require inclusion of phmap.h
+    return cap + kWidth + cap * sizeof( typename phmap::flat_hash_map<Ts...>::slot_type );
+}
+
 /// \}
 
 } // namespace MR

--- a/source/MRMesh/MRMeshDiff.cpp
+++ b/source/MRMesh/MRMeshDiff.cpp
@@ -86,7 +86,7 @@ void MeshDiff::applyAndSwap( Mesh & m )
 
 size_t MeshDiff::heapBytes() const
 {
-    return MR::heapBytes( changedPoints_ );
+    return MR::heapBytes( changedPoints_ ) + MR::heapBytes( changedEdges_ );
 }
 
 TEST(MRMesh, MeshDiff)

--- a/source/MRMesh/MRMeshDiff.cpp
+++ b/source/MRMesh/MRMeshDiff.cpp
@@ -2,6 +2,7 @@
 #include "MRMesh.h"
 #include "MRTimer.h"
 #include "MRMeshBuilder.h"
+#include "MRHeapBytes.h"
 #include "MRGTest.h"
 
 namespace MR
@@ -81,6 +82,11 @@ void MeshDiff::applyAndSwap( Mesh & m )
     toEdgesSize_ = mEdgesSize;
 
     m.topology.computeAllFromEdges_();
+}
+
+size_t MeshDiff::heapBytes() const
+{
+    return MR::heapBytes( changedPoints_ );
 }
 
 TEST(MRMesh, MeshDiff)

--- a/source/MRMesh/MRMeshDiff.h
+++ b/source/MRMesh/MRMeshDiff.h
@@ -25,7 +25,7 @@ public:
     [[nodiscard]] bool any() const { return !changedPoints_.empty() || !changedEdges_.empty(); }
 
     /// returns the amount of memory this object occupies on heap
-    [[nodiscard]] size_t heapBytes() const;
+    [[nodiscard]] MRMESH_API size_t heapBytes() const;
 
 private:
     size_t toPointsSize_ = 0;

--- a/source/MRMesh/MRMeshDiff.h
+++ b/source/MRMesh/MRMeshDiff.h
@@ -24,11 +24,14 @@ public:
     /// then the method will return false since nothing is stored here
     [[nodiscard]] bool any() const { return !changedPoints_.empty() || !changedEdges_.empty(); }
 
+    /// returns the amount of memory this object occupies on heap
+    [[nodiscard]] size_t heapBytes() const;
+
 private:
     size_t toPointsSize_ = 0;
-    ParallelHashMap<VertId, Vector3f> changedPoints_;
+    HashMap<VertId, Vector3f> changedPoints_;
     size_t toEdgesSize_ = 0;
-    ParallelHashMap<EdgeId, MeshTopology::HalfEdgeRecord> changedEdges_;
+    HashMap<EdgeId, MeshTopology::HalfEdgeRecord> changedEdges_;
 };
 
 } // namespace MR


### PR DESCRIPTION
1. The function for computing heap memory allocated by `HashMap`:
`size_t heapBytes( const phmap::flat_hash_map<Ts...>& hashMap )`
2. `class MeshDiff` switched to HashMap
3. `size_t MeshDiff::heapBytes() const` added