### PR TITLE
Better error message for mesh loading from unsupported file extensions

### DIFF
--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -745,10 +745,15 @@ Expected<Mesh> fromAnySupportedFormat( const std::filesystem::path& file, const 
     auto loader = getMeshLoader( ext );
     if ( !loader.fileLoad )
     {
+        if ( loader.streamLoad )
+        {
+            std::ifstream in( file, std::ifstream::binary );
+            if ( !in )
+                return unexpected( std::string( "Cannot open file for reading " ) + utf8string( file ) );
+            return addFileNameInError( loader.streamLoad( in, settings ), file );
+        }
         // the error string must start with stringUnsupportedFileExtension()
         std::string err = fmt::format( "{} {} for mesh loading.", stringUnsupportedFileExtension(), ext );
-        if ( loader.streamLoad )
-            return unexpected( err + "\nPlease use stream opening version of mesh loading." );
         if ( SceneLoad::getSceneLoader( ext ) )
             return unexpected( err + "\nPlease open this format using scene loading function." );
         return unexpected( err );

--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -744,7 +744,15 @@ Expected<Mesh> fromAnySupportedFormat( const std::filesystem::path& file, const 
 
     auto loader = getMeshLoader( ext );
     if ( !loader.fileLoad )
-        return unexpectedUnsupportedFileExtension();
+    {
+        // the error string must start with stringUnsupportedFileExtension()
+        std::string err = fmt::format( "{} {} for mesh loading.", stringUnsupportedFileExtension(), ext );
+        if ( loader.streamLoad )
+            return unexpected( err + "\nPlease use stream opening version of mesh loading." );
+        if ( SceneLoad::getSceneLoader( ext ) )
+            return unexpected( err + "\nPlease open this format using scene loading function." );
+        return unexpected( err );
+    }
 
     return loader.fileLoad( file, settings );
 }
@@ -757,7 +765,15 @@ Expected<Mesh> fromAnySupportedFormat( std::istream& in, const std::string& exte
 
     auto loader = getMeshLoader( ext );
     if ( !loader.streamLoad )
-        return unexpectedUnsupportedFileExtension();
+    {
+        // the error string must start with stringUnsupportedFileExtension()
+        std::string err = fmt::format( "{} {} for mesh loading.", stringUnsupportedFileExtension(), ext );
+        if ( loader.fileLoad )
+            return unexpected( err + "\nPlease use file opening version of mesh loading." );
+        if ( SceneLoad::getSceneLoader( ext ) )
+            return unexpected( err + "\nPlease open this format using scene loading function." );
+        return unexpected( err );
+    }
 
     return loader.streamLoad( in, settings );
 }

--- a/source/MRMesh/MRObjectLoad.cpp
+++ b/source/MRMesh/MRObjectLoad.cpp
@@ -335,7 +335,7 @@ Expected<LoadedObjects> loadObjectFromFile( const std::filesystem::path& filenam
             maybe->obj->select( true );
             result = LoadedObjects{ .objs = { maybe->obj }, .warnings = std::move( std::move( maybe->warnings ) ) };
         }
-        else if ( maybe.error() != stringUnsupportedFileExtension() )
+        else if ( !maybe.error().starts_with( stringUnsupportedFileExtension() ) )
             result = unexpected( std::move( maybe.error() ) );
     }
 


### PR DESCRIPTION
Currently the error message is simply `Unsupported file extension`.

After this change 
1. The error message will at least include requested extension and requested operation, e.g. `Unsupported file extension *.xyz for mesh loading.`
2. And for formats that cannot be open as meshes, but can be open as scenes the error will be
```
Unsupported file extension *.glb for mesh loading.
Please open this format using scene loading function.
```
3. Also added clarification for formats that can be open only from files.

If the user tries to open a file, but only stream loader is available, then it will be done without error as previously.