### PR TITLE
delete Polyline<V>::contours2()

### DIFF
--- a/source/MRMesh/MRPolyline.cpp
+++ b/source/MRMesh/MRPolyline.cpp
@@ -233,18 +233,6 @@ Contours<V> Polyline<V>::contours( std::vector<std::vector<VertId>>* vertMap ) c
 }
 
 template<typename V>
-Contours2f Polyline<V>::contours2( std::vector<std::vector<VertId>>* vertMap ) const
-{
-    MR_TIMER;
-    return topology.convertToContours<Vector2f>(
-        [&points = this->points] ( VertId v )
-        {
-            return Vector2f{ points[v] };
-        }, vertMap
-    );
-}
-
-template<typename V>
 EdgeId Polyline<V>::addFromEdgePath( const Mesh& mesh, const EdgePath& path )
 {
     assert( isEdgePath( mesh.topology, path ) );

--- a/source/MRMesh/MRPolyline.h
+++ b/source/MRMesh/MRPolyline.h
@@ -132,11 +132,6 @@ public:
     /// \param vertMap optional output map for for each contour point to corresponding VertId
     [[nodiscard]] MRMESH_API Contours<V> contours( std::vector<std::vector<VertId>>* vertMap = nullptr ) const;
 
-    /// convert Polyline to simple 2D contour structures with vector of points inside
-    /// \details if all even edges are consistently oriented, then the output contours will be oriented the same
-    /// \param vertMap optional output map for for each contour point to corresponding VertId
-    [[nodiscard]] MRMESH_API Contours2f contours2( std::vector<std::vector<VertId>>* vertMap = nullptr ) const;
-
     /// convert Polyline3 to Polyline2 or vice versa
     template<typename U>
     [[nodiscard]] Polyline<U> toPolyline() const;

--- a/test_regression/test_algorithms/test_dm_from_contour.py
+++ b/test_regression/test_algorithms/test_dm_from_contour.py
@@ -9,7 +9,7 @@ def test_dm_from_contour(tmp_path):
     #  Load input point
     input_folder = Path(test_files_path) / "algorithms" / "lines_to_dm"
     pl3 = mrmeshpy.loadLines(input_folder / "input.mrlines")
-    pl2 = mrmeshpy.Polyline2(pl3.contours2())
+    pl2 = mrmeshpy.Polyline2(mrmeshpy.convertContoursTo2f(pl3.contours()))
 
     # process
     params = mrmeshpy.ContourToDistanceMapParams()

--- a/test_regression/test_cuda/test_cuda_dm_from_contour.py
+++ b/test_regression/test_cuda/test_cuda_dm_from_contour.py
@@ -15,7 +15,7 @@ def test_dm_from_contour(cuda_module, tmp_path):
     #  Load input point
     input_folder = Path(test_files_path) / "cuda" / "lines_to_dm"
     pl3 = mrmeshpy.loadLines(input_folder / "input.mrlines")
-    pl2 = mrmeshpy.Polyline2(pl3.contours2())
+    pl2 = mrmeshpy.Polyline2(mrmeshpy.convertContoursTo2f(pl3.contours()))
 
     # process
     params = mrmeshpy.ContourToDistanceMapParams()


### PR DESCRIPTION
Please use `Polyline<V>::contours()` instead, and convert the result in 2-dimensions using `convertContours` function.