### PR TITLE
Get rid of std::optional<MeshProjectionResult>

### DIFF
--- a/source/MRMesh/MRAABBTree.cpp
+++ b/source/MRMesh/MRAABBTree.cpp
@@ -124,7 +124,7 @@ TEST(MRMesh, AABBTree)
 TEST(MRMesh, ProjectionToEmptyMesh)
 {
     Vector3f p( 1.f, 2.f, 3.f );
-    bool hasProjection = Mesh{}.projectPoint( p ).has_value();
+    bool hasProjection = Mesh{}.projectPoint( p ).valid();
     EXPECT_FALSE( hasProjection );
 }
 

--- a/source/MRMesh/MRContoursSeparation.cpp
+++ b/source/MRMesh/MRContoursSeparation.cpp
@@ -23,9 +23,8 @@ std::vector<FaceBitSet> separateClosedContour( const Mesh& mesh, const std::vect
     {
         for ( int i = range.begin(); i < range.end(); ++i )
         {
-            auto projRes = mesh.projectPoint( contour[i] );
-            if ( projRes )
-                projections[i] = projRes->mtp;
+            if ( auto projRes = mesh.projectPoint( contour[i] ) )
+                projections[i] = projRes.mtp;
         }
     } );
     for ( const auto& mtp : projections )

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -557,13 +557,9 @@ bool Mesh::projectPoint( const Vector3f& point, MeshProjectionResult& res, float
     return true;
 }
 
-std::optional<MeshProjectionResult> Mesh::projectPoint( const Vector3f& point, float maxDistSq, const FaceBitSet * region, const AffineXf3f * xf ) const
+MeshProjectionResult Mesh::projectPoint( const Vector3f& point, float maxDistSq, const FaceBitSet * region, const AffineXf3f * xf ) const
 {
-    auto proj = findProjection( point, { *this, region }, maxDistSq, xf );
-    if ( !( proj.distSq < maxDistSq ) )
-        return {};
-
-    return proj;
+    return findProjection( point, { *this, region }, maxDistSq, xf );
 }
 
 const AABBTree & Mesh::getAABBTree() const

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -457,8 +457,8 @@ struct [[nodiscard]] Mesh
     /// \param xf is mesh-to-point transformation, if not specified then identity transformation is assumed and works much faster;
     /// \return found closest point including Euclidean coordinates, barycentric coordinates, FaceId and squared distance to point
     ///         or std::nullopt if no mesh point is found in the ball with sqrt(maxDistSq) radius around given point
-    [[nodiscard]] MRMESH_API std::optional<MeshProjectionResult> projectPoint( const Vector3f& point, float maxDistSq = FLT_MAX, const FaceBitSet * region = nullptr, const AffineXf3f * xf = nullptr ) const;
-    [[nodiscard]] std::optional<MeshProjectionResult> findClosestPoint( const Vector3f& point, float maxDistSq = FLT_MAX, const FaceBitSet * region = nullptr, const AffineXf3f * xf = nullptr ) const { return projectPoint( point, maxDistSq, region, xf ); }
+    [[nodiscard]] MRMESH_API MeshProjectionResult projectPoint( const Vector3f& point, float maxDistSq = FLT_MAX, const FaceBitSet * region = nullptr, const AffineXf3f * xf = nullptr ) const;
+    [[nodiscard]] MeshProjectionResult findClosestPoint( const Vector3f& point, float maxDistSq = FLT_MAX, const FaceBitSet * region = nullptr, const AffineXf3f * xf = nullptr ) const { return projectPoint( point, maxDistSq, region, xf ); }
 
     /// returns cached aabb-tree for this mesh, creating it if it did not exist in a thread-safe manner
     MRMESH_API const AABBTree & getAABBTree() const;

--- a/source/MRVoxels/MRToolPath.cpp
+++ b/source/MRVoxels/MRToolPath.cpp
@@ -362,11 +362,11 @@ Intervals getIntervals( const MeshPart& mp, const MeshPart* offset, const V3fIt 
         const float maxDistSq = 2 * toolRadius * toolRadius;
         const auto mpr = offset ? offset->mesh.projectPoint( *it, maxDistSq ) : mp.mesh.projectPoint( *it, maxDistSq );
 
-        bool isInsideSelection = mpr.has_value();
+        bool isInsideSelection = mpr.valid();
 
         if ( isInsideSelection )
         {
-            const auto faceId = offset ? offset->mesh.topology.left( mpr->mtp.e ) : mp.mesh.topology.left( mpr->mtp.e );
+            const auto faceId = offset ? offset->mesh.topology.left( mpr.mtp.e ) : mp.mesh.topology.left( mpr.mtp.e );
 
             isInsideSelection = offset ?
                 ( !offset->region || ( mpr && offset->region->test( faceId ) ) ) :


### PR DESCRIPTION
`MeshProjectionResult` already contains flag about its validity, so no need to wrap it inside `std::optional`