### PR TITLE
rebuildMesh: preSubdivide option

### DIFF
--- a/source/MRMesh/MRMeshSubdivide.cpp
+++ b/source/MRMesh/MRMeshSubdivide.cpp
@@ -212,7 +212,7 @@ int subdivideMesh( Mesh & mesh, const SubdivideSettings & settings )
     return splitsDone;
 }
 
-Expected<Mesh> copySubdividePackMesh( const MeshPart & mp, float approxMaxEdgeLen, const ProgressCallback & cb )
+Expected<Mesh> copySubdividePackMesh( const MeshPart & mp, float voxelSize, const ProgressCallback & cb )
 {
     MR_TIMER
     Mesh subMesh;
@@ -225,12 +225,16 @@ Expected<Mesh> copySubdividePackMesh( const MeshPart & mp, float approxMaxEdgeLe
     if ( !reportProgress( cb, 0.25f ) )
         return unexpectedOperationCanceled();
 
+    // smaller edge lengths require too much space and time for subdivision,
+    // larger edge lengths do not give significant benefits in AABB-tree optimized searches
+    const float approxMaxEdgeLen = 5 * voxelSize;
+
     // subdivide copied mesh
     SubdivideSettings subSettings
     {
         .maxEdgeLen = approxMaxEdgeLen,
         .maxEdgeSplits = int( subMesh.area() / sqr( approxMaxEdgeLen ) ),
-        .maxDeviationAfterFlip = 0.1f * approxMaxEdgeLen,
+        .maxDeviationAfterFlip = 0.1f * voxelSize,
         .progressCallback = subprogress( cb, 0.25f, 0.75f )
     };
     subdivideMesh( subMesh, subSettings );

--- a/source/MRMesh/MRMeshSubdivide.cpp
+++ b/source/MRMesh/MRMeshSubdivide.cpp
@@ -12,6 +12,7 @@
 #include "MRRegionBoundary.h"
 #include "MRBitSetParallelFor.h"
 #include "MRParallelFor.h"
+#include "MRBuffer.h"
 #include <queue>
 
 namespace MR
@@ -211,7 +212,40 @@ int subdivideMesh( Mesh & mesh, const SubdivideSettings & settings )
     return splitsDone;
 }
 
-TEST(MRMesh, SubdivideMesh) 
+Expected<Mesh> copySubdividePackMesh( const MeshPart & mp, float approxMaxEdgeLen, const ProgressCallback & cb )
+{
+    MR_TIMER
+    Mesh subMesh;
+
+    // copy mesh
+    if ( mp.region )
+        subMesh.addMeshPart( mp );
+    else
+        subMesh = mp.mesh;
+    if ( !reportProgress( cb, 0.25f ) )
+        return unexpectedOperationCanceled();
+
+    // subdivide copied mesh
+    SubdivideSettings subSettings
+    {
+        .maxEdgeLen = approxMaxEdgeLen,
+        .maxEdgeSplits = int( subMesh.area() / sqr( approxMaxEdgeLen ) ),
+        .maxDeviationAfterFlip = 0.1f * approxMaxEdgeLen,
+        .progressCallback = subprogress( cb, 0.25f, 0.75f )
+    };
+    subdivideMesh( subMesh, subSettings );
+    if ( !reportProgress( cb, 0.75f ) )
+        return unexpectedOperationCanceled();
+
+    // pack subdivided mesh
+    subMesh.packOptimally();
+    if ( !reportProgress( cb, 1.0f ) )
+        return unexpectedOperationCanceled();
+
+    return subMesh;
+}
+
+TEST(MRMesh, SubdivideMesh)
 {
     Triangulation t{
         { 0_v, 1_v, 2_v },

--- a/source/MRMesh/MRMeshSubdivide.h
+++ b/source/MRMesh/MRMeshSubdivide.h
@@ -18,47 +18,64 @@ struct SubdivideSettings
 {
     /// Subdivision is stopped when all edges inside or on the boundary of the region are not longer than this value
     float maxEdgeLen = 0;
+
     /// Maximum number of edge splits allowed
     int maxEdgeSplits = 1000;
+
     /// Improves local mesh triangulation by doing edge flips if it does not make too big surface deviation
     float maxDeviationAfterFlip = 1;
+
     /// Improves local mesh triangulation by doing edge flips if it does not change dihedral angle more than on this value (in radians)
     float maxAngleChangeAfterFlip = FLT_MAX;
+
     /// If this value is less than FLT_MAX then edge flips will
     /// ignore dihedral angle check if one of triangles has aspect ratio more than this value
     /// Unit: rad
     float criticalAspectRatioFlip = 1000.0f;
+
     /// Region on mesh to be subdivided, it is updated during the operation
     FaceBitSet * region = nullptr;
+
     /// Edges specified by this bit-set will never be flipped, but they can be split so it is updated during the operation
     UndirectedEdgeBitSet* notFlippable = nullptr;
+
     /// New vertices appeared during subdivision will be added here
     VertBitSet * newVerts = nullptr;
+
     /// If false do not touch border edges (cannot subdivide lone faces)\n
     /// use \ref MR::findRegionOuterFaces to find boundary faces
     bool subdivideBorder = true;
+
     /// The subdivision stops as soon as all triangles (in the region) have aspect ratio below or equal to this value
     float maxTriAspectRatio = 0;
+
     /// An edge is subdivided only if both its left and right triangles have aspect ratio below or equal to this value.
     /// So this is a maximum aspect ratio of a triangle that can be split on two before Delone optimization.
     /// Please set it to a smaller value only if subdivideBorder==false, otherwise many narrow triangles can appear near border
     float maxSplittableTriAspectRatio = FLT_MAX;
+
     /// Puts new vertices so that they form a smooth surface together with existing vertices.
     /// This option works best for natural surfaces without sharp edges in between triangles
     bool smoothMode = false;
+
     /// In case of activated smoothMode, the smoothness is locally deactivated at the edges having
     /// dihedral angle at least this value
     float minSharpDihedralAngle = PI_F / 6; // 30 degrees
+
     /// if true, then every new vertex will be projected on the original mesh (before smoothing)
     bool projectOnOriginalMesh = false;
-    /// this function is called each time a new vertex has been created, but before the ring is made Delone
-    std::function<void(VertId)> onVertCreated;
-    /// this function is called each time edge (e) is split into (e1->e), but before the ring is made Delone
-    std::function<void(EdgeId e1, EdgeId e)> onEdgeSplit;
+
     /// this function is called each time edge (e) is going to split, if it returns false then this split will be skipped
     std::function<bool(EdgeId e)> beforeEdgeSplit;
+
+    /// this function is called each time a new vertex has been created, but before the ring is made Delone
+    std::function<void(VertId)> onVertCreated;
+
+    /// this function is called each time edge (e) is split into (e1->e), but before the ring is made Delone
+    std::function<void(EdgeId e1, EdgeId e)> onEdgeSplit;
+
     /// callback to report algorithm progress and cancel it by user request
-    ProgressCallback progressCallback = {};
+    ProgressCallback progressCallback;
 };
 
 /// Split edges in mesh region according to the settings;\n

--- a/source/MRMesh/MRMeshSubdivide.h
+++ b/source/MRMesh/MRMeshSubdivide.h
@@ -78,12 +78,13 @@ struct SubdivideSettings
     ProgressCallback progressCallback;
 };
 
-/// Split edges in mesh region according to the settings;\n
+/// splits edges in mesh region according to the settings;\n
 /// \return The total number of edge splits performed
 MRMESH_API int subdivideMesh( Mesh & mesh, const SubdivideSettings & settings = {} );
 
-/// create a copy of given mesh part, subdivides it to get approximate maximum edge length given, then pack resulting mesh
-[[nodiscard]] MRMESH_API Expected<Mesh> copySubdividePackMesh( const MeshPart & mp, float approxMaxEdgeLen, const ProgressCallback & cb = {} );
+/// creates a copy of given mesh part, subdivides it to get rid of too long edges compared with voxelSize, then packs resulting mesh,
+/// this is called typically in preparation for 3D space sampling with voxelSize step, and subdivision is important for making leaves of AABB tree not too big compared with voxelSize
+[[nodiscard]] MRMESH_API Expected<Mesh> copySubdividePackMesh( const MeshPart & mp, float voxelSize, const ProgressCallback & cb = {} );
 
 /// \}
 

--- a/source/MRMesh/MRMeshSubdivide.h
+++ b/source/MRMesh/MRMeshSubdivide.h
@@ -2,6 +2,7 @@
 
 #include "MRMeshFwd.h"
 #include "MRProgressCallback.h"
+#include "MRExpected.h"
 #include "MRConstants.h"
 #include <cfloat>
 #include <functional>
@@ -64,6 +65,9 @@ struct SubdivideSettings
 /// \return The total number of edge splits performed
 MRMESH_API int subdivideMesh( Mesh & mesh, const SubdivideSettings & settings = {} );
 
+/// create a copy of given mesh part, subdivides it to get approximate maximum edge length given, then pack resulting mesh
+[[nodiscard]] MRMESH_API Expected<Mesh> copySubdividePackMesh( const MeshPart & mp, float approxMaxEdgeLen, const ProgressCallback & cb = {} );
+
 /// \}
 
-}
+} //namespace MR

--- a/source/MRVoxels/MRRebuildMesh.cpp
+++ b/source/MRVoxels/MRRebuildMesh.cpp
@@ -19,12 +19,12 @@ Expected<Mesh> rebuildMesh( MeshPart mp, const RebuildMeshSettings& settings )
     Mesh subMesh;
     if ( settings.preSubdivide )
     {
-        if ( auto maybeMesh = copySubdividePackMesh( mp, settings.voxelSize, subprogress( progress, 0.0f, 0.2f ) ) )
+        if ( auto maybeMesh = copySubdividePackMesh( mp, settings.voxelSize, subprogress( progress, 0.0f, 0.1f ) ) )
             subMesh = std::move( *maybeMesh );
         else
             return unexpected( std::move( maybeMesh.error() ) );
         mp = MeshPart{ subMesh };
-        progress = subprogress( progress, 0.2f, 1.0f );
+        progress = subprogress( progress, 0.1f, 1.0f );
     }
 
     GeneralOffsetParameters genOffsetParams;

--- a/source/MRVoxels/MRRebuildMesh.h
+++ b/source/MRVoxels/MRRebuildMesh.h
@@ -60,6 +60,6 @@ struct RebuildMeshSettings
 
 /// fixes all types of issues in input mesh (degenerations, holes, self-intersections, etc.)
 /// by first converting mesh in voxel representation, and then backward
-[[nodiscard]] MRVOXELS_API Expected<Mesh> rebuildMesh( MeshPart mp, const RebuildMeshSettings& settings );
+[[nodiscard]] MRVOXELS_API Expected<Mesh> rebuildMesh( const MeshPart& mp, const RebuildMeshSettings& settings );
 
 } //namespace MR

--- a/source/MRVoxels/MRRebuildMesh.h
+++ b/source/MRVoxels/MRRebuildMesh.h
@@ -13,7 +13,9 @@ struct RebuildMeshSettings
 {
     /// whether to make subdivision of initial mesh before conversion to voxels,
     /// despite time and memory required for the subdivision, it typically makes the whole rebuilding faster (or even much faster in case of large initial triangles),
-    /// because AABB tree contains small triangles in leaves, which is good for both closest triangle location and winding number approximation
+    /// because AABB tree contains small triangles in leaves, which is good for both
+    /// 1) search for closest triangle because the closest box more frequently contains the closest triangle,
+    /// 2) and winding number approximation because of more frequent usage of approximation for distant dipoles
     bool preSubdivide = true;
 
     /// Size of voxel in grid conversions;

--- a/source/MRVoxels/MRRebuildMesh.h
+++ b/source/MRVoxels/MRRebuildMesh.h
@@ -11,6 +11,11 @@ namespace MR
 
 struct RebuildMeshSettings
 {
+    /// whether to make subdivision of initial mesh before conversion to voxels,
+    /// despite time and memory required for the subdivision, it typically makes the whole rebuilding faster (or even much faster in case of large initial triangles),
+    /// because AABB tree contains small triangles in leaves, which is good for both closest triangle location and winding number approximation
+    bool preSubdivide = true;
+
     /// Size of voxel in grid conversions;
     /// The user is responsible for setting some positive value here
     float voxelSize = 0;
@@ -55,6 +60,6 @@ struct RebuildMeshSettings
 
 /// fixes all types of issues in input mesh (degenerations, holes, self-intersections, etc.)
 /// by first converting mesh in voxel representation, and then backward
-[[nodiscard]] MRVOXELS_API Expected<Mesh> rebuildMesh( const MeshPart& mp, const RebuildMeshSettings& settings );
+[[nodiscard]] MRVOXELS_API Expected<Mesh> rebuildMesh( MeshPart mp, const RebuildMeshSettings& settings );
 
 } //namespace MR


### PR DESCRIPTION
New option whether to make subdivision of initial mesh before conversion to voxels. Despite time and memory required for the subdivision, it typically makes the whole rebuilding faster (or even much faster in case of large initial triangles), because AABB tree contains small triangles in leaves, which is good for both closest triangle location and winding number approximation.

`copySubdividePackMesh` function exposed for similar to `rebuildMesh` algorithms in using intermediate voxels.
