### PR TITLE
MeshNormals improvements

### DIFF
--- a/source/MRMesh/MRMeshNormals.cpp
+++ b/source/MRMesh/MRMeshNormals.cpp
@@ -4,8 +4,8 @@
 #include "MRBuffer.h"
 #include "MRVector4.h"
 #include "MRBitSetParallelFor.h"
+#include "MRParallelFor.h"
 #include "MRTimer.h"
-#include "MRPch/MRTBB.h"
 
 namespace MR
 {
@@ -13,49 +13,31 @@ namespace MR
 FaceNormals computePerFaceNormals( const Mesh & mesh )
 {
     MR_TIMER
-    FaceId lastValidFace = mesh.topology.lastValidFace();
-
-    const auto & edgePerFace = mesh.topology.edgePerFace();
-    std::vector<Vector3f> res( lastValidFace + 1 );
-    tbb::parallel_for( tbb::blocked_range<FaceId>( FaceId{0}, lastValidFace + 1 ), [&]( const tbb::blocked_range<FaceId> & range )
+    std::vector<Vector3f> res( mesh.topology.faceSize() );
+    BitSetParallelFor( mesh.topology.getValidFaces(), [&]( FaceId f )
     {
-        for ( FaceId f = range.begin(); f < range.end(); ++f )
-        {
-            auto e = edgePerFace[f];
-            if ( !e.valid() )
-                continue;
-            res[f] = mesh.leftNormal( e );
-        }
+        res[f] = mesh.normal( f );
     } );
-
     return res;
 }
 
 void computePerFaceNormals4( const Mesh & mesh, Vector4f* faceNormals, size_t size )
 {
     MR_TIMER
-    FaceId lastValidFace = mesh.topology.lastValidFace();
-    size = std::min( size, size_t( lastValidFace + 1 ) );
-
-    const auto & edgePerFace = mesh.topology.edgePerFace();
-    tbb::parallel_for( tbb::blocked_range<FaceId>( FaceId{ 0 }, FaceId{ size } ), [&]( const tbb::blocked_range<FaceId> & range )
+    size = std::min( size, mesh.topology.faceSize() );
+    ParallelFor( 0_f, FaceId( size ), [&]( FaceId f )
     {
-        for ( FaceId f = range.begin(); f < range.end(); ++f )
-        {
-            auto e = edgePerFace[f];
-            if ( !e.valid() )
-                continue;
-            const auto norm = mesh.leftNormal( e );
-            faceNormals[f] = Vector4f{ norm.x, norm.y, norm.z, 1.0f };
-        }
+        if ( !mesh.topology.hasFace( f ) )
+            return;
+        const auto norm = mesh.normal( f );
+        faceNormals[f] = Vector4f{ norm.x, norm.y, norm.z, 1.0f };
     } );
 }
 
 VertNormals computePerVertNormals( const Mesh & mesh )
 {
     MR_TIMER
-    VertId lastValidVert = mesh.topology.lastValidVert();
-    std::vector<Vector3f> res( lastValidVert + 1 );
+    std::vector<Vector3f> res( mesh.topology.vertSize() );
     BitSetParallelFor( mesh.topology.getValidVerts(), [&] ( VertId v )
     {
         res[v] = mesh.normal( v );
@@ -66,8 +48,7 @@ VertNormals computePerVertNormals( const Mesh & mesh )
 VertNormals computePerVertPseudoNormals( const Mesh & mesh )
 {
     MR_TIMER
-    VertId lastValidVert = mesh.topology.lastValidVert();
-    std::vector<Vector3f> res( lastValidVert + 1 );
+    std::vector<Vector3f> res( mesh.topology.vertSize() );
     BitSetParallelFor( mesh.topology.getValidVerts(), [&] ( VertId v )
     {
         res[v] = mesh.pseudonormal( v );
@@ -81,15 +62,10 @@ MeshNormals computeMeshNormals( const Mesh & mesh )
     MeshNormals res;
 
     // compute directional areas of each mesh triangle
-    FaceId lastValidFace = mesh.topology.lastValidFace();
-    res.faceNormals.resize( lastValidFace + 1 );
-    tbb::parallel_for( tbb::blocked_range<FaceId>( FaceId{0}, lastValidFace + 1 ), [&]( const tbb::blocked_range<FaceId> & range )
+    res.faceNormals.resize( mesh.topology.faceSize() );
+    BitSetParallelFor( mesh.topology.getValidFaces(), [&]( FaceId f )
     {
-        for ( FaceId f = range.begin(); f < range.end(); ++f )
-        {
-            if ( mesh.topology.hasFace( f ) )
-                res.faceNormals[f] = mesh.dirDblArea( f );
-        }
+        res.faceNormals[f] = mesh.dirDblArea( f );
     } );
 
     // compute per-vertex normals from directional areas
@@ -106,24 +82,16 @@ MeshNormals computeMeshNormals( const Mesh & mesh )
         return sum.normalized();
     };
 
-    VertId lastValidVert = mesh.topology.lastValidVert();
-    res.vertNormals.resize( lastValidVert + 1 );
-    tbb::parallel_for( tbb::blocked_range<VertId>( VertId{0}, lastValidVert + 1 ), [&]( const tbb::blocked_range<VertId> & range )
+    res.vertNormals.resize( mesh.topology.vertSize() );
+    BitSetParallelFor( mesh.topology.getValidVerts(), [&] ( VertId v )
     {
-        for ( VertId v = range.begin(); v < range.end(); ++v )
-        {
-            if ( mesh.topology.hasVert( v ) )
-                res.vertNormals[v] = computeVertNormal( v );
-        }
+        res.vertNormals[v] = computeVertNormal( v );
     } );
 
     // compute per-face normals from directional areas
-    tbb::parallel_for( tbb::blocked_range<FaceId>( FaceId{0}, lastValidFace + 1 ), [&]( const tbb::blocked_range<FaceId> & range )
+    BitSetParallelFor( mesh.topology.getValidFaces(), [&]( FaceId f )
     {
-        for ( FaceId f = range.begin(); f < range.end(); ++f )
-        {
-            res.faceNormals[f] = res.faceNormals[f].normalized();
-        }
+        res.faceNormals[f] = res.faceNormals[f].normalized();
     } );
 
     return res;
@@ -132,10 +100,8 @@ MeshNormals computeMeshNormals( const Mesh & mesh )
 Vector<TriangleCornerNormals, FaceId> computePerCornerNormals( const Mesh & mesh, const UndirectedEdgeBitSet * creases )
 {
     MR_TIMER
-    VertId lastValidVert = mesh.topology.lastValidVert();
-    FaceId lastValidFace = mesh.topology.lastValidFace();
 
-    Vector<TriangleCornerNormals, FaceId> res( lastValidFace + 1 );
+    Vector<TriangleCornerNormals, FaceId> res( mesh.topology.faceSize() );
     // converts edge to the normal in its left face at the corner of its origin
     auto edgeToLeftOrgNormal = [&]( EdgeId e ) -> Vector3f &
     {
@@ -153,64 +119,60 @@ Vector<TriangleCornerNormals, FaceId> computePerCornerNormals( const Mesh & mesh
         return res[f][ne];
     };
 
-    tbb::parallel_for( tbb::blocked_range<VertId>( VertId{0}, lastValidVert + 1 ), [&]( const tbb::blocked_range<VertId> & range )
+    BitSetParallelFor( mesh.topology.getValidVerts(), [&] ( VertId v )
     {
-        for ( VertId v = range.begin(); v < range.end(); ++v )
+        auto e0 = mesh.topology.edgeWithOrg( v );
+        assert( e0 );
+        bool creaseVert = false;
+        if ( creases )
         {
-            auto e0 = mesh.topology.edgeWithOrg( v );
-            if ( !e0 )
-                continue;
-            bool creaseVert = false;
-            if ( creases )
+            for ( EdgeId e : orgRing( mesh.topology, e0 ) )
             {
-                for ( EdgeId e : orgRing( mesh.topology, e0 ) )
+                if ( creases->test( e.undirected() ) )
                 {
-                    if ( creases->test( e.undirected() ) )
-                    {
-                        creaseVert = true;
-                        e0 = e;
-                        break;
-                    }
+                    creaseVert = true;
+                    e0 = e;
+                    break;
                 }
             }
-            if ( !creaseVert )
+        }
+        if ( !creaseVert )
+        {
+            const auto norm = mesh.normal( v );
+            for ( EdgeId e : orgRing( mesh.topology, e0 ) )
+                if ( mesh.topology.left( e ) )
+                    edgeToLeftOrgNormal( e ) = norm;
+        }
+        else
+        {
+            // this vertex has at least one incident crease
+            EdgeId efirst = e0;
+            for ( ;;)
             {
-                const auto norm = mesh.normal( v );
-                for ( EdgeId e : orgRing( mesh.topology, e0 ) )
+                // compute average normal from crease edge to crease edge
+                EdgeId elast = e0;
+                Vector3f sum;
+                for ( EdgeId e : orgRing( mesh.topology, efirst ) )
+                {
+                    if ( e != efirst && creases->test( e.undirected() ) )
+                    {
+                        elast = e;
+                        break;
+                    }
+                    if ( mesh.topology.left( e ) )
+                        sum += mesh.leftDirDblArea( e );
+                }
+                const auto norm = sum.normalized();
+                for ( EdgeId e : orgRing( mesh.topology, efirst ) )
+                {
+                    if ( e != efirst && e == elast )
+                        break;
                     if ( mesh.topology.left( e ) )
                         edgeToLeftOrgNormal( e ) = norm;
-            }
-            else
-            {
-                // this vertex has at least one incident crease
-                EdgeId efirst = e0;
-                for ( ;;)
-                {
-                    // compute average normal from crease edge to crease edge
-                    EdgeId elast = e0;
-                    Vector3f sum;
-                    for ( EdgeId e : orgRing( mesh.topology, efirst ) )
-                    {
-                        if ( e != efirst && creases->test( e.undirected() ) )
-                        {
-                            elast = e;
-                            break;
-                        }
-                        if ( mesh.topology.left( e ) )
-                            sum += mesh.leftDirDblArea( e );
-                    }
-                    const auto norm = sum.normalized();
-                    for ( EdgeId e : orgRing( mesh.topology, efirst ) )
-                    {
-                        if ( e != efirst && e == elast )
-                            break;
-                        if ( mesh.topology.left( e ) )
-                            edgeToLeftOrgNormal( e ) = norm;
-                    }
-                    if ( elast == e0 )
-                        break;
-                    efirst = elast;
                 }
+                if ( elast == e0 )
+                    break;
+                efirst = elast;
             }
         }
     } );


### PR DESCRIPTION
* Allocate memory by the number of elements in topology vectors, and not searching for the actual last valid element, which was slow for large sparse meshes.
* Simplify parallel-fors and check for element existence in bitset, which again faster for large sparse meshes.