### PR TITLE
Mesh::addMeshPart

### DIFF
--- a/scripts/devops/collect_ci_stats.py
+++ b/scripts/devops/collect_ci_stats.py
@@ -20,7 +20,7 @@ def parse_iso8601(s):
     return datetime.datetime.strptime(s, '%Y-%m-%dT%H:%M:%S%z')
 
 def get_duration(obj):
-    if obj.get('started_at') and obj.get('completed_at'):
+    if 'started_at' in obj and 'completed_at' in obj:
         return parse_iso8601(obj['completed_at']) - parse_iso8601(obj['started_at'])
 
 def parse_step(step: dict):

--- a/source/MRIOExtras/MR3mf.cpp
+++ b/source/MRIOExtras/MR3mf.cpp
@@ -451,13 +451,13 @@ Expected<void> Node::loadObject_( const tinyxml2::XMLElement* xmlNode, ProgressC
             bgColor = it->second->bgColor;
             if ( transform == AffineXf3f() )
             {
-                mesh.addPart( it->second->mesh );
+                mesh.addMesh( it->second->mesh );
             }
             else
             {
                 auto meshCopy = it->second->mesh;
                 meshCopy.transform( transform );
-                mesh.addPart( std::move( meshCopy ) );
+                mesh.addMesh( meshCopy );
             }
         }
         return {};

--- a/source/MRIOExtras/MRStep.cpp
+++ b/source/MRIOExtras/MRStep.cpp
@@ -763,7 +763,7 @@ Expected<Mesh> fromStepImpl( const std::function<Expected<void> ( STEPControl_Re
     {
         auto& mesh = objMesh->varMesh();
         mesh->transform( objMesh->worldXf() );
-        result.addPart( *mesh );
+        result.addMesh( *mesh );
     }
     return result;
 }

--- a/source/MRMesh/MRArrow.cpp
+++ b/source/MRMesh/MRArrow.cpp
@@ -61,8 +61,8 @@ Mesh makeBasisAxes(const float& size, const float& thickness, const float& coneR
     Mesh meshObjX = makeArrow(base, base + Vector3f::plusX() * size, thickness, coneRadius, coneSize, qual);
     Mesh meshObjY = makeArrow(base, base + Vector3f::plusY() * size, thickness, coneRadius, coneSize, qual);
     Mesh meshObjZ = makeArrow(base, base + Vector3f::plusZ() * size, thickness, coneRadius, coneSize, qual);
-    meshObjX.addPart(meshObjY);
-    meshObjX.addPart(meshObjZ);
+    meshObjX.addMesh( meshObjY );
+    meshObjX.addMesh( meshObjZ );
     return meshObjX;
 }
 

--- a/source/MRMesh/MRBooleanOperation.cpp
+++ b/source/MRMesh/MRBooleanOperation.cpp
@@ -111,7 +111,7 @@ bool preparePart( const Mesh& origin, std::vector<EdgePath>& cutPaths, Mesh& out
     auto compsMap = MeshComponents::getAllComponentsMap( origin );
     leftPart = preparePart( origin, compsMap, leftPart, otherMesh, needInsidePart, originIsA, rigidB2A, mergeAllNonIntersectingComponents, intParams );
 
-    outMesh.addPartByMask( origin, leftPart, needFlip, {}, {},
+    outMesh.addMeshPart( { origin, &leftPart }, needFlip, {}, {},
         HashToVectorMappingConverter( origin.topology, fMapPtr, vMapPtr, eMapPtr ).getPartMapping() );
 
     for ( auto& path : cutPaths )
@@ -141,14 +141,14 @@ void connectPreparedParts( Mesh& partA, Mesh& partB, bool pathsHaveLeftHole,
     VertMap* vMapNewPtr = mapper ? &vMapNew : nullptr;
 
     if ( pathsA.empty() )
-        partA.addPart( partB, fMapNewPtr, vMapNewPtr, eMapNewPtr );
+        partA.addMesh( partB, fMapNewPtr, vMapNewPtr, eMapNewPtr );
     else
     {
         if ( !pathsHaveLeftHole )
-            partA.addPartByMask( partB, partB.topology.getValidFaces(), false, pathsA, pathsB, 
+            partA.addMeshPart( partB, false, pathsA, pathsB,
                 HashToVectorMappingConverter( partB.topology, fMapNewPtr, vMapNewPtr, eMapNewPtr ).getPartMapping() );
         else
-            partB.addPartByMask( partA, partA.topology.getValidFaces(), false, pathsB, pathsA,
+            partB.addMeshPart( partA, false, pathsB, pathsA,
                 HashToVectorMappingConverter( partA.topology, fMapNewPtr, vMapNewPtr, eMapNewPtr ).getPartMapping() );
     }
 
@@ -203,7 +203,7 @@ Mesh doTrivialBooleanOperation( Mesh&& meshACut, Mesh&& meshBCut, BooleanOperati
         WholeEdgeMap* eMapPtr = mapper ? &mapper->maps[int( BooleanResultMapper::MapObject::A )].old2newEdges : nullptr;
         VertMap* vMapPtr = mapper ? &mapper->maps[int( BooleanResultMapper::MapObject::A )].old2newVerts : nullptr;
 
-        aPart.addPartByMask( std::move( meshACut ), aPartFbs, operation == BooleanOperation::DifferenceBA,
+        aPart.addMeshPart( { meshACut, &aPartFbs }, operation == BooleanOperation::DifferenceBA,
                              {}, {}, HashToVectorMappingConverter( meshACut.topology, fMapPtr, vMapPtr, eMapPtr ).getPartMapping() );
     }
 
@@ -213,7 +213,7 @@ Mesh doTrivialBooleanOperation( Mesh&& meshACut, Mesh&& meshBCut, BooleanOperati
         WholeEdgeMap* eMapPtr = mapper ? &mapper->maps[int( BooleanResultMapper::MapObject::B )].old2newEdges : nullptr;
         VertMap* vMapPtr = mapper ? &mapper->maps[int( BooleanResultMapper::MapObject::B )].old2newVerts : nullptr;
 
-        bPart.addPartByMask( std::move( meshBCut ), bPartFbs, operation == BooleanOperation::DifferenceAB,
+        bPart.addMeshPart( { meshBCut, &bPartFbs }, operation == BooleanOperation::DifferenceAB,
                              {}, {}, HashToVectorMappingConverter( meshBCut.topology, fMapPtr, vMapPtr, eMapPtr ).getPartMapping() );
     }
 

--- a/source/MRMesh/MREmbedTerrainStructure.cpp
+++ b/source/MRMesh/MREmbedTerrainStructure.cpp
@@ -350,7 +350,7 @@ TerrainEmbedder::ConnectionEdges TerrainEmbedder::connect_( std::vector<EdgeLoop
 {
     WholeEdgeMap emap;
     auto faceNum = int( result_.topology.faceSize() );
-    result_.addPart( std::move( cutStructure_ ), nullptr, nullptr, &emap );
+    result_.addMesh( cutStructure_, nullptr, nullptr, &emap );
     if ( params_.outStructFaces )
     {
         params_.outStructFaces->resize( result_.topology.faceSize() );

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -173,7 +173,7 @@ Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepres
     }
     
     // add patch surface to original mesh
-    mesh.addPartByMask( patchMesh, patchMesh.topology.getValidFaces(), false, paths, newPaths );
+    mesh.addMeshPart( patchMesh, false, paths, newPaths );
     return {};
 }
 
@@ -183,7 +183,7 @@ TEST( MRMesh, fillContours2D )
     Mesh sphereSmall = makeUVSphere( 0.7f, 16, 16 );
 
     sphereSmall.topology.flipOrientation();
-    sphereBig.addPart( std::move( sphereSmall ) );
+    sphereBig.addMesh( sphereSmall );
 
     trimWithPlane( sphereBig, TrimWithPlaneParams{ .plane = Plane3f::fromDirAndPt( Vector3f::plusZ(), Vector3f() ) } );
     sphereBig.pack();

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -978,7 +978,7 @@ VertId Mesh::splitFace( FaceId f, const Vector3f & newVertPos, FaceBitSet * regi
     return newv;
 }
 
-void Mesh::addPart( const Mesh & from,
+void Mesh::addMesh( const Mesh & from,
     FaceMap * outFmap, VertMap * outVmap, WholeEdgeMap * outEmap, bool rearrangeTriangles )
 {
     MR_TIMER
@@ -1000,18 +1000,19 @@ void Mesh::addPart( const Mesh & from,
     invalidateCaches();
 }
 
-void Mesh::addPartByMask( const Mesh & from, const FaceBitSet & fromFaces, const PartMapping & map )
+void Mesh::addMeshPart( const MeshPart & from, const PartMapping & map )
 {
-    addPartByMask( from, fromFaces, false, {}, {}, map );
+    addMeshPart( from, false, {}, {}, map );
 }
 
-void Mesh::addPartByMask( const Mesh & from, const FaceBitSet & fromFaces, bool flipOrientation,
+void Mesh::addMeshPart( const MeshPart & from, bool flipOrientation,
     const std::vector<EdgePath> & thisContours,
     const std::vector<EdgePath> & fromContours,
     const PartMapping & map )
 {
     MR_TIMER
-    addPartBy( from, begin( fromFaces ), end( fromFaces ), fromFaces.count(), flipOrientation, thisContours, fromContours, map );
+    const auto & fromFaces = from.mesh.topology.getFaceIds( from.region );
+    addPartBy( from.mesh, begin( fromFaces ), end( fromFaces ), fromFaces.count(), flipOrientation, thisContours, fromContours, map );
 }
 
 void Mesh::addPartByFaceMap( const Mesh & from, const FaceMap & fromFaces, bool flipOrientation,
@@ -1068,7 +1069,7 @@ Mesh Mesh::cloneRegion( const FaceBitSet & region, bool flipOrientation, const P
     const auto ecount = 2 * getIncidentEdges( topology, region ).count();
     res.topology.edgeReserve( ecount );
 
-    res.addPartByMask( *this, region, flipOrientation, {}, {}, map );
+    res.addMeshPart( { *this, &region }, flipOrientation, {}, {}, map );
 
     assert( res.topology.faceSize() == fcount );
     assert( res.topology.faceCapacity() == fcount );
@@ -1090,7 +1091,7 @@ void Mesh::pack( FaceMap * outFmap, VertMap * outVmap, WholeEdgeMap * outEmap, b
     packed.topology.vertReserve( topology.numValidVerts() );
     packed.topology.faceReserve( topology.numValidFaces() );
     packed.topology.edgeReserve( 2 * topology.computeNotLoneUndirectedEdges() );
-    packed.addPart( *this, outFmap, outVmap, outEmap, rearrangeTriangles );
+    packed.addMesh( *this, outFmap, outVmap, outEmap, rearrangeTriangles );
     *this = std::move( packed );
 }
 

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -371,28 +371,34 @@ struct [[nodiscard]] Mesh
     VertId splitFace( FaceId f, FaceBitSet * region = nullptr, FaceHashMap * new2Old = nullptr ) { return splitFace( f, triCenter( f ), region, new2Old ); }
 
     /// appends mesh (from) in addition to this mesh: creates new edges, faces, verts and points
-    MRMESH_API void addPart( const Mesh & from,
+    MRMESH_API void addMesh( const Mesh & from,
         // optionally returns mappings: from.id -> this.id
         FaceMap * outFmap = nullptr, VertMap * outVmap = nullptr, WholeEdgeMap * outEmap = nullptr, bool rearrangeTriangles = false );
+    [[deprecated]] void addPart( const Mesh & from, FaceMap * outFmap = nullptr, VertMap * outVmap = nullptr, WholeEdgeMap * outEmap = nullptr, bool rearrangeTriangles = false )
+        { addMesh( from, outFmap, outVmap, outEmap, rearrangeTriangles ); }
 
     /// the same but copies only portion of (from) specified by fromFaces
-    MRMESH_API void addPartByMask( const Mesh & from, const FaceBitSet & fromFaces, const PartMapping & map );
+    MRMESH_API void addMeshPart( const MeshPart & from, const PartMapping & map );
+    [[deprecated]] void addPartByMask( const Mesh & from, const FaceBitSet & fromFaces, const PartMapping & map ) { addMeshPart( { from, &fromFaces }, map ); }
 
     /// this version has more parameters:
     ///   if flipOrientation then every from triangle is inverted before adding
-    MRMESH_API void addPartByMask( const Mesh & from, const FaceBitSet & fromFaces, bool flipOrientation = false,
+    MRMESH_API void addMeshPart( const MeshPart & from, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, // contours on this mesh that have to be stitched with
         const std::vector<EdgePath> & fromContours = {}, // contours on from mesh during addition
         // optionally returns mappings: from.id -> this.id
         const PartMapping & map = {} );
+    [[deprecated]] void addPartByMask( const Mesh & from, const FaceBitSet & fromFaces, bool flipOrientation = false,
+        const std::vector<EdgePath> & thisContours = {}, const std::vector<EdgePath> & fromContours = {}, const PartMapping & map = {} )
+        { addMeshPart( { from, &fromFaces }, flipOrientation, thisContours, fromContours, map ); }
 
     /// fromFaces contains mapping from this-mesh (considering it is empty) to from-mesh
     MRMESH_API void addPartByFaceMap( const Mesh & from, const FaceMap & fromFaces, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, // contours on this mesh that have to be stitched with
         const std::vector<EdgePath> & fromContours = {}, // contours on from mesh during addition
         // optionally returns mappings: from.id -> this.id
-    
         const PartMapping & map = {} );
+
     /// both addPartByMask and addPartByFaceMap call this general implementation
     template<typename I>
     MRMESH_API void addPartBy( const Mesh & from, I fbegin, I fend, size_t fcount, bool flipOrientation = false,

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -370,19 +370,19 @@ struct [[nodiscard]] Mesh
     // same, putting new vertex in the centroid of original triangle
     VertId splitFace( FaceId f, FaceBitSet * region = nullptr, FaceHashMap * new2Old = nullptr ) { return splitFace( f, triCenter( f ), region, new2Old ); }
 
-    /// appends mesh (from) in addition to this mesh: creates new edges, faces, verts and points
+    /// appends another mesh as separate connected component(s) to this
     MRMESH_API void addMesh( const Mesh & from,
         // optionally returns mappings: from.id -> this.id
         FaceMap * outFmap = nullptr, VertMap * outVmap = nullptr, WholeEdgeMap * outEmap = nullptr, bool rearrangeTriangles = false );
     [[deprecated]] void addPart( const Mesh & from, FaceMap * outFmap = nullptr, VertMap * outVmap = nullptr, WholeEdgeMap * outEmap = nullptr, bool rearrangeTriangles = false )
         { addMesh( from, outFmap, outVmap, outEmap, rearrangeTriangles ); }
 
-    /// the same but copies only portion of (from) specified by fromFaces
+    /// appends whole or part of another mesh as separate connected component(s) to this
     MRMESH_API void addMeshPart( const MeshPart & from, const PartMapping & map );
     [[deprecated]] void addPartByMask( const Mesh & from, const FaceBitSet & fromFaces, const PartMapping & map ) { addMeshPart( { from, &fromFaces }, map ); }
 
-    /// this version has more parameters:
-    ///   if flipOrientation then every from triangle is inverted before adding
+    /// appends whole or part of another mesh as separate connected component(s) to this
+    /// \param flipOrientation true means that every (from) triangle is inverted before adding
     MRMESH_API void addMeshPart( const MeshPart & from, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, // contours on this mesh that have to be stitched with
         const std::vector<EdgePath> & fromContours = {}, // contours on from mesh during addition

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -381,7 +381,7 @@ struct [[nodiscard]] Mesh
     MRMESH_API void addMeshPart( const MeshPart & from, const PartMapping & map );
     [[deprecated]] void addPartByMask( const Mesh & from, const FaceBitSet & fromFaces, const PartMapping & map ) { addMeshPart( { from, &fromFaces }, map ); }
 
-    /// appends whole or part of another mesh as separate connected component(s) to this
+    /// appends whole or part of another mesh to this joining added faces with existed ones along given contours
     /// \param flipOrientation true means that every (from) triangle is inverted before adding
     MRMESH_API void addMeshPart( const MeshPart & from, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, // contours on this mesh that have to be stitched with

--- a/source/MRMesh/MRMeshBoolean.cpp
+++ b/source/MRMesh/MRMeshBoolean.cpp
@@ -611,7 +611,7 @@ TEST( MRMesh, BooleanMultipleEdgePropogationSort )
 
         auto border = trackRightBoundaryLoop( meshA.topology, meshA.topology.findHoleRepresentiveEdges()[0] );
 
-        meshA.addPartByMask( meshASup, meshASup.topology.getValidFaces(), true, { border }, { border } );
+        meshA.addMeshPart( meshASup, true, { border }, { border } );
     }
 
     auto meshB = makeCube( Vector3f::diagonal( 2.0f ) );

--- a/source/MRMesh/MRMeshTests.cpp
+++ b/source/MRMesh/MRMeshTests.cpp
@@ -28,7 +28,7 @@ TEST(MRMesh, Pack)
     EXPECT_EQ( mesh.topology.lastNotLoneEdge(), EdgeId(9) ); // 5*2 = 10 half-edges in total
 
     Mesh dbl = mesh;
-    dbl.addPart( mesh );
+    dbl.addMesh( mesh );
     EXPECT_TRUE( dbl.topology.checkValidity() );
     EXPECT_EQ( dbl.points.size(), 8 );
     EXPECT_EQ( dbl.topology.numValidVerts(), 8 );
@@ -94,7 +94,7 @@ TEST(MRMesh, AddPartByMask)
     mapping.src2tgtFaces = &meshIntoMesh2;
     mapping.tgt2srcFaces = &mesh2IntoMesh;
 
-    mesh.addPartByMask( mesh2, faces, mapping );
+    mesh.addMeshPart( { mesh2, &faces }, mapping );
     for ( auto [f, f2] : meshIntoMesh2 )
         EXPECT_EQ( mesh2IntoMesh[f2], f );
 
@@ -110,7 +110,7 @@ TEST(MRMesh, AddPartByMask)
 
     faces.set( 0_f );
     faces.reset( 1_f );
-    mesh.addPartByMask( mesh2, faces );
+    mesh.addMeshPart( { mesh2, &faces } );
 
     EXPECT_EQ( mesh.points.size(), 10 );
     EXPECT_EQ( mesh.topology.edgePerVertex().size(), 10 );

--- a/source/MRMesh/MRObjectMesh.cpp
+++ b/source/MRMesh/MRObjectMesh.cpp
@@ -286,7 +286,7 @@ std::shared_ptr<ObjectMesh> merge( const std::vector<std::shared_ptr<ObjectMesh>
 
         VertMap vertMap;
         FaceMap faceMap;
-        mesh->addPart( *obj->mesh(), hasFaceColorMap || needTexturePerFace ? &faceMap : nullptr, &vertMap );
+        mesh->addMesh( *obj->mesh(), hasFaceColorMap || needTexturePerFace ? &faceMap : nullptr, &vertMap );
 
         auto worldXf = obj->worldXf();
         for ( const auto& vInd : vertMap )

--- a/source/MRMesh/MRObjectSave.cpp
+++ b/source/MRMesh/MRObjectSave.cpp
@@ -41,7 +41,7 @@ Mesh mergeToMesh( const Object& object )
             continue;
 
         VertMap vmap;
-        result.addPart( *objMesh->mesh(), nullptr, &vmap );
+        result.addMesh( *objMesh->mesh(), nullptr, &vmap );
 
         const auto xf = objMesh->worldXf();
         for ( const auto v : vmap )

--- a/source/MRMesh/MRUniteManyMeshes.cpp
+++ b/source/MRMesh/MRUniteManyMeshes.cpp
@@ -116,7 +116,7 @@ public:
             else
             {
                 FaceMap fMap;
-                resultMesh.addPart( y.resultMesh, collectNewFaces_ ? &fMap : nullptr );
+                resultMesh.addMesh( y.resultMesh, collectNewFaces_ ? &fMap : nullptr );
                 if ( collectNewFaces_ )
                 {
                     newFaces.resize( fMap.size() );
@@ -287,7 +287,7 @@ Expected<Mesh> uniteManyMeshes(
                 auto& mergedMesh = mergedMeshes[i];
                 auto& mergeGroup = nonIntersectingGroups[i];
                 for ( auto meshIndex : mergeGroup )
-                    mergedMesh.addPart( *meshes[meshIndex] );
+                    mergedMesh.addMesh( *meshes[meshIndex] );
             }
         } );
     }

--- a/source/MRMeshC/MRMesh.cpp
+++ b/source/MRMeshC/MRMesh.cpp
@@ -126,7 +126,7 @@ void mrMeshAddPartByMask( MRMesh* mesh_, const MRMesh* from_, const MRFaceBitSet
         fromContoursVec.assign( fromContours.begin(), fromContours.end() );
     }
 
-    mesh.addPartByMask( from, fromFaces, flipOrientation, thisContoursVec, fromContoursVec );
+    mesh.addMeshPart( { from, &fromFaces }, flipOrientation, thisContoursVec, fromContoursVec );
 }
 
 void mrMeshFree( MRMesh* mesh_ )

--- a/source/MRSymbolMesh/MRObjectLabel.cpp
+++ b/source/MRSymbolMesh/MRObjectLabel.cpp
@@ -198,7 +198,7 @@ void ObjectLabel::buildMeshFromText() const
         mesh.transform( AffineXf3f::translation(
             Vector3f::minusY() * SymbolMeshParams::MaxGeneratedFontHeight * 1.3f * float( i ) ) );
 
-        mesh_->addPart( mesh );
+        mesh_->addMesh( mesh );
     }
 
     meshBox_ = mesh_->computeBoundingBox();

--- a/source/MRSymbolMesh/MRSymbolMesh.cpp
+++ b/source/MRSymbolMesh/MRSymbolMesh.cpp
@@ -299,7 +299,7 @@ void addBaseToPlanarMesh( Mesh & mesh, float zOffset )
 
     mesh2.topology.flipOrientation();
 
-    mesh.addPart( mesh2 );
+    mesh.addMesh( mesh2 );
 
     auto edges = mesh.topology.findHoleRepresentiveEdges();
     for ( int bi = 0; bi < edges.size() / 2; ++bi )

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -1979,8 +1979,8 @@ void Viewer::initGlobalBasisAxesObject_()
         }
         basis.transform( rotTramsform );
         cone.transform( rotTramsform * translate );
-        mesh.addPart( basis );
-        mesh.addPart( cone );
+        mesh.addMesh( basis );
+        mesh.addMesh( cone );
         std::vector<Color> colors( basis.points.size(), Color( PlusAxis[i] ) );
         std::vector<Color> colorsCone( cone.points.size(), Color( PlusAxis[i] ) );
         vertsColors.insert( vertsColors.end(), colors.begin(), colors.end() );

--- a/source/MRVoxels/MROffset.cpp
+++ b/source/MRVoxels/MROffset.cpp
@@ -272,13 +272,13 @@ Expected<Mesh> thickenMesh( const Mesh& mesh, float offset, const GeneralOffsetP
     if ( offset >= 0 )
     {
         // add original mesh to the result with flipping
-        resMesh.addPartByMask( mesh, mesh.topology.getValidFaces(), true ); // true = with flipping
+        resMesh.addMeshPart( mesh, true ); // true = with flipping
     }
     else
     {
         resMesh.topology.flipOrientation(); // flip to have inversed offset
         // add original mesh to the result without flipping
-        resMesh.addPart( mesh );
+        resMesh.addMesh( mesh );
     }
     return res;
 }

--- a/source/MRVoxels/MRVoxelsConversionsByParts.cpp
+++ b/source/MRVoxels/MRVoxelsConversionsByParts.cpp
@@ -133,7 +133,7 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
         if ( !mapping.src2tgtEdges )
             mapping.src2tgtEdges = &src2tgtEdges;
 
-        mesh.addPartByMask( part, part.topology.getValidFaces(), mapping );
+        mesh.addMeshPart( part, mapping );
 
         if ( settings.postMerge )
             settings.postMerge( mesh, mapping );
@@ -161,7 +161,7 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
     if ( !mapping.src2tgtEdges )
         mapping.src2tgtEdges = &src2tgtEdges;
 
-    mesh.addPartByMask( part, part.topology.getValidFaces(), false, cutContours, leftCutContours, mapping );
+    mesh.addMeshPart( part, false, cutContours, leftCutContours, mapping );
 
     if ( settings.postMerge )
         settings.postMerge( mesh, mapping );

--- a/source/mrmeshpy/MRPythonMeshExposing.cpp
+++ b/source/mrmeshpy/MRPythonMeshExposing.cpp
@@ -328,8 +328,8 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Mesh, [] ( pybind11::module_& m )
             "if region is given, then it must include (f) and new faces will be added there as well\n"
             "\tnew2Old receive mapping from newly appeared triangle to its original triangle (part to full)" ).
 
-        def( "addPartByMask", ( void( Mesh::* )( const Mesh&, const FaceBitSet&, const PartMapping& ) )& Mesh::addPartByMask,
-            pybind11::arg( "from" ), pybind11::arg( "fromFaces" ) = nullptr, pybind11::arg_v( "map", PartMapping(), "PartMapping()" ),
+        def( "addMeshPart", ( void( Mesh::* )( const MeshPart&, const PartMapping& ) )& Mesh::addMeshPart,
+            pybind11::arg( "from" ), pybind11::arg_v( "map", PartMapping(), "PartMapping()" ),
             "appends mesh (from) in addition to this mesh: creates new edges, faces, verts and points\n"
             "copies only portion of (from) specified by fromFaces" ).
 
@@ -536,7 +536,7 @@ Mesh pythonMergeMeshes( const pybind11::list& meshes )
 {
     Mesh res;
     for ( int i = 0; i < pybind11::len( meshes ); ++i )
-        res.addPart( pybind11::cast<Mesh>( meshes[i] ) );
+        res.addMesh( pybind11::cast<Mesh>( meshes[i] ) );
     return res;
 }
 

--- a/source/mrmeshpy/MRPythonMeshExposing.cpp
+++ b/source/mrmeshpy/MRPythonMeshExposing.cpp
@@ -328,11 +328,18 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Mesh, [] ( pybind11::module_& m )
             "if region is given, then it must include (f) and new faces will be added there as well\n"
             "\tnew2Old receive mapping from newly appeared triangle to its original triangle (part to full)" ).
 
+        def( "addMesh", []( Mesh & to, const Mesh & from ) { to.addMesh( from ); },
+            pybind11::arg( "from" ),
+            "appends another mesh as separate connected component(s) to this" ).
+
+        def( "addMeshPart", ( void ( Mesh::* )( const MeshPart &, const PartMapping & ) ) &Mesh::addMeshPart,
+            pybind11::arg( "from" ), pybind11::arg_v( "map", PartMapping(), "PartMapping()" ),
+            "appends whole or part of another mesh as separate connected component(s) to this" ).
+
         def( "addPartByMask", []( Mesh & to, const Mesh & from, const FaceBitSet & fromFaces, const PartMapping & map )
             { to.addMeshPart( { from, &fromFaces }, map ); },
             pybind11::arg( "from" ), pybind11::arg( "fromFaces" ) = nullptr, pybind11::arg_v( "map", PartMapping(), "PartMapping()" ),
-            "appends mesh (from) in addition to this mesh: creates new edges, faces, verts and points\n"
-            "copies only portion of (from) specified by fromFaces" ).
+            "appends whole or part of another mesh as separate connected component(s) to this" ).
 
         def( "holePerimiter", &Mesh::holePerimiter, pybind11::arg( "e" ), "computes the perimeter of the hole specified by one of its edges with no valid left face (left is hole)" ).
         def( "holeDirArea", &Mesh::holeDirArea, pybind11::arg( "e" ), 

--- a/source/mrmeshpy/MRPythonMeshExposing.cpp
+++ b/source/mrmeshpy/MRPythonMeshExposing.cpp
@@ -328,8 +328,9 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Mesh, [] ( pybind11::module_& m )
             "if region is given, then it must include (f) and new faces will be added there as well\n"
             "\tnew2Old receive mapping from newly appeared triangle to its original triangle (part to full)" ).
 
-        def( "addMeshPart", ( void( Mesh::* )( const MeshPart&, const PartMapping& ) )& Mesh::addMeshPart,
-            pybind11::arg( "from" ), pybind11::arg_v( "map", PartMapping(), "PartMapping()" ),
+        def( "addPartByMask", []( Mesh & to, const Mesh & from, const FaceBitSet & fromFaces, const PartMapping & map )
+            { to.addMeshPart( { from, &fromFaces }, map ); },
+            pybind11::arg( "from" ), pybind11::arg( "fromFaces" ) = nullptr, pybind11::arg_v( "map", PartMapping(), "PartMapping()" ),
             "appends mesh (from) in addition to this mesh: creates new edges, faces, verts and points\n"
             "copies only portion of (from) specified by fromFaces" ).
 

--- a/test_python/test_copyMesh.py
+++ b/test_python/test_copyMesh.py
@@ -13,9 +13,9 @@ def test_copy_mesh():
 def test_copy_part_mesh():
     torus = mrmesh.makeOuterHalfTorus(2, 1, 10, 10, None)
     copyMesh = mrmesh.Mesh()
-    copyMesh.addPartByMask(torus, torus.topology.getValidFaces())
+    copyMesh.addMesh(torus)
     assert copyMesh.topology.numValidFaces() == torus.topology.numValidFaces()
 
-    copyMesh.addPartByMask(torus, torus.topology.getValidFaces())
+    copyMesh.addMesh(torus)
 
     assert copyMesh.topology.numValidFaces() == 2 * torus.topology.numValidFaces()

--- a/test_python/test_copyMesh.py
+++ b/test_python/test_copyMesh.py
@@ -13,9 +13,9 @@ def test_copy_mesh():
 def test_copy_part_mesh():
     torus = mrmesh.makeOuterHalfTorus(2, 1, 10, 10, None)
     copyMesh = mrmesh.Mesh()
-    copyMesh.addMesh(torus)
+    copyMesh.addPartByMask(torus, torus.topology.getValidFaces())
     assert copyMesh.topology.numValidFaces() == torus.topology.numValidFaces()
 
-    copyMesh.addMesh(torus)
+    copyMesh.addPartByMask(torus, torus.topology.getValidFaces())
 
     assert copyMesh.topology.numValidFaces() == 2 * torus.topology.numValidFaces()

--- a/test_python/test_movement_body.py
+++ b/test_python/test_movement_body.py
@@ -31,7 +31,7 @@ def test_movement_body():
             for j in range(plSections[i].size()):
                 contours[i][j] = inputMesh.edgePoint( plSections[i][j] )
         moveMesh = mrmesh.makeMovementBuildBody(bodyContours,contours)
-        sumMesh.addMesh(moveMesh)
+        sumMesh.addPartByMask(moveMesh,moveMesh.topology.getValidFaces())
         start = start + step;
         pass
 

--- a/test_python/test_movement_body.py
+++ b/test_python/test_movement_body.py
@@ -31,7 +31,7 @@ def test_movement_body():
             for j in range(plSections[i].size()):
                 contours[i][j] = inputMesh.edgePoint( plSections[i][j] )
         moveMesh = mrmesh.makeMovementBuildBody(bodyContours,contours)
-        sumMesh.addPartByMask(moveMesh,moveMesh.topology.getValidFaces())
+        sumMesh.addMesh(moveMesh)
         start = start + step;
         pass
 

--- a/test_regression/test_issues/test_issue_2899.py
+++ b/test_regression/test_issues/test_issue_2899.py
@@ -65,7 +65,7 @@ def test_issue_2899(tmp_path):
     # Separate result on Slide and Slope
     slope_faces = mr.MeshComponents.getLargestComponent(mesh)
     slope_res = mr.Mesh()
-    slope_res.addPartByMask(mesh, slope_faces)
+    slope_res.addMeshPart(mr.MeshPart(mesh, slope_faces))
     slide_res = mr.Mesh()
     slide_res.addPartByMask(mesh, mesh.topology.getValidFaces() - slope_faces)
 

--- a/test_regression/test_issues/test_issue_2899.py
+++ b/test_regression/test_issues/test_issue_2899.py
@@ -65,9 +65,9 @@ def test_issue_2899(tmp_path):
     # Separate result on Slide and Slope
     slope_faces = mr.MeshComponents.getLargestComponent(mesh)
     slope_res = mr.Mesh()
-    slope_res.addPartByMask(mesh, slope_faces)
+    slope_res.addMeshPart(mr.MeshPart(mesh, slope_faces))
     slide_res = mr.Mesh()
-    slide_res.addPartByMask(mesh, mesh.topology.getValidFaces() - slope_faces)
+    slide_res.addMeshPart(mr.MeshPart(mesh, mesh.topology.getValidFaces() - slope_faces))
 
     # Save in files
     mr.saveMesh(slope_res, tmp_path / "slopeRes.off")

--- a/test_regression/test_issues/test_issue_2899.py
+++ b/test_regression/test_issues/test_issue_2899.py
@@ -65,9 +65,9 @@ def test_issue_2899(tmp_path):
     # Separate result on Slide and Slope
     slope_faces = mr.MeshComponents.getLargestComponent(mesh)
     slope_res = mr.Mesh()
-    slope_res.addMeshPart(mr.MeshPart(mesh, slope_faces))
+    slope_res.addPartByMask(mesh, slope_faces)
     slide_res = mr.Mesh()
-    slide_res.addMeshPart(mr.MeshPart(mesh, mesh.topology.getValidFaces() - slope_faces))
+    slide_res.addPartByMask(mesh, mesh.topology.getValidFaces() - slope_faces)
 
     # Save in files
     mr.saveMesh(slope_res, tmp_path / "slopeRes.off")


### PR DESCRIPTION
* `Mesh::addPart` is renamed to `Mesh::addMesh`
* `Mesh::addPartByMask` is renamed to `Mesh::addMeshPart`, and the first two parameters are passed as `MeshPart`
* Old methods are kept as `[[deprecated]]` for now
* Comments clarified