### PR TITLE
fillPlanarHole( ObjectMeshData& data, std::vector<EdgeLoop>& holeContours )

### DIFF
--- a/source/MRMesh/MRFillContours2D.h
+++ b/source/MRMesh/MRFillContours2D.h
@@ -21,9 +21,9 @@ MRMESH_API Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>&
 MRMESH_API AffineXf3f getXfFromOxyPlane( const Contours3f& contours );
 MRMESH_API AffineXf3f getXfFromOxyPlane( const Mesh& mesh, const std::vector<EdgePath>& paths );
 
-/// given an ObjectMesh and the contours of a planar hole in it,
-/// fills the hole using fillContours2D function and updates object's attributes;
-/// if some contours were not closed on input, then closes them by adding a bridge edge in each
-MRMESH_API Expected<void> fillPlanarHole( ObjectMesh& obj, std::vector<EdgeLoop>& holeContours );
+/// given an ObjectMeshData and the contours of a planar hole in it,
+/// fills the hole using fillContours2D function and updates all per-element attributes;
+/// if some contours were not closed on input, then it closes them by adding a bridge edge in each
+MRMESH_API Expected<void> fillPlanarHole( ObjectMeshData& data, std::vector<EdgeLoop>& holeContours );
 
 } //namespace MR


### PR DESCRIPTION
`fillPlanarHole` operates with `ObjectMeshData` instead of `ObjectMesh`