### PR TITLE
findPointsInBall improvements

### DIFF
--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -19,10 +19,11 @@ void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, float radiu
     const auto rr = sqr( r );
     neis.clear();
     findPointsInBall( cloud, { cloud.points[v], sqr( 2 * radius ) },
-        [&neis, v]( VertId n, const Vector3f& )
+        [&neis, v]( const PointsProjectionResult & found, const Vector3f&, Ball3f & )
         {
-            if ( v != n )
-                neis.push_back( n );
+            if ( v != found.vId )
+                neis.push_back( found.vId );
+            return Processing::Continue;
         } );
     for ( int i = 0; i + 1 < neis.size(); ++i )
     {

--- a/source/MRMesh/MRCloseVertices.cpp
+++ b/source/MRMesh/MRCloseVertices.cpp
@@ -23,11 +23,11 @@ std::optional<VertMap> findSmallestCloseVerticesUsingTree( const VertCoords & po
         VertId smallestCloseVert = v;
         if ( !valid || valid->test( v ) )
         {
-            findPointsInBall( tree, { points[v], closeDistSq }, [&]( VertId cv, const Vector3f& )
+            findPointsInBall( tree, { points[v], closeDistSq }, [&]( const PointsProjectionResult & found, const Vector3f &, Ball3f & )
             {
-                if ( cv == v )
-                    return;
-                smallestCloseVert = std::min( smallestCloseVert, cv );
+                if ( found.vId != v )
+                    smallestCloseVert = std::min( smallestCloseVert, found.vId );
+                return Processing::Continue;
             } );
         }
         res[v] = smallestCloseVert;
@@ -48,13 +48,15 @@ std::optional<VertMap> findSmallestCloseVerticesUsingTree( const VertCoords & po
 
         // find another closest
         smallestCloseVert = v;
-        findPointsInBall( tree, { points[v], closeDistSq }, [&]( VertId cv, const Vector3f& )
+        findPointsInBall( tree, { points[v], closeDistSq }, [&]( const PointsProjectionResult & found, const Vector3f &, Ball3f & )
         {
+            const auto cv = found.vId;
             if ( cv == v )
-                return;
+                return Processing::Continue;
             if ( res[cv] != cv )
-                return; // cv vertex is removed by itself
+                return Processing::Continue; // cv vertex is removed by itself
             smallestCloseVert = std::min( smallestCloseVert, cv );
+            return Processing::Continue;
         } );
         res[v] = smallestCloseVert;
     }

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -425,6 +425,7 @@ struct PointOnObject;
 struct MeshTriPoint;
 struct MeshProjectionResult;
 struct MeshIntersectionResult;
+struct PointsProjectionResult;
 template <typename T> struct IntersectionPrecomputes;
 
 template <typename I> struct IteratorRange;

--- a/source/MRMesh/MRMeshProject.cpp
+++ b/source/MRMesh/MRMeshProject.cpp
@@ -147,22 +147,19 @@ void findTrisInBall( const MeshPart & mp, Ball3f ball, const FoundTriCallback& f
         return tree.nodes()[n].box.getDistanceSq( ball.center );
     };
 
-    auto addSubTask = [&]( NodeId n, float boxDistSq )
+    auto addSubTask = [&]( NodeId n )
     {
-        if ( boxDistSq < ball.radiusSq ) // ball intersects the box
-        {
-            assert( stackSize < MaxStackSize );
-            subtasks[stackSize++] = n;
-        }
+        assert( stackSize < MaxStackSize );
+        subtasks[stackSize++] = n;
     };
 
-    addSubTask( tree.rootNodeId(), boxDistSq( tree.rootNodeId() ) );
+    addSubTask( tree.rootNodeId() );
 
     while( stackSize > 0 )
     {
         const auto n = subtasks[--stackSize];
         const auto & node = tree[n];
-        if ( !( boxDistSq( n ) < ball.radiusSq ) ) // check again in case the ball has changed
+        if ( !( boxDistSq( n ) < ball.radiusSq ) )
             continue;
 
         if ( node.leaf() )
@@ -197,13 +194,13 @@ void findTrisInBall( const MeshPart & mp, Ball3f ball, const FoundTriCallback& f
         /// first go in the node located closer to ball's center (in case the ball will shrink and the other node will be away)
         if ( lDistSq <= rDistSq )
         {
-            addSubTask( node.r, rDistSq );
-            addSubTask( node.l, lDistSq );
+            addSubTask( node.r );
+            addSubTask( node.l );
         }
         else
         {
-            addSubTask( node.l, lDistSq );
-            addSubTask( node.r, rDistSq );
+            addSubTask( node.l );
+            addSubTask( node.r );
         }
     }
 }

--- a/source/MRMesh/MRPointCloudRadius.cpp
+++ b/source/MRMesh/MRPointCloudRadius.cpp
@@ -65,13 +65,14 @@ bool dilateRegion( const PointCloud& pointCloud, VertBitSet& region, float dilat
 
         const Vector3f point = xf ? (*xf)( pointCloud.points[testVertex] ) : pointCloud.points[testVertex];
 
-        findPointsInBall( pointCloud, { point, dilationSq }, [&] ( VertId v, const Vector3f& )
+        findPointsInBall( pointCloud, { point, dilationSq }, [&] ( const PointsProjectionResult & found, const Vector3f&, Ball3f & )
         {
-            if ( regionCopy.test( testVertex ) )
-                return;
-
-            if ( region.test( v ) )
+            if ( region.test( found.vId ) )
+            {
                 regionCopy.set( testVertex, true );
+                return Processing::Stop;
+            }
+            return Processing::Continue;
         }, xf );
     }, cb );
 
@@ -93,13 +94,14 @@ bool erodeRegion( const PointCloud& pointCloud, VertBitSet& region, float erosio
 
         const Vector3f point = xf ? ( *xf )( pointCloud.points[testVertex] ) : pointCloud.points[testVertex];
 
-        findPointsInBall( pointCloud, { point, erosionSq }, [&] ( VertId v, const Vector3f& )
+        findPointsInBall( pointCloud, { point, erosionSq }, [&] ( const PointsProjectionResult & found, const Vector3f&, Ball3f & )
         {
-            if ( !regionCopy.test( testVertex ) )
-                return;
-
-            if ( !region.test( v ) )
+            if ( region.test( found.vId ) )
+            {
                 regionCopy.set( testVertex, false );
+                return Processing::Stop;
+            }
+            return Processing::Continue;
         }, xf );
     }, cb );
 

--- a/source/MRMesh/MRPointCloudTriangulationHelpers.cpp
+++ b/source/MRMesh/MRPointCloudTriangulationHelpers.cpp
@@ -104,10 +104,11 @@ void findNeighborsInBall( const PointCloud& pointCloud, VertId v, float radius, 
 {
     neighbors.clear();
     const auto& points = pointCloud.points;
-    findPointsInBall( pointCloud, { points[v], sqr( radius ) }, [&]( VertId vid, const Vector3f& )
+    findPointsInBall( pointCloud, { points[v], sqr( radius ) }, [&]( const PointsProjectionResult & found, const Vector3f &, Ball3f & )
     {
-        if ( vid != v )
-            neighbors.push_back( vid );
+        if ( found.vId != v )
+            neighbors.push_back( found.vId );
+        return Processing::Continue;
     } );
 }
 

--- a/source/MRMesh/MRPointsComponents.cpp
+++ b/source/MRMesh/MRPointsComponents.cpp
@@ -203,8 +203,9 @@ Expected<UnionFind<VertId>> getUnionFindStructureVerts( const PointCloud& pointC
             if ( !contains( vertsRegion, v0 ) )
                 return;
             findPointsInBall( pointCloud.getAABBTree(), { pointCloud.points[v0], maxDistSq },
-                [&] ( VertId v1, const Vector3f& )
+                [&] ( const PointsProjectionResult & found, const Vector3f &, Ball3f & )
             {
+                const auto v1 = found.vId;
                 if ( v0 < v1 && contains( vertsRegion, v1 ) )
                 {
                     if ( v1 >= range.end )
@@ -212,6 +213,7 @@ Expected<UnionFind<VertId>> getUnionFindStructureVerts( const PointCloud& pointC
                     else
                         unionFindStructure.unite( v0, v1 );
                 }
+                return Processing::Continue;
             } );
         }, subPc );
         if ( !reportProgress( subPc, 1.f ) )
@@ -225,12 +227,14 @@ Expected<UnionFind<VertId>> getUnionFindStructureVerts( const PointCloud& pointC
     for ( auto v0 : *lastPassVerts )
     {
         findPointsInBall( pointCloud.getAABBTree(), { pointCloud.points[v0], maxDistSq },
-            [&] ( VertId v1, const Vector3f& )
+            [&] ( const PointsProjectionResult & found, const Vector3f &, Ball3f & )
         {
+            const auto v1 = found.vId;
             if ( v0 < v1 && contains( vertsRegion, v1 ) )
             {
                 unionFindStructure.unite( v0, v1 );
             }
+            return Processing::Continue;
         } );
         ++counterProcessedVerts;
         if ( !reportProgress( subPc, counterProcessedVerts / counterMax, counterProcessedVerts, counterDivider ) )

--- a/source/MRMesh/MRPointsInBall.cpp
+++ b/source/MRMesh/MRPointsInBall.cpp
@@ -2,24 +2,46 @@
 #include "MRPointCloud.h"
 #include "MRMesh.h"
 #include "MRAABBTreePoints.h"
+#include "MRPointsProject.h"
 
 namespace MR
 {
 
+static auto newCallback( const FoundPointCallback& foundCallback )
+{
+    return [&foundCallback]( const PointsProjectionResult & found, const Vector3f& foundXfPos, Ball3f & )
+    {
+        foundCallback( found.vId, foundXfPos );
+        return Processing::Continue;
+    };
+};
+
+MRMESH_API void findPointsInBall( const PointCloud& pointCloud, const Ball3f & ball,
+    const OnPointInBallFound& foundCallback, const AffineXf3f* xf )
+{
+    findPointsInBall( pointCloud.getAABBTree(), ball, foundCallback, xf );
+}
+
 void findPointsInBall( const PointCloud& pointCloud, const Ball3f& ball,
     const FoundPointCallback& foundCallback, const AffineXf3f* xf )
 {
-    findPointsInBall( pointCloud.getAABBTree(), ball, foundCallback, xf );
+    findPointsInBall( pointCloud.getAABBTree(), ball, newCallback( foundCallback ), xf );
+}
+
+void findPointsInBall( const Mesh& mesh, const Ball3f& ball,
+    const OnPointInBallFound& foundCallback, const AffineXf3f* xf )
+{
+    findPointsInBall( mesh.getAABBTreePoints(), ball, foundCallback, xf );
 }
 
 void findPointsInBall( const Mesh& mesh, const Ball3f& ball,
     const FoundPointCallback& foundCallback, const AffineXf3f* xf )
 {
-    findPointsInBall( mesh.getAABBTreePoints(), ball, foundCallback, xf );
+    findPointsInBall( mesh.getAABBTreePoints(), ball, newCallback( foundCallback ), xf );
 }
 
-void findPointsInBall( const AABBTreePoints& tree, const Ball3f& ball,
-    const FoundPointCallback& foundCallback, const AffineXf3f* xf )
+void findPointsInBall( const AABBTreePoints& tree, Ball3f ball,
+    const OnPointInBallFound& foundCallback, const AffineXf3f* xf )
 {
     if ( !foundCallback )
     {
@@ -36,15 +58,19 @@ void findPointsInBall( const AABBTreePoints& tree, const Ball3f& ball,
     NodeId subtasks[MaxStackSize];
     int stackSize = 0;
 
-    auto addSubTask = [&]( NodeId n )
+    auto boxDistSq = [&]( NodeId n ) // squared distance from ball center to the transformed box with interior
     {
         const auto & box = tree.nodes()[n].box;
-        float distSq = xf ? transformed( box, *xf ).getDistanceSq( ball.center ) : box.getDistanceSq( ball.center );
-        if ( distSq <= ball.radiusSq )
+        return xf ? transformed( box, *xf ).getDistanceSq( ball.center ) : box.getDistanceSq( ball.center );
+    };
+
+    auto addSubTask = [&]( NodeId n, float boxDistSq )
+    {
+        if ( boxDistSq <= ball.radiusSq )
             subtasks[stackSize++] = n;
     };
 
-    addSubTask( tree.rootNodeId() );
+    addSubTask( tree.rootNodeId(), boxDistSq( tree.rootNodeId() ) );
 
     while ( stackSize > 0 )
     {
@@ -57,15 +83,46 @@ void findPointsInBall( const AABBTreePoints& tree, const Ball3f& ball,
             for ( int i = first; i < last; ++i )
             {
                 auto coord = xf ? ( *xf )( orderedPoints[i].coord ) : orderedPoints[i].coord;
-                if ( !ball.outside( coord ) )
-                    foundCallback( orderedPoints[i].id, coord );
+
+                const PointsProjectionResult candidate
+                {
+                    .distSq = distanceSq( coord, ball.center ),
+                    .vId = orderedPoints[i].id
+                };
+                if ( candidate.distSq < ball.radiusSq )
+                {
+                    if ( foundCallback( candidate, coord, ball ) == Processing::Stop )
+                        return;
+                }
             }
             continue;
         }
 
-        addSubTask( node.rightOrLast ); // look at right node later
-        addSubTask( node.leftOrFirst ); // look at left node first
+        auto lDistSq = boxDistSq( node.leftOrFirst );
+        auto rDistSq = boxDistSq( node.rightOrLast );
+        /// first go in the node located closer to ball's center (in case the ball will shrink and the other node will be away)
+        if ( lDistSq <= rDistSq )
+        {
+            addSubTask( node.rightOrLast, rDistSq );
+            addSubTask( node.leftOrFirst, lDistSq );
+        }
+        else
+        {
+            addSubTask( node.leftOrFirst, lDistSq );
+            addSubTask( node.rightOrLast, rDistSq );
+        }
     }
+}
+
+void findPointsInBall( const AABBTreePoints& tree, const Ball3f& ball,
+    const FoundPointCallback& foundCallback, const AffineXf3f* xf )
+{
+    if ( !foundCallback )
+    {
+        assert( false );
+        return;
+    }
+    findPointsInBall( tree, Ball3f{ ball }, newCallback( foundCallback ), xf );
 }
 
 } //namespace MR

--- a/source/MRMesh/MRPointsInBall.cpp
+++ b/source/MRMesh/MRPointsInBall.cpp
@@ -89,7 +89,7 @@ void findPointsInBall( const AABBTreePoints& tree, Ball3f ball,
                     .distSq = distanceSq( coord, ball.center ),
                     .vId = orderedPoints[i].id
                 };
-                if ( candidate.distSq < ball.radiusSq )
+                if ( candidate.distSq <= ball.radiusSq )
                 {
                     if ( foundCallback( candidate, coord, ball ) == Processing::Stop )
                         return;

--- a/source/MRMesh/MRPointsInBall.cpp
+++ b/source/MRMesh/MRPointsInBall.cpp
@@ -14,7 +14,7 @@ static auto newCallback( const FoundPointCallback& foundCallback )
         foundCallback( found.vId, foundXfPos );
         return Processing::Continue;
     };
-};
+}
 
 MRMESH_API void findPointsInBall( const PointCloud& pointCloud, const Ball3f & ball,
     const OnPointInBallFound& foundCallback, const AffineXf3f* xf )

--- a/source/MRMesh/MRPointsInBall.h
+++ b/source/MRMesh/MRPointsInBall.h
@@ -24,7 +24,7 @@ MRMESH_API void findPointsInBall( const PointCloud& pointCloud, const Ball3f & b
 /// Finds all valid points of pointCloud that are inside or on the surface of given ball
 /// \ingroup AABBTreeGroup
 /// \param xf points-to-center transformation, if not specified then identity transformation is assumed
-/*[[deprecated]]*/ MRMESH_API void findPointsInBall( const PointCloud& pointCloud, const Ball3f& ball,
+[[deprecated]] MRMESH_API void findPointsInBall( const PointCloud& pointCloud, const Ball3f& ball,
     const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr );
 
 /// Finds all valid vertices of the mesh that are inside or on the surface of given ball until callback returns Stop;
@@ -37,7 +37,7 @@ MRMESH_API void findPointsInBall( const Mesh& mesh, const Ball3f& ball,
 /// Finds all valid vertices of the mesh that are inside or on the surface of given ball
 /// \ingroup AABBTreeGroup
 /// \param xf points-to-center transformation, if not specified then identity transformation is assumed
-/*[[deprecated]]*/ MRMESH_API void findPointsInBall( const Mesh& mesh, const Ball3f& ball,
+[[deprecated]] MRMESH_API void findPointsInBall( const Mesh& mesh, const Ball3f& ball,
     const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr );
 
 /// Finds all points in tree that are inside or on the surface of given ball until callback returns Stop;
@@ -50,7 +50,7 @@ MRMESH_API void findPointsInBall( const AABBTreePoints& tree, Ball3f ball,
 /// Finds all points in tree that are inside or on the surface of given ball
 /// \ingroup AABBTreeGroup
 /// \param xf points-to-center transformation, if not specified then identity transformation is assumed
-/*[[deprecated]]*/ MRMESH_API void findPointsInBall( const AABBTreePoints& tree, const Ball3f& ball,
+[[deprecated]] MRMESH_API void findPointsInBall( const AABBTreePoints& tree, const Ball3f& ball,
     const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr );
 
 } //namespace MR

--- a/source/MRMesh/MRPointsInBall.h
+++ b/source/MRMesh/MRPointsInBall.h
@@ -3,34 +3,54 @@
 #include "MRMeshFwd.h"
 #include "MRBall.h"
 #include "MRVector3.h"
+#include "MRPointsProject.h"
+#include "MREnums.h"
 
 namespace MR
 {
 
 using FoundPointCallback = std::function<void( VertId, const Vector3f& )>;
 
+/// this callback is invoked on every point located within the ball, and allows changing the ball for search continuation
+using OnPointInBallFound = std::function<Processing( const PointsProjectionResult & found, const Vector3f & foundXfPos, Ball3f & ball )>;
+
+/// Finds all valid points of pointCloud that are inside or on the surface of given ball until callback returns Stop;
+/// the ball can shrink (new ball is always within the previous one) during the search but never expand
+/// \ingroup AABBTreeGroup
+/// \param xf points-to-center transformation, if not specified then identity transformation is assumed
+MRMESH_API void findPointsInBall( const PointCloud& pointCloud, const Ball3f & ball,
+    const OnPointInBallFound& foundCallback, const AffineXf3f* xf = nullptr );
+
 /// Finds all valid points of pointCloud that are inside or on the surface of given ball
 /// \ingroup AABBTreeGroup
 /// \param xf points-to-center transformation, if not specified then identity transformation is assumed
-MRMESH_API void findPointsInBall( const PointCloud& pointCloud, const Ball3f& ball,
+/*[[deprecated]]*/ MRMESH_API void findPointsInBall( const PointCloud& pointCloud, const Ball3f& ball,
     const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr );
-[[deprecated]] inline void findPointsInBall( const PointCloud& pointCloud, const Vector3f& center, float radius,
-    const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr ) { return findPointsInBall( pointCloud, { center, sqr( radius ) }, foundCallback, xf ); }
+
+/// Finds all valid vertices of the mesh that are inside or on the surface of given ball until callback returns Stop;
+/// the ball can shrink (new ball is always within the previous one) during the search but never expand
+/// \ingroup AABBTreeGroup
+/// \param xf points-to-center transformation, if not specified then identity transformation is assumed
+MRMESH_API void findPointsInBall( const Mesh& mesh, const Ball3f& ball,
+    const OnPointInBallFound& foundCallback, const AffineXf3f* xf = nullptr );
 
 /// Finds all valid vertices of the mesh that are inside or on the surface of given ball
 /// \ingroup AABBTreeGroup
 /// \param xf points-to-center transformation, if not specified then identity transformation is assumed
-MRMESH_API void findPointsInBall( const Mesh& mesh, const Ball3f& ball,
+/*[[deprecated]]*/ MRMESH_API void findPointsInBall( const Mesh& mesh, const Ball3f& ball,
     const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr );
-[[deprecated]] inline void findPointsInBall( const Mesh& mesh, const Vector3f& center, float radius,
-    const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr ) { return findPointsInBall( mesh, { center, sqr( radius ) }, foundCallback, xf ); }
+
+/// Finds all points in tree that are inside or on the surface of given ball until callback returns Stop;
+/// the ball can shrink (new ball is always within the previous one) during the search but never expand
+/// \ingroup AABBTreeGroup
+/// \param xf points-to-center transformation, if not specified then identity transformation is assumed
+MRMESH_API void findPointsInBall( const AABBTreePoints& tree, Ball3f ball,
+    const OnPointInBallFound& foundCallback, const AffineXf3f* xf = nullptr );
 
 /// Finds all points in tree that are inside or on the surface of given ball
 /// \ingroup AABBTreeGroup
 /// \param xf points-to-center transformation, if not specified then identity transformation is assumed
-MRMESH_API void findPointsInBall( const AABBTreePoints& tree, const Ball3f& ball,
+/*[[deprecated]]*/ MRMESH_API void findPointsInBall( const AABBTreePoints& tree, const Ball3f& ball,
     const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr );
-[[deprecated]] inline void findPointsInBall( const AABBTreePoints& tree, const Vector3f& center, float radius,
-    const FoundPointCallback& foundCallback, const AffineXf3f* xf = nullptr ) { return findPointsInBall( tree, { center, sqr( radius ) }, foundCallback, xf ); }
 
 } //namespace MR

--- a/source/MRMesh/MRUniformSampling.cpp
+++ b/source/MRMesh/MRUniformSampling.cpp
@@ -37,15 +37,14 @@ std::optional<VertBitSet> pointUniformSampling( const PointCloud& pointCloud, co
         sampled.set( v );
         const auto c = pointCloud.points[v];
         float localMaxDistSq = sqr( settings.distance );
-        findPointsInBall( pointCloud, { c, localMaxDistSq }, [&] ( VertId u, const Vector3f& pu )
+        findPointsInBall( pointCloud, { c, localMaxDistSq }, [&] ( const PointsProjectionResult & found, const Vector3f&, Ball3f & )
         {
-            const auto distSq = ( c - pu ).lengthSq();
+            const auto u = found.vId;
             if ( pNormals && std::abs( dot( (*pNormals)[v], (*pNormals)[u] ) ) < settings.minNormalDot )
-            {
-                localMaxDistSq = std::min( localMaxDistSq, distSq );
-                return;
-            }
-            nearVerts.push_back( { u, distSq } );
+                localMaxDistSq = std::min( localMaxDistSq, found.distSq );
+            else
+                nearVerts.push_back( { u, found.distSq } );
+            return Processing::Continue;
         } );
         for ( const auto & [ u, distSq ] : nearVerts )
         {

--- a/source/MRVoxels/MRPointsToDistanceVolume.cpp
+++ b/source/MRVoxels/MRPointsToDistanceVolume.cpp
@@ -29,12 +29,13 @@ FunctionVolume pointsToDistanceFunctionVolume( const PointCloud & cloud, const P
 
             float sumDist = 0;
             float sumWeight = 0;
-            findPointsInBall( cloud, { voxelCenter, ballRadiusSq }, [&]( VertId v, const Vector3f& p )
+            findPointsInBall( cloud, { voxelCenter, ballRadiusSq }, [&]( const PointsProjectionResult & found, const Vector3f & p, Ball3f & )
             {
                 const auto distSq = ( voxelCenter - p ).lengthSq();
                 const auto w = std::exp( distSq * inv2SgSq );
                 sumWeight += w;
-                sumDist += dot( normals[v], voxelCenter - p ) * w;
+                sumDist += dot( normals[found.vId], voxelCenter - p ) * w;
+                return Processing::Continue;
             } );
 
             return sumWeight >= params.minWeight ? sumDist / sumWeight : cQuietNan;
@@ -67,12 +68,13 @@ Expected<VertColors> calcAvgColors( const PointCloud & cloud, const VertColors &
 
         Vector4f sumColors;
         float sumWeight = 0;
-        findPointsInBall( cloud, { pos, ballRadiusSq }, [&]( VertId v, const Vector3f& p )
+        findPointsInBall( cloud, { pos, ballRadiusSq }, [&]( const PointsProjectionResult & found, const Vector3f & p, Ball3f & )
         {
             const auto distSq = ( pos - p ).lengthSq();
             const auto w = std::exp( distSq * inv2SgSq );
             sumWeight += w;
-            sumColors += Vector4f( colors[v] ) * w;
+            sumColors += Vector4f( colors[found.vId] ) * w;
+            return Processing::Continue;
         } );
         if ( sumWeight > 0 )
             res[tv] = Color( sumColors / sumWeight );

--- a/source/MRVoxels/MRPointsToDistanceVolume.cpp
+++ b/source/MRVoxels/MRPointsToDistanceVolume.cpp
@@ -31,8 +31,7 @@ FunctionVolume pointsToDistanceFunctionVolume( const PointCloud & cloud, const P
             float sumWeight = 0;
             findPointsInBall( cloud, { voxelCenter, ballRadiusSq }, [&]( const PointsProjectionResult & found, const Vector3f & p, Ball3f & )
             {
-                const auto distSq = ( voxelCenter - p ).lengthSq();
-                const auto w = std::exp( distSq * inv2SgSq );
+                const auto w = std::exp( found.distSq * inv2SgSq );
                 sumWeight += w;
                 sumDist += dot( normals[found.vId], voxelCenter - p ) * w;
                 return Processing::Continue;
@@ -68,10 +67,9 @@ Expected<VertColors> calcAvgColors( const PointCloud & cloud, const VertColors &
 
         Vector4f sumColors;
         float sumWeight = 0;
-        findPointsInBall( cloud, { pos, ballRadiusSq }, [&]( const PointsProjectionResult & found, const Vector3f & p, Ball3f & )
+        findPointsInBall( cloud, { pos, ballRadiusSq }, [&]( const PointsProjectionResult & found, const Vector3f &, Ball3f & )
         {
-            const auto distSq = ( pos - p ).lengthSq();
-            const auto w = std::exp( distSq * inv2SgSq );
+            const auto w = std::exp( found.distSq * inv2SgSq );
             sumWeight += w;
             sumColors += Vector4f( colors[found.vId] ) * w;
             return Processing::Continue;


### PR DESCRIPTION
`findPointsInBall` function got new callback that
* returns `Continue` or `Stop` to allow the user stop searching after any point;
* receives `distSq` inside `PointsProjectionResult` to avoid its computation on user side;
* permits shrinking the ball after any point.

Internally `findPointsInBall` first processes AABB boxes closer to sphere's center.

Old `findPointsInBall` functions are retained but deprecated.