### PR TITLE
Fix zip loading in singlethread wasm

### DIFF
--- a/source/MRViewer/MROpenObjects.cpp
+++ b/source/MRViewer/MROpenObjects.cpp
@@ -180,12 +180,13 @@ Expected<LoadedObject> makeObjectTreeFromFolder( const std::filesystem::path & f
             completed += 1;
         } );
     }
-
+#if !defined( __EMSCRIPTEN__ ) || defined( __EMSCRIPTEN_PTHREADS__ )
     while ( !loadingCanceled && completed < nodes.size() )
     {
         std::this_thread::sleep_for( std::chrono::milliseconds ( 200 ) );
         loadingCanceled = !cb();
     }
+#endif
     group.wait();
 
     if ( loadingCanceled )


### PR DESCRIPTION
we cannot use `sleep` for main thread in singlethreaded wasm