### PR TITLE
IFastWindingNumber refactoring

### DIFF
--- a/source/MRCuda/MRCudaBasic.hpp
+++ b/source/MRCuda/MRCudaBasic.hpp
@@ -18,16 +18,16 @@ namespace Cuda
 MRCUDA_API cudaError_t logError( cudaError_t code, const char * file = nullptr, int line = 0 );
 
 /// executes given CUDA function and logs the error if any
-#define CUDA_EXEC( func ) logError( func, __FILE__ , __LINE__ )
+#define CUDA_EXEC( func ) MR::Cuda::logError( func, __FILE__ , __LINE__ )
 
 /// executes given CUDA function, logs if it fails and returns error code
 #define CUDA_EXEC_RETURN( func ) if ( auto code = CUDA_EXEC( func ); code != cudaError::cudaSuccess ) return code
 
 /// if func evaluates not to cudaError::cudaSuccess, then returns MR::unexpected with the error string without logging
-#define CUDA_RETURN_UNEXPECTED( func ) if ( auto code = func; code != cudaError::cudaSuccess ) return MR::unexpected( getError( code ) )
+#define CUDA_RETURN_UNEXPECTED( func ) if ( auto code = ( func ); code != cudaError::cudaSuccess ) return MR::unexpected( MR::Cuda::getError( code ) )
 
 /// executes given CUDA function, logs if it fails and returns MR::unexpected with the error string
-#define CUDA_EXEC_RETURN_UNEXPECTED( func ) if ( auto code = CUDA_EXEC( func ); code != cudaError::cudaSuccess ) return MR::unexpected( getError( code ) )
+#define CUDA_EXEC_RETURN_UNEXPECTED( func ) if ( auto code = CUDA_EXEC( func ); code != cudaError::cudaSuccess ) return MR::unexpected( MR::Cuda::getError( code ) )
 
 template<typename T>
 DynamicArray<T>::DynamicArray( size_t size )

--- a/source/MRCuda/MRCudaBasic.hpp
+++ b/source/MRCuda/MRCudaBasic.hpp
@@ -17,11 +17,17 @@ namespace Cuda
 /// spdlog::error the information about some CUDA error including optional filename and line number
 MRCUDA_API cudaError_t logError( cudaError_t code, const char * file = nullptr, int line = 0 );
 
-/// executes given CUDA function and checks the error code after
+/// executes given CUDA function and logs the error if any
 #define CUDA_EXEC( func ) logError( func, __FILE__ , __LINE__ )
 
-/// executes given CUDA function and returns error if it fails
+/// executes given CUDA function, logs if it fails and returns error code
 #define CUDA_EXEC_RETURN( func ) if ( auto code = CUDA_EXEC( func ); code != cudaError::cudaSuccess ) return code
+
+/// if func evaluates not to cudaError::cudaSuccess, then returns MR::unexpected with the error string without logging
+#define CUDA_RETURN_UNEXPECTED( func ) if ( auto code = func; code != cudaError::cudaSuccess ) return MR::unexpected( getError( code ) )
+
+/// executes given CUDA function, logs if it fails and returns MR::unexpected with the error string
+#define CUDA_EXEC_RETURN_UNEXPECTED( func ) if ( auto code = CUDA_EXEC( func ); code != cudaError::cudaSuccess ) return MR::unexpected( getError( code ) )
 
 template<typename T>
 DynamicArray<T>::DynamicArray( size_t size )

--- a/source/MRCuda/MRCudaFastWindingNumber.h
+++ b/source/MRCuda/MRCudaFastWindingNumber.h
@@ -30,7 +30,7 @@ public:
     MRCUDA_API Expected<void> calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, const DistanceToMeshOptions& options, const ProgressCallback& cb ) override;
 
 private:
-    bool prepareData_( ProgressCallback cb );
+    Expected<void> prepareData_( ProgressCallback cb );
 };
 
 } // namespace Cuda

--- a/source/MRCuda/MRCudaFastWindingNumber.h
+++ b/source/MRCuda/MRCudaFastWindingNumber.h
@@ -24,7 +24,7 @@ public:
     MRCUDA_API FastWindingNumber( const Mesh& mesh );
 
     // see methods' descriptions in IFastWindingNumber
-    MRCUDA_API void calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace = {} ) override;
+    MRCUDA_API Expected<void> calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace, const ProgressCallback& cb ) override;
     MRCUDA_API bool calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb ) override;
     MRCUDA_API Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
     MRCUDA_API Expected<void> calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, const DistanceToMeshOptions& options, const ProgressCallback& cb ) override;

--- a/source/MRCuda/MRCudaFastWindingNumber.h
+++ b/source/MRCuda/MRCudaFastWindingNumber.h
@@ -25,7 +25,7 @@ public:
 
     // see methods' descriptions in IFastWindingNumber
     MRCUDA_API Expected<void> calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace, const ProgressCallback& cb ) override;
-    MRCUDA_API bool calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb ) override;
+    MRCUDA_API Expected<void> calcSelfIntersections( FaceBitSet& res, float beta, const ProgressCallback& cb ) override;
     MRCUDA_API Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
     MRCUDA_API Expected<void> calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, const DistanceToMeshOptions& options, const ProgressCallback& cb ) override;
 

--- a/source/MRCuda/MRCudaFastWindingNumber.h
+++ b/source/MRCuda/MRCudaFastWindingNumber.h
@@ -26,7 +26,7 @@ public:
     // see methods' descriptions in IFastWindingNumber
     MRCUDA_API Expected<void> calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace, const ProgressCallback& cb ) override;
     MRCUDA_API Expected<void> calcSelfIntersections( FaceBitSet& res, float beta, const ProgressCallback& cb ) override;
-    MRCUDA_API Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
+    MRCUDA_API Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, const ProgressCallback& cb ) override;
     MRCUDA_API Expected<void> calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, const DistanceToMeshOptions& options, const ProgressCallback& cb ) override;
 
 private:

--- a/source/MRCuda/MRCudaTest.cpp
+++ b/source/MRCuda/MRCudaTest.cpp
@@ -11,19 +11,16 @@ namespace Cuda
 {
 Expected<void> negatePicture( Image& image )
 {
-    if ( auto code = CUDA_EXEC( cudaSetDevice( 0 ) ) )
-        return unexpected( Cuda::getError( code ) );
+    CUDA_EXEC_RETURN_UNEXPECTED( cudaSetDevice( 0 ) );
 
     DynamicArray<Cuda::Color> cudaArray;
-    if ( auto code = cudaArray.fromVector( image.pixels ) )
-        return unexpected( Cuda::getError( code ) );
+    CUDA_RETURN_UNEXPECTED( cudaArray.fromVector( image.pixels ) );
 
     negatePictureKernel( cudaArray );
-    if ( auto code = CUDA_EXEC( cudaGetLastError() ) )
-        return unexpected( Cuda::getError( code ) );
+    CUDA_EXEC_RETURN_UNEXPECTED( cudaGetLastError() );
 
-    if ( auto code = cudaArray.toVector( image.pixels ) )
-        return unexpected( Cuda::getError( code ) );
+    CUDA_RETURN_UNEXPECTED( cudaArray.toVector( image.pixels ) );
+
     return {};
 }
 

--- a/source/MRCuda/MRCudaTest.cpp
+++ b/source/MRCuda/MRCudaTest.cpp
@@ -11,15 +11,15 @@ namespace Cuda
 {
 Expected<void> negatePicture( Image& image )
 {
-    CUDA_EXEC_RETURN_UNEXPECTED( cudaSetDevice( 0 ) );
+    CUDA_LOGE_RETURN_UNEXPECTED( cudaSetDevice( 0 ) );
 
     DynamicArray<Cuda::Color> cudaArray;
-    CUDA_RETURN_UNEXPECTED( cudaArray.fromVector( image.pixels ) );
+    CUDA_LOGE_RETURN_UNEXPECTED( cudaArray.fromVector( image.pixels ) );
 
     negatePictureKernel( cudaArray );
-    CUDA_EXEC_RETURN_UNEXPECTED( cudaGetLastError() );
+    CUDA_LOGE_RETURN_UNEXPECTED( cudaGetLastError() );
 
-    CUDA_RETURN_UNEXPECTED( cudaArray.toVector( image.pixels ) );
+    CUDA_LOGE_RETURN_UNEXPECTED( cudaArray.toVector( image.pixels ) );
 
     return {};
 }

--- a/source/MRMesh/MRFastWindingNumber.cpp
+++ b/source/MRMesh/MRFastWindingNumber.cpp
@@ -37,15 +37,18 @@ Expected<void> FastWindingNumber::calcFromVector( std::vector<float>& res, const
     return {};
 }
 
-bool FastWindingNumber::calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb )
+Expected<void> FastWindingNumber::calcSelfIntersections( FaceBitSet& res, float beta, const ProgressCallback& cb )
 {
+    MR_TIMER
     res.resize( mesh_.topology.faceSize() );
-    return BitSetParallelFor( mesh_.topology.getValidFaces(), [&] ( FaceId f )
+    if ( !BitSetParallelFor( mesh_.topology.getValidFaces(), [&] ( FaceId f )
     {
         auto wn = calc_( mesh_.triCenter( f ), beta, f );
         if ( wn < 0 || wn > 1 )
             res.set( f );
-    }, cb );
+    }, cb ) )
+        return unexpectedOperationCanceled();
+    return {};
 }
 
 Expected<void> FastWindingNumber::calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb )

--- a/source/MRMesh/MRFastWindingNumber.cpp
+++ b/source/MRMesh/MRFastWindingNumber.cpp
@@ -25,13 +25,16 @@ inline float FastWindingNumber::calc_( const Vector3f & q, float beta, FaceId sk
     return calcFastWindingNumber( dipoles_, tree_, mesh_, q, beta, skipFace );
 }
 
-void FastWindingNumber::calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace )
+Expected<void> FastWindingNumber::calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace, const ProgressCallback& cb )
 {
+    MR_TIMER
     res.resize( points.size() );
-    ParallelFor( points, [&]( size_t i )
+    if ( !ParallelFor( points, [&]( size_t i )
     {
         res[i] = calc_( points[i], beta, skipFace );
-    } );
+    }, cb ) )
+        return unexpectedOperationCanceled();
+    return {};
 }
 
 bool FastWindingNumber::calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb )

--- a/source/MRMesh/MRFastWindingNumber.cpp
+++ b/source/MRMesh/MRFastWindingNumber.cpp
@@ -51,7 +51,7 @@ Expected<void> FastWindingNumber::calcSelfIntersections( FaceBitSet& res, float 
     return {};
 }
 
-Expected<void> FastWindingNumber::calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb )
+Expected<void> FastWindingNumber::calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, const ProgressCallback& cb )
 {
     MR_TIMER
 

--- a/source/MRMesh/MRFastWindingNumber.h
+++ b/source/MRMesh/MRFastWindingNumber.h
@@ -27,8 +27,7 @@ public:
     /// </summary>
     /// <param name="res">resulting bit set</param>
     /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    /// <returns>false if the operation was canceled by the user</returns>
-    virtual bool calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb = {} ) = 0;
+    virtual Expected<void> calcSelfIntersections( FaceBitSet& res, float beta, const ProgressCallback& cb = {} ) = 0;
 
     /// <summary>
     /// calculates winding numbers in each point from a three-dimensional grid
@@ -61,7 +60,7 @@ public:
 
     // see methods' descriptions in IFastWindingNumber
     MRMESH_API Expected<void> calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace, const ProgressCallback& cb ) override;
-    MRMESH_API bool calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb ) override;
+    MRMESH_API Expected<void> calcSelfIntersections( FaceBitSet& res, float beta, const ProgressCallback& cb ) override;
     MRMESH_API Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
     MRMESH_API float calcWithDistances( const Vector3f& p, const DistanceToMeshOptions& options );
     MRMESH_API Expected<void> calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, const DistanceToMeshOptions& options, const ProgressCallback& cb ) override;

--- a/source/MRMesh/MRFastWindingNumber.h
+++ b/source/MRMesh/MRFastWindingNumber.h
@@ -20,7 +20,7 @@ public:
     /// <param name="points">incoming points</param>
     /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
     /// <param name="skipFace">this triangle (if it is close to `q`) will be skipped from summation</param>
-    virtual void calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace = {} ) = 0;
+    virtual Expected<void> calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace = {}, const ProgressCallback& cb = {} ) = 0;
 
     /// <summary>
     /// calculates winding numbers for all centers of mesh's triangles. if winding number is less than 0 or greater then 1, that face is marked as self-intersected
@@ -60,7 +60,7 @@ public:
     [[nodiscard]] MRMESH_API FastWindingNumber( const Mesh & mesh );
 
     // see methods' descriptions in IFastWindingNumber
-    MRMESH_API void calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace = {} ) override;
+    MRMESH_API Expected<void> calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace, const ProgressCallback& cb ) override;
     MRMESH_API bool calcSelfIntersections( FaceBitSet& res, float beta, ProgressCallback cb ) override;
     MRMESH_API Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
     MRMESH_API float calcWithDistances( const Vector3f& p, const DistanceToMeshOptions& options );

--- a/source/MRMesh/MRFastWindingNumber.h
+++ b/source/MRMesh/MRFastWindingNumber.h
@@ -36,7 +36,7 @@ public:
     /// <param name="dims">dimensions of the grid</param>
     /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
     /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    virtual Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb = {} ) = 0;
+    virtual Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, const ProgressCallback& cb = {} ) = 0;
 
     /// <summary>
     /// calculates distances with the sign obtained from generalized winding number in each point from a three-dimensional grid;
@@ -61,7 +61,7 @@ public:
     // see methods' descriptions in IFastWindingNumber
     MRMESH_API Expected<void> calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace, const ProgressCallback& cb ) override;
     MRMESH_API Expected<void> calcSelfIntersections( FaceBitSet& res, float beta, const ProgressCallback& cb ) override;
-    MRMESH_API Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, ProgressCallback cb ) override;
+    MRMESH_API Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, const ProgressCallback& cb ) override;
     MRMESH_API float calcWithDistances( const Vector3f& p, const DistanceToMeshOptions& options );
     MRMESH_API Expected<void> calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, const DistanceToMeshOptions& options, const ProgressCallback& cb ) override;
 


### PR DESCRIPTION
* All member function in `IFastWindingNumber` uniformly return `Expected<void>` and take `const ProgressCallback&`, allowing their cancellation at least in CPU implementation.
* New `CUDA_RETURN_UNEXPECTED` and `CUDA_LOGE_RETURN_UNEXPECTED` macros introduced to simplify returning CUDA errors in `MR::expected`
* `CUDA_LOGE` and `CUDA_LOGE_RETURN` now replace `CUDA_EXEC` and `CUDA_EXEC_RETURN`, which remain but depracated.
* `Cuda::FastWindingNumber` checks for all errors and return them in `MR::expected`.