### PR TITLE
MeshTopology: more consistent boundary testing

### DIFF
--- a/source/MRMesh/MRFillHoleNicely.cpp
+++ b/source/MRMesh/MRFillHoleNicely.cpp
@@ -67,7 +67,7 @@ FaceBitSet fillHoleNicely( Mesh & mesh,
         if ( settings.smoothCurvature )
         {
             // exclude boundary vertices from positionVertsSmoothly(), since it tends to move them inside the mesh
-            auto vertsForSmoothing = newVerts - mesh.topology.findBoundaryVerts( &newVerts );
+            auto vertsForSmoothing = newVerts - mesh.topology.findBdVerts( nullptr, &newVerts );
             positionVertsSmoothlySharpBd( mesh, vertsForSmoothing );
             positionVertsSmoothly( mesh, vertsForSmoothing, settings.edgeWeights, settings.vmass );
             if ( settings.naturalSmooth )
@@ -79,7 +79,7 @@ FaceBitSet fillHoleNicely( Mesh & mesh,
                 MeshComponents::excludeFullySelectedComponents( mesh, incidentVerts );
                 if ( incidentVerts.any() )
                 {
-                    vertsForSmoothing = incidentVerts - mesh.topology.findBoundaryVerts( &incidentVerts );
+                    vertsForSmoothing = incidentVerts - mesh.topology.findBdVerts( nullptr, &incidentVerts );
                     positionVertsSmoothlySharpBd( mesh, vertsForSmoothing );
                     positionVertsSmoothly( mesh, vertsForSmoothing, settings.edgeWeights, settings.vmass );
                 }

--- a/source/MRMesh/MRFixSelfIntersections.cpp
+++ b/source/MRMesh/MRFixSelfIntersections.cpp
@@ -187,7 +187,7 @@ Expected<void> fix( Mesh& mesh, const Settings& settings )
     }
     else
     {
-        auto boundaryEdges = mesh.topology.findBdEdges();
+        auto boundaryEdges = mesh.topology.findLeftBdEdges();
         mesh.topology.deleteFaces( *res );
         mesh.topology.deleteFaces( findHoleComplicatingFaces( mesh ) );
         mesh.invalidateCaches();

--- a/source/MRMesh/MRFixSelfIntersections.cpp
+++ b/source/MRMesh/MRFixSelfIntersections.cpp
@@ -187,7 +187,7 @@ Expected<void> fix( Mesh& mesh, const Settings& settings )
     }
     else
     {
-        auto boundaryEdges = mesh.topology.findBoundaryEdges();
+        auto boundaryEdges = mesh.topology.findBdEdges();
         mesh.topology.deleteFaces( *res );
         mesh.topology.deleteFaces( findHoleComplicatingFaces( mesh ) );
         mesh.invalidateCaches();

--- a/source/MRMesh/MRMeshBuilder.cpp
+++ b/source/MRMesh/MRMeshBuilder.cpp
@@ -847,7 +847,7 @@ int uniteCloseVertices( Mesh & mesh, float closeDist, bool uniteOnlyBd, VertMap 
     MR_TIMER;
     VertBitSet bdVerts;
     if ( uniteOnlyBd )
-        bdVerts = mesh.topology.findBoundaryVerts();
+        bdVerts = mesh.topology.findBdVerts();
 
     const VertMap vertOldToNew = uniteOnlyBd ?
         *findSmallestCloseVertices( mesh.points, closeDist, &bdVerts ) :

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -720,6 +720,16 @@ EdgeBitSet MeshTopology::findBoundaryEdges() const
     return res;
 }
 
+bool MeshTopology::isBdEdge( EdgeId e, const FaceBitSet * region ) const
+{
+    if ( !region )
+    {
+        assert( !isLoneEdge( e ) );
+        return !left( e ) || !right( e );
+    }
+    return isLeftInRegion( e, region ) != isLeftInRegion( e.sym(), region );
+}
+
 EdgeBitSet MeshTopology::findLeftBdEdges( const FaceBitSet * region, const EdgeBitSet * test ) const
 {
     MR_TIMER;
@@ -728,6 +738,8 @@ EdgeBitSet MeshTopology::findLeftBdEdges( const FaceBitSet * region, const EdgeB
     {
         if ( test && !test->test( e ) )
             return;
+        if ( !region && !left( e ) && !isLoneEdge( e ) )
+            res.set( e );
         if ( isLeftInRegion( e.sym(), region ) && !isLeftInRegion( e, region ) ) // shall skip lone edges
             res.set( e );
     } );

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -634,7 +634,7 @@ int MeshTopology::findNumHoles( EdgeBitSet * holeRepresentativeEdges ) const
         holeRepresentativeEdges->resize( edgeSize(), false );
     }
 
-    auto bdEdges = findBdEdges();
+    auto bdEdges = findLeftBdEdges();
     std::atomic<int> res;
 
     const int endBlock = int( bdEdges.size() + bdEdges.bits_per_block - 1 ) / bdEdges.bits_per_block;
@@ -720,7 +720,7 @@ EdgeBitSet MeshTopology::findBoundaryEdges() const
     return res;
 }
 
-EdgeBitSet MeshTopology::findBdEdges( const FaceBitSet * region, const EdgeBitSet * test ) const
+EdgeBitSet MeshTopology::findLeftBdEdges( const FaceBitSet * region, const EdgeBitSet * test ) const
 {
     MR_TIMER;
     EdgeBitSet res( edges_.size() );
@@ -728,7 +728,7 @@ EdgeBitSet MeshTopology::findBdEdges( const FaceBitSet * region, const EdgeBitSe
     {
         if ( test && !test->test( e ) )
             return;
-        if ( isBdEdge( e, region ) ) // shall skip lone edges
+        if ( isLeftInRegion( e.sym(), region ) && !isLeftInRegion( e, region ) ) // shall skip lone edges
             res.set( e );
     } );
     return res;

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -449,16 +449,6 @@ EdgeId MeshTopology::bdEdgeSameLeft( EdgeId e, const FaceBitSet * region ) const
     return {};
 }
 
-bool MeshTopology::isLeftBdFace( EdgeId e, const FaceBitSet * region ) const
-{
-    const auto l = left( e );
-    if ( !l )
-        return true;
-    if ( region && !region->test( l ) )
-        return false;
-    return bdEdgeSameLeft( e, region ).valid();
-}
-
 EdgeId MeshTopology::bdEdgeSameOrigin( EdgeId e, const FaceBitSet * region ) const
 {
     for ( auto ei : orgRing( *this, e ) )

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -284,9 +284,9 @@ public:
     /// returns invalid edge if no boundary edge is found
     [[nodiscard]] MRMESH_API EdgeId bdEdgeSameLeft( EdgeId e, const FaceBitSet * region = nullptr ) const;
 
-    /// returns true if there is a hole to the left of edge,
-    /// or left face belongs to the region and it has a boundary edge (isBdEdge(e,region) == true)
-    [[nodiscard]] MRMESH_API bool isLeftBdFace( EdgeId e, const FaceBitSet * region = nullptr ) const;
+    /// returns true if left(e) is a valid (region) face,
+    /// and it has a boundary edge (isBdEdge(e,region) == true)
+    [[nodiscard]] bool isLeftBdFace( EdgeId e, const FaceBitSet * region = nullptr ) const { return contains( region, left( e ) ) && bdEdgeSameLeft( e, region ).valid(); }
 
     /// returns a boundary edge with given left face considering boundary of given region (or for whole mesh if region is nullptr);
     /// returns invalid edge if no boundary edge is found

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -280,19 +280,23 @@ public:
         return region ? *region : validFaces_;
     }
 
-    /// returns the first boundary edge (for given region or for whole mesh if region is nullptr) in counter-clockwise order starting from given edge with the same left;
+    /// returns the first boundary edge (for given region or for whole mesh if region is nullptr) in counter-clockwise order starting from given edge with the same left face or hole;
     /// returns invalid edge if no boundary edge is found
     [[nodiscard]] MRMESH_API EdgeId bdEdgeSameLeft( EdgeId e, const FaceBitSet * region = nullptr ) const;
 
-    /// returns true if edge's left is on (region) boundary
-    [[nodiscard]] bool isBdVertexInLeft( EdgeId e, const FaceBitSet * region = nullptr ) const { return bdEdgeSameLeft( e, region ).valid(); }
+    /// returns true if there is a hole to the left of edge,
+    /// or left face belongs to the region and it has a boundary edge (isBdEdge(e,region) == true)
+    [[nodiscard]] MRMESH_API bool isLeftBdFace( EdgeId e, const FaceBitSet * region = nullptr ) const;
 
     /// returns a boundary edge with given left face considering boundary of given region (or for whole mesh if region is nullptr);
     /// returns invalid edge if no boundary edge is found
     [[nodiscard]] EdgeId bdEdgeWithLeft( FaceId f, const FaceBitSet * region = nullptr ) const { return bdEdgeSameLeft( edgeWithLeft( f ), region ); }
 
-    /// returns true if given face is on (region) boundary
-    [[nodiscard]] bool isBdFace( FaceId f, const FaceBitSet * region = nullptr ) const { return isBdVertexInLeft( edgeWithLeft( f ), region ); }
+    /// returns true if given face belongs to the region and it has a boundary edge (isBdEdge(e,region) == true)
+    [[nodiscard]] bool isBdFace( FaceId f, const FaceBitSet * region = nullptr ) const { return isLeftBdFace( edgeWithLeft( f ), region ); }
+
+    /// returns all faces for which isBdFace(f, region) is true
+    [[nodiscard]] MRMESH_API FaceBitSet findBdFaces( const FaceBitSet * region = nullptr ) const;
 
 
     /// return true if left face of given edge belongs to region (or just have valid id if region is nullptr)
@@ -301,8 +305,15 @@ public:
     /// return true if given edge is inner for given region (or for whole mesh if region is nullptr)
     [[nodiscard]] bool isInnerEdge( EdgeId e, const FaceBitSet * region = nullptr ) const { return isLeftInRegion( e, region ) && isLeftInRegion( e.sym(), region ); }
 
-    /// return true if given edge is boundary for given region (or for whole mesh if region is nullptr)
+    /// isBdEdge(e) returns true, if the edge (e) is a boundary edge of the mesh:
+    ///     (e) has a valid face from one side and a hole from the other side.
+    /// isBdEdge(e, region) returns true, if the edge (e) is a boundary edge of the given region:
+    ///     (e) has a region's face from one side (region.test(f0)==true) and a hole or not-region face from the other side (!f1 || region.test(f1)==false).
+    /// If the region contains all faces of the mesh then isBdEdge(e) == isBdEdge(e, region).
     [[nodiscard]] bool isBdEdge( EdgeId e, const FaceBitSet * region = nullptr ) const { return isLeftInRegion( e, region ) != isLeftInRegion( e.sym(), region ); }
+
+    /// returns all (test) edges for which isBdEdge(e, region) is true
+    [[nodiscard]] MRMESH_API EdgeBitSet findBdEdges( const FaceBitSet * region = nullptr, const EdgeBitSet * test = nullptr ) const;
 
     /// returns the first boundary edge (for given region or for whole mesh if region is nullptr) in counter-clockwise order starting from given edge with the same origin;
     /// returns invalid edge if no boundary edge is found
@@ -317,6 +328,9 @@ public:
 
     /// returns true if given vertex is on (region) boundary
     [[nodiscard]] bool isBdVertex( VertId v, const FaceBitSet * region = nullptr ) const { return isBdVertexInOrg( edgeWithOrg( v ), region ); }
+
+    /// returns all (test) vertices for which isBdVertex(v, region) is true
+    [[nodiscard]] MRMESH_API VertBitSet findBdVerts( const FaceBitSet * region = nullptr, const VertBitSet * test = nullptr ) const;
 
     /// returns true if one of incident faces of given vertex pertain to given region (or any such face exists if region is nullptr)
     [[nodiscard]] MRMESH_API bool isInnerOrBdVertex( VertId v, const FaceBitSet * region = nullptr ) const;
@@ -356,15 +370,15 @@ public:
     [[nodiscard]] MRMESH_API std::vector<EdgeLoop> getLeftRings( const std::vector<EdgeId> & es ) const;
 
     /// returns all boundary edges, where each edge does not have valid left face
-    [[nodiscard]] MRMESH_API EdgeBitSet findBoundaryEdges() const;
+    [[nodiscard]] [[deprecated( "Use findBdEdges")]] MRMESH_API EdgeBitSet findBoundaryEdges() const;
 
     /// returns all boundary faces, having at least one boundary edge;
     /// \param region if given then search among faces there otherwise among all valid faces
-    [[nodiscard]] MRMESH_API FaceBitSet findBoundaryFaces( const FaceBitSet * region = nullptr ) const;
+    [[nodiscard]] [[deprecated( "Use findBdFaces")]] MRMESH_API FaceBitSet findBoundaryFaces( const FaceBitSet * region = nullptr ) const;
 
     /// returns all boundary vertices, incident to at least one boundary edge;
     /// \param region if given then search among vertices there otherwise among all valid vertices
-    [[nodiscard]] MRMESH_API VertBitSet findBoundaryVerts( const VertBitSet * region = nullptr ) const;
+    [[nodiscard]] [[deprecated( "Use findBdVerts")]] MRMESH_API VertBitSet findBoundaryVerts( const VertBitSet * region = nullptr ) const;
 
 
     /// returns all vertices incident to path edges

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -306,13 +306,13 @@ public:
     [[nodiscard]] bool isInnerEdge( EdgeId e, const FaceBitSet * region = nullptr ) const { return isLeftInRegion( e, region ) && isLeftInRegion( e.sym(), region ); }
 
     /// isBdEdge(e) returns true, if the edge (e) is a boundary edge of the mesh:
-    ///     (e) has a valid face from one side and a hole from the other side.
+    ///     (e) has a hole from one or both sides.
     /// isBdEdge(e, region) returns true, if the edge (e) is a boundary edge of the given region:
     ///     (e) has a region's face from one side (region.test(f0)==true) and a hole or not-region face from the other side (!f1 || region.test(f1)==false).
-    /// If the region contains all faces of the mesh then isBdEdge(e) == isBdEdge(e, region).
-    [[nodiscard]] bool isBdEdge( EdgeId e, const FaceBitSet * region = nullptr ) const { return isLeftInRegion( e, region ) != isLeftInRegion( e.sym(), region ); }
+    /// If the region contains all faces of the mesh then isBdEdge(e) is the union of isBdEdge(e, region) and not-lone edges without both left and right faces.
+    [[nodiscard]] MRMESH_API bool isBdEdge( EdgeId e, const FaceBitSet * region = nullptr ) const;
 
-    /// returns all (test) edges for which right(e) belongs to the region and isBdEdge(e, region) is true
+    /// returns all (test) edges for which left(e) does not belong to the region and isBdEdge(e, region) is true
     [[nodiscard]] MRMESH_API EdgeBitSet findLeftBdEdges( const FaceBitSet * region = nullptr, const EdgeBitSet * test = nullptr ) const;
 
     /// returns the first boundary edge (for given region or for whole mesh if region is nullptr) in counter-clockwise order starting from given edge with the same origin;

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -312,8 +312,8 @@ public:
     /// If the region contains all faces of the mesh then isBdEdge(e) == isBdEdge(e, region).
     [[nodiscard]] bool isBdEdge( EdgeId e, const FaceBitSet * region = nullptr ) const { return isLeftInRegion( e, region ) != isLeftInRegion( e.sym(), region ); }
 
-    /// returns all (test) edges for which isBdEdge(e, region) is true
-    [[nodiscard]] MRMESH_API EdgeBitSet findBdEdges( const FaceBitSet * region = nullptr, const EdgeBitSet * test = nullptr ) const;
+    /// returns all (test) edges for which right(e) belongs to the region and isBdEdge(e, region) is true
+    [[nodiscard]] MRMESH_API EdgeBitSet findLeftBdEdges( const FaceBitSet * region = nullptr, const EdgeBitSet * test = nullptr ) const;
 
     /// returns the first boundary edge (for given region or for whole mesh if region is nullptr) in counter-clockwise order starting from given edge with the same origin;
     /// returns invalid edge if no boundary edge is found
@@ -370,7 +370,7 @@ public:
     [[nodiscard]] MRMESH_API std::vector<EdgeLoop> getLeftRings( const std::vector<EdgeId> & es ) const;
 
     /// returns all boundary edges, where each edge does not have valid left face
-    [[nodiscard]] [[deprecated( "Use findBdEdges")]] MRMESH_API EdgeBitSet findBoundaryEdges() const;
+    [[nodiscard]] [[deprecated( "Use findLeftBdEdges")]] MRMESH_API EdgeBitSet findBoundaryEdges() const;
 
     /// returns all boundary faces, having at least one boundary edge;
     /// \param region if given then search among faces there otherwise among all valid faces

--- a/source/MRMesh/MRRadiusCompensation.cpp
+++ b/source/MRMesh/MRRadiusCompensation.cpp
@@ -83,7 +83,7 @@ Expected<void> RadiusCompensator::init()
     vertRegion_ = getInnerVerts( mesh_.topology, *faceRegion );
     auto vertRegionWithBounds = getIncidentVerts( mesh_.topology, *faceRegion );
 
-    if ( MeshComponents::hasFullySelectedComponent( mesh_, vertRegion_ - mesh_.topology.findBoundaryVerts( &vertRegion_ ) ) )
+    if ( MeshComponents::hasFullySelectedComponent( mesh_, vertRegion_ - mesh_.topology.findBdVerts( nullptr, &vertRegion_ ) ) )
         return unexpected( "MeshPart should not contain closed components" );
 
     auto [xvec, yvec] = params_.direction.perpendicular();


### PR DESCRIPTION
* `isBdFace(f, region)` method returns `true` only for region faces (and not for out-of-region first layer faces)
* `isBdEdge(e)` method now returns `true` if edge `e` does not have both left and right faces
* `isBdVertexInLeft` method replaced with `isLeftBdFace`
* deprecated methods: `findBoundaryFaces`, `findBoundaryEdges`, `findBoundaryVerts`
* new replacement methods: `findBdFaces`, `findLeftBdEdges` and `findBdVerts`
* better comments