### PR TITLE
Parallel filling of VoxelsVolumeCachingAccessor

### DIFF
--- a/source/MRVoxels/MRMeshToDistanceVolume.cpp
+++ b/source/MRVoxels/MRMeshToDistanceVolume.cpp
@@ -67,7 +67,13 @@ Expected<SimpleVolumeMinMax> meshToDistanceVolume( const MeshPart& mp, const Mes
 
 FunctionVolume meshToDistanceFunctionVolume( const MeshPart& mp, const MeshToDistanceVolumeParams& params )
 {
+    MR_TIMER
     assert( params.dist.signMode != SignDetectionMode::OpenVDB );
+
+    // prepare all trees before returned function will be called from parallel threads
+    mp.mesh.getAABBTree();
+    if ( params.dist.signMode == SignDetectionMode::HoleWindingRule )
+        mp.mesh.getDipoles();
 
     return FunctionVolume
     {

--- a/source/MRVoxels/MROffset.cpp
+++ b/source/MRVoxels/MROffset.cpp
@@ -174,6 +174,8 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
         vmParams.lessInside = true;
         vmParams.outVoxelPerFaceMap = outMap;
 
+        if ( params.signDetectionMode == SignDetectionMode::HoleWindingRule )
+            mp.mesh.getDipoles(); // prepare all trees before parallel regions
         if ( funcVolume )
         {
             return marchingCubes( meshToDistanceFunctionVolume( mp, msParams ), vmParams );

--- a/source/MRVoxels/MROffset.cpp
+++ b/source/MRVoxels/MROffset.cpp
@@ -174,8 +174,6 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
         vmParams.lessInside = true;
         vmParams.outVoxelPerFaceMap = outMap;
 
-        if ( params.signDetectionMode == SignDetectionMode::HoleWindingRule )
-            mp.mesh.getDipoles(); // prepare all trees before parallel regions
         if ( funcVolume )
         {
             return marchingCubes( meshToDistanceFunctionVolume( mp, msParams ), vmParams );

--- a/source/MRVoxels/MRVoxelsVolumeCachingAccessor.h
+++ b/source/MRVoxels/MRVoxelsVolumeCachingAccessor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MRVoxelsVolumeAccess.h"
+#include "MRMesh/MRParallelFor.h"
 #include "MRMesh/MRTimer.h"
 
 namespace MR
@@ -89,12 +90,14 @@ private:
         const auto z = z_ + (int)layerIndex;
         const auto& dims = indexer_.dims();
         assert( 0 <= z && z < dims.z );
-        auto loc = indexer_.toLoc( Vector3i{ 0, 0, z } );
-        firstLayerVoxelId_[layerIndex] = loc.id;
-        size_t n = 0;
-        for ( loc.pos.y = 0; loc.pos.y < dims.y; ++loc.pos.y )
+        firstLayerVoxelId_[layerIndex] = indexer_.toVoxelId( Vector3i{ 0, 0, z } );
+        ParallelFor( 0, dims.y, [&]( int y )
+        {
+            auto loc = indexer_.toLoc( Vector3i{ 0, y, z } );
+            size_t n = size_t( y ) * dims.x;
             for ( loc.pos.x = 0; loc.pos.x < dims.x; ++loc.pos.x, ++loc.id, ++n )
                 layer[n] = accessor_.get( loc );
+        } );
     }
 
 private:

--- a/source/MRVoxels/MRVoxelsVolumeCachingAccessor.h
+++ b/source/MRVoxels/MRVoxelsVolumeCachingAccessor.h
@@ -93,10 +93,11 @@ private:
         firstLayerVoxelId_[layerIndex] = indexer_.toVoxelId( Vector3i{ 0, 0, z } );
         ParallelFor( 0, dims.y, [&]( int y )
         {
+            auto accessor = accessor_; // only for OpenVDB accessor, which is not thread-safe
             auto loc = indexer_.toLoc( Vector3i{ 0, y, z } );
             size_t n = size_t( y ) * dims.x;
             for ( loc.pos.x = 0; loc.pos.x < dims.x; ++loc.pos.x, ++loc.id, ++n )
-                layer[n] = accessor_.get( loc );
+                layer[n] = accessor.get( loc );
         } );
     }
 


### PR DESCRIPTION
On our today's test case with 1M triangles Auto Repair Mesh results:
```
Tolerance    Current     This PR    PR/Current
5.78 mm      82.4 sec     65.7 sec (80%)
   3 mm     478.0 sec    405.4 sec (84%)
   2 mm    1482.0 sec   1316.2 sec (89%)
```

The drawbacks are
1. All trees for the mesh must be prepared before calling of Marching Cubes, otherwise stack overflows happen due to work stealing in TBB
2. Since CPU consumption increases, the computer becomes almost not-responsive during Auto Repair Mesh