### PR TITLE
pip-build: set CMAKE_POLICY_VERSION_MINIMUM: 3.5

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -29,6 +29,8 @@ env:
   CUDA-VERSION: '11.4.2.47141'
   CUDA-MAJOR: '11'
   CUDA-MINOR: '4'
+  # CMake 4 compatibility
+  CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
 
 jobs:


### PR DESCRIPTION
pip-build fails: https://github.com/MeshInspector/MeshLib/actions/runs/14230378955/job/39879622714#step:5:531