### PR TITLE
Include proper version of expected class from precompiled header

### DIFF
--- a/source/MRMesh/MRExpected.cpp
+++ b/source/MRMesh/MRExpected.cpp
@@ -1,11 +1,15 @@
 #include "MRExpected.h"
 
-#if __cpp_lib_expected >= 202211
-  #pragma message("std::expected with monadic functions from C++23 is available")
-#else
-  #ifdef __cpp_lib_expected
-    #pragma message("std::expected available but WITHOUT monadic functions, using tl::expected instead")
+#if MR_USE_STD_EXPECTED
+  #if __cpp_lib_expected >= 202211
+    #pragma message("std::expected with monadic functions from C++23 is available")
   #else
-    #pragma message("std::expected is NOT available, using tl::expected instead")
+    #ifdef __cpp_lib_expected
+      #pragma message("std::expected available but WITHOUT monadic functions, using tl::expected instead")
+    #else
+      #pragma message("std::expected is NOT available, using tl::expected instead")
+    #endif
   #endif
+#else
+  #pragma message("!MR_USE_STD_EXPECTED, using tl::expected instead")
 #endif

--- a/source/MRMesh/MRExpected.h
+++ b/source/MRMesh/MRExpected.h
@@ -2,41 +2,7 @@
 
 #include "MRMeshFwd.h"
 #include "MRPch/MRBindingMacros.h"
-
-#include <version>
-#ifndef MR_USE_STD_EXPECTED
-// #if __cpp_lib_expected >= 202211
-// Currently not using `std::expected` for simplicity, because:
-// 1. Clang 18 doesn't support libstdc++'s `std::expected`, which is a problem for the Python bindings. This got fixed in Clang 19.
-// 2. `MRMeshDotNet` can't use `std::expected` too.
-// In theory both can be fixed by defining `MR_DOT_NET_BUILD`.
-#define MR_USE_STD_EXPECTED 0
-#endif
-
-#if MR_USE_STD_EXPECTED
-#include <expected>
-#else
-#include <tl/expected.hpp>
-/// we have C++/CLI project MRMeshDotNet which doesn't support std::expected
-/// So we have to wrap tl::expected with this class in std namespace for correct linking
-#ifdef MR_DOT_NET_BUILD
-namespace std
-{
-template<typename T, typename E>
-class expected : public tl::expected<T, E>
-{
-    using tl::expected<T, E>::expected;
-};
-
-template <class E>
-inline auto unexpected( E &&e )
-{
-    return tl::make_unexpected( std::forward<E>( e ) );
-}
-}
-#endif
-#endif
-
+#include "MRPch/MRExpected.h"
 #include <string>
 
 namespace MR

--- a/source/MRPch/MRExpected.h
+++ b/source/MRPch/MRExpected.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#ifndef MR_USE_STD_EXPECTED
+// #include <version>
+// #if __cpp_lib_expected >= 202211
+// Currently not using `std::expected` for simplicity, because:
+// 1. Clang 18 doesn't support libstdc++'s `std::expected`, which is a problem for the Python bindings. This got fixed in Clang 19.
+// 2. `MRMeshDotNet` can't use `std::expected` too.
+// In theory both can be fixed by defining `MR_DOT_NET_BUILD`.
+#define MR_USE_STD_EXPECTED 0
+#endif
+
+#if MR_USE_STD_EXPECTED
+#include <expected>
+#else
+#include <tl/expected.hpp>
+/// we have C++/CLI project MRMeshDotNet which doesn't support std::expected
+/// So we have to wrap tl::expected with this class in std namespace for correct linking
+#ifdef MR_DOT_NET_BUILD
+namespace std
+{
+template<typename T, typename E>
+class expected : public tl::expected<T, E>
+{
+    using tl::expected<T, E>::expected;
+};
+
+template <class E>
+inline auto unexpected( E &&e )
+{
+    return tl::make_unexpected( std::forward<E>( e ) );
+}
+}
+#endif
+#endif
+

--- a/source/MRPch/MRPch.h
+++ b/source/MRPch/MRPch.h
@@ -7,12 +7,7 @@
 
 #include <parallel_hashmap/phmap.h>
 
-#include <version>
-#ifdef __cpp_lib_expected
-#include <expected>
-#else
-#include <tl/expected.hpp>
-#endif
+#include "MRExpected.h"
 
 #pragma warning(push)
 #pragma warning(disable: 4619) //#pragma warning: there is no warning number
@@ -95,6 +90,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include <version>
 
 #ifdef MR_PCH_USE_EXTRA_HEADERS
 #include "MRMesh/MRIOFilters.h"

--- a/source/MRPch/MRPch.vcxproj
+++ b/source/MRPch/MRPch.vcxproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MREigenCore.h" />
+    <ClInclude Include="MRExpected.h" />
     <ClInclude Include="MRFilesystem.h" />
     <ClInclude Include="MRFmt.h" />
     <ClInclude Include="MRWasm.h" />

--- a/source/MRPch/MRPch.vcxproj.filters
+++ b/source/MRPch/MRPch.vcxproj.filters
@@ -15,6 +15,7 @@
     <ClInclude Include="MRFilesystem.h" />
     <ClInclude Include="MRBindingMacros.h" />
     <ClInclude Include="MRWinapi.h" />
+    <ClInclude Include="MRExpected.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRPch.cpp" />


### PR DESCRIPTION
* Introduce new `MRPch/MRExpected.h` to include either `std::expected` or `tl::expected` in the precompiled header.
* Share the logic of inclusion with `MRMesh/MRExpected.h`.