### PR TITLE
ExtractIsolines improvements

### DIFF
--- a/source/MRMesh/MRExtractIsolines.h
+++ b/source/MRMesh/MRExtractIsolines.h
@@ -47,6 +47,13 @@ namespace MR
 [[nodiscard]] MRMESH_API Expected<PlaneSection> trackSection( const MeshPart& mp,
     const MeshTriPoint& start, const MeshTriPoint& end, const Vector3f& planePoint, bool ccw );
 
+/// returns true if left(isoline[i].e) == right(isoline[i+1].e) and valid for all i;
+/// all above functions produce consistently oriented lines
+[[nodiscard]] MRMESH_API bool isConsistentlyOriented( const MeshTopology & topology, const IsoLine & isoline );
+
+/// for a consistently oriented isoline, returns all faces it goes inside
+[[nodiscard]] MRMESH_API FaceBitSet getCrossedFaces( const MeshTopology & topology, const IsoLine & isoline );
+
 /// converts PlaneSections in 2D contours by computing coordinate of each point, applying given xf to it, and retaining only x and y
 [[nodiscard]] MRMESH_API Contour2f planeSectionToContour2f( const Mesh & mesh, const PlaneSection & section, const AffineXf3f & meshToPlane );
 [[nodiscard]] MRMESH_API Contours2f planeSectionsToContours2f( const Mesh & mesh, const PlaneSections & sections, const AffineXf3f & meshToPlane );

--- a/source/MRMesh/MRExtractIsolinesTests.cpp
+++ b/source/MRMesh/MRExtractIsolinesTests.cpp
@@ -65,6 +65,7 @@ TEST( MRMesh, ExtractPlaneSections )
     ASSERT_EQ( res.size(), 1 );
     EXPECT_EQ( res[0].size(), 11 );
     EXPECT_EQ( res[0].front(), res[0].back() );
+    EXPECT_EQ( getCrossedFaces( mesh.topology, res[0] ).count(), 10 );
     for ( const auto& i : res[0] )
     {
         Vector3f point = mesh.edgePoint( i );
@@ -79,6 +80,12 @@ TEST( MRMesh, ExtractPlaneSections )
     ASSERT_EQ( res.size(), 1 );
     EXPECT_EQ( res[0].size(), 10 );
     EXPECT_NE( res[0].front(), res[0].back() );
+    EXPECT_EQ( getCrossedFaces( mesh.topology, res[0] ).count(), 9 );
+    for ( const auto& i : res[0] )
+    {
+        Vector3f point = mesh.edgePoint( i );
+        EXPECT_LE( std::abs( plane.distance( point ) ), delta );
+    }
 }
 
 

--- a/source/MRMesh/MRExtractIsolinesTests.cpp
+++ b/source/MRMesh/MRExtractIsolinesTests.cpp
@@ -64,11 +64,21 @@ TEST( MRMesh, ExtractPlaneSections )
     res = extractPlaneSections( mesh, plane );
     ASSERT_EQ( res.size(), 1 );
     EXPECT_EQ( res[0].size(), 11 );
+    EXPECT_EQ( res[0].front(), res[0].back() );
     for ( const auto& i : res[0] )
     {
         Vector3f point = mesh.edgePoint( i );
         EXPECT_LE( std::abs( plane.distance( point ) ), delta );
     }
+
+    // make a hole in mesh to extract not closed contour
+    FaceBitSet fs;
+    fs.autoResizeSet( 2_f );
+    mesh.deleteFaces( fs );
+    res = extractPlaneSections( mesh, plane );
+    ASSERT_EQ( res.size(), 1 );
+    EXPECT_EQ( res[0].size(), 10 );
+    EXPECT_NE( res[0].front(), res[0].back() );
 }
 
 


### PR DESCRIPTION
New functions:
* `isConsistentlyOriented` that must be true for all produced isolines,
* `getCrossedFaces` to get all crossed faces

Extend unit test to cover the case of mesh with holes and new functions.