### PR TITLE
Polyline improvements

### DIFF
--- a/source/MRMesh/MRContour.h
+++ b/source/MRMesh/MRContour.h
@@ -65,7 +65,7 @@ R calcLength( const Contour<V>& contour )
     return l;
 }
 
-/// copy double-contour to float-contour, or vice versa
+/// copy double-contour to float-contour, or 2D contour to 3D contour, or vice versa
 template<typename To, typename From>
 To copyContour( const From & from )
 {
@@ -76,7 +76,7 @@ To copyContour( const From & from )
     return res;
 }
 
-/// copy double-contours to float-contours, or vice versa
+/// copy double-contours to float-contours, or 2D contours to 3D contours, or vice versa
 template<typename To, typename From>
 To copyContours( const From & from )
 {

--- a/source/MRMesh/MRPolyline.cpp
+++ b/source/MRMesh/MRPolyline.cpp
@@ -4,7 +4,6 @@
 #include "MRAffineXf2.h"
 #include "MRAffineXf3.h"
 #include "MRVector2.h"
-#include "MRGTest.h"
 #include "MRTimer.h"
 #include "MRMesh.h"
 #include "MRComputeBoundingBox.h"
@@ -15,27 +14,13 @@ namespace MR
 {
 
 template<typename V>
-Polyline<V>::Polyline( const Contours2f& contours )
+Polyline<V>::Polyline( const Contour<V>& contours )
 {
-    MR_TIMER;
-    topology.buildFromContours( contours,
-        [&points = this->points]( size_t sz )
-        {
-            points.reserve( sz );
-        },
-        [&points = this->points]( const Vector2f & p )
-        {
-            if constexpr ( V::elements == 2 )
-                points.emplace_back( p.x, p.y );
-            else
-                points.emplace_back( p.x, p.y, 0.0f );
-            return points.backId();
-        }
-    );
+    addFromPoints( contours.data(), contours.size() );
 }
 
 template<typename V>
-Polyline<V>::Polyline( const Contours3f& contours )
+Polyline<V>::Polyline( const Contours<V>& contours )
 {
     MR_TIMER;
     topology.buildFromContours( contours,
@@ -43,12 +28,9 @@ Polyline<V>::Polyline( const Contours3f& contours )
         {
             points.reserve( sz );
         },
-        [&points = this->points]( const Vector3f & p )
+        [&points = this->points]( const V & p )
         {
-            if constexpr ( V::elements == 2 )
-                points.emplace_back( p.x, p.y );
-            else
-                points.push_back( p );
+            points.push_back( p );
             return points.backId();
         }
     );
@@ -382,111 +364,5 @@ size_t Polyline<V>::heapBytes() const
 
 template struct Polyline<Vector2f>;
 template struct Polyline<Vector3f>;
-
-TEST( MRMesh, Polyline2 )
-{
-    Contour2f cont;
-    cont.push_back( Vector2f( 0.f, 0.f ) );
-    cont.push_back( Vector2f( 1.f, 0.f ) );
-    cont.push_back( Vector2f( 0.f, 1.f ) );
-    cont.push_back( Vector2f( 1.f, 1.f ) );
-
-    Contour2f cont2;
-    cont2.push_back( Vector2f( 2.f, 0.f ) );
-    cont2.push_back( Vector2f( 3.f, 0.f ) );
-    cont2.push_back( Vector2f( 2.f, 1.f ) );
-    cont2.push_back( Vector2f( 3.f, 1.f ) );
-
-    Contours2f conts{ cont,cont2 };
-
-    Polyline2 pl( conts );
-    auto conts2 = pl.contours();
-
-    for ( auto i = 0; i < conts.size(); i++ )
-{
-        auto& c1 = conts[i];
-        auto& c2 = conts2[i];
-        for ( auto j = 0; j < c1.size(); j++ )
-{
-            auto v1 = c1[j];
-            auto v2 = c2[j];
-            EXPECT_NEAR( v1[0], v2[0], 1e-8 );
-            EXPECT_NEAR( v1[1], v2[1], 1e-8 );
-        }
-    }
-}
-
-TEST( MRMesh, Polyline2LoopDir )
-{
-    Contour2f cont;
-    cont.push_back( Vector2f( 0.f, 0.f ) );
-    cont.push_back( Vector2f( 1.f, 0.f ) );
-    cont.push_back( Vector2f( 1.f, 1.f ) );
-    cont.push_back( Vector2f( 0.f, 1.f ) );
-
-    Polyline2 plNotClosed( { cont } );
-    EXPECT_TRUE( plNotClosed.loopDirArea( 0_e ).z == FLT_MAX );
-
-    cont.push_back( Vector2f( 0.f, 0.f ) );
-
-    Polyline2 plClosed( { cont } );
-    EXPECT_TRUE( plClosed.loopDirArea( 0_e ).z > 0.0f );
-    EXPECT_TRUE( plClosed.loopDirArea( 1_e ).z < 0.0f );
-}
-
-TEST( MRMesh, Polyline3 )
-{
-    Contour2f cont;
-    cont.push_back( Vector2f( 0.f, 0.f ) );
-    cont.push_back( Vector2f( 1.f, 0.f ) );
-    cont.push_back( Vector2f( 0.f, 1.f ) );
-    cont.push_back( Vector2f( 1.f, 1.f ) );
-
-    Contour2f cont2;
-    cont2.push_back( Vector2f( 2.f, 0.f ) );
-    cont2.push_back( Vector2f( 3.f, 0.f ) );
-    cont2.push_back( Vector2f( 2.f, 1.f ) );
-    cont2.push_back( Vector2f( 3.f, 1.f ) );
-
-    Contours2f conts{ cont,cont2 };
-
-    Polyline3 pl( conts );
-    auto conts2 = pl.contours();
-
-    for ( auto i = 0; i < conts.size(); i++ )
-    {
-        auto& c1 = conts[i];
-        auto& c2 = conts2[i];
-        for ( auto j = 0; j < c1.size(); j++ )
-        {
-            auto v1 = c1[j];
-            auto v2 = c2[j];
-            EXPECT_NEAR( v1[0], v2[0], 1e-8 );
-            EXPECT_NEAR( v1[1], v2[1], 1e-8 );
-        }
-    }
-}
-
-TEST( MRMesh, PolylineSplitEdge )
-{
-    Contour2f cont;
-    cont.push_back( Vector2f( 0.f, 0.f ) );
-    cont.push_back( Vector2f( 1.f, 0.f ) );
-    Polyline2 polyline( { cont } );
-
-    EXPECT_EQ( polyline.topology.numValidVerts(), 2 );
-    EXPECT_EQ( polyline.points.size(), 2 );
-    EXPECT_EQ( polyline.topology.lastNotLoneEdge(), EdgeId(1) ); // 1*2 = 2 half-edges in total
-
-    auto e01 = polyline.topology.findEdge( 0_v, 1_v );
-    EXPECT_TRUE( e01.valid() );
-    auto ex = polyline.splitEdge( e01 );
-    VertId v01 = polyline.topology.org( e01 );
-    EXPECT_EQ( polyline.topology.dest( ex ), v01 );
-    EXPECT_EQ( polyline.topology.numValidVerts(), 3 );
-    EXPECT_EQ( polyline.points.size(), 3 );
-    EXPECT_EQ( polyline.topology.lastNotLoneEdge(), EdgeId(3) ); // 2*2 = 4 half-edges in total
-    EXPECT_EQ( polyline.points[v01], ( Vector2f(.5f, 0.f) ) );
-}
 
 } //namespace MR

--- a/source/MRMesh/MRPolyline.cpp
+++ b/source/MRMesh/MRPolyline.cpp
@@ -233,18 +233,6 @@ Contours<V> Polyline<V>::contours( std::vector<std::vector<VertId>>* vertMap ) c
 }
 
 template<typename V>
-Contours2f Polyline<V>::contours2( std::vector<std::vector<VertId>>* vertMap ) const
-{
-    MR_TIMER;
-    return topology.convertToContours<Vector2f>(
-        [&points = this->points] ( VertId v )
-        {
-            return Vector2f{ points[v] };
-        }, vertMap
-    );
-}
-
-template<typename V>
 EdgeId Polyline<V>::addFromEdgePath( const Mesh& mesh, const EdgePath& path )
 {
     assert( isEdgePath( mesh.topology, path ) );

--- a/source/MRMesh/MRPolyline.cpp
+++ b/source/MRMesh/MRPolyline.cpp
@@ -233,6 +233,18 @@ Contours<V> Polyline<V>::contours( std::vector<std::vector<VertId>>* vertMap ) c
 }
 
 template<typename V>
+Contours2f Polyline<V>::contours2( std::vector<std::vector<VertId>>* vertMap ) const
+{
+    MR_TIMER;
+    return topology.convertToContours<Vector2f>(
+        [&points = this->points] ( VertId v )
+        {
+            return Vector2f{ points[v] };
+        }, vertMap
+    );
+}
+
+template<typename V>
 EdgeId Polyline<V>::addFromEdgePath( const Mesh& mesh, const EdgePath& path )
 {
     assert( isEdgePath( mesh.topology, path ) );

--- a/source/MRMesh/MRPolyline.h
+++ b/source/MRMesh/MRPolyline.h
@@ -132,11 +132,6 @@ public:
     /// \param vertMap optional output map for for each contour point to corresponding VertId
     [[nodiscard]] MRMESH_API Contours<V> contours( std::vector<std::vector<VertId>>* vertMap = nullptr ) const;
 
-    /// convert Polyline to simple 2D contour structures with vector of points inside
-    /// \details if all even edges are consistently oriented, then the output contours will be oriented the same
-    /// \param vertMap optional output map for for each contour point to corresponding VertId
-    [[nodiscard]] MRMESH_API Contours2f contours2( std::vector<std::vector<VertId>>* vertMap = nullptr ) const;
-
     /// convert Polyline3 to Polyline2 or vice versa
     template<typename U>
     [[nodiscard]] Polyline<U> toPolyline() const;

--- a/source/MRMesh/MRPolyline.h
+++ b/source/MRMesh/MRPolyline.h
@@ -132,6 +132,11 @@ public:
     /// \param vertMap optional output map for for each contour point to corresponding VertId
     [[nodiscard]] MRMESH_API Contours<V> contours( std::vector<std::vector<VertId>>* vertMap = nullptr ) const;
 
+    /// convert Polyline to simple 2D contour structures with vector of points inside
+    /// \details if all even edges are consistently oriented, then the output contours will be oriented the same
+    /// \param vertMap optional output map for for each contour point to corresponding VertId
+    [[nodiscard]] MRMESH_API Contours2f contours2( std::vector<std::vector<VertId>>* vertMap = nullptr ) const;
+
     /// convert Polyline3 to Polyline2 or vice versa
     template<typename U>
     [[nodiscard]] Polyline<U> toPolyline() const;

--- a/source/MRMesh/MRPolyline.h
+++ b/source/MRMesh/MRPolyline.h
@@ -22,11 +22,11 @@ public:
 
     Polyline() = default;
 
-    /// creates polyline from 2D contours, 3D polyline will get zero z-component
-    MRMESH_API Polyline( const Contours2f& contours );
+    /// creates polyline from one contour (open or closed)
+    MRMESH_API Polyline( const Contour<V>& contour );
 
-    /// creates polyline from 3D contours, 2D polyline will lose z-component
-    MRMESH_API Polyline( const Contours3f& contours );
+    /// creates polyline from several contours (each can be open or closed)
+    MRMESH_API Polyline( const Contours<V>& contours );
 
     /// creates comp2firstVert.size()-1 not-closed polylines
     /// each pair (a,b) of indices in \param comp2firstVert defines vertex range of a polyline [a,b)

--- a/source/MRTest/MRPolylineTests.cpp
+++ b/source/MRTest/MRPolylineTests.cpp
@@ -1,0 +1,113 @@
+#include <MRMesh/MRPolyline.h>
+#include <MRMesh/MRGTest.h>
+
+namespace MR
+{
+
+TEST( MRMesh, Polyline2 )
+{
+    Contour2f cont;
+    cont.push_back( Vector2f( 0.f, 0.f ) );
+    cont.push_back( Vector2f( 1.f, 0.f ) );
+    cont.push_back( Vector2f( 0.f, 1.f ) );
+    cont.push_back( Vector2f( 1.f, 1.f ) );
+
+    Contour2f cont2;
+    cont2.push_back( Vector2f( 2.f, 0.f ) );
+    cont2.push_back( Vector2f( 3.f, 0.f ) );
+    cont2.push_back( Vector2f( 2.f, 1.f ) );
+    cont2.push_back( Vector2f( 3.f, 1.f ) );
+
+    Contours2f conts{ cont,cont2 };
+
+    Polyline2 pl( conts );
+    auto conts2 = pl.contours();
+
+    for ( auto i = 0; i < conts.size(); i++ )
+{
+        auto& c1 = conts[i];
+        auto& c2 = conts2[i];
+        for ( auto j = 0; j < c1.size(); j++ )
+{
+            auto v1 = c1[j];
+            auto v2 = c2[j];
+            EXPECT_NEAR( v1[0], v2[0], 1e-8 );
+            EXPECT_NEAR( v1[1], v2[1], 1e-8 );
+        }
+    }
+}
+
+TEST( MRMesh, Polyline2LoopDir )
+{
+    Contour2f cont;
+    cont.push_back( Vector2f( 0.f, 0.f ) );
+    cont.push_back( Vector2f( 1.f, 0.f ) );
+    cont.push_back( Vector2f( 1.f, 1.f ) );
+    cont.push_back( Vector2f( 0.f, 1.f ) );
+
+    Polyline2 plNotClosed( { cont } );
+    EXPECT_TRUE( plNotClosed.loopDirArea( 0_e ).z == FLT_MAX );
+
+    cont.push_back( Vector2f( 0.f, 0.f ) );
+
+    Polyline2 plClosed( { cont } );
+    EXPECT_TRUE( plClosed.loopDirArea( 0_e ).z > 0.0f );
+    EXPECT_TRUE( plClosed.loopDirArea( 1_e ).z < 0.0f );
+}
+
+TEST( MRMesh, Polyline3 )
+{
+    Contour3f cont;
+    cont.push_back( Vector3f( 0.f, 0.f, 0.f ) );
+    cont.push_back( Vector3f( 1.f, 0.f, 0.f ) );
+    cont.push_back( Vector3f( 0.f, 1.f, 0.f ) );
+    cont.push_back( Vector3f( 1.f, 1.f, 0.f ) );
+
+    Contour3f cont2;
+    cont2.push_back( Vector3f( 2.f, 0.f, 0.f ) );
+    cont2.push_back( Vector3f( 3.f, 0.f, 0.f ) );
+    cont2.push_back( Vector3f( 2.f, 1.f, 0.f ) );
+    cont2.push_back( Vector3f( 3.f, 1.f, 0.f ) );
+
+    Contours3f conts{ cont,cont2 };
+
+    Polyline3 pl( conts );
+    auto conts2 = pl.contours();
+
+    for ( auto i = 0; i < conts.size(); i++ )
+    {
+        auto& c1 = conts[i];
+        auto& c2 = conts2[i];
+        for ( auto j = 0; j < c1.size(); j++ )
+        {
+            auto v1 = c1[j];
+            auto v2 = c2[j];
+            EXPECT_NEAR( v1[0], v2[0], 1e-8 );
+            EXPECT_NEAR( v1[1], v2[1], 1e-8 );
+        }
+    }
+}
+
+TEST( MRMesh, PolylineSplitEdge )
+{
+    Contour2f cont;
+    cont.push_back( Vector2f( 0.f, 0.f ) );
+    cont.push_back( Vector2f( 1.f, 0.f ) );
+    Polyline2 polyline( { cont } );
+
+    EXPECT_EQ( polyline.topology.numValidVerts(), 2 );
+    EXPECT_EQ( polyline.points.size(), 2 );
+    EXPECT_EQ( polyline.topology.lastNotLoneEdge(), EdgeId(1) ); // 1*2 = 2 half-edges in total
+
+    auto e01 = polyline.topology.findEdge( 0_v, 1_v );
+    EXPECT_TRUE( e01.valid() );
+    auto ex = polyline.splitEdge( e01 );
+    VertId v01 = polyline.topology.org( e01 );
+    EXPECT_EQ( polyline.topology.dest( ex ), v01 );
+    EXPECT_EQ( polyline.topology.numValidVerts(), 3 );
+    EXPECT_EQ( polyline.points.size(), 3 );
+    EXPECT_EQ( polyline.topology.lastNotLoneEdge(), EdgeId(3) ); // 2*2 = 4 half-edges in total
+    EXPECT_EQ( polyline.points[v01], ( Vector2f(.5f, 0.f) ) );
+}
+
+} //namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -26,6 +26,7 @@
     <ClCompile Include="MRPdfTests.cpp" />
     <ClCompile Include="MRPointCloudVariadicOffsetTests.cpp" />
     <ClCompile Include="MRPolyline2IntersectTests.cpp" />
+    <ClCompile Include="MRPolylineTests.cpp" />
     <ClCompile Include="MRPolylineTrimWithPlane.cpp" />
     <ClCompile Include="MRSpdlog.cpp" />
     <ClCompile Include="MRSurfacePathTests.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -82,6 +82,9 @@
     <ClCompile Include="MRLaplacianTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRPolylineTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />

--- a/source/MRViewer/MRAncillaryLines.cpp
+++ b/source/MRViewer/MRAncillaryLines.cpp
@@ -7,15 +7,26 @@
 namespace MR
 {
 
-void AncillaryLines::make( Object &parent, const Contours3f& contours )
+void AncillaryLines::make( Object &parent )
 {
     reset();
     obj = std::make_shared<ObjectLines>();
     obj->setAncillary( true );
     obj->setFrontColor( SceneColors::get( SceneColors::Type::Labels ), false );
-    obj->setPolyline( std::make_shared<Polyline3>( contours ) );
     obj->setPickable( false );
     parent.addChild( obj );
+}
+
+void AncillaryLines::make( Object &parent, const Contour3f& contour )
+{
+    make( parent );
+    obj->setPolyline( std::make_shared<Polyline3>( contour ) );
+}
+
+void AncillaryLines::make( Object &parent, const Contours3f& contours )
+{
+    make( parent );
+    obj->setPolyline( std::make_shared<Polyline3>( contours ) );
 }
 
 void AncillaryLines::reset()

--- a/source/MRViewer/MRAncillaryLines.h
+++ b/source/MRViewer/MRAncillaryLines.h
@@ -20,10 +20,13 @@ struct MRVIEWER_CLASS AncillaryLines
     AncillaryLines & operator =( AncillaryLines && b ) { reset(); obj = std::move( b.obj ); return *this; }
 
     /// Make not-pickable ancillary object, link it to parent object, and set line geometry
-    explicit AncillaryLines( Object& parent, const Contours3f& contours = {} ) { make( parent, contours ); }
+    explicit AncillaryLines( Object& parent, const Contour3f& contour = {} ) { make( parent, contour ); }
+    explicit AncillaryLines( Object& parent, const Contours3f& contours ) { make( parent, contours ); }
 
     /// Make not-pickable ancillary object, link it to parent object, and set line geometry
-    MRVIEWER_API void make( Object& parent, const Contours3f& contours = {} );
+    MRVIEWER_API void make( Object& parent );
+    MRVIEWER_API void make( Object& parent, const Contour3f& contour );
+    MRVIEWER_API void make( Object& parent, const Contours3f& contours );
 
     /// detach owned object from parent, stops owning it
     MRVIEWER_API void reset();

--- a/source/MRViewer/MRPlaneWidget.cpp
+++ b/source/MRViewer/MRPlaneWidget.cpp
@@ -240,7 +240,7 @@ bool PlaneWidget::onMouseMove_( int mouse_x, int mouse_y )
 
     auto viewportStop = viewer->screenToViewport(  { endMousePos_.x, endMousePos_.y, screenOrigin.z } , viewport.id );
     auto stop = viewport.unprojectFromViewportSpace( viewportStop );
-    const Polyline3 polyline( { { start, stop } } );
+    const Polyline3 polyline( { start, stop } );
    
     line_->setPolyline( std::make_shared<Polyline3>( polyline ) );
 


### PR DESCRIPTION
* Polyline constructors from one `const Contour<V>& contour` and many `const Contours<V>& contours`, and similar in `AncillaryLines`
* No polyline constructors from `Contours2f` and `Contours3f`
* Polyline tests moved in `MRTest`