### PR TITLE
SplineSettings/iterations in MRMarkedContour.h

### DIFF
--- a/source/MRMesh/MRMarkedContour.cpp
+++ b/source/MRMesh/MRMarkedContour.cpp
@@ -196,7 +196,22 @@ MarkedContour3f makeSpline( MarkedContour3f mc, float markStability )
 
 MarkedContour3f makeSpline( const Contour3f & controlPoints, const SplineSettings & settings )
 {
-    return makeSpline( resample( markedContour( controlPoints ), settings.samplingStep ), settings.controlStability );
+    MR_TIMER
+    assert( settings.iterations >= 1 );
+    MarkedContour3f res = markedContour( controlPoints );
+    for( int i = 0; i < settings.iterations; ++i )
+    {
+        assert( controlPoints.size() == res.marks.count() );
+        if ( i > 0 )
+        {
+            // restore exact control points positions
+            int n = 0;
+            for ( auto m : res.marks )
+                res.contour[m] = controlPoints[n++];
+        }
+        res = makeSpline( resample( res, settings.samplingStep ), settings.controlStability );
+    }
+    return res;
 }
 
 TEST(MRMesh, MarkedContour)

--- a/source/MRMesh/MRMarkedContour.h
+++ b/source/MRMesh/MRMarkedContour.h
@@ -49,6 +49,11 @@ struct SplineSettings
 
     /// a positive value, the more the value the closer resulting spline will be to given control points
     float controlStability = 1;
+
+    /// the shape of resulting spline depends on the total number of points in the contour,
+    /// which in turn depends on the length of input contour being sampled;
+    /// setting iterations greater than one allows you to pass a constructed spline as a better input contour to the next run of the algorithm
+    int iterations = 1;
 };
 
 /// \param controlPoints ordered point the spline to interpolate


### PR DESCRIPTION
Example of resulting splines with same 4 control points and settings, but distinct number of iterations:
![image](https://github.com/user-attachments/assets/3001824a-9c41-44bc-b778-31ff4fdfafb3)
