### PR TITLE
RebuildMeshSettings::closeHolesInHoleWindingNumber

### DIFF
--- a/source/MRMesh/MRMeshDistance.cpp
+++ b/source/MRMesh/MRMeshDistance.cpp
@@ -13,8 +13,10 @@ std::optional<float> signedDistanceToMesh( const MeshPart& mp, const Vector3f& p
 {
     assert( op.signMode != SignDetectionMode::OpenVDB );
     const auto proj = findProjection( p, mp, op.maxDistSq, nullptr, op.minDistSq );
-    if ( op.signMode != SignDetectionMode::HoleWindingRule // for HoleWindingRule the sign can change even for too small or too large distances
-        && ( proj.distSq < op.minDistSq || proj.distSq >= op.maxDistSq ) ) // note that proj.distSq == op.minDistSq (e.g. == 0) is a valid situation
+
+    // please note that in HoleWindingRule the sign can change even for too small or too large distances,
+    // so if you would like to get closed mesh from marching cubes, do not change op.minDistSq and op.maxDistSq
+    if ( proj.distSq < op.minDistSq || proj.distSq >= op.maxDistSq ) // note that proj.distSq == op.minDistSq (e.g. == 0) is a valid situation
         return {}; // distance is too small or too large, discard them
 
     float dist = std::sqrt( proj.distSq );

--- a/source/MRVoxels/MROffset.cpp
+++ b/source/MRVoxels/MROffset.cpp
@@ -154,9 +154,12 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
         msParams.vol.origin = origin;
         msParams.vol.voxelSize = Vector3f::diagonal( params.voxelSize );
         msParams.vol.dimensions = dimensions;
-        msParams.dist.maxDistSq = sqr( absOffset + 1.001f * params.voxelSize ); // we multiply by 1.001f to be sure not to have rounding errors (which may lead to unexpected NaN values )
-        msParams.dist.minDistSq = sqr( std::max( absOffset - 1.001f * params.voxelSize, 0.0f ) ); // we multiply by 1.001f to be sure not to have rounding errors (which may lead to unexpected NaN values )
         msParams.dist.signMode = params.signDetectionMode;
+        if ( params.signDetectionMode != SignDetectionMode::HoleWindingRule || !params.closeHolesInHoleWindingNumber )
+        {
+            msParams.dist.maxDistSq = sqr( absOffset + 1.001f * params.voxelSize ); // we multiply by 1.001f to be sure not to have rounding errors (which may lead to unexpected NaN values )
+            msParams.dist.minDistSq = sqr( std::max( absOffset - 1.001f * params.voxelSize, 0.0f ) ); // we multiply by 1.001f to be sure not to have rounding errors (which may lead to unexpected NaN values )
+        }
         msParams.dist.windingNumberThreshold = params.windingNumberThreshold;
         msParams.dist.windingNumberBeta = params.windingNumberBeta;
         msParams.fwn = params.fwn;

--- a/source/MRVoxels/MROffset.h
+++ b/source/MRVoxels/MROffset.h
@@ -29,6 +29,9 @@ struct OffsetParameters : BaseShellParameters
     /// determines the method to compute distance sign
     SignDetectionMode signDetectionMode = SignDetectionMode::OpenVDB;
 
+    /// whether to construct closed mesh in signMode = SignDetectionModeShort::HoleWindingNumber
+    bool closeHolesInHoleWindingNumber = true;
+
     /// only for SignDetectionMode::HoleWindingRule:
     /// positive distance if winding number below or equal this threshold;
     /// ideal threshold: 0.5 for closed meshes; 0.0 for planar meshes

--- a/source/MRVoxels/MRRebuildMesh.cpp
+++ b/source/MRVoxels/MRRebuildMesh.cpp
@@ -48,6 +48,7 @@ Expected<Mesh> rebuildMesh( const MeshPart& mp, const RebuildMeshSettings& setti
     if ( settings.onSignDetectionModeSelected )
         settings.onSignDetectionModeSelected( genOffsetParams.signDetectionMode );
 
+    genOffsetParams.closeHolesInHoleWindingNumber = settings.closeHolesInHoleWindingNumber;
     genOffsetParams.voxelSize = settings.voxelSize;
     genOffsetParams.mode = settings.offsetMode;
     genOffsetParams.windingNumberThreshold = settings.windingNumberThreshold;

--- a/source/MRVoxels/MRRebuildMesh.h
+++ b/source/MRVoxels/MRRebuildMesh.h
@@ -17,6 +17,9 @@ struct RebuildMeshSettings
 
     SignDetectionModeShort signMode = SignDetectionModeShort::Auto;
 
+    /// whether to construct closed mesh in signMode = SignDetectionModeShort::HoleWindingNumber
+    bool closeHolesInHoleWindingNumber = true;
+
     OffsetMode offsetMode = OffsetMode::Standard;
 
     /// if non-null then created sharp edges (only if offsetMode = OffsetMode::Sharpening) will be saved here


### PR DESCRIPTION
New option to not fill holes in rebuild mesh and offset in HoleWindingNumber sign detection mode.