### PR TITLE
Function overloads taking topology+points instead of mesh

### DIFF
--- a/source/MRMesh/MREdgeMetric.cpp
+++ b/source/MRMesh/MREdgeMetric.cpp
@@ -13,42 +13,62 @@ EdgeMetric identityMetric()
     return []( EdgeId ) { return 1.0f; };
 }
 
+EdgeMetric edgeLengthMetric( const MeshTopology& topology, const VertCoords& points )
+{
+    return [&topology, &points]( EdgeId e )
+    {
+        return edgeLength( topology, points, e );
+    };
+}
+
 EdgeMetric edgeLengthMetric( const Mesh & mesh )
 {
-    return [&mesh]( EdgeId e )
+    return edgeLengthMetric( mesh.topology, mesh.points );
+}
+
+EdgeMetric discreteAbsMeanCurvatureMetric( const MeshTopology& topology, const VertCoords& points )
+{
+    return [&topology, &points]( EdgeId e )
     {
-        return mesh.edgeLength( e );
+        return std::abs( discreteMeanCurvature( topology, points, e.undirected() ) );
     };
 }
 
 EdgeMetric discreteAbsMeanCurvatureMetric( const Mesh & mesh )
 {
-    return [&mesh]( EdgeId e )
+    return discreteAbsMeanCurvatureMetric( mesh.topology, mesh.points );
+}
+
+EdgeMetric discreteMinusAbsMeanCurvatureMetric( const MeshTopology& topology, const VertCoords& points )
+{
+    return [&topology, &points]( EdgeId e )
     {
-        return std::abs( mesh.discreteMeanCurvature( e.undirected() ) );
+        return -std::abs( discreteMeanCurvature( topology, points, e.undirected() ) );
     };
 }
 
 EdgeMetric discreteMinusAbsMeanCurvatureMetric( const Mesh & mesh )
 {
-    return [&mesh]( EdgeId e )
+    return discreteMinusAbsMeanCurvatureMetric( mesh.topology, mesh.points );
+}
+
+EdgeMetric edgeCurvMetric( const MeshTopology& topology, const VertCoords& points, float angleSinFactor, float angleSinForBoundary )
+{
+    const float bdFactor = exp( angleSinFactor * angleSinForBoundary );
+
+    return [&topology, &points, angleSinFactor, bdFactor ]( EdgeId e ) -> float
     {
-        return -std::abs( mesh.discreteMeanCurvature( e.undirected() ) );
+        auto edgeLen = edgeLength( topology, points, e );
+        if ( topology.isBdEdge( e, nullptr ) )
+            return edgeLen * bdFactor;
+
+        return edgeLen * exp( angleSinFactor * dihedralAngleSin( topology, points, e ) );
     };
 }
 
 EdgeMetric edgeCurvMetric( const Mesh & mesh, float angleSinFactor, float angleSinForBoundary )
 {
-    const float bdFactor = exp( angleSinFactor * angleSinForBoundary );
-
-    return [&mesh, angleSinFactor, bdFactor ]( EdgeId e ) -> float
-    {
-        auto edgeLen = mesh.edgeLength( e );
-        if ( mesh.topology.isBdEdge( e, nullptr ) )
-            return edgeLen * bdFactor;
-
-        return edgeLen * exp( angleSinFactor * mesh.dihedralAngleSin( e ) );
-    };
+    return edgeCurvMetric( mesh.topology, mesh.points, angleSinFactor, angleSinForBoundary );
 }
 
 EdgeMetric edgeTableSymMetric( const MeshTopology & topology, const EdgeMetric & metric )

--- a/source/MRMesh/MREdgeMetric.h
+++ b/source/MRMesh/MREdgeMetric.h
@@ -15,22 +15,26 @@ namespace MR
 /// returns edge's length as a metric;
 /// this metric is symmetric: m(e) == m(e.sym())
 [[nodiscard]] MRMESH_API EdgeMetric edgeLengthMetric( const Mesh & mesh );
+[[nodiscard]] MRMESH_API EdgeMetric edgeLengthMetric( const MeshTopology& topology, const VertCoords& points );
 
 /// returns edge's absolute discrete mean curvature as a metric;
 /// the metric is minimal in the planar regions of mesh;
 /// this metric is symmetric: m(e) == m(e.sym())
 [[nodiscard]] MRMESH_API EdgeMetric discreteAbsMeanCurvatureMetric( const Mesh & mesh );
+[[nodiscard]] MRMESH_API EdgeMetric discreteAbsMeanCurvatureMetric( const MeshTopology& topology, const VertCoords& points );
 
 /// returns minus of edge's absolute discrete mean curvature as a metric;
 /// the metric is minimal in the most curved regions of mesh;
 /// this metric is symmetric: m(e) == m(e.sym())
 [[nodiscard]] MRMESH_API EdgeMetric discreteMinusAbsMeanCurvatureMetric( const Mesh & mesh );
+[[nodiscard]] MRMESH_API EdgeMetric discreteMinusAbsMeanCurvatureMetric( const MeshTopology& topology, const VertCoords& points );
 
 /// returns edge's metric that depends both on edge's length and on the angle between its left and right faces
 /// \param angleSinFactor multiplier before dihedral angle sine in edge metric calculation (positive to prefer concave angles, negative - convex)
 /// \param angleSinForBoundary consider this dihedral angle sine for boundary edges;
 /// this metric is symmetric: m(e) == m(e.sym())
 [[nodiscard]] MRMESH_API EdgeMetric edgeCurvMetric( const Mesh & mesh, float angleSinFactor = 2, float angleSinForBoundary = 0 );
+[[nodiscard]] MRMESH_API EdgeMetric edgeCurvMetric( const MeshTopology& topology, const VertCoords& points, float angleSinFactor = 2, float angleSinForBoundary = 0 );
 
 /// pre-computes the metric for all mesh edges to quickly return it later for any edge;
 /// input metric must be symmetric: metric(e) == metric(e.sym())

--- a/source/MRMesh/MREdgePaths.cpp
+++ b/source/MRMesh/MREdgePaths.cpp
@@ -570,6 +570,21 @@ bool dilateRegion( const Mesh& mesh, UndirectedEdgeBitSet& region, float dilatio
     return dilateRegionByMetric( mesh.topology, edgeLengthMetric( mesh ), region, dilation, callback );
 }
 
+bool dilateRegion( const MeshTopology& topology, const VertCoords& points, FaceBitSet& region, float dilation, ProgressCallback callback )
+{
+    return dilateRegionByMetric( topology, edgeLengthMetric( topology, points ), region, dilation, callback );
+}
+
+bool dilateRegion( const MeshTopology& topology, const VertCoords& points, VertBitSet& region, float dilation, ProgressCallback callback )
+{
+    return dilateRegionByMetric( topology, edgeLengthMetric( topology, points ), region, dilation, callback );
+}
+
+bool dilateRegion( const MeshTopology& topology, const VertCoords& points, UndirectedEdgeBitSet& region, float dilation, ProgressCallback callback )
+{
+    return dilateRegionByMetric( topology, edgeLengthMetric( topology, points ), region, dilation, callback );
+}
+
 bool erodeRegion( const Mesh& mesh, FaceBitSet & region, float dilation, ProgressCallback callback )
 {
     return erodeRegionByMetric( mesh.topology, edgeLengthMetric( mesh ), region, dilation, callback );
@@ -583,6 +598,21 @@ bool erodeRegion( const Mesh& mesh, VertBitSet & region, float dilation, Progres
 bool erodeRegion( const Mesh& mesh, UndirectedEdgeBitSet& region, float dilation, ProgressCallback callback )
 {
     return erodeRegionByMetric( mesh.topology, edgeLengthMetric( mesh ), region, dilation, callback );
+}
+
+bool erodeRegion( const MeshTopology& topology, const VertCoords& points, FaceBitSet & region, float dilation, ProgressCallback callback )
+{
+    return erodeRegionByMetric( topology, edgeLengthMetric( topology, points ), region, dilation, callback );
+}
+
+bool erodeRegion( const MeshTopology& topology, const VertCoords& points, VertBitSet & region, float dilation, ProgressCallback callback )
+{
+    return erodeRegionByMetric( topology, edgeLengthMetric( topology, points ), region, dilation, callback );
+}
+
+bool erodeRegion( const MeshTopology& topology, const VertCoords& points, UndirectedEdgeBitSet& region, float dilation, ProgressCallback callback )
+{
+    return erodeRegionByMetric( topology, edgeLengthMetric( topology, points ), region, dilation, callback );
 }
 
 int getPathPlaneIntersections( const Mesh & mesh, const EdgePath & path, const Plane3f & plane,

--- a/source/MRMesh/MREdgePaths.h
+++ b/source/MRMesh/MREdgePaths.h
@@ -128,11 +128,17 @@ MRMESH_API bool erodeRegionByMetric( const MeshTopology& topology, const EdgeMet
 MRMESH_API bool dilateRegion( const Mesh& mesh, FaceBitSet& region, float dilation, ProgressCallback callback = {} );
 MRMESH_API bool dilateRegion( const Mesh& mesh, VertBitSet& region, float dilation, ProgressCallback callback = {} );
 MRMESH_API bool dilateRegion( const Mesh& mesh, UndirectedEdgeBitSet& region, float dilation, ProgressCallback callback = {} );
+MRMESH_API bool dilateRegion( const MeshTopology& topology, const VertCoords& points, FaceBitSet& region, float dilation, ProgressCallback callback = {} );
+MRMESH_API bool dilateRegion( const MeshTopology& topology, const VertCoords& points, VertBitSet& region, float dilation, ProgressCallback callback = {} );
+MRMESH_API bool dilateRegion( const MeshTopology& topology, const VertCoords& points, UndirectedEdgeBitSet& region, float dilation, ProgressCallback callback = {} );
 
 /// shrinks the region (of faces or vertices) on given value (in meters). returns false if callback also returns false
 MRMESH_API bool erodeRegion( const Mesh& mesh, FaceBitSet& region, float dilation, ProgressCallback callback = {} );
 MRMESH_API bool erodeRegion( const Mesh& mesh, VertBitSet& region, float dilation, ProgressCallback callback = {} );
 MRMESH_API bool erodeRegion( const Mesh& mesh, UndirectedEdgeBitSet& region, float dilation, ProgressCallback callback = {} );
+MRMESH_API bool erodeRegion( const MeshTopology& topology, const VertCoords& points, FaceBitSet& region, float dilation, ProgressCallback callback = {} );
+MRMESH_API bool erodeRegion( const MeshTopology& topology, const VertCoords& points, VertBitSet& region, float dilation, ProgressCallback callback = {} );
+MRMESH_API bool erodeRegion( const MeshTopology& topology, const VertCoords& points, UndirectedEdgeBitSet& region, float dilation, ProgressCallback callback = {} );
 
 /// finds all intersection points between given path and plane, adds them in outIntersections and returns their number
 MRMESH_API int getPathPlaneIntersections( const Mesh & mesh, const EdgePath & path, const Plane3f & plane,

--- a/source/MRMesh/MRMeshRelax.h
+++ b/source/MRMesh/MRMeshRelax.h
@@ -21,11 +21,13 @@ struct MeshRelaxParams : RelaxParams
 
 /// applies given number of relaxation iterations to the whole mesh ( or some region if it is specified )
 /// \return true if was finished successfully, false if was interrupted by progress callback
-MRMESH_API bool relax( Mesh& mesh, const MeshRelaxParams& params = {}, ProgressCallback cb = {} );
+MRMESH_API bool relax( Mesh& mesh, const MeshRelaxParams& params = {}, const ProgressCallback& cb = {} );
+MRMESH_API bool relax( const MeshTopology& topology, VertCoords& points, const MeshRelaxParams& params = {}, const ProgressCallback& cb = {} );
 
 /// computes position of a vertex, when all neighbor triangles have almost equal areas,
 /// more precisely it minimizes sum_i (area_i)^2 by adjusting the position of this vertex only
 [[nodiscard]] MRMESH_API Vector3f vertexPosEqualNeiAreas( const Mesh& mesh, VertId v, bool noShrinkage );
+[[nodiscard]] MRMESH_API Vector3f vertexPosEqualNeiAreas( const MeshTopology& topology, const VertCoords& points, VertId v, bool noShrinkage );
 
 struct MeshEqualizeTriAreasParams : MeshRelaxParams
 {
@@ -36,12 +38,14 @@ struct MeshEqualizeTriAreasParams : MeshRelaxParams
 
 /// applies given number of iterations with movement toward vertexPosEqualNeiAreas() to the whole mesh ( or some region if it is specified )
 /// \return true if the operation completed successfully, and false if it was interrupted by the progress callback.
-MRMESH_API bool equalizeTriAreas( Mesh& mesh, const MeshEqualizeTriAreasParams& params = {}, ProgressCallback cb = {} );
+MRMESH_API bool equalizeTriAreas( Mesh& mesh, const MeshEqualizeTriAreasParams& params = {}, const ProgressCallback& cb = {} );
+MRMESH_API bool equalizeTriAreas( const MeshTopology& topology, VertCoords& points, const MeshEqualizeTriAreasParams& params = {}, const ProgressCallback& cb = {} );
 
 /// applies given number of relaxation iterations to the whole mesh ( or some region if it is specified ) \n
 /// do not really keeps volume but tries hard
 /// \return true if the operation completed successfully, and false if it was interrupted by the progress callback.
-MRMESH_API bool relaxKeepVolume( Mesh& mesh, const MeshRelaxParams& params = {}, ProgressCallback cb = {} );
+MRMESH_API bool relaxKeepVolume( Mesh& mesh, const MeshRelaxParams& params = {}, const ProgressCallback& cb = {} );
+MRMESH_API bool relaxKeepVolume( const MeshTopology& topology, VertCoords& points, const MeshRelaxParams& params = {}, const ProgressCallback& cb = {} );
 
 struct MeshApproxRelaxParams : MeshRelaxParams
 {
@@ -54,10 +58,12 @@ struct MeshApproxRelaxParams : MeshRelaxParams
 /// applies given number of relaxation iterations to the whole mesh ( or some region if it is specified )
 /// approx neighborhoods
 /// \return true if the operation completed successfully, and false if it was interrupted by the progress callback.
-MRMESH_API bool relaxApprox( Mesh& mesh, const MeshApproxRelaxParams& params = {}, ProgressCallback cb = {} );
+MRMESH_API bool relaxApprox( Mesh& mesh, const MeshApproxRelaxParams& params = {}, const ProgressCallback& cb = {} );
+MRMESH_API bool relaxApprox( const MeshTopology& topology, VertCoords& points, const MeshApproxRelaxParams& params = {}, const ProgressCallback& cb = {} );
 
 /// applies at most given number of relaxation iterations the spikes detected by given threshold
 MRMESH_API void removeSpikes( Mesh & mesh, int maxIterations, float minSumAngle, const VertBitSet * region = nullptr );
+MRMESH_API void removeSpikes( const MeshTopology& topology, VertCoords& points, int maxIterations, float minSumAngle, const VertBitSet * region = nullptr );
 
 /// given a region of faces on the mesh, moves boundary vertices of the region
 /// to make the region contour much smoother with minor optimization of mesh topology near region boundary;
@@ -67,6 +73,7 @@ MRMESH_API void smoothRegionBoundary( Mesh & mesh, const FaceBitSet & regionFace
 
 /// move all region vertices with exactly three neighbor vertices in the center of the neighbors
 MRMESH_API void hardSmoothTetrahedrons( Mesh & mesh, const VertBitSet *region = nullptr );
+MRMESH_API void hardSmoothTetrahedrons( const MeshTopology& topology, VertCoords& points,const VertBitSet *region = nullptr );
 
 /// \}
 

--- a/source/MRMesh/MRMeshRelax.hpp
+++ b/source/MRMesh/MRMeshRelax.hpp
@@ -13,7 +13,7 @@ namespace MR
 
 /// set the field in the vertices with exactly three neighbor vertices as the average value of the field in the neighbors
 template<typename T>
-void hardSmoothTetrahedrons( const MeshTopology & topology, Vector<T, VertId> & field, const VertBitSet *region = nullptr )
+void hardSmoothTetrahedronsT( const MeshTopology & topology, Vector<T, VertId> & field, const VertBitSet *region = nullptr )
 {
     MR_TIMER
     auto tetrahedrons = findNRingVerts( topology, 3, region );
@@ -57,7 +57,7 @@ private:
 /// applies given number of relaxation iterations to given field on mesh vertices;
 /// \return true if was finished successfully, false if was interrupted by progress callback
 template<typename T>
-bool relax( const MeshTopology & topology, Vector<T, VertId> & field, const MeshRelaxParams& params = {}, ProgressCallback cb = {} )
+bool relaxT( const MeshTopology & topology, Vector<T, VertId> & field, const MeshRelaxParams& params = {}, const ProgressCallback& cb = {} )
 {
     if ( params.iterations <= 0 )
         return true;
@@ -103,7 +103,7 @@ bool relax( const MeshTopology & topology, Vector<T, VertId> & field, const Mesh
         field.swap( newField );
     }
     if ( params.hardSmoothTetrahedrons )
-        hardSmoothTetrahedrons( topology, field, params.region );
+        hardSmoothTetrahedronsT( topology, field, params.region );
     return true;
 }
 

--- a/source/mrmeshpy/MRPythonMeshPlugins.cpp
+++ b/source/mrmeshpy/MRPythonMeshPlugins.cpp
@@ -11,7 +11,6 @@
 #include "MRMesh/MRMeshRelax.h"
 #include "MRMesh/MRSurfacePath.h"
 #include "MRMesh/MRGeodesicPath.h"
-#include "MRMesh/MRMeshRelax.h"
 #include "MRMesh/MRMeshDelone.h"
 #include "MRMesh/MRMeshSubdivide.h"
 #include "MRMesh/MRMeshComponents.h"
@@ -144,7 +143,7 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, DegenerationsDetection, [] ( pybind11::modul
     m.def( "hasMultipleEdges", &MR::hasMultipleEdges,
         pybind11::arg( "topology" ), "finds multiple edges in the mesh" );
 
-    m.def( "removeSpikes", &MR::removeSpikes,
+    m.def( "removeSpikes", ( void( * )( MR::Mesh&, int, float, const MR::VertBitSet * ) ) &MR::removeSpikes,
         pybind11::arg( "mesh" ), pybind11::arg( "maxIterations" ), pybind11::arg( "minSumAngle" ), pybind11::arg( "region" ) = nullptr,
         "applies at most given number of relaxation iterations the spikes detected by given threshold" );
 } )
@@ -313,18 +312,18 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, Relax, [] ( pybind11::module_& m )
         def_readwrite( "surfaceDilateRadius", &MeshApproxRelaxParams::surfaceDilateRadius, "Radius to find neighbors by surface. `0.0f - default = 1e-3 * sqrt(surface area)`" ).
         def_readwrite( "type", &MeshApproxRelaxParams::type, "" );
 
-    m.def( "relax", ( bool( * )( Mesh&, const MeshRelaxParams&, ProgressCallback ) )& relax,
+    m.def( "relax", ( bool( * )( Mesh&, const MeshRelaxParams&, const ProgressCallback& ) )& relax,
         pybind11::arg( "mesh" ), pybind11::arg_v( "params", MeshRelaxParams(), "MeshRelaxParams()" ), pybind11::arg( "cb" ) = ProgressCallback{},
         "Applies the given number of relaxation iterations to the whole mesh (or some region if it is specified in the params).\n"
         "\tReturns `True` if the operation completed succesfully, and `False` if it was interrupted by the progress callback." );
 
-    m.def( "relaxKeepVolume", &relaxKeepVolume,
+    m.def( "relaxKeepVolume", ( bool( * )( Mesh&, const MeshRelaxParams&, const ProgressCallback& ) )& relaxKeepVolume,
         pybind11::arg( "mesh" ), pybind11::arg_v( "params", MeshRelaxParams(), "MeshRelaxParams()" ), pybind11::arg( "cb" ) = ProgressCallback{},
         "Applies the given number of relaxation iterations to the whole mesh (or some region if it is specified in the params).\n"
         "do not really keeps volume but tries hard \n"
         "\tReturns `True` if the operation completed succesfully, and `False` if it was interrupted by the progress callback." );
 
-    m.def( "relaxApprox", &relaxApprox,
+    m.def( "relaxApprox", ( bool( * )( Mesh&, const MeshApproxRelaxParams&, const ProgressCallback& ) )& relaxApprox,
         pybind11::arg( "mesh" ), pybind11::arg_v( "params", MeshApproxRelaxParams(), "MeshApproxRelaxParams()" ), pybind11::arg( "cb" ) = ProgressCallback{},
         "Applies the given number of relaxation iterations to the whole mesh (or some region if it is specified through the params).\n"
         "The algorithm looks at approx neighborhoods to smooth the mesh\n"

--- a/source/mrmeshpy/MRPythonSegmentation.cpp
+++ b/source/mrmeshpy/MRPythonSegmentation.cpp
@@ -72,8 +72,8 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrmeshpy, EdgeMetrics, [] ( pybind11::module_& m )
     pybind11::class_<MR::EdgeMetric>( m, "EdgeMetric" );
 
     m.def( "identityMetric", &MR::identityMetric, "metric returning 1 for every edge" );
-    m.def( "edgeLengthMetric", &MR::edgeLengthMetric, pybind11::arg( "mesh" ), "returns edge's length as a metric" );
-    m.def( "edgeCurvMetric", &MR::edgeCurvMetric,
+    m.def( "edgeLengthMetric", ( MR::EdgeMetric( * )( const MR::Mesh & ) ) &MR::edgeLengthMetric, pybind11::arg( "mesh" ), "returns edge's length as a metric" );
+    m.def( "edgeCurvMetric", ( MR::EdgeMetric( * )( const MR::Mesh &, float, float ) ) &MR::edgeCurvMetric,
         pybind11::arg( "mesh" ), pybind11::arg( "angleSinFactor" ) = 2.0f, pybind11::arg( "angleSinForBoundary" ) = 0.0f,
         "returns edge's metric that depends both on edge's length and on the angle between its left and right faces\n"
         "\tangleSinFactor - multiplier before dihedral angle sine in edge metric calculation (positive to prefer concave angles, negative - convex)\n"


### PR DESCRIPTION
New overloads take topology and points by (const) reference and do not require constructing `Mesh` object.

Changed headers: `MRMeshRelax.h`, `MREdgePaths.h`, `MREdgeMetric.h`