### PR TITLE
AABBTreePoints::Node: rename left and right children

### DIFF
--- a/source/MRMesh/MRAABBTreePoints.cpp
+++ b/source/MRMesh/MRAABBTreePoints.cpp
@@ -89,12 +89,12 @@ std::pair<SubtreePoints, SubtreePoints> AABBTreePointsMaker::makeNode( const Sub
     const int midPoint = partitionPoints( node.box, s.firstPoint, s.firstPoint + s.numPoints );
     const int leftNumPoints = midPoint - s.firstPoint;
     const int rightNumPoints = s.numPoints - leftNumPoints;
-    node.leftOrFirst = s.root + 1;
-    node.rightOrLast = s.root + 1 + getNumNodesPoints( leftNumPoints );
+    node.l = s.root + 1;
+    node.r = s.root + 1 + getNumNodesPoints( leftNumPoints );
     return
     {
-        SubtreePoints( node.leftOrFirst, s.firstPoint, leftNumPoints ),
-        SubtreePoints( node.rightOrLast, midPoint,     rightNumPoints )
+        SubtreePoints( node.l, s.firstPoint, leftNumPoints ),
+        SubtreePoints( node.r, midPoint,     rightNumPoints )
     };
 }
 
@@ -285,11 +285,11 @@ void AABBTreePoints::refit( const VertCoords & newCoords, const VertBitSet & cha
         auto & node = nodes_[nid];
         if ( node.leaf() )
             continue;
-        if ( !changedNodes.test( node.leftOrFirst ) && !changedNodes.test( node.rightOrLast ) )
+        if ( !changedNodes.test( node.l ) && !changedNodes.test( node.r ) )
             continue;
         changedNodes.set( nid );
-        node.box = nodes_[node.leftOrFirst].box;
-        node.box.include( nodes_[node.rightOrLast].box );
+        node.box = nodes_[node.l].box;
+        node.box.include( nodes_[node.r].box );
     }
 }
 
@@ -305,8 +305,8 @@ TEST( MRMesh, AABBTreePoints )
 
     EXPECT_EQ( tree[AABBTreePoints::rootNodeId()].box, box );
 
-    EXPECT_TRUE( tree[AABBTreePoints::rootNodeId()].leftOrFirst.valid() );
-    EXPECT_TRUE( tree[AABBTreePoints::rootNodeId()].rightOrLast.valid() );
+    EXPECT_TRUE( tree[AABBTreePoints::rootNodeId()].l.valid() );
+    EXPECT_TRUE( tree[AABBTreePoints::rootNodeId()].r.valid() );
 
     assert( !tree.nodes().empty() );
     auto m = std::move( tree );
@@ -325,8 +325,8 @@ TEST( MRMesh, AABBTreePointsFromMesh )
 
     EXPECT_EQ( tree[AABBTreePoints::rootNodeId()].box, box );
 
-    EXPECT_TRUE( tree[AABBTreePoints::rootNodeId()].leftOrFirst.valid() );
-    EXPECT_TRUE( tree[AABBTreePoints::rootNodeId()].rightOrLast.valid() );
+    EXPECT_TRUE( tree[AABBTreePoints::rootNodeId()].l.valid() );
+    EXPECT_TRUE( tree[AABBTreePoints::rootNodeId()].r.valid() );
 
     assert( !tree.nodes().empty() );
     auto m = std::move( tree );

--- a/source/MRMesh/MRAABBTreePoints.h
+++ b/source/MRMesh/MRAABBTreePoints.h
@@ -18,13 +18,14 @@ public:
     struct Node
     {
         Box3f box; ///< bounding box of whole subtree
-        NodeId leftOrFirst, rightOrLast; ///< child nodes indices if >=0, points indices if < 0
+        NodeId l;  ///< left child node for an inner node, or -(l+1) is the index of the first point in a leaf node
+        NodeId r;  ///< right child node for an inner node, or -(r+1) is the index of the last point in a leaf node
         /// returns true if node represent real points, false if it has child nodes
-        bool leaf() const { return !leftOrFirst.valid(); }
+        bool leaf() const { return !l.valid(); }
         /// returns [first,last) indices of leaf points
-        std::pair<int, int> getLeafPointRange() const { assert( leaf() ); return {-( leftOrFirst + 1 ),-( rightOrLast + 1 )}; }
+        std::pair<int, int> getLeafPointRange() const { assert( leaf() ); return { -( l + 1 ),-( r + 1 ) }; }
         /// sets [first,last) to this node (leaf)
-        void setLeafPointRange( int first, int last ) { leftOrFirst = NodeId( -( first + 1 ) ); rightOrLast = NodeId( -( last + 1 ) ); }
+        void setLeafPointRange( int first, int last ) { l = NodeId( -( first + 1 ) ); r = NodeId( -( last + 1 ) ); }
     };
     using NodeVec = Vector<Node, NodeId>;
     using NodeBitSet = TaggedBitSet<NodeTag>;

--- a/source/MRMesh/MRPointsInBall.cpp
+++ b/source/MRMesh/MRPointsInBall.cpp
@@ -99,18 +99,18 @@ void findPointsInBall( const AABBTreePoints& tree, Ball3f ball,
             continue;
         }
 
-        auto lDistSq = boxDistSq( node.leftOrFirst );
-        auto rDistSq = boxDistSq( node.rightOrLast );
+        auto lDistSq = boxDistSq( node.l );
+        auto rDistSq = boxDistSq( node.r );
         /// first go in the node located closer to ball's center (in case the ball will shrink and the other node will be away)
         if ( lDistSq <= rDistSq )
         {
-            addSubTask( node.rightOrLast );
-            addSubTask( node.leftOrFirst );
+            addSubTask( node.r );
+            addSubTask( node.l );
         }
         else
         {
-            addSubTask( node.leftOrFirst );
-            addSubTask( node.rightOrLast );
+            addSubTask( node.l );
+            addSubTask( node.r );
         }
     }
 }

--- a/source/MRMesh/MRPointsInBox.cpp
+++ b/source/MRMesh/MRPointsInBox.cpp
@@ -62,8 +62,8 @@ void findPointsInBox( const AABBTreePoints& tree, const Box3f& box,
             continue;
         }
 
-        addSubTask( node.rightOrLast ); // look at right node later
-        addSubTask( node.leftOrFirst ); // look at left node first
+        addSubTask( node.r ); // look at right node later
+        addSubTask( node.l ); // look at left node first
     }
 }
 

--- a/source/MRMesh/MRPointsProject.cpp
+++ b/source/MRMesh/MRPointsProject.cpp
@@ -90,8 +90,8 @@ PointsProjectionResult findProjectionOnPoints( const Vector3f& pt, const PointCl
             continue;
         }
 
-        auto s1 = getSubTask( node.leftOrFirst );
-        auto s2 = getSubTask( node.rightOrLast );
+        auto s1 = getSubTask( node.l );
+        auto s2 = getSubTask( node.r );
         // add task with smaller distance last to descend there first
         if ( s1.distSq < s2.distSq )
         {
@@ -176,8 +176,8 @@ void findFewClosestPoints( const Vector3f& pt, const PointCloud& pc, FewSmallest
             continue;
         }
 
-        auto s1 = getSubTask( node.leftOrFirst );
-        auto s2 = getSubTask( node.rightOrLast );
+        auto s1 = getSubTask( node.l );
+        auto s2 = getSubTask( node.r );
         // add task with smaller distance last to descend there first
         if ( s1.distSq < s2.distSq )
         {


### PR DESCRIPTION
This is to simplify writing generic algorithms for both AABBTree and AABBTreePoints