### PR TITLE
Default serialization format for objects of one type

### DIFF
--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -59,18 +59,18 @@ Expected<std::future<Expected<void>>> ObjectMeshHolder::serializeModel_( const s
     saveSettings.rearrangeTriangles = false;
     if ( !vertsColorMap_.empty() )
         saveSettings.colors = &vertsColorMap_;
-    auto save = [mesh = mesh_, saveMeshFormat = saveMeshFormat_, path, saveSettings]()
+    auto save = [mesh = mesh_, serializeFormat = serializeFormat_ ? serializeFormat_ : defaultSerializeMeshFormat(), path, saveSettings]()
     {
         auto filename = path;
-        const auto extension = std::string( "*" ) + saveMeshFormat;
+        const auto extension = std::string( "*" ) + serializeFormat;
         if ( auto meshSaver = MeshSave::getMeshSaver( extension ); meshSaver.fileSave != nullptr )
         {
-            filename += saveMeshFormat;
+            filename += serializeFormat;
             return meshSaver.fileSave( *mesh, filename, saveSettings );
         }
         else
         {
-            filename += ".mrmesh";
+            filename += ".ply";
             return MR::MeshSave::toAnySupportedFormat( *mesh, filename, saveSettings );
         }
     };
@@ -689,14 +689,14 @@ size_t ObjectMeshHolder::heapBytes() const
         + MR::heapBytes( mesh_ );
 }
 
-void ObjectMeshHolder::setSaveMeshFormat( const char * newFormat )
+void ObjectMeshHolder::setSerializeFormat( const char * newFormat )
 {
     if ( newFormat && *newFormat != '.' )
     {
         assert( false );
         return;
     }
-    saveMeshFormat_ = newFormat;
+    serializeFormat_ = newFormat;
 }
 
 size_t ObjectMeshHolder::numUndirectedEdges() const
@@ -849,12 +849,12 @@ void ObjectMeshHolder::setDefaultSceneProperties_()
 // .PLY format is the most compact among other formats with zero compression costs
 static std::string sDefaultSaveMeshFormat = ".ply";
 
-const std::string & defaultSaveMeshFormat()
+const std::string & defaultSerializeMeshFormat()
 {
     return sDefaultSaveMeshFormat;
 }
 
-void setDefaultSaveMeshFormat( std::string newFormat )
+void setDefaultSerializeMeshFormat( std::string newFormat )
 {
     sDefaultSaveMeshFormat = std::move( newFormat );
 }

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -856,6 +856,7 @@ const std::string & defaultSerializeMeshFormat()
 
 void setDefaultSerializeMeshFormat( std::string newFormat )
 {
+    assert( !newFormat.empty() && newFormat[0] == '.' );
     sDefaultSerializeMeshFormat = std::move( newFormat );
 }
 

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -691,7 +691,7 @@ size_t ObjectMeshHolder::heapBytes() const
 
 void ObjectMeshHolder::setSaveMeshFormat( const char * newFormat )
 {
-    if ( !newFormat || *newFormat != '.' )
+    if ( newFormat && *newFormat != '.' )
     {
         assert( false );
         return;
@@ -844,6 +844,19 @@ void ObjectMeshHolder::setDefaultSceneProperties_()
 {
     setDefaultColors_();
     setFlatShading( SceneSettings::getDefaultShadingMode() == SceneSettings::ShadingMode::Flat );
+}
+
+// .PLY format is the most compact among other formats with zero compression costs
+static std::string sDefaultSaveMeshFormat = ".ply";
+
+const std::string & defaultSaveMeshFormat()
+{
+    return sDefaultSaveMeshFormat;
+}
+
+void setDefaultSaveMeshFormat( std::string newFormat )
+{
+    sDefaultSaveMeshFormat = std::move( newFormat );
 }
 
 } //namespace MR

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -847,16 +847,16 @@ void ObjectMeshHolder::setDefaultSceneProperties_()
 }
 
 // .PLY format is the most compact among other formats with zero compression costs
-static std::string sDefaultSaveMeshFormat = ".ply";
+static std::string sDefaultSerializeMeshFormat = ".ply";
 
 const std::string & defaultSerializeMeshFormat()
 {
-    return sDefaultSaveMeshFormat;
+    return sDefaultSerializeMeshFormat;
 }
 
 void setDefaultSerializeMeshFormat( std::string newFormat )
 {
-    sDefaultSaveMeshFormat = std::move( newFormat );
+    sDefaultSerializeMeshFormat = std::move( newFormat );
 }
 
 } //namespace MR

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -212,12 +212,12 @@ public:
     /// returns the amount of memory this object occupies on heap
     [[nodiscard]] MRMESH_API virtual size_t heapBytes() const override;
 
-    /// returns overriden file extension used to serialize mesh inside this object, nullptr means defaultSaveMeshFormat()
-    [[nodiscard]] const char * saveMeshFormat() const { return saveMeshFormat_; }
+    /// returns overriden file extension used to serialize mesh inside this object, nullptr means defaultSerializeMeshFormat()
+    [[nodiscard]] const char * serializeFormat() const { return serializeFormat_; }
 
     /// overrides file extension used to serialize mesh inside this object: must start from '.',
-    /// nullptr means serialize in defaultSaveMeshFormat()
-    MRMESH_API void setSaveMeshFormat( const char * newFormat );
+    /// nullptr means serialize in defaultSerializeMeshFormat()
+    MRMESH_API void setSerializeFormat( const char * newFormat );
 
     /// signal about face selection changing, triggered in selectFaces
     using SelectionChangedSignal = Signal<void()>;
@@ -308,17 +308,17 @@ private:
     /// set default scene-related properties
     void setDefaultSceneProperties_();
 
-    const char * saveMeshFormat_ = nullptr; // means use defaultSaveMeshFormat()
+    const char * serializeFormat_ = nullptr; // means use defaultSerializeMeshFormat()
 };
 
 /// returns file extension used to serialize ObjectMeshHolder by default (if not overridden in specific object),
 /// the string starts with '.'
-[[nodiscard]] MRMESH_API const std::string & defaultSaveMeshFormat();
+[[nodiscard]] MRMESH_API const std::string & defaultSerializeMeshFormat();
 
 /// sets file extension used to serialize serialize ObjectMeshHolder by default (if not overridden in specific object),
 /// must be not null and must start from '.';
 // serialization falls back to the PLY format if given format support is available
 // NOTE: CTM format support is available in the MRIOExtras library; make sure to load it if you prefer CTM
-MRMESH_API void setDefaultSaveMeshFormat( std::string newFormat );
+MRMESH_API void setDefaultSerializeMeshFormat( std::string newFormat );
 
 } // namespace MR

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -214,10 +214,12 @@ public:
 
     /// returns overriden file extension used to serialize mesh inside this object, nullptr means defaultSerializeMeshFormat()
     [[nodiscard]] const char * serializeFormat() const { return serializeFormat_; }
+    [[deprecated]] const char * saveMeshFormat() const { return serializeFormat(); }
 
     /// overrides file extension used to serialize mesh inside this object: must start from '.',
     /// nullptr means serialize in defaultSerializeMeshFormat()
     MRMESH_API void setSerializeFormat( const char * newFormat );
+    [[deprecated]] void setSaveMeshFormat( const char * newFormat ) { setSerializeFormat( newFormat ); }
 
     /// signal about face selection changing, triggered in selectFaces
     using SelectionChangedSignal = Signal<void()>;

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -316,7 +316,7 @@ private:
 [[nodiscard]] MRMESH_API const std::string & defaultSerializeMeshFormat();
 
 /// sets file extension used to serialize serialize ObjectMeshHolder by default (if not overridden in specific object),
-/// must be not null and must start from '.';
+/// the string must start from '.';
 // serialization falls back to the PLY format if given format support is available
 // NOTE: CTM format support is available in the MRIOExtras library; make sure to load it if you prefer CTM
 MRMESH_API void setDefaultSerializeMeshFormat( std::string newFormat );

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -212,10 +212,11 @@ public:
     /// returns the amount of memory this object occupies on heap
     [[nodiscard]] MRMESH_API virtual size_t heapBytes() const override;
 
-    /// returns file extension used to serialize the mesh
+    /// returns overriden file extension used to serialize mesh inside this object, nullptr means defaultSaveMeshFormat()
     [[nodiscard]] const char * saveMeshFormat() const { return saveMeshFormat_; }
 
-    /// sets file extension used to serialize the mesh: must be not null and must start from '.'
+    /// overrides file extension used to serialize mesh inside this object: must start from '.',
+    /// nullptr means serialize in defaultSaveMeshFormat()
     MRMESH_API void setSaveMeshFormat( const char * newFormat );
 
     /// signal about face selection changing, triggered in selectFaces
@@ -307,9 +308,17 @@ private:
     /// set default scene-related properties
     void setDefaultSceneProperties_();
 
-    // falls back to the internal format if no CTM format support is available
-    // NOTE: CTM format support is available in the MRIOExtras library; make sure to load it if you prefer CTM
-    const char * saveMeshFormat_ = ".ctm";
+    const char * saveMeshFormat_ = nullptr; // means use defaultSaveMeshFormat()
 };
+
+/// returns file extension used to serialize ObjectMeshHolder by default (if not overridden in specific object),
+/// the string starts with '.'
+[[nodiscard]] MRMESH_API const std::string & defaultSaveMeshFormat();
+
+/// sets file extension used to serialize serialize ObjectMeshHolder by default (if not overridden in specific object),
+/// must be not null and must start from '.';
+// serialization falls back to the PLY format if given format support is available
+// NOTE: CTM format support is available in the MRIOExtras library; make sure to load it if you prefer CTM
+MRMESH_API void setDefaultSaveMeshFormat( std::string newFormat );
 
 } // namespace MR

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -215,14 +215,14 @@ void ObjectPointsHolder::setMaxRenderingPoints( int val )
     updateRenderDiscretization_();
 }
 
-void ObjectPointsHolder::setSavePointsFormat( const char * newFormat )
+void ObjectPointsHolder::setSerializeFormat( const char * newFormat )
 {
     if ( newFormat && *newFormat != '.' )
     {
         assert( false );
         return;
     }
-    savePointsFormat_ = newFormat;
+    serializeFormat_ = newFormat;
 }
 
 void ObjectPointsHolder::swapBase_( Object& other )
@@ -261,13 +261,13 @@ Expected<std::future<Expected<void>>> ObjectPointsHolder::serializeModel_( const
     saveSettings.rearrangeTriangles = false;
     if ( !vertsColorMap_.empty() )
         saveSettings.colors = &vertsColorMap_;
-    auto save = [points = points_, savePointsFormat = savePointsFormat_ ? savePointsFormat_ : defaultSavePointsFormat(), path, saveSettings]()
+    auto save = [points = points_, serializeFormat = serializeFormat_ ? serializeFormat_ : defaultSerializePointsFormat(), path, saveSettings]()
     {
         auto filename = path;
-        const auto extension = std::string( "*" ) + savePointsFormat;
+        const auto extension = std::string( "*" ) + serializeFormat;
         if ( auto pointsSaver = PointsSave::getPointsSaver( extension ); pointsSaver.fileSave != nullptr )
         {
-            filename += savePointsFormat;
+            filename += serializeFormat;
             return pointsSaver.fileSave( *points, filename, saveSettings );
         }
         else
@@ -391,12 +391,12 @@ void ObjectPointsHolder::updateRenderDiscretization_()
 // .PLY format is the most compact among other formats with zero compression costs
 static std::string sDefaultSavePointsFormat = ".ply";
 
-const std::string & defaultSavePointsFormat()
+const std::string & defaultSerializePointsFormat()
 {
     return sDefaultSavePointsFormat;
 }
 
-void setDefaultSavePointsFormat( std::string newFormat )
+void setDefaultSerializePointsFormat( std::string newFormat )
 {
     sDefaultSavePointsFormat = std::move( newFormat );
 }

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -389,16 +389,17 @@ void ObjectPointsHolder::updateRenderDiscretization_()
 }
 
 // .PLY format is the most compact among other formats with zero compression costs
-static std::string sDefaultSavePointsFormat = ".ply";
+static std::string sDefaultSerializePointsFormat = ".ply";
 
 const std::string & defaultSerializePointsFormat()
 {
-    return sDefaultSavePointsFormat;
+    return sDefaultSerializePointsFormat;
 }
 
 void setDefaultSerializePointsFormat( std::string newFormat )
 {
-    sDefaultSavePointsFormat = std::move( newFormat );
+    assert( !newFormat.empty() && newFormat[0] == '.' );
+    sDefaultSerializePointsFormat = std::move( newFormat );
 }
 
 } //namespace MR

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -217,7 +217,7 @@ void ObjectPointsHolder::setMaxRenderingPoints( int val )
 
 void ObjectPointsHolder::setSavePointsFormat( const char * newFormat )
 {
-    if ( !newFormat || *newFormat != '.' )
+    if ( newFormat && *newFormat != '.' )
     {
         assert( false );
         return;
@@ -261,7 +261,7 @@ Expected<std::future<Expected<void>>> ObjectPointsHolder::serializeModel_( const
     saveSettings.rearrangeTriangles = false;
     if ( !vertsColorMap_.empty() )
         saveSettings.colors = &vertsColorMap_;
-    auto save = [points = points_, savePointsFormat = savePointsFormat_, path, saveSettings]()
+    auto save = [points = points_, savePointsFormat = savePointsFormat_ ? savePointsFormat_ : defaultSavePointsFormat(), path, saveSettings]()
     {
         auto filename = path;
         const auto extension = std::string( "*" ) + savePointsFormat;
@@ -388,4 +388,17 @@ void ObjectPointsHolder::updateRenderDiscretization_()
     renderDiscretizationChangedSignal();
 }
 
+// .PLY format is the most compact among other formats with zero compression costs
+static std::string sDefaultSavePointsFormat = ".ply";
+
+const std::string & defaultSavePointsFormat()
+{
+    return sDefaultSavePointsFormat;
 }
+
+void setDefaultSavePointsFormat( std::string newFormat )
+{
+    sDefaultSavePointsFormat = std::move( newFormat );
+}
+
+} //namespace MR

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -113,12 +113,12 @@ public:
     /// \sa \ref getRenderDiscretization, \ref MaxRenderingPointsDefault, \ref MaxRenderingPointsUnlimited
     MRMESH_API void setMaxRenderingPoints( int val );
 
-    /// returns overriden file extension used to serialize point cloud inside this object, nullptr means defaultSavePointsFormat()
-    [[nodiscard]] const char * savePointsFormat() const { return savePointsFormat_; }
+    /// returns overriden file extension used to serialize point cloud inside this object, nullptr means defaultSerializePointsFormat()
+    [[nodiscard]] const char * serializeFormat() const { return serializeFormat_; }
 
     /// overrides file extension used to serialize point cloud inside this object: must start from '.',
-    /// nullptr means serialize in defaultSavePointsFormat()
-    MRMESH_API void setSavePointsFormat( const char * newFormat );
+    /// nullptr means serialize in defaultSerializePointsFormat()
+    MRMESH_API void setSerializeFormat( const char * newFormat );
 
     /// signal about points selection changing, triggered in selectPoints
     using SelectionChangedSignal = Signal<void()>;
@@ -179,17 +179,17 @@ private:
 
     int renderDiscretization_ = 1; // auxiliary parameter to avoid recalculation in every frame
 
-    const char * savePointsFormat_ = nullptr; // means use defaultSavePointsFormat()
+    const char * serializeFormat_ = nullptr; // means use defaultSerializePointsFormat()
 };
 
 /// returns file extension used to serialize ObjectPointsHolder by default (if not overridden in specific object),
 /// the string starts with '.'
-[[nodiscard]] MRMESH_API const std::string & defaultSavePointsFormat();
+[[nodiscard]] MRMESH_API const std::string & defaultSerializePointsFormat();
 
 /// sets file extension used to serialize serialize ObjectPointsHolder by default (if not overridden in specific object),
 /// must be not null and must start from '.';
 // serialization falls back to the PLY format if given format support is available
 // NOTE: CTM format support is available in the MRIOExtras library; make sure to load it if you prefer CTM
-MRMESH_API void setDefaultSavePointsFormat( std::string newFormat );
+MRMESH_API void setDefaultSerializePointsFormat( std::string newFormat );
 
 } //namespace MR

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -113,10 +113,10 @@ public:
     /// \sa \ref getRenderDiscretization, \ref MaxRenderingPointsDefault, \ref MaxRenderingPointsUnlimited
     MRMESH_API void setMaxRenderingPoints( int val );
 
-    /// returns overriden file extension used to serialize the points, nullptr means defaultSavePointsFormat()
+    /// returns overriden file extension used to serialize point cloud inside this object, nullptr means defaultSavePointsFormat()
     [[nodiscard]] const char * savePointsFormat() const { return savePointsFormat_; }
 
-    /// overrides file extension used to serialize this object: must start from '.',
+    /// overrides file extension used to serialize point cloud inside this object: must start from '.',
     /// nullptr means serialize in defaultSavePointsFormat()
     MRMESH_API void setSavePointsFormat( const char * newFormat );
 
@@ -179,7 +179,7 @@ private:
 
     int renderDiscretization_ = 1; // auxiliary parameter to avoid recalculation in every frame
 
-    const char * savePointsFormat_ = nullptr;
+    const char * savePointsFormat_ = nullptr; // means use defaultSavePointsFormat()
 };
 
 /// returns file extension used to serialize ObjectPointsHolder by default (if not overridden in specific object),

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -187,7 +187,7 @@ private:
 [[nodiscard]] MRMESH_API const std::string & defaultSerializePointsFormat();
 
 /// sets file extension used to serialize serialize ObjectPointsHolder by default (if not overridden in specific object),
-/// must be not null and must start from '.';
+/// the string must start from '.';
 // serialization falls back to the PLY format if given format support is available
 // NOTE: CTM format support is available in the MRIOExtras library; make sure to load it if you prefer CTM
 MRMESH_API void setDefaultSerializePointsFormat( std::string newFormat );

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -113,10 +113,11 @@ public:
     /// \sa \ref getRenderDiscretization, \ref MaxRenderingPointsDefault, \ref MaxRenderingPointsUnlimited
     MRMESH_API void setMaxRenderingPoints( int val );
 
-    /// returns file extension used to serialize the points
+    /// returns overriden file extension used to serialize the points, nullptr means defaultSavePointsFormat()
     [[nodiscard]] const char * savePointsFormat() const { return savePointsFormat_; }
 
-    /// sets file extension used to serialize the points: must be not null and must start from '.'
+    /// overrides file extension used to serialize this object: must start from '.',
+    /// nullptr means serialize in defaultSavePointsFormat()
     MRMESH_API void setSavePointsFormat( const char * newFormat );
 
     /// signal about points selection changing, triggered in selectPoints
@@ -178,9 +179,17 @@ private:
 
     int renderDiscretization_ = 1; // auxiliary parameter to avoid recalculation in every frame
 
-    // falls back to the PLY format if no CTM format support is available
-    // NOTE: CTM format support is available in the MRIOExtras library; make sure to load it if you prefer CTM
-    const char * savePointsFormat_ = ".ctm";
+    const char * savePointsFormat_ = nullptr;
 };
 
-}
+/// returns file extension used to serialize ObjectPointsHolder by default (if not overridden in specific object),
+/// the string starts with '.'
+[[nodiscard]] MRMESH_API const std::string & defaultSavePointsFormat();
+
+/// sets file extension used to serialize serialize ObjectPointsHolder by default (if not overridden in specific object),
+/// must be not null and must start from '.';
+// serialization falls back to the PLY format if given format support is available
+// NOTE: CTM format support is available in the MRIOExtras library; make sure to load it if you prefer CTM
+MRMESH_API void setDefaultSavePointsFormat( std::string newFormat );
+
+} //namespace MR

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -115,10 +115,12 @@ public:
 
     /// returns overriden file extension used to serialize point cloud inside this object, nullptr means defaultSerializePointsFormat()
     [[nodiscard]] const char * serializeFormat() const { return serializeFormat_; }
+    [[deprecated]] const char * savePointsFormat() const { return serializeFormat(); }
 
     /// overrides file extension used to serialize point cloud inside this object: must start from '.',
     /// nullptr means serialize in defaultSerializePointsFormat()
     MRMESH_API void setSerializeFormat( const char * newFormat );
+    [[deprecated]] void setSavePointsFormat( const char * newFormat ) { setSerializeFormat( newFormat ); }
 
     /// signal about points selection changing, triggered in selectPoints
     using SelectionChangedSignal = Signal<void()>;

--- a/source/MRMesh/MRSerializer.cpp
+++ b/source/MRMesh/MRSerializer.cpp
@@ -540,10 +540,10 @@ Expected<Mesh> deserializeFromJson( const Json::Value& root, VertColors* colors 
     return MeshLoad::fromPly( in, { .colors = colors } );
 }
 
-Expected<void> serializeMesh( const Mesh& mesh, const std::filesystem::path& path, const FaceBitSet* selection, const char * saveMeshFormat )
+Expected<void> serializeMesh( const Mesh& mesh, const std::filesystem::path& path, const FaceBitSet* selection, const char * serializeFormat )
 {
     ObjectMesh obj;
-    obj.setSaveMeshFormat( saveMeshFormat );
+    obj.setSerializeFormat( serializeFormat );
     obj.setMesh( std::make_shared<Mesh>( mesh ) );
     if ( selection )
         obj.selectFaces( *selection );

--- a/source/MRMesh/MRSerializer.h
+++ b/source/MRMesh/MRSerializer.h
@@ -32,7 +32,7 @@ MRMESH_API Expected<Json::Value> deserializeJsonValue( const std::filesystem::pa
 /// this is very convenient for saving intermediate states during algorithm debugging;
 /// ".mrmesh" save mesh format is not space efficient, but guaranties no changes in the topology after loading
 MRMESH_API Expected<void> serializeMesh( const Mesh& mesh, const std::filesystem::path& path, const FaceBitSet* selection = nullptr,
-    const char * saveMeshFormat = ".mrmesh" );
+    const char * serializeFormat = ".mrmesh" );
 
 /// saves an object into json value
 MRMESH_API void serializeToJson( const Vector2i& vec, Json::Value& root );

--- a/source/MRVoxels/MRObjectVoxels.cpp
+++ b/source/MRVoxels/MRObjectVoxels.cpp
@@ -545,7 +545,7 @@ size_t ObjectVoxels::heapBytes() const
 
 void ObjectVoxels::setSerializeFormat( const char * newFormat )
 {
-    if ( !newFormat || *newFormat != '.' )
+    if ( newFormat && *newFormat != '.' )
     {
         assert( false );
         return;
@@ -625,7 +625,7 @@ Expected<std::future<Expected<void>>> ObjectVoxels::serializeModel_( const std::
         return {};
 
     return std::async( getAsyncLaunchType(),
-        [this, filename = std::filesystem::path( path ) += serializeFormat_] ()
+        [this, filename = std::filesystem::path( path ) += serializeFormat_ ? serializeFormat_ : defaultSerializeVoxelsFormat()] ()
     {
         return MR::VoxelsSave::toAnySupportedFormat( vdbVolume_, filename );
     } );
@@ -740,4 +740,17 @@ std::vector<std::string> ObjectVoxels::getInfoLines() const
     return res;
 }
 
+static std::string sDefaultSerializeVoxelsFormat = ".vdb";
+
+const std::string & defaultSerializeVoxelsFormat()
+{
+    return sDefaultSerializeVoxelsFormat;
 }
+
+void setDefaultSerializeVoxelsFormat( std::string newFormat )
+{
+    assert( !newFormat.empty() && newFormat[0] == '.' );
+    sDefaultSerializeVoxelsFormat = std::move( newFormat );
+}
+
+} //namespace MR

--- a/source/MRVoxels/MRObjectVoxels.h
+++ b/source/MRVoxels/MRObjectVoxels.h
@@ -206,10 +206,11 @@ public:
     /// returns the amount of memory this object occupies on heap
     [[nodiscard]] MRVOXELS_API virtual size_t heapBytes() const override;
 
-    /// returns file extension used to serialize the voxels
+    /// returns overriden file extension used to serialize voxels inside this object, nullptr means defaultSerializeVoxelsFormat()
     [[nodiscard]] const char * serializeFormat() const { return serializeFormat_; }
 
-    /// sets file extension used to serialize the voxels: must be not null and must start from '.'
+    /// overrides file extension used to serialize voxels inside this object: must start from '.',
+    /// nullptr means serialize in defaultSerializeVoxelsFormat()
     MRVOXELS_API void setSerializeFormat( const char * newFormat );
 
     /// signal about Iso-surface changes (from updateIsoSurface)
@@ -229,7 +230,7 @@ private:
     mutable std::optional<Box3i> activeBounds_;
     mutable std::optional<size_t> activeVoxels_;
 
-    const char * serializeFormat_ = ".vdb";
+    const char * serializeFormat_ = nullptr; //means defaultSerializeVoxelsFormat()
 
     /// Service data
     VolumeIndexer indexer_ = VolumeIndexer( vdbVolume_.dims );
@@ -266,5 +267,12 @@ protected:
     MRVOXELS_API virtual Expected<std::future<Expected<void>>> serializeModel_( const std::filesystem::path& path ) const override;
 };
 
+/// returns file extension used to serialize ObjectVoxels by default (if not overridden in specific object),
+/// the string starts with '.'
+[[nodiscard]] MRVOXELS_API const std::string & defaultSerializeVoxelsFormat();
 
-}
+/// sets file extension used to serialize serialize ObjectVoxels by default (if not overridden in specific object),
+/// the string must start from '.'
+MRVOXELS_API void setDefaultSerializeVoxelsFormat( std::string newFormat );
+
+} //namespace MR


### PR DESCRIPTION
* Introduce functions to set serialization format for all `ObjectMeshHolder`s, `ObjectPointsHolder`s, `ObjectVoxels`.
* Individual objects can still override their serialization format.
* Serialize meshes and point clouds in .PLY format by default instead of .CTM, because it is much faster, and does not consume excessive memory.