### PR TITLE
extractPlaneSections optimized with AABB-trees

### DIFF
--- a/source/MRMesh/MRExtractIsolines.h
+++ b/source/MRMesh/MRExtractIsolines.h
@@ -24,10 +24,10 @@ namespace MR
     const VertScalars & vertValues, float isoValue, const FaceBitSet * region = nullptr );
 
 /// extracts all plane sections of given mesh
-[[nodiscard]] MRMESH_API PlaneSections extractPlaneSections( const MeshPart & mp, const Plane3f & plane );
+[[nodiscard]] MRMESH_API PlaneSections extractPlaneSections( const MeshPart & mp, const Plane3f & plane, UseAABBTree u = UseAABBTree::Yes );
 
 /// quickly returns true if extractPlaneSections produce not-empty set for the same arguments
-[[nodiscard]] MRMESH_API bool hasAnyPlaneSection( const MeshPart & mp, const Plane3f & plane );
+[[nodiscard]] MRMESH_API bool hasAnyPlaneSection( const MeshPart & mp, const Plane3f & plane, UseAABBTree u = UseAABBTree::Yes );
 
 /// extracts all sections of given mesh with the plane z=zLevel
 [[nodiscard]] MRMESH_API PlaneSections extractXYPlaneSections( const MeshPart & mp, float zLevel, UseAABBTree u = UseAABBTree::Yes );

--- a/source/MRMesh/MRMeshIntersect.cpp
+++ b/source/MRMesh/MRMeshIntersect.cpp
@@ -7,8 +7,7 @@
 #include "MRPrecisePredicates3.h"
 #include "MRVector3.h"
 #include "MRLine3.h"
-#include "MRMakeSphereMesh.h"
-#include "MRGTest.h"
+#include "MRPlane3.h"
 #include "MRMeshBuilder.h"
 #include "MRParallelFor.h"
 #include "MRBitSetParallelFor.h"
@@ -23,10 +22,9 @@ MeshIntersectionResult meshRayIntersect_( const MeshPart& meshPart, const Line3<
     T rayStart, T rayEnd, const IntersectionPrecomputes<T>& prec, bool closestIntersect, const FacePredicate & validFaces )
 {
     const auto& m = meshPart.mesh;
-    constexpr int maxTreeDepth = 32;
     const auto& tree = m.getAABBTree();
     MeshIntersectionResult res;
-    if( tree.nodes().size() == 0 )
+    if( tree.nodes().empty() )
         return res;
 
     RayOrigin<T> rayOrigin{ line.p };
@@ -34,6 +32,7 @@ MeshIntersectionResult meshRayIntersect_( const MeshPart& meshPart, const Line3<
     if( !rayBoxIntersect( Box3<T>{ tree[tree.rootNodeId()].box }, rayOrigin, s, e, prec ) )
         return res;
 
+    constexpr int maxTreeDepth = 32;
     std::pair< NodeId,T> nodesStack[maxTreeDepth];
     int currentNode = 0;
     nodesStack[0] = { tree.rootNodeId(), rayStart };
@@ -256,9 +255,8 @@ void rayMeshIntersectAll_( const MeshPart& meshPart, const Line3<T>& line, MeshI
         return;
 
     const auto& m = meshPart.mesh;
-    constexpr int maxTreeDepth = 32;
     const auto& tree = m.getAABBTree();
-    if( tree.nodes().size() == 0 )
+    if( tree.nodes().empty() )
         return;
 
     RayOrigin<T> rayOrigin{ line.p };
@@ -268,6 +266,7 @@ void rayMeshIntersectAll_( const MeshPart& meshPart, const Line3<T>& line, MeshI
         return;
     }
 
+    constexpr int maxTreeDepth = 32;
     NodeId nodesStack[maxTreeDepth];
     int currentNode = 0;
     nodesStack[0] = tree.rootNodeId();
@@ -387,6 +386,85 @@ void rayMeshIntersectAll( const MeshPart& meshPart, const Line3d& line, MeshInte
     }
 }
 
+void planeMeshIntersect( const MeshPart& meshPart, const Plane3f & plane,
+    FaceBitSet * fs, UndirectedEdgeBitSet * ues, VertBitSet * vs, std::vector<FaceId> * fsVec )
+{
+    MR_TIMER
+    assert( fs || ues || vs || fsVec );
+
+    const auto& m = meshPart.mesh;
+    const auto& tree = m.getAABBTree();
+    if( tree.nodes().empty() )
+        return;
+
+    assert( !fs  || fs->size()  >= m.topology.faceSize() );
+    assert( !ues || ues->size() >= m.topology.undirectedEdgeSize() );
+    assert( !vs  || vs->size()  >= m.topology.vertSize() );
+
+    constexpr int maxTreeDepth = 32;
+    NodeId nodesStack[maxTreeDepth];
+    int currentNode = -1;
+
+    auto minCorner = Box3f::getMinBoxCorner( plane.n );
+    auto maxCorner = minCorner;
+    for ( auto & v : maxCorner )
+        v = !v;
+
+    auto addNode = [&]( NodeId nid )
+    {
+        const auto & box = tree[nid].box;
+        if ( dot( plane.n, box.corner( minCorner ) ) > plane.d )
+            return;
+        if ( dot( plane.n, box.corner( maxCorner ) ) < plane.d )
+            return;
+        nodesStack[++currentNode] = nid;
+    };
+    addNode( tree.rootNodeId() );
+
+    while( currentNode >= 0 )
+    {
+        if( currentNode >= maxTreeDepth ) // max depth exceeded
+        {
+            spdlog::critical( "Maximal AABBTree depth reached!" );
+            assert( false );
+            break;
+        }
+
+        const auto& node = tree[nodesStack[currentNode--]];
+        if( node.leaf() )
+        {
+            auto face = node.leafId();
+            if( !meshPart.region || meshPart.region->test( face ) )
+            {
+                if ( fs )
+                    fs->set( face );
+                if ( fsVec )
+                    fsVec->push_back( face );
+                if ( ues || vs )
+                {
+                    EdgeId e0, e1, e2;
+                    m.topology.getTriEdges( face, e0, e1, e2 );
+                    if ( ues )
+                    {
+                        ues->set( e0 );
+                        ues->set( e1 );
+                        ues->set( e2 );
+                    }
+                    if ( vs )
+                    {
+                        vs->set( m.topology.org( e0 ) );
+                        vs->set( m.topology.org( e1 ) );
+                        vs->set( m.topology.org( e2 ) );
+                    }
+                }
+            }
+            continue;
+        }
+        addNode( node.r ); // push first to go there later
+        addNode( node.l );
+    }
+}
+
 void xyPlaneMeshIntersect( const MeshPart& meshPart, float zLevel,
     FaceBitSet * fs, UndirectedEdgeBitSet * ues, VertBitSet * vs, std::vector<FaceId> * fsVec )
 {
@@ -394,15 +472,15 @@ void xyPlaneMeshIntersect( const MeshPart& meshPart, float zLevel,
     assert( fs || ues || vs || fsVec );
 
     const auto& m = meshPart.mesh;
-    constexpr int maxTreeDepth = 32;
     const auto& tree = m.getAABBTree();
-    if( tree.nodes().size() == 0 )
+    if( tree.nodes().empty() )
         return;
 
     assert( !fs  || fs->size()  >= m.topology.faceSize() );
     assert( !ues || ues->size() >= m.topology.undirectedEdgeSize() );
     assert( !vs  || vs->size()  >= m.topology.vertSize() );
 
+    constexpr int maxTreeDepth = 32;
     NodeId nodesStack[maxTreeDepth];
     int currentNode = -1;
 
@@ -455,26 +533,6 @@ void xyPlaneMeshIntersect( const MeshPart& meshPart, float zLevel,
         }
         addNode( node.r ); // push first to go there later
         addNode( node.l );
-    }
-}
-
-TEST(MRMesh, MeshIntersect) 
-{
-    Mesh sphere = makeUVSphere( 1, 8, 8 );
-
-    std::vector<MeshIntersectionResult> allFound;
-    auto callback = [&allFound]( const MeshIntersectionResult & found ) -> bool
-    {
-        allFound.push_back( found );
-        return true;
-    };
-
-    Vector3f d{ 1, 2, 3 };
-    rayMeshIntersectAll( sphere, { 2.0f * d, -d.normalized() }, callback );
-    ASSERT_EQ( allFound.size(), 2 );
-    for ( const auto & found : allFound )
-    {
-        ASSERT_NEAR( found.proj.point.length(), 1.0f, 0.05f ); //our sphere is very approximate
     }
 }
 

--- a/source/MRMesh/MRMeshIntersect.h
+++ b/source/MRMesh/MRMeshIntersect.h
@@ -108,6 +108,15 @@ MRMESH_API void rayMeshIntersectAll( const MeshPart& meshPart, const Line3f& lin
 MRMESH_API void rayMeshIntersectAll( const MeshPart& meshPart, const Line3d& line, MeshIntersectionCallback callback,
     double rayStart = 0.0, double rayEnd = DBL_MAX, const IntersectionPrecomputes<double>* prec = nullptr );
 
+/// given mesh part and arbitrary plane, outputs
+/// \param fs  triangles from boxes crossed or touched by the plane
+/// \param ues edges of these triangles
+/// \param vs  vertices of these triangles
+/// \param fsVec triangles from boxes crossed or touched by the plane in unspecified order
+MRMESH_API void planeMeshIntersect( const MeshPart& meshPart, const Plane3f & plane,
+    FaceBitSet * fs, UndirectedEdgeBitSet * ues, VertBitSet * vs,
+    std::vector<FaceId> * fsVec = nullptr );
+
 /// given mesh part and plane z=zLevel, outputs
 /// \param fs  triangles crossed or touched by the plane
 /// \param ues edges of these triangles

--- a/source/MRTest/MRMeshIntersectTests.cpp
+++ b/source/MRTest/MRMeshIntersectTests.cpp
@@ -1,0 +1,30 @@
+#include <MRMesh/MRGTest.h>
+#include <MRMesh/MRMakeSphereMesh.h>
+#include <MRMesh/MRMesh.h>
+#include <MRMesh/MRMeshIntersect.h>
+#include <MRMesh/MRLine3.h>
+
+namespace MR
+{
+
+TEST(MRMesh, MeshIntersect) 
+{
+    Mesh sphere = makeUVSphere( 1, 8, 8 );
+
+    std::vector<MeshIntersectionResult> allFound;
+    auto callback = [&allFound]( const MeshIntersectionResult & found ) -> bool
+    {
+        allFound.push_back( found );
+        return true;
+    };
+
+    Vector3f d{ 1, 2, 3 };
+    rayMeshIntersectAll( sphere, { 2.0f * d, -d.normalized() }, callback );
+    ASSERT_EQ( allFound.size(), 2 );
+    for ( const auto & found : allFound )
+    {
+        ASSERT_NEAR( found.proj.point.length(), 1.0f, 0.05f ); //our sphere is very approximate
+    }
+}
+
+} //namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -17,6 +17,7 @@
     <ClCompile Include="MRChunkIterator.cpp" />
     <ClCompile Include="MRExampleTest.cpp" />
     <ClCompile Include="MRExtractIsolinesTests.cpp" />
+    <ClCompile Include="MRMeshIntersectTests.cpp" />
     <ClCompile Include="MRMeshLoadSaveTest.cpp" />
     <ClCompile Include="MRMeshTests.cpp" />
     <ClCompile Include="MRNaNTest.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -58,6 +58,9 @@
     <ClCompile Include="MRBoxTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRMeshIntersectTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />

--- a/source/mrmeshpy/MRPythonMeshPlugins.cpp
+++ b/source/mrmeshpy/MRPythonMeshPlugins.cpp
@@ -248,8 +248,13 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, MeshMeshSignedDistanceResult, [] ( pybind11:
 
 MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, PlaneSections, [] ( pybind11::module_& m )
 {
+    pybind11::enum_<MR::UseAABBTree>( m, "UseAABBTree", "Determines the usage of AABB-tree in a function" ).
+        value( "No", MR::UseAABBTree::No, "AABB-tree of the mesh will not be used, even if it is available" ).
+        value( "Yes", MR::UseAABBTree::Yes, "AABB-tree of the mesh will be used even if it has to be constructed" ).
+        value( "YesIfAlreadyConstructed", MR::UseAABBTree::YesIfAlreadyConstructed, "AABB-tree of the mesh will be used if it was previously constructed and available, and will not be used otherwise" );
+
     m.def( "extractPlaneSections", &extractPlaneSections,
-        pybind11::arg( "mp" ), pybind11::arg( "plane" ),
+        pybind11::arg( "mp" ), pybind11::arg( "plane" ), pybind11::arg( "u" ) = MR::UseAABBTree::Yes,
         "extracts all plane sections of given mesh" );
 
     m.def( "planeSectionsToContours2f", &planeSectionsToContours2f,


### PR DESCRIPTION
* The functions `extractPlaneSections` and `hasAnyPlaneSection` use AABB-tree by default for better performance.
* New function `planeMeshIntersect` for finding boxes intersected by a plane.
* `TEST(MRMesh, MeshIntersect)` moved in MRTest project