### PR TITLE
Rename DICOM load functions

### DIFF
--- a/source/MRVoxels/MRDicom.cpp
+++ b/source/MRVoxels/MRDicom.cpp
@@ -37,13 +37,11 @@ struct VoxelTraits<openvdb::FloatGrid::Accessor>
 
 using VolumeMinMaxAccessor = VoxelsVolumeMinMax<openvdb::FloatGrid::Accessor>;
 
-}
+namespace VoxelsLoad
+{
 
 namespace
 {
-
-using namespace MR;
-using namespace MR::VoxelsLoad;
 
 ScalarType convertToScalarType( const gdcm::PixelFormat& format )
 {
@@ -83,112 +81,6 @@ std::pair<gdcm::PixelFormat::ScalarType, gdcm::Tag> getGDCMTypeAndTag()
         return { gdcm::PixelFormat::ScalarType::UINT16, gdcm::Tag( 0x7FE0, 0x0010 ) };
     else
         static_assert( dependent_false<T>, "Unsupported type T" );
-}
-
-} // namespace
-
-namespace MR
-{
-
-namespace VoxelsLoad
-{
-
-bool isDicomFile( const std::filesystem::path& path, std::string* seriesUid )
-{
-    std::ifstream ifs( path, std::ios_base::binary );
-
-#ifdef __EMSCRIPTEN__
-    // try to detect by ourselves
-    // GDCM uses exceptions which causes problems on Wasm
-    constexpr auto cDicomMagicNumberOffset = 0x80;
-    constexpr std::array cDicomMagicNumber { 'D', 'I', 'C', 'M' };
-    // NOTE: std::ifstream::get appends a null character
-    std::array<char, std::size( cDicomMagicNumber ) + 1> buf;
-    if ( !ifs.seekg( cDicomMagicNumberOffset, std::ios::beg ) || !ifs.get( buf.data(), buf.size(), '\0' ) )
-        return false;
-    if ( std::strncmp( buf.data(), cDicomMagicNumber.data(), cDicomMagicNumber.size() ) != 0 )
-        return false;
-    ifs.seekg( 0, std::ios::beg );
-    assert( ifs );
-#endif
-
-    gdcm::ImageReader ir;
-    ir.SetStream( ifs );
-    if ( !ir.CanRead() )
-        return false;
-    // we read these tags to be able to determine whether this file is dicom dir or image
-    auto tags = {
-        gdcm::Tag( 0x0002, 0x0002 ), // media storage
-        gdcm::Tag( 0x0008, 0x0016 ), // media storage
-        gdcm::Keywords::PhotometricInterpretation::GetTag(),
-        gdcm::Keywords::ImagePositionPatient::GetTag(), // is for image origin in mm,
-        gdcm::Keywords::SeriesInstanceUID::GetTag(),
-        gdcm::Tag( 0x0028, 0x0010 ),gdcm::Tag( 0x0028, 0x0011 ),gdcm::Tag( 0x0028, 0x0008 )}; // is for dimensions
-    if ( !ir.ReadSelectedTags( tags ) )
-        return false;
-    gdcm::MediaStorage ms;
-    ms.SetFromFile( ir.GetFile() );
-
-    // skip unsupported media storage
-    if ( ms == gdcm::MediaStorage::MediaStorageDirectoryStorage || ms == gdcm::MediaStorage::SecondaryCaptureImageStorage
-        || ms == gdcm::MediaStorage::BasicTextSR )
-    {
-        spdlog::warn( "DICOM file {} has unsupported media storage {}", utf8string( path ), (int)ms );
-        return false;
-    }
-
-    // unfortunatly gdcm::ImageHelper::GetPhotometricInterpretationValue returns something even if no data in the file
-    if ( !gdcm::ImageHelper::GetPointerFromElement( gdcm::Keywords::PhotometricInterpretation::GetTag(), ir.GetFile() ) )
-    {
-        spdlog::warn( "DICOM file {} does not have Photometric Interpretation", utf8string( path ) );
-        return false;
-    }
-
-    auto photometric = gdcm::ImageHelper::GetPhotometricInterpretationValue( ir.GetFile() );
-    if ( photometric != gdcm::PhotometricInterpretation::MONOCHROME2 &&
-         photometric != gdcm::PhotometricInterpretation::MONOCHROME1 )
-    {
-        spdlog::warn( "DICOM file {} has Photometric Interpretation other than Monochrome", utf8string( path ) );
-        return false;
-    }
-
-    auto dims = gdcm::ImageHelper::GetDimensionsValue( ir.GetFile() );
-    if ( dims.size() != 3 )
-    {
-        spdlog::warn( "DICOM file {} has Dimensions Value other than 3", utf8string( path ) );
-        return false;
-    }
-
-    if ( seriesUid )
-    {
-        const auto& ds = ir.GetFile().GetDataSet();
-        if ( ds.FindDataElement( gdcm::Keywords::SeriesInstanceUID::GetTag() ) )
-        {
-            const auto& de = ds.GetDataElement( gdcm::Keywords::SeriesInstanceUID::GetTag() );
-            gdcm::Keywords::SeriesInstanceUID uid;
-            uid.SetFromDataElement( de );
-            auto uidVal = uid.GetValue();
-            *seriesUid = uidVal;
-        }
-    }
-
-    return true;
-}
-
-bool isDicomFolder( const std::filesystem::path& dirPath )
-{
-    std::error_code ec;
-    for ( const auto& entry : Directory { dirPath, ec } )
-    {
-        if ( entry.is_regular_file( ec ) || entry.is_symlink( ec ) )
-        {
-            const auto& path = entry.path();
-            const auto ext = toLower( utf8string( path.extension() ) );
-            if ( ext == ".dcm" && VoxelsLoad::isDicomFile( path ) )
-                return true;
-        }
-    }
-    return false;
 }
 
 struct DCMFileLoadResult
@@ -410,112 +302,27 @@ DCMFileLoadResult loadSingleFile( const std::filesystem::path& path, T& data, si
     return res;
 }
 
-struct SeriesInfo
+template <typename T>
+Expected<DicomVolumeT<T>> loadDicomFile( const std::filesystem::path& file, const ProgressCallback& cb )
 {
-    float sliceSize{ 0.0f };
-    int numSlices{ 0 };
-    BitSet missedSlices;
-};
+    MR_TIMER
+    if ( !reportProgress( cb, 0.0f ) )
+        return unexpectedOperationCanceled();
 
-SeriesInfo sortDICOMFiles( std::vector<std::filesystem::path>& files, unsigned maxNumThreads )
-{
-    SeriesInfo res;
+    T vol{};
+    vol.voxelSize = Vector3f();
+    vol.dims.z = 1;
+    auto fileRes = loadSingleFile( file, vol, 0 );
+    if ( !fileRes.success )
+        return unexpected( "loadDicomFile: error load file: " + utf8string( file ) );
+    vol.max = fileRes.max;
+    vol.min = fileRes.min;
 
-    if ( files.empty() )
-        return res;
-
-    std::vector<SliceInfo> zOrder( files.size() );
-
-    tbb::task_arena limitedArena( maxNumThreads );
-    limitedArena.execute( [&]
-    {
-        tbb::parallel_for( tbb::blocked_range( 0, int( files.size() ) ),
-            [&] ( const tbb::blocked_range<int>& range )
-        {
-            for ( int i = range.begin(); i < range.end(); ++i )
-            {
-                gdcm::ImageReader ir;
-                std::ifstream ifs( files[i], std::ios_base::binary );
-                ir.SetStream( ifs );
-                ir.ReadSelectedTags( {
-                    gdcm::Tag( 0x0002, 0x0002 ),
-                    gdcm::Tag( 0x0008, 0x0016 ),
-                    gdcm::Keywords::InstanceNumber::GetTag(),
-                    gdcm::Keywords::ImagePositionPatient::GetTag() } );
-
-                SliceInfo sl;
-                sl.fileNum = i;
-                const auto origin = gdcm::ImageHelper::GetOriginValue( ir.GetFile() );
-                sl.z = origin[2];
-                sl.imagePos = { origin[0], origin[1], origin[2] };
-
-                // if Instance Number is available then sort by it
-                const gdcm::DataSet& ds = ir.GetFile().GetDataSet();
-                if( ds.FindDataElement( gdcm::Keywords::InstanceNumber::GetTag() ) )
-                {
-                    const gdcm::DataElement& de = ds.GetDataElement( gdcm::Keywords::InstanceNumber::GetTag() );
-                    gdcm::Keywords::InstanceNumber at = {0}; // default value if empty
-                    at.SetFromDataElement( de );
-                    sl.instanceNum = at.GetValue();
-                }
-                zOrder[i] = sl;
-            }
-        } );
-    } );
-
-    bool zPosPresent = std::any_of( zOrder.begin(), zOrder.end(), [] ( const SliceInfo& el )
-    {
-        return el.z != 0.0;
-    } );
-    if ( !zPosPresent )
-    {
-        putScanFileNameInZ( files, zOrder );
-    }
-
-    sortScansByOrder( files, zOrder );
-
-    if ( zOrder.size() > 1 )
-    {
-        auto denom = std::max( 1.0f, float( zOrder[1].instanceNum - zOrder[0].instanceNum ) );
-        res.sliceSize = float( ( zOrder[1].imagePos - zOrder[0].imagePos ).length() / denom / 1000.0 );
-        res.numSlices = zOrder.back().instanceNum - zOrder.front().instanceNum + 1;
-
-        bool needReverse = zOrder[1].imagePos.z < zOrder[0].imagePos.z;
-
-        if ( res.numSlices != 0 )
-        {
-            res.missedSlices.resize( res.numSlices );
-
-            auto startIN = zOrder[0].instanceNum;
-            for ( int i = 1; i < zOrder.size(); ++i )
-            {
-                auto prevIN = zOrder[i - 1].instanceNum;
-                auto diff = zOrder[i].instanceNum - prevIN;
-                if ( diff == 1 )
-                    continue;
-                if ( diff == 0 )
-                {
-                    res.numSlices = 0;
-                    res.missedSlices.clear();
-                    break; // non-consistent instances
-                }
-
-                int startMissedIndex = ( prevIN - startIN + 1 );
-                for ( int j = startMissedIndex; j + 1 < startMissedIndex + diff; ++j )
-                    res.missedSlices.set( needReverse ? ( res.numSlices - 1 - j ) : j );
-            }
-        }
-
-        // if slices go in descending z-order then reverse them
-        if ( needReverse )
-            std::reverse( files.begin(), files.end() );
-    }
+    DicomVolumeT<T> res;
+    res.vol = std::move( vol );
+    res.name = utf8string( file.stem() );
     return res;
 }
-
-
-namespace
-{
 
 struct LoadSlicesResult
 {
@@ -630,9 +437,108 @@ private:
     VolumeIndexer ind_;
 };
 
+struct SeriesInfo
+{
+    float sliceSize{ 0.0f };
+    int numSlices{ 0 };
+    BitSet missedSlices;
+};
 
+SeriesInfo sortDICOMFiles( std::vector<std::filesystem::path>& files, unsigned maxNumThreads )
+{
+    SeriesInfo res;
+
+    if ( files.empty() )
+        return res;
+
+    std::vector<SliceInfo> zOrder( files.size() );
+
+    tbb::task_arena limitedArena( maxNumThreads );
+    limitedArena.execute( [&]
+    {
+        tbb::parallel_for( tbb::blocked_range( 0, int( files.size() ) ),
+            [&] ( const tbb::blocked_range<int>& range )
+        {
+            for ( int i = range.begin(); i < range.end(); ++i )
+            {
+                gdcm::ImageReader ir;
+                std::ifstream ifs( files[i], std::ios_base::binary );
+                ir.SetStream( ifs );
+                ir.ReadSelectedTags( {
+                    gdcm::Tag( 0x0002, 0x0002 ),
+                    gdcm::Tag( 0x0008, 0x0016 ),
+                    gdcm::Keywords::InstanceNumber::GetTag(),
+                    gdcm::Keywords::ImagePositionPatient::GetTag() } );
+
+                SliceInfo sl;
+                sl.fileNum = i;
+                const auto origin = gdcm::ImageHelper::GetOriginValue( ir.GetFile() );
+                sl.z = origin[2];
+                sl.imagePos = { origin[0], origin[1], origin[2] };
+
+                // if Instance Number is available then sort by it
+                const gdcm::DataSet& ds = ir.GetFile().GetDataSet();
+                if( ds.FindDataElement( gdcm::Keywords::InstanceNumber::GetTag() ) )
+                {
+                    const gdcm::DataElement& de = ds.GetDataElement( gdcm::Keywords::InstanceNumber::GetTag() );
+                    gdcm::Keywords::InstanceNumber at = {0}; // default value if empty
+                    at.SetFromDataElement( de );
+                    sl.instanceNum = at.GetValue();
+                }
+                zOrder[i] = sl;
+            }
+        } );
+    } );
+
+    bool zPosPresent = std::any_of( zOrder.begin(), zOrder.end(), [] ( const SliceInfo& el )
+    {
+        return el.z != 0.0;
+    } );
+    if ( !zPosPresent )
+    {
+        putScanFileNameInZ( files, zOrder );
+    }
+
+    sortScansByOrder( files, zOrder );
+
+    if ( zOrder.size() > 1 )
+    {
+        auto denom = std::max( 1.0f, float( zOrder[1].instanceNum - zOrder[0].instanceNum ) );
+        res.sliceSize = float( ( zOrder[1].imagePos - zOrder[0].imagePos ).length() / denom / 1000.0 );
+        res.numSlices = zOrder.back().instanceNum - zOrder.front().instanceNum + 1;
+
+        bool needReverse = zOrder[1].imagePos.z < zOrder[0].imagePos.z;
+
+        if ( res.numSlices != 0 )
+        {
+            res.missedSlices.resize( res.numSlices );
+
+            auto startIN = zOrder[0].instanceNum;
+            for ( int i = 1; i < zOrder.size(); ++i )
+            {
+                auto prevIN = zOrder[i - 1].instanceNum;
+                auto diff = zOrder[i].instanceNum - prevIN;
+                if ( diff == 1 )
+                    continue;
+                if ( diff == 0 )
+                {
+                    res.numSlices = 0;
+                    res.missedSlices.clear();
+                    break; // non-consistent instances
+                }
+
+                int startMissedIndex = ( prevIN - startIN + 1 );
+                for ( int j = startMissedIndex; j + 1 < startMissedIndex + diff; ++j )
+                    res.missedSlices.set( needReverse ? ( res.numSlices - 1 - j ) : j );
+            }
+        }
+
+        // if slices go in descending z-order then reverse them
+        if ( needReverse )
+            std::reverse( files.begin(), files.end() );
+    }
+    return res;
 }
-
 
 template <typename T>
 Expected<DicomVolumeT<T>> loadSingleDicomFolder( std::vector<std::filesystem::path>& files,
@@ -810,6 +716,106 @@ Expected<DicomVolumeT<T>> loadDicomFolder( const std::filesystem::path& path, un
     return loadSingleDicomFolder<T>( seriesMap->begin()->second, maxNumThreads, subprogress( cb, 0.3f, 1.0f ) );
 }
 
+} // anonymous namespace
+
+bool isDicomFile( const std::filesystem::path& path, std::string* seriesUid )
+{
+    std::ifstream ifs( path, std::ios_base::binary );
+
+#ifdef __EMSCRIPTEN__
+    // try to detect by ourselves
+    // GDCM uses exceptions which causes problems on Wasm
+    constexpr auto cDicomMagicNumberOffset = 0x80;
+    constexpr std::array cDicomMagicNumber { 'D', 'I', 'C', 'M' };
+    // NOTE: std::ifstream::get appends a null character
+    std::array<char, std::size( cDicomMagicNumber ) + 1> buf;
+    if ( !ifs.seekg( cDicomMagicNumberOffset, std::ios::beg ) || !ifs.get( buf.data(), buf.size(), '\0' ) )
+        return false;
+    if ( std::strncmp( buf.data(), cDicomMagicNumber.data(), cDicomMagicNumber.size() ) != 0 )
+        return false;
+    ifs.seekg( 0, std::ios::beg );
+    assert( ifs );
+#endif
+
+    gdcm::ImageReader ir;
+    ir.SetStream( ifs );
+    if ( !ir.CanRead() )
+        return false;
+    // we read these tags to be able to determine whether this file is dicom dir or image
+    auto tags = {
+        gdcm::Tag( 0x0002, 0x0002 ), // media storage
+        gdcm::Tag( 0x0008, 0x0016 ), // media storage
+        gdcm::Keywords::PhotometricInterpretation::GetTag(),
+        gdcm::Keywords::ImagePositionPatient::GetTag(), // is for image origin in mm,
+        gdcm::Keywords::SeriesInstanceUID::GetTag(),
+        gdcm::Tag( 0x0028, 0x0010 ),gdcm::Tag( 0x0028, 0x0011 ),gdcm::Tag( 0x0028, 0x0008 )}; // is for dimensions
+    if ( !ir.ReadSelectedTags( tags ) )
+        return false;
+    gdcm::MediaStorage ms;
+    ms.SetFromFile( ir.GetFile() );
+
+    // skip unsupported media storage
+    if ( ms == gdcm::MediaStorage::MediaStorageDirectoryStorage || ms == gdcm::MediaStorage::SecondaryCaptureImageStorage
+        || ms == gdcm::MediaStorage::BasicTextSR )
+    {
+        spdlog::warn( "DICOM file {} has unsupported media storage {}", utf8string( path ), (int)ms );
+        return false;
+    }
+
+    // unfortunatly gdcm::ImageHelper::GetPhotometricInterpretationValue returns something even if no data in the file
+    if ( !gdcm::ImageHelper::GetPointerFromElement( gdcm::Keywords::PhotometricInterpretation::GetTag(), ir.GetFile() ) )
+    {
+        spdlog::warn( "DICOM file {} does not have Photometric Interpretation", utf8string( path ) );
+        return false;
+    }
+
+    auto photometric = gdcm::ImageHelper::GetPhotometricInterpretationValue( ir.GetFile() );
+    if ( photometric != gdcm::PhotometricInterpretation::MONOCHROME2 &&
+         photometric != gdcm::PhotometricInterpretation::MONOCHROME1 )
+    {
+        spdlog::warn( "DICOM file {} has Photometric Interpretation other than Monochrome", utf8string( path ) );
+        return false;
+    }
+
+    auto dims = gdcm::ImageHelper::GetDimensionsValue( ir.GetFile() );
+    if ( dims.size() != 3 )
+    {
+        spdlog::warn( "DICOM file {} has Dimensions Value other than 3", utf8string( path ) );
+        return false;
+    }
+
+    if ( seriesUid )
+    {
+        const auto& ds = ir.GetFile().GetDataSet();
+        if ( ds.FindDataElement( gdcm::Keywords::SeriesInstanceUID::GetTag() ) )
+        {
+            const auto& de = ds.GetDataElement( gdcm::Keywords::SeriesInstanceUID::GetTag() );
+            gdcm::Keywords::SeriesInstanceUID uid;
+            uid.SetFromDataElement( de );
+            auto uidVal = uid.GetValue();
+            *seriesUid = uidVal;
+        }
+    }
+
+    return true;
+}
+
+bool isDicomFolder( const std::filesystem::path& dirPath )
+{
+    std::error_code ec;
+    for ( const auto& entry : Directory { dirPath, ec } )
+    {
+        if ( entry.is_regular_file( ec ) || entry.is_symlink( ec ) )
+        {
+            const auto& path = entry.path();
+            const auto ext = toLower( utf8string( path.extension() ) );
+            if ( ext == ".dcm" && VoxelsLoad::isDicomFile( path ) )
+                return true;
+        }
+    }
+    return false;
+}
+
 std::vector<Expected<DicomVolumeAsVdb>> loadDicomsFolderTreeAsVdb( const std::filesystem::path& path, unsigned maxNumThreads, const ProgressCallback& cb )
 {
     MR_TIMER;
@@ -874,28 +880,6 @@ Expected<LoadedObjects> makeObjectVoxelsFromDicomFolder( const std::filesystem::
     return res;
 }
 
-template <typename T>
-Expected<DicomVolumeT<T>> loadDicomFile( const std::filesystem::path& file, const ProgressCallback& cb )
-{
-    MR_TIMER
-    if ( !reportProgress( cb, 0.0f ) )
-        return unexpectedOperationCanceled();
-
-    T vol{};
-    vol.voxelSize = Vector3f();
-    vol.dims.z = 1;
-    auto fileRes = loadSingleFile( file, vol, 0 );
-    if ( !fileRes.success )
-        return unexpected( "loadDicomFile: error load file: " + utf8string( file ) );
-    vol.max = fileRes.max;
-    vol.min = fileRes.min;
-
-    DicomVolumeT<T> res;
-    res.vol = std::move( vol );
-    res.name = utf8string( file.stem() );
-    return res;
-}
-
 Expected<DicomVolume> loadDicomFolder( const std::filesystem::path& path, unsigned maxNumThreads, const ProgressCallback& cb )
 {
     return loadDicomFolder<SimpleVolumeMinMax>( path, maxNumThreads, cb );
@@ -947,7 +931,7 @@ Expected<void> toDicom( const VoxelsVolume<std::vector<T>>& volume, const std::f
     if ( !reportProgress( cb, 0.0f ) )
         return unexpectedOperationCanceled();
 
-    auto [gdcmScalar, gdcmTag] = getGDCMTypeAndTag<T>();
+    auto [gdcmScalar, gdcmTag] = MR::VoxelsLoad::getGDCMTypeAndTag<T>();
 
     gdcm::ImageWriter iw;
     auto& image = iw.GetImage();
@@ -1011,8 +995,8 @@ MR_ON_INIT
         filter,
         []( const std::filesystem::path& path, const ProgressCallback& cb )
         {
-            return loadDicomFile<VdbVolume>( path, cb ).transform(
-                []( DicomVolumeAsVdb&& r )
+            return MR::VoxelsLoad::loadDicomFileAsVdb( path, cb ).transform(
+                []( MR::VoxelsLoad::DicomVolumeAsVdb&& r )
                 {
                     std::vector<VdbVolume> ret;
                     ret.push_back( std::move( r.vol ) ); // Not using `return std::vector{ std::move( r.vdbVolume ) }` because that would always copy `v`.

--- a/source/MRVoxels/MRDicom.h
+++ b/source/MRVoxels/MRDicom.h
@@ -32,24 +32,26 @@ struct DicomVolumeT
     AffineXf3f xf;
 };
 
+using DicomVolume = DicomVolumeT<SimpleVolumeMinMax>;
+using DicomVolumeAsVdb = DicomVolumeT<VdbVolume>;
 
-/// Loads 3D all volumetric data from DICOM files in a folder
-/// @note Explicitly instantiated for T = SimpleVolumeMinMax and T = VdbVolume
-template <typename T = SimpleVolumeMinMax>
-MRVOXELS_API std::vector<Expected<DicomVolumeT<T>>> loadDicomsFolder( const std::filesystem::path& path,
-                                                                      unsigned maxNumThreads = 4, const ProgressCallback& cb = {} );
+/// Loads full volume from single DICOM file (not a slice file) as SimpleVolumeMinMax
+MRVOXELS_API Expected<DicomVolume> loadDicomFile( const std::filesystem::path& file, const ProgressCallback& cb = {} );
 
-extern template MRVOXELS_API std::vector<Expected<DicomVolumeT<SimpleVolumeMinMax>>> loadDicomsFolder( const std::filesystem::path& path, unsigned maxNumThreads, const ProgressCallback& cb );
-extern template MRVOXELS_API std::vector<Expected<DicomVolumeT<VdbVolume         >>> loadDicomsFolder( const std::filesystem::path& path, unsigned maxNumThreads, const ProgressCallback& cb );
+/// Loads full volume from single DICOM file (not a slice file) as VdbVolume
+MRVOXELS_API Expected<DicomVolumeAsVdb> loadDicomFileAsVdb( const std::filesystem::path& file, const ProgressCallback& cb = {} );
 
-/// Loads 3D first volumetric data from DICOM files in a folder
-/// @note Explicitly instantiated for T = SimpleVolumeMinMax and T = VdbVolume
-template <typename T = SimpleVolumeMinMax>
-MRVOXELS_API Expected<DicomVolumeT<T>> loadDicomFolder( const std::filesystem::path& path,
-                                                    unsigned maxNumThreads = 4, const ProgressCallback& cb = {} );
+/// Loads one volume from DICOM files located in given folder as SimpleVolumeMinMax
+MRVOXELS_API Expected<DicomVolume> loadDicomFolder( const std::filesystem::path& path, unsigned maxNumThreads, const ProgressCallback& cb = {} );
 
-extern template MRVOXELS_API Expected<DicomVolumeT<SimpleVolumeMinMax>> loadDicomFolder( const std::filesystem::path& path, unsigned maxNumThreads, const ProgressCallback& cb );
-extern template MRVOXELS_API Expected<DicomVolumeT<VdbVolume         >> loadDicomFolder( const std::filesystem::path& path, unsigned maxNumThreads, const ProgressCallback& cb );
+/// Loads one volume from DICOM files located in given folder as VdbVolume
+MRVOXELS_API Expected<DicomVolumeAsVdb> loadDicomFolderAsVdb( const std::filesystem::path& path, unsigned maxNumThreads, const ProgressCallback& cb = {} );
+
+/// Loads all volumes from DICOM files located in given folder as a number of SimpleVolumeMinMax
+MRVOXELS_API std::vector<Expected<DicomVolume>> loadDicomsFolder( const std::filesystem::path& path, unsigned maxNumThreads, const ProgressCallback& cb = {} );
+
+/// Loads all volumes from DICOM files located in given folder as a number of VdbVolume
+MRVOXELS_API std::vector<Expected<DicomVolumeAsVdb>> loadDicomsFolderAsVdb( const std::filesystem::path& path, unsigned maxNumThreads, const ProgressCallback& cb = {} );
 
 /// Loads every subfolder with DICOM volume as new object
 MRVOXELS_API std::vector<Expected<DicomVolumeAsVdb>> loadDicomsFolderTreeAsVdb( const std::filesystem::path& path,
@@ -60,13 +62,6 @@ MRVOXELS_API Expected<std::shared_ptr<ObjectVoxels>> createObjectVoxels( const D
 
 /// Loads 3D volumetric data from dicom-files in given folder, and converts them into an ObjectVoxels
 MRVOXELS_API Expected<LoadedObjects> makeObjectVoxelsFromDicomFolder( const std::filesystem::path& folder, const ProgressCallback& callback = {} );
-
-/// Loads 3D volumetric data from a single DICOM file
-template <typename T = SimpleVolumeMinMax>
-MRVOXELS_API Expected<DicomVolumeT<T>> loadDicomFile( const std::filesystem::path& path, const ProgressCallback& cb = {} );
-
-extern template MRVOXELS_API Expected<DicomVolumeT<SimpleVolumeMinMax>> loadDicomFile( const std::filesystem::path& path, const ProgressCallback& cb );
-extern template MRVOXELS_API Expected<DicomVolumeT<VdbVolume         >> loadDicomFile( const std::filesystem::path& path, const ProgressCallback& cb );
 
 } // namespace VoxelsLoad
 

--- a/source/MRVoxels/MRDicom.h
+++ b/source/MRVoxels/MRDicom.h
@@ -32,9 +32,6 @@ struct DicomVolumeT
     AffineXf3f xf;
 };
 
-using DicomVolume = DicomVolumeT<SimpleVolumeMinMax>;
-using DicomVolumeAsVdb = DicomVolumeT<VdbVolume>;
-
 /// Loads full volume from single DICOM file (not a slice file) as SimpleVolumeMinMax
 MRVOXELS_API Expected<DicomVolume> loadDicomFile( const std::filesystem::path& file, const ProgressCallback& cb = {} );
 

--- a/source/mrmeshpy/MRPythonIO.cpp
+++ b/source/mrmeshpy/MRPythonIO.cpp
@@ -361,14 +361,14 @@ MR_ADD_PYTHON_VEC( mrmeshpy, LoadDCMResults, MR::VoxelsLoad::DicomVolumeAsVdb )
 
 MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, LoadVoxelsDicom, [] ( pybind11::module_& m )
 {
-    m.def( "loadDicomFolderAsVdb", MR::decorateExpected( &MR::VoxelsLoad::loadDicomFolder<VdbVolume> ),
+    m.def( "loadDicomFolderAsVdb", MR::decorateExpected( &MR::VoxelsLoad::loadDicomFolderAsVdb ),
         pybind11::arg( "path" ), pybind11::arg( "maxNumThreads" ) = 4, pybind11::arg( "callback" ) = ProgressCallback{},
         "Loads first volumetric data from DICOM file(s)" );
 
     m.def( "loadDicomsFolderAsVdb",
         [] ( const std::filesystem::path& p, unsigned maxNumThreads, const ProgressCallback& cb)
     {
-        auto res = MR::VoxelsLoad::loadDicomsFolder<VdbVolume>( p, maxNumThreads, cb );
+        auto res = MR::VoxelsLoad::loadDicomsFolderAsVdb( p, maxNumThreads, cb );
         std::vector<MR::VoxelsLoad::DicomVolumeAsVdb> resVec;
         std::string accumError;
         for ( auto& r : res )


### PR DESCRIPTION
* Simplify names of DICOM load functions
* Remove templates from public API to get same function names in Python
* Hide implementation of internal functions in anonymous namespace 