### PR TITLE
meshToDistanceVolume support for SignDetectionMode::OpenVDB

### DIFF
--- a/source/MRVoxels/MRMeshToDistanceVolume.cpp
+++ b/source/MRVoxels/MRMeshToDistanceVolume.cpp
@@ -27,7 +27,7 @@ Expected<SimpleVolumeMinMax> meshToDistanceVolume( const MeshPart& mp, const Mes
             .cb = subprogress( cParams.vol.cb, 0.0f, 0.8f )
         };
         return meshToDistanceVdbVolume( mp, m2vPrams ).and_then(
-            [&cParams]( VdbVolume && vdbVolume ) -> Expected<SimpleVolumeMinMax>
+            [&cParams]( VdbVolume && vdbVolume )
             {
                 return vdbVolumeToSimpleVolume( vdbVolume, Box3i{ Vector3i( 0, 0, 0 ), cParams.vol.dimensions }, subprogress( cParams.vol.cb, 0.8f, 1.0f ) );
             } );

--- a/source/MRVoxels/MRMeshToDistanceVolume.cpp
+++ b/source/MRVoxels/MRMeshToDistanceVolume.cpp
@@ -26,6 +26,12 @@ Expected<SimpleVolumeMinMax> meshToDistanceVolume( const MeshPart& mp, const Mes
             .worldXf = AffineXf3f::translation( -cParams.vol.origin - 0.5f * cParams.vol.voxelSize ),
             .cb = subprogress( cParams.vol.cb, 0.0f, 0.8f )
         };
+        assert( cParams.dist.maxDistSq < FLT_MAX ); // the amount of work is proportional to maximal distance
+        if ( cParams.dist.maxDistSq < FLT_MAX )
+        {
+            m2vPrams.surfaceOffset = std::sqrt( cParams.dist.maxDistSq )
+                / std::min( { cParams.vol.voxelSize.x, cParams.vol.voxelSize.y, cParams.vol.voxelSize.z } );
+        }
         return meshToDistanceVdbVolume( mp, m2vPrams ).and_then(
             [&cParams]( VdbVolume && vdbVolume )
             {

--- a/source/MRVoxels/MROffset.cpp
+++ b/source/MRVoxels/MROffset.cpp
@@ -116,8 +116,41 @@ Expected<Mesh> doubleOffsetMesh( const MeshPart& mp, float offsetA, float offset
 Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
     const OffsetParameters& params, Vector<VoxelId, FaceId> * outMap )
 {
-    MR_TIMER;
-    auto meshToLSCb = subprogress( params.callBack, 0.0f, 0.4f );
+    MR_TIMER
+
+    MeshToDistanceVolumeParams msParams;
+    msParams.vol.cb = params.callBack;
+    auto absOffset = std::abs( offset );
+    const auto box = mp.mesh.computeBoundingBox( mp.region ).expanded( Vector3f::diagonal( absOffset ) );
+    const auto [origin, dimensions] = calcOriginAndDimensions( box, params.voxelSize );
+    msParams.vol.origin = origin;
+    msParams.vol.voxelSize = Vector3f::diagonal( params.voxelSize );
+    msParams.vol.dimensions = dimensions;
+    msParams.dist.maxDistSq = sqr( absOffset + 1.001f * params.voxelSize ); // we multiply by 1.001f to be sure not to have rounding errors (which may lead to unexpected NaN values )
+    msParams.dist.minDistSq = sqr( std::max( absOffset - 1.001f * params.voxelSize, 0.0f ) ); // we multiply by 1.001f to be sure not to have rounding errors (which may lead to unexpected NaN values )
+    msParams.dist.signMode = SignDetectionMode::OpenVDB;// params.signDetectionMode;
+    msParams.dist.windingNumberThreshold = params.windingNumberThreshold;
+    msParams.dist.windingNumberBeta = params.windingNumberBeta;
+    //msParams.fwn = params.fwn;
+
+    MarchingCubesParams vmParams;
+    vmParams.origin = msParams.vol.origin;
+    vmParams.iso = offset;
+    vmParams.cb = subprogress( params.callBack, 0.4f, 1.0f );
+    vmParams.lessInside = true;
+    vmParams.outVoxelPerFaceMap = outMap;
+
+    return meshToDistanceVolume( mp, msParams ).and_then( [&vmParams] ( SimpleVolumeMinMax&& volume )
+    {
+        vmParams.freeVolume = [&volume]
+        {
+            Timer t( "~SimpleVolume" );
+            volume = {};
+        };
+        return marchingCubes( volume, vmParams );
+    } );
+
+/*    auto meshToLSCb = subprogress( params.callBack, 0.0f, 0.4f );
     if ( params.signDetectionMode == SignDetectionMode::OpenVDB )
     {
         auto offsetInVoxels = offset / params.voxelSize;
@@ -184,7 +217,7 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
                 return marchingCubes( volume, vmParams );
             } );
         }
-    }
+    }*/
 }
 
 Expected<Mesh> mcShellMeshRegion( const Mesh& mesh, const FaceBitSet& region, float offset,

--- a/source/MRVoxels/MRVDBConversions.cpp
+++ b/source/MRVoxels/MRVDBConversions.cpp
@@ -211,27 +211,23 @@ void evalGridMinMax( const FloatGrid& grid, float& min, float& max )
 #endif
 }
 
-Expected<VdbVolume> meshToVolume( const MeshPart& mp, const MeshToVolumeParams& params /*= {} */ )
+Expected<VdbVolume> meshToDistanceVdbVolume( const MeshPart& mp, const MeshToVolumeParams& params /*= {} */ )
 {
     if ( params.type == MeshToVolumeParams::Type::Signed && !mp.mesh.topology.isClosed( mp.region ) )
         return unexpected( "Only closed mesh can be converted to signed volume" );
     MR_TIMER
 
-    auto shift = AffineXf3f::translation( mp.mesh.computeBoundingBox( mp.region, &params.worldXf ).min - params.surfaceOffset * params.voxelSize );
     FloatGrid grid;
     if ( params.type == MeshToVolumeParams::Type::Signed )
-        grid = meshToLevelSet( mp, shift.inverse() * params.worldXf, params.voxelSize, params.surfaceOffset, params.cb );
+        grid = meshToLevelSet( mp, params.worldXf, params.voxelSize, params.surfaceOffset, params.cb );
     else
-        grid = meshToDistanceField( mp, shift.inverse() * params.worldXf, params.voxelSize, params.surfaceOffset, params.cb );
+        grid = meshToDistanceField( mp, params.worldXf, params.voxelSize, params.surfaceOffset, params.cb );
 
     if ( !grid )
         return unexpectedOperationCanceled();
 
     // to get proper normal orientation both for signed and unsigned cases
     grid->setGridClass( openvdb::GRID_LEVEL_SET );
-
-    if ( params.outXf )
-        *params.outXf = shift;
 
     VdbVolume res;
     res.data = grid;
@@ -241,6 +237,20 @@ Expected<VdbVolume> meshToVolume( const MeshPart& mp, const MeshToVolumeParams& 
     res.voxelSize = params.voxelSize;
 
     return res;
+}
+
+Expected<VdbVolume> meshToVolume( const MeshPart& mp, const MeshToVolumeParams& cParams /*= {} */ )
+{
+    MR_TIMER
+
+    auto shift = AffineXf3f::translation( mp.mesh.computeBoundingBox( mp.region, &cParams.worldXf ).min
+        - cParams.surfaceOffset * cParams.voxelSize );
+    if ( cParams.outXf )
+        *cParams.outXf = shift;
+
+    auto params = cParams;
+    params.worldXf = shift.inverse() * cParams.worldXf;
+    return meshToDistanceVdbVolume( mp, params );
 }
 
 VdbVolume floatGridToVdbVolume( FloatGrid grid )

--- a/source/MRVoxels/MRVDBConversions.h
+++ b/source/MRVoxels/MRVDBConversions.h
@@ -48,7 +48,14 @@ struct MeshToVolumeParams
 MRVOXELS_API void evalGridMinMax( const FloatGrid& grid, float& min, float& max );
 
 /// converts mesh (or its part) into a volume filled with signed or unsigned distances to mesh using OpenVDB library;
-/// for signed distances the mesh must be closed
+/// for signed distances the mesh must be closed;
+/// *params.outXf is untouched
+MRVOXELS_API Expected<VdbVolume> meshToDistanceVdbVolume( const MeshPart& mp, const MeshToVolumeParams& params = {} );
+
+/// converts mesh (or its part) into a volume filled with signed or unsigned distances to mesh using OpenVDB library;
+/// for signed distances the mesh must be closed;
+/// prior to conversion, world space is shifted to ensure that the bounding box of offset mesh is in positive quarter-space,
+/// and the shift is written in *params.outXf
 MRVOXELS_API Expected<VdbVolume> meshToVolume( const MeshPart& mp, const MeshToVolumeParams& params = {} );
 
 // fills VdbVolume data from FloatGrid (does not fill voxels size, cause we expect it outside)


### PR DESCRIPTION
* `meshToDistanceVolume` function now supports `SignDetectionMode::OpenVDB` mode
* new `meshToDistanceVdbVolume` function with the core processing of `meshToVolume` function, just without shift auto-computation

It was requested in #3902 