### PR TITLE
PickPointManager: auto hover last inserted point

### DIFF
--- a/source/MRViewer/MRPickPointManager.cpp
+++ b/source/MRViewer/MRPickPointManager.cpp
@@ -219,6 +219,65 @@ std::shared_ptr<SurfacePointWidget> PickPointManager::createPickWidget_( const s
     newPoint->setParameters( params.surfacePointParams );
     newPoint->create( obj, pt );
 
+    newPoint->setStartMoveCallback( [this, obj = obj] ( SurfacePointWidget & pointWidget, const PickedPoint& point )
+    {
+        const int index = getPointIndex( obj, pointWidget );
+        if ( index < 0 )
+        {
+            assert( false );
+            return;
+        }
+        moveClosedPoint_ = false;
+        const auto& contour = pickedPoints_[obj];
+        if ( isClosedCountour( obj ) )
+            moveClosedPoint_ = &pointWidget == contour[0].get();
+        if ( params.writeHistory )
+        {
+            SCOPED_HISTORY( "Move Point" + params.historyNameSuffix );
+            AppendHistory<MovePointHistoryAction>( *this, obj, point, index );
+            if ( moveClosedPoint_ )
+                AppendHistory<MovePointHistoryAction>( *this, obj, point, int( contour.size() ) - 1 );
+        }
+        assert( hoveredPointWidget_ == &pointWidget );
+        draggedPointWidget_ = &pointWidget;
+        if ( params.onPointMoveStart )
+            params.onPointMoveStart( obj, index );
+
+    } );
+
+    newPoint->setOnMoveCallback( [this, obj = obj] ( SurfacePointWidget & pointWidget, const PickedPoint& point )
+    {
+        if ( moveClosedPoint_ )
+        {
+            const auto& contour = pickedPoints_[obj];
+            if ( &pointWidget == contour[0].get() )
+                contour.back()->setCurrentPosition( point );
+        }
+        assert( draggedPointWidget_ == &pointWidget );
+        if ( params.onPointMove )
+        {
+            const int index = getPointIndex( obj, pointWidget );
+            if ( index >= 0 )
+                params.onPointMove( obj, index );
+            else
+                assert( false );
+        }
+    } );
+
+    newPoint->setEndMoveCallback( [this, obj = obj] ( [[maybe_unused]] SurfacePointWidget & pointWidget, const PickedPoint& )
+    {
+        assert( draggedPointWidget_ == &pointWidget );
+        draggedPointWidget_ = nullptr;
+        if ( params.onPointMoveFinish )
+        {
+            const int index = getPointIndex( obj, pointWidget );
+            if ( index >= 0 )
+                params.onPointMoveFinish( obj, index );
+            else
+                assert( false );
+        }
+    } );
+
     if ( connectionHolders_.find( obj ) == connectionHolders_.end() )
     {
         ConnectionHolder holder;
@@ -320,6 +379,26 @@ std::shared_ptr<SurfacePointWidget> PickPointManager::getPointWidget( const std:
     return res;
 }
 
+int PickPointManager::getPointIndex( const std::shared_ptr<VisualObject>& obj, SurfacePointWidget& pointWidget ) const
+{
+    assert( obj );
+    int res = 01;
+    const auto it = pickedPoints_.find( obj );
+    if ( it != pickedPoints_.end() )
+    {
+        const auto& contour = it->second;
+        for ( int i = 0; i < contour.size(); ++i )
+        {
+            if ( contour[i].get() == &pointWidget )
+            {
+                res = i;
+                break;
+            }
+        }
+    }
+    return res;
+}
+
 bool PickPointManager::appendPoint( const std::shared_ptr<VisualObject>& obj, const PickedPoint& triPoint )
 {
     appendHistory_( AddRemovePointHistoryAction::appendAndGetUndo( *this, obj, triPoint ) );
@@ -339,6 +418,9 @@ bool PickPointManager::onMouseDown_( Viewer::MouseButton button, int mod )
 
     auto [obj, pick] = pick_();
     if ( !obj )
+        return false;
+
+    if ( myPickSpheres_.contains( obj.get() ) )
         return false;
 
     if ( ( params.surfacePointParams.pickInBackFaceObject == false ) && ( SurfacePointWidget::isPickIntoBackFace( obj, pick, getViewerInstance().viewport().getCameraPoint() ) ) )
@@ -485,48 +567,6 @@ bool PickPointManager::onMouseMove_( int, int )
             {
                 widget->setHovered( true );
                 hoveredPointWidget_ = widget.get();
-                // setting callback is very cheap operation (in comparison to pick_ above),
-                // and we do it here because here we know up-today index of the point
-                widget->setStartMoveCallback( [this, obj = obj, index] ( SurfacePointWidget & pointWidget, const PickedPoint& point )
-                {
-                    moveClosedPoint_ = false;
-                    const auto& contour = pickedPoints_[obj];
-                    if ( isClosedCountour( obj ) )
-                        moveClosedPoint_ = &pointWidget == contour[0].get();
-                    if ( params.writeHistory )
-                    {
-                        SCOPED_HISTORY( "Move Point" + params.historyNameSuffix );
-                        AppendHistory<MovePointHistoryAction>( *this, obj, point, index );
-                        if ( moveClosedPoint_ )
-                            AppendHistory<MovePointHistoryAction>( *this, obj, point, int( contour.size() ) - 1 );
-                    }
-                    assert( hoveredPointWidget_ == &pointWidget );
-                    draggedPointWidget_ = &pointWidget;
-                    if ( params.onPointMoveStart )
-                        params.onPointMoveStart( obj, index );
-
-                } );
-
-                widget->setOnMoveCallback( [this, obj = obj, index] ( SurfacePointWidget & pointWidget, const PickedPoint& point )
-                {
-                    if ( moveClosedPoint_ )
-                    {
-                        const auto& contour = pickedPoints_[obj];
-                        if ( &pointWidget == contour[0].get() )
-                            contour.back()->setCurrentPosition( point );
-                    }
-                    assert( draggedPointWidget_ == &pointWidget );
-                    if ( params.onPointMove )
-                        params.onPointMove( obj, index );
-                } );
-
-                widget->setEndMoveCallback( [this, obj = obj, index] ( [[maybe_unused]] SurfacePointWidget & pointWidget, const PickedPoint& )
-                {
-                    assert( draggedPointWidget_ == &pointWidget );
-                    draggedPointWidget_ = nullptr;
-                    if ( params.onPointMoveFinish )
-                        params.onPointMoveFinish( obj, index );
-                } );
             }
         }
     }

--- a/source/MRViewer/MRPickPointManager.cpp
+++ b/source/MRViewer/MRPickPointManager.cpp
@@ -218,6 +218,7 @@ std::shared_ptr<SurfacePointWidget> PickPointManager::createPickWidget_( const s
     newPoint->setAutoHover( false );
     newPoint->setParameters( params.surfacePointParams );
     newPoint->create( obj, pt );
+    setHoveredPointWidget_( newPoint.get() );
 
     newPoint->setStartMoveCallback( [this, obj = obj] ( SurfacePointWidget & pointWidget, const PickedPoint& point )
     {
@@ -546,10 +547,7 @@ bool PickPointManager::onMouseMove_( int, int )
 
     auto [pickObj, pick] = pick_();
     if ( hoveredPointWidget_ && pickObj != hoveredPointWidget_->getPickSphere() )
-    {
-        hoveredPointWidget_->setHovered( false );
-        hoveredPointWidget_ = nullptr;
-    }
+        setHoveredPointWidget_( nullptr );
     if ( !pickObj )
         return false;
 
@@ -560,13 +558,13 @@ bool PickPointManager::onMouseMove_( int, int )
     {
         if ( hoveredPointWidget_ )
             break;
-        for ( int index = 0; !hoveredPointWidget_ && index < widgets.size(); ++index )
+        for ( int index = 0; index < widgets.size(); ++index )
         {
             const auto& widget = widgets[index];
             if ( pickObj == widget->getPickSphere() )
             {
-                widget->setHovered( true );
-                hoveredPointWidget_ = widget.get();
+                setHoveredPointWidget_( widget.get() );
+                break;
             }
         }
     }
@@ -660,6 +658,17 @@ void PickPointManager::appendHistory_( std::shared_ptr<HistoryAction> action ) c
 {
     if ( params.writeHistory )
         AppendHistory( std::move( action ) );
+}
+
+void PickPointManager::setHoveredPointWidget_( SurfacePointWidget* newHoveredPoint )
+{
+    if ( hoveredPointWidget_ == newHoveredPoint )
+        return;
+    if ( hoveredPointWidget_ )
+        hoveredPointWidget_->setHovered( false );
+    hoveredPointWidget_ = newHoveredPoint;
+    if ( hoveredPointWidget_ )
+        hoveredPointWidget_->setHovered( true );
 }
 
 } // namespace MR

--- a/source/MRViewer/MRPickPointManager.h
+++ b/source/MRViewer/MRPickPointManager.h
@@ -105,6 +105,9 @@ public:
     /// returns point widget by index from given object or nullptr if no such widget exists
     [[nodiscard]] MRVIEWER_API std::shared_ptr<SurfacePointWidget> getPointWidget( const std::shared_ptr<VisualObject>& obj, int index ) const;
 
+    /// returns index of given point widget on given object or -1 if this widget is not from given object
+    [[nodiscard]] MRVIEWER_API int getPointIndex( const std::shared_ptr<VisualObject>& obj, SurfacePointWidget& pointWidget ) const;
+
     /// returns point widget currently dragged by mouse
     [[nodiscard]] SurfacePointWidget* draggedPointWidget() const { return draggedPointWidget_; }
 

--- a/source/MRViewer/MRPickPointManager.h
+++ b/source/MRViewer/MRPickPointManager.h
@@ -172,6 +172,9 @@ private:
     /// if history writing is enabled, appends given history action to global store
     void appendHistory_( std::shared_ptr<HistoryAction> action ) const;
 
+    /// setup new hovered point widget, and removes hovering from the previous one
+    void setHoveredPointWidget_( SurfacePointWidget* newHoveredPoint );
+
     // whether the contour was closed before dragging of point #0, so we need to move the last point on end drag
     bool moveClosedPoint_ = false;
 


### PR DESCRIPTION
* Previously hovering was set on mouse move, and without hovering the point cannot be dragged. Now we hover the last added/inserted point.
* Widget callbacks now can find point index and not store it permanently (it can change with other actions)