### PR TITLE
Laplacian: VertexMass option

### DIFF
--- a/examples/c-examples/LaplacianDeformation.dox.c
+++ b/examples/c-examples/LaplacianDeformation.dox.c
@@ -27,7 +27,7 @@ int main( int argc, char* argv[] )
     mrExpandVertRegion( mrMeshTopology( mesh ), freeVerts, 5 );
 
     // Initialize laplacian
-    mrLaplacianInit( lDeformer, freeVerts, MREdgeWeightsCotanWithAreaEqWeight, MRLaplacianRememberShapeYes );
+    mrLaplacianInit( lDeformer, freeVerts, MREdgeWeightsCotan, MRVertexMassNeiArea, MRLaplacianRememberShapeYes );
 
     MRBox3f bbox = mrMeshComputeBoundingBox( mesh, NULL );
     float shiftAmount = mrBox3fDiagonal( &bbox ) * 0.01f;

--- a/examples/cpp-examples/LaplacianDeformation.dox.cpp
+++ b/examples/cpp-examples/LaplacianDeformation.dox.cpp
@@ -26,7 +26,7 @@ int main()
     MR::expand( mesh->topology, freeVerts, 5 );
 
     // Initialize laplacian
-    lDeformer.init( freeVerts, MR::EdgeWeights::CotanWithAreaEqWeight );
+    lDeformer.init( freeVerts, MR::EdgeWeights::Cotan, MR::VertexMass::NeiArea );
 
     const auto shiftAmount = mesh->computeBoundingBox().diagonal() * 0.01f;
     // Fix the anchor vertices in the required position

--- a/examples/python-examples/LaplacianExample.dox.py
+++ b/examples/python-examples/LaplacianExample.dox.py
@@ -18,7 +18,7 @@ freeVerts.set( ancV1, True )
 mm.expand(mesh.topology,freeVerts,5)
 
 # Initialize laplacian
-lDeformer.init(freeVerts,mm.EdgeWeights.CotanWithAreaEqWeight)
+lDeformer.init(freeVerts,mm.EdgeWeights.Cotan,mm.VertexMass.NeiArea)
 
 shiftAmount = mesh.computeBoundingBox().diagonal()*0.01
 # Fix anchor vertices in required position

--- a/source/MRMesh/MREnums.h
+++ b/source/MRMesh/MREnums.h
@@ -3,6 +3,16 @@
 namespace MR
 {
 
+/// determines the weight or mass of each vertex in applications like Laplacian
+enum class VertexMass
+{
+    /// all vertices have same mass=1
+    Unit = 0,
+
+    /// vertex mass depends on local geometry and proportional to the area of first-ring triangles
+    NeiArea
+};
+
 /// determines the weight of each edge in applications like Laplacian
 enum class EdgeWeights
 {
@@ -10,10 +20,10 @@ enum class EdgeWeights
     Unit = 0,
 
     /// edge weight depends on local geometry and uses cotangent values
-    Cotan,
+    Cotan
 
     /// cotangent edge weights and equation weights inversely proportional to square root of local area
-    CotanWithAreaEqWeight
+    // CotanWithAreaEqWeight => use EdgeWeights::Cotan and VertexMass::NeiArea instead
 };
 
 /// typically returned from callbacks to control the behavior of main algorithm

--- a/source/MRMesh/MRFillHoleNicely.cpp
+++ b/source/MRMesh/MRFillHoleNicely.cpp
@@ -69,7 +69,7 @@ FaceBitSet fillHoleNicely( Mesh & mesh,
             // exclude boundary vertices from positionVertsSmoothly(), since it tends to move them inside the mesh
             auto vertsForSmoothing = newVerts - mesh.topology.findBoundaryVerts( &newVerts );
             positionVertsSmoothlySharpBd( mesh, vertsForSmoothing );
-            positionVertsSmoothly( mesh, vertsForSmoothing, settings.edgeWeights );
+            positionVertsSmoothly( mesh, vertsForSmoothing, settings.edgeWeights, settings.vmass );
             if ( settings.naturalSmooth )
             {
                 auto undirectedEdgeBitSet = findRegionBoundaryUndirectedEdgesInsideMesh( mesh.topology, newFaces );
@@ -81,7 +81,7 @@ FaceBitSet fillHoleNicely( Mesh & mesh,
                 {
                     vertsForSmoothing = incidentVerts - mesh.topology.findBoundaryVerts( &incidentVerts );
                     positionVertsSmoothlySharpBd( mesh, vertsForSmoothing );
-                    positionVertsSmoothly( mesh, vertsForSmoothing, settings.edgeWeights );
+                    positionVertsSmoothly( mesh, vertsForSmoothing, settings.edgeWeights, settings.vmass );
                 }
             }
         }

--- a/source/MRMesh/MRFillHoleNicely.h
+++ b/source/MRMesh/MRFillHoleNicely.h
@@ -39,6 +39,9 @@ struct FillHoleNicelySettings
     /// edge weighting scheme for smoothCurvature mode
     EdgeWeights edgeWeights = EdgeWeights::Cotan;
 
+    /// vertex mass scheme for smoothCurvature mode
+    VertexMass vmass = VertexMass::Unit;
+
     /// optional uv-coordinates of vertices; if provided then elements corresponding to new vertices will be added there
     VertUVCoords * uvCoords = {};
 

--- a/source/MRMesh/MRLaplacian.h
+++ b/source/MRMesh/MRLaplacian.h
@@ -41,7 +41,8 @@ public:
 
     // initialize Laplacian for the region being deformed, here region properties are remembered and precomputed;
     // \param freeVerts must not include all vertices of a mesh connected component
-    MRMESH_API void init( const VertBitSet & freeVerts, EdgeWeights weights, RememberShape rem = Laplacian::RememberShape::Yes );
+    MRMESH_API void init( const VertBitSet & freeVerts, EdgeWeights weights, VertexMass vmass = VertexMass::Unit,
+        RememberShape rem = Laplacian::RememberShape::Yes );
 
     // notify Laplacian that given vertex has changed after init and must be fixed during apply;
     // \param smooth whether to make the surface smooth in this vertex (sharp otherwise)
@@ -68,8 +69,6 @@ public:
 
     // return fixed vertices from the first layer around free vertices
     VertBitSet firstLayerFixedVerts() const { assert( solverValid_ ); return firstLayerFixedVerts_; }
-
-    using EdgeWeights [[deprecated]] = MR::EdgeWeights;
 
 private:
     // updates solver_ only

--- a/source/MRMesh/MRMeshRelax.cpp
+++ b/source/MRMesh/MRMeshRelax.cpp
@@ -338,7 +338,7 @@ void smoothRegionBoundary( Mesh & mesh, const FaceBitSet & regionFaces, int numI
     std::vector<Vector3f> newPos;
     for( int iter = 0; iter < numIters; ++iter )
     {
-        lap.init( freeVerts, EdgeWeights::Cotan, Laplacian::RememberShape::No );
+        lap.init( freeVerts, EdgeWeights::Cotan, VertexMass::Unit, Laplacian::RememberShape::No );
         lap.applyToScalar( scalarField );
 
         newPos.clear();

--- a/source/MRMesh/MRMeshSubdivide.cpp
+++ b/source/MRMesh/MRMeshSubdivide.cpp
@@ -205,7 +205,7 @@ int subdivideMesh( Mesh & mesh, const SubdivideSettings & settings )
             const auto sharpVerts = getIncidentVerts( mesh.topology, creaseUEdges );
             if ( settings.progressCallback && !settings.progressCallback( 0.77f ) )
                 return 0;
-            positionVertsSmoothly( mesh, newVerts, EdgeWeights::Cotan, &sharpVerts );
+            positionVertsSmoothly( mesh, newVerts, EdgeWeights::Cotan, VertexMass::Unit, &sharpVerts );
         }
         else
             positionVertsSmoothly( mesh, newVerts, EdgeWeights::Cotan );

--- a/source/MRMesh/MRPositionVertsSmoothly.cpp
+++ b/source/MRMesh/MRPositionVertsSmoothly.cpp
@@ -15,13 +15,13 @@ namespace MR
 {
 
 void positionVertsSmoothly( Mesh& mesh, const VertBitSet& verts,
-    EdgeWeights edgeWeightsType,
+    EdgeWeights edgeWeights, VertexMass vmass,
     const VertBitSet * fixedSharpVertices )
 {
     MR_TIMER
 
     Laplacian laplacian( mesh );
-    laplacian.init( verts, edgeWeightsType, Laplacian::RememberShape::No );
+    laplacian.init( verts, edgeWeights, vmass, Laplacian::RememberShape::No );
     if ( fixedSharpVertices )
         for ( auto v : *fixedSharpVertices )
             laplacian.fixVertex( v, false );

--- a/source/MRMesh/MRPositionVertsSmoothly.h
+++ b/source/MRMesh/MRPositionVertsSmoothly.h
@@ -10,7 +10,7 @@ namespace MR
 /// \param verts must not include all vertices of a mesh connected component
 /// \param fixedSharpVertices in these vertices the surface can be not-smooth
 MRMESH_API void positionVertsSmoothly( Mesh& mesh, const VertBitSet& verts,
-    EdgeWeights edgeWeightsType = EdgeWeights::Cotan,
+    EdgeWeights edgeWeights = EdgeWeights::Cotan, VertexMass vmass = VertexMass::Unit,
     const VertBitSet * fixedSharpVertices = nullptr );
 
 /// Puts given vertices in such positions to make smooth surface inside verts-region, but sharp on its boundary;

--- a/source/MRMesh/MRSurfacePath.cpp
+++ b/source/MRMesh/MRSurfacePath.cpp
@@ -609,7 +609,7 @@ SurfacePaths getSurfacePathsViaVertices( const Mesh & mesh, const VertBitSet & v
     }
 
     Laplacian lap( const_cast<Mesh&>( mesh ) ); //mesh will not be changed
-    lap.init( freeVerts, EdgeWeights::Unit, Laplacian::RememberShape::No );
+    lap.init( freeVerts, EdgeWeights::Unit, VertexMass::Unit, Laplacian::RememberShape::No );
     lap.applyToScalar( scalarField );
     res = extractIsolines( mesh.topology, scalarField, 0 );
 

--- a/source/MRMeshC/MRFillHoleNicely.cpp
+++ b/source/MRMeshC/MRFillHoleNicely.cpp
@@ -18,13 +18,14 @@ MRFillHoleNicelyParams mrFillHoleNicelyParamsNew( void )
     MRFillHoleNicelyParams params;
     FillHoleNicelySettings defaultParams;
     params.triangulateParams = mrFillHoleParamsNew();
-    params.triangulateOnly = defaultParams.triangulateOnly;    
+    params.triangulateOnly = defaultParams.triangulateOnly;
     params.maxEdgeLen = defaultParams.maxEdgeLen;
     params.maxEdgeSplits = defaultParams.maxEdgeSplits;
     params.maxAngleChangeAfterFlip = defaultParams.maxAngleChangeAfterFlip;
     params.smoothCurvature = defaultParams.smoothCurvature;
     params.naturalSmooth = defaultParams.naturalSmooth;
     params.edgeWeights = (MREdgeWeights)defaultParams.edgeWeights;
+    params.vmass = (MRVertexMass)defaultParams.vmass;
 
     return params;
 }
@@ -52,6 +53,7 @@ MRFaceBitSet* mrFillHoleNicely( MRMesh* mesh_, MREdgeId holeEdge_, const MRFillH
         params.smoothCurvature = params_->smoothCurvature;
         params.naturalSmooth = params_->naturalSmooth;
         params.edgeWeights = (MR::EdgeWeights)params_->edgeWeights;
+        params.vmass = (MR::VertexMass)params_->vmass;
     }
     RETURN_NEW(fillHoleNicely( mesh, holeEdge, params ) );
 }

--- a/source/MRMeshC/MRFillHoleNicely.h
+++ b/source/MRMeshC/MRFillHoleNicely.h
@@ -3,14 +3,22 @@
 
 MR_EXTERN_C_BEGIN
 
+typedef enum MRVertexMass
+{
+    /// all vertices have same mass=1
+    MRVertexMassUnit,
+    /// vertex mass depends on local geometry and proportional to the area of first-ring triangles
+    MRVertexMassNeiArea
+} MRVertexMass;
+
 typedef enum MREdgeWeights
 {  
     /// all edges have same weight=1
     MREdgeWeightsUnit,
     /// edge weight depends on local geometry and uses cotangent values
-    MREdgeWeightsCotan,
+    MREdgeWeightsCotan
     /// cotangent edge weights and equation weights inversely proportional to square root of local area
-    MREdgeWeightsCotanWithAreaEqWeight
+    //MREdgeWeightsCotanWithAreaEqWeight => use MREdgeWeights::Cotan and MRVertexMass::NeiArea instead
 } MREdgeWeights;
 
 typedef struct MRFillHoleNicelyParams
@@ -31,6 +39,8 @@ typedef struct MRFillHoleNicelyParams
     bool naturalSmooth;
     /// edge weighting scheme for smoothCurvature mode
     MREdgeWeights edgeWeights;
+    /// vertex mass scheme for smoothCurvature mode
+    MRVertexMass vmass;
 } MRFillHoleNicelyParams;
 
 MRMESHC_API MRFillHoleNicelyParams mrFillHoleNicelyParamsNew( void );

--- a/source/MRMeshC/MRLaplacian.cpp
+++ b/source/MRMeshC/MRLaplacian.cpp
@@ -7,6 +7,7 @@
 using namespace MR;
 
 REGISTER_AUTO_CAST( EdgeWeights )
+REGISTER_AUTO_CAST( VertexMass )
 REGISTER_AUTO_CAST( Laplacian )
 REGISTER_AUTO_CAST( Mesh )
 REGISTER_AUTO_CAST( Vector3f )
@@ -26,10 +27,10 @@ void mrLaplacianFree( MRLaplacian* laplacian_ )
     delete laplacian;
 }
 
-void mrLaplacianInit( MRLaplacian* laplacian_, const MRVertBitSet* freeVerts_, MREdgeWeights weights_, MRLaplacianRememberShape rem_ )
+void mrLaplacianInit( MRLaplacian* laplacian_, const MRVertBitSet* freeVerts_, MREdgeWeights weights_, MRVertexMass vmass_, MRLaplacianRememberShape rem_ )
 {
-    ARG( laplacian ); ARG( freeVerts ); ARG_VAL( weights ); ARG_VAL( rem );
-    laplacian.init( freeVerts, weights, rem );
+    ARG( laplacian ); ARG( freeVerts ); ARG_VAL( weights ); ARG_VAL( vmass ); ARG_VAL( rem );
+    laplacian.init( freeVerts, weights, vmass, rem );
 }
 
 void mrLaplacianFixVertex( MRLaplacian* laplacian_, MRVertId v_, const MRVector3f* fixedPos_, bool smooth )

--- a/source/MRMeshC/MRLaplacian.h
+++ b/source/MRMeshC/MRLaplacian.h
@@ -26,7 +26,7 @@ MRMESHC_API void mrLaplacianFree( MRLaplacian* laplacian );
 
 // initialize Laplacian for the region being deformed, here region properties are remembered and precomputed;
 // \param freeVerts must not include all vertices of a mesh connected component
-MRMESHC_API void mrLaplacianInit( MRLaplacian* laplacian, const MRVertBitSet* freeVerts, MREdgeWeights weights, MRLaplacianRememberShape rem );
+MRMESHC_API void mrLaplacianInit( MRLaplacian* laplacian, const MRVertBitSet* freeVerts, MREdgeWeights weights, MRVertexMass vmass, MRLaplacianRememberShape rem );
 
 // sets position of given vertex after init and it must be fixed during apply (THIS METHOD CHANGES THE MESH);
 // \param smooth whether to make the surface smooth in this vertex (sharp otherwise)

--- a/source/mrmeshpy/MRPythonMeshPlugins.cpp
+++ b/source/mrmeshpy/MRPythonMeshPlugins.cpp
@@ -391,11 +391,16 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, LaplacianEdgeWeightsParam, [] ( pybind11::mo
 {
     pybind11::enum_<EdgeWeights>( m, "LaplacianEdgeWeightsParam" ).
         value( "Unit", EdgeWeights::Unit, "all edges have same weight=1" ).
-        value( "Cotan", EdgeWeights::Cotan, "edge weight depends on local geometry and uses cotangent values" ).
-        value( "CotanWithAreaEqWeight", EdgeWeights::CotanWithAreaEqWeight, "cotangent edge weights and equation weights inversely proportional to square root of local area" );
+        value( "Cotan", EdgeWeights::Cotan, "edge weight depends on local geometry and uses cotangent values" );
+
+    pybind11::enum_<VertexMass>( m, "LaplacianVertexMassParam" ).
+        value( "Unit", VertexMass::Unit, "all vertices have same mass=1" ).
+        value( "Cotan", VertexMass::NeiArea, "vertex mass depends on local geometry and proportional to the area of first-ring triangles" );
 
     m.def( "positionVertsSmoothly", &MR::positionVertsSmoothly,
-        pybind11::arg( "mesh" ), pybind11::arg( "verts" ), pybind11::arg_v( "edgeWeightsType", MR::EdgeWeights::Cotan, "LaplacianEdgeWeightsParam.Cotan" ),
+        pybind11::arg( "mesh" ), pybind11::arg( "verts" ),
+        pybind11::arg_v( "edgeWeights", MR::EdgeWeights::Cotan, "LaplacianEdgeWeightsParam.Cotan" ),
+        pybind11::arg_v( "vmass", MR::VertexMass::Unit, "LaplacianVertexMassParam.Unit" ),
         pybind11::arg( "fixedSharpVertices" ) = nullptr,
         "Puts given vertices in such positions to make smooth surface both inside verts-region and on its boundary" );
 


### PR DESCRIPTION
In Laplacian:
* `EdgeWeights::CotanWithAreaEqWeight` must be replaced on `EdgeWeights::Cotan` and `VertexMass::NeiArea`
* `VertexMass::NeiArea` can now be used with `EdgeWeights::Unit` as well.