### PR TITLE
getPickedPointNormal( const VisualObject& object, const PickedPoint& point )

### DIFF
--- a/source/MRMesh/MRMeshMath.cpp
+++ b/source/MRMesh/MRMeshMath.cpp
@@ -463,6 +463,13 @@ Vector3f dirDblArea( const MeshTopology & topology, const VertCoords & points, V
 
 Vector3f normal( const MeshTopology & topology, const VertCoords & points, const MeshTriPoint & p )
 {
+    if ( p.bary.b == 0 )
+    {
+        // do not require to have triangular face to the left of p.e
+        const Vector3f n0 = normal( topology, points, topology.org( p.e ) );
+        const Vector3f n1 = normal( topology, points, topology.dest( p.e ) );
+        return lerp( n0, n1, p.bary.a ).normalized();
+    }
     VertId a, b, c;
     topology.getLeftTriVerts( p.e, a, b, c );
     auto n0 = normal( topology, points, a );

--- a/source/MRMesh/MRPointOnObject.h
+++ b/source/MRMesh/MRPointOnObject.h
@@ -43,7 +43,7 @@ using PickedPoint = std::variant<std::monostate, MeshTriPoint, EdgePoint, VertId
 /// Converts PointOnObject coordinates depending on the object type to the PickedPoint variant
 MRMESH_API PickedPoint pointOnObjectToPickedPoint( const VisualObject* object, const PointOnObject& pos );
 
-/// Converts pickedPoint into local coordinates of its object,
+/// Converts given point into local coordinates of its object,
 /// returns std::nullopt if object or point is invalid, or if it does not present in the object's topology
 MRMESH_API std::optional<Vector3f> getPickedPointPosition( const VisualObject& object, const PickedPoint& point );
 
@@ -52,5 +52,9 @@ MRMESH_API std::optional<Vector3f> getPickedPointPosition( const VisualObject& o
 
 /// Checks that the picked point presents in the object's topology
 [[deprecated( "use getPickedPointPosition() instead" )]] MRMESH_API bool isPickedPointValid( const VisualObject* object, const PickedPoint& point );
+
+/// Returns object normal in local coordinates at given point,
+/// returns std::nullopt if object or point is invalid, or if it is ObjectLines or ObjectPoints without normals
+MRMESH_API std::optional<Vector3f> getPickedPointNormal( const VisualObject& object, const PickedPoint& point );
 
 } //namespace MR

--- a/source/MRViewer/MRSurfacePointPicker.cpp
+++ b/source/MRViewer/MRSurfacePointPicker.cpp
@@ -271,7 +271,7 @@ void SurfacePointWidget::updatePositionAndRadius_()
     if ( const MeshTriPoint* triPoint = std::get_if<MeshTriPoint>( &currentPos_ ) )
         updatePositionAndRadiusMesh_( *triPoint );
 
-    if ( auto p = toCoords() )
+    if ( auto p = findCoords() )
     {
         pickSphere_->setCenter( *p );
         setPointRadius_();
@@ -316,6 +316,11 @@ void SurfacePointWidget::setPointRadius_()
 void SurfacePointWidget::preDraw_()
 {
     setPointRadius_();
+}
+
+Vector3f SurfacePointWidget::getCoords() const
+{
+    return pickSphere_ ? pickSphere_->getCenter() : Vector3f{};
 }
 
 void SurfacePointWidget::setCurrentPosition( const PointOnObject& pos )

--- a/source/MRViewer/MRSurfacePointPicker.cpp
+++ b/source/MRViewer/MRSurfacePointPicker.cpp
@@ -207,24 +207,6 @@ bool SurfacePointWidget::onMouseMove_( int, int )
     return false;
 }
 
-Vector3f SurfacePointWidget::toVector3f() const
-{
-    return getPickedPointPosition( *baseObject_, currentPos_ ).value_or( Vector3f{} );
-}
-
-void SurfacePointWidget::updatePositionAndRadiusPoints_( const VertId& /* v */ )
-{
-    pickSphere_->setCenter( toVector3f() );
-    setPointRadius_();
-}
-
-void SurfacePointWidget::updatePositionAndRadiusLines_( const EdgePoint& /* ep */ )
-{
-    pickSphere_->setCenter( toVector3f() );
-    setPointRadius_();
-}
-
-
 void SurfacePointWidget::updatePositionAndRadiusMesh_( MeshTriPoint mtp )
 {
     assert( pickSphere_ );
@@ -253,7 +235,7 @@ void SurfacePointWidget::updatePositionAndRadiusMesh_( MeshTriPoint mtp )
                 currentPos_ = mesh.toTriPoint( f, ep );
             }
             break;
-        case PositionType::EdgeCeneters:
+        case PositionType::EdgeCenters:
         {
             auto closestEdge = EdgeId( mesh.getClosestEdge( PointOnFace{ f, mesh.triPoint( mtp ) } ) );
             if ( mesh.topology.left( closestEdge ) != f )
@@ -282,26 +264,18 @@ void SurfacePointWidget::updatePositionAndRadiusMesh_( MeshTriPoint mtp )
             }
             break;
     }
-
-    pickSphere_->setCenter( toVector3f() );
-    setPointRadius_();
 }
 
 void SurfacePointWidget::updatePositionAndRadius_()
 {
     if ( const MeshTriPoint* triPoint = std::get_if<MeshTriPoint>( &currentPos_ ) )
-    {
         updatePositionAndRadiusMesh_( *triPoint );
-    }
-    else if ( const EdgePoint* edgePoint = std::get_if<EdgePoint>( &currentPos_ ) )
+
+    if ( auto p = toCoords() )
     {
-        updatePositionAndRadiusLines_( *edgePoint );
+        pickSphere_->setCenter( *p );
+        setPointRadius_();
     }
-    else if ( const VertId* vertId = std::get_if<VertId>( &currentPos_ ) )
-    {
-        updatePositionAndRadiusPoints_( *vertId );
-    }
-    // pick in empty space
 }
 
 void SurfacePointWidget::setPointRadius_()

--- a/source/MRViewer/MRSurfacePointPicker.h
+++ b/source/MRViewer/MRSurfacePointPicker.h
@@ -24,7 +24,7 @@ public:
         Faces, // point can be in any place of surface
         FaceCenters, // point can be only in face center
         Edges, // point can be only on edges
-        EdgeCeneters, // point can be only in edge center
+        EdgeCenters, // point can be only in edge center
         Verts // point can be only in vertex
     };
 
@@ -102,8 +102,12 @@ public:
         return currentPos_;
     }
 
-    /// return current position transformed to Vector3f
-    MRVIEWER_API Vector3f toVector3f() const;
+    /// return local object's coordinates at the current position, or std::nullopt if it is invalid
+    std::optional<Vector3f> toCoords() const { return getPickedPointPosition( *baseObject_, currentPos_ ); }
+    [[deprecated]] Vector3f toVector3f() const { return toCoords().value_or( Vector3f{} ); }
+
+    /// return the normal in local object's coordinates at the current position, or std::nullopt if it is invalid or normal is not defined
+    std::optional<Vector3f> toNormal() const { return getPickedPointNormal( *baseObject_, currentPos_ ); }
 
     /// returns stored position as MeshTriPoint, otherwise returns invalid (default) MeshTriPoint
     MeshTriPoint getCurrentPositionMeshTriPoint() const
@@ -162,8 +166,6 @@ private:
 
     void updatePositionAndRadius_();
     void updatePositionAndRadiusMesh_( MeshTriPoint mtp );
-    void updatePositionAndRadiusPoints_( const VertId& v );
-    void updatePositionAndRadiusLines_( const EdgePoint& ep );
 
     Parameters params_;
 

--- a/source/MRViewer/MRSurfacePointPicker.h
+++ b/source/MRViewer/MRSurfacePointPicker.h
@@ -102,12 +102,15 @@ public:
         return currentPos_;
     }
 
+    /// return local object's coordinates at the current position where the center of sphere is located
+    MRVIEWER_API Vector3f getCoords() const;
+    [[deprecated]] Vector3f toVector3f() const { return getCoords(); }
+
     /// return local object's coordinates at the current position, or std::nullopt if it is invalid
-    std::optional<Vector3f> toCoords() const { return getPickedPointPosition( *baseObject_, currentPos_ ); }
-    [[deprecated]] Vector3f toVector3f() const { return toCoords().value_or( Vector3f{} ); }
+    std::optional<Vector3f> findCoords() const { return getPickedPointPosition( *baseObject_, currentPos_ ); }
 
     /// return the normal in local object's coordinates at the current position, or std::nullopt if it is invalid or normal is not defined
-    std::optional<Vector3f> toNormal() const { return getPickedPointNormal( *baseObject_, currentPos_ ); }
+    std::optional<Vector3f> findNormal() const { return getPickedPointNormal( *baseObject_, currentPos_ ); }
 
     /// returns stored position as MeshTriPoint, otherwise returns invalid (default) MeshTriPoint
     MeshTriPoint getCurrentPositionMeshTriPoint() const


### PR DESCRIPTION
* New function `getPickedPointNormal` for getting object normal in local coordinates at given PickedPoint.
* `Vector3f normal( const MeshTopology & topology, const VertCoords & points, const MeshTriPoint & p )` function supports point-on-edge mode much like `triPoint` function.
* `SurfacePointPicker`: typo fixes, `toVector3f()` deprecated, `getCoords()`, `findCoords()` and `findNormal()` introduced instead.