### PR TITLE
struct ObjectMeshData

### DIFF
--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -143,6 +143,7 @@
     <ClInclude Include="MRMutexOwner.h" />
     <ClInclude Include="MRNormalDenoising.h" />
     <ClInclude Include="MRNormalsToPoints.h" />
+    <ClInclude Include="MRObjectMeshData.h" />
     <ClInclude Include="MROffsetContours.h" />
     <ClInclude Include="MROutlierPoints.h" />
     <ClInclude Include="MRParabola.h" />
@@ -402,6 +403,7 @@
     <ClInclude Include="MRScopedValue.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="MRObjectMeshData.cpp" />
     <ClCompile Include="MROutlierPoints.cpp" />
     <ClCompile Include="MRParallelProgressReporter.cpp" />
     <ClCompile Include="MR2DContoursTriangulation.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -58,9 +58,6 @@
     <Filter Include="Source Files\DataModel\Measurements">
       <UniqueIdentifier>{744e0637-b69b-442b-b0f8-19f0f815c033}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\DataModel\ModelHolder">
-      <UniqueIdentifier>{2e5c8a08-b968-4732-be0c-9b07bb4b051e}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Source Files\MeshBuilder">
       <UniqueIdentifier>{c83e4212-7072-40c2-8354-827c896c1628}</UniqueIdentifier>
     </Filter>
@@ -543,9 +540,6 @@
     <ClInclude Include="MRSphereObject.h">
       <Filter>Source Files\DataModel\Features</Filter>
     </ClInclude>
-    <ClInclude Include="MRObjectMeshHolder.h">
-      <Filter>Source Files\DataModel\ModelHolder</Filter>
-    </ClInclude>
     <ClInclude Include="MR2to3.h">
       <Filter>Source Files\Math</Filter>
     </ClInclude>
@@ -554,9 +548,6 @@
     </ClInclude>
     <ClInclude Include="MRPolyline.h">
       <Filter>Source Files\Polyline</Filter>
-    </ClInclude>
-    <ClInclude Include="MRObjectLinesHolder.h">
-      <Filter>Source Files\DataModel\ModelHolder</Filter>
     </ClInclude>
     <ClInclude Include="MRLineObject.h">
       <Filter>Source Files\DataModel\Features</Filter>
@@ -569,9 +560,6 @@
     </ClInclude>
     <ClInclude Include="MRHeapBytes.h">
       <Filter>Source Files\Basic</Filter>
-    </ClInclude>
-    <ClInclude Include="MRObjectPointsHolder.h">
-      <Filter>Source Files\DataModel\ModelHolder</Filter>
     </ClInclude>
     <ClInclude Include="MRChangePointCloudAction.h">
       <Filter>Source Files\History</Filter>
@@ -1275,6 +1263,18 @@
     <ClInclude Include="MROutlierPoints.h">
       <Filter>Source Files\PointCloud</Filter>
     </ClInclude>
+    <ClInclude Include="MRObjectLinesHolder.h">
+      <Filter>Source Files\DataModel</Filter>
+    </ClInclude>
+    <ClInclude Include="MRObjectMeshHolder.h">
+      <Filter>Source Files\DataModel</Filter>
+    </ClInclude>
+    <ClInclude Include="MRObjectPointsHolder.h">
+      <Filter>Source Files\DataModel</Filter>
+    </ClInclude>
+    <ClInclude Include="MRObjectMeshData.h">
+      <Filter>Source Files\DataModel</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRParallelProgressReporter.cpp">
@@ -1586,17 +1586,11 @@
     <ClCompile Include="MRSphereObject.cpp">
       <Filter>Source Files\DataModel\Features</Filter>
     </ClCompile>
-    <ClCompile Include="MRObjectMeshHolder.cpp">
-      <Filter>Source Files\DataModel\ModelHolder</Filter>
-    </ClCompile>
     <ClCompile Include="MRPlaneObject.cpp">
       <Filter>Source Files\DataModel\Features</Filter>
     </ClCompile>
     <ClCompile Include="MRPolyline.cpp">
       <Filter>Source Files\Polyline</Filter>
-    </ClCompile>
-    <ClCompile Include="MRObjectLinesHolder.cpp">
-      <Filter>Source Files\DataModel\ModelHolder</Filter>
     </ClCompile>
     <ClCompile Include="MRLineObject.cpp">
       <Filter>Source Files\DataModel\Features</Filter>
@@ -1606,9 +1600,6 @@
     </ClCompile>
     <ClCompile Include="MRPolyline2Collide.cpp">
       <Filter>Source Files\AABBTree</Filter>
-    </ClCompile>
-    <ClCompile Include="MRObjectPointsHolder.cpp">
-      <Filter>Source Files\DataModel\ModelHolder</Filter>
     </ClCompile>
     <ClCompile Include="MRPointObject.cpp">
       <Filter>Source Files\DataModel\Features</Filter>
@@ -2098,6 +2089,18 @@
     </ClCompile>
     <ClCompile Include="MROutlierPoints.cpp">
       <Filter>Source Files\PointCloud</Filter>
+    </ClCompile>
+    <ClCompile Include="MRObjectLinesHolder.cpp">
+      <Filter>Source Files\DataModel</Filter>
+    </ClCompile>
+    <ClCompile Include="MRObjectMeshHolder.cpp">
+      <Filter>Source Files\DataModel</Filter>
+    </ClCompile>
+    <ClCompile Include="MRObjectPointsHolder.cpp">
+      <Filter>Source Files\DataModel</Filter>
+    </ClCompile>
+    <ClCompile Include="MRObjectMeshData.cpp">
+      <Filter>Source Files\DataModel</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -574,6 +574,7 @@ class SceneRootObject;
 class VisualObject;
 class ObjectMeshHolder;
 class ObjectMesh;
+struct ObjectMeshData;
 class ObjectPointsHolder;
 class ObjectPoints;
 class ObjectLinesHolder;

--- a/source/MRMesh/MRObjectDistanceMap.cpp
+++ b/source/MRMesh/MRObjectDistanceMap.cpp
@@ -28,8 +28,8 @@ void ObjectDistanceMap::applyScale( float scaleFactor )
 std::shared_ptr<MR::Object> ObjectDistanceMap::clone() const
 {
     auto res = std::make_shared<ObjectDistanceMap>( ProtectedStruct{}, *this );
-    if ( mesh_ )
-        res->mesh_ = std::make_shared<Mesh>( *mesh_ );
+    if ( data_.mesh )
+        res->data_.mesh = std::make_shared<Mesh>( *data_.mesh );
     if ( dmap_ )
         res->dmap_ = std::make_shared<DistanceMap>( *dmap_ );
     return res;
@@ -102,7 +102,7 @@ std::shared_ptr<Mesh> ObjectDistanceMap::calculateMesh( ProgressCallback cb ) co
 
 void ObjectDistanceMap::updateMesh( const std::shared_ptr<Mesh>& mesh )
 {
-    mesh_ = mesh;
+    data_.mesh = mesh;
     setDirtyFlags( DIRTY_ALL );
 }
 

--- a/source/MRMesh/MRObjectMesh.h
+++ b/source/MRMesh/MRObjectMesh.h
@@ -19,7 +19,7 @@ public:
     virtual const char* typeName() const override { return TypeName(); }
 
     /// returns variable mesh, if const mesh is needed use `mesh()` instead
-    virtual const std::shared_ptr< Mesh > & varMesh() { return mesh_; }
+    virtual const std::shared_ptr< Mesh > & varMesh() { return data_.mesh; }
 
     /// sets given mesh to this, resets selection and creases
     MRMESH_API virtual void setMesh( std::shared_ptr< Mesh > mesh );

--- a/source/MRMesh/MRObjectMeshData.cpp
+++ b/source/MRMesh/MRObjectMeshData.cpp
@@ -1,0 +1,21 @@
+#include "MRObjectMeshData.h"
+#include "MRHeapBytes.h"
+#include "MRColor.h"
+#include "MRMesh.h"
+
+namespace MR
+{
+
+size_t ObjectMeshData::heapBytes() const
+{
+    return MR::heapBytes( mesh )
+        + selectedFaces.heapBytes()
+        + selectedEdges.heapBytes()
+        + creases.heapBytes()
+        + vertColors.heapBytes()
+        + faceColors.heapBytes()
+        + uvCoordinates.heapBytes()
+        + texturePerFace.heapBytes();
+}
+
+} //namespace MR

--- a/source/MRMesh/MRObjectMeshData.h
+++ b/source/MRMesh/MRObjectMeshData.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "MRMeshFwd.h"
+#include "MRVector.h"
+#include "MRBitSet.h"
+
+namespace MR
+{
+
+/// mesh and its per-element attributes for ObjectMeshHolder
+struct ObjectMeshData
+{
+    std::shared_ptr<Mesh> mesh;
+
+    // selection
+    FaceBitSet selectedFaces;
+    UndirectedEdgeBitSet selectedEdges;
+
+    UndirectedEdgeBitSet creases;
+
+    // colors
+    VertColors vertColors;
+    FaceColors faceColors;
+
+    // textures
+    VertUVCoords uvCoordinates; ///< vertices coordinates in texture
+    TexturePerFace texturePerFace;
+
+    /// returns the amount of memory this object occupies on heap
+    [[nodiscard]] MRMESH_API size_t heapBytes() const;
+};
+
+} //namespace MR

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -3,6 +3,7 @@
 #include "MRVisualObject.h"
 #include "MRXfBasedCache.h"
 #include "MRMeshPart.h"
+#include "MRObjectMeshData.h"
 
 namespace MR
 {
@@ -42,27 +43,27 @@ public:
     /// mesh object can be seen if the mesh has at least one edge
     MRMESH_API virtual bool hasVisualRepresentation() const override;
 
-    [[nodiscard]] virtual bool hasModel() const override { return bool( mesh_ ); }
+    [[nodiscard]] virtual bool hasModel() const override { return bool( data_.mesh ); }
 
     const std::shared_ptr< const Mesh >& mesh() const
-    { return reinterpret_cast< const std::shared_ptr<const Mesh>& >( mesh_ ); } // reinterpret_cast to avoid making a copy of shared_ptr
+    { return reinterpret_cast< const std::shared_ptr<const Mesh>& >( data_.mesh ); } // reinterpret_cast to avoid making a copy of shared_ptr
 
     /// \return the pair ( mesh, selected triangles ) if any triangle is selected or whole mesh otherwise
-    MeshPart meshPart() const { return selectedTriangles_.any() ? MeshPart{ *mesh_, &selectedTriangles_ } : *mesh_; }
+    MeshPart meshPart() const { return data_.selectedFaces.any() ? MeshPart{ *data_.mesh, &data_.selectedFaces } : *data_.mesh; }
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;
 
     MRMESH_API virtual void setDirtyFlags( uint32_t mask, bool invalidateCaches = true ) override;
 
-    const FaceBitSet& getSelectedFaces() const { return selectedTriangles_; }
+    const FaceBitSet& getSelectedFaces() const { return data_.selectedFaces; }
     MRMESH_API virtual void selectFaces( FaceBitSet newSelection );
     /// returns colors of selected triangles
     MRMESH_API const Color& getSelectedFacesColor( ViewportId id = {} ) const;
     /// sets colors of selected triangles
     MRMESH_API virtual void setSelectedFacesColor( const Color& color, ViewportId id = {} );
 
-    const UndirectedEdgeBitSet& getSelectedEdges() const { return selectedEdges_; }
+    const UndirectedEdgeBitSet& getSelectedEdges() const { return data_.selectedEdges; }
     MRMESH_API virtual void selectEdges( UndirectedEdgeBitSet newSelection );
     /// returns colors of selected edges
     MRMESH_API const Color& getSelectedEdgesColor( ViewportId id = {} ) const;
@@ -82,7 +83,7 @@ public:
     MRMESH_API virtual void setBordersColorsForAllViewports( ViewportProperty<Color> val );
 
     /// Edges on mesh, that will have sharp visualization even with smooth shading
-    const UndirectedEdgeBitSet& creases() const { return creases_; }
+    const UndirectedEdgeBitSet& creases() const { return data_.creases; }
     MRMESH_API virtual void setCreases( UndirectedEdgeBitSet creases );
 
     /// sets flat (true) or smooth (false) shading
@@ -99,17 +100,17 @@ public:
     MRMESH_API const ViewportMask& getVisualizePropertyMask( AnyVisualizeMaskEnum type ) const override;
 
     /// returns per-vertex colors of the object
-    const VertColors& getVertsColorMap() const { return vertsColorMap_; }
+    const VertColors& getVertsColorMap() const { return data_.vertColors; }
 
     /// sets per-vertex colors of the object
-    virtual void setVertsColorMap( VertColors vertsColorMap ) { vertsColorMap_ = std::move( vertsColorMap ); dirty_ |= DIRTY_VERTS_COLORMAP; }
+    virtual void setVertsColorMap( VertColors vertsColorMap ) { data_.vertColors = std::move( vertsColorMap ); dirty_ |= DIRTY_VERTS_COLORMAP; }
 
     /// swaps per-vertex colors of the object with given argument
-    virtual void updateVertsColorMap( VertColors& vertsColorMap ) { std::swap( vertsColorMap_, vertsColorMap ); dirty_ |= DIRTY_VERTS_COLORMAP; }
+    virtual void updateVertsColorMap( VertColors& vertsColorMap ) { std::swap( data_.vertColors, vertsColorMap ); dirty_ |= DIRTY_VERTS_COLORMAP; }
 
-    const FaceColors& getFacesColorMap() const { return facesColorMap_; }
-    virtual void setFacesColorMap( FaceColors facesColorMap ) { facesColorMap_ = std::move( facesColorMap ); dirty_ |= DIRTY_PRIMITIVE_COLORMAP; }
-    virtual void updateFacesColorMap( FaceColors& updated ) { std::swap( facesColorMap_, updated ); dirty_ |= DIRTY_PRIMITIVE_COLORMAP; }
+    const FaceColors& getFacesColorMap() const { return data_.faceColors; }
+    virtual void setFacesColorMap( FaceColors facesColorMap ) { data_.faceColors = std::move( facesColorMap ); dirty_ |= DIRTY_PRIMITIVE_COLORMAP; }
+    virtual void updateFacesColorMap( FaceColors& updated ) { std::swap( data_.faceColors, updated ); dirty_ |= DIRTY_PRIMITIVE_COLORMAP; }
 
     MRMESH_API virtual void setEdgeWidth( float edgeWidth );
     float getEdgeWidth() const { return edgeWidth_; }
@@ -142,15 +143,15 @@ public:
     virtual void updateTextures( Vector<MeshTexture, TextureId>& updated ) { std::swap( textures_, updated ); dirty_ |= DIRTY_TEXTURE; }
 
     /// the texture ids for the faces if more than one texture is used to texture the object
-    /// texture coordinates (uvCoordinates_) at a point can belong to different textures, depending on which face the point belongs to
-    virtual void setTexturePerFace( Vector<TextureId, FaceId> texturePerFace ) { texturePerFace_ = std::move( texturePerFace ); dirty_ |= DIRTY_TEXTURE_PER_FACE; }
-    virtual void updateTexturePerFace( Vector<TextureId, FaceId>& texturePerFace ) { std::swap( texturePerFace_, texturePerFace ); dirty_ |= DIRTY_TEXTURE_PER_FACE; }
+    /// texture coordinates (data_.uvCoordinates) at a point can belong to different textures, depending on which face the point belongs to
+    virtual void setTexturePerFace( Vector<TextureId, FaceId> texturePerFace ) { data_.texturePerFace = std::move( texturePerFace ); dirty_ |= DIRTY_TEXTURE_PER_FACE; }
+    virtual void updateTexturePerFace( Vector<TextureId, FaceId>& texturePerFace ) { std::swap( data_.texturePerFace, texturePerFace ); dirty_ |= DIRTY_TEXTURE_PER_FACE; }
     virtual void addTexture( MeshTexture texture ) { textures_.emplace_back( std::move( texture ) ); dirty_ |= DIRTY_TEXTURE_PER_FACE; }
-    const TexturePerFace& getTexturePerFace() const { return texturePerFace_; }
+    const TexturePerFace& getTexturePerFace() const { return data_.texturePerFace; }
     
-    const VertUVCoords& getUVCoords() const { return uvCoordinates_; }
-    virtual void setUVCoords( VertUVCoords uvCoordinates ) { uvCoordinates_ = std::move( uvCoordinates ); dirty_ |= DIRTY_UV; }
-    virtual void updateUVCoords( VertUVCoords& updated ) { std::swap( uvCoordinates_, updated ); dirty_ |= DIRTY_UV; }
+    const VertUVCoords& getUVCoords() const { return data_.uvCoordinates; }
+    virtual void setUVCoords( VertUVCoords uvCoordinates ) { data_.uvCoordinates = std::move( uvCoordinates ); dirty_ |= DIRTY_UV; }
+    virtual void updateUVCoords( VertUVCoords& updated ) { std::swap( data_.uvCoordinates, updated ); dirty_ |= DIRTY_UV; }
 
     /// copies texture, UV-coordinates and vertex colors from given source object \param src using given map \param thisToSrc
     MRMESH_API virtual void copyTextureAndColors( const ObjectMeshHolder& src, const VertMap& thisToSrc, const FaceMap& thisToSrcFaces = {} );
@@ -236,15 +237,10 @@ public:
     SelectionChangedSignal creasesChangedSignal;
 
 protected:
-    FaceBitSet selectedTriangles_;
-    UndirectedEdgeBitSet selectedEdges_;
-    UndirectedEdgeBitSet creases_;
+    ObjectMeshData data_;
 
     /// Texture options
     Vector<MeshTexture, TextureId> textures_;
-    VertUVCoords uvCoordinates_; ///< vertices coordinates in texture
-
-    Vector<TextureId, FaceId> texturePerFace_;
 
     MeshTexture ancillaryTexture_;
     VertUVCoords ancillaryUVCoordinates_; ///< vertices coordinates in ancillary texture
@@ -305,12 +301,8 @@ protected:
     ViewportProperty<Color> edgeSelectionColor_;
     ViewportProperty<Color> faceSelectionColor_;
 
-    VertColors vertsColorMap_;
-    FaceColors facesColorMap_;
     float edgeWidth_{ 0.5f };
     float pointSize_{ 5.f };
-
-    std::shared_ptr<Mesh> mesh_;
 
 private:
     /// this is private function to set default colors of this type (ObjectMeshHolder) in constructor only

--- a/source/MRVoxels/MRObjectVoxels.cpp
+++ b/source/MRVoxels/MRObjectVoxels.cpp
@@ -31,7 +31,7 @@ constexpr size_t cVoxelsHistogramBinsNumber = 256;
 
 void ObjectVoxels::construct( const SimpleVolume& simpleVolume, const std::optional<Vector2f> & minmax, ProgressCallback cb, bool normalPlusGrad )
 {
-    mesh_.reset();
+    data_.mesh.reset();
     activeVoxels_.reset();
     activeBounds_.reset();
     if ( minmax )
@@ -104,13 +104,13 @@ void ObjectVoxels::updateHistogramAndSurface( ProgressCallback cb )
 
     evalGridMinMax( vdbVolume_.data, min, max );
 
-    const float progressTo = ( mesh_ && cb ) ? 0.5f : 1.f;
+    const float progressTo = ( data_.mesh && cb ) ? 0.5f : 1.f;
     updateHistogram_( min, max, subprogress( cb, 0.f, progressTo ) );
     vdbVolume_.min = min;
     vdbVolume_.max = max;
-    if ( mesh_ )
+    if ( data_.mesh )
     {
-        mesh_.reset();
+        data_.mesh.reset();
 
         const float progressFrom = cb ? 0.5f : 0.f;
         setIsoValue( isoValue_, subprogress( cb, progressFrom, 1.f ) );
@@ -121,7 +121,7 @@ Expected<bool> ObjectVoxels::setIsoValue( float iso, ProgressCallback cb, bool u
 {
     if ( !vdbVolume_.data )
         return false; // no volume presented in this
-    if ( mesh_ && iso == isoValue_ )
+    if ( data_.mesh && iso == isoValue_ )
         return false; // current iso surface represents required iso value
 
     isoValue_ = iso;
@@ -139,9 +139,9 @@ Expected<bool> ObjectVoxels::setIsoValue( float iso, ProgressCallback cb, bool u
 
 std::shared_ptr<Mesh> ObjectVoxels::updateIsoSurface( std::shared_ptr<Mesh> mesh )
 {
-    if ( mesh != mesh_ )
+    if ( mesh != data_.mesh )
     {
-        mesh_.swap( mesh );
+        data_.mesh.swap( mesh );
         setDirtyFlags( DIRTY_ALL );
         isoSurfaceChangedSignal();
     }
@@ -486,7 +486,7 @@ bool ObjectVoxels::hasVisualRepresentation() const
 {
     if ( isVolumeRenderingEnabled() )
         return false;
-    return bool( mesh_ );
+    return bool( data_.mesh );
 }
 
 void ObjectVoxels::setMaxSurfaceVertices( int maxVerts )
@@ -494,17 +494,17 @@ void ObjectVoxels::setMaxSurfaceVertices( int maxVerts )
     if ( maxVerts == maxSurfaceVertices_ )
         return;
     maxSurfaceVertices_ = maxVerts;
-    if ( !mesh_ || mesh_->topology.numValidVerts() <= maxSurfaceVertices_ )
+    if ( !data_.mesh || data_.mesh->topology.numValidVerts() <= maxSurfaceVertices_ )
         return;
-    mesh_.reset();
+    data_.mesh.reset();
     setIsoValue( isoValue_ );
 }
 
 std::shared_ptr<Object> ObjectVoxels::clone() const
 {
     auto res = std::make_shared<ObjectVoxels>( ProtectedStruct{}, *this );
-    if ( mesh_ )
-        res->mesh_ = std::make_shared<Mesh>( *mesh_ );
+    if ( data_.mesh )
+        res->data_.mesh = std::make_shared<Mesh>( *data_.mesh );
     if ( vdbVolume_.data )
         res->vdbVolume_.data = MakeFloatGrid( vdbVolume_.data->deepCopy() );
     return res;
@@ -513,8 +513,8 @@ std::shared_ptr<Object> ObjectVoxels::clone() const
 std::shared_ptr<Object> ObjectVoxels::shallowClone() const
 {
     auto res = std::make_shared<ObjectVoxels>( ProtectedStruct{}, *this );
-    if ( mesh_ )
-        res->mesh_ = mesh_;
+    if ( data_.mesh )
+        res->data_.mesh = data_.mesh;
     if ( vdbVolume_.data )
         res->vdbVolume_ = vdbVolume_;
     return res;
@@ -524,8 +524,8 @@ void ObjectVoxels::setDirtyFlags( uint32_t mask, bool invalidateCaches )
 {
     ObjectMeshHolder::setDirtyFlags( mask, invalidateCaches );
 
-    if ( invalidateCaches && ( mask & DIRTY_POSITION || mask & DIRTY_FACE ) && mesh_ )
-        mesh_->invalidateCaches();
+    if ( invalidateCaches && ( mask & DIRTY_POSITION || mask & DIRTY_FACE ) && data_.mesh )
+        data_.mesh->invalidateCaches();
 }
 
 size_t ObjectVoxels::activeVoxels() const

--- a/source/MRVoxels/MRObjectVoxels.h
+++ b/source/MRVoxels/MRObjectVoxels.h
@@ -27,7 +27,7 @@ public:
     MRVOXELS_API virtual void applyScale( float scaleFactor ) override;
 
     /// Returns iso surface, empty if iso value is not set
-    const std::shared_ptr<Mesh>& surface() const { return mesh_; }
+    const std::shared_ptr<Mesh>& surface() const { return data_.mesh; }
 
     /// Return VdbVolume
     const VdbVolume& vdbVolume() const { return vdbVolume_; };


### PR DESCRIPTION
Move mesh and per-element attributes from `ObjectMeshHolder` in new `struct ObjectMeshData`. It will be convenient to write algorithms operating with new struct.