### PR TITLE
Introduce MoveTool dead zone

### DIFF
--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.cpp
@@ -92,11 +92,11 @@ bool MoveObjectByMouse::onDragEnd_( MouseButton btn, int modifiers )
 
 void MoveObjectByMouse::postDraw_()
 {
-    if (const auto& menu = getViewerInstance().getMenuPlugin() )
+    if ( const auto& menu = getViewerInstance().getMenuPlugin() )
         moveByMouse_.onDrawDialog( menu->menu_scaling() );
 }
 
-ObjAndPick MoveObjectByMouse::MoveObjectByMouseWithSelected::pickObjects_( std::vector<std::shared_ptr<Object>>& objects, int modifiers )
+ObjAndPick MoveObjectByMouse::MoveObjectByMouseWithSelected::pickObjects_( std::vector<std::shared_ptr<Object>>& objects, int modifiers ) const
 {
     Viewer& viewerRef = getViewerInstance();
     Viewport& viewport = viewerRef.viewport( viewerRef.getHoveredViewportId() );
@@ -126,9 +126,9 @@ ObjAndPick MoveObjectByMouse::MoveObjectByMouseWithSelected::pickObjects_( std::
     return res;
 }
 
-MoveObjectByMouseImpl::TransformMode MoveObjectByMouse::MoveObjectByMouseWithSelected::modeFromPick_( MouseButton button, int modifiers )
+MoveObjectByMouseImpl::TransformMode MoveObjectByMouse::MoveObjectByMouseWithSelected::modeFromPickModifiers_( int modifiers ) const
 {
-    if ( button != MouseButton::Left || ( modifiers & ~( GLFW_MOD_SHIFT | GLFW_MOD_CONTROL | GLFW_MOD_ALT ) ) != 0 ||
+    if ( ( modifiers & ~( GLFW_MOD_SHIFT | GLFW_MOD_CONTROL | GLFW_MOD_ALT ) ) != 0 ||
      ( modifiers & ( GLFW_MOD_CONTROL | GLFW_MOD_ALT ) ) == ( GLFW_MOD_CONTROL | GLFW_MOD_ALT ) )
         return TransformMode::None;
 
@@ -140,7 +140,7 @@ MoveObjectByMouseImpl::TransformMode MoveObjectByMouse::MoveObjectByMouseWithSel
         return TransformMode::Translation;
 }
 
-void MoveObjectByMouse::MoveObjectByMouseWithSelected::setStartPoint_( const ObjAndPick& objPick, Vector3f& startPoint )
+void MoveObjectByMouse::MoveObjectByMouseWithSelected::setStartPoint_( const ObjAndPick& objPick, Vector3f& startPoint ) const
 {
     const auto& [obj, pick] = objPick;
     if ( obj )

--- a/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
+++ b/source/MRCommonPlugins/Basic/MRMoveObjectByMouse.h
@@ -40,9 +40,9 @@ private:
     class MoveObjectByMouseWithSelected : public MoveObjectByMouseImpl
     {
     protected:
-        virtual ObjAndPick pickObjects_( std::vector<std::shared_ptr<Object>>& objects, int modifiers ) override;
-        virtual TransformMode modeFromPick_( MouseButton button, int modifiers ) override;
-        virtual void setStartPoint_( const ObjAndPick& pick, Vector3f& startPoint ) override;
+        virtual ObjAndPick pickObjects_( std::vector<std::shared_ptr<Object>>& objects, int modifiers ) const override;
+        virtual TransformMode modeFromPickModifiers_( int modifiers ) const override;
+        virtual void setStartPoint_( const ObjAndPick& pick, Vector3f& startPoint ) const override;
     public:
         // Options are provided externally rather than directly from modifiers
         UI::RadioButtonOrModifierState modXfMode{};    // XfMode

--- a/source/MRViewer/MRMoveObjectByMouseImpl.cpp
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.cpp
@@ -31,8 +31,53 @@ constexpr MR::Vector2i cNoPoint{ std::numeric_limits<int>::max(), 0 };
 namespace MR
 {
 
-void MoveObjectByMouseImpl::onDrawDialog( float /*menuScaling*/ ) const
+void MoveObjectByMouseImpl::onDrawDialog( float menuScaling ) const
 {
+    if ( deadZonePixelRadius_ > 0.0f )
+    {
+        std::vector<std::shared_ptr<Object>> tempObjects;
+        TransformMode expectedMode = transformMode_;
+
+        if ( objects_.empty() )
+        {
+            int mods = 0;
+            if ( ImGui::GetIO().KeyMods & ImGuiMod_Ctrl )
+                mods |= GLFW_MOD_CONTROL;
+            if ( ImGui::GetIO().KeyMods & ImGuiMod_Shift )
+                mods |= GLFW_MOD_SHIFT;
+            if ( ImGui::GetIO().KeyMods & ImGuiMod_Alt )
+                mods |= GLFW_MOD_ALT;
+            if ( ImGui::GetIO().KeyMods & ImGuiMod_Super )
+                mods |= GLFW_MOD_SUPER;
+            expectedMode = modeFromPickModifiers_( mods );
+            if ( expectedMode == TransformMode::Rotation || expectedMode == TransformMode::Scale )
+                pickObjects_( tempObjects, mods );
+        }
+        const auto& objs = objects_.empty() ? tempObjects : objects_;
+
+        if ( !objs.empty() && ( expectedMode == TransformMode::Rotation || expectedMode == TransformMode::Scale ) )
+        {
+            ViewportId vpId = getViewerInstance().viewport().id;
+            Vector3f centerPoint = xfCenterPoint_;
+            if ( objects_.empty() )
+            {
+                Box3f box = getBbox_( objs );
+                centerPoint = box.valid() ? box.center() : Vector3f{};
+                vpId = getViewerInstance().getHoveredViewportId();
+            }
+
+            const auto& vp = getViewerInstance().viewport( vpId );
+            auto screenPos = getViewerInstance().viewportToScreen( vp.projectToViewportSpace( centerPoint ), vpId );
+
+            auto drawList = ImGui::GetBackgroundDrawList();
+            drawList->AddCircleFilled( ImVec2( screenPos.x, screenPos.y ), menuScaling * deadZonePixelRadius_, Color::gray().scaledAlpha( 0.5f ).getUInt32() );
+            if ( deadZonePixelRadius_ * 0.5f > 4.0f )
+            {
+                drawList->AddCircleFilled( ImVec2( screenPos.x, screenPos.y ), menuScaling * 4.0f, Color::red().getUInt32() );
+            }
+        }
+    }
+
     if ( !isMoving() )
         return;
     if ( transformMode_ != TransformMode::None )
@@ -64,23 +109,41 @@ bool MoveObjectByMouseImpl::onMouseDown( MouseButton button, int modifiers )
 
     currentButton_ = button;
     screenStartPoint_ = minDistance() > 0 ? viewer.mouseController().getMousePos() : cNoPoint;
+
+    auto viewportStartPoint = viewport.projectToViewportSpace( worldStartPoint_ );
+    viewportStartPointZ_ = viewportStartPoint.z;
+
+    Vector3f viewportCenterPoint;
+    if ( transformMode_ == TransformMode::Rotation || transformMode_ == TransformMode::Scale )
+    {
+        viewportCenterPoint = viewport.projectToViewportSpace( xfCenterPoint_ );
+
+        if ( deadZonePixelRadius_ > 0.0f )
+        {
+            float realDeadZone = deadZonePixelRadius_;
+            if ( const auto& menu = viewer.getMenuPlugin() )
+                realDeadZone *= menu->menu_scaling();
+            if ( to2dim( viewportStartPoint - viewportCenterPoint ).lengthSq() <= sqr( realDeadZone ) )
+            {
+                clear_();
+                return false;
+            }
+        }
+    }
+
     angle_ = 0.f;
     shift_ = 0.f;
     scale_ = 1.f;
     currentXf_ = {};
-    viewportStartPointZ_ = viewport.projectToViewportSpace( worldStartPoint_ ).z;
     initialXfs_.clear();
     for ( std::shared_ptr<Object>& obj : objects_ )
         initialXfs_.push_back( obj->worldXf() );
 
     if ( transformMode_ == TransformMode::Rotation )
     {
-        Vector3f viewportCenterPoint = viewport.projectToViewportSpace( xfCenterPoint_ );
-
         Line3f centerAxis = viewport.unprojectPixelRay( Vector2f( viewportCenterPoint.x, viewportCenterPoint.y ) );
         referencePlane_ = Plane3f::fromDirAndPt( centerAxis.d.normalized(), xfCenterPoint_ );
 
-        Vector3f viewportStartPoint = viewport.projectToViewportSpace( worldStartPoint_ );
         Line3f startAxis = viewport.unprojectPixelRay( Vector2f( viewportStartPoint.x, viewportStartPoint.y ) );
 
         if ( auto crossPL = intersection( referencePlane_, startAxis ) )
@@ -92,12 +155,9 @@ bool MoveObjectByMouseImpl::onMouseDown( MouseButton button, int modifiers )
     }
     else if ( transformMode_ == TransformMode::Scale )
     {
-        Vector3f viewportCenterPoint = viewport.projectToViewportSpace( xfCenterPoint_ );
-
         Line3f centerAxis = viewport.unprojectPixelRay( Vector2f( viewportCenterPoint.x, viewportCenterPoint.y ) );
         referencePlane_ = Plane3f::fromDirAndPt( centerAxis.d.normalized(), xfCenterPoint_ );
 
-        Vector3f viewportStartPoint = viewport.projectToViewportSpace( worldStartPoint_ );
         Line3f startAxis = viewport.unprojectPixelRay( Vector2f( viewportStartPoint.x, viewportStartPoint.y ) );
 
         if ( auto crossPL = intersection( referencePlane_, startAxis ) )
@@ -249,7 +309,7 @@ MoveObjectByMouseImpl::TransformMode MoveObjectByMouseImpl::pick_( MouseButton b
     return mode;
 }
 
-ObjAndPick MoveObjectByMouseImpl::pickObjects_( std::vector<std::shared_ptr<Object>>& objects, int /*modifiers*/ )
+ObjAndPick MoveObjectByMouseImpl::pickObjects_( std::vector<std::shared_ptr<Object>>& objects, int /*modifiers*/ ) const
 {
     Viewer& viewer = getViewerInstance();
     Viewport& viewport = viewer.viewport( viewer.getHoveredViewportId() );
@@ -265,14 +325,23 @@ ObjAndPick MoveObjectByMouseImpl::pickObjects_( std::vector<std::shared_ptr<Obje
     return res;
 }
 
-MoveObjectByMouseImpl::TransformMode MoveObjectByMouseImpl::modeFromPick_( MouseButton button, int modifiers )
+MoveObjectByMouseImpl::TransformMode MoveObjectByMouseImpl::modeFromPickModifiers_( int modifiers ) const
 {
-    if ( !( button == MouseButton::Left && ( modifiers == 0 || modifiers == GLFW_MOD_CONTROL ) ) )
-        return TransformMode::None;
-    return modifiers == 0 ? TransformMode::Translation : TransformMode::Rotation;
+    if ( modifiers == 0 )
+        return TransformMode::Translation;
+    else if ( modifiers == GLFW_MOD_CONTROL )
+        return TransformMode::Rotation;
+    return TransformMode::None;
 }
 
-void MoveObjectByMouseImpl::setStartPoint_( const ObjAndPick& objPick, Vector3f& startPoint )
+MoveObjectByMouseImpl::TransformMode MoveObjectByMouseImpl::modeFromPick_( MouseButton button, int modifiers ) const
+{
+    if ( button != MouseButton::Left )
+        return TransformMode::None;
+    return modeFromPickModifiers_( modifiers );
+}
+
+void MoveObjectByMouseImpl::setStartPoint_( const ObjAndPick& objPick, Vector3f& startPoint ) const
 {
     const auto& [obj, pick] = objPick;
     if ( !obj )
@@ -285,7 +354,7 @@ void MoveObjectByMouseImpl::setStartPoint_( const ObjAndPick& objPick, Vector3f&
     // startPoint = viewport.unprojectPixelRay( Vector2f( viewportPos.x, viewportPos.y ) ).project( startPoint );
 }
 
-Box3f MoveObjectByMouseImpl::getBbox_( const std::vector<std::shared_ptr<Object>>& objects )
+Box3f MoveObjectByMouseImpl::getBbox_( const std::vector<std::shared_ptr<Object>>& objects ) const
 {
     Box3f worldBbox;
     for ( const std::shared_ptr<Object>& obj : objects )

--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -63,19 +63,26 @@ protected:
         Scale
     };
 
+    /// if this value is > 0.0f then Rotation and Scale, will be blocked in this zone around xf center
+    /// (this value IS automatically modified by menuScaling)
+    float deadZonePixelRadius_{ 20.0f };
+
     /// This function is called from `onMouseMove` to update current active objects
     /// `objects` - list of objects to be affected by transformation
-    MRVIEWER_API virtual ObjAndPick pickObjects_( std::vector<std::shared_ptr<Object>>& objects, int modifiers );
+    MRVIEWER_API virtual ObjAndPick pickObjects_( std::vector<std::shared_ptr<Object>>& objects, int modifiers ) const;
+
+    /// Helper function to determine TransformMode based on modifiers
+    MRVIEWER_API virtual TransformMode modeFromPickModifiers_( int modifiers ) const;
 
     /// this function is called from `onMouseDown` to verify if pick should proceed, if None is returned - `onMouseDown` is canceled
-    MRVIEWER_API virtual TransformMode modeFromPick_( MouseButton button, int modifiers );
+    MRVIEWER_API virtual TransformMode modeFromPick_( MouseButton button, int modifiers ) const;
 
     /// `startPoint` - a point under cursor for transform calculation, can be the picked point or else (world coordinates)
-    MRVIEWER_API virtual void setStartPoint_( const ObjAndPick& pick, Vector3f& startPoint );
+    MRVIEWER_API virtual void setStartPoint_( const ObjAndPick& pick, Vector3f& startPoint ) const;
 
     /// Helper function to calculate world bounding box for several objects
     /// Note: can be invalid (feature objects give an invalid box etc.)
-    MRVIEWER_API Box3f getBbox_( const std::vector<std::shared_ptr<Object>>& objects );
+    MRVIEWER_API Box3f getBbox_( const std::vector<std::shared_ptr<Object>>& objects ) const;
 
 private:
     int minDistance_ = 0;

--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -63,7 +63,7 @@ protected:
         Scale
     };
 
-    /// if this value is > 0.0f then Rotation and Scale, will be blocked in this zone around xf center
+    /// if this value is > 0.0f, then Rotation and Scale will be blocked in this zone around xf center
     /// (this value IS automatically modified by menuScaling)
     float deadZonePixelRadius_{ 20.0f };
 


### PR DESCRIPTION
Dead zone can block rotation or scaling if it started too close to center, also highlighted in UI