### PR TITLE
Set Vdb background in `loadDicomFile`.

### DIFF
--- a/source/MRVoxels/MRDicom.cpp
+++ b/source/MRVoxels/MRDicom.cpp
@@ -318,6 +318,9 @@ Expected<DicomVolumeT<T>> loadDicomFile( const std::filesystem::path& file, cons
     vol.max = fileRes.max;
     vol.min = fileRes.min;
 
+    if constexpr ( std::same_as<T, VdbVolume> )
+        openvdb::tools::changeBackground( vol.data->tree(), vol.min );
+
     DicomVolumeT<T> res;
     res.vol = std::move( vol );
     res.name = utf8string( file.stem() );


### PR DESCRIPTION
When loading a single DICOM file, the background value must be set.