### PR TITLE
MapOrHashMap in PartMapping

### DIFF
--- a/source/MRMesh/MRBooleanOperation.cpp
+++ b/source/MRMesh/MRBooleanOperation.cpp
@@ -112,7 +112,7 @@ bool preparePart( const Mesh& origin, std::vector<EdgePath>& cutPaths, Mesh& out
     leftPart = preparePart( origin, compsMap, leftPart, otherMesh, needInsidePart, originIsA, rigidB2A, mergeAllNonIntersectingComponents, intParams );
 
     outMesh.addMeshPart( { origin, &leftPart }, needFlip, {}, {},
-        HashToVectorMappingConverter( origin.topology, fMapPtr, vMapPtr, eMapPtr ).getPartMapping() );
+        HashToVectorMappingConverter( fMapPtr, vMapPtr, eMapPtr ).getPartMapping() );
 
     for ( auto& path : cutPaths )
         for ( auto& e : path )
@@ -146,10 +146,10 @@ void connectPreparedParts( Mesh& partA, Mesh& partB, bool pathsHaveLeftHole,
     {
         if ( !pathsHaveLeftHole )
             partA.addMeshPart( partB, false, pathsA, pathsB,
-                HashToVectorMappingConverter( partB.topology, fMapNewPtr, vMapNewPtr, eMapNewPtr ).getPartMapping() );
+                HashToVectorMappingConverter( fMapNewPtr, vMapNewPtr, eMapNewPtr ).getPartMapping() );
         else
             partB.addMeshPart( partA, false, pathsB, pathsA,
-                HashToVectorMappingConverter( partA.topology, fMapNewPtr, vMapNewPtr, eMapNewPtr ).getPartMapping() );
+                HashToVectorMappingConverter( fMapNewPtr, vMapNewPtr, eMapNewPtr ).getPartMapping() );
     }
 
     if ( mapper )
@@ -204,7 +204,7 @@ Mesh doTrivialBooleanOperation( Mesh&& meshACut, Mesh&& meshBCut, BooleanOperati
         VertMap* vMapPtr = mapper ? &mapper->maps[int( BooleanResultMapper::MapObject::A )].old2newVerts : nullptr;
 
         aPart.addMeshPart( { meshACut, &aPartFbs }, operation == BooleanOperation::DifferenceBA,
-                             {}, {}, HashToVectorMappingConverter( meshACut.topology, fMapPtr, vMapPtr, eMapPtr ).getPartMapping() );
+                             {}, {}, HashToVectorMappingConverter( fMapPtr, vMapPtr, eMapPtr ).getPartMapping() );
     }
 
     if ( bPartFbs.count() != 0 )
@@ -214,7 +214,7 @@ Mesh doTrivialBooleanOperation( Mesh&& meshACut, Mesh&& meshBCut, BooleanOperati
         VertMap* vMapPtr = mapper ? &mapper->maps[int( BooleanResultMapper::MapObject::B )].old2newVerts : nullptr;
 
         bPart.addMeshPart( { meshBCut, &bPartFbs }, operation == BooleanOperation::DifferenceAB,
-                             {}, {}, HashToVectorMappingConverter( meshBCut.topology, fMapPtr, vMapPtr, eMapPtr ).getPartMapping() );
+                             {}, {}, HashToVectorMappingConverter( fMapPtr, vMapPtr, eMapPtr ).getPartMapping() );
     }
 
     connectPreparedParts( aPart, bPart, false, {}, {}, rigidB2A, mapper );

--- a/source/MRMesh/MRFixSelfIntersections.cpp
+++ b/source/MRMesh/MRFixSelfIntersections.cpp
@@ -230,9 +230,9 @@ Expected<void> fix( Mesh& mesh, const Settings& settings )
 // Helper function to find own self-intersections on a mesh part
 static Expected<FaceBitSet> findSelfCollidingTrianglesBSForPart( Mesh& mesh, const FaceBitSet& part, ProgressCallback cb, bool touchIsIntersection )
 {
-    FaceMap tgt2srcFaceMap;
+    FaceMap tgt2srcFaces;
     PartMapping mapping;
-    mapping.tgt2srcFaceMap = &tgt2srcFaceMap;
+    mapping.tgt2srcFaces = &tgt2srcFaces;
     Mesh partMesh = mesh.cloneRegion( part, false, mapping );
     // Faster than searching in mesh part due to AABB tree rebuild
     auto res = findSelfCollidingTrianglesBS( { partMesh }, cb, nullptr, touchIsIntersection );
@@ -240,7 +240,7 @@ static Expected<FaceBitSet> findSelfCollidingTrianglesBSForPart( Mesh& mesh, con
         return unexpected( res.error() );
     FaceBitSet result( mesh.topology.lastValidFace() + 1 );
     for ( FaceId f : *res )
-        result.set( tgt2srcFaceMap[f] );
+        result.set( tgt2srcFaces[f] );
     return result;
 }
 

--- a/source/MRMesh/MRMapEdge.h
+++ b/source/MRMesh/MRMapEdge.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "MRphmap.h"
-#include "MRVector.h"
+#include "MRMapOrHashMap.h"
 #include "MRBuffer.h"
 
 namespace MR
@@ -28,6 +27,15 @@ namespace MR
             res = res.sym();
     }
     return res;
+}
+
+/// given input edge (src), converts its id using given map
+[[nodiscard]] inline EdgeId mapEdge( const WholeEdgeMapOrHashMap & m, EdgeId src )
+{
+    return std::visit( overloaded{
+        [src]( const WholeEdgeMap& map ) { return mapEdge( map, src ); },
+        [src]( const WholeEdgeHashMap& hashMap ) { return mapEdge( hashMap, src ); }
+    }, m.var );
 }
 
 /// given input edge (src), converts its id using given map

--- a/source/MRMesh/MRMapOrHashMap.h
+++ b/source/MRMesh/MRMapOrHashMap.h
@@ -13,19 +13,19 @@ namespace MR
 template <typename K, typename V>
 struct MapOrHashMap
 {
-    using Map = Vector<V, K>;
-    using HashMap = HashMap<K, V>;
+    using Dense = Vector<V, K>;
+    using Hash = HashMap<K, V>;
     // default construction will select dense map
-    std::variant<Map, HashMap> var;
+    std::variant<Dense, Hash> var;
 
     [[nodiscard]] static MapOrHashMap createMap( size_t size = 0 );
     [[nodiscard]] static MapOrHashMap createHashMap( size_t capacity = 0 );
 
-    [[nodiscard]]       Map* getMap()       { return get_if<Map>( &var ); }
-    [[nodiscard]] const Map* getMap() const { return get_if<Map>( &var ); }
+    [[nodiscard]]       Dense* getMap()       { return get_if<Dense>( &var ); }
+    [[nodiscard]] const Dense* getMap() const { return get_if<Dense>( &var ); }
 
-    [[nodiscard]]       HashMap* getHashMap()       { return get_if<HashMap>( &var ); }
-    [[nodiscard]] const HashMap* getHashMap() const { return get_if<HashMap>( &var ); }
+    [[nodiscard]]       Hash* getHashMap()       { return get_if<Hash>( &var ); }
+    [[nodiscard]] const Hash* getHashMap() const { return get_if<Hash>( &var ); }
 
     void clear();
 };
@@ -34,7 +34,7 @@ template <typename K, typename V>
 inline MapOrHashMap<K,V> MapOrHashMap<K,V>::createMap( size_t size )
 {
     MapOrHashMap<K,V> res;
-    res.var = Map( size );
+    res.var = Dense( size );
     return res;
 }
 
@@ -42,7 +42,7 @@ template <typename K, typename V>
 inline MapOrHashMap<K,V> MapOrHashMap<K,V>::createHashMap( size_t capacity )
 {
     MapOrHashMap<K,V> res;
-    HashMap hmap;
+    Hash hmap;
     if ( capacity > 0 )
         hmap.reserve( capacity );
     res.var = std::move( hmap );
@@ -53,8 +53,8 @@ template <typename K, typename V>
 void MapOrHashMap<K,V>::clear()
 {
     std::visit( overloaded{
-        []( Map& map ) { map.clear(); },
-        []( HashMap& hashMap ) { hashMap.clear(); }
+        []( Dense& map ) { map.clear(); },
+        []( Hash& hashMap ) { hashMap.clear(); }
     }, var );
 }
 

--- a/source/MRMesh/MRMapOrHashMap.h
+++ b/source/MRMesh/MRMapOrHashMap.h
@@ -7,6 +7,9 @@
 namespace MR
 {
 
+/// stores a mapping from keys K to values V in one of two forms:
+/// 1) as dense map (vector) preferable when there are few missing keys in a range [0, endKey)
+/// 2) as hash map preferable when valid keys are a small subset of the range
 template <typename K, typename V>
 struct MapOrHashMap
 {

--- a/source/MRMesh/MRMapOrHashMap.h
+++ b/source/MRMesh/MRMapOrHashMap.h
@@ -18,7 +18,10 @@ struct MapOrHashMap
     [[nodiscard]] static MapOrHashMap createMap( size_t size = 0 );
     [[nodiscard]] static MapOrHashMap createHashMap( size_t capacity = 0 );
 
+    [[nodiscard]]       Map* getMap()       { return get_if<Map>( &var ); }
     [[nodiscard]] const Map* getMap() const { return get_if<Map>( &var ); }
+
+    [[nodiscard]]       HashMap* getHashMap()       { return get_if<HashMap>( &var ); }
     [[nodiscard]] const HashMap* getHashMap() const { return get_if<HashMap>( &var ); }
 
     void clear();

--- a/source/MRMesh/MRMapOrHashMap.h
+++ b/source/MRMesh/MRMapOrHashMap.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "MRVector.h"
+#include "MRphmap.h"
+#include <variant>
+
+namespace MR
+{
+
+template <typename K, typename V>
+struct MapOrHashMap
+{
+    using Map = Vector<V, K>;
+    using HashMap = HashMap<K, V>;
+    std::variant<Map, HashMap> var;
+
+    static MapOrHashMap createMap( size_t size = 0 );
+    static MapOrHashMap createHashMap( size_t capacity = 0 );
+
+    bool isMap() const;
+    bool isHashMap() const { return !isMap(); }
+};
+
+template <typename K, typename V>
+inline MapOrHashMap<K,V> MapOrHashMap<K,V>::createMap( size_t size )
+{
+    MapOrHashMap<K,V> res;
+    res.var = Map( size );
+    return res;
+}
+
+template <typename K, typename V>
+inline MapOrHashMap<K,V> MapOrHashMap<K,V>::createHashMap( size_t capacity )
+{
+    MapOrHashMap<K,V> res;
+    HashMap hmap;
+    if ( capacity > 0 )
+        hmap.reserve( capacity );
+    res.var = std::move( hmap );
+    return res;
+}
+
+template <typename K, typename V>
+inline bool MapOrHashMap<K,V>::isMap() const
+{
+    std::visit( overloaded{
+        []( const Map& map ) { return true; },
+        []( const HashMap& hashMap ) { return false; }
+    }, var );
+}
+
+template <typename K, typename V>
+inline V getAt( const MapOrHashMap<K, V> & m, K key, V def = {} )
+{
+    std::visit( overloaded{
+        []( const Vector<V, K>& map ) { getAt( map, key, def ); },
+        []( const HashMap<K, V>& hashMap ) { getAt( hashMap, key, def ); }
+    }, m.var );
+}
+
+template <typename K, typename V>
+inline void setAt( MapOrHashMap<K, V> & m, K key, V val )
+{
+    std::visit( overloaded{
+        []( Vector<V, K>& map ) { map[key] = val; },
+        []( HashMap<K, V>& hashMap ) { hashMap[key] = val; }
+    }, m.var );
+}
+
+} //namespace MR

--- a/source/MRMesh/MRMapOrHashMap.h
+++ b/source/MRMesh/MRMapOrHashMap.h
@@ -24,6 +24,10 @@ struct MapOrHashMap
     void setMap( Dense && m ) { var = std::move( m ); }
     void setHashMap( Hash && m ) { var = std::move( m ); }
 
+    /// if this stores dense map then resizes it to denseTotalSize;
+    /// if this stores hash map then sets its capacity to size()+hashAdditionalCapacity
+    void resizeReserve( size_t denseTotalSize, size_t hashAdditionalCapacity );
+
     [[nodiscard]]       Dense* getMap()       { return get_if<Dense>( &var ); }
     [[nodiscard]] const Dense* getMap() const { return get_if<Dense>( &var ); }
 
@@ -50,6 +54,15 @@ inline MapOrHashMap<K,V> MapOrHashMap<K,V>::createHashMap( size_t capacity )
         hmap.reserve( capacity );
     res.var = std::move( hmap );
     return res;
+}
+
+template <typename K, typename V>
+void MapOrHashMap<K,V>::resizeReserve( size_t denseTotalSize, size_t hashAdditionalCapacity )
+{
+    std::visit( overloaded{
+        [denseTotalSize]( Dense& map ) { map.resize( denseTotalSize ); },
+        [hashAdditionalCapacity]( Hash& hashMap ) { hashMap.reserve( hashMap.size() + hashAdditionalCapacity ); }
+    }, var );
 }
 
 template <typename K, typename V>

--- a/source/MRMesh/MRMapOrHashMap.h
+++ b/source/MRMesh/MRMapOrHashMap.h
@@ -21,6 +21,9 @@ struct MapOrHashMap
     [[nodiscard]] static MapOrHashMap createMap( size_t size = 0 );
     [[nodiscard]] static MapOrHashMap createHashMap( size_t capacity = 0 );
 
+    void setMap( Dense && m ) { var = std::move( m ); }
+    void setHashMap( Hash && m ) { var = std::move( m ); }
+
     [[nodiscard]]       Dense* getMap()       { return get_if<Dense>( &var ); }
     [[nodiscard]] const Dense* getMap() const { return get_if<Dense>( &var ); }
 

--- a/source/MRMesh/MRMathInstatiate.cpp
+++ b/source/MRMesh/MRMathInstatiate.cpp
@@ -20,9 +20,6 @@
 namespace MR
 {
 
-#if !defined _MSC_VER || _MSC_VER < 1944 // Visual Studio 2022 version 17.14
-// https://developercommunity.visualstudio.com/t/Internal-compiler-error-ICE-on-explici/10903887
-
 // verifies that templates can be instantiated with typical parameters
 
 template struct Matrix2<float>;
@@ -96,7 +93,5 @@ template Matrix3<double> orthonormalized( const Matrix3<double> & m );
 
 template AffineXf3<float>  orthonormalized( const AffineXf3<float> & xf,  const Vector3<float> & center );
 template AffineXf3<double> orthonormalized( const AffineXf3<double> & xf, const Vector3<double> & center );
-
-#endif
 
 } //namespace MR

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -408,8 +408,16 @@ void Mesh::addPartBy( const Mesh & from, I fbegin, I fend, size_t fcount, bool f
     if ( points.size() < lastPointId + 1 )
         points.resize( lastPointId + 1 );
 
-    for ( const auto & [ fromVert, thisVert ] : *map.src2tgtVerts->getHashMap() )
-        points[thisVert] = from.points[fromVert];
+    if ( auto * vec = map.src2tgtVerts->getMap() )
+    {
+        for ( auto fromVert = 0_v; fromVert < vec->size(); ++fromVert )
+            points[(*vec)[fromVert]] = from.points[fromVert];
+    }
+    else
+    {
+        for ( const auto & [ fromVert, thisVert ] : *map.src2tgtVerts->getHashMap() )
+            points[thisVert] = from.points[fromVert];
+    }
 
     invalidateCaches();
 }

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -400,7 +400,7 @@ void Mesh::addPartBy( const Mesh & from, I fbegin, I fend, size_t fcount, bool f
 {
     MR_TIMER;
 
-    VertHashMap localVmap;
+    auto localVmap = VertMapOrHashMap::createHashMap();
     if ( !map.src2tgtVerts )
         map.src2tgtVerts = &localVmap;
     topology.addPartBy( from.topology, fbegin, fend, fcount, flipOrientation, thisContours, fromContours, map );
@@ -408,7 +408,7 @@ void Mesh::addPartBy( const Mesh & from, I fbegin, I fend, size_t fcount, bool f
     if ( points.size() < lastPointId + 1 )
         points.resize( lastPointId + 1 );
 
-    for ( const auto & [ fromVert, thisVert ] : *map.src2tgtVerts )
+    for ( const auto & [ fromVert, thisVert ] : *map.src2tgtVerts->getHashMap() )
         points[thisVert] = from.points[fromVert];
 
     invalidateCaches();

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -411,7 +411,8 @@ void Mesh::addPartBy( const Mesh & from, I fbegin, I fend, size_t fcount, bool f
     if ( auto * vec = map.src2tgtVerts->getMap() )
     {
         for ( auto fromVert = 0_v; fromVert < vec->size(); ++fromVert )
-            points[(*vec)[fromVert]] = from.points[fromVert];
+            if ( auto thisVert = (*vec)[fromVert] )
+                points[thisVert] = from.points[fromVert];
     }
     else
     {

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -401,14 +401,14 @@ void Mesh::addPartBy( const Mesh & from, I fbegin, I fend, size_t fcount, bool f
     MR_TIMER;
 
     VertHashMap localVmap;
-    if ( !map.src2tgtVertHashMap )
-        map.src2tgtVertHashMap = &localVmap;
+    if ( !map.src2tgtVerts )
+        map.src2tgtVerts = &localVmap;
     topology.addPartBy( from.topology, fbegin, fend, fcount, flipOrientation, thisContours, fromContours, map );
     VertId lastPointId = topology.lastValidVert();
     if ( points.size() < lastPointId + 1 )
         points.resize( lastPointId + 1 );
 
-    for ( const auto & [ fromVert, thisVert ] : *map.src2tgtVertHashMap )
+    for ( const auto & [ fromVert, thisVert ] : *map.src2tgtVerts )
         points[thisVert] = from.points[fromVert];
 
     invalidateCaches();

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -11,6 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="MRMapOrHashMap.h" />
     <ClInclude Include="MRAABBTreeBase.h" />
     <ClInclude Include="MRAABBTreeBase.hpp" />
     <ClInclude Include="MRAABBTreeMaker.hpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1318,6 +1318,9 @@
     <ClInclude Include="MRChrono.h">
       <Filter>Source Files\System</Filter>
     </ClInclude>
+    <ClInclude Include="MRMapOrHashMap.h">
+      <Filter>Source Files\Basic</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRParallelProgressReporter.cpp">

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -528,6 +528,16 @@ using UndirectedEdgeHashMap = HashMap<UndirectedEdgeId, UndirectedEdgeId>;
 ///  mapping of whole edges: map[e]->f, map[e.sym()]->f.sym(), where only map[e] for even edges is stored
 using WholeEdgeHashMap = HashMap<UndirectedEdgeId, EdgeId>;
 
+template <typename K, typename V>
+struct MapOrHashMap;
+
+using FaceMapOrHashMap = MapOrHashMap<FaceId, FaceId>;
+using VertMapOrHashMap = MapOrHashMap<VertId, VertId>;
+using EdgeMapOrHashMap = MapOrHashMap<EdgeId, EdgeId>;
+using UndirectedEdgeMapOrHashMap = MapOrHashMap<UndirectedEdgeId, UndirectedEdgeId>;
+///  mapping of whole edges: map[e]->f, map[e.sym()]->f.sym(), where only map[e] for even edges is stored
+using WholeEdgeMapOrHashMap = MapOrHashMap<UndirectedEdgeId, EdgeId>;
+
 template <typename I> class UnionFind;
 template <typename T, typename I, typename P> class Heap;
 

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1696,10 +1696,8 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
     const auto szContours = thisContours.size();
     assert( szContours == fromContours.size() );
 
-
     // in all maps: from index -> to index
-    FaceHashMap fmap;
-    fmap.reserve( fcount );
+    auto fmap = MapOrHashMap<FaceId, FaceId>::createHashMap( fcount );
     WholeEdgeHashMap emap;
     emap.reserve( std::min( 2 * fcount, from.undirectedEdgeSize() ) ); // if whole connected component is copied then ecount=3/2*fcount; if unconnected triangles are copied then ecount=3*fcount
     VertHashMap vmap;
@@ -1799,7 +1797,7 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
         auto nf = addFaceId();
         if ( map.tgt2srcFaces )
             map.tgt2srcFaces ->push_back( f );
-        fmap[f] = nf;
+        setAt( fmap, f, nf );
         edgePerFace_[nf] = mapEdge( emap, flipOrientation ? efrom.sym() : efrom );
         if ( updateValids_ )
         {
@@ -1825,7 +1823,7 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
             {
                 eNx = flipOrientation ? from.prev( eNx ) : from.next( eNx );
                 auto cf = flipOrientation ? from.right( eNx ) : from.left( eNx );
-                if ( ( cf && fmap[cf] ) || eNx == e.sym() )
+                if ( getAt( fmap, cf ) || eNx == e.sym() )
                     break;
             }
             if ( !existingEdges.test( eNx.undirected() ) )
@@ -1839,7 +1837,7 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
             {
                 ePr = flipOrientation ? from.next( ePr ) : from.prev( ePr );
                 auto cf = flipOrientation ? from.left( ePr ) : from.right( ePr );
-                if ( ( cf && fmap[cf] ) || ePr == e )
+                if ( getAt( fmap, cf ) || ePr == e )
                     break;
             }
             if ( !existingEdges.test( ePr.undirected() ) )

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1698,8 +1698,7 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
 
     // in all maps: from index -> to index
     auto fmap = FaceMapOrHashMap::createHashMap( fcount );
-    WholeEdgeHashMap emap;
-    emap.reserve( std::min( 2 * fcount, from.undirectedEdgeSize() ) ); // if whole connected component is copied then ecount=3/2*fcount; if unconnected triangles are copied then ecount=3*fcount
+    auto emap = WholeEdgeMapOrHashMap::createHashMap( std::min( 2 * fcount, from.undirectedEdgeSize() ) ); // if whole connected component is copied then ecount=3/2*fcount; if unconnected triangles are copied then ecount=3*fcount
     auto vmap = VertMapOrHashMap::createHashMap( std::min( fcount, from.vertSize() ) ); // if whole connected component is copied then vcount=1/2*fcount; if unconnected triangles are copied then vcount=3*fcount
     if ( map.tgt2srcEdges )
         map.tgt2srcEdges->resize( undirectedEdgeSize() );
@@ -1747,8 +1746,8 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
             assert( ( flipOrientation && !from.left( e ) ) || ( !flipOrientation && !from.right( e ) ) );
             setVmap( from.org( e ), org( e1 ) );
             setVmap( from.dest( e ), dest( e1 ) );
-            [[maybe_unused]] bool eInserted = emap.insert( { e.undirected(), e.even() ? e1 : e1.sym() } ).second;
-            assert( eInserted ); // all contour edges must be unique
+            assert( !getAt( emap, e.undirected() ) );
+            setAt( emap, e.undirected(), e.even() ? e1 : e1.sym() );
             existingEdges.autoResizeSet( e.undirected() );
         }
     }
@@ -1765,8 +1764,8 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
             const UndirectedEdgeId ue = e.undirected();
             if ( fromEdges.test_set( ue, false ) )
             {
-                [[maybe_unused]] bool inserted = emap.insert( { ue, edges_.endId() } ).second;
-                assert( inserted );
+                assert( !getAt( emap, ue ) );
+                setAt( emap, ue, edges_.endId() );
                 edges_.push_back( from.edges_[EdgeId{ ue }] );
                 edges_.push_back( from.edges_[EdgeId{ ue }.sym()] );
                 if ( map.tgt2srcEdges )

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1696,10 +1696,17 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
     const auto szContours = thisContours.size();
     assert( szContours == fromContours.size() );
 
-    // in all maps: from index -> to index
-    auto fmap = FaceMapOrHashMap::createHashMap( fcount );
-    auto emap = WholeEdgeMapOrHashMap::createHashMap( std::min( 2 * fcount, from.undirectedEdgeSize() ) ); // if whole connected component is copied then ecount=3/2*fcount; if unconnected triangles are copied then ecount=3*fcount
-    auto vmap = VertMapOrHashMap::createHashMap( std::min( fcount, from.vertSize() ) ); // if whole connected component is copied then vcount=1/2*fcount; if unconnected triangles are copied then vcount=3*fcount
+    // in all maps: from index -> to index;
+    // use dense map only if requested by the user, otherwise hash map
+    auto fmap = ( map.src2tgtFaces && map.src2tgtFaces->getMap() ) ?
+        FaceMapOrHashMap::createMap( from.faceSize() ) :
+        FaceMapOrHashMap::createHashMap( fcount );
+    auto emap = ( map.src2tgtEdges && map.src2tgtEdges->getMap() ) ?
+        WholeEdgeMapOrHashMap::createMap( from.undirectedEdgeSize() ) :
+        WholeEdgeMapOrHashMap::createHashMap( std::min( 2 * fcount, from.undirectedEdgeSize() ) ); // if whole connected component is copied then ecount=3/2*fcount; if unconnected triangles are copied then ecount=3*fcount
+    auto vmap = ( map.src2tgtVerts && map.src2tgtVerts->getMap() ) ?
+        VertMapOrHashMap::createMap( from.vertSize() ) :
+        VertMapOrHashMap::createHashMap( std::min( fcount, from.vertSize() ) ); // if whole connected component is copied then vcount=1/2*fcount; if unconnected triangles are copied then vcount=3*fcount
     if ( map.tgt2srcEdges )
         map.tgt2srcEdges->resize( undirectedEdgeSize() );
     if ( map.tgt2srcVerts )

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1696,7 +1696,7 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
     const auto szContours = thisContours.size();
     assert( szContours == fromContours.size() );
 
-    // in all maps: from index -> to index;
+    // maps: from index -> to index;
     // use dense map only if requested by the user, otherwise hash map
     auto fmap = ( map.src2tgtFaces && map.src2tgtFaces->getMap() ) ?
         FaceMapOrHashMap::createMap( from.faceSize() ) :
@@ -1707,6 +1707,8 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
     auto vmap = ( map.src2tgtVerts && map.src2tgtVerts->getMap() ) ?
         VertMapOrHashMap::createMap( from.vertSize() ) :
         VertMapOrHashMap::createHashMap( std::min( fcount, from.vertSize() ) ); // if whole connected component is copied then vcount=1/2*fcount; if unconnected triangles are copied then vcount=3*fcount
+
+    // maps: to index -> from index
     if ( map.tgt2srcEdges )
         map.tgt2srcEdges->resize( undirectedEdgeSize() );
     if ( map.tgt2srcVerts )

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1704,12 +1704,12 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
     emap.reserve( std::min( 2 * fcount, from.undirectedEdgeSize() ) ); // if whole connected component is copied then ecount=3/2*fcount; if unconnected triangles are copied then ecount=3*fcount
     VertHashMap vmap;
     vmap.reserve( std::min( fcount, from.vertSize() ) ); // if whole connected component is copied then vcount=1/2*fcount; if unconnected triangles are copied then vcount=3*fcount
-    if ( map.tgt2srcWholeEdgeMap )
-        map.tgt2srcWholeEdgeMap->resize( undirectedEdgeSize() );
-    if ( map.tgt2srcVertMap )
-        map.tgt2srcVertMap->resize( vertSize() );
-    if ( map.tgt2srcFaceMap )
-        map.tgt2srcFaceMap->resize( faceSize() );
+    if ( map.tgt2srcEdges )
+        map.tgt2srcEdges->resize( undirectedEdgeSize() );
+    if ( map.tgt2srcVerts )
+        map.tgt2srcVerts->resize( vertSize() );
+    if ( map.tgt2srcFaces )
+        map.tgt2srcFaces->resize( faceSize() );
 
     VertBitSet fromVerts = from.getValidVerts();
     auto setVmap = [&] ( VertId key, VertId val )
@@ -1773,9 +1773,9 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
                 assert( inserted );
                 edges_.push_back( from.edges_[EdgeId{ ue }] );
                 edges_.push_back( from.edges_[EdgeId{ ue }.sym()] );
-                if ( map.tgt2srcWholeEdgeMap )
+                if ( map.tgt2srcEdges )
                 {
-                    map.tgt2srcWholeEdgeMap->push_back( EdgeId{ ue } );
+                    map.tgt2srcEdges->push_back( EdgeId{ ue } );
                 }
             }
             if ( auto v = from.org( e ); v.valid() )
@@ -1785,8 +1785,8 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
                     auto nv = addVertId();
                     [[maybe_unused]] bool inserted = vmap.insert( { v, nv } ).second;
                     assert( inserted );
-                    if ( map.tgt2srcVertMap )
-                        map.tgt2srcVertMap->push_back( v );
+                    if ( map.tgt2srcVerts )
+                        map.tgt2srcVerts->push_back( v );
                     edgePerVertex_[nv] = mapEdge( emap, e );
                     if ( updateValids_ )
                     {
@@ -1797,8 +1797,8 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
             }
         }
         auto nf = addFaceId();
-        if ( map.tgt2srcFaceMap )
-            map.tgt2srcFaceMap ->push_back( f );
+        if ( map.tgt2srcFaces )
+            map.tgt2srcFaces ->push_back( f );
         fmap[f] = nf;
         edgePerFace_[nf] = mapEdge( emap, flipOrientation ? efrom.sym() : efrom );
         if ( updateValids_ )
@@ -1903,19 +1903,19 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
         edges_[eNx].prev = ePr;
     }
 
-    if ( map.tgt2srcWholeEdgeMap )
-        assert( map.tgt2srcWholeEdgeMap->size() == undirectedEdgeSize() );
-    if ( map.tgt2srcVertMap )
-        assert( map.tgt2srcVertMap->size() == vertSize() );
-    if ( map.tgt2srcFaceMap )
-        assert( map.tgt2srcFaceMap->size() == faceSize() );
+    if ( map.tgt2srcEdges )
+        assert( map.tgt2srcEdges->size() == undirectedEdgeSize() );
+    if ( map.tgt2srcVerts )
+        assert( map.tgt2srcVerts->size() == vertSize() );
+    if ( map.tgt2srcFaces )
+        assert( map.tgt2srcFaces->size() == faceSize() );
 
-    if ( map.src2tgtFaceHashMap )
-        *map.src2tgtFaceHashMap = std::move( fmap );
-    if ( map.src2tgtVertHashMap )
-        *map.src2tgtVertHashMap = std::move( vmap );
-    if ( map.src2tgtWholeEdgeHashMap )
-        *map.src2tgtWholeEdgeHashMap = std::move( emap );
+    if ( map.src2tgtFaces )
+        *map.src2tgtFaces = std::move( fmap );
+    if ( map.src2tgtVerts )
+        *map.src2tgtVerts = std::move( vmap );
+    if ( map.src2tgtEdges )
+        *map.src2tgtEdges = std::move( emap );
 }
 
 template MRMESH_API void MeshTopology::addPartBy( const MeshTopology & from,

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1698,15 +1698,14 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
 
     // maps: from index -> to index;
     // use dense map only if requested by the user, otherwise hash map
-    auto fmap = ( map.src2tgtFaces && map.src2tgtFaces->getMap() ) ?
-        FaceMapOrHashMap::createMap( from.faceSize() ) :
-        FaceMapOrHashMap::createHashMap( fcount );
-    auto emap = ( map.src2tgtEdges && map.src2tgtEdges->getMap() ) ?
-        WholeEdgeMapOrHashMap::createMap( from.undirectedEdgeSize() ) :
-        WholeEdgeMapOrHashMap::createHashMap( std::min( 2 * fcount, from.undirectedEdgeSize() ) ); // if whole connected component is copied then ecount=3/2*fcount; if unconnected triangles are copied then ecount=3*fcount
-    auto vmap = ( map.src2tgtVerts && map.src2tgtVerts->getMap() ) ?
-        VertMapOrHashMap::createMap( from.vertSize() ) :
-        VertMapOrHashMap::createHashMap( std::min( fcount, from.vertSize() ) ); // if whole connected component is copied then vcount=1/2*fcount; if unconnected triangles are copied then vcount=3*fcount
+    auto fmap = map.src2tgtFaces ? std::move( *map.src2tgtFaces ) : FaceMapOrHashMap::createHashMap();
+    fmap.resizeReserve( from.faceSize(), fcount );
+
+    auto emap = map.src2tgtEdges ? std::move( *map.src2tgtEdges ) : WholeEdgeMapOrHashMap::createHashMap();
+    emap.resizeReserve( from.undirectedEdgeSize(), std::min( 2 * fcount, from.undirectedEdgeSize() ) ); // if whole connected component is copied then ecount=3/2*fcount; if unconnected triangles are copied then ecount=3*fcount
+
+    auto vmap = map.src2tgtVerts ? std::move( *map.src2tgtVerts ) : VertMapOrHashMap::createHashMap();
+    vmap.resizeReserve( from.vertSize(), std::min( fcount, from.vertSize() ) ); // if whole connected component is copied then vcount=1/2*fcount; if unconnected triangles are copied then vcount=3*fcount
 
     // maps: to index -> from index
     if ( map.tgt2srcEdges )

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1697,7 +1697,7 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
     assert( szContours == fromContours.size() );
 
     // in all maps: from index -> to index
-    auto fmap = MapOrHashMap<FaceId, FaceId>::createHashMap( fcount );
+    auto fmap = FaceMapOrHashMap::createHashMap( fcount );
     WholeEdgeHashMap emap;
     emap.reserve( std::min( 2 * fcount, from.undirectedEdgeSize() ) ); // if whole connected component is copied then ecount=3/2*fcount; if unconnected triangles are copied then ecount=3*fcount
     VertHashMap vmap;

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1700,8 +1700,7 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
     auto fmap = FaceMapOrHashMap::createHashMap( fcount );
     WholeEdgeHashMap emap;
     emap.reserve( std::min( 2 * fcount, from.undirectedEdgeSize() ) ); // if whole connected component is copied then ecount=3/2*fcount; if unconnected triangles are copied then ecount=3*fcount
-    VertHashMap vmap;
-    vmap.reserve( std::min( fcount, from.vertSize() ) ); // if whole connected component is copied then vcount=1/2*fcount; if unconnected triangles are copied then vcount=3*fcount
+    auto vmap = VertMapOrHashMap::createHashMap( std::min( fcount, from.vertSize() ) ); // if whole connected component is copied then vcount=1/2*fcount; if unconnected triangles are copied then vcount=3*fcount
     if ( map.tgt2srcEdges )
         map.tgt2srcEdges->resize( undirectedEdgeSize() );
     if ( map.tgt2srcVerts )
@@ -1714,14 +1713,13 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
     {
         if ( fromVerts.test_set( key, false ) )
         {
-            [[maybe_unused]] bool inserted = vmap.insert( std::make_pair( key, val ) ).second;
-            assert( inserted );
+            assert( !getAt( vmap, key ) );
+            setAt( vmap, key, val );
         }
 #ifndef NDEBUG
         else
         {
-            auto it = vmap.find( key );
-            assert( it != vmap.end() && it->second == val );
+            assert( getAt( vmap, key ) == val );
         }
 #endif
     };
@@ -1781,8 +1779,8 @@ void MeshTopology::addPartBy( const MeshTopology & from, I fbegin, I fend, size_
                 if ( fromVerts.test_set( v, false ) )
                 {
                     auto nv = addVertId();
-                    [[maybe_unused]] bool inserted = vmap.insert( { v, nv } ).second;
-                    assert( inserted );
+                    assert( !getAt( vmap, v ) );
+                    setAt( vmap, v, nv );
                     if ( map.tgt2srcVerts )
                         map.tgt2srcVerts->push_back( v );
                     edgePerVertex_[nv] = mapEdge( emap, e );

--- a/source/MRMesh/MRObjectMesh.cpp
+++ b/source/MRMesh/MRObjectMesh.cpp
@@ -415,9 +415,9 @@ std::shared_ptr<MR::ObjectMesh> cloneRegion( const std::shared_ptr<ObjectMesh>& 
     FaceMap faceMap;
     PartMapping partMapping;
     if ( !objMesh->getVertsColorMap().empty() || !objMesh->getUVCoords().empty() )
-        partMapping.tgt2srcVertMap = &vertMap;
+        partMapping.tgt2srcVerts = &vertMap;
     if ( !objMesh->getFacesColorMap().empty() || !objMesh->getTexturePerFace().empty() )
-        partMapping.tgt2srcFaceMap = &faceMap;
+        partMapping.tgt2srcFaces = &faceMap;
     std::shared_ptr<Mesh> newMesh = std::make_shared<Mesh>( objMesh->mesh()->cloneRegion( region, false, partMapping ) );
     std::shared_ptr<ObjectMesh> newObj = std::make_shared<ObjectMesh>();
     newObj->setFrontColor( objMesh->getFrontColor( true ), true );

--- a/source/MRMesh/MRPartMapping.cpp
+++ b/source/MRMesh/MRPartMapping.cpp
@@ -9,12 +9,14 @@ HashToVectorMappingConverter::HashToVectorMappingConverter( const MeshTopology &
 {
     if ( outFmap )
     {
+        src2tgtFaces_ = FaceMapOrHashMap::createHashMap();
         map_.src2tgtFaces = &src2tgtFaces_;
         outFmap->clear();
         outFmap->resize( (int)srcTopology.lastValidFace() + 1 );
     }
     if ( outVmap )
     {
+        src2tgtVerts_ = VertMapOrHashMap::createHashMap();
         map_.src2tgtVerts = &src2tgtVerts_;
         outVmap->clear();
         outVmap->resize( (int)srcTopology.lastValidVert() + 1 );
@@ -36,7 +38,7 @@ HashToVectorMappingConverter::~HashToVectorMappingConverter()
     }
     if ( outVmap_ )
     {
-        for ( const auto & [ fromVert, thisVert ] : src2tgtVerts_ )
+        for ( const auto & [ fromVert, thisVert ] : *src2tgtVerts_.getHashMap() )
             (*outVmap_)[fromVert] = thisVert;
     }
     if ( outEmap_ )

--- a/source/MRMesh/MRPartMapping.cpp
+++ b/source/MRMesh/MRPartMapping.cpp
@@ -23,6 +23,7 @@ HashToVectorMappingConverter::HashToVectorMappingConverter( const MeshTopology &
     }
     if ( outEmap )
     {
+        src2tgtEdges_ = WholeEdgeMapOrHashMap::createHashMap();
         map_.src2tgtEdges = &src2tgtEdges_;
         outEmap->clear();
         outEmap->resize( srcTopology.undirectedEdgeSize() );
@@ -43,7 +44,7 @@ HashToVectorMappingConverter::~HashToVectorMappingConverter()
     }
     if ( outEmap_ )
     {
-        for ( const auto & [ fromEdge, thisEdge ] : src2tgtEdges_ )
+        for ( const auto & [ fromEdge, thisEdge ] : *src2tgtEdges_.getHashMap() )
             (*outEmap_)[fromEdge] = thisEdge;
     }
 }

--- a/source/MRMesh/MRPartMapping.cpp
+++ b/source/MRMesh/MRPartMapping.cpp
@@ -20,26 +20,23 @@ void PartMapping::clear()
         tgt2srcEdges->clear();
 }
 
-HashToVectorMappingConverter::HashToVectorMappingConverter( const MeshTopology & srcTopology, FaceMap * outFmap, VertMap * outVmap, WholeEdgeMap * outEmap )
+HashToVectorMappingConverter::HashToVectorMappingConverter( FaceMap * outFmap, VertMap * outVmap, WholeEdgeMap * outEmap )
     : outFmap_( outFmap ), outVmap_( outVmap ), outEmap_( outEmap )
 {
     if ( outFmap )
     {
+        src2tgtFaces_.setMap( std::move( *outFmap_ ) );
         map_.src2tgtFaces = &src2tgtFaces_;
-        outFmap->clear();
-        outFmap->resize( (int)srcTopology.lastValidFace() + 1 );
     }
     if ( outVmap )
     {
+        src2tgtVerts_.setMap( std::move( *outVmap_ ) );
         map_.src2tgtVerts = &src2tgtVerts_;
-        outVmap->clear();
-        outVmap->resize( (int)srcTopology.lastValidVert() + 1 );
     }
     if ( outEmap )
     {
+        src2tgtEdges_.setMap( std::move( *outEmap_ ) );
         map_.src2tgtEdges = &src2tgtEdges_;
-        outEmap->clear();
-        outEmap->resize( srcTopology.undirectedEdgeSize() );
     }
 }
 

--- a/source/MRMesh/MRPartMapping.cpp
+++ b/source/MRMesh/MRPartMapping.cpp
@@ -4,6 +4,22 @@
 namespace MR
 {
 
+void PartMapping::clear()
+{
+    if ( src2tgtFaces )
+        src2tgtFaces->clear();
+    if ( src2tgtVerts )
+        src2tgtVerts->clear();
+    if ( src2tgtEdges )
+        src2tgtEdges->clear();
+    if ( tgt2srcFaces )
+        tgt2srcFaces->clear();
+    if ( tgt2srcVerts )
+        tgt2srcVerts->clear();
+    if ( tgt2srcEdges )
+        tgt2srcEdges->clear();
+}
+
 HashToVectorMappingConverter::HashToVectorMappingConverter( const MeshTopology & srcTopology, FaceMap * outFmap, VertMap * outVmap, WholeEdgeMap * outEmap )
     : outFmap_( outFmap ), outVmap_( outVmap ), outEmap_( outEmap )
 {

--- a/source/MRMesh/MRPartMapping.cpp
+++ b/source/MRMesh/MRPartMapping.cpp
@@ -4,40 +4,24 @@
 namespace MR
 {
 
-void PartMapping::clear()
-{
-    if ( src2tgtFaceHashMap )
-        src2tgtFaceHashMap->clear();
-    if ( src2tgtVertHashMap )
-        src2tgtVertHashMap->clear();
-    if ( src2tgtWholeEdgeHashMap )
-        src2tgtWholeEdgeHashMap->clear();
-    if ( tgt2srcFaceMap )
-        tgt2srcFaceMap->clear();
-    if ( tgt2srcVertMap )
-        tgt2srcVertMap->clear();
-    if ( tgt2srcWholeEdgeMap )
-        tgt2srcWholeEdgeMap->clear();
-}
-
 HashToVectorMappingConverter::HashToVectorMappingConverter( const MeshTopology & srcTopology, FaceMap * outFmap, VertMap * outVmap, WholeEdgeMap * outEmap )
     : outFmap_( outFmap ), outVmap_( outVmap ), outEmap_( outEmap )
 {
     if ( outFmap )
     {
-        map_.src2tgtFaceHashMap = &src2tgtFaces_;
+        map_.src2tgtFaces = &src2tgtFaces_;
         outFmap->clear();
         outFmap->resize( (int)srcTopology.lastValidFace() + 1 );
     }
     if ( outVmap )
     {
-        map_.src2tgtVertHashMap = &src2tgtVerts_;
+        map_.src2tgtVerts = &src2tgtVerts_;
         outVmap->clear();
         outVmap->resize( (int)srcTopology.lastValidVert() + 1 );
     }
     if ( outEmap )
     {
-        map_.src2tgtWholeEdgeHashMap = &src2tgtEdges_;
+        map_.src2tgtEdges = &src2tgtEdges_;
         outEmap->clear();
         outEmap->resize( srcTopology.undirectedEdgeSize() );
     }

--- a/source/MRMesh/MRPartMapping.cpp
+++ b/source/MRMesh/MRPartMapping.cpp
@@ -31,7 +31,7 @@ HashToVectorMappingConverter::~HashToVectorMappingConverter()
 {
     if ( outFmap_ )
     {
-        for ( const auto & [ fromFace, thisFace ] : src2tgtFaces_ )
+        for ( const auto & [ fromFace, thisFace ] : *src2tgtFaces_.getHashMap() )
             (*outFmap_)[fromFace] = thisFace;
     }
     if ( outVmap_ )

--- a/source/MRMesh/MRPartMapping.cpp
+++ b/source/MRMesh/MRPartMapping.cpp
@@ -9,21 +9,18 @@ HashToVectorMappingConverter::HashToVectorMappingConverter( const MeshTopology &
 {
     if ( outFmap )
     {
-        src2tgtFaces_ = FaceMapOrHashMap::createHashMap();
         map_.src2tgtFaces = &src2tgtFaces_;
         outFmap->clear();
         outFmap->resize( (int)srcTopology.lastValidFace() + 1 );
     }
     if ( outVmap )
     {
-        src2tgtVerts_ = VertMapOrHashMap::createHashMap();
         map_.src2tgtVerts = &src2tgtVerts_;
         outVmap->clear();
         outVmap->resize( (int)srcTopology.lastValidVert() + 1 );
     }
     if ( outEmap )
     {
-        src2tgtEdges_ = WholeEdgeMapOrHashMap::createHashMap();
         map_.src2tgtEdges = &src2tgtEdges_;
         outEmap->clear();
         outEmap->resize( srcTopology.undirectedEdgeSize() );
@@ -33,20 +30,11 @@ HashToVectorMappingConverter::HashToVectorMappingConverter( const MeshTopology &
 HashToVectorMappingConverter::~HashToVectorMappingConverter()
 {
     if ( outFmap_ )
-    {
-        for ( const auto & [ fromFace, thisFace ] : *src2tgtFaces_.getHashMap() )
-            (*outFmap_)[fromFace] = thisFace;
-    }
+        *outFmap_ = std::move( *src2tgtFaces_.getMap() );
     if ( outVmap_ )
-    {
-        for ( const auto & [ fromVert, thisVert ] : *src2tgtVerts_.getHashMap() )
-            (*outVmap_)[fromVert] = thisVert;
-    }
+        *outVmap_ = std::move( *src2tgtVerts_.getMap() );
     if ( outEmap_ )
-    {
-        for ( const auto & [ fromEdge, thisEdge ] : *src2tgtEdges_.getHashMap() )
-            (*outEmap_)[fromEdge] = thisEdge;
-    }
+        *outEmap_ = std::move( *src2tgtEdges_.getMap() );
 }
 
 } //namespace MR

--- a/source/MRMesh/MRPartMapping.h
+++ b/source/MRMesh/MRPartMapping.h
@@ -11,7 +11,7 @@ struct PartMapping
     // source.id -> target.id
     // hash maps minimize memory consumption when only a small portion of source mesh is copied
     FaceMapOrHashMap * src2tgtFaces = nullptr;
-    VertHashMap * src2tgtVerts = nullptr;
+    VertMapOrHashMap * src2tgtVerts = nullptr;
     WholeEdgeHashMap * src2tgtEdges = nullptr;
 
     // target.id -> source.id
@@ -35,7 +35,7 @@ private:
     WholeEdgeMap * outEmap_ = nullptr;
     PartMapping map_;
     FaceMapOrHashMap src2tgtFaces_;
-    VertHashMap src2tgtVerts_;
+    VertMapOrHashMap src2tgtVerts_;
     WholeEdgeHashMap src2tgtEdges_;
 };
 

--- a/source/MRMesh/MRPartMapping.h
+++ b/source/MRMesh/MRPartMapping.h
@@ -5,26 +5,21 @@
 namespace MR
 {
 
-/// mapping among elements of source mesh, from which a part is taken, and target mesh
+// mapping among elements of source mesh, from which a part is taken, and target (this) mesh
 struct PartMapping
 {
-    // source.id -> target.id
-    // hash maps minimize memory consumption when only a small portion of source mesh is copied
-    FaceHashMap * src2tgtFaceHashMap = nullptr;
-    VertHashMap * src2tgtVertHashMap = nullptr;
-    WholeEdgeHashMap * src2tgtWholeEdgeHashMap = nullptr;
-
-    // target.id -> source.id
-    // dense vectors are better by speed and memory when target mesh was empty before copying
-    FaceMap * tgt2srcFaceMap = nullptr;
-    VertMap * tgt2srcVertMap = nullptr;
-    WholeEdgeMap * tgt2srcWholeEdgeMap = nullptr;
-
-    /// clears all memeber maps
-    MRMESH_API void clear();
+    // from.id -> this.id
+    // hash maps are used to minimize memory consumption when only a small portion of source mesh is copied
+    FaceHashMap * src2tgtFaces = nullptr;
+    VertHashMap * src2tgtVerts = nullptr;
+    WholeEdgeHashMap * src2tgtEdges = nullptr;
+    // this.id -> from.id
+    FaceMap * tgt2srcFaces = nullptr;
+    VertMap * tgt2srcVerts = nullptr;
+    WholeEdgeMap * tgt2srcEdges = nullptr;
 };
 
-/// the class to convert mappings from new HashMap format to old Vector format
+// the class to convert mappings from new HashMap format to old Vector format
 class HashToVectorMappingConverter
 {
 public:

--- a/source/MRMesh/MRPartMapping.h
+++ b/source/MRMesh/MRPartMapping.h
@@ -30,7 +30,10 @@ struct PartMapping
 class HashToVectorMappingConverter
 {
 public:
-    MRMESH_API HashToVectorMappingConverter( const MeshTopology & srcTopology, FaceMap * outFmap, VertMap * outVmap, WholeEdgeMap * outEmap );
+    MRMESH_API HashToVectorMappingConverter( FaceMap * outFmap, VertMap * outVmap, WholeEdgeMap * outEmap );
+    [[deprecated]] HashToVectorMappingConverter( const MeshTopology &, FaceMap * outFmap, VertMap * outVmap, WholeEdgeMap * outEmap )
+        : HashToVectorMappingConverter( outFmap, outVmap, outEmap ) {}
+
     const PartMapping & getPartMapping() const { return map_; }
     MRMESH_API ~HashToVectorMappingConverter(); //conversion takes place here
 

--- a/source/MRMesh/MRPartMapping.h
+++ b/source/MRMesh/MRPartMapping.h
@@ -10,7 +10,7 @@ struct PartMapping
 {
     // source.id -> target.id
     // hash maps minimize memory consumption when only a small portion of source mesh is copied
-    MapOrHashMap<FaceId, FaceId> * src2tgtFaces = nullptr;
+    FaceMapOrHashMap * src2tgtFaces = nullptr;
     VertHashMap * src2tgtVerts = nullptr;
     WholeEdgeHashMap * src2tgtEdges = nullptr;
 
@@ -34,7 +34,7 @@ private:
     VertMap * outVmap_ = nullptr;
     WholeEdgeMap * outEmap_ = nullptr;
     PartMapping map_;
-    MapOrHashMap<FaceId, FaceId> src2tgtFaces_;
+    FaceMapOrHashMap src2tgtFaces_;
     VertHashMap src2tgtVerts_;
     WholeEdgeHashMap src2tgtEdges_;
 };

--- a/source/MRMesh/MRPartMapping.h
+++ b/source/MRMesh/MRPartMapping.h
@@ -10,7 +10,7 @@ struct PartMapping
 {
     // source.id -> target.id
     // hash maps minimize memory consumption when only a small portion of source mesh is copied
-    FaceHashMap * src2tgtFaces = nullptr;
+    MapOrHashMap<FaceId, FaceId> * src2tgtFaces = nullptr;
     VertHashMap * src2tgtVerts = nullptr;
     WholeEdgeHashMap * src2tgtEdges = nullptr;
 
@@ -34,7 +34,7 @@ private:
     VertMap * outVmap_ = nullptr;
     WholeEdgeMap * outEmap_ = nullptr;
     PartMapping map_;
-    FaceHashMap src2tgtFaces_;
+    MapOrHashMap<FaceId, FaceId> src2tgtFaces_;
     VertHashMap src2tgtVerts_;
     WholeEdgeHashMap src2tgtEdges_;
 };

--- a/source/MRMesh/MRPartMapping.h
+++ b/source/MRMesh/MRPartMapping.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MRphmap.h"
+#include "MRMapOrHashMap.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRPartMapping.h
+++ b/source/MRMesh/MRPartMapping.h
@@ -12,7 +12,7 @@ struct PartMapping
     // hash maps minimize memory consumption when only a small portion of source mesh is copied
     FaceMapOrHashMap * src2tgtFaces = nullptr;
     VertMapOrHashMap * src2tgtVerts = nullptr;
-    WholeEdgeHashMap * src2tgtEdges = nullptr;
+    WholeEdgeMapOrHashMap * src2tgtEdges = nullptr;
 
     // target.id -> source.id
     // dense vectors are better by speed and memory when target mesh was empty before copying
@@ -36,7 +36,7 @@ private:
     PartMapping map_;
     FaceMapOrHashMap src2tgtFaces_;
     VertMapOrHashMap src2tgtVerts_;
-    WholeEdgeHashMap src2tgtEdges_;
+    WholeEdgeMapOrHashMap src2tgtEdges_;
 };
 
 }

--- a/source/MRMesh/MRPartMapping.h
+++ b/source/MRMesh/MRPartMapping.h
@@ -5,21 +5,23 @@
 namespace MR
 {
 
-// mapping among elements of source mesh, from which a part is taken, and target (this) mesh
+/// mapping among elements of source mesh, from which a part is taken, and target mesh
 struct PartMapping
 {
-    // from.id -> this.id
-    // hash maps are used to minimize memory consumption when only a small portion of source mesh is copied
+    // source.id -> target.id
+    // hash maps minimize memory consumption when only a small portion of source mesh is copied
     FaceHashMap * src2tgtFaces = nullptr;
     VertHashMap * src2tgtVerts = nullptr;
     WholeEdgeHashMap * src2tgtEdges = nullptr;
-    // this.id -> from.id
+
+    // target.id -> source.id
+    // dense vectors are better by speed and memory when target mesh was empty before copying
     FaceMap * tgt2srcFaces = nullptr;
     VertMap * tgt2srcVerts = nullptr;
     WholeEdgeMap * tgt2srcEdges = nullptr;
 };
 
-// the class to convert mappings from new HashMap format to old Vector format
+/// the class to convert mappings from new HashMap format to old Vector format
 class HashToVectorMappingConverter
 {
 public:

--- a/source/MRMesh/MRPartMapping.h
+++ b/source/MRMesh/MRPartMapping.h
@@ -9,6 +9,8 @@ namespace MR
 struct PartMapping
 {
     // source.id -> target.id
+    // each map here can be either dense vector or hash map, the type is set by the user and preserved by mesh copying functions;
+    // dense maps are better by speed and memory when source mesh is packed and must be copied entirely;
     // hash maps minimize memory consumption when only a small portion of source mesh is copied
     FaceMapOrHashMap * src2tgtFaces = nullptr;
     VertMapOrHashMap * src2tgtVerts = nullptr;
@@ -19,9 +21,12 @@ struct PartMapping
     FaceMap * tgt2srcFaces = nullptr;
     VertMap * tgt2srcVerts = nullptr;
     WholeEdgeMap * tgt2srcEdges = nullptr;
+
+    /// clears all member maps
+    MRMESH_API void clear();
 };
 
-/// the class to convert mappings from new HashMap format to old Vector format
+/// adapter for old code expecting source to target mapping in vector format
 class HashToVectorMappingConverter
 {
 public:

--- a/source/MRTest/MRMeshTests.cpp
+++ b/source/MRTest/MRMeshTests.cpp
@@ -91,8 +91,8 @@ TEST(MRMesh, AddPartByMask)
     FaceHashMap meshIntoMesh2;
     FaceMap mesh2IntoMesh;
     PartMapping mapping;
-    mapping.src2tgtFaceHashMap = &meshIntoMesh2;
-    mapping.tgt2srcFaceMap = &mesh2IntoMesh;
+    mapping.src2tgtFaces = &meshIntoMesh2;
+    mapping.tgt2srcFaces = &mesh2IntoMesh;
 
     mesh.addMeshPart( { mesh2, &faces }, mapping );
     for ( auto [f, f2] : meshIntoMesh2 )

--- a/source/MRTest/MRMeshTests.cpp
+++ b/source/MRTest/MRMeshTests.cpp
@@ -88,7 +88,7 @@ TEST(MRMesh, AddPartByMask)
     FaceBitSet faces( 2 );
     faces.set( 1_f );
 
-    MapOrHashMap<FaceId, FaceId> meshIntoMesh2;
+    FaceMapOrHashMap meshIntoMesh2;
     FaceMap mesh2IntoMesh;
     PartMapping mapping;
     mapping.src2tgtFaces = &meshIntoMesh2;

--- a/source/MRTest/MRMeshTests.cpp
+++ b/source/MRTest/MRMeshTests.cpp
@@ -88,18 +88,19 @@ TEST(MRMesh, AddPartByMask)
     FaceBitSet faces( 2 );
     faces.set( 1_f );
 
-    FaceHashMap meshIntoMesh2;
+    MapOrHashMap<FaceId, FaceId> meshIntoMesh2;
     FaceMap mesh2IntoMesh;
     PartMapping mapping;
     mapping.src2tgtFaces = &meshIntoMesh2;
     mapping.tgt2srcFaces = &mesh2IntoMesh;
 
     mesh.addMeshPart( { mesh2, &faces }, mapping );
-    for ( auto [f, f2] : meshIntoMesh2 )
+    EXPECT_TRUE( meshIntoMesh2.getHashMap() != nullptr );
+    for ( auto [f, f2] : *meshIntoMesh2.getHashMap() )
         EXPECT_EQ( mesh2IntoMesh[f2], f );
 
     faces.set( 0_f ); // set an id without mapping
-    auto added = faces.getMapping( meshIntoMesh2 );
+    auto added = faces.getMapping( *meshIntoMesh2.getHashMap() );
 
     EXPECT_EQ( mesh.points.size(), 7 );
     EXPECT_EQ( mesh.topology.edgePerVertex().size(), 7 );

--- a/source/MRTest/MRMeshTests.cpp
+++ b/source/MRTest/MRMeshTests.cpp
@@ -88,7 +88,7 @@ TEST(MRMesh, AddPartByMask)
     FaceBitSet faces( 2 );
     faces.set( 1_f );
 
-    FaceMapOrHashMap meshIntoMesh2;
+    auto meshIntoMesh2 = FaceMapOrHashMap::createHashMap();
     FaceMap mesh2IntoMesh;
     PartMapping mapping;
     mapping.src2tgtFaces = &meshIntoMesh2;

--- a/source/MRVoxels/MRVoxelsConversionsByParts.cpp
+++ b/source/MRVoxels/MRVoxelsConversionsByParts.cpp
@@ -21,6 +21,22 @@ namespace
 
 using namespace MR;
 
+void clearPartMapping( PartMapping& mapping )
+{
+    if ( mapping.src2tgtFaces )
+        mapping.src2tgtFaces->clear();
+    if ( mapping.src2tgtVerts )
+        mapping.src2tgtVerts->clear();
+    if ( mapping.src2tgtEdges )
+        mapping.src2tgtEdges->clear();
+    if ( mapping.tgt2srcFaces )
+        mapping.tgt2srcFaces->clear();
+    if ( mapping.tgt2srcVerts )
+        mapping.tgt2srcVerts->clear();
+    if ( mapping.tgt2srcEdges )
+        mapping.tgt2srcEdges->clear();
+}
+
 void sortEdgePaths( const Mesh& mesh, std::vector<EdgePath>& paths )
 {
     std::sort( paths.begin(), paths.end(), [&] ( const EdgePath& ep1, const EdgePath& ep2 )
@@ -108,13 +124,13 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
         settings.postCut( part );
 
     auto mapping = settings.mapping;
-    mapping.clear();
+    clearPartMapping( mapping );
 
     if ( leftCutContours.empty() && cutContours.empty() )
     {
-        WholeEdgeHashMap src2tgtWholeEdgeHashMap;
-        if ( !mapping.src2tgtWholeEdgeHashMap )
-            mapping.src2tgtWholeEdgeHashMap = &src2tgtWholeEdgeHashMap;
+        WholeEdgeHashMap src2tgtEdges;
+        if ( !mapping.src2tgtEdges )
+            mapping.src2tgtEdges = &src2tgtEdges;
 
         mesh.addMeshPart( part, mapping );
 
@@ -125,7 +141,7 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
         {
             for ( auto& e : contour )
             {
-                const auto ue = ( *mapping.src2tgtWholeEdgeHashMap )[e];
+                const auto ue = ( *mapping.src2tgtEdges )[e];
                 e = e.even() ? ue : ue.sym();
             }
         }
@@ -140,9 +156,9 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
         if ( cutContours[i].size() != leftCutContours[i].size() )
             return unexpected( "Mesh cut contours mismatch" );
 
-    WholeEdgeHashMap src2tgtWholeEdgeHashMap;
-    if ( !mapping.src2tgtWholeEdgeHashMap )
-        mapping.src2tgtWholeEdgeHashMap = &src2tgtWholeEdgeHashMap;
+    WholeEdgeHashMap src2tgtEdges;
+    if ( !mapping.src2tgtEdges )
+        mapping.src2tgtEdges = &src2tgtEdges;
 
     mesh.addMeshPart( part, false, cutContours, leftCutContours, mapping );
 
@@ -153,7 +169,7 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
     {
         for ( auto& e : contour )
         {
-            const auto ue = ( *mapping.src2tgtWholeEdgeHashMap )[e];
+            const auto ue = ( *mapping.src2tgtEdges )[e];
             e = e.even() ? ue : ue.sym();
         }
     }

--- a/source/MRVoxels/MRVoxelsConversionsByParts.cpp
+++ b/source/MRVoxels/MRVoxelsConversionsByParts.cpp
@@ -13,6 +13,7 @@
 #include "MRMesh/MRTimer.h"
 #include "MRMesh/MRVolumeIndexer.h"
 #include "MRMesh/MRParallelFor.h"
+#include "MRMesh/MRMapEdge.h"
 
 #include "MRPch/MRFmt.h"
 
@@ -128,7 +129,7 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
 
     if ( leftCutContours.empty() && cutContours.empty() )
     {
-        WholeEdgeHashMap src2tgtEdges;
+        WholeEdgeMapOrHashMap src2tgtEdges;
         if ( !mapping.src2tgtEdges )
             mapping.src2tgtEdges = &src2tgtEdges;
 
@@ -140,10 +141,7 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
         for ( auto& contour : rightCutContours )
         {
             for ( auto& e : contour )
-            {
-                const auto ue = ( *mapping.src2tgtEdges )[e];
-                e = e.even() ? ue : ue.sym();
-            }
+                e = mapEdge( src2tgtEdges, e );
         }
         cutContours = std::move( rightCutContours );
 
@@ -156,7 +154,7 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
         if ( cutContours[i].size() != leftCutContours[i].size() )
             return unexpected( "Mesh cut contours mismatch" );
 
-    WholeEdgeHashMap src2tgtEdges;
+    WholeEdgeMapOrHashMap src2tgtEdges;
     if ( !mapping.src2tgtEdges )
         mapping.src2tgtEdges = &src2tgtEdges;
 
@@ -168,10 +166,7 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
     for ( auto& contour : rightCutContours )
     {
         for ( auto& e : contour )
-        {
-            const auto ue = ( *mapping.src2tgtEdges )[e];
-            e = e.even() ? ue : ue.sym();
-        }
+            e = mapEdge( src2tgtEdges, e );
     }
     cutContours = std::move( rightCutContours );
 

--- a/source/MRVoxels/MRVoxelsConversionsByParts.cpp
+++ b/source/MRVoxels/MRVoxelsConversionsByParts.cpp
@@ -22,22 +22,6 @@ namespace
 
 using namespace MR;
 
-void clearPartMapping( PartMapping& mapping )
-{
-    if ( mapping.src2tgtFaces )
-        mapping.src2tgtFaces->clear();
-    if ( mapping.src2tgtVerts )
-        mapping.src2tgtVerts->clear();
-    if ( mapping.src2tgtEdges )
-        mapping.src2tgtEdges->clear();
-    if ( mapping.tgt2srcFaces )
-        mapping.tgt2srcFaces->clear();
-    if ( mapping.tgt2srcVerts )
-        mapping.tgt2srcVerts->clear();
-    if ( mapping.tgt2srcEdges )
-        mapping.tgt2srcEdges->clear();
-}
-
 void sortEdgePaths( const Mesh& mesh, std::vector<EdgePath>& paths )
 {
     std::sort( paths.begin(), paths.end(), [&] ( const EdgePath& ep1, const EdgePath& ep2 )
@@ -125,7 +109,7 @@ mergeVolumePart( Mesh &mesh, std::vector<EdgePath> &cutContours, Volume &&volume
         settings.postCut( part );
 
     auto mapping = settings.mapping;
-    clearPartMapping( mapping );
+    mapping.clear();
 
     if ( leftCutContours.empty() && cutContours.empty() )
     {

--- a/source/MRVoxels/MRVoxelsConversionsByParts.h
+++ b/source/MRVoxels/MRVoxelsConversionsByParts.h
@@ -24,7 +24,7 @@ struct MergeVolumePartSettings
     PostCutCallback postCut = nullptr;
     /// callback to process the destination mesh after merging, usually to map the generated mesh's faces/edges/vertices
     /// the second parameter is identical to the `mapping` field, except for one case:
-    /// if the mapping is not initialized, only `src2tgtWholeEdgeHashMap` map will be provided (since it's used during processing)
+    /// if the mapping is not initialized, only `src2tgtEdges` map will be provided (since it's used during processing)
     using PostMergeCallback = std::function<void( Mesh&, const PartMapping& )>;
     PostMergeCallback postMerge = nullptr;
     /// mapping with initialized maps required for the `postMerge` callback


### PR DESCRIPTION
* Mostly revert #4560 
* Introduce new type `MapOrHashMap` that can act as `Vector` or as `HashMap`
* Use new type for source->target maps in `PartMapping`
* `MeshTopology::addPart` respects user selected mapping format
* The implementation of `HashToVectorMappingConverter` is trivial now.