### PR TITLE
Improve objects tree from folder

### DIFF
--- a/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
@@ -413,15 +413,6 @@ void OpenDirectoryMenuItem::openDirectory( const std::filesystem::path& director
     if ( directory.empty() )
         return;
 
-#if !defined( MESHLIB_NO_VOXELS ) && !defined( MRVOXELS_NO_DICOM )
-    // check if the directory can be opened as a DICOM archive
-    if ( VoxelsLoad::isDicomFolder( directory ) )
-    {
-        sOpenDICOMs( directory, "Failed to open directory as DICOM:\n" + utf8string( directory ) );
-        return;
-    }
-#endif
-
     bool isAnySupportedFiles = isSupportedFileInSubfolders( directory );
     if ( isAnySupportedFiles )
     {

--- a/source/MRViewer/MROpenObjects.cpp
+++ b/source/MRViewer/MROpenObjects.cpp
@@ -48,7 +48,7 @@ public:
         const float totalWeight = totalWeight_;
         progress_ = progress_ * totalWeight / ( totalWeight + weight );
         totalWeight_ += weight;
-        return PerTaskReporter( this, &perTaskInfo_.emplace_front() );
+        return PerTaskReporter( this, &perTaskInfo_.emplace_front( TaskInfo{ .progress = 0.f, .weight = weight } ) );
     }
 
     bool updateTask( float delta )

--- a/source/MRVoxels/MRDicom.cpp
+++ b/source/MRVoxels/MRDicom.cpp
@@ -857,16 +857,19 @@ Expected<std::shared_ptr<ObjectVoxels>> createObjectVoxels( const DicomVolumeAsV
 
     obj->select( true );
     obj->setXf( dcm.xf );
+
+    reportProgress( cb, 1.f );
+
     return obj;
 }
 
 Expected<LoadedObjectVoxels> makeObjectVoxelsFromDicomFolder( const std::filesystem::path& folder, const ProgressCallback& callback )
 {
     MR_TIMER
-    return loadDicomFolder<VdbVolume>( folder, 4, subprogress( callback, 0.0f, 0.5f ) ).and_then(
+    return loadDicomFolder<VdbVolume>( folder, 4, subprogress( callback, 0.0f, 0.7f ) ).and_then(
     [&]( DicomVolumeAsVdb && vdb )
     {
-        return createObjectVoxels( vdb, subprogress( callback, 0.5f, 1.0f ) );
+        return createObjectVoxels( vdb, subprogress( callback, 0.7f, 1.0f ) );
     } ).and_then(
     [&]( std::shared_ptr<ObjectVoxels> && objVoxels ) -> Expected<LoadedObjectVoxels>
     {


### PR DESCRIPTION
1. If a folder is found to be a DICOM folder, and it contains only one series, then the empty "wrapper" object is no longer created. This is consistent with the way DICOM folders are loaded from the "Open DICOMs" plugin.
2. Each opening function reports its own progress, instead of simply reporting the number of opened files divided by the total number. 

These two improvements should make the function behave similarly (from the user perspective) to the "Open DICOMs" regarding the state of the scene and the way progress is reported.