### PR TITLE
Append history action improvements

### DIFF
--- a/source/MRViewer/MRAppendHistory.h
+++ b/source/MRViewer/MRAppendHistory.h
@@ -8,7 +8,7 @@
 namespace MR
 {
 
-// This function appends history action to viewers global history store
+/// This function constructs history action and appends it to viewer's global history store
 template<class HistoryActionType, typename... Args>
 void AppendHistory( Args&&... args )
 {
@@ -17,12 +17,11 @@ void AppendHistory( Args&&... args )
         s->appendAction( std::make_shared<HistoryActionType>( std::forward<Args>( args )... ) );
 }
 
-template<class HistoryActionType>
-void AppendHistory( std::shared_ptr<HistoryActionType> action )
+/// This function appends given history action to viewer's global history store
+inline void AppendHistory( std::shared_ptr<HistoryAction> action )
 {
-    static_assert( std::is_base_of_v<HistoryAction, HistoryActionType> );
     if ( const auto & s = HistoryStore::getViewerInstance() )
-        s->appendAction( action );
+        s->appendAction( std::move( action ) );
 }
 
 // if undo history is enabled, creates given action in the constructor;

--- a/source/MRViewer/MRHistoryStore.cpp
+++ b/source/MRViewer/MRHistoryStore.cpp
@@ -18,7 +18,7 @@ HistoryStore::~HistoryStore()
     clear();
 }
 
-void HistoryStore::appendAction( const std::shared_ptr<HistoryAction>& action )
+void HistoryStore::appendAction( std::shared_ptr<HistoryAction> action )
 {
     assert( !undoRedoInProgress_ );
     if ( undoRedoInProgress_ )
@@ -27,14 +27,14 @@ void HistoryStore::appendAction( const std::shared_ptr<HistoryAction>& action )
         return;
     if ( scopedBlock_ )
     {
-        scopedBlock_->push_back( action );
+        scopedBlock_->push_back( std::move( action ) );
         return;
     }
     spdlog::info( "History action append: \"{}\"", action->name() );
     assert( !action->name().empty() );
 
     stack_.resize( firstRedoIndex_ + 1 );
-    stack_[firstRedoIndex_] = action;
+    stack_[firstRedoIndex_] = std::move( action );
     ++firstRedoIndex_;
 
     changedSignal( *this, ChangeType::AppendAction );

--- a/source/MRViewer/MRHistoryStore.h
+++ b/source/MRViewer/MRHistoryStore.h
@@ -22,7 +22,7 @@ public:
 
     /// Adds action in history stack (clears available redo actions)
     /// adds actions to scope block if scope mode is active (do not affect main stack)
-    MRVIEWER_API virtual void appendAction( const std::shared_ptr<HistoryAction>& action );
+    MRVIEWER_API virtual void appendAction( std::shared_ptr<HistoryAction> action );
 
     /// Returns current scope ptr
     [[nodiscard]] HistoryActionsVector* getScopeBlockPtr() const { return scopedBlock_; }


### PR DESCRIPTION
* `HistoryStore::appendAction` and `AppendHistory` take `std::shared_ptr<HistoryAction> action` by value to move it inside.
* `AppendHistory` taking already constructed history action is not template any more.