### PR TITLE
Allow empty groups in Ribbon

### DIFF
--- a/source/MRCommonPlugins/MRRibbonCommonMenuStructure.ui.json
+++ b/source/MRCommonPlugins/MRRibbonCommonMenuStructure.ui.json
@@ -162,6 +162,11 @@
 				{
 					"Name": "Basic",
 					"List": [
+					]
+				},
+				{
+					"Name": "Binary",
+					"List": [
 						{
 							"Name": "Binary Operations"
 						}

--- a/source/MRViewer/MRRibbonSchema.cpp
+++ b/source/MRViewer/MRRibbonSchema.cpp
@@ -655,25 +655,11 @@ void RibbonSchemaLoader::readUIJson_( const Json::Value& itemsStructure ) const
                 assert( false );
                 continue;
             }
-            auto listSize = int( list.size() );
-            if ( listSize == 0 )
-            {
-                spdlog::warn( "\"List\" array is empty in group: \"{}\", in tab: \"{}\"", groupName.asString(), tabName.asString() );
-                assert( false );
-                continue;
-            }
             MenuItemsList items;
             readMenuItemsList( list, items );
-            if ( items.empty() )
-            {
-#ifndef __EMSCRIPTEN__
-                spdlog::warn( "\"List\" array has no valid items in group: \"{}\", in tab: \"{}\"", groupName.asString(), tabName.asString() );
-                assert( false );
-#endif
-                continue;
-            }
-            auto& groupsMapRef = RibbonSchemaHolder::schema().groupsMap[tabName.asString() + groupName.asString()];
-            if ( groupsMapRef.empty() )
+            auto [it, inserted] = RibbonSchemaHolder::schema().groupsMap.insert( { tabName.asString() + groupName.asString(), MenuItemsList{} } );
+            auto& groupsMapRef = it->second;
+            if ( inserted )
             {
                 groupsMapRef = std::move( items );
                 newGroupsVec.push_back( groupName.asString() );

--- a/source/MRViewer/MRRibbonSchema.h
+++ b/source/MRViewer/MRRibbonSchema.h
@@ -51,6 +51,12 @@ struct RibbonSchema
     MenuItemsList defaultQuickAccessList;
     MenuItemsList headerQuickAccessList;
     MenuItemsList sceneButtonsList;
+
+    /// deletes empty groups (and references on them from tabs)
+    MRVIEWER_API void eliminateEmptyGroups();
+
+    /// re-order items in tabsOrder according to their priority, the order of items having same priority is preserved
+    MRVIEWER_API void sortTabsByPriority();
 };
 
 // This class holds static ribbon schema,


### PR DESCRIPTION
* Temporary allow empty Ribbon groups during loading, such groups can be populated by the following .ui.json files and the buttons in them can appear before some buttons from initial .ui.json file.
* Remove empty groups when the loading of all .ui.json files has finished.