### PR TITLE
Make the `MeshViewer` app a bundle on MacOS and adjust the paths acco…

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Run Start-and-Exit Tests
         timeout-minutes: 3
-        run: MR_LOCAL_RESOURCES=1 ./build/${{ matrix.config }}/bin/MeshViewer -tryHidden -noEventLoop -unloadPluginsAtEnd
+        run: MR_LOCAL_RESOURCES=1 ./build/${{ matrix.config }}/bin/MeshViewer.app/Contents/MacOS/MeshViewer -tryHidden -noEventLoop -unloadPluginsAtEnd
 
       - name: Unit Tests
         run: ./build/${{ matrix.config }}/bin/MRTest

--- a/source/MRMesh/MRSystemPath.cpp
+++ b/source/MRMesh/MRSystemPath.cpp
@@ -42,7 +42,11 @@ std::filesystem::path defaultDirectory( SystemPath::Directory dir )
 #elif defined( __APPLE__ )
     // TODO: use getLibraryDirectory()
     if ( resourcesAreNearExe() )
-        return SystemPath::getExecutableDirectory().value_or( "/" );
+    {
+        // Back out from `<AppName>.app/Contents/MacOS`. This is only needed for apps that are MacOS bundles, but we do it unconditionally for simplicity.
+        // It's easier to require all apps to be bundles (which is needed to package them anyway) than to make this conditional.
+        return SystemPath::getExecutableDirectory().value_or( "/" ) / "../../..";
+    }
 
     const auto libDir = SystemPath::getLibraryDirectory().value_or( "/" );
     using Directory = SystemPath::Directory;

--- a/source/MRViewerApp/CMakeLists.txt
+++ b/source/MRViewerApp/CMakeLists.txt
@@ -4,7 +4,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(MeshViewer CXX)
 
-add_executable(${PROJECT_NAME} WIN32 MRViewerApp.cpp)
+# We make this a `MACOSX_BUNDLE` even though we don't package it, solely to unify
+#   the `MR_LOCAL_RESOURCES=1` search path between this and our other apps that actually need to be bundles.
+add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE MRViewerApp.cpp)
 
 file(GLOB PNGS "*.png")
 file(COPY ${PNGS} DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})


### PR DESCRIPTION
…rdingly, for consistency with our other consumers that must use bundles.