### PR TITLE
Points and topology partial changes history

### DIFF
--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -132,6 +132,7 @@
     <ClInclude Include="MRMeshReplicate.h" />
     <ClInclude Include="MRMeshSubdivideCallbacks.h" />
     <ClInclude Include="MRMeshThickness.h" />
+    <ClInclude Include="MRMeshTopologyDiff.h" />
     <ClInclude Include="MRMisonLoad.h" />
     <ClInclude Include="MRMovementBuildBody.h" />
     <ClInclude Include="MRMultiwayAligningTransform.h" />
@@ -317,6 +318,7 @@
     <ClInclude Include="MRUnorientedTriangle.h" />
     <ClInclude Include="MRUVSphere.h" />
     <ClInclude Include="MRVector2.h" />
+    <ClInclude Include="MRVertCoordsDiff.h" />
     <ClInclude Include="MRVertexAttributeGradient.h" />
     <ClInclude Include="MRViewportId.h" />
     <ClInclude Include="MRViewportProperty.h" />
@@ -497,6 +499,7 @@
     <ClCompile Include="MRMeshReplicate.cpp" />
     <ClCompile Include="MRMeshSubdivideCallbacks.cpp" />
     <ClCompile Include="MRMeshThickness.cpp" />
+    <ClCompile Include="MRMeshTopologyDiff.cpp" />
     <ClCompile Include="MRMisonLoad.cpp" />
     <ClCompile Include="MRMovementBuildBody.cpp" />
     <ClCompile Include="MRMultiwayAligningTransform.cpp" />
@@ -603,6 +606,7 @@
     <ClCompile Include="MRStringConvert.cpp" />
     <ClCompile Include="MRSurfacePath.cpp" />
     <ClCompile Include="MRTriDist.cpp" />
+    <ClCompile Include="MRVertCoordsDiff.cpp" />
     <ClCompile Include="MRVertexAttributeGradient.cpp" />
     <ClCompile Include="MRViewportId.cpp" />
     <ClCompile Include="MRVolumeIndexer.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1239,6 +1239,12 @@
     <ClInclude Include="MRPartialChangeMeshAction.h">
       <Filter>Source Files\History</Filter>
     </ClInclude>
+    <ClInclude Include="MRVertCoordsDiff.h">
+      <Filter>Source Files\Mesh</Filter>
+    </ClInclude>
+    <ClInclude Include="MRMeshTopologyDiff.h">
+      <Filter>Source Files\Mesh</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRObject.cpp">
@@ -2035,6 +2041,12 @@
     </ClCompile>
     <ClCompile Include="MRMarkedContour.cpp">
       <Filter>Source Files\Math</Filter>
+    </ClCompile>
+    <ClCompile Include="MRVertCoordsDiff.cpp">
+      <Filter>Source Files\Mesh</Filter>
+    </ClCompile>
+    <ClCompile Include="MRMeshTopologyDiff.cpp">
+      <Filter>Source Files\Mesh</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/source/MRMesh/MRMeshDiff.cpp
+++ b/source/MRMesh/MRMeshDiff.cpp
@@ -2,7 +2,6 @@
 #include "MRMesh.h"
 #include "MRTimer.h"
 #include "MRMeshBuilder.h"
-#include "MRHeapBytes.h"
 #include "MRGTest.h"
 
 namespace MR
@@ -11,82 +10,15 @@ namespace MR
 MeshDiff::MeshDiff( const Mesh & from, const Mesh & to )
 {
     MR_TIMER
-
-    toPointsSize_ = to.points.size();
-    for ( VertId v{0}; v < toPointsSize_; ++v )
-    {
-        if ( v >= from.points.size() || from.points[v] != to.points[v] )
-            changedPoints_[v] = to.points[v];
-    }
-
-    toEdgesSize_ = to.topology.edges_.size();
-    for ( EdgeId e{0}; e < toEdgesSize_; ++e )
-    {
-        if ( e >= from.topology.edges_.size() || from.topology.edges_[e] != to.topology.edges_[e] )
-            changedEdges_[e] = to.topology.edges_[e];
-    }
+    pointsDiff_ = VertCoordsDiff( from.points, to.points );
+    topologyDiff_ = MeshTopologyDiff( from.topology, to.topology );
 }
 
 void MeshDiff::applyAndSwap( Mesh & m )
 {
     MR_TIMER
-
-    auto mPointsSize = m.points.size();
-    // remember points being deleted from m
-    for ( VertId v{toPointsSize_}; v < mPointsSize; ++v )
-    {
-        changedPoints_[v] = m.points[v];
-    }
-    m.points.resize( toPointsSize_ );
-    // swap common points and delete points for vertices missing in original m (that will be next target)
-    for ( auto it = changedPoints_.begin(); it != changedPoints_.end(); )
-    {
-        auto v = it->first;
-        auto & pos = it->second;
-        if ( v < toPointsSize_ )
-        {
-            std::swap( pos, m.points[v] );
-            if ( v >= mPointsSize )
-            {
-                it = changedPoints_.erase( it );
-                continue;
-            }
-        }
-        ++it;
-    }
-    toPointsSize_ = mPointsSize;
-
-    auto mEdgesSize = m.topology.edges_.size();
-    // remember topology.edges_ being deleted from m
-    for ( EdgeId e{toEdgesSize_}; e < mEdgesSize; ++e )
-    {
-        changedEdges_[e] = m.topology.edges_[e];
-    }
-    m.topology.edges_.resize( toEdgesSize_ );
-    // swap common topology.edges_ and delete topology.edges_ for vertices missing in original m (that will be next target)
-    for ( auto it = changedEdges_.begin(); it != changedEdges_.end(); )
-    {
-        auto e = it->first;
-        auto & pos = it->second;
-        if ( e < toEdgesSize_ )
-        {
-            std::swap( pos, m.topology.edges_[e] );
-            if ( e >= mEdgesSize )
-            {
-                it = changedEdges_.erase( it );
-                continue;
-            }
-        }
-        ++it;
-    }
-    toEdgesSize_ = mEdgesSize;
-
-    m.topology.computeAllFromEdges_();
-}
-
-size_t MeshDiff::heapBytes() const
-{
-    return MR::heapBytes( changedPoints_ ) + MR::heapBytes( changedEdges_ );
+    pointsDiff_.applyAndSwap( m.points );
+    topologyDiff_.applyAndSwap( m.topology );
 }
 
 TEST(MRMesh, MeshDiff)

--- a/source/MRMesh/MRMeshDiff.h
+++ b/source/MRMesh/MRMeshDiff.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "MRMeshTopology.h"
-#include "MRphmap.h"
+#include "MRVertCoordsDiff.h"
+#include "MRMeshTopologyDiff.h"
 
 namespace MR
 {
 
 /// this object stores a difference between two meshes: both in coordinates and in topology
-/// \details if the meshes are similar then this object is small, if the meshes are very distinct then this object will be comparable to a mesh in size
+/// \details if the meshes are similar then this object is small, if the meshes are very distinct then this object will be even larger than one mesh itself
 /// \ingroup MeshAlgorithmGroup
 class MeshDiff
 {
@@ -25,16 +25,14 @@ public:
     /// returns true if this object does contain some difference in point coordinates or in topology;
     /// if (from) mesh has just more points or more topology elements than (to) and the common elements are the same,
     /// then the method will return false since nothing is stored here
-    [[nodiscard]] bool any() const { return !changedPoints_.empty() || !changedEdges_.empty(); }
+    [[nodiscard]] bool any() const { return pointsDiff_.any() || topologyDiff_.any(); }
 
     /// returns the amount of memory this object occupies on heap
-    [[nodiscard]] MRMESH_API size_t heapBytes() const;
+    [[nodiscard]] size_t heapBytes() const { return pointsDiff_.heapBytes() + topologyDiff_.heapBytes(); }
 
 private:
-    size_t toPointsSize_ = 0;
-    HashMap<VertId, Vector3f> changedPoints_;
-    size_t toEdgesSize_ = 0;
-    HashMap<EdgeId, MeshTopology::HalfEdgeRecord> changedEdges_;
+    VertCoordsDiff pointsDiff_;
+    MeshTopologyDiff topologyDiff_;
 };
 
 } // namespace MR

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -512,7 +512,7 @@ public:
     MRMESH_API bool checkValidity( ProgressCallback cb = {}, bool allVerts = true ) const;
 
 private:
-    friend class MeshDiff;
+    friend class MeshTopologyDiff;
     /// computes from edges_ all remaining fields: \n
     /// 1) numValidVerts_, 2) validVerts_, 3) edgePerVertex_,
     /// 4) numValidFaces_, 5) validFaces_, 6) edgePerFace_

--- a/source/MRMesh/MRMeshTopologyDiff.cpp
+++ b/source/MRMesh/MRMeshTopologyDiff.cpp
@@ -1,0 +1,56 @@
+#include "MRMeshTopologyDiff.h"
+#include "MRTimer.h"
+#include "MRHeapBytes.h"
+
+namespace MR
+{
+
+MeshTopologyDiff::MeshTopologyDiff( const MeshTopology & from, const MeshTopology & to )
+{
+    MR_TIMER
+
+    toEdgesSize_ = to.edges_.size();
+    for ( EdgeId e{0}; e < toEdgesSize_; ++e )
+    {
+        if ( e >= from.edges_.size() || from.edges_[e] != to.edges_[e] )
+            changedEdges_[e] = to.edges_[e];
+    }
+}
+
+void MeshTopologyDiff::applyAndSwap( MeshTopology & m )
+{
+    MR_TIMER
+
+    auto mEdgesSize = m.edges_.size();
+    // remember edges_ being deleted from m
+    for ( EdgeId e{toEdgesSize_}; e < mEdgesSize; ++e )
+    {
+        changedEdges_[e] = m.edges_[e];
+    }
+    m.edges_.resize( toEdgesSize_ );
+    // swap common edges_ and delete edges_ for vertices missing in original m (that will be next target)
+    for ( auto it = changedEdges_.begin(); it != changedEdges_.end(); )
+    {
+        auto e = it->first;
+        auto & pos = it->second;
+        if ( e < toEdgesSize_ )
+        {
+            std::swap( pos, m.edges_[e] );
+            if ( e >= mEdgesSize )
+            {
+                it = changedEdges_.erase( it );
+                continue;
+            }
+        }
+        ++it;
+    }
+    toEdgesSize_ = mEdgesSize;
+
+    m.computeAllFromEdges_();
+}
+
+size_t MeshTopologyDiff::heapBytes() const
+{
+    return MR::heapBytes( changedEdges_ );
+}
+} // namespace MR

--- a/source/MRMesh/MRMeshTopologyDiff.h
+++ b/source/MRMesh/MRMeshTopologyDiff.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "MRMeshTopology.h"
+#include "MRphmap.h"
+
+namespace MR
+{
+
+/// this object stores a difference between two topologies: both in coordinates and in topology
+/// \details if the topologies are similar then this object is small, if the topologies are very distinct then this object will be even larger than one topology itself
+/// \ingroup MeshAlgorithmGroup
+class MeshTopologyDiff
+{
+public:
+    /// constructs minimal difference, where applyAndSwap( t ) will produce empty topology
+    MeshTopologyDiff() = default;
+
+    /// computes the difference, that can be applied to topology-from in order to get topology-to
+    MRMESH_API MeshTopologyDiff( const MeshTopology & from, const MeshTopology & to );
+
+    /// given topology-from on input converts it in topology-to,
+    /// this object is updated to become the reverse difference from original topology-to to original topology-from
+    MRMESH_API void applyAndSwap( MeshTopology & t );
+
+    /// returns true if this object does contain some difference in topology;
+    /// if (from) has more topology elements than (to) and the common elements are the same,
+    /// then the method will return false since nothing is stored here
+    [[nodiscard]] bool any() const { return !changedEdges_.empty(); }
+
+    /// returns the amount of memory this object occupies on heap
+    [[nodiscard]] MRMESH_API size_t heapBytes() const;
+
+private:
+    size_t toEdgesSize_ = 0;
+    HashMap<EdgeId, MeshTopology::HalfEdgeRecord> changedEdges_;
+};
+
+} // namespace MR

--- a/source/MRMesh/MRPartialChangeMeshAction.h
+++ b/source/MRMesh/MRPartialChangeMeshAction.h
@@ -15,13 +15,13 @@ namespace MR
 class PartialChangeMeshAction : public HistoryAction
 {
 public:
-    /// use this constructor to set new object mesh and remember its difference from existed mesh for future undoing
-    PartialChangeMeshAction( std::string name, const std::shared_ptr<ObjectMesh>& obj, std::shared_ptr<Mesh>&& newMesh ) :
-        objMesh_{ obj },
+    /// use this constructor to set new object's mesh and remember its difference from existed mesh for future undoing
+    PartialChangeMeshAction( std::string name, std::shared_ptr<ObjectMesh> obj, std::shared_ptr<Mesh>&& newMesh ) :
+        objMesh_{ std::move( obj ) },
         name_{ std::move( name ) }
     {
-        assert( obj && newMesh );
-        if ( obj )
+        assert( objMesh_ && newMesh );
+        if ( objMesh_ )
         {
             auto oldMesh = objMesh_->updateMesh( std::move( newMesh ) );
             if ( oldMesh && objMesh_->mesh() )
@@ -56,6 +56,110 @@ public:
 private:
     std::shared_ptr<ObjectMesh> objMesh_;
     MeshDiff meshDiff_;
+
+    std::string name_;
+};
+
+/// Undo action for efficiently storage of partial change in mesh points (e.g. a modification of small region)
+class PartialChangeMeshPointsAction : public HistoryAction
+{
+public:
+    /// use this constructor to set new object's points and remember its difference from existed points for future undoing
+    PartialChangeMeshPointsAction( std::string name, std::shared_ptr<ObjectMesh> obj, VertCoords&& newPoints ) :
+        objMesh_{ std::move( obj ) },
+        name_{ std::move( name ) }
+    {
+        assert( objMesh_ );
+        if ( !objMesh_ )
+            return;
+
+        if ( auto m = objMesh_->varMesh() )
+        {
+            pointsDiff_ = VertCoordsDiff( newPoints, m->points );
+            m->points = std::move( newPoints );
+            objMesh_->setDirtyFlags( DIRTY_POSITION );
+        }
+    }
+
+    virtual std::string name() const override
+    {
+        return name_;
+    }
+
+    virtual void action( HistoryAction::Type ) override
+    {
+        if ( !objMesh_ )
+            return;
+
+        auto m = objMesh_->varMesh();
+        assert( m );
+        if ( !m )
+            return;
+
+        pointsDiff_.applyAndSwap( m->points );
+        objMesh_->setDirtyFlags( DIRTY_POSITION );
+    }
+
+    [[nodiscard]] virtual size_t heapBytes() const override
+    {
+        return name_.capacity() + pointsDiff_.heapBytes();
+    }
+
+private:
+    std::shared_ptr<ObjectMesh> objMesh_;
+    VertCoordsDiff pointsDiff_;
+
+    std::string name_;
+};
+
+/// Undo action for efficiently storage of partial change in mesh topology (e.g. a modification of small region)
+class PartialChangeMeshTopologyAction : public HistoryAction
+{
+public:
+    /// use this constructor to set new object's topology and remember its difference from existed topology for future undoing
+    PartialChangeMeshTopologyAction( std::string name, std::shared_ptr<ObjectMesh> obj, MeshTopology&& newTopology ) :
+        objMesh_{ std::move( obj ) },
+        name_{ std::move( name ) }
+    {
+        assert( objMesh_ );
+        if ( !objMesh_ )
+            return;
+
+        if ( auto m = objMesh_->varMesh() )
+        {
+            topologyDiff_ = MeshTopologyDiff( newTopology, m->topology );
+            m->topology = std::move( newTopology );
+            objMesh_->setDirtyFlags( DIRTY_FACE );
+        }
+    }
+
+    virtual std::string name() const override
+    {
+        return name_;
+    }
+
+    virtual void action( HistoryAction::Type ) override
+    {
+        if ( !objMesh_ )
+            return;
+
+        auto m = objMesh_->varMesh();
+        assert( m );
+        if ( !m )
+            return;
+
+        topologyDiff_.applyAndSwap( m->topology );
+        objMesh_->setDirtyFlags( DIRTY_FACE );
+    }
+
+    [[nodiscard]] virtual size_t heapBytes() const override
+    {
+        return name_.capacity() + topologyDiff_.heapBytes();
+    }
+
+private:
+    std::shared_ptr<ObjectMesh> objMesh_;
+    MeshTopologyDiff topologyDiff_;
 
     std::string name_;
 };

--- a/source/MRMesh/MRPartialChangeMeshAction.h
+++ b/source/MRMesh/MRPartialChangeMeshAction.h
@@ -11,12 +11,31 @@ namespace MR
 /// \defgroup HistoryGroup History group
 /// \{
 
+/// argument of this type indicates that the object is already in new state, and the following argument is old state
+struct CmpOld {};
+inline constexpr CmpOld cmpOld;
+
+/// argument of this type indicates that the object is in old state, and the following argument is new state to be set
+struct SetNew {};
+inline constexpr SetNew setNew;
+
 /// Undo action for efficiently storage of partial change in mesh (e.g. a modification of small region)
 class PartialChangeMeshAction : public HistoryAction
 {
 public:
+    /// use this constructor after the object already contains new mesh,
+    /// and old mesh is passed to remember the difference for future undoing
+    PartialChangeMeshAction( std::string name, std::shared_ptr<ObjectMesh> obj, CmpOld, const Mesh &oldMesh ) :
+        objMesh_{ std::move( obj ) },
+        name_{ std::move( name ) }
+    {
+        assert( objMesh_ );
+        if ( objMesh_ && objMesh_->mesh() )
+            meshDiff_ = MeshDiff( *objMesh_->mesh(), oldMesh );
+    }
+
     /// use this constructor to set new object's mesh and remember its difference from existed mesh for future undoing
-    PartialChangeMeshAction( std::string name, std::shared_ptr<ObjectMesh> obj, std::shared_ptr<Mesh>&& newMesh ) :
+    PartialChangeMeshAction( std::string name, std::shared_ptr<ObjectMesh> obj, SetNew, std::shared_ptr<Mesh>&& newMesh ) :
         objMesh_{ std::move( obj ) },
         name_{ std::move( name ) }
     {
@@ -64,8 +83,22 @@ private:
 class PartialChangeMeshPointsAction : public HistoryAction
 {
 public:
+    /// use this constructor after the object already contains new points,
+    /// and old points are passed to remember the difference for future undoing
+    PartialChangeMeshPointsAction( std::string name, std::shared_ptr<ObjectMesh> obj, CmpOld, const VertCoords& oldPoints ) :
+        objMesh_{ std::move( obj ) },
+        name_{ std::move( name ) }
+    {
+        assert( objMesh_ );
+        if ( !objMesh_ )
+            return;
+
+        if ( auto m = objMesh_->varMesh() )
+            pointsDiff_ = VertCoordsDiff( m->points, oldPoints );
+    }
+
     /// use this constructor to set new object's points and remember its difference from existed points for future undoing
-    PartialChangeMeshPointsAction( std::string name, std::shared_ptr<ObjectMesh> obj, VertCoords&& newPoints ) :
+    PartialChangeMeshPointsAction( std::string name, std::shared_ptr<ObjectMesh> obj, SetNew, VertCoords&& newPoints ) :
         objMesh_{ std::move( obj ) },
         name_{ std::move( name ) }
     {
@@ -116,8 +149,22 @@ private:
 class PartialChangeMeshTopologyAction : public HistoryAction
 {
 public:
+    /// use this constructor after the object already contains new topology,
+    /// and old topology is passed to remember the difference for future undoing
+    PartialChangeMeshTopologyAction( std::string name, std::shared_ptr<ObjectMesh> obj, CmpOld, const MeshTopology& oldTopology ) :
+        objMesh_{ std::move( obj ) },
+        name_{ std::move( name ) }
+    {
+        assert( objMesh_ );
+        if ( !objMesh_ )
+            return;
+
+        if ( auto m = objMesh_->varMesh() )
+            topologyDiff_ = MeshTopologyDiff( m->topology, oldTopology );
+    }
+
     /// use this constructor to set new object's topology and remember its difference from existed topology for future undoing
-    PartialChangeMeshTopologyAction( std::string name, std::shared_ptr<ObjectMesh> obj, MeshTopology&& newTopology ) :
+    PartialChangeMeshTopologyAction( std::string name, std::shared_ptr<ObjectMesh> obj, SetNew, MeshTopology&& newTopology ) :
         objMesh_{ std::move( obj ) },
         name_{ std::move( name ) }
     {

--- a/source/MRMesh/MRVertCoordsDiff.cpp
+++ b/source/MRMesh/MRVertCoordsDiff.cpp
@@ -1,0 +1,56 @@
+#include "MRVertCoordsDiff.h"
+#include "MRVector.h"
+#include "MRTimer.h"
+#include "MRHeapBytes.h"
+
+namespace MR
+{
+
+VertCoordsDiff::VertCoordsDiff( const VertCoords & from, const VertCoords & to )
+{
+    MR_TIMER
+
+    toPointsSize_ = to.size();
+    for ( VertId v{0}; v < toPointsSize_; ++v )
+    {
+        if ( v >= from.size() || from[v] != to[v] )
+            changedPoints_[v] = to[v];
+    }
+}
+
+void VertCoordsDiff::applyAndSwap( VertCoords & m )
+{
+    MR_TIMER
+
+    auto mPointsSize = m.size();
+    // remember points being deleted from m
+    for ( VertId v{toPointsSize_}; v < mPointsSize; ++v )
+    {
+        changedPoints_[v] = m[v];
+    }
+    m.resize( toPointsSize_ );
+    // swap common points and delete points for vertices missing in original m (that will be next target)
+    for ( auto it = changedPoints_.begin(); it != changedPoints_.end(); )
+    {
+        auto v = it->first;
+        auto & pos = it->second;
+        if ( v < toPointsSize_ )
+        {
+            std::swap( pos, m[v] );
+            if ( v >= mPointsSize )
+            {
+                it = changedPoints_.erase( it );
+                continue;
+            }
+        }
+        ++it;
+    }
+    toPointsSize_ = mPointsSize;
+}
+
+size_t VertCoordsDiff::heapBytes() const
+{
+    return MR::heapBytes( changedPoints_ );
+}
+
+} // namespace MR

--- a/source/MRMesh/MRVertCoordsDiff.h
+++ b/source/MRMesh/MRVertCoordsDiff.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "MRphmap.h"
+
+namespace MR
+{
+
+/// this object stores a difference between two vectors with 3D coordinates
+/// \details if the vectors are similar then this object is small, if the vectors are very distinct then this object will be even larger than one vector itself
+/// \ingroup MeshAlgorithmGroup
+class VertCoordsDiff
+{
+public:
+    /// constructs minimal difference, where applyAndSwap( v ) will produce empty vector
+    VertCoordsDiff() = default;
+
+    /// computes the difference, that can be applied to vector-from in order to get vector-to
+    MRMESH_API VertCoordsDiff( const VertCoords & from, const VertCoords & to );
+
+    /// given vector-from on input converts it in vector-to,
+    /// this object is updated to become the reverse difference from original vector-to to original vector-from
+    MRMESH_API void applyAndSwap( VertCoords & m );
+
+    /// returns true if this object does contain some difference in point coordinates;
+    /// if (from) vector has just more points and the common elements are the same,
+    /// then the method will return false since nothing is stored here
+    [[nodiscard]] bool any() const { return !changedPoints_.empty(); }
+
+    /// returns the amount of memory this object occupies on heap
+    [[nodiscard]] MRMESH_API size_t heapBytes() const;
+
+private:
+    size_t toPointsSize_ = 0;
+    HashMap<VertId, Vector3f> changedPoints_;
+};
+
+} // namespace MR

--- a/source/MRViewer/MRSurfaceManipulationWidget.cpp
+++ b/source/MRViewer/MRSurfaceManipulationWidget.cpp
@@ -289,7 +289,7 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
             FaceBitSet newFaces = getInnerFaces( newMesh->topology, newVerts );
             auto meshAttribs = projectMeshAttributes( *obj_, MeshPart( *newMesh, &newFaces ) );
 
-            AppendHistory( std::make_shared<PartialChangeMeshAction>( "mesh", obj_, std::move( newMesh ) ) );
+            AppendHistory( std::make_shared<PartialChangeMeshAction>( "mesh", obj_, setNew, std::move( newMesh ) ) );
             if ( meshAttribs )
                 emplaceMeshAttributes( obj_, std::move( *meshAttribs ) );
 

--- a/source/MRViewer/MRSurfaceManipulationWidget.cpp
+++ b/source/MRViewer/MRSurfaceManipulationWidget.cpp
@@ -1,12 +1,14 @@
 #include "MRSurfaceManipulationWidget.h"
 #include "MRMouseController.h"
 #include "MRViewport.h"
-#include "MRMesh/MRObjectMesh.h"
-#include "MRMesh/MRMesh.h"
 #include "MRViewer.h"
 #include "MRAppendHistory.h"
 #include "MRMouse.h"
+#include "MRPalette.h"
+#include "MRProjectMeshAttributes.h"
 #include "MRViewer/MRGladGlfw.h"
+#include "MRMesh/MRObjectMesh.h"
+#include "MRMesh/MRMesh.h"
 #include "MRMesh/MREdgePaths.h"
 #include "MRMesh/MRPositionVertsSmoothly.h"
 #include "MRMesh/MRSurfaceDistance.h"
@@ -19,11 +21,10 @@
 #include "MRMesh/MRFillHoleNicely.h"
 #include "MRMesh/MRLaplacian.h"
 #include "MRMesh/MRMeshFwd.h"
-#include "MRPalette.h"
 #include "MRMesh/MRPointsToMeshProjector.h"
 #include "MRMesh/MRRingIterator.h"
 #include "MRMesh/MRParallelFor.h"
-#include "MRProjectMeshAttributes.h"
+#include "MRMesh/MRPartialChangeMeshAction.h"
 
 namespace MR
 {
@@ -288,7 +289,7 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
             FaceBitSet newFaces = getInnerFaces( newMesh->topology, newVerts );
             auto meshAttribs = projectMeshAttributes( *obj_, MeshPart( *newMesh, &newFaces ) );
 
-            Historian<ChangeMeshAction>( "mesh", obj_, newMesh );
+            AppendHistory( std::make_shared<PartialChangeMeshAction>( "mesh", obj_, std::move( newMesh ) ) );
             if ( meshAttribs )
                 emplaceMeshAttributes( obj_, std::move( *meshAttribs ) );
 


### PR DESCRIPTION
* `MeshDiff` is split on `VertCoordsDiff` and `MeshTopologyDiff`
* new `PartialChangeMeshPointsAction` and `PartialChangeMeshTopologyAction` in addition to `PartialChangeMeshAction`, all of which can be initialized from old or new object state
* Brush/Patch is implemented via `PartialChangeMeshAction`