### PR TITLE
signedDistanceToMesh: if the sign is determined by the normal at projection point then projection point must be found precisely

### DIFF
--- a/source/MRMesh/MRMeshDistance.cpp
+++ b/source/MRMesh/MRMeshDistance.cpp
@@ -22,11 +22,10 @@ std::optional<float> signedDistanceToMesh( const MeshPart& mp, const Vector3f& p
         maxDistSq = FLT_MAX;
     }
     const auto proj = findProjection( p, mp, maxDistSq, nullptr, minDistSq );
-    if ( !proj )
+    if ( !proj && op.signMode == SignDetectionMode::ProjectionNormal )
         return {}; // no projection point found
-    assert( proj.distSq < maxDistSq );
 
-    if ( op.nullOutsideMinMax && proj.distSq < minDistSq ) // note that proj.distSq == minDistSq (e.g. == 0) is a valid situation
+    if ( op.nullOutsideMinMax && ( proj.distSq < minDistSq || proj.distSq >= maxDistSq ) ) // note that proj.distSq == minDistSq (e.g. == 0) is a valid situation
         return {}; // distance is too small or too large, discard them
 
     float dist = std::sqrt( proj.distSq );

--- a/source/MRMesh/MRMeshDistance.cpp
+++ b/source/MRMesh/MRMeshDistance.cpp
@@ -12,9 +12,21 @@ namespace MR
 std::optional<float> signedDistanceToMesh( const MeshPart& mp, const Vector3f& p, const SignedDistanceToMeshOptions& op )
 {
     assert( op.signMode != SignDetectionMode::OpenVDB );
-    const auto proj = findProjection( p, mp, op.maxDistSq, nullptr, op.minDistSq );
 
-    if ( op.nullOutsideMinMax && ( proj.distSq < op.minDistSq || proj.distSq >= op.maxDistSq ) ) // note that proj.distSq == op.minDistSq (e.g. == 0) is a valid situation
+    auto minDistSq = op.minDistSq;
+    auto maxDistSq = op.maxDistSq;
+    if ( !op.nullOutsideMinMax && op.signMode == SignDetectionMode::ProjectionNormal )
+    {
+        // if the sign is determined by the normal at projection point then projection point must be found precisely
+        minDistSq = 0;
+        maxDistSq = FLT_MAX;
+    }
+    const auto proj = findProjection( p, mp, maxDistSq, nullptr, minDistSq );
+    if ( !proj )
+        return {}; // no projection point found
+    assert( proj.distSq < maxDistSq );
+
+    if ( op.nullOutsideMinMax && proj.distSq < minDistSq ) // note that proj.distSq == minDistSq (e.g. == 0) is a valid situation
         return {}; // distance is too small or too large, discard them
 
     float dist = std::sqrt( proj.distSq );

--- a/source/MRMesh/MRMeshProject.h
+++ b/source/MRMesh/MRMeshProject.h
@@ -18,10 +18,16 @@ struct MeshProjectionResult
 {
     /// the closest point on mesh, transformed by xf if it is given
     PointOnFace proj;
+
     /// its barycentric representation
     MeshTriPoint mtp;
-    /// squared distance from pt to proj
+
+    /// squared distance from original projected point to proj
     float distSq = 0;
+
+    /// check for validity, otherwise the projection was not found
+    [[nodiscard]] bool valid() const { return proj.valid(); }
+    [[nodiscard]] explicit operator bool() const { return proj.valid(); }
 };
 
 struct MeshProjectionTransforms

--- a/source/MRMesh/MRPointOnFace.h
+++ b/source/MRMesh/MRPointOnFace.h
@@ -6,11 +6,18 @@
 namespace MR
 {
 
-// point located on some mesh face
+/// a point located on some mesh's face
 struct PointOnFace
 {
+    /// mesh's face containing the point
     FaceId face;
+
+    /// a point of the mesh's face
     Vector3f point;
+
+    /// check for validity, otherwise the point is not defined
+    [[nodiscard]] bool valid() const { return face.valid(); }
+    [[nodiscard]] explicit operator bool() const { return face.valid(); }
 };
 
 } //namespace MR

--- a/source/MRMesh/MRPolylineProject.h
+++ b/source/MRMesh/MRPolylineProject.h
@@ -22,8 +22,9 @@ struct PolylineProjectionResult
     /// squared distance from pt to proj
     float distSq = 0;
 
-    /// check for validity
-    explicit operator bool() const { return line.valid(); }
+    /// check for validity, otherwise the projection was not found
+    [[nodiscard]] bool valid() const { return line.valid(); }
+    [[nodiscard]] explicit operator bool() const { return line.valid(); }
 };
 
 /**


### PR DESCRIPTION
Also adds check for validity for `PointOnFace` and `MeshProjectionResult`