### PR TITLE
Serialize voxels by default in VDB format

### DIFF
--- a/source/MRVoxels/MRObjectVoxels.h
+++ b/source/MRVoxels/MRObjectVoxels.h
@@ -229,7 +229,7 @@ private:
     mutable std::optional<Box3i> activeBounds_;
     mutable std::optional<size_t> activeVoxels_;
 
-    const char * serializeFormat_ = ".raw";
+    const char * serializeFormat_ = ".vdb";
 
     /// Service data
     VolumeIndexer indexer_ = VolumeIndexer( vdbVolume_.dims );


### PR DESCRIPTION
* VDB format is native for `openvdb::FloatGrid` in which data are stored in `ObjectVoxels`
* Previously we used RAW format, because VDB was not supported in Wasm, now it is supported
* We can expect much faster opening and saving, and less memory consumption avoiding extra conversions
* The saving will be significant for sparse volumes
* But even for dense volumes some improvement can be seen on practice