### PR TITLE
ScopeHistory provides CombinedHistoryAction being populated

### DIFF
--- a/source/MRMesh/MRCombinedHistoryAction.h
+++ b/source/MRMesh/MRCombinedHistoryAction.h
@@ -21,6 +21,7 @@ public:
 
     MRMESH_API virtual void action( HistoryAction::Type type ) override;
 
+          HistoryActionsVector& getStack()       { return actions_; }
     const HistoryActionsVector& getStack() const { return actions_; }
 
     /// Remove some actions according to condition inside combined actions.

--- a/source/MRViewer/MRAppendHistory.cpp
+++ b/source/MRViewer/MRAppendHistory.cpp
@@ -16,8 +16,7 @@ void FilterHistoryByCondition( HistoryStackFilter condition, bool deepFiltering 
     store->filterStack( condition, deepFiltering );
 }
 
-ScopeHistory::ScopeHistory( const std::string& name ) :
-    name_{ name }
+ScopeHistory::ScopeHistory( const std::string& name )
 {
     auto viewer = Viewer::instance();
     if ( !viewer )
@@ -26,7 +25,8 @@ ScopeHistory::ScopeHistory( const std::string& name ) :
     if ( !store_ )
         return;
     parentScopePtr_ = store_->getScopeBlockPtr();
-    store_->setScopeBlockPtr( &scope_ );
+    combinedAction_ = std::make_shared<CombinedHistoryAction>( name, HistoryActionsVector{} );
+    store_->setScopeBlockPtr( &combinedAction_->getStack() );
 }
 
 ScopeHistory::~ScopeHistory()
@@ -35,8 +35,8 @@ ScopeHistory::~ScopeHistory()
         return;
     store_->setScopeBlockPtr( parentScopePtr_ );
     parentScopePtr_ = nullptr;
-    if ( !scope_.empty() )
-        AppendHistory<CombinedHistoryAction>( name_, std::move( scope_ ) );
+    if ( combinedAction_ && !combinedAction_->getStack().empty() )
+        store_->appendAction( std::move( combinedAction_ ) );
 }
 
-}
+} //namespace MR

--- a/source/MRViewer/MRAppendHistory.h
+++ b/source/MRViewer/MRAppendHistory.h
@@ -68,17 +68,22 @@ private:
 /// @param deepFiltering - filter actions into combined actions
 MRVIEWER_API void FilterHistoryByCondition( HistoryStackFilter filteringCondition, bool deepFiltering = true );
 
-// This class store history actions that are appended to global history stack all together as CombinedHistoryAction in destructor (if scoped stack is not empty)
+/// The purpose of this class is to combine all actions appended to global history store in one big action to undo/redo them all at once.
 class ScopeHistory
 {
 public:
+    /// creates new CombinedHistoryAction, and setups global history store to append all new actions there during this object lifetime
     MRVIEWER_API ScopeHistory( const std::string& name );
+
+    /// created before CombinedHistoryAction if not empty is appended (with all sub-actions) in the global history store
     MRVIEWER_API ~ScopeHistory();
 
+    /// returns the action being populated
+    const std::shared_ptr<CombinedHistoryAction>& combinedAction() const { return combinedAction_; }
+
 private:
-    std::string name_;
     std::shared_ptr<HistoryStore> store_;
-    HistoryActionsVector scope_;
+    std::shared_ptr<CombinedHistoryAction> combinedAction_;
     HistoryActionsVector* parentScopePtr_{ nullptr };
 };
 


### PR DESCRIPTION
`ScopedHisotry`:
* in the constructor, immediately creates new `CombinedHistoryAction`, and setups global history store to use its stack;
* during lifetime, provides access to created `CombinedHistoryAction`;
* the destructor just pushes already created `CombinedHistoryAction` in global history store.

`CombinedHistoryAction` now can give write access to its stack.

All above is necessary to remember the action created by particular `ScopedHisotry`.