### PR TITLE
DirectionWidget improvements

### DIFF
--- a/source/MRViewer/MRDirectionWidget.cpp
+++ b/source/MRViewer/MRDirectionWidget.cpp
@@ -232,6 +232,22 @@ Vector3f DirectionWidget::getDirection() const
     return ( directionObj_->worldXf().A * Vector3f::plusZ() ).normalized();
 }
 
+float DirectionWidget::getLocalLength() const
+{
+    if ( !directionObj_ )
+        return assert( false ), 0.0f;
+
+    return ( directionObj_->xf().A * Vector3f::plusZ() ).length();
+}
+
+float DirectionWidget::getLength() const
+{
+    if ( !directionObj_ )
+        return assert( false ), 0.0f;
+
+    return ( directionObj_->worldXf().A * Vector3f::plusZ() ).length();
+}
+
 auto DirectionWidget::getLocalArrow() const -> Arrow
 {
     Arrow res;

--- a/source/MRViewer/MRDirectionWidget.cpp
+++ b/source/MRViewer/MRDirectionWidget.cpp
@@ -5,7 +5,6 @@
 #include "MRMesh/MRObjectMesh.h"
 #include "MRMesh/MRArrow.h"
 #include "MRMesh/MRSceneRoot.h"
-#include "MRMesh/MRMatrix3Decompose.h"
 
 namespace MR
 {
@@ -240,12 +239,11 @@ auto DirectionWidget::getLocalArrow() const -> Arrow
         return assert( false ), res;
 
     const auto xf = directionObj_->xf();
-    res.dir = ( xf.A * Vector3f::plusZ() ).normalized();
+    const auto arrowVec = xf.A * Vector3f::plusZ();
+    res.length = arrowVec.length();
+    if ( res.length )
+        res.dir = arrowVec / res.length;
     res.base = xf.b;
-
-    Matrix3f r, s;
-    decomposeMatrix3( xf.A, r, s );
-    res.length = ( s.x.x + s.y.y + s.z.z ) / 3;
     return res;
 }
 
@@ -256,12 +254,11 @@ auto DirectionWidget::getArrow() const -> Arrow
         return assert( false ), res;
 
     const auto xf = directionObj_->worldXf();
-    res.dir = ( xf.A * Vector3f::plusZ() ).normalized();
+    const auto arrowVec = xf.A * Vector3f::plusZ();
+    res.length = arrowVec.length();
+    if ( res.length )
+        res.dir = arrowVec / res.length;
     res.base = xf.b;
-
-    Matrix3f r, s;
-    decomposeMatrix3( xf.A, r, s );
-    res.length = ( s.x.x + s.y.y + s.z.z ) / 3; // assumes uniform scaling in all parent objects
     return res;
 }
 

--- a/source/MRViewer/MRDirectionWidget.cpp
+++ b/source/MRViewer/MRDirectionWidget.cpp
@@ -10,11 +10,9 @@
 namespace MR
 {
 
-void DirectionWidget::create( const Vector3f& dir, const Vector3f& base, float length, OnDirectionChangedCallback onDirectionChanged, Object* parent )
+void DirectionWidget::create( Object* parent )
 {
     reset();
-    length_ = length;
-    onDirectionChanged_ = onDirectionChanged;
     connect( &getViewerInstance(), 10, boost::signals2::at_front );
 
     std::shared_ptr<Mesh> mesh = std::make_shared<Mesh>( makeArrow( {}, length_ * Vector3f::plusZ(), length_ * 0.02f, length_ * 0.04f, length_ * 0.08f));
@@ -27,9 +25,16 @@ void DirectionWidget::create( const Vector3f& dir, const Vector3f& base, float l
     if ( !parent )
         parent = &SceneRoot::get();
     parent->addChild( directionObj_ );
+}
 
-    updateDirection( dir );
-    updateBase( base );
+void DirectionWidget::create( const Vector3f& worldDir, const Vector3f& worldBase, float length, OnDirectionChangedCallback onDirectionChanged, Object* parent )
+{
+    length_ = length;
+    onDirectionChanged_ = onDirectionChanged;
+    create( parent );
+
+    updateDirection( worldDir );
+    updateBase( worldBase );
 }
 
 void DirectionWidget::reset()

--- a/source/MRViewer/MRDirectionWidget.cpp
+++ b/source/MRViewer/MRDirectionWidget.cpp
@@ -30,10 +30,7 @@ void DirectionWidget::create( const Vector3f& worldDir, const Vector3f& worldBas
 {
     onDirectionChanged_ = onDirectionChanged;
     create( parent );
-
-    updateDirection( worldDir );
-    updateBase( worldBase );
-    updateLength( worldLength );
+    updateArrow( { .dir = worldDir, .base = worldBase, .length = worldLength } );
 }
 
 void DirectionWidget::reset()

--- a/source/MRViewer/MRDirectionWidget.h
+++ b/source/MRViewer/MRDirectionWidget.h
@@ -17,34 +17,13 @@ public:
     /// This callback is invoked every time when the direction is changed by mouse
     using OnDirectionChangedCallback = std::function<void( const Vector3f&, bool )>;
 
-    /// This history action must be created before the change in widget's direction or base to make them undo-able
+    /// This history action must be created before the change in widget's direction, base or length to make them undo-able
     class ChangeDirAction : public ChangeXfAction
     {
     public:
         ChangeDirAction( DirectionWidget& widget, const std::string& name = "Change Direction" ) :
             ChangeXfAction( name, static_pointer_cast<Object>( widget.directionObj_ ) )
         {}
-    };
-
-    /// history action for changing the length. It should be added to the history stack by user code
-    class ChangeLengthAction : public ChangeXfAction
-    {
-    public:
-        ChangeLengthAction( DirectionWidget& widget ) :
-            ChangeXfAction( "Change Length", static_pointer_cast< Object >( widget.directionObj_ ) ),
-            widget_{ widget },
-            length_{ widget.length_ }
-        {}
-        virtual void action( Type ) override
-        {
-            auto len = widget_.length_;
-            widget_.updateLength( length_ );
-            length_ = len;
-
-        }
-    private:
-        DirectionWidget& widget_;
-        float length_;
     };
 
     /// history action for changing the visible. It should be added to the history stack by user code
@@ -78,7 +57,6 @@ public:
 private:
     std::shared_ptr<ObjectMesh> directionObj_;
 
-    float length_ = 1;
     bool mousePressed_ = false;
     // if blocked cannot be moved with mouse
     bool blockedMouse_{ false };
@@ -91,7 +69,7 @@ private:
 
 public:
     /// Creates a new widget for visualizing the direction and adds it to scene;
-    /// subscribes to viewer events; intial local direction is (0,0,1), initial local base (0,0,0), the length is 1 (or the last manually set value)
+    /// subscribes to viewer events; intial local direction is (0,0,1), initial local base (0,0,0), the length is 1
     /// @param parent parent object for the widget, nullptr means scene root
     MRVIEWER_API void create( Object* parent = nullptr );
 
@@ -99,10 +77,10 @@ public:
     /// subscribes to viewer events
     /// @param dir initial direction, in world space
     /// @param base initial base of the arrow, in world space
-    /// @param length length of the arrow
+    /// @param length length of the arrow, in world space
     /// @param onDirectionChanged callback for the direction change
     /// @param parent parent object for the widget, nullptr means scene root
-    MRVIEWER_API void create( const Vector3f& worldDir, const Vector3f& worldBase, float length, OnDirectionChangedCallback onDirectionChanged, Object* parent = nullptr );
+    MRVIEWER_API void create( const Vector3f& worldDir, const Vector3f& worldBase, float worldLength, OnDirectionChangedCallback onDirectionChanged, Object* parent = nullptr );
 
     /// Removes the widget from the scene
     /// unsubscribes from viewer events
@@ -123,14 +101,14 @@ public:
     /// Updates the base of the arrow in parent's space
     MRVIEWER_API void updateLocalBase( const Vector3f& base );
 
-    /// Updates the length of the arrow
+    /// Updates the length of the arrow, in world space
     MRVIEWER_API void updateLength( float length );
 
-    /// Updates the base and the length of the arrow
-    MRVIEWER_API void updateArrow( const Vector3f& base, float length );
-    
+    /// Updates the length of the arrow in parent's space
+    MRVIEWER_API void updateLocalLength( float length );
+
     /// Returns internal data model object of this widget
-    std::shared_ptr<ObjectMesh> obj() const { return directionObj_; }
+    const std::shared_ptr<ObjectMesh>& obj() const { return directionObj_; }
 
     /// Sets the visibility of the widget
     MRVIEWER_API void setVisible( bool visible );
@@ -155,6 +133,12 @@ public:
     /// Returns the direction of the widget in parent's space
     MRVIEWER_API Vector3f getLocalDirection() const;
 
+    /// Returns the length of the arrow in world space
+    MRVIEWER_API float getLength() const;
+
+    /// Returns the length of the arrow in parent's space
+    MRVIEWER_API float getLocalLength() const;
+
     /// Returns pointer to parent object, always not-null after create() and before reset()
     MRVIEWER_API Object* getParentPtr() const;
 
@@ -162,6 +146,7 @@ public:
     bool isMouseBlocked() const { return blockedMouse_; }
 
     void setMouseBlocked( bool blocked ) { blockedMouse_ = blocked; }
+
 private:
     MRVIEWER_API virtual bool onMouseDown_( MouseButton button, int modifier ) override;
     MRVIEWER_API virtual bool onMouseUp_( MouseButton button, int modifier ) override;

--- a/source/MRViewer/MRDirectionWidget.h
+++ b/source/MRViewer/MRDirectionWidget.h
@@ -82,9 +82,9 @@ public:
 
     /// Creates a new widget for visualizing the direction and adds it to scene
     /// subscribes to viewer events
-    /// @param dir initial direction, in world space
-    /// @param base initial base of the arrow, in world space
-    /// @param length length of the arrow, in world space
+    /// @param worldDir initial direction, in world space
+    /// @param worldBase initial base of the arrow, in world space
+    /// @param worldLength length of the arrow, in world space
     /// @param onDirectionChanged callback for the direction change
     /// @param parent parent object for the widget, nullptr means scene root
     MRVIEWER_API void create( const Vector3f& worldDir, const Vector3f& worldBase, float worldLength, OnDirectionChangedCallback onDirectionChanged, Object* parent = nullptr );

--- a/source/MRViewer/MRDirectionWidget.h
+++ b/source/MRViewer/MRDirectionWidget.h
@@ -153,10 +153,10 @@ public:
     MRVIEWER_API Vector3f getLocalDirection() const;
 
     /// Returns the length of the arrow in world space
-    float getLength() const { return getArrow().length; }
+    MRVIEWER_API float getLength() const;
 
     /// Returns the length of the arrow in parent's space
-    float getLocalLength() const { return getLocalArrow().length; }
+    MRVIEWER_API float getLocalLength() const;
 
     /// Returns pointer to parent object, always not-null after create() and before reset()
     MRVIEWER_API Object* getParentPtr() const;

--- a/source/MRViewer/MRDirectionWidget.h
+++ b/source/MRViewer/MRDirectionWidget.h
@@ -78,7 +78,7 @@ public:
 private:
     std::shared_ptr<ObjectMesh> directionObj_;
 
-    float length_ = 0;
+    float length_ = 1;
     bool mousePressed_ = false;
     // if blocked cannot be moved with mouse
     bool blockedMouse_{ false };
@@ -90,14 +90,19 @@ private:
     void clear_();
 
 public:
+    /// Creates a new widget for visualizing the direction and adds it to scene;
+    /// subscribes to viewer events; intial local direction is (0,0,1), initial local base (0,0,0), the length is 1 (or the last manually set value)
+    /// @param parent parent object for the widget, nullptr means scene root
+    MRVIEWER_API void create( Object* parent = nullptr );
+
     /// Creates a new widget for visualizing the direction and adds it to scene
     /// subscribes to viewer events
-    /// @param dir initial direction
-    /// @param base initial base of the arrow
+    /// @param dir initial direction, in world space
+    /// @param base initial base of the arrow, in world space
     /// @param length length of the arrow
     /// @param onDirectionChanged callback for the direction change
     /// @param parent parent object for the widget, nullptr means scene root
-    MRVIEWER_API void create( const Vector3f& dir, const Vector3f& base, float length, OnDirectionChangedCallback onDirectionChanged, Object* parent = nullptr  );
+    MRVIEWER_API void create( const Vector3f& worldDir, const Vector3f& worldBase, float length, OnDirectionChangedCallback onDirectionChanged, Object* parent = nullptr );
 
     /// Removes the widget from the scene
     /// unsubscribes from viewer events

--- a/source/MRViewer/MRDirectionWidget.h
+++ b/source/MRViewer/MRDirectionWidget.h
@@ -68,6 +68,13 @@ private:
     void clear_();
 
 public:
+    struct Arrow
+    {
+        Vector3f dir;     ///< unit direction along arrow
+        Vector3f base;    ///< the point from which the arrow starts
+        float length = 1; ///< the length of the arrow
+    };
+
     /// Creates a new widget for visualizing the direction and adds it to scene;
     /// subscribes to viewer events; intial local direction is (0,0,1), initial local base (0,0,0), the length is 1
     /// @param parent parent object for the widget, nullptr means scene root
@@ -88,6 +95,12 @@ public:
 
     /// Manually set callback function
     MRVIEWER_API void setOnDirectionChangedCallback( OnDirectionChangedCallback cb );
+
+    /// Updates the arrow, in world space
+    MRVIEWER_API void updateArrow( const Arrow& arrow );
+
+    /// Updates the arrow in parent's space
+    MRVIEWER_API void updateLocalArrow( const Arrow& arrow );
 
     /// Updates the direction of the arrow, in world space
     MRVIEWER_API void updateDirection( const Vector3f& dir );
@@ -121,6 +134,12 @@ public:
     /// Returns the color of the widget
     MRVIEWER_API const Color& getColor() const;
 
+    /// Returns the arrow's properties, in world space
+    MRVIEWER_API Arrow getArrow() const;
+
+    /// Returns the arrow's properties in parent's space
+    MRVIEWER_API Arrow getLocalArrow() const;
+
     /// Returns the base of the widget, in world space
     MRVIEWER_API Vector3f getBase() const;
 
@@ -134,10 +153,10 @@ public:
     MRVIEWER_API Vector3f getLocalDirection() const;
 
     /// Returns the length of the arrow in world space
-    MRVIEWER_API float getLength() const;
+    float getLength() const { return getArrow().length; }
 
     /// Returns the length of the arrow in parent's space
-    MRVIEWER_API float getLocalLength() const;
+    float getLocalLength() const { return getLocalArrow().length; }
 
     /// Returns pointer to parent object, always not-null after create() and before reset()
     MRVIEWER_API Object* getParentPtr() const;


### PR DESCRIPTION
* Arrow length is stored as a uniform scale in the transformation. No need in separate `ChangeLengthAction` now.
* Simple version of `create( Object* parent = nullptr )` method.
* `struct Arrow` with all properties extracted from the transformation.
* New methods: `updateArrow`, `updateLocalArrow`, `updateLocalLength`, `getArrow`, `getLocalArrow`, `getLength`, `getLocalLength`.