### PR TITLE
extractXYPlaneSections: option to use or not the tree

### DIFF
--- a/source/MRMesh/MRExtractIsolines.h
+++ b/source/MRMesh/MRExtractIsolines.h
@@ -29,13 +29,11 @@ namespace MR
 /// quickly returns true if extractPlaneSections produce not-empty set for the same arguments
 [[nodiscard]] MRMESH_API bool hasAnyPlaneSection( const MeshPart & mp, const Plane3f & plane );
 
-/// extracts all sections of given mesh with the plane z=zLevel;
-/// this function works faster than general extractPlaneSections(...) for the same plane
-/// if the sections cross relatively small number of mesh triangles and AABB tree has already been constructed
-[[nodiscard]] MRMESH_API PlaneSections extractXYPlaneSections( const MeshPart & mp, float zLevel );
+/// extracts all sections of given mesh with the plane z=zLevel
+[[nodiscard]] MRMESH_API PlaneSections extractXYPlaneSections( const MeshPart & mp, float zLevel, UseAABBTree u = UseAABBTree::Yes );
 
 /// quickly returns true if extractXYPlaneSections produce not-empty set for the same arguments
-[[nodiscard]] MRMESH_API bool hasAnyXYPlaneSection( const MeshPart & mp, float zLevel );
+[[nodiscard]] MRMESH_API bool hasAnyXYPlaneSection( const MeshPart & mp, float zLevel, UseAABBTree u = UseAABBTree::Yes );
 
 /// finds all intersected triangles by the plane z=zLevel
 /// \return the section's line segment within each such triangle;

--- a/source/MRTest/MRExtractIsolinesTests.cpp
+++ b/source/MRTest/MRExtractIsolinesTests.cpp
@@ -91,11 +91,17 @@ TEST( MRMesh, ExtractXYPlaneSections )
 {
     Mesh mesh = MR::makeCube( Vector3f::diagonal( 1.F ), Vector3f() );
 
-    auto res = extractXYPlaneSections( mesh, -0.5f );
+    EXPECT_FALSE( hasAnyXYPlaneSection( mesh, -0.5f, UseAABBTree::No ) );
+    EXPECT_FALSE( hasAnyXYPlaneSection( mesh, -0.5f, UseAABBTree::Yes ) );
+    auto res = extractXYPlaneSections( mesh, -0.5f, UseAABBTree::No );
+    EXPECT_EQ( res, extractXYPlaneSections( mesh, -0.5f, UseAABBTree::Yes ) );
     EXPECT_EQ( res.size(), 0 );
 
     const auto testLevel = 0.5f;
-    res = extractXYPlaneSections( mesh, testLevel );
+    EXPECT_TRUE( hasAnyXYPlaneSection( mesh, testLevel, UseAABBTree::No ) );
+    EXPECT_TRUE( hasAnyXYPlaneSection( mesh, testLevel, UseAABBTree::Yes ) );
+    res = extractXYPlaneSections( mesh, testLevel, UseAABBTree::No );
+    EXPECT_EQ( res, extractXYPlaneSections( mesh, testLevel, UseAABBTree::Yes ) );
     EXPECT_EQ( res.size(), 1 );
     EXPECT_EQ( res[0].size(), 9 );
     EXPECT_EQ( res[0].front(), res[0].back() );
@@ -110,7 +116,10 @@ TEST( MRMesh, ExtractXYPlaneSections )
     FaceBitSet fs;
     fs.autoResizeSet( 5_f );
     fs.set( 2_f );
-    res = extractXYPlaneSections( { mesh, &fs }, testLevel );
+    EXPECT_TRUE( hasAnyXYPlaneSection( { mesh, &fs }, testLevel, UseAABBTree::No ) );
+    EXPECT_TRUE( hasAnyXYPlaneSection( { mesh, &fs }, testLevel, UseAABBTree::Yes ) );
+    res = extractXYPlaneSections( { mesh, &fs }, testLevel, UseAABBTree::No );
+    EXPECT_EQ( res, extractXYPlaneSections( { mesh, &fs }, testLevel, UseAABBTree::Yes ) );
     EXPECT_EQ( res.size(), 1 );
     EXPECT_EQ( res[0].size(), 3 );
     EXPECT_NE( res[0].front(), res[0].back() );


### PR DESCRIPTION
```
[[nodiscard]] MRMESH_API PlaneSections extractXYPlaneSections( const MeshPart & mp, float zLevel, UseAABBTree u = UseAABBTree::Yes );
[[nodiscard]] MRMESH_API bool hasAnyXYPlaneSection( const MeshPart & mp, float zLevel, UseAABBTree u = UseAABBTree::Yes );