### PR TITLE
Fix regions interpolation.

### DIFF
--- a/source/MRVoxels/MRWeightedPointsShell.cpp
+++ b/source/MRVoxels/MRWeightedPointsShell.cpp
@@ -196,7 +196,9 @@ VertScalars calculateShellWeightsFromRegions(
 
     // precalculate the weights
     VertScalars weights( mesh.topology.getValidVerts().find_last() + 1, 0 );
-    BitSetParallelFor( allVerts, [&weights, &pointWeight] ( VertId v )
+    VertBitSet allVertsExtended = allVerts;
+    dilateRegion( mesh, allVertsExtended, interpolationDist );
+    BitSetParallelFor( allVertsExtended, [&weights, &pointWeight] ( VertId v )
     {
         weights[v] = pointWeight( v );
     } );

--- a/source/MRVoxels/MRWeightedPointsShell.cpp
+++ b/source/MRVoxels/MRWeightedPointsShell.cpp
@@ -12,6 +12,7 @@
 
 #include "MRPch/MRSpdlog.h"
 #include "MRMesh/MRParallelFor.h"
+#include "MRMesh/MREdgePaths.h"
 
 namespace MR
 {


### PR DESCRIPTION
The approach used requires to extend region by the radius of the interpolation in order to produce smooth transition.