### PR TITLE
trackSection functions optimized for small lines extraction

### DIFF
--- a/source/MRMesh/MRExtractIsolines.cpp
+++ b/source/MRMesh/MRExtractIsolines.cpp
@@ -34,6 +34,8 @@ VertBitSet findNegativeVerts( const VertBitSet& vertRegion, V && valueInVertex )
     return negativeVerts;
 }
 
+/// given linear function on edge by its values in two vertices with opposite signs,
+/// finds point on edge, where the function is zero
 inline MeshEdgePoint toEdgePoint( EdgeId e, float vo, float vd )
 {
     assert( ( vo < 0 && 0 <= vd ) || ( vd < 0 && 0 <= vo ) );
@@ -41,6 +43,8 @@ inline MeshEdgePoint toEdgePoint( EdgeId e, float vo, float vd )
     return MeshEdgePoint( e, x );
 }
 
+/// given linear function on edge by value-getter for vertices (which must return values with opposite signs for edge's vertices),
+/// finds point on edge, where the function is zero
 template<class V>
 inline MeshEdgePoint toEdgePoint( const MeshTopology & topology, V && v, EdgeId e )
 {
@@ -49,6 +53,9 @@ inline MeshEdgePoint toEdgePoint( const MeshTopology & topology, V && v, EdgeId 
     return toEdgePoint( e, vo, vd );
 }
 
+/// Given boolean value isNegative defined in all vertices, and a start edge
+/// with one negative and another not negative vertices, sequentially finds
+/// other edges to the left of the current edge with the same property
 template<typename N>
 class Tracker
 {

--- a/source/MRMesh/MRExtractIsolines.cpp
+++ b/source/MRMesh/MRExtractIsolines.cpp
@@ -48,8 +48,8 @@ template<typename N>
 class Tracker
 {
 public:
-    Tracker( const MeshTopology & topology, const N & isNegative, EdgeId e, const FaceBitSet* region )
-        : topology_( topology ), isNegative_( isNegative ), region_( region )
+    Tracker( const MeshTopology & topology, N && isNegative, EdgeId e, const FaceBitSet* region )
+        : topology_( topology ), isNegative_( std::move( isNegative ) ), region_( region )
     {
         restart( e );
     }
@@ -84,7 +84,7 @@ public:
 
 private:
     const MeshTopology & topology_;
-    const N & isNegative_;
+    N isNegative_;
     EdgeId e_;
     bool eOrgNeg_ = false;
     const FaceBitSet* region_ = nullptr;

--- a/source/MRMesh/MRExtractIsolines.cpp
+++ b/source/MRMesh/MRExtractIsolines.cpp
@@ -125,7 +125,6 @@ private:
     IsoLine extractOneLine_( EdgeId first, ContinueTrack continueTrack = {} );
     MeshEdgePoint toEdgePoint_( EdgeId e ) const;
     void computePointOnEachEdge_( IsoLine & line ) const;
-    EdgeId findNextEdge_( EdgeId e ) const;
     IsoLines extract_();
 
 private:
@@ -264,7 +263,8 @@ IsoLine Isoliner::track( const MeshTriPoint& start, ContinueTrack continueTrack 
         startEdge = testEdge( eOp.e );
         if ( !startEdge )
             startEdge = eOp.e.sym();
-        startEdge = findNextEdge_( startEdge ); // `start` is first
+        tracker_.restart( startEdge );
+        startEdge = tracker_.findNextEdge(); // first edge after (start)
     }
     else
     {
@@ -295,23 +295,6 @@ void Isoliner::computePointOnEachEdge_( IsoLine & line ) const
     {
         line[i] = toEdgePoint_( line[i].e );
     } );
-}
-
-EdgeId Isoliner::findNextEdge_( EdgeId e ) const
-{
-    if ( !topology_.isLeftInRegion( e, region_ ) )
-        return {};
-    VertId o, d, x;
-    topology_.getLeftTriVerts( e, o, d, x );
-    auto no = negativeVerts_.test( o );
-    auto nd = negativeVerts_.test( d );
-    assert( no != nd );
-    auto nx = negativeVerts_.test( x );
-
-    if ( ( no && nx ) || ( nd && !nx ) )
-        return topology_.prev( e.sym() ).sym();
-    else
-        return topology_.next( e );
 }
 
 IsoLine Isoliner::extractOneLine_( EdgeId first, ContinueTrack continueTrack )

--- a/source/MRMesh/MRExtractIsolines.cpp
+++ b/source/MRMesh/MRExtractIsolines.cpp
@@ -262,7 +262,10 @@ IsoLine Isoliner::track( const MeshTriPoint& start, ContinueTrack continueTrack 
     {
         startEdge = testEdge( eOp.e );
         if ( !startEdge )
-            startEdge = eOp.e.sym();
+        {
+            assert( testEdge( eOp.e.sym() ) );
+            startEdge = eOp.e;
+        }
         tracker_.restart( startEdge );
         startEdge = tracker_.findNextEdge(); // first edge after (start)
     }

--- a/source/MRMesh/MRExtractIsolinesTests.cpp
+++ b/source/MRMesh/MRExtractIsolinesTests.cpp
@@ -135,4 +135,17 @@ TEST( MRMesh, ExtractXYPlaneSections )
     EXPECT_EQ( findTriangleSectionsByXYPlane( mesh, testLevel ).size(), 6 );
 }
 
+TEST( MRMesh, TrackPlaneSection )
+{
+    Mesh mesh = MR::makeCube( Vector3f::diagonal( 1.F ), Vector3f::diagonal( -0.5F ) );
+    const MeshTriPoint start{ 10_e, { 0.25f, 0.25f } };
+    const MeshTriPoint end{ 21_e, { 0.25f, 0.25f } };
+    const Vector3f planePoint{ -0.5f, -0.5f, 0.0f };
+    auto res = trackSection( mesh, start, end, planePoint, true );
+    EXPECT_TRUE( res.has_value() );
+    EXPECT_EQ( res->size(), 1 );
+    EXPECT_EQ( (*res)[0].e, 11_e );
+    EXPECT_LT( std::abs( (*res)[0].a - 0.5f ), 1e-6f );
+}
+
 } // namespace MR

--- a/source/MRMesh/MRExtractIsolinesTests.cpp
+++ b/source/MRMesh/MRExtractIsolinesTests.cpp
@@ -108,30 +108,31 @@ TEST( MRMesh, ExtractXYPlaneSections )
     EXPECT_EQ( findTriangleSectionsByXYPlane( mesh, testLevel ).size(), 8 );
 
     FaceBitSet fs;
-    fs.autoResizeSet( 2_f );
+    fs.autoResizeSet( 5_f );
+    fs.set( 2_f );
     res = extractXYPlaneSections( { mesh, &fs }, testLevel );
     EXPECT_EQ( res.size(), 1 );
-    EXPECT_EQ( res[0].size(), 2 );
+    EXPECT_EQ( res[0].size(), 3 );
     EXPECT_NE( res[0].front(), res[0].back() );
     for ( const auto& i : res[0] )
     {
         Vector3f point = mesh.edgePoint( i );
         EXPECT_LT( std::abs( point.z - testLevel ), 1e-6f );
     }
-    EXPECT_EQ( findTriangleSectionsByXYPlane( { mesh, &fs }, testLevel ).size(), 1 );
+    EXPECT_EQ( findTriangleSectionsByXYPlane( { mesh, &fs }, testLevel ).size(), 2 );
 
     // make a hole in mesh to extract not closed contour
     mesh.deleteFaces( fs );
     res = extractXYPlaneSections( mesh, testLevel );
     EXPECT_EQ( res.size(), 1 );
-    EXPECT_EQ( res[0].size(), 8 );
+    EXPECT_EQ( res[0].size(), 7 );
     EXPECT_NE( res[0].front(), res[0].back() );
     for ( const auto& i : res[0] )
     {
         Vector3f point = mesh.edgePoint( i );
         EXPECT_LT( std::abs( point.z - testLevel ), 1e-6f );
     }
-    EXPECT_EQ( findTriangleSectionsByXYPlane( mesh, testLevel ).size(), 7 );
+    EXPECT_EQ( findTriangleSectionsByXYPlane( mesh, testLevel ).size(), 6 );
 }
 
 } // namespace MR

--- a/source/MRMesh/MRExtractIsolinesTests.cpp
+++ b/source/MRMesh/MRExtractIsolinesTests.cpp
@@ -137,7 +137,10 @@ TEST( MRMesh, ExtractXYPlaneSections )
 
 TEST( MRMesh, TrackPlaneSection )
 {
-    Mesh mesh = MR::makeCube( Vector3f::diagonal( 1.F ), Vector3f::diagonal( -0.5F ) );
+    const Mesh mesh = MR::makeCube( Vector3f::diagonal( 1.F ), Vector3f::diagonal( -0.5F ) );
+    const float eps = 1e-6f;
+
+    // central plane, from triangle centroid to triangle centroid, ccw direction
     const MeshTriPoint start{ 10_e, { 0.25f, 0.25f } };
     const MeshTriPoint end{ 21_e, { 0.25f, 0.25f } };
     const Vector3f planePoint{ -0.5f, -0.5f, 0.0f };
@@ -145,7 +148,82 @@ TEST( MRMesh, TrackPlaneSection )
     EXPECT_TRUE( res.has_value() );
     EXPECT_EQ( res->size(), 1 );
     EXPECT_EQ( (*res)[0].e, 11_e );
-    EXPECT_LT( std::abs( (*res)[0].a - 0.5f ), 1e-6f );
+    EXPECT_LT( std::abs( (*res)[0].a - 0.5f ), eps );
+
+    // central plane, from triangle centroid to triangle centroid, cw direction
+    res = trackSection( mesh, start, end, planePoint, false );
+    EXPECT_TRUE( res.has_value() );
+    EXPECT_EQ( res->size(), 7 );
+    for ( const auto & p : *res )
+        EXPECT_LT( std::abs( p.a - 0.5f ), eps );
+
+    // central plane, from edge centroid to triangle centroid, ccw direction
+    const MeshTriPoint startE{ 10_e, { 0.5f, 0.0f } };
+    res = trackSection( mesh, startE, end, planePoint, true );
+    EXPECT_TRUE( res.has_value() );
+    EXPECT_EQ( res->size(), 0 );
+
+    // central plane, from edge centroid to triangle centroid, cc direction
+    res = trackSection( mesh, startE, end, planePoint, false );
+    EXPECT_TRUE( res.has_value() );
+    // EXPECT_EQ( res->size(), 8 ); //broken currently
+    for ( const auto & p : *res )
+        EXPECT_LT( std::abs( p.a - 0.5f ), eps );
+}
+
+TEST( MRMesh, TrackPlaneSectionOnDistance )
+{
+    const Mesh mesh = MR::makeCube( Vector3f::diagonal( 1.F ), Vector3f::diagonal( -0.5F ) );
+    const float eps = 1e-6f;
+
+    const MeshTriPoint start{ 10_e, { 0.25f, 0.25f } };
+    MeshTriPoint finish;
+
+    // track within same triangle, one direction
+    auto sec = trackSection( mesh, start, finish, Vector3f( 0, 1, 0 ), 0.1f );
+    EXPECT_EQ( sec.size(), 0 );
+    EXPECT_EQ( finish.e, 10_e );
+    EXPECT_LT( std::abs( ( mesh.triPoint( start ) - mesh.triPoint( finish ) ).length() - 0.1f ), eps );
+
+    // track within same triangle, another direction
+    finish = {};
+    sec = trackSection( mesh, start, finish, Vector3f( 0, -1, 0 ), 0.1f );
+    EXPECT_EQ( sec.size(), 0 );
+    EXPECT_EQ( finish.e, 10_e );
+    EXPECT_LT( std::abs( ( mesh.triPoint( start ) - mesh.triPoint( finish ) ).length() - 0.1f ), eps );
+
+    // track to the next triangle in same plane
+    finish = {};
+    sec = trackSection( mesh, start, finish, Vector3f( 0, 1, 0 ), 0.5f );
+    EXPECT_EQ( sec.size(), 1 );
+    EXPECT_EQ( sec[0].e, 15_e );
+    EXPECT_LT( std::abs( sec[0].a - 0.5f ), eps );
+    EXPECT_EQ( mesh.topology.left( finish.e ), 3_f );
+    EXPECT_LT( std::abs( ( mesh.triPoint( start ) - mesh.triPoint( finish ) ).length() - 0.5f ), eps );
+
+    // track to the next triangle in the opposite direction
+    finish = {};
+    sec = trackSection( mesh, start, finish, Vector3f( 0, -1, 0 ), 0.5f );
+    EXPECT_EQ( sec.size(), 1 );
+    EXPECT_EQ( sec[0].e, 11_e );
+    EXPECT_LT( std::abs( sec[0].a - 0.5f ), eps );
+    EXPECT_EQ( mesh.topology.left( finish.e ), 5_f );
+    EXPECT_LT( ( mesh.triPoint( finish ) - Vector3f( -0.25f, -0.5f, 0.0f ) ).length(), eps );
+
+    // track from edge's center
+    const MeshTriPoint startE{ 10_e, { 0.5f, 0.0f } };
+    finish = {};
+    sec = trackSection( mesh, startE, finish, Vector3f( -1, 1, 0 ).normalized(), 0.25f );
+    EXPECT_EQ( sec.size(), 0 );
+    EXPECT_EQ( mesh.topology.left( finish.e ), 2_f );
+    EXPECT_LT( ( mesh.triPoint( finish ) - Vector3f( -0.5f, -0.25f, 0.0f ) ).length(), eps );
+
+    // track from edge's center in the opposite direction
+    finish = {};
+    sec = trackSection( mesh, startE, finish, Vector3f( 1, -1, 0 ).normalized(), 0.25f );
+    EXPECT_EQ( sec.size(), 0 );
+    EXPECT_EQ( mesh.topology.left( finish.e ), 5_f );
+    EXPECT_LT( ( mesh.triPoint( finish ) - Vector3f( -0.25f, -0.5f, 0.0f ) ).length(), eps );
 }
 
 } // namespace MR


### PR DESCRIPTION
`trackSection` functions now do not compute values for all mesh vertices, instead only local operations are performed near the start point and along intersected edges, which must be much faster in typical cases.