### PR TITLE
Allow variable surface offset for meshtripoints

### DIFF
--- a/source/MRMesh/MRContoursCut.cpp
+++ b/source/MRMesh/MRContoursCut.cpp
@@ -1138,30 +1138,116 @@ Expected<OneMeshContour> convertMeshTriPointsToMeshContour( const Mesh& mesh, co
     return convertMeshTriPointsToMeshContour( mesh, meshTriPointsOrg, conFn, pivotIndices );
 }
 
-Expected<OneMeshContours> convertMeshTriPointsIsoLineToMeshContour( const Mesh& mesh, const std::vector<MeshTriPoint>& meshTriPoints, float isoValue, SearchPathSettings searchSettings /*= {} */ )
+Expected<OneMeshContours> convertMeshTriPointsSurfaceOffsetToMeshContours( const Mesh& mesh, const std::vector<MeshTriPoint>& meshTriPoints, float isoValue, SearchPathSettings searchSettings /*= {} */ )
 {
-    auto initCutContours = convertMeshTriPointsToMeshContour( mesh, meshTriPoints, searchSettings );
-    if ( !initCutContours.has_value() )
-        return unexpected( initCutContours.error() );
+    return convertMeshTriPointsSurfaceOffsetToMeshContours( mesh, meshTriPoints, 
+        [isoValue] ( int )
+    {
+        return isoValue;
+    }, searchSettings );
+}
 
-    if ( isoValue == 0.0f )
-        return OneMeshContours{ std::move( *initCutContours ) };
+Expected<OneMeshContours> convertMeshTriPointsSurfaceOffsetToMeshContours( const Mesh& mesh, const std::vector<MeshTriPoint>& meshTriPoints, 
+    const std::function<float( int )>& offsetAtPoint, SearchPathSettings searchSettings /*= {}*/ )
+{
+    if ( !offsetAtPoint )
+    {
+        assert( false );
+        return {};
+    }
+    MinMaxf mmOffset;
+    for ( int i = 0; i < meshTriPoints.size(); ++i )
+        mmOffset.include( std::abs( offsetAtPoint( i ) ) );
 
-    // need to set non-cut vertices too
-    VertBitSet startVertices( mesh.topology.lastValidVert() + 1 );
-    for ( const auto& i : initCutContours->intersections )
-        if ( i.primitiveId.index() == OneMeshIntersection::VariantIndex::Vertex )
-            startVertices.set( std::get<VertId>( i.primitiveId ) );
+    std::vector<int> pivotIndices; // only used if offset is variable
+    auto initCutContourRes = convertMeshTriPointsToMeshContour( mesh, meshTriPoints, searchSettings, mmOffset.min == mmOffset.max ? nullptr : &pivotIndices );
+    if ( !initCutContourRes.has_value() )
+        return unexpected( initCutContourRes.error() );
+
+    OneMeshContours initCutContoursVec = OneMeshContours{ std::move( *initCutContourRes ) };
+
+    if ( mmOffset.min == 0.0f && mmOffset.max == 0.0f )
+        return initCutContoursVec;
 
     Mesh meshAfterCut = mesh;
     NewEdgesMap nEM;
     // .forceFillMode = CutMeshParameters::ForceFill::All
     // because we don't really care about intermediate mesh quality
-    auto cutRes = cutMesh( meshAfterCut, { std::move( *initCutContours ) }, { .forceFillMode = CutMeshParameters::ForceFill::All,.new2oldEdgesMap = &nEM } );
+    auto cutRes = cutMesh( meshAfterCut, initCutContoursVec, { .forceFillMode = CutMeshParameters::ForceFill::All,.new2oldEdgesMap = &nEM } );
 
-    startVertices |= ( meshAfterCut.topology.getValidVerts() - mesh.topology.getValidVerts() );
-    auto distances = computeSurfaceDistances( meshAfterCut, startVertices, FLT_MAX );
-    auto isoLines = extractIsolines( meshAfterCut.topology, distances, isoValue );
+    const auto& initCutContours = initCutContoursVec[0];
+
+    // setup start vertices
+    VertBitSet startVertices( meshAfterCut.topology.lastValidVert() + 1 );
+    HashMap<VertId, float> startVerticesValues; // only used if offset is variable
+    std::vector<float> sumLength; // only used if offset is variable
+    struct InterInfo
+    {
+        float length{ 0.0f };
+        int startPivot{ -1 };
+        int endPivot{ -1 };
+    };
+    std::vector<InterInfo> singleSegmentInfo; // only used if offset is variable
+    if ( !pivotIndices.empty() ) // if offset is variable
+    {
+        sumLength.resize( pivotIndices.size(), 0.0f );
+        singleSegmentInfo.resize( initCutContours.intersections.size() );
+        int startPivot = 0;
+        int endPivot = 0;
+        while ( pivotIndices[startPivot] == -1 )
+            startPivot = ( startPivot + 1 ) % int( pivotIndices.size() );
+        while ( pivotIndices[endPivot] == -1 )
+            endPivot = ( endPivot + 1 ) % int( pivotIndices.size() );
+        bool lastSegment = false;
+        for ( int i = 0; i < initCutContours.intersections.size(); ++i )
+        {
+            if ( !lastSegment && pivotIndices[endPivot] <= i )
+            {
+                startPivot = endPivot;
+                endPivot = ( startPivot + 1 ) % int( pivotIndices.size() );
+                while ( pivotIndices[endPivot] == -1 )
+                    endPivot = ( endPivot + 1 ) % int( pivotIndices.size() );
+                if ( endPivot < startPivot )
+                    lastSegment = true;
+            }
+            float length = 0.0f;
+            if ( pivotIndices[startPivot] != i )
+            {
+                int prevI = ( i - 1 + int( singleSegmentInfo.size() ) ) % int( singleSegmentInfo.size() );
+                length = ( initCutContours.intersections[i].coordinate - initCutContours.intersections[prevI].coordinate ).length();
+            }
+            singleSegmentInfo[i].length += length;
+            singleSegmentInfo[i].startPivot = startPivot;
+            singleSegmentInfo[i].endPivot = endPivot;
+            sumLength[startPivot] += length;
+        }
+    }
+    VertId currentId = mesh.topology.lastValidVert() + 1;
+    for ( int i = 0; i < initCutContours.intersections.size(); ++i )
+    {
+        const auto inter = initCutContours.intersections[i];
+        VertId interVertId;
+        if ( inter.primitiveId.index() == OneMeshIntersection::VariantIndex::Vertex )
+            interVertId = std::get<VertId>( inter.primitiveId );
+        else
+            interVertId = currentId++;
+        startVertices.set( interVertId );
+        if ( !pivotIndices.empty() ) // if offset is variable
+        {
+            auto curSumLength = sumLength[singleSegmentInfo[i].startPivot];
+            float ratio = curSumLength > 0.0f ? singleSegmentInfo[i].length / curSumLength : 0.5f;
+            float offsetValue = ( 1.0f - ratio ) * offsetAtPoint( singleSegmentInfo[i].startPivot ) + ratio * offsetAtPoint( singleSegmentInfo[i].endPivot );
+            startVerticesValues[interVertId] = mmOffset.max - offsetValue;
+        }
+    }
+
+    // calculate isolines
+    VertScalars distances;
+    if ( pivotIndices.empty() ) // if offset is static
+        distances = computeSurfaceDistances( meshAfterCut, startVertices, FLT_MAX );
+    else
+        distances = computeSurfaceDistances( meshAfterCut, startVerticesValues, FLT_MAX );
+    auto isoLines = extractIsolines( meshAfterCut.topology, distances, mmOffset.max );
 
     OneMeshContours res;
     res.resize( isoLines.size() );

--- a/source/MRMesh/MRContoursCut.cpp
+++ b/source/MRMesh/MRContoursCut.cpp
@@ -562,6 +562,20 @@ OneMeshContours getOneMeshIntersectionContours( const Mesh& meshA, const Mesh& m
     return res;
 }
 
+Contours3f extractMeshContours( const OneMeshContours& meshContours )
+{
+    Contours3f res( meshContours.size() );
+    for ( int i = 0; i < res.size(); ++i )
+    {
+        auto& resI = res[i];
+        const auto& imputI = meshContours[i].intersections;
+        resI.resize( imputI.size() );
+        for ( int j = 0; j < resI.size(); ++j )
+            resI[j] = imputI[j].coordinate;
+    }
+    return res;
+}
+
 // finds FaceId if face, shared among vid eid and mtp, if there is no one returns left(mtp.e)
 FaceId findSharedFace( const MeshTopology& topology, VertId vid, EdgeId eid, const MeshTriPoint& mtp )
 {

--- a/source/MRMesh/MRContoursCut.h
+++ b/source/MRMesh/MRContoursCut.h
@@ -92,13 +92,24 @@ MRMESH_API Expected<OneMeshContour> convertMeshTriPointsToMeshContour( const Mes
 /** \ingroup BooleanGroup
   * \brief Makes continuous contour by iso-line from mesh tri points, if first and last meshTriPoint is the same, makes closed contour
   *
-  * Finds shortest paths between neighbor \p meshTriPoints and build contour MR::cutMesh input
-  * \param isoValue amount of offset form given point, note that absolute value is used and isoline in both direction returned
-  * \param searchSettings settings for search geo path
+  * Finds shortest paths between neighbor \p meshTriPoints and build offset contour on surface for MR::cutMesh input
+  * \param offset amount of offset form given point, note that absolute value is used and isoline in both direction returned
+  * \param searchSettings settings for search geodesic path
   */
 [[nodiscard]]
-MRMESH_API Expected<OneMeshContours> convertMeshTriPointsIsoLineToMeshContour( const Mesh& mesh, const std::vector<MeshTriPoint>& meshTriPoints,
-    float isoValue, SearchPathSettings searchSettings = {} );
+MRMESH_API Expected<OneMeshContours> convertMeshTriPointsSurfaceOffsetToMeshContours( const Mesh& mesh, const std::vector<MeshTriPoint>& meshTriPoints,
+    float offset, SearchPathSettings searchSettings = {} );
+
+/** \ingroup BooleanGroup
+  * \brief Makes continuous contour by iso-line from mesh tri points, if first and last meshTriPoint is the same, makes closed contour
+  *
+  * Finds shortest paths between neighbor \p meshTriPoints and build offset contour on surface for MR::cutMesh input
+  * \param offsetAtPoint functor that returns amount of offset form arg point, note that absolute value is used and isoline in both direction returned
+  * \param searchSettings settings for search geodesic path
+  */
+[[nodiscard]]
+MRMESH_API Expected<OneMeshContours> convertMeshTriPointsSurfaceOffsetToMeshContours( const Mesh& mesh, const std::vector<MeshTriPoint>& meshTriPoints,
+    const std::function<float(int)>& offsetAtPoint, SearchPathSettings searchSettings = {});
 
 /** \ingroup BooleanGroup
   * \brief Makes closed continuous contour by mesh tri points, note that first and last meshTriPoint should not be same

--- a/source/MRMesh/MRContoursCut.h
+++ b/source/MRMesh/MRContoursCut.h
@@ -59,16 +59,20 @@ MRMESH_API OneMeshContours getOneMeshIntersectionContours( const Mesh& meshA, co
     const CoordinateConverters& converters, const AffineXf3f* rigidB2A = nullptr );
 
 
+// Converts OneMeshContours contours representation to Contours3f: set of coordinates
+[[nodiscard]]
+MRMESH_API Contours3f extractMeshContours( const OneMeshContours& meshContours );
+
 using MeshTriPointsConnector = std::function<Expected<SurfacePath>( const MeshTriPoint& start, const MeshTriPoint& end, int startIndex, int endIndex )>;
 /** \ingroup BooleanGroup
   * \brief Makes continuous contour by mesh tri points, if first and last meshTriPoint is the same, makes closed contour
   *
-  * Finds paths between neighbor \p meshTriPoints with MeshTriPointsConnector function and build contour MR::cutMesh input
-  * \param connectorFn function to build path between neighbor meshTriPoints, if not present simple geodesic path function is used
-  * \param pivotIndices optional output indices of given meshTriPoints in result OneMeshContour
+  * Finds paths between neighbor \p surfaceLine with MeshTriPointsConnector function and build contour MR::cutMesh input
+  * \param connectorFn function to build path between neighbor surfaceLine, if not present simple geodesic path function is used
+  * \param pivotIndices optional output indices of given surfaceLine in result OneMeshContour
   */
 [[nodiscard]]
-MR_BIND_IGNORE MRMESH_API Expected<OneMeshContour> convertMeshTriPointsToMeshContour( const Mesh& mesh, const std::vector<MeshTriPoint>& meshTriPoints,
+MR_BIND_IGNORE MRMESH_API Expected<OneMeshContour> convertMeshTriPointsToMeshContour( const Mesh& mesh, const std::vector<MeshTriPoint>& surfaceLine,
     MeshTriPointsConnector connectorFn, std::vector<int>* pivotIndices = nullptr );
 
 /// Geo path search settings
@@ -81,45 +85,45 @@ struct SearchPathSettings
 /** \ingroup BooleanGroup
   * \brief Makes continuous contour by mesh tri points, if first and last meshTriPoint is the same, makes closed contour
   *
-  * Finds shortest paths between neighbor \p meshTriPoints and build contour MR::cutMesh input
+  * Finds shortest paths between neighbor \p surfaceLine and build contour MR::cutMesh input
   * \param searchSettings settings for search geo path 
-  * \param pivotIndices optional output indices of given meshTriPoints in result OneMeshContour
+  * \param pivotIndices optional output indices of given surfaceLine in result OneMeshContour
   */
 [[nodiscard]]
-MRMESH_API Expected<OneMeshContour> convertMeshTriPointsToMeshContour( const Mesh& mesh, const std::vector<MeshTriPoint>& meshTriPoints,
+MRMESH_API Expected<OneMeshContour> convertMeshTriPointsToMeshContour( const Mesh& mesh, const std::vector<MeshTriPoint>& surfaceLine,
     SearchPathSettings searchSettings = {}, std::vector<int>* pivotIndices = nullptr );
 
 /** \ingroup BooleanGroup
   * \brief Makes continuous contour by iso-line from mesh tri points, if first and last meshTriPoint is the same, makes closed contour
   *
-  * Finds shortest paths between neighbor \p meshTriPoints and build offset contour on surface for MR::cutMesh input
+  * Finds shortest paths between neighbor \p surfaceLine and build offset contour on surface for MR::cutMesh input
   * \param offset amount of offset form given point, note that absolute value is used and isoline in both direction returned
   * \param searchSettings settings for search geodesic path
   */
 [[nodiscard]]
-MRMESH_API Expected<OneMeshContours> convertMeshTriPointsSurfaceOffsetToMeshContours( const Mesh& mesh, const std::vector<MeshTriPoint>& meshTriPoints,
+MRMESH_API Expected<OneMeshContours> convertMeshTriPointsSurfaceOffsetToMeshContours( const Mesh& mesh, const std::vector<MeshTriPoint>& surfaceLine,
     float offset, SearchPathSettings searchSettings = {} );
 
 /** \ingroup BooleanGroup
   * \brief Makes continuous contour by iso-line from mesh tri points, if first and last meshTriPoint is the same, makes closed contour
   *
-  * Finds shortest paths between neighbor \p meshTriPoints and build offset contour on surface for MR::cutMesh input
+  * Finds shortest paths between neighbor \p surfaceLine and build offset contour on surface for MR::cutMesh input
   * \param offsetAtPoint functor that returns amount of offset form arg point, note that absolute value is used and isoline in both direction returned
   * \param searchSettings settings for search geodesic path
   */
 [[nodiscard]]
-MRMESH_API Expected<OneMeshContours> convertMeshTriPointsSurfaceOffsetToMeshContours( const Mesh& mesh, const std::vector<MeshTriPoint>& meshTriPoints,
+MRMESH_API Expected<OneMeshContours> convertMeshTriPointsSurfaceOffsetToMeshContours( const Mesh& mesh, const std::vector<MeshTriPoint>& surfaceLine,
     const std::function<float(int)>& offsetAtPoint, SearchPathSettings searchSettings = {});
 
 /** \ingroup BooleanGroup
   * \brief Makes closed continuous contour by mesh tri points, note that first and last meshTriPoint should not be same
   * 
-  * Finds shortest paths between neighbor \p meshTriPoints and build closed contour MR::cutMesh input
-  * \param pivotIndices optional output indices of given meshTriPoints in result OneMeshContour
+  * Finds shortest paths between neighbor \p surfaceLine and build closed contour MR::cutMesh input
+  * \param pivotIndices optional output indices of given surfaceLine in result OneMeshContour
   * \note better use convertMeshTriPointsToMeshContour(...) instead, note that it requires same front and back MeshTriPoints for closed contour
   */
 [[nodiscard]]
-MRMESH_API Expected<OneMeshContour> convertMeshTriPointsToClosedContour( const Mesh& mesh, const std::vector<MeshTriPoint>& meshTriPoints,
+MRMESH_API Expected<OneMeshContour> convertMeshTriPointsToClosedContour( const Mesh& mesh, const std::vector<MeshTriPoint>& surfaceLine,
     SearchPathSettings searchSettings = {}, std::vector<int>* pivotIndices = nullptr );
 
 /** \ingroup BooleanGroup

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -218,6 +218,7 @@
     <ClInclude Include="MRSolarRadiation.h" />
     <ClInclude Include="MRSphere.h" />
     <ClInclude Include="MRStacktrace.h" />
+    <ClInclude Include="MRSurfaceLineOffset.h" />
     <ClInclude Include="MRSymMatrix4.h" />
     <ClInclude Include="MRSystemPath.h" />
     <ClInclude Include="MRTiffIO.h" />
@@ -575,6 +576,7 @@
     <ClCompile Include="MRSignDetectionMode.cpp" />
     <ClCompile Include="MRSolarRadiation.cpp" />
     <ClCompile Include="MRStacktrace.cpp" />
+    <ClCompile Include="MRSurfaceLineOffset.cpp" />
     <ClCompile Include="MRSystemPath.cpp" />
     <ClCompile Include="MRTiffIO.cpp" />
     <ClCompile Include="MRRectIndexer.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1257,6 +1257,9 @@
     <ClInclude Include="MRRadiusCompensation.h">
       <Filter>Source Files\Gcode</Filter>
     </ClInclude>
+    <ClInclude Include="MRSurfaceLineOffset.h">
+      <Filter>Source Files\Mesh</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRParallelProgressReporter.cpp">
@@ -2065,6 +2068,9 @@
     </ClCompile>
     <ClCompile Include="MRRadiusCompensation.cpp">
       <Filter>Source Files\Gcode</Filter>
+    </ClCompile>
+    <ClCompile Include="MRSurfaceLineOffset.cpp">
+      <Filter>Source Files\Mesh</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/source/MRMesh/MRSurfaceLineOffset.cpp
+++ b/source/MRMesh/MRSurfaceLineOffset.cpp
@@ -1,0 +1,24 @@
+#include "MRSurfaceLineOffset.h"
+#include "MRContoursCut.h"
+
+namespace MR
+{
+
+Expected<Contours3f> offsetSurfaceLine( const Mesh& mesh, const std::vector<MeshTriPoint>& surfaceLine, const std::function<float( int )>& offsetAtPoint )
+{
+    auto offsetRes = convertMeshTriPointsSurfaceOffsetToMeshContours( mesh, surfaceLine, offsetAtPoint );
+    if ( !offsetRes.has_value() )
+        return unexpected( std::move( offsetRes.error() ) );
+
+    return extractMeshContours( std::move( *offsetRes ) );
+}
+
+Expected<Contours3f> offsetSurfaceLine( const Mesh& mesh, const std::vector<MeshTriPoint>& surfaceLine, float offset )
+{
+    return offsetSurfaceLine( mesh, surfaceLine, [offset] ( int )->float
+    {
+        return offset;
+    } );
+}
+
+}

--- a/source/MRMesh/MRSurfaceLineOffset.h
+++ b/source/MRMesh/MRSurfaceLineOffset.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "MRMeshFwd.h"
+#include "MRExpected.h"
+#include <functional>
+
+namespace MR
+{
+
+/// <summary>
+/// Returns contours in \p mesh space that are offset from \p surfaceLine on \p offset amount in all directions
+/// </summary>
+/// <param name="mesh">mesh to perform offset on</param>
+/// <param name="surfaceLine">surface line to perofrm offset from</param>
+/// <param name="offset">amount of offset, note that absolute value is used</param>
+/// <returns>resulting offset contours or error if something goes wrong</returns>
+[[nodiscard]]
+MRMESH_API Expected<Contours3f> offsetSurfaceLine( const Mesh& mesh, const std::vector<MeshTriPoint>& surfaceLine, float offset );
+
+/// <summary>
+/// Returns contours in \p mesh space that are offset from \p surfaceLine on \p offsetAtPoint amount in all directions
+/// </summary>
+/// <param name="mesh">mesh to perform offset on</param>
+/// <param name="surfaceLine">surface line to perofrm offset from</param>
+/// <param name="offsetAtPoint">function that can return different amount of offset in different point (argument is index of point in \p surfaceLine), note that absolute value is used</param>
+/// <returns>resulting offset contours or error if something goes wrong</returns>
+[[nodiscard]]
+MRMESH_API Expected<Contours3f> offsetSurfaceLine( const Mesh& mesh, const std::vector<MeshTriPoint>& surfaceLine, const std::function<float( int )>& offsetAtPoint );
+
+}


### PR DESCRIPTION
1) rename `convertMeshTriPointsIsoLineToMeshContour` to `convertMeshTriPointsSurfaceOffsetToMeshContours`
2) make 2nd version of the function that can be used for variable offset
3) add `extractMeshContours` function for easy conversion from `OneMeshContours` to `Contours3f`
4) add `offsetSurfaceLine` function for easier usage