### PR TITLE
DM-based Radius Compensation fixes

### DIFF
--- a/source/MRMesh/MRRadiusCompensation.cpp
+++ b/source/MRMesh/MRRadiusCompensation.cpp
@@ -215,7 +215,7 @@ Expected<void> RadiusCompensator::applyCompensation()
     MeshSave::toAnySupportedFormat( mesh_, "C:\\WORK\\MODELS\\Radius_compensation\\RadiusCompensation\\RadiusCompensation\\#11 result\\debug0.mrmesh" );
 
     // fix inverted faces (undercuts on original mesh)
-    for ( ;;) // repeat untill no flipped faces left
+    for ( int iFlipped = 0; iFlipped < 10; ++iFlipped ) // repeat until no flipped faces left, 10 - max iters
     {
         // only fix flipped areas
         auto sumDirArea = Vector3f( mesh_.dirArea( faceRegion_ ).normalized() ); // we only care about direction

--- a/source/MRMesh/MRRadiusCompensation.cpp
+++ b/source/MRMesh/MRRadiusCompensation.cpp
@@ -15,7 +15,6 @@
 #include "MRMeshDecimate.h"
 #include "MRPch/MRTBB.h"
 #include "MRTimer.h"
-#include "MRMeshSave.h"
 
 namespace MR
 {
@@ -212,8 +211,6 @@ Expected<void> RadiusCompensator::applyCompensation()
         mesh_.points[v] = to3dim( to2dim( toDmXf_( mesh_.points[v] ) ) );
     }
 
-    MeshSave::toAnySupportedFormat( mesh_, "C:\\WORK\\MODELS\\Radius_compensation\\RadiusCompensation\\RadiusCompensation\\#11 result\\debug0.mrmesh" );
-
     // fix inverted faces (undercuts on original mesh)
     for ( int iFlipped = 0; iFlipped < 10; ++iFlipped ) // repeat until no flipped faces left, 10 - max iters
     {
@@ -247,7 +244,6 @@ Expected<void> RadiusCompensator::applyCompensation()
         makeDeloneEdgeFlips( mesh_, dParams, etParams.iterations * 20 );
     }
 
-    MeshSave::toAnySupportedFormat( mesh_, "C:\\WORK\\MODELS\\Radius_compensation\\RadiusCompensation\\RadiusCompensation\\#11 result\\debug1.mrmesh" );
     i = 0;
     for ( auto v : bounds )
         mesh_.points[v] = backupBounds[i++];
@@ -266,11 +262,9 @@ Expected<void> RadiusCompensator::applyCompensation()
         vertRegion_.reset( v );
     }, subprogress( params_.callback, 0.65f, 0.8f ) );
 
-    MeshSave::toAnySupportedFormat( mesh_, "C:\\WORK\\MODELS\\Radius_compensation\\RadiusCompensation\\RadiusCompensation\\#11 result\\debug2.mrmesh" );
     if ( vertRegion_.any() )
         positionVertsSmoothlySharpBd( mesh_, vertRegion_ );
 
-    MeshSave::toAnySupportedFormat( mesh_, "C:\\WORK\\MODELS\\Radius_compensation\\RadiusCompensation\\RadiusCompensation\\#11 result\\debug3.mrmesh" );
     if ( !keepGoing )
         return unexpectedOperationCanceled();
 

--- a/source/MRMesh/MRRadiusCompensation.h
+++ b/source/MRMesh/MRRadiusCompensation.h
@@ -17,13 +17,17 @@ struct CompensateRadiusParams
     float toolRadius{ 0.0f };
 
     /// resolution of distance map that is used for compensation
-    Vector2i distanceMapResolution = Vector2i( 100, 100 );
+    Vector2i distanceMapResolution = Vector2i( 150, 150 );
 
     /// region of the mesh that will be compensated
     /// it should not contain closed components
     /// it is updated during algorithm
     /// also please note that boundaries of the region are fixed
     FaceBitSet* region{ nullptr };
+
+    /// this value will be used for post-process re-meshing
+    /// value less or equal to zero will use average mesh edge length
+    float remeshTargetEdgeLength{ -1.0f };
 
     ProgressCallback callback;
 };


### PR DESCRIPTION
1. Use (Volume/Area) cost approximation
2. Introduce 1e-6 tolerance for dm values (needed to skip blank compensations)
3. Fix flipped faces until done (max 10 iters)