### PR TITLE
findTriangleSectionsByXYPlane optimization

### DIFF
--- a/source/MRMesh/MRMeshIntersect.cpp
+++ b/source/MRMesh/MRMeshIntersect.cpp
@@ -388,10 +388,10 @@ void rayMeshIntersectAll( const MeshPart& meshPart, const Line3d& line, MeshInte
 }
 
 void xyPlaneMeshIntersect( const MeshPart& meshPart, float zLevel,
-    FaceBitSet * fs, UndirectedEdgeBitSet * ues, VertBitSet * vs )
+    FaceBitSet * fs, UndirectedEdgeBitSet * ues, VertBitSet * vs, std::vector<FaceId> * fsVec )
 {
     MR_TIMER
-    assert( fs || ues || vs );
+    assert( fs || ues || vs || fsVec );
 
     const auto& m = meshPart.mesh;
     constexpr int maxTreeDepth = 32;
@@ -431,6 +431,8 @@ void xyPlaneMeshIntersect( const MeshPart& meshPart, float zLevel,
             {
                 if ( fs )
                     fs->set( face );
+                if ( fsVec )
+                    fsVec->push_back( face );
                 if ( ues || vs )
                 {
                     EdgeId e0, e1, e2;

--- a/source/MRMesh/MRMeshIntersect.h
+++ b/source/MRMesh/MRMeshIntersect.h
@@ -112,8 +112,10 @@ MRMESH_API void rayMeshIntersectAll( const MeshPart& meshPart, const Line3d& lin
 /// \param fs  triangles crossed or touched by the plane
 /// \param ues edges of these triangles
 /// \param vs  vertices of these triangles
+/// \param fsVec triangles crossed or touched by the plane in unspecified order
 MRMESH_API void xyPlaneMeshIntersect( const MeshPart& meshPart, float zLevel,
-    FaceBitSet * fs, UndirectedEdgeBitSet * ues, VertBitSet * vs );
+    FaceBitSet * fs, UndirectedEdgeBitSet * ues, VertBitSet * vs,
+    std::vector<FaceId> * fsVec = nullptr );
 
 /// \}
 


### PR DESCRIPTION
In AABB-tree-version of `findTriangleSectionsByXYPlane` function, do not allocate `FaceBitSet crossedFaces`, which takes considerable time for large meshes.

In common section, process crossed triangles in a more optimal way.