### PR TITLE
Laplacian takes const topology

### DIFF
--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -761,16 +761,7 @@ float Mesh::leftCotan( EdgeId e ) const
 {
     if ( !topology.left( e ).valid() )
         return 0;
-    Vector3f p0, p1, p2;
-    getLeftTriPoints( e, p0, p1, p2 );
-    auto a = p0 - p2;
-    auto b = p1 - p2;
-    auto nom = dot( a, b );
-    auto den = cross( a, b ).length();
-    static constexpr float maxval = 1e5f;
-    if ( fabs( nom ) >= maxval * den )
-        return maxval * sgn( nom );
-    return nom / den;
+    return MR::cotan( getLeftTriPoints( e ) );
 }
 
 QuadraticForm3f Mesh::quadraticForm( VertId v, bool angleWeigted, const FaceBitSet * region, const UndirectedEdgeBitSet * creases ) const

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -79,13 +79,13 @@ struct [[nodiscard]] Mesh
     /// computes the center of given edge
     [[nodiscard]] Vector3f edgeCenter( UndirectedEdgeId e ) const { return edgePoint( e, 0.5f ); }
 
-    /// returns three points of left face of e
+    /// returns three points of left face of e: v0 = orgPnt( e ), v1 = destPnt( e )
     MRMESH_API void getLeftTriPoints( EdgeId e, Vector3f & v0, Vector3f & v1, Vector3f & v2 ) const;
 
-    /// returns three points of left face of e
+    /// returns three points of left face of e: v[0] = orgPnt( e ), v[1] = destPnt( e )
     void getLeftTriPoints( EdgeId e, Vector3f (&v)[3] ) const { getLeftTriPoints( e, v[0], v[1], v[2] ); }
 
-    /// returns three points of left face of e
+    /// returns three points of left face of e: res[0] = orgPnt( e ), res[1] = destPnt( e )
     [[nodiscard]] Triangle3f getLeftTriPoints( EdgeId e ) const { Triangle3f res; getLeftTriPoints( e, res[0], res[1], res[2] ); return res; }
 
     /// returns three points of given face

--- a/source/MRMesh/MRMeshComponents.h
+++ b/source/MRMesh/MRMeshComponents.h
@@ -138,19 +138,21 @@ struct LargeByAreaComponentsSettings
 
 /// returns true if all vertices of a mesh connected component are present in selection
 [[nodiscard]] MRMESH_API bool hasFullySelectedComponent( const Mesh& mesh, const VertBitSet & selection );
+[[nodiscard]] MRMESH_API bool hasFullySelectedComponent( const MeshTopology& topology, const VertBitSet & selection );
 
-/// if all vertices of a mesh connected component are present in selection exludes these vertices
+/// if all vertices of a mesh connected component are present in selection, excludes these vertices
 MRMESH_API void excludeFullySelectedComponents( const Mesh& mesh, VertBitSet& selection );
 
 /// gets union-find structure for faces with different options of face-connectivity
 [[nodiscard]] MRMESH_API UnionFind<FaceId> getUnionFindStructureFaces( const MeshPart& meshPart, FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgePredicate & isCompBd = {} );
 
 /// gets union-find structure for faces with connectivity by shared edge, and optional edge predicate whether to skip uniting components over it
-/// it is guaranteed that isCompBd is invoked in a thead-safe manner (that left and right face are always processed by one thread)
+/// it is guaranteed that isCompBd is invoked in a thread-safe manner (that left and right face are always processed by one thread)
 [[nodiscard]] MRMESH_API UnionFind<FaceId> getUnionFindStructureFacesPerEdge( const MeshPart& meshPart, const UndirectedEdgePredicate& isCompBd = {} );
 
 /// gets union-find structure for vertices
 [[nodiscard]] MRMESH_API UnionFind<VertId> getUnionFindStructureVerts( const Mesh& mesh, const VertBitSet* region = nullptr );
+[[nodiscard]] MRMESH_API UnionFind<VertId> getUnionFindStructureVerts( const MeshTopology& topology, const VertBitSet* region = nullptr );
 
 /// gets union-find structure for vertices, considering connections by given edges only
 [[nodiscard]] MRMESH_API UnionFind<VertId> getUnionFindStructureVerts( const Mesh& mesh, const EdgeBitSet & edges );

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -141,7 +141,7 @@ public:
     [[nodiscard]] MRMESH_API Triangulation getTriangulation() const;
 
     /// gets 3 vertices of the left face ( face-id may not exist, but the shape must be triangular)
-    /// the vertices are returned in counter-clockwise order if look from mesh outside
+    /// the vertices are returned in counter-clockwise order if look from mesh outside: v0 = org( a ), v1 = dest( a )
     MRMESH_API void getLeftTriVerts( EdgeId a, VertId & v0, VertId & v1, VertId & v2 ) const;
                void getLeftTriVerts( EdgeId a, VertId (&v)[3] ) const { getLeftTriVerts( a, v[0], v[1], v[2] ); }
                void getLeftTriVerts( EdgeId a, ThreeVertIds & v ) const { getLeftTriVerts( a, v[0], v[1], v[2] ); }

--- a/source/MRMesh/MRPositionVertsSmoothly.cpp
+++ b/source/MRMesh/MRPositionVertsSmoothly.cpp
@@ -20,6 +20,7 @@ void positionVertsSmoothly( Mesh& mesh, const VertBitSet& verts,
 {
     MR_TIMER
 
+    mesh.invalidateCaches();
     Laplacian laplacian( mesh );
     laplacian.init( verts, edgeWeights, vmass, Laplacian::RememberShape::No );
     if ( fixedSharpVertices )

--- a/source/MRMesh/MRTriMath.h
+++ b/source/MRMesh/MRTriMath.h
@@ -165,6 +165,13 @@ template<typename T>
 
 /// computes twice the area of given triangle
 template<typename T>
+[[nodiscard]] inline T dblArea( const Triangle3<T> & t )
+{
+    return dirDblArea( t ).length();
+}
+
+/// computes twice the area of given triangle
+template<typename T>
 [[nodiscard]] inline T dblArea( const Vector3<T> & p, const Vector3<T> & q, const Vector3<T> & r )
 {
     return dirDblArea( p, q, r ).length();
@@ -322,6 +329,20 @@ template <typename T>
     if ( num <= 0 )
         return 0;
     return num / den;
+}
+
+/// given triangle by its three vertices: t[0], t[1], t[2],
+/// returns the cotangent of the angle at t[2], but not larger by magnitude than absMaxVal
+template <typename T>
+[[nodiscard]] inline T cotan( const Triangle3<T> & t, T absMaxVal = std::numeric_limits<T>::max() )
+{
+    auto a = t[0] - t[2];
+    auto b = t[1] - t[2];
+    auto nom = dot( a, b );
+    auto den = cross( a, b ).length();
+    if ( fabs( nom ) >= absMaxVal * den )
+        return absMaxVal * sgn( nom );
+    return nom / den;
 }
 
 /// given (a, b, c) - the side lengths of a triangle,

--- a/source/MRTest/MRLaplacianTests.cpp
+++ b/source/MRTest/MRLaplacianTests.cpp
@@ -1,0 +1,32 @@
+#include <MRMesh/MRLaplacian.h>
+#include <MRMesh/MRMakeSphereMesh.h>
+#include <MRMesh/MRGTest.h>
+
+namespace MR
+{
+
+TEST( MRMesh, Laplacian )
+{
+    Mesh sphere = makeUVSphere( 1, 8, 8 );
+
+    {
+        VertBitSet vs;
+        vs.autoResizeSet( 0_v );
+        Laplacian laplacian( sphere );
+        laplacian.init( vs, EdgeWeights::Cotan );
+        laplacian.apply();
+
+        // fix the only free vertex
+        laplacian.fixVertex( 0_v );
+        laplacian.apply();
+    }
+
+    {
+        Laplacian laplacian( sphere );
+        // no free verts
+        laplacian.init( {}, EdgeWeights::Cotan );
+        laplacian.apply();
+    }
+}
+
+} //namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -18,6 +18,7 @@
     <ClCompile Include="MREdgeLengthMeshTests.cpp" />
     <ClCompile Include="MRExampleTest.cpp" />
     <ClCompile Include="MRExtractIsolinesTests.cpp" />
+    <ClCompile Include="MRLaplacianTests.cpp" />
     <ClCompile Include="MRMeshIntersectTests.cpp" />
     <ClCompile Include="MRMeshLoadSaveTest.cpp" />
     <ClCompile Include="MRMeshTests.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -79,6 +79,9 @@
     <ClCompile Include="MREdgeLengthMeshTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRLaplacianTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />


### PR DESCRIPTION
* `Laplacian` stores `const MeshTopology &`, and `VertCoords & points` to be able to use it for new points preparation with `const Mesh`.
* cotangent computation from point positions moved in `MRTriMath.h`
* some `MeshComponent` functions can take `MeshTopology` instead of `Mesh`
* test on `Laplacian` moved in `MRTests`
* better comments in `Mesh` and `MeshTopology`