### PR TITLE
Decimate mesh: update queue periodically

### DIFF
--- a/.github/actions/python-regression-tests/action.yml
+++ b/.github/actions/python-regression-tests/action.yml
@@ -4,7 +4,7 @@ inputs:
   autotest_data_s3_url:
     required: false
     type: string
-    default: "s3://data-autotest/test_data_2024-12-19"
+    default: "s3://data-autotest/test_data_2025-01-21"
   build_config:
     description: "Build config (Release, Debug)"
     required: true

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -206,6 +206,7 @@
     <ClInclude Include="MRPrecipitationSimulator.h" />
     <ClInclude Include="MRPrecisePredicates2.h" />
     <ClInclude Include="MRPrimitiveMapsComposition.h" />
+    <ClInclude Include="MRPriorityQueue.h" />
     <ClInclude Include="MRPrism.h" />
     <ClInclude Include="MRProgressReadWrite.h" />
     <ClInclude Include="MRRadiusCompensation.h" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1257,6 +1257,9 @@
     <ClInclude Include="MRRadiusCompensation.h">
       <Filter>Source Files\Gcode</Filter>
     </ClInclude>
+    <ClInclude Include="MRPriorityQueue.h">
+      <Filter>Source Files\Basic</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRParallelProgressReporter.cpp">

--- a/source/MRMesh/MRMeshDecimate.cpp
+++ b/source/MRMesh/MRMeshDecimate.cpp
@@ -801,13 +801,13 @@ DecimateResult MeshDecimator::run()
     const int maxFacesDeleted = std::min(
         settings_.region ? (int)settings_.region->count() : mesh_.topology.numValidFaces(), settings_.maxDeletedFaces );
     // intermediate packs shall improve performance of overall decimation
-    auto nextPackOn = 9 * queue_.size() / 10;
+    auto nextPackOn = 11 * queue_.size() / 12;
     while ( !queue_.empty() )
     {
         if ( queue_.size() <= nextPackOn )
         {
             packQueue_();
-            nextPackOn = 9 * queue_.size() / 10;
+            nextPackOn = 11 * queue_.size() / 12;
             if ( queue_.empty() )
                 break; // if old queue was filled only with invalid elements
         }

--- a/source/MRMesh/MRMeshDecimate.cpp
+++ b/source/MRMesh/MRMeshDecimate.cpp
@@ -348,12 +348,9 @@ void MeshDecimator::packQueue_()
         if ( !validInQueue_.test( qe.uedgeId() ) )
             return;
         if ( auto n = computeQueueElement_( qe.uedgeId(), qe.x.edgeOp == EdgeOp::CollapseOptPos ) )
-        {
-            if ( n->c > qe.c )
-                qe = *n;
-            return;
-        }
-        del.set( i );
+            qe = *n;
+        else
+            del.set( i );
     } );
 
     t.restart( "invalidate" );

--- a/source/MRMesh/MRMeshDecimate.cpp
+++ b/source/MRMesh/MRMeshDecimate.cpp
@@ -801,13 +801,13 @@ DecimateResult MeshDecimator::run()
     const int maxFacesDeleted = std::min(
         settings_.region ? (int)settings_.region->count() : mesh_.topology.numValidFaces(), settings_.maxDeletedFaces );
     // intermediate packs shall improve performance of overall decimation
-    int nextPackOnNumFaces = mesh_.topology.numValidFaces() / 2;
+    auto nextPackOn = 9 * queue_.size() / 10;
     while ( !queue_.empty() )
     {
-        if ( mesh_.topology.numValidFaces() <= nextPackOnNumFaces )
+        if ( queue_.size() <= nextPackOn )
         {
             packQueue_();
-            nextPackOnNumFaces = mesh_.topology.numValidFaces() / 2;
+            nextPackOn = 9 * queue_.size() / 10;
             if ( queue_.empty() )
                 break; // if old queue was filled only with invalid elements
         }

--- a/source/MRMesh/MRPriorityQueue.h
+++ b/source/MRMesh/MRPriorityQueue.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "MRTimer.h"
+#include <vector>
+#include <algorithm>
+
+namespace MR
+{
+
+/// similar to std::priority_queue, but with ability to access underlying vector to custom modify its elements
+template <typename T, typename P = std::less<T>>
+class PriorityQueue
+{
+public:
+    using value_type = T;
+    using Container = std::vector<T>;
+    using size_type = typename Container::size_type;
+
+    /// constructs empty queue
+    PriorityQueue() {}
+    explicit PriorityQueue( const P& pred ) : pred_( pred ) {}
+
+    /// initializes queue elements from given vector
+    explicit PriorityQueue( const P& pred, Container&& v );
+
+    /// checks if the queue has no elements
+    bool empty() const { return c.empty(); }
+
+    /// returns the number of elements
+    size_type size() const { return c.size(); }
+
+    /// accesses the top element
+    const T & top() const { return c.front(); }
+
+    /// inserts element in the queue
+    void push( const value_type& value ) { c.push_back( value ); onPush_(); }
+    void push( value_type&& value ) { c.push_back( std::move( value ) ); onPush_(); }
+    template< class... Args >
+    void emplace( Args&&... args ) { c.emplace_back( std::forward<Args>(args)... ); onPush_(); }
+
+    /// removes the top element from the priority queue
+    void pop() { std::pop_heap( c.begin(), c.end(), pred_ ); c.pop_back(); }
+
+    /// intentionally left public to allow user access to it,
+    /// but the user is responsible for restore heap-property of this vector before calling of any method
+    Container c;
+
+private:
+    void onPush_() { std::push_heap( c.begin(), c.end(), pred_ ); };
+
+private:
+    [[no_unique_address]] P pred_;
+};
+
+template <typename T, typename P>
+PriorityQueue<T, P>::PriorityQueue( const P& pred, Container&& v ) : c( std::move( v ) ), pred_( pred )
+{
+    MR_TIMER
+    std::make_heap( c.begin(), c.end(), pred_ );
+}
+
+} // namespace MR


### PR DESCRIPTION
Priority queue in mesh decimation with time contains a lot of elements for deleted edges, and a lot of outdated values for existing edges. With this change, such queue's state is detected and the queue is quickly updated:
1. invalid records are removed,
2. the errors for outdated edges are recomputed.

For that purpose `std::priority_queue` is replaced with `MR::PriorityQueue`, which gives access to all its elements.

Also `MeshDecimator::initializeQueue_` was optimized for better performance.

The decimation (with subdivide parts = 1) from 105M triangles to 1K triangles, reduced on my computer 540 sec from to 360 sec (-33%).