### PR TITLE
Report progress of CTM compression

### DIFF
--- a/source/MRIOExtras/MRCtm.cpp
+++ b/source/MRIOExtras/MRCtm.cpp
@@ -16,10 +16,11 @@
 
 #include <fstream>
 
-namespace
+namespace MR
 {
 
-using namespace MR;
+namespace
+{
 
 class NormalXfMatrix
 {
@@ -40,10 +41,52 @@ private:
     const Matrix3d * pNormXf_ = nullptr;
 };
 
-} // namespace
-
-namespace MR
+class Saver
 {
+public:
+    Saver( CTMcontext context, std::ostream& outStream, const ProgressCallback & cb )
+        : context_( context ), stream_( outStream ), cb_( cb ) {}
+    Expected<void> run();
+
+private:
+    CTMcontext context_;
+    std::ostream& stream_;
+    const ProgressCallback & cb_;
+    float lastProgress_ = 0;
+};
+
+Expected<void> Saver::run()
+{
+    MR_TIMER
+    if ( !stream_ )
+        return unexpected( std::string( "Bad stream before CTM-encoding" ) );
+    ctmSaveCustom( context_, []( const void* buf, CTMuint size, void* data ) -> CTMuint
+    {
+        Saver& self = *reinterpret_cast< Saver* >( data );
+        writeByBlocks( self.stream_, (const char*) buf, size );
+        if ( !self.stream_ || !reportProgress( self.cb_, self.lastProgress_ ) )
+            return 0; // stop
+        return size;
+    },
+    []( size_t pos, size_t total, void* data )
+    {
+        assert( pos < total );
+        Saver& self = *reinterpret_cast< Saver* >( data );
+        self.lastProgress_ = float( pos ) / total;
+        return reportProgress( self.cb_, self.lastProgress_ ) ? 0 : 1;
+    },
+    this );
+
+    if ( !reportProgress( cb_, 1.0f ) )
+        return unexpectedOperationCanceled();
+    if ( !stream_ )
+        return unexpected( std::string( "Error writing in stream during CTM-encoding" ) );
+    if ( auto err = ctmGetError( context_ ); err != CTM_NONE )
+        return unexpected( "Error " + std::to_string( err ) + " during CTM-encoding" );
+    return {};
+}
+
+} // anonymous namespace
 
 namespace MeshLoad
 {
@@ -230,9 +273,6 @@ Expected<void> toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOption
         (const CTMfloat *)xfVerts.data(), aVertexCount,
         aIndices.data(), numSaveFaces, nullptr );
 
-    if ( ctmGetError(context) != CTM_NONE )
-        return unexpected( "Error encoding in CTM-format" );
-
     std::vector<Vector4f> colors4f; // should be alive when save is performed
     if ( options.colors )
     {
@@ -248,88 +288,10 @@ Expected<void> toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOption
         ctmAddAttribMap( context, (const CTMfloat*) colors4f.data(), "Color" );
     }
 
-    if ( ctmGetError( context ) != CTM_NONE )
-        return unexpected( "Error encoding in CTM-format colors" );
+    if ( ctmGetError(context) != CTM_NONE )
+        return unexpected( "Error encoding in CTM-format" );
 
-    struct SaveData
-    {
-        std::function<bool( float )> callbackFn{};
-        std::ostream* stream;
-        size_t sum{ 0 };
-        size_t blockSize{ 0 };
-        size_t maxSize{ 0 };
-        bool wasCanceled{ false };
-    } saveData;
-    if ( options.progress )
-    {
-        if ( options.meshCompression == CtmSaveOptions::MeshCompression::None )
-        {
-            saveData.callbackFn = [callback = options.progress, &saveData] ( float progress )
-            {
-                // calculate full progress
-                progress = ( saveData.sum + progress * saveData.blockSize ) / saveData.maxSize;
-                return callback( progress );
-            };
-        }
-        else
-        {
-            saveData.callbackFn = [callback = options.progress, &saveData] ( float progress )
-            {
-                // calculate full progress in partial-linear scale (we don't know compressed size and it less than real size)
-                // conversion rules:
-                // step 1) range (0, rangeBefore) is converted in range (0, rangeAfter)
-                // step 2) moving on to new ranges: (rangeBefore, 1) and (rangeAfter, 1)
-                // step 3) go to step 1)
-                const float rangeBefore = 0.2f;
-                const float rangeAfter = 0.7f;
-                progress = ( saveData.sum + progress * saveData.blockSize ) / saveData.maxSize;
-                float newProgress = 0.f;
-                for ( ; newProgress < 98.5f; )
-                {
-                    if ( progress < rangeBefore )
-                    {
-                        newProgress += progress / rangeBefore * rangeAfter * ( 1 - newProgress );
-                        break;
-                    }
-                    else
-                    {
-                        progress = ( progress - rangeBefore ) / ( 1 - rangeBefore );
-                        newProgress += ( 1 - newProgress ) * rangeAfter;
-                    }
-                }
-                return callback( newProgress );
-            };
-        }
-    }
-    saveData.stream = &out;
-    saveData.maxSize = mesh.points.size() * sizeof( Vector3f ) + mesh.topology.getValidFaces().count() * 3 * sizeof( int ) + 150; // 150 - reserve for some ctm specific data
-    ctmSaveCustom( context, []( const void * buf, CTMuint size, void * data )
-    {
-        SaveData& saveData = *reinterpret_cast< SaveData* >( data );
-        std::ostream& outStream = *saveData.stream;
-        saveData.blockSize = size;
-
-        saveData.wasCanceled |= !MR::writeByBlocks( outStream, (const char*) buf, size, saveData.callbackFn, 1u << 12 );
-        saveData.sum += size;
-        if ( saveData.wasCanceled )
-            return 0u;
-
-        return outStream.good() ? size : 0;
-    },
-    [](size_t pos, size_t total, void * /*aUserData*/)
-    {
-        spdlog::info( "CTM compress progress {}/{}", pos, total );
-        return 0;
-    },
-    &saveData );
-
-    if ( saveData.wasCanceled )
-        return unexpectedOperationCanceled();
-    if ( !out || ctmGetError(context) != CTM_NONE )
-        return unexpected( std::string( "Error saving in CTM-format" ) );
-
-    reportProgress( options.progress, 1.f );
-    return {};
+    return Saver( context, out, options.progress ).run();
 }
 
 Expected<void> toCtm( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings& settings )
@@ -514,9 +476,6 @@ Expected<void> toCtm( const PointCloud& cloud, std::ostream& out, const CtmSaveP
                        aIndices.data(), 1, saveNormals ? ( const CTMfloat* )cloud.normals.data() : nullptr );
     }
 
-    if ( ctmGetError( context ) != CTM_NONE )
-        return unexpected( "Error encoding in CTM-format" );
-
     std::vector<Vector4f> colors4f; // should be alive when save is performed
     if ( options.colors && options.colors->size() >= cloud.points.size() )
     {
@@ -531,75 +490,9 @@ Expected<void> toCtm( const PointCloud& cloud, std::ostream& out, const CtmSaveP
     }
 
     if ( ctmGetError( context ) != CTM_NONE )
-        return unexpected( "Error encoding in CTM-format colors" );
+        return unexpected( "Error encoding in CTM-format" );
 
-    struct SaveData
-    {
-        std::function<bool( float )> callbackFn{};
-        std::ostream* stream;
-        size_t sum{ 0 };
-        size_t blockSize{ 0 };
-        size_t maxSize{ 0 };
-        bool wasCanceled{ false };
-    } saveData;
-    if ( options.progress )
-    {
-        saveData.callbackFn = [callback = options.progress, &saveData] ( float progress )
-        {
-            // calculate full progress in partial-linear scale (we don't know compressed size and it less than real size)
-            // conversion rules:
-            // step 1) range (0, rangeBefore) is converted in range (0, rangeAfter)
-            // step 2) moving on to new ranges: (rangeBefore, 1) and (rangeAfter, 1)
-            // step 3) go to step 1)
-            const float rangeBefore = 0.2f;
-            const float rangeAfter = 0.7f;
-            progress = ( saveData.sum + progress * saveData.blockSize ) / saveData.maxSize;
-            float newProgress = 0.f;
-            for ( ; newProgress < 98.5f; )
-            {
-                if ( progress < rangeBefore )
-                {
-                    newProgress += progress / rangeBefore * rangeAfter * ( 1 - newProgress );
-                    break;
-                }
-                else
-                {
-                    progress = ( progress - rangeBefore ) / ( 1 - rangeBefore );
-                    newProgress += ( 1 - newProgress ) * rangeAfter;
-                }
-            }
-            return callback( newProgress );
-        };
-    }
-    saveData.stream = &out;
-    saveData.maxSize = aVertexCount * sizeof( Vector3f ) + cloud.normals.size() * sizeof( Vector3f ) + 150; // 150 - reserve for some ctm specific data
-    ctmSaveCustom( context, []( const void* buf, CTMuint size, void* data )
-    {
-        SaveData& saveData = *reinterpret_cast< SaveData* >( data );
-        std::ostream& outStream = *saveData.stream;
-        saveData.blockSize = size;
-
-        saveData.wasCanceled |= !MR::writeByBlocks( outStream, (const char*) buf, size, saveData.callbackFn, 1u << 12 );
-        saveData.sum += size;
-        if ( saveData.wasCanceled )
-            return 0u;
-
-        return outStream.good() ? size : 0;
-    },
-    [](size_t pos, size_t total, void * /*aUserData*/)
-    {
-        spdlog::info( "CTM compress progress {}/{}", pos, total );
-        return 0;
-    },
-    &saveData );
-
-    if ( saveData.wasCanceled )
-        return unexpectedOperationCanceled();
-    if ( !out || ctmGetError( context ) != CTM_NONE )
-        return unexpected( std::string( "Error saving in CTM-format" ) );
-
-    reportProgress( options.progress, 1.f );
-    return {};
+    return Saver( context, out, options.progress ).run();
 }
 
 Expected<void> toCtm( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )

--- a/source/MRIOExtras/MRCtm.cpp
+++ b/source/MRIOExtras/MRCtm.cpp
@@ -315,7 +315,13 @@ Expected<void> toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOption
             return 0u;
 
         return outStream.good() ? size : 0;
-    }, &saveData );
+    },
+    [](size_t pos, size_t total, void * /*aUserData*/)
+    {
+        spdlog::info( "CTM compress progress {}/{}", pos, total );
+        return 0;
+    },
+    &saveData );
 
     if ( saveData.wasCanceled )
         return unexpectedOperationCanceled();
@@ -567,7 +573,7 @@ Expected<void> toCtm( const PointCloud& cloud, std::ostream& out, const CtmSaveP
     }
     saveData.stream = &out;
     saveData.maxSize = aVertexCount * sizeof( Vector3f ) + cloud.normals.size() * sizeof( Vector3f ) + 150; // 150 - reserve for some ctm specific data
-    ctmSaveCustom( context, [] ( const void* buf, CTMuint size, void* data )
+    ctmSaveCustom( context, []( const void* buf, CTMuint size, void* data )
     {
         SaveData& saveData = *reinterpret_cast< SaveData* >( data );
         std::ostream& outStream = *saveData.stream;
@@ -579,7 +585,13 @@ Expected<void> toCtm( const PointCloud& cloud, std::ostream& out, const CtmSaveP
             return 0u;
 
         return outStream.good() ? size : 0;
-    }, &saveData );
+    },
+    [](size_t pos, size_t total, void * /*aUserData*/)
+    {
+        spdlog::info( "CTM compress progress {}/{}", pos, total );
+        return 0;
+    },
+    &saveData );
 
     if ( saveData.wasCanceled )
         return unexpectedOperationCanceled();

--- a/thirdparty/OpenCTM/LzmaLib.c
+++ b/thirdparty/OpenCTM/LzmaLib.c
@@ -21,7 +21,8 @@ MY_STDAPI LzmaCompress(unsigned char *dest, size_t  *destLen, const unsigned cha
   int pb, /* 0 <= pb <= 4, default = 2  */
   int fb,  /* 5 <= fb <= 273, default = 32 */
   int numThreads, /* 1 or 2, default = 2 */
-  int algo /* 0 = fast, 1 = normal */
+  int algo, /* 0 = fast, 1 = normal */
+  ICompressProgress *progress
 )
 {
   CLzmaEncProps props;
@@ -36,7 +37,7 @@ MY_STDAPI LzmaCompress(unsigned char *dest, size_t  *destLen, const unsigned cha
   props.algo = algo;
 
   return LzmaEncode(dest, destLen, src, srcLen, &props, outProps, outPropsSize, 0,
-      NULL, &g_Alloc, &g_Alloc);
+      progress, &g_Alloc, &g_Alloc);
 }
 
 

--- a/thirdparty/OpenCTM/LzmaLib.h
+++ b/thirdparty/OpenCTM/LzmaLib.h
@@ -108,7 +108,8 @@ MY_STDAPI LzmaCompress(unsigned char *dest, size_t *destLen, const unsigned char
   int pb,         /* 0 <= pb <= 4, default = 2  */
   int fb,         /* 5 <= fb <= 273, default = 32 */
   int numThreads, /* 1 or 2, default = 2 */
-  int algo        /* 0 = fast, 1 = normal, default = 0 for level < 5, 1 for level >= 5 */
+  int algo,       /* 0 = fast, 1 = normal, default = 0 for level < 5, 1 for level >= 5 */
+  ICompressProgress *progress
   );
 
 /*

--- a/thirdparty/OpenCTM/compressMG2.c
+++ b/thirdparty/OpenCTM/compressMG2.c
@@ -852,6 +852,25 @@ int _ctmCompressMesh_MG2(_CTMcontext * self)
   }
   _ctmMakeVertexDeltas(self, intVertices, sortVertices, &grid);
 
+  self->mBytesAlreadyCompressed = 0;
+  self->mTotalBytesToCompress = sizeof(CTMint) * 3 * self->mVertexCount
+      + sizeof(CTMint) * self->mVertexCount
+      + sizeof(CTMint) * 3 * self->mTriangleCount;
+  if(self->mNormals)
+      self->mNormals += sizeof(CTMint) * 3 * self->mVertexCount;
+  map = self->mUVMaps;
+  while(map)
+  {
+    self->mTotalBytesToCompress += sizeof(CTMint) * 2 * self->mVertexCount;
+    map = map->mNext;
+  }
+  map = self->mAttribMaps;
+  while(map)
+  {
+    self->mTotalBytesToCompress += sizeof(CTMint) * 4 * self->mVertexCount;
+    map = map->mNext;
+  }
+
   // Write vertices
 #ifdef __DEBUG_
   printf("Vertices: ");
@@ -863,6 +882,7 @@ int _ctmCompressMesh_MG2(_CTMcontext * self)
     free((void *) sortVertices);
     return CTM_FALSE;
   }
+  self->mBytesAlreadyCompressed += sizeof(CTMint) * 3 * self->mVertexCount;
 
   // Prepare grid indices (deltas)
   gridIndices = (CTMuint *) malloc(sizeof(CTMuint) * self->mVertexCount);
@@ -889,6 +909,7 @@ int _ctmCompressMesh_MG2(_CTMcontext * self)
     free((void *) sortVertices);
     return CTM_FALSE;
   }
+  self->mBytesAlreadyCompressed += sizeof(CTMint) * self->mVertexCount;
 
   // Calculate the result of the compressed -> decompressed vertices, in order
   // to use the same vertex data for calculating nominal normals as the
@@ -911,7 +932,7 @@ int _ctmCompressMesh_MG2(_CTMcontext * self)
   free((void *) gridIndices);
   free((void *) intVertices);
 
-  // Perpare (sort) indices
+  // Prepare (sort) indices
   indices = (CTMuint *) malloc(sizeof(CTMuint) * self->mTriangleCount * 3);
   if(!indices)
   {
@@ -956,6 +977,7 @@ int _ctmCompressMesh_MG2(_CTMcontext * self)
     free((void *) sortVertices);
     return CTM_FALSE;
   }
+  self->mBytesAlreadyCompressed += sizeof(CTMint) * 3 * self->mTriangleCount;
 
   // Free temporary data for the indices
   free((void *) deltaIndices);
@@ -994,6 +1016,7 @@ int _ctmCompressMesh_MG2(_CTMcontext * self)
       free((void *) sortVertices);
       return CTM_FALSE;
     }
+    self->mBytesAlreadyCompressed += sizeof(CTMint) * 3 * self->mVertexCount;
 
     // Free temporary normal data
     free((void *) intNormals);
@@ -1031,6 +1054,7 @@ int _ctmCompressMesh_MG2(_CTMcontext * self)
       free((void *) sortVertices);
       return CTM_FALSE;
     }
+    self->mBytesAlreadyCompressed += sizeof(CTMint) * 2 * self->mVertexCount;
 
     // Free temporary UV coordinate data
     free((void *) intUVCoords);
@@ -1065,6 +1089,7 @@ int _ctmCompressMesh_MG2(_CTMcontext * self)
       free((void *) sortVertices);
       return CTM_FALSE;
     }
+    self->mBytesAlreadyCompressed += sizeof(CTMint) * 4 * self->mVertexCount;
 
     // Free temporary vertex attribute data
     free((void *) intAttribs);

--- a/thirdparty/OpenCTM/internal.h
+++ b/thirdparty/OpenCTM/internal.h
@@ -100,6 +100,8 @@ typedef struct {
   // Write() function pointer
   CTMwritefn mWriteFn;
 
+  CTMcompressProgress mCompressProgressFn;
+
   // User data (for stream read/write - usually the stream handle)
   void * mUserData;
 

--- a/thirdparty/OpenCTM/internal.h
+++ b/thirdparty/OpenCTM/internal.h
@@ -100,10 +100,13 @@ typedef struct {
   // Write() function pointer
   CTMwritefn mWriteFn;
 
+  // Optional function pointer to report compression progress during writing and cancellation
   CTMcompressProgress mCompressProgressFn;
 
+  // The number of bytes already compressed in this saving, before current buffer compression
   size_t mBytesAlreadyCompressed;
 
+  // The total number of bytes to be compressed during this saving
   size_t mTotalBytesToCompress;
 
   // User data (for stream read/write - usually the stream handle)

--- a/thirdparty/OpenCTM/internal.h
+++ b/thirdparty/OpenCTM/internal.h
@@ -102,6 +102,10 @@ typedef struct {
 
   CTMcompressProgress mCompressProgressFn;
 
+  size_t mBytesAlreadyCompressed;
+
+  size_t mTotalBytesToCompress;
+
   // User data (for stream read/write - usually the stream handle)
   void * mUserData;
 

--- a/thirdparty/OpenCTM/openctm.c
+++ b/thirdparty/OpenCTM/openctm.c
@@ -1335,7 +1335,7 @@ CTMEXPORT void CTMCALL ctmSave(CTMcontext aContext, const char * aFileName)
   }
 
   // Save the file
-  ctmSaveCustom(self, _ctmDefaultWrite, (void *) f);
+  ctmSaveCustom(self, _ctmDefaultWrite, NULL, (void *) f);
 
   // Close file stream
   fclose(f);
@@ -1344,7 +1344,7 @@ CTMEXPORT void CTMCALL ctmSave(CTMcontext aContext, const char * aFileName)
 //-----------------------------------------------------------------------------
 // ctmSaveCustom()
 //-----------------------------------------------------------------------------
-void CTMCALL ctmSaveCustom(CTMcontext aContext, CTMwritefn aWriteFn,
+void CTMCALL ctmSaveCustom(CTMcontext aContext, CTMwritefn aWriteFn, CTMcompressProgress aProgressFn,
   void * aUserData)
 {
   _CTMcontext * self = (_CTMcontext *) aContext;
@@ -1367,6 +1367,7 @@ void CTMCALL ctmSaveCustom(CTMcontext aContext, CTMwritefn aWriteFn,
 
   // Initialize stream
   self->mWriteFn = aWriteFn;
+  self->mCompressProgressFn = aProgressFn;
   self->mUserData = aUserData;
 
   // Determine flags
@@ -1393,7 +1394,7 @@ void CTMCALL ctmSaveCustom(CTMcontext aContext, CTMwritefn aWriteFn,
 
     default:
       self->mError = CTM_INTERNAL_ERROR;
-      return;
+      goto end;
   }
   _ctmStreamWriteUINT(self, self->mVertexCount);
   _ctmStreamWriteUINT(self, self->mTriangleCount);
@@ -1419,6 +1420,9 @@ void CTMCALL ctmSaveCustom(CTMcontext aContext, CTMwritefn aWriteFn,
 
     default:
       self->mError = CTM_INTERNAL_ERROR;
-      return;
+      goto end;
   }
+
+end:
+  self->mCompressProgressFn = NULL;
 }

--- a/thirdparty/OpenCTM/openctm.h
+++ b/thirdparty/OpenCTM/openctm.h
@@ -264,6 +264,8 @@ typedef CTMuint (CTMCALL * CTMreadfn)(void * aBuf, CTMuint aCount, void * aUserD
 ///         indicates that an error occured).
 typedef CTMuint (CTMCALL * CTMwritefn)(const void * aBuf, CTMuint aCount, void * aUserData);
 
+typedef int (CTMCALL * CTMcompressProgress)(size_t pos, size_t total, void * aUserData);
+
 /// Create a new OpenCTM context. The context is used for all subsequent
 /// OpenCTM function calls. Several contexts can coexist at the same time.
 /// @param[in] aMode An OpenCTM context mode. Set this to CTM_IMPORT if the

--- a/thirdparty/OpenCTM/openctm.h
+++ b/thirdparty/OpenCTM/openctm.h
@@ -638,7 +638,7 @@ CTMEXPORT void CTMCALL ctmSave(CTMcontext aContext, const char * aFileName);
 ///            of any type. The user data pointer will be passed to the
 ///            custom stream write function.
 /// @see CTMwritefn.
-CTMEXPORT void CTMCALL ctmSaveCustom(CTMcontext aContext, CTMwritefn aWriteFn,
+CTMEXPORT void CTMCALL ctmSaveCustom(CTMcontext aContext, CTMwritefn aWriteFn, CTMcompressProgress aProgressFn,
   void * aUserData);
 
 #ifdef __cplusplus

--- a/thirdparty/OpenCTM/openctm.h
+++ b/thirdparty/OpenCTM/openctm.h
@@ -262,9 +262,13 @@ typedef CTMuint (CTMCALL * CTMreadfn)(void * aBuf, CTMuint aCount, void * aUserD
 /// @param[in] aUserData The custom user data that was passed to the
 ///            ctmSaveCustom() function.
 /// @return The number of bytes actually written (if this is less than aCount, it
-///         indicates that an error occured).
+///         indicates that an error occurred).
 typedef CTMuint (CTMCALL * CTMwritefn)(const void * aBuf, CTMuint aCount, void * aUserData);
 
+/// function pointer to report compression progress during writing and cancellation
+/// @param[in] pos The number of bytes compressed so far
+/// @param[in] total The number of bytes to be compressed overall. (pos) gradually increases till (total)
+/// @return (result != 0) means break.
 typedef int (CTMCALL * CTMcompressProgress)(size_t pos, size_t total, void * aUserData);
 
 /// Create a new OpenCTM context. The context is used for all subsequent

--- a/thirdparty/OpenCTM/openctm.h
+++ b/thirdparty/OpenCTM/openctm.h
@@ -154,7 +154,7 @@ extern "C" {
 #else
   #include <stdint.h>
 #endif
-
+#include <stddef.h> // size_t
 
 /// OpenCTM API version (1.0).
 #define CTM_API_VERSION 0x00000100

--- a/thirdparty/OpenCTM/openctm.h
+++ b/thirdparty/OpenCTM/openctm.h
@@ -154,6 +154,7 @@ extern "C" {
 #else
   #include <stdint.h>
 #endif
+
 #include <stddef.h> // size_t
 
 /// OpenCTM API version (1.0).

--- a/thirdparty/OpenCTM/openctmpp.h
+++ b/thirdparty/OpenCTM/openctmpp.h
@@ -360,7 +360,7 @@ class CTMexporter {
     /// Wrapper for ctmSaveCustom()
     void SaveCustom(CTMwritefn aWriteFn, void * aUserData)
     {
-      ctmSaveCustom(mContext, aWriteFn, aUserData);
+      ctmSaveCustom(mContext, aWriteFn, NULL, aUserData);
       CheckError();
     }
 

--- a/thirdparty/OpenCTM/stream.c
+++ b/thirdparty/OpenCTM/stream.c
@@ -311,7 +311,8 @@ int _ctmStreamWritePackedInts(_CTMcontext * self, CTMint * aData,
                          &outPropsSize,
                          self->mCompressionLevel, // Level (0-9)
                          0, -1, -1, -1, -1, -1,   // Default values (set by level)
-                         lzmaAlgo                 // Algorithm (0 = fast, 1 = normal)
+                         lzmaAlgo,                // Algorithm (0 = fast, 1 = normal)
+                         NULL
                         );
 
   // Free temporary array
@@ -478,7 +479,8 @@ int _ctmStreamWritePackedFloats(_CTMcontext * self, CTMfloat * aData,
                          &outPropsSize,
                          self->mCompressionLevel, // Level (0-9)
                          0, -1, -1, -1, -1, -1,   // Default values (set by level)
-                         lzmaAlgo                 // Algorithm (0 = fast, 1 = normal)
+                         lzmaAlgo,                // Algorithm (0 = fast, 1 = normal)
+                         NULL
                         );
 
   // Free temporary array

--- a/thirdparty/OpenCTM/stream.c
+++ b/thirdparty/OpenCTM/stream.c
@@ -246,6 +246,14 @@ int _ctmStreamReadPackedInts(_CTMcontext * self, CTMint * aData,
   return CTM_TRUE;
 }
 
+static SRes compressProgress(void *p, UInt64 inSize, UInt64 outSize)
+{
+  _CTMcontext * self = (_CTMcontext *)p;
+  return self->mCompressProgressFn(inSize, outSize/*!!!*/, self->mUserData);
+}
+
+static ICompressProgress g_CompressProgress = { compressProgress };
+
 //-----------------------------------------------------------------------------
 // _ctmStreamWritePackedInts() - Compress a binary integer data array, and
 // write it to a stream.
@@ -312,7 +320,7 @@ int _ctmStreamWritePackedInts(_CTMcontext * self, CTMint * aData,
                          self->mCompressionLevel, // Level (0-9)
                          0, -1, -1, -1, -1, -1,   // Default values (set by level)
                          lzmaAlgo,                // Algorithm (0 = fast, 1 = normal)
-                         NULL
+                         self->mCompressProgressFn ? &g_CompressProgress : NULL
                         );
 
   // Free temporary array
@@ -480,7 +488,7 @@ int _ctmStreamWritePackedFloats(_CTMcontext * self, CTMfloat * aData,
                          self->mCompressionLevel, // Level (0-9)
                          0, -1, -1, -1, -1, -1,   // Default values (set by level)
                          lzmaAlgo,                // Algorithm (0 = fast, 1 = normal)
-                         NULL
+                         self->mCompressProgressFn ? &g_CompressProgress : NULL
                         );
 
   // Free temporary array


### PR DESCRIPTION
* OpenCTM library received new callback to report compression progress, and cancel compression
* MeshLib reports exact progress by the number of bytes compressed and remaining (instead of approximate progress by the number of saved bytes)
* Fixed hang on saving of colored points without normals