### PR TITLE
findPointsInBall functions take Ball3f argument

### DIFF
--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -18,7 +18,7 @@ void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, float radiu
     const auto r = double( radius );
     const auto rr = sqr( r );
     neis.clear();
-    findPointsInBall( cloud, cloud.points[v], 2 * radius,
+    findPointsInBall( cloud, { cloud.points[v], sqr( 2 * radius ) },
         [&neis, v]( VertId n, const Vector3f& )
         {
             if ( v != n )

--- a/source/MRMesh/MRBall.h
+++ b/source/MRMesh/MRBall.h
@@ -16,6 +16,12 @@ struct Ball
 
     V center; ///< ball's center
     T radiusSq = 0; ///< ball's squared radius
+
+    /// returns true if given point is strictly inside the ball (not on its spherical surface)
+    bool inside( const V & pt ) const { return distanceSq( pt, center ) < radiusSq; }
+
+    /// returns true if given point is strictly outside the ball (not on its spherical surface)
+    bool outside( const V & pt ) const { return distanceSq( pt, center ) > radiusSq; }
 };
 
 } //namespace MR

--- a/source/MRMesh/MRCloseVertices.cpp
+++ b/source/MRMesh/MRCloseVertices.cpp
@@ -17,12 +17,13 @@ std::optional<VertMap> findSmallestCloseVerticesUsingTree( const VertCoords & po
 
     VertMap res;
     res.resizeNoInit( points.size() );
+    const auto closeDistSq = sqr( closeDist );
     if ( !ParallelFor( points, [&]( VertId v )
     {
         VertId smallestCloseVert = v;
         if ( !valid || valid->test( v ) )
         {
-            findPointsInBall( tree, points[v], closeDist, [&]( VertId cv, const Vector3f& )
+            findPointsInBall( tree, { points[v], closeDistSq }, [&]( VertId cv, const Vector3f& )
             {
                 if ( cv == v )
                     return;
@@ -47,7 +48,7 @@ std::optional<VertMap> findSmallestCloseVerticesUsingTree( const VertCoords & po
 
         // find another closest
         smallestCloseVert = v;
-        findPointsInBall( tree, points[v], closeDist, [&]( VertId cv, const Vector3f& )
+        findPointsInBall( tree, { points[v], closeDistSq }, [&]( VertId cv, const Vector3f& )
         {
             if ( cv == v )
                 return;

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -652,6 +652,12 @@ constexpr inline T sqr( T x ) noexcept { return x * x; }
 template <typename T>
 constexpr inline int sgn( T x ) noexcept { return x > 0 ? 1 : ( x < 0 ? -1 : 0 ); }
 
+template <typename T>
+constexpr inline T distance( T x, T y ) noexcept { return x >= y ? x - y : y - x; }
+
+template <typename T>
+constexpr inline T distanceSq( T x, T y ) noexcept { return sqr( x - y ); }
+
 template<typename...>
 inline constexpr bool dependent_false = false;
 

--- a/source/MRMesh/MRPointCloudMakeNormals.cpp
+++ b/source/MRMesh/MRPointCloudMakeNormals.cpp
@@ -24,10 +24,10 @@ std::optional<VertNormals> makeUnorientedNormals( const PointCloud& pointCloud, 
 
     VertNormals normals;
     normals.resizeNoInit( pointCloud.points.size() );
-    if ( !BitSetParallelFor( pointCloud.validPoints, [&]( VertId vid )
+    if ( !BitSetParallelFor( pointCloud.validPoints, [&, radiusSq = sqr( radius )]( VertId vid )
     {
         PointAccumulator accum;
-        findPointsInBall( pointCloud, pointCloud.points[vid], radius, [&]( VertId, const Vector3f& coord )
+        findPointsInBall( pointCloud, { pointCloud.points[vid], radiusSq }, [&]( VertId, const Vector3f& coord )
         {
             accum.addPoint( Vector3d( coord ) );
         } );
@@ -183,9 +183,9 @@ bool orientNormalsCore( const PointCloud& pointCloud, VertNormals& normals, cons
 bool orientNormals( const PointCloud& pointCloud, VertNormals& normals, float radius, const ProgressCallback & progress )
 {
     return orientNormalsCore( pointCloud, normals,
-        [&]( VertId base, auto callback )
+        [&, radiusSq = sqr( radius )]( VertId base, auto callback )
         {
-            findPointsInBall( pointCloud, pointCloud.points[base], radius,
+            findPointsInBall( pointCloud, { pointCloud.points[base], radiusSq },
                 [&]( VertId v, const Vector3f& )
                 {
                     if ( v == base )

--- a/source/MRMesh/MRPointCloudRadius.cpp
+++ b/source/MRMesh/MRPointCloudRadius.cpp
@@ -58,14 +58,14 @@ bool dilateRegion( const PointCloud& pointCloud, VertBitSet& region, float dilat
 {
     auto regionCopy = region;
 
-    const auto res =  BitSetParallelForAll( region, [&] ( VertId testVertex )
+    const auto res =  BitSetParallelForAll( region, [&, dilationSq = sqr( dilation )] ( VertId testVertex )
     {
         if ( regionCopy.test( testVertex ) )
             return;
 
         const Vector3f point = xf ? (*xf)( pointCloud.points[testVertex] ) : pointCloud.points[testVertex];
 
-        findPointsInBall( pointCloud, point, dilation, [&] ( VertId v, const Vector3f& )
+        findPointsInBall( pointCloud, { point, dilationSq }, [&] ( VertId v, const Vector3f& )
         {
             if ( regionCopy.test( testVertex ) )
                 return;
@@ -86,14 +86,14 @@ bool erodeRegion( const PointCloud& pointCloud, VertBitSet& region, float erosio
 {
     auto regionCopy = region;
 
-    const auto res =  BitSetParallelForAll( region, [&] ( VertId testVertex )
+    const auto res =  BitSetParallelForAll( region, [&, erosionSq = sqr( erosion )] ( VertId testVertex )
     {
         if ( !regionCopy.test( testVertex ) )
             return;
 
         const Vector3f point = xf ? ( *xf )( pointCloud.points[testVertex] ) : pointCloud.points[testVertex];
 
-        findPointsInBall( pointCloud, point, erosion, [&] ( VertId v, const Vector3f& )
+        findPointsInBall( pointCloud, { point, erosionSq }, [&] ( VertId v, const Vector3f& )
         {
             if ( !regionCopy.test( testVertex ) )
                 return;

--- a/source/MRMesh/MRPointCloudRelax.cpp
+++ b/source/MRMesh/MRPointCloudRelax.cpp
@@ -41,11 +41,11 @@ bool relax( PointCloud& pointCloud, const PointCloudRelaxParams& params /*= {} *
             };
         }
         newPoints = pointCloud.points;
-        keepGoing = BitSetParallelFor( zone, [&] ( VertId v )
+        keepGoing = BitSetParallelFor( zone, [&, radiusSq = sqr( radius )] ( VertId v )
         {
             Vector3d sumPos;
             int count = 0;
-            findPointsInBall( pointCloud, pointCloud.points[v], radius,
+            findPointsInBall( pointCloud, { pointCloud.points[v], radiusSq },
                 [&] ( VertId newV, const Vector3f& position )
             {
                 if ( newV != v )
@@ -107,11 +107,11 @@ bool relaxKeepVolume( PointCloud& pointCloud, const PointCloudRelaxParams& param
             };
         }
         newPoints = pointCloud.points;
-        keepGoing = BitSetParallelFor( zone, [&] ( VertId v )
+        keepGoing = BitSetParallelFor( zone, [&, radiusSq = sqr( radius )] ( VertId v )
         {
             Vector3d sumPos;
             int count = 0;
-            findPointsInBall( pointCloud, pointCloud.points[v], radius,
+            findPointsInBall( pointCloud, { pointCloud.points[v], radiusSq },
                 [&] ( VertId nv, const Vector3f& position )
             {
                 if ( nv != v && zone.test( nv ) )
@@ -126,11 +126,11 @@ bool relaxKeepVolume( PointCloud& pointCloud, const PointCloudRelaxParams& param
         }, internalCb1 );
         if ( !keepGoing )
             break;
-        keepGoing = BitSetParallelFor( zone, [&] ( VertId v )
+        keepGoing = BitSetParallelFor( zone, [&, radiusSq = sqr( radius )] ( VertId v )
         {
             Vector3d sumForces;
             int count = 0;
-            findPointsInBall( pointCloud, pointCloud.points[v], radius,
+            findPointsInBall( pointCloud, { pointCloud.points[v], radiusSq },
                 [&] ( VertId nv, const Vector3f& )
             {
                 if ( nv != v && zone.test( nv ) )
@@ -186,12 +186,12 @@ bool relaxApprox( PointCloud& pointCloud, const PointCloudApproxRelaxParams& par
             };
         }
         newPoints = pointCloud.points;
-        keepGoing = BitSetParallelFor( zone, [&] ( VertId v )
+        keepGoing = BitSetParallelFor( zone, [&, radiusSq = sqr( radius )] ( VertId v )
         {
             PointAccumulator accum;
             std::vector<std::pair<VertId, double>> weightedNeighbors;
 
-            findPointsInBall( pointCloud, pointCloud.points[v], radius,
+            findPointsInBall( pointCloud, { pointCloud.points[v], radiusSq },
                 [&] ( VertId newV, const Vector3f& position )
             {
                 double w = 1.0;

--- a/source/MRMesh/MRPointCloudTriangulationHelpers.cpp
+++ b/source/MRMesh/MRPointCloudTriangulationHelpers.cpp
@@ -104,7 +104,7 @@ void findNeighborsInBall( const PointCloud& pointCloud, VertId v, float radius, 
 {
     neighbors.clear();
     const auto& points = pointCloud.points;
-    findPointsInBall( pointCloud, points[v], radius, [&]( VertId vid, const Vector3f& )
+    findPointsInBall( pointCloud, { points[v], sqr( radius ) }, [&]( VertId vid, const Vector3f& )
     {
         if ( vid != v )
             neighbors.push_back( vid );

--- a/source/MRMesh/MRPointsComponents.cpp
+++ b/source/MRMesh/MRPointsComponents.cpp
@@ -192,6 +192,7 @@ Expected<UnionFind<VertId>> getUnionFindStructureVerts( const PointCloud& pointC
 
     VertBitSet bdVerts;
     ProgressCallback subPc = subprogress( pc, 0.f, 1.0f );
+    const auto maxDistSq = sqr( maxDist );
     if ( numThreads > 1 )
     {
         bdVerts.resize( numVerts );
@@ -201,7 +202,7 @@ Expected<UnionFind<VertId>> getUnionFindStructureVerts( const PointCloud& pointC
         {
             if ( !contains( vertsRegion, v0 ) )
                 return;
-            findPointsInBall( pointCloud.getAABBTree(), pointCloud.points[v0], maxDist,
+            findPointsInBall( pointCloud.getAABBTree(), { pointCloud.points[v0], maxDistSq },
                 [&] ( VertId v1, const Vector3f& )
             {
                 if ( v0 < v1 && contains( vertsRegion, v1 ) )
@@ -223,7 +224,7 @@ Expected<UnionFind<VertId>> getUnionFindStructureVerts( const PointCloud& pointC
     const int counterDivider = int( lastPassVerts->count() ) / 100;
     for ( auto v0 : *lastPassVerts )
     {
-        findPointsInBall( pointCloud.getAABBTree(), pointCloud.points[v0], maxDist,
+        findPointsInBall( pointCloud.getAABBTree(), { pointCloud.points[v0], maxDistSq },
             [&] ( VertId v1, const Vector3f& )
         {
             if ( v0 < v1 && contains( vertsRegion, v1 ) )

--- a/source/MRMesh/MRPointsInBall.h
+++ b/source/MRMesh/MRPointsInBall.h
@@ -1,29 +1,36 @@
 #pragma once
+
 #include "MRMeshFwd.h"
-#include "MRBitSet.h"
-#include "MRId.h"
+#include "MRBall.h"
+#include "MRVector3.h"
 
 namespace MR
 {
 
 using FoundPointCallback = std::function<void( VertId, const Vector3f& )>;
 
-/// Finds all valid points of pointCloud that are inside or on the surface of given ball (center, radius)
+/// Finds all valid points of pointCloud that are inside or on the surface of given ball
 /// \ingroup AABBTreeGroup
 /// \param xf points-to-center transformation, if not specified then identity transformation is assumed
-MRMESH_API void findPointsInBall( const PointCloud& pointCloud, const Vector3f& center, float radius, 
+MRMESH_API void findPointsInBall( const PointCloud& pointCloud, const Ball3f& ball,
     const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr );
+[[deprecated]] inline void findPointsInBall( const PointCloud& pointCloud, const Vector3f& center, float radius,
+    const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr ) { return findPointsInBall( pointCloud, { center, sqr( radius ) }, foundCallback, xf ); }
 
-/// Finds all valid vertices of the mesh that are inside or on the surface of given ball (center, radius)
+/// Finds all valid vertices of the mesh that are inside or on the surface of given ball
 /// \ingroup AABBTreeGroup
 /// \param xf points-to-center transformation, if not specified then identity transformation is assumed
-MRMESH_API void findPointsInBall( const Mesh& mesh, const Vector3f& center, float radius, 
+MRMESH_API void findPointsInBall( const Mesh& mesh, const Ball3f& ball,
     const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr );
+[[deprecated]] inline void findPointsInBall( const Mesh& mesh, const Vector3f& center, float radius,
+    const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr ) { return findPointsInBall( mesh, { center, sqr( radius ) }, foundCallback, xf ); }
 
-/// Finds all points in tree that are inside or on the surface of given ball (center, radius)
+/// Finds all points in tree that are inside or on the surface of given ball
 /// \ingroup AABBTreeGroup
 /// \param xf points-to-center transformation, if not specified then identity transformation is assumed
-MRMESH_API void findPointsInBall( const AABBTreePoints& tree, const Vector3f& center, float radius, 
+MRMESH_API void findPointsInBall( const AABBTreePoints& tree, const Ball3f& ball,
     const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr );
+[[deprecated]] inline void findPointsInBall( const AABBTreePoints& tree, const Vector3f& center, float radius,
+    const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr ) { return findPointsInBall( tree, { center, sqr( radius ) }, foundCallback, xf ); }
 
-}
+} //namespace MR

--- a/source/MRMesh/MRUniformSampling.cpp
+++ b/source/MRMesh/MRUniformSampling.cpp
@@ -37,7 +37,7 @@ std::optional<VertBitSet> pointUniformSampling( const PointCloud& pointCloud, co
         sampled.set( v );
         const auto c = pointCloud.points[v];
         float localMaxDistSq = sqr( settings.distance );
-        findPointsInBall( pointCloud, c, settings.distance, [&] ( VertId u, const Vector3f& pu )
+        findPointsInBall( pointCloud, { c, localMaxDistSq }, [&] ( VertId u, const Vector3f& pu )
         {
             const auto distSq = ( c - pu ).lengthSq();
             if ( pNormals && std::abs( dot( (*pNormals)[v], (*pNormals)[u] ) ) < settings.minNormalDot )


### PR DESCRIPTION
* `findPointsInBall` functions take `Ball3f` argument instead of separate center and radius;
* old signatures of `findPointsInBall` are deprecated;
* the code using `findPointsInBall` switched to new signatures with squared radius precomputation where possible;
* `struct Ball` gets new methods: `inside` and `outside`;
* `distance` and `distanceSq` functions declared for scalars