### PR TITLE
Remove extensions from c# pinvoke dll name

### DIFF
--- a/source/MRDotNet/MRAffineXf.cs
+++ b/source/MRDotNet/MRAffineXf.cs
@@ -18,10 +18,10 @@ namespace MR
         /// affine transformation: y = A*x + b, where A in VxV, and b in V
         public class AffineXf3f
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRAffineXf3f mrAffineXf3fMul(ref MRAffineXf3f a, ref MRAffineXf3f b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrAffineXf3fApply(ref MRAffineXf3f xf, ref MRVector3f v);
 
             internal MRAffineXf3f xf_;

--- a/source/MRDotNet/MRBitSet.cs
+++ b/source/MRDotNet/MRBitSet.cs
@@ -10,24 +10,24 @@ namespace MR
         /// container of bits with read-only access
         public abstract class BitSetReadOnly
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ulong mrBitSetSize(IntPtr bs);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ulong mrBitSetCount(IntPtr bs);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             [return: MarshalAs(UnmanagedType.I1)]
             private static extern bool mrBitSetEq(IntPtr a, IntPtr b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             [return: MarshalAs(UnmanagedType.I1)]
             private static extern bool mrBitSetTest(IntPtr bs, ulong index);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ulong mrBitSetFindFirst(IntPtr bs);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ulong mrBitSetFindLast(IntPtr bs);
 
             internal IntPtr bs_;
@@ -83,28 +83,28 @@ namespace MR
         /// container of bits with full access
         public class BitSet : BitSetReadOnly, IDisposable
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetCopy(IntPtr bs);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetNew(ulong numBits, bool fillValue);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrBitSetSet(IntPtr bs, ulong index, bool value);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrBitSetResize(IntPtr bs, ulong size, bool value);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrBitSetAutoResizeSet(IntPtr bs, ulong pos, bool value);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetSub(IntPtr a, IntPtr b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetOr(IntPtr a, IntPtr b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrBitSetFree(IntPtr bs);
 
             /// creates empty bitset
@@ -204,13 +204,13 @@ namespace MR
         /// container of bits representing vert indices
         public class VertBitSet : BitSet
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetCopy(IntPtr bs);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetSub(IntPtr a, IntPtr b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetOr(IntPtr a, IntPtr b);
 
             internal VertBitSet(IntPtr bs) : base(bs) { }
@@ -238,13 +238,13 @@ namespace MR
         /// container of bits representing face indices
         public class FaceBitSet : BitSet
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetCopy(IntPtr bs);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetSub(IntPtr a, IntPtr b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetOr(IntPtr a, IntPtr b);
 
             internal FaceBitSet(IntPtr bs) : base(bs) { }
@@ -273,13 +273,13 @@ namespace MR
         /// container of bits representing edge indices
         public class EdgeBitSet : BitSet
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetCopy(IntPtr bs);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetSub(IntPtr a, IntPtr b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetOr(IntPtr a, IntPtr b);
 
             internal EdgeBitSet(IntPtr bs) : base(bs) { }
@@ -309,13 +309,13 @@ namespace MR
         /// container of bits representing undirected edge indices
         public class UndirectedEdgeBitSet : BitSet
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetCopy(IntPtr bs);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetSub(IntPtr a, IntPtr b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetOr(IntPtr a, IntPtr b);
 
             internal UndirectedEdgeBitSet(IntPtr bs) : base(bs) { }
@@ -345,13 +345,13 @@ namespace MR
         /// container of bits representing voxel indices
         public class VoxelBitSet : BitSet
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetCopy(IntPtr bs);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetSub(IntPtr a, IntPtr b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrBitSetOr(IntPtr a, IntPtr b);
 
             internal VoxelBitSet(IntPtr bs) : base(bs) { }

--- a/source/MRDotNet/MRBooleanResultMapper.cs
+++ b/source/MRDotNet/MRBooleanResultMapper.cs
@@ -42,18 +42,18 @@ namespace MR
 
         public class BooleanMaps
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern MRFaceMap mrBooleanResultMapperMapsCut2origin(IntPtr maps);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern MRFaceMap mrBooleanResultMapperMapsCut2newFaces(IntPtr maps);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern MRVertMap mrBooleanResultMapperMapsOld2NewVerts(IntPtr maps);
 
             /// old topology indexes are valid if true
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern bool mrBooleanResultMapperMapsIdentity(IntPtr maps);
 
             internal BooleanMaps(IntPtr maps)
@@ -144,26 +144,26 @@ namespace MR
         ///this class allows to map faces, vertices and edges of mesh `A` and mesh `B` input of MeshBoolean to result mesh topology primitives
         public class BooleanResultMapper : IDisposable
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrBooleanResultMapperNew();
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrBooleanResultMapperMapFaces(IntPtr mapper, IntPtr oldBS, MapObject obj);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrBooleanResultMapperMapVerts(IntPtr mapper, IntPtr oldBS, MapObject obj);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrBooleanResultMapperNewFaces(IntPtr mapper);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrBooleanResultMapperFilteredOldFaceBitSet(IntPtr mapper, IntPtr oldBS, MapObject obj);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrBooleanResultMapperGetMaps(IntPtr mapper, MapObject index);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrBooleanResultMapperFree(IntPtr mapper);
 
             #region constructor and destructor

--- a/source/MRDotNet/MRBox3.cs
+++ b/source/MRDotNet/MRBox3.cs
@@ -18,25 +18,25 @@ namespace MR
             };
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRBox3f mrBox3fNew();
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             [return: MarshalAs(UnmanagedType.I1)]
             private static extern bool mrBox3fValid(ref MRBox3f box);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrBox3fSize(ref MRBox3f box);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern float mrBox3fDiagonal(ref MRBox3f box);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern float mrBox3fVolume(ref MRBox3f box);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrBox3fCenter(ref MRBox3f box);
 
             MRBox3f box_;
@@ -105,22 +105,22 @@ namespace MR
             };
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRBox3i mrBox3iNew();
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             [return: MarshalAs(UnmanagedType.I1)]
             private static extern bool mrBox3iValid(ref MRBox3i box);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3i mrBox3iSize(ref MRBox3i box);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern int mrBox3iVolume(ref MRBox3i box);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3i mrBox3iCenter(ref MRBox3i box);
 
             MRBox3i box_;

--- a/source/MRDotNet/MRColor.cs
+++ b/source/MRDotNet/MRColor.cs
@@ -17,11 +17,11 @@ namespace MR
                 public MRColor() { }
             };
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRColor mrColorFromComponents(byte r, byte g, byte b, byte a);            
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRColor mrColorFromFloatComponents(float r, float g, float b, float a);
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern uint mrColorGetUInt32( ref MRColor color );
 
             internal MRColor color_;
@@ -58,13 +58,13 @@ namespace MR
                 public IntPtr reserved;
             }
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrVertColorsNew();
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrVertColorsNewSized(ulong size);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrVertColorsFree(IntPtr colors);
 
 

--- a/source/MRDotNet/MRContoursCut.cs
+++ b/source/MRDotNet/MRContoursCut.cs
@@ -82,16 +82,16 @@ namespace MR
             public MRVariableEdgeTri() { }
         };
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+        [DllImport("MRMeshC", CharSet = CharSet.Auto)]
         private static extern MROneMeshContour mrOneMeshContoursGet(IntPtr contours, ulong index);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+        [DllImport("MRMeshC", CharSet = CharSet.Auto)]
         private static extern ulong mrOneMeshContoursSize(IntPtr contours);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+        [DllImport("MRMeshC", CharSet = CharSet.Auto)]
         private static extern void mrOneMeshContoursFree(IntPtr contours);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+        [DllImport("MRMeshC", CharSet = CharSet.Auto)]
         private static extern IntPtr mrGetOneMeshIntersectionContours(IntPtr meshA, IntPtr meshB,
                                                                      IntPtr continousContours,
                                                                      bool getMeshAIntersections,

--- a/source/MRDotNet/MRConvexHull.cs
+++ b/source/MRDotNet/MRConvexHull.cs
@@ -7,10 +7,10 @@ namespace MR
 {
     public partial class DotNet
     {
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+        [DllImport("MRMeshC", CharSet = CharSet.Auto)]
         private static extern IntPtr mrMakeConvexHullFromMesh(IntPtr mesh);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+        [DllImport("MRMeshC", CharSet = CharSet.Auto)]
         private static extern IntPtr mrMakeConvexHullFromPointCloud(IntPtr pointCloud);
 
         /// computes the mesh of convex hull from given mesh

--- a/source/MRDotNet/MRCoordinateConverters.cs
+++ b/source/MRDotNet/MRCoordinateConverters.cs
@@ -19,13 +19,13 @@ namespace MR
                 public MRCoordinateConverters() { }
             }
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRCoordinateConverters mrGetVectorConverters(ref MRMeshPart a, ref MRMeshPart b, IntPtr rigidB2A);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrConvertToIntVectorFree(IntPtr conv);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrConvertToFloatVectorFree(IntPtr conv);
 
             /// creates new converters for given pair of meshes

--- a/source/MRDotNet/MRExpandShrink.cs
+++ b/source/MRDotNet/MRExpandShrink.cs
@@ -7,22 +7,22 @@ namespace MR
 {
     public partial class DotNet
     {
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern void mrExpandFaceRegion(IntPtr top, IntPtr region, int hops);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrExpandFaceRegionFromFace(IntPtr top, FaceId face, int hops);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern void mrExpandVertRegion(IntPtr top, IntPtr region, int hops);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrExpandVertRegionFromVert(IntPtr top, VertId vert, int hops);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern void mrShrinkFaceRegion(IntPtr top, IntPtr region, int hops);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern void mrShrinkVertRegion(IntPtr top, IntPtr region, int hops);
 
         /// adds to the region all faces within given number of hops (stars) from the initial region boundary

--- a/source/MRDotNet/MRFixSelfIntersections.cs
+++ b/source/MRDotNet/MRFixSelfIntersections.cs
@@ -42,15 +42,15 @@ namespace MR
                 public MRFixSelfIntersectionsSettings() { }
             };
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrStringData(IntPtr str);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrFixSelfIntersectionsGetFaces(IntPtr mesh, IntPtr cb, ref IntPtr errorString);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrFixSelfIntersectionsFix(IntPtr mesh, ref MRFixSelfIntersectionsSettings settings, ref IntPtr errorString);
 
             /// Find all self-intersections faces component-wise

--- a/source/MRDotNet/MRFreeFormDeformer.cs
+++ b/source/MRDotNet/MRFreeFormDeformer.cs
@@ -10,22 +10,22 @@ namespace MR
     {
         public class FreeFormDeformer : IDisposable
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrFreeFormDeformerNewFromMesh(IntPtr mesh, IntPtr region);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrFreeFormDeformerFree(IntPtr deformer);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrFreeFormDeformerInit(IntPtr deformer, ref MRVector3i resolution, ref MRBox3f initialBox);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrFreeFormDeformerSetRefGridPointPosition(IntPtr deformer, ref MRVector3i coordOfPointInGrid, ref MRVector3f newPos);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrFreeFormDeformerGetRefGridPointPosition(IntPtr deformer, ref MRVector3i coordOfPointInGrid);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrFreeFormDeformerApply(IntPtr deformer);
 
             internal IntPtr deformer_;

--- a/source/MRDotNet/MRICP.cs
+++ b/source/MRDotNet/MRICP.cs
@@ -221,78 +221,78 @@ namespace MR
                 public MRICPProperties() { }
             };
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ref MRICPPairData mrIPointPairsGet(IntPtr pp, ulong idx);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ulong mrIPointPairsSize(IntPtr pp);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ref MRICPPairData mrIPointPairsGetRef(IntPtr pp, ulong idx);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrICPNew(IntPtr fltObj, IntPtr refObj, float samplingVoxelSize);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrICPNewFromSamples(IntPtr fltObj, IntPtr refObj, IntPtr fltSamples, IntPtr refSamples);
 
             /// tune algorithm params before run calculateTransformation()
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrICPSetParams(IntPtr icp, ref MRICPProperties prop);
 
             /// select pairs with origin samples on both objects
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrICPSamplePoints(IntPtr icp, float samplingVoxelSize);
 
             /// automatically selects initial transformation for the floating object
             /// based on covariance matrices of both floating and reference objects;
             /// applies the transformation to the floating object and returns it
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRAffineXf3f mrICPAutoSelectFloatXf(IntPtr icp);
 
             /// recompute point pairs after manual change of transformations or parameters
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrICPUpdatePointPairs(IntPtr icp);
 
             /// returns status info string
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrICPGetStatusInfo(IntPtr icp);
 
             /// computes the number of samples able to form pairs
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ulong mrICPGetNumSamples(IntPtr icp);
 
             /// computes the number of active point pairs
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ulong mrICPGetNumActivePairs(IntPtr icp);
 
             /// computes root-mean-square deviation between points
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern float mrICPGetMeanSqDistToPoint(IntPtr icp);
 
             /// computes root-mean-square deviation from points to target planes
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern float mrICPGetMeanSqDistToPlane(IntPtr icp);
 
             /// returns current pairs formed from samples on floating object and projections on reference object
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrICPGetFlt2RefPairs(IntPtr icp);
 
             /// returns current pairs formed from samples on reference object and projections on floating object
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrICPGetRef2FltPairs(IntPtr icp);
 
             /// runs ICP algorithm given input objects, transformations, and parameters;
             /// \return adjusted transformation of the floating object to match reference object
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRAffineXf3f mrICPCalculateTransformation(IntPtr icp);
 
             /// deallocates an ICP object
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrICPFree(IntPtr icp);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrStringData(IntPtr str);
 
             /// Constructs ICP framework with given sample points on both objects

--- a/source/MRDotNet/MRIntersectionContour.cs
+++ b/source/MRDotNet/MRIntersectionContour.cs
@@ -30,13 +30,13 @@ namespace MR
                 public MRContinuousContour() { }
             }
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRContinuousContour mrContinuousContoursGet(IntPtr contours, ulong index);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ulong mrContinuousContoursSize(IntPtr contours);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrContinuousContoursFree(IntPtr contours);
 
             internal ContinousContours(IntPtr mrContours)
@@ -103,7 +103,7 @@ namespace MR
         }
         public class IntersectionContour
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrOrderIntersectionContours(IntPtr topologyA, IntPtr topologyB, IntPtr intersections);
             /// combines individual intersections into ordered contours with the properties:
             /// a. left  of contours on mesh A is inside of mesh B,

--- a/source/MRDotNet/MRMatrix3.cs
+++ b/source/MRDotNet/MRMatrix3.cs
@@ -17,28 +17,28 @@ namespace MR
                 public Vector3f.MRVector3f z;
             };
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRMatrix3f mrMatrix3fIdentity();
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRMatrix3f mrMatrix3fRotationScalar(ref MRVector3f axis, float angle);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRMatrix3f mrMatrix3fRotationVector(ref MRVector3f from, ref MRVector3f to);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRMatrix3f mrMatrix3fAdd(ref MRMatrix3f a, ref MRMatrix3f b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRMatrix3f mrMatrix3fSub(ref MRMatrix3f a, ref MRMatrix3f b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRMatrix3f mrMatrix3fMul(ref MRMatrix3f a, ref MRMatrix3f b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrMatrix3fMulVector(ref MRMatrix3f a, ref MRVector3f b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             [return: MarshalAs(UnmanagedType.I1)]
             private static extern bool mrMatrix3fEqual(ref MRMatrix3f a, ref MRMatrix3f b);
 

--- a/source/MRDotNet/MRMesh.cs
+++ b/source/MRDotNet/MRMesh.cs
@@ -164,13 +164,13 @@ namespace MR
             public MeshOrPoints obj;
             public AffineXf3f xf;
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMeshOrPointsXfFromMesh(IntPtr mesh, ref MRAffineXf3f xf);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMeshOrPointsXfFromPointCloud(IntPtr pc, ref MRAffineXf3f xf);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrMeshOrPointsXfFree(IntPtr mp);
 
             public MeshOrPointsXf(MeshOrPoints obj, AffineXf3f xf)
@@ -200,137 +200,137 @@ namespace MR
             #region C_FUNCTIONS
 
             /// tightly packs all arrays eliminating lone edges and invalid faces and vertices
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrMeshTopologyPack(IntPtr top);
 
             /// returns cached set of all valid vertices
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMeshTopologyGetValidVerts(IntPtr top);
 
             /// returns cached set of all valid faces
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMeshTopologyGetValidFaces(IntPtr top);
 
 
             /// returns three vertex ids for valid triangles (which can be accessed by FaceId),
             /// vertex ids for invalid triangles are undefined, and shall not be read
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern ref MRTriangulation mrMeshTopologyGetTriangulation(IntPtr top);
 
             /// returns the number of face records including invalid ones
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern ulong mrMeshTopologyFaceSize(IntPtr top);
             /// returns one edge with no valid left face for every boundary in the mesh
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern ref MREdgePath mrMeshTopologyFindHoleRepresentiveEdges(IntPtr top);
 
             /// gets 3 vertices of given triangular face;
             /// the vertices are returned in counter-clockwise order if look from mesh outside
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrMeshTopologyGetLeftTriVerts(IntPtr top, EdgeId a, ref VertId v0, ref VertId v1, ref VertId v2);
 
             /// returns the number of hole loops in the mesh;
             /// \param holeRepresentativeEdges optional output of the smallest edge id with no valid left face in every hole
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern int mrMeshTopologyFindNumHoles(IntPtr top, IntPtr holeRepresentativeEdges);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMeshFromTriangles(IntPtr vertexCoordinates, ulong vertexCoordinatesNum, IntPtr t, ulong tNum);
 
             /// constructs a mesh from vertex coordinates and a set of triangles with given ids;
             /// unlike simple \ref mrMeshFromTriangles it tries to resolve non-manifold vertices by creating duplicate vertices
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMeshFromTrianglesDuplicatingNonManifoldVertices(IntPtr vertexCoordinates, ulong vertexCoordinatesNum, IntPtr t, ulong tNum);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMeshPoints(IntPtr mesh);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern ulong mrMeshPointsNum(IntPtr mesh);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMakeCube(ref MRVector3f size, ref MRVector3f baseCoords);
 
             /// initializes a default instance
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern MRMakeTorusParameters mrMakeTorusParametersNew();
 
             /// creates a mesh representing a torus
             /// Z is symmetry axis of this torus
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMakeTorus(ref MRMakeTorusParameters parameters);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMakeTorusWithSelfIntersections(ref MRMakeTorusParameters parameters);
 
             /// initializes a default instance <summary>
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern MRSphereParams mrSphereParamsNew();
 
             /// creates a mesh of sphere with irregular triangulation
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMakeSphere(ref MRSphereParams parameters);
 
             /// passes through all valid vertices and finds the minimal bounding box containing all of them;
             /// if toWorld transformation is given then returns minimal bounding box in world space
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern Box3f.MRBox3f mrMeshComputeBoundingBox(IntPtr mesh, IntPtr toWorld);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrMeshTransform(IntPtr mesh, ref MRAffineXf3f xf, IntPtr region);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern double mrMeshVolume(IntPtr mesh, IntPtr region);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrMeshPackOptimally(IntPtr mesh, bool preserveAABBTree);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMeshTopology(IntPtr mesh);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMeshCopy(IntPtr mesh);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrMeshFree(IntPtr mesh);
 
             /// creates a default instance
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern MRFindProjectionParameters mrFindProjectionParametersNew();
 
             /// computes the closest point on mesh (or its region) to given point
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern MRMeshProjectionResult mrFindProjection(ref MRVector3f pt, ref MRMeshPart mp, ref MRFindProjectionParameters parameters);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrStringData(IntPtr str);
 
             /// gets total length of the string
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern ulong mrStringSize(IntPtr str);
 
             /// deallocates the string object
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrStringFree(IntPtr str);
 
             /// computes the area of given face-region (or whole mesh if region is null)
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern double mrMeshArea(IntPtr mesh, IntPtr region);
 
             /// deletes multiple given faces, also deletes adjacent edges and vertices if they were not shared by remaining faces and not in \param keepEdges
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrMeshDeleteFaces(IntPtr mesh, IntPtr fs, IntPtr keepEdges);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern float mrMeshEdgeLength(IntPtr mesh, UndirectedEdgeId e);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern float mrMeshEdgeLengthSq(IntPtr mesh, UndirectedEdgeId e);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMeshToPointCloud(IntPtr mesh, byte saveNormals, IntPtr verts);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrMeshInvalidateCaches(IntPtr mesh, bool pointsChanged);
 
 

--- a/source/MRDotNet/MRMeshBoolean.cs
+++ b/source/MRDotNet/MRMeshBoolean.cs
@@ -62,7 +62,7 @@ namespace MR
             public MRBooleanResult() { }
         }
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern MRBooleanResult mrBoolean(IntPtr meshA, IntPtr meshB, BooleanOperation operation, ref MRBooleanParameters parameters);
 
         /// Makes new mesh - result of boolean operation on mesh `A` and mesh `B`

--- a/source/MRDotNet/MRMeshBuilder.cs
+++ b/source/MRDotNet/MRMeshBuilder.cs
@@ -10,13 +10,13 @@ namespace MR
     {
         public class MeshBuilder
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             unsafe private static extern MRVertMap* mrVertMapNew();
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             unsafe private static extern void mrVertMapFree(MRVertMap* vertMap);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             unsafe private static extern int mrMeshBuilderUniteCloseVertices(IntPtr mesh, float closeDist, bool uniteOnlyBd, MRVertMap* optionalVertOldToNew);
 
             /// the function finds groups of mesh vertices located closer to each other than \param closeDist, and unites such vertices in one;

--- a/source/MRDotNet/MRMeshCollidePrecise.cs
+++ b/source/MRDotNet/MRMeshCollidePrecise.cs
@@ -17,7 +17,7 @@ namespace MR
         };
         public class PreciseCollisionResult : IDisposable
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern bool mrEdgeTriEq(ref EdgeTri a, ref EdgeTri b);
 
             [StructLayout(LayoutKind.Sequential)]
@@ -30,15 +30,15 @@ namespace MR
             };
 
             /// each edge is directed to have its origin inside and its destination outside of the other mesh
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVectorEdgeTri mrPreciseCollisionResultEdgesAtrisB(IntPtr result);
 
             /// each edge is directed to have its origin inside and its destination outside of the other mesh
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVectorEdgeTri mrPreciseCollisionResultEdgesBtrisA(IntPtr result);
 
             /// deallocates the PreciseCollisionResult object
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrPreciseCollisionResultFree(IntPtr result);
 
 
@@ -119,7 +119,7 @@ namespace MR
          * \param rigidB2A rigid transformation from B-mesh space to A mesh space, NULL considered as identity transformation
          * \param anyIntersection if true then the function returns as fast as it finds any intersection
          */
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+        [DllImport("MRMeshC", CharSet = CharSet.Auto)]
         private static extern IntPtr mrFindCollidingEdgeTrisPrecise(ref MRMeshPart a, ref MRMeshPart b, IntPtr conv, IntPtr rigidB2A, bool anyIntersection);
 
         public static PreciseCollisionResult FindCollidingEdgeTrisPrecise(MeshPart meshA, MeshPart meshB, CoordinateConverters conv, AffineXf3f? rigidB2A = null, bool anyIntersection = false)

--- a/source/MRDotNet/MRMeshComponents.cs
+++ b/source/MRDotNet/MRMeshComponents.cs
@@ -33,7 +33,7 @@ namespace MR
 
                 public int NumComponents = 0;
 
-                [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+                [DllImport("MRMeshC", CharSet = CharSet.Auto)]
                 unsafe private static extern void mrMeshComponentsAllComponentsMapFree(MRMeshComponentsMap* map);
 
                 unsafe internal MeshComponentsMap(MRMeshComponentsMap mrMap)
@@ -95,22 +95,22 @@ namespace MR
                 public MRMeshRegions() { }
             };
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrMeshComponentsGetComponent(ref MRMeshPart mp, FaceId id, FaceIncidence incidence, IntPtr cb);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             unsafe private static extern IntPtr mrMeshComponentsGetLargestComponent(ref MRMeshPart mp, FaceIncidence incidence, IntPtr cb, float minArea, int* numSmallerComponents);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrMeshComponentsGetLargeByAreaComponents(ref MRMeshPart mp, float minArea, IntPtr cb);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRMeshComponentsMap mrMeshComponentsGetAllComponentsMap(ref MRMeshPart mp, FaceIncidence incidence);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             unsafe private static extern MRMeshRegions mrMeshComponentsGetLargeByAreaRegions(ref MRMeshPart mp, MRFace2RegionMap* face2RegionMap, int numRegions, float minArea);
 
             /// gets all connected components of mesh part as

--- a/source/MRDotNet/MRMeshDecimate.cs
+++ b/source/MRDotNet/MRMeshDecimate.cs
@@ -204,15 +204,15 @@ namespace MR
             public MRResolveMeshDegenParameters() { }
         };
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern DecimateResult mrDecimateMesh(IntPtr mesh, ref MRDecimateParameters settings);
 
         /// Splits too long and eliminates too short edges from the mesh
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.U1)]
         private static extern bool mrRemesh(IntPtr mesh, ref MRRemeshParameters settings);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.U1)]
         private static extern bool mrResolveMeshDegenerations(IntPtr mesh, ref MRResolveMeshDegenParameters settings );
 

--- a/source/MRDotNet/MRMeshFillHole.cs
+++ b/source/MRDotNet/MRMeshFillHole.cs
@@ -116,13 +116,13 @@ namespace MR
             public MRFillHoleNicelyParams() { }
         };
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern void mrFillHole(IntPtr mesh, EdgeId a, ref MRFillHoleParams parameters);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern void mrFillHoles(IntPtr mesh, IntPtr pAs, ulong asNum, ref MRFillHoleParams parameters);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrFillHoleNicely(IntPtr mesh, EdgeId holeEdge, ref MRFillHoleNicelyParams parameters);
 
         /** \brief Fills hole in mesh\n

--- a/source/MRDotNet/MRMeshFixer.cs
+++ b/source/MRDotNet/MRMeshFixer.cs
@@ -13,22 +13,22 @@ namespace MR
             VertId v0;
             VertId v1;
         }
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrFindHoleComplicatingFaces(IntPtr mesh);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrFindDegenerateFaces(ref MRMeshPart mp, float criticalAspectRatio, IntPtr cb, ref IntPtr errorStr);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrFindShortEdges(ref MRMeshPart mp, float criticalLength, IntPtr cb, ref IntPtr errorStr);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         unsafe private static extern void fixMultipleEdges(IntPtr mesh, MultipleEdge* multipleEdges, ulong multipleEdgesNum);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern void findAndFixMultipleEdges(IntPtr mesh);
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrStringData(IntPtr str);
 
         /// returns all faces that complicate one of mesh holes;

--- a/source/MRDotNet/MRMeshLoad.cs
+++ b/source/MRDotNet/MRMeshLoad.cs
@@ -34,7 +34,7 @@ namespace MR
         // inherits List<NamedMesh> and correctly disposes native resource
         public class NamedMeshList : List<NamedMesh>, IDisposable
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrVectorMeshLoadNamedMeshFree(IntPtr vector);
 
             internal NamedMeshList(IntPtr nativeList) : base()
@@ -98,25 +98,25 @@ namespace MR
 
         public class MeshLoad
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern MRMeshLoadNamedMesh mrVectorMeshLoadNamedMeshGet(IntPtr vector, ulong index);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern ulong mrVectorMeshLoadNamedMeshSize(IntPtr vector);
 
 
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMeshLoadFromSceneObjFile(string file, bool combineAllObjects, ref MRMeshLoadObjLoadSettings settings, ref IntPtr errorString);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrStringData(IntPtr str);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             unsafe private static extern IntPtr mrMeshLoadFromAnySupportedFormat(string file, IntPtr* errorStr);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrLoadIOExtras();
             /// loads mesh from file of any supported format
             unsafe public static Mesh FromAnySupportedFormat(string path)

--- a/source/MRDotNet/MRMeshMetrics.cs
+++ b/source/MRDotNet/MRMeshMetrics.cs
@@ -9,31 +9,31 @@ namespace MR
     {
         public class FillHoleMetric
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrFillHoleMetricFree(IntPtr metric);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern double mrCalcCombinedFillMetric(IntPtr mesh, IntPtr filledRegion, IntPtr metric);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetCircumscribedMetric(IntPtr mesh);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetPlaneFillMetric(IntPtr mesh, EdgeId e);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetPlaneNormalizedFillMetric(IntPtr mesh, EdgeId e);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetComplexFillMetric(IntPtr mesh, EdgeId e);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetUniversalMetric(IntPtr mesh);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetMinAreaMetric(IntPtr mesh);
 
             private FillHoleMetric(IntPtr metric)

--- a/source/MRDotNet/MRMeshNormals.cs
+++ b/source/MRDotNet/MRMeshNormals.cs
@@ -25,11 +25,11 @@ namespace MR
             }
 
             /// returns a vector with face-normal in every element for valid mesh faces
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             unsafe private static extern MRFaceNormals* mrComputePerFaceNormals(IntPtr mesh);
 
             /// returns a vector with vertex normals in every element for valid mesh vertices
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             unsafe private static extern MRFaceNormals* mrComputePerVertNormals(IntPtr mesh);
 
             unsafe public static VertNormals ComputePerVertNormals(Mesh mesh)

--- a/source/MRDotNet/MRMeshSave.cs
+++ b/source/MRDotNet/MRMeshSave.cs
@@ -26,16 +26,16 @@ namespace MR
 
         public class MeshSave
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrStringData(IntPtr str);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrMeshSaveSceneToObj(IntPtr objects, ulong objectsNum, string file, ref IntPtr errorString);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrLoadIOExtras();
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrMeshSaveToAnySupportedFormat(IntPtr mesh, string file, ref MRSaveSettings settings, ref IntPtr errorStr);
 
             /// saves mesh to file of any supported format

--- a/source/MRDotNet/MRMultiwayICP.cs
+++ b/source/MRDotNet/MRMultiwayICP.cs
@@ -51,35 +51,35 @@ namespace MR
                 public MRVectorAffineXf3f() { }
             }
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern IntPtr mrMultiwayICPNew(IntPtr objects, ulong objectsNum, ref MRMultiwayICPSamplingParameters samplingParams);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             unsafe private static extern MRVectorAffineXf3f* mrMultiwayICPCalculateTransformations(IntPtr mwicp, IntPtr cb);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern bool mrMultiwayICPResamplePoints(IntPtr mwicp, ref MRMultiwayICPSamplingParameters samplingParams);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern bool mrMultiwayICPUpdateAllPointPairs(IntPtr mwicp, IntPtr cb);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrMultiwayICPSetParams(IntPtr mwicp, ref MRICPProperties prop);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             unsafe private static extern float mrMultiWayICPGetMeanSqDistToPoint(IntPtr mwicp, double* value);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             unsafe private static extern float mrMultiWayICPGetMeanSqDistToPlane(IntPtr mwicp, double* value);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ulong mrMultiWayICPGetNumSamples(IntPtr mwicp);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern ulong mrMultiWayICPGetNumActivePairs(IntPtr mwicp);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern void mrMultiwayICPFree(IntPtr mwicp);
 
             unsafe public MultiwayICP(List<MeshOrPointsXf> objs, MultiwayICPSamplingParameters samplingParams)

--- a/source/MRDotNet/MROffset.cs
+++ b/source/MRDotNet/MROffset.cs
@@ -84,34 +84,34 @@ namespace MR
             };
 
             ///
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern float mrSuggestVoxelSize(MRMeshPart mp, float approxNumVoxels);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrOffsetMesh(MRMeshPart mp, float offset, ref MROffsetParameters parameters, ref IntPtr errorString);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrDoubleOffsetMesh(MRMeshPart mp, float offsetA, float offsetB, ref MROffsetParameters parameters, ref IntPtr errorString);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMcOffsetMesh(MRMeshPart mp, float offset, ref MROffsetParameters parameters, ref IntPtr errorString);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrMcShellMeshRegion(IntPtr mesh, IntPtr region, float offset, ref MROffsetParameters parameters, ref IntPtr errorString);
 
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrSharpOffsetMesh(MRMeshPart mp, float offset, ref MROffsetParameters parameters, ref MRGeneralOffsetParameters generalParams, ref IntPtr errorString);
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGeneralOffsetMesh(MRMeshPart mp, float offset, ref MROffsetParameters parameters, ref MRGeneralOffsetParameters generalParams, ref IntPtr errorString);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrThickenMesh(IntPtr mesh, float offset, ref MROffsetParameters parameters, ref MRGeneralOffsetParameters generalParams, ref IntPtr errorString);
 
             /// computes size of a cubical voxel to get approximately given number of voxels during rasterization

--- a/source/MRDotNet/MRPointCloud.cs
+++ b/source/MRDotNet/MRPointCloud.cs
@@ -17,51 +17,51 @@ namespace MR
         {
 
             /// creates a new PointCloud object
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrPointCloudNew();
 
             /// creates a new point cloud from existing points
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrPointCloudFromPoints(IntPtr points, ulong pointsNum);
 
             /// coordinates of points
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrPointCloudPoints(IntPtr pc);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrPointCloudPointsRef(IntPtr pc);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern ulong mrPointCloudPointsNum(IntPtr pc);
 
             /// unit normal directions of points (can be empty if no normals are known)
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrPointCloudNormals(IntPtr pc);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern ulong mrPointCloudNormalsNum(IntPtr pc);
 
             /// only points and normals corresponding to set bits here are valid
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrPointCloudValidPoints(IntPtr pc);
 
             /// passes through all valid points and finds the minimal bounding box containing all of them;
             /// if toWorld transformation is given then returns minimal bounding box in world space
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern MRBox3f mrPointCloudComputeBoundingBox(IntPtr pc, IntPtr toWorld);
 
             /// appends a point and returns its VertId
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern VertId mrPointCloudAddPoint(IntPtr pc, ref MRVector3f point);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern VertId mrPointCloudAddPointWithNormal(IntPtr pc, ref MRVector3f point, ref MRVector3f normal);
 
             /// deallocates a PointCloud object
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrPointCloudFree(IntPtr pc);                
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrStringData(IntPtr str);
 
             /// creates a new PointCloud object

--- a/source/MRDotNet/MRPointCloudTriangulation.cs
+++ b/source/MRDotNet/MRPointCloudTriangulation.cs
@@ -60,7 +60,7 @@ namespace MR
             public MRTriangulationParameters() { }
         };
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrTriangulatePointCloud(IntPtr pointCloud, ref MRTriangulationParameters parameters);
 
         /**        

--- a/source/MRDotNet/MRPointsLoad.cs
+++ b/source/MRDotNet/MRPointsLoad.cs
@@ -8,10 +8,10 @@ namespace MR
     {
         public class PointsLoad
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrPointsLoadFromAnySupportedFormat(string filename, ref MRPointsLoadSettings settings, ref IntPtr errorString);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrLoadIOExtras();
 
             /// loads point cloud from file of any supported format

--- a/source/MRDotNet/MRPointsSave.cs
+++ b/source/MRDotNet/MRPointsSave.cs
@@ -9,10 +9,10 @@ namespace MR
     {
         public class PointsSave
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrPointsSaveToAnySupportedFormat(IntPtr pc, string file, ref MRSaveSettings settings, ref IntPtr errorString);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrLoadIOExtras();
 
             /// saves point cloud to file of any supported format

--- a/source/MRDotNet/MRRegionBoundary.cs
+++ b/source/MRDotNet/MRRegionBoundary.cs
@@ -19,7 +19,7 @@ namespace MR
 
         public class EdgeLoop : List<EdgeId>, IDisposable
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             unsafe private static extern void mrEdgePathFree(MREdgeLoop* loop);
 
             unsafe internal EdgeLoop(MREdgeLoop* mrLoop)
@@ -61,13 +61,13 @@ namespace MR
 
         public class EdgeLoops : List<List<EdgeId>>, IDisposable
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern MREdgeLoop mrEdgeLoopsGet(IntPtr loops, ulong index);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern ulong mrEdgeLoopsSize(IntPtr loops);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrEdgeLoopsFree(IntPtr loops);
 
             public EdgeLoops(IntPtr mrLoops)
@@ -116,43 +116,43 @@ namespace MR
 
         public class RegionBoundary
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrFindRightBoundary(IntPtr topology, IntPtr region);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             unsafe private static extern MREdgeLoop* mrTrackRightBoundaryLoop(IntPtr topology, EdgeId e0, IntPtr region);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetIncidentFacesFromVerts(IntPtr topology, IntPtr region);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetIncidentFacesFromEdges(IntPtr topology, IntPtr region);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetIncidentVertsFromFaces(IntPtr topology, IntPtr faces);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetIncidentVertsFromEdges(IntPtr topology, IntPtr edges);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetInnerVertsFromFaces(IntPtr topology, IntPtr region);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetInnerVertsFromEdges(IntPtr topology, IntPtr edges);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetInnerFacesFromVerts(IntPtr topology, IntPtr verts);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetIncidentEdgesFromFaces(IntPtr topology, IntPtr faces);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetIncidentEdgesFromEdges(IntPtr topology, IntPtr edges);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetInnerEdgesFromVerts(IntPtr topology, IntPtr verts);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrGetInnerEdgesFromFaces(IntPtr topology, IntPtr region);
 
             /// returns closed loop of region boundary starting from given region boundary edge (region faces on the right, and not-region faces or holes on the left);

--- a/source/MRDotNet/MRVDBConversions.cs
+++ b/source/MRDotNet/MRVDBConversions.cs
@@ -73,16 +73,16 @@ namespace MR
             public MRGridToMeshSettings() { }
         }
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         unsafe private static extern void mrVdbConversionsEvalGridMinMax( IntPtr grid, float* min, float* max );
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern MRVdbVolume mrVdbConversionsMeshToVolume( IntPtr mesh, ref MRMeshToVolumeSettings settings, ref IntPtr errorStr );
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern MRVdbVolume mrVdbConversionsFloatGridToVdbVolume( IntPtr grid );
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrVdbConversionsGridToMesh( IntPtr grid, ref MRGridToMeshSettings settings, ref IntPtr errorStr );
 
         // eval min max value from FloatGrid

--- a/source/MRDotNet/MRVdbVolume.cs
+++ b/source/MRDotNet/MRVdbVolume.cs
@@ -11,22 +11,22 @@ namespace MR
 {
     public partial class DotNet
     {        
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrFloatGridResampledUniformly( IntPtr grid, float voxelScale, IntPtr cb );
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrFloatGridResampled( IntPtr grid, ref MRVector3f voxelScale, IntPtr cb );
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern IntPtr mrFloatGridCropped( IntPtr grid, ref MRBox3i box, IntPtr cb );
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern float mrFloatGridGetValue( IntPtr grid, ref MRVector3i p );
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern void mrFloatGridSetValue(IntPtr grid, ref MRVector3i p, float value );
 
-        [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+        [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
         private static extern void mrFloatGridSetValueForRegion(IntPtr grid, IntPtr region, float value );
 
         /// stores a pointer to a native OpenVDB object
@@ -110,15 +110,15 @@ namespace MR
         public class VdbVolumes : List<VdbVolume>, IDisposable 
         {
             /// gets the volumes' value at index
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern MRVdbVolume mrVdbVolumesGet( IntPtr volumes, ulong index );
 
             /// gets the volumes' size
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern ulong mrVdbVolumesSize( IntPtr volumes );
 
             /// deallocates the VdbVolumes object
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrVdbVolumesFree(IntPtr volumes);
 
             internal IntPtr mrVdbVolumes_;

--- a/source/MRDotNet/MRVector3.cs
+++ b/source/MRDotNet/MRVector3.cs
@@ -16,31 +16,31 @@ namespace MR
                 public MRVector3f() { }
             };
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrVector3fDiagonal(float a);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrVector3fPlusX();
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrVector3fPlusY();
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrVector3fPlusZ();
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrVector3fAdd(ref MRVector3f a, ref MRVector3f b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrVector3fSub(ref MRVector3f a, ref MRVector3f b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3f mrVector3fMulScalar(ref MRVector3f a, float b);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern float mrVector3fLength(ref MRVector3f a);
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern float mrVector3fLengthSq(ref MRVector3f a);
 
             internal MRVector3f vec_;
@@ -123,7 +123,7 @@ namespace MR
                 public MRVector3i() { }
             };
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Auto)]
+            [DllImport("MRMeshC", CharSet = CharSet.Auto)]
             private static extern MRVector3i mrVector3iDiagonal(int a);
 
             internal MRVector3i vec_;

--- a/source/MRDotNet/MRVoxelsLoad.cs
+++ b/source/MRDotNet/MRVoxelsLoad.cs
@@ -7,10 +7,10 @@ namespace MR
     {
         public class VoxelsLoad
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrVoxelsLoadFromAnySupportedFormat( string file, IntPtr cb, ref IntPtr errorStr );
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrStringData(IntPtr str);
             
             /// Detects the format from file extension and loads voxels from it

--- a/source/MRDotNet/MRVoxelsSave.cs
+++ b/source/MRDotNet/MRVoxelsSave.cs
@@ -8,11 +8,11 @@ namespace MR
     {
         public class VoxelsSave
         {
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern void mrVoxelsSaveToAnySupportedFormat( ref MRVdbVolume volume, string file, IntPtr cb, ref IntPtr errorStr );
 
 
-            [DllImport("MRMeshC.dll", CharSet = CharSet.Ansi)]
+            [DllImport("MRMeshC", CharSet = CharSet.Ansi)]
             private static extern IntPtr mrStringData(IntPtr str);
             
             /// Saves voxels in a file, detecting the format from file extension


### PR DESCRIPTION
according to https://learn.microsoft.com/en-us/dotnet/standard/native-interop/native-library-loading we can use dll name without extension, so it will try to find correct lib on different systems