### PR TITLE
Move Object better history support

### DIFF
--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -114,7 +114,8 @@ private:
     std::vector<AffineXf3f> initialXfs_;
 
     TransformMode transformMode_ = TransformMode::None;
-    Vector2i screenStartPoint_; // cNoPoint when moving actually started, {} when inactive
+    Vector2i screenStartPoint_; // onMouseDown() writes here the position of mouse when mouse dragging was started
+    bool xfChanged_ = false; // it becomes true when onMouseMove changes transform of objects for the first time and optionally appends history actions
     MouseButton currentButton_ = MouseButton::NoButton;
 
     // Data used to calculate transform

--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -1,9 +1,10 @@
 #pragma once
+#include "MRViewerFwd.h"
+#include "MRMouse.h"
+#include "MRImGui.h"
 #include "MRMesh/MRPlane3.h"
 #include "MRMesh/MRAffineXf3.h"
-#include "MRViewer/MRViewerFwd.h"
-#include "MRViewer/MRMouse.h"
-#include "MRViewer/MRImGui.h"
+#include "MRMesh/MRSignal.h"
 
 namespace MR
 {

--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -42,7 +42,7 @@ public:
     /// Return false if not active, or object picked but `minDistance` has not yet reached
     MRVIEWER_API bool isMoving() const;
 
-    /// Reset transformation and stop moving the object(s). Does nothing if not moving anything
+    /// Stop moving the object(s). Does nothing if not moving anything
     /// Calling `onMouseUp` is not necessary after this
     /// Should be called when closing plugin etc.
     MRVIEWER_API void cancel();
@@ -107,7 +107,6 @@ private:
     void clear_();
 
     void applyCurrentXf_();
-    void resetXfs_();
 
     void setVisualizeVectors_( std::vector<Vector3f> worldPoints );
 

--- a/source/MRViewer/MRMoveObjectByMouseImpl.h
+++ b/source/MRViewer/MRMoveObjectByMouseImpl.h
@@ -106,7 +106,7 @@ private:
 
     void clear_();
 
-    void applyCurrentXf_( bool history );
+    void applyCurrentXf_();
     void resetXfs_();
 
     void setVisualizeVectors_( std::vector<Vector3f> worldPoints );
@@ -131,6 +131,10 @@ private:
     bool historyEnabled_{ true };
 
     std::vector<ImVec2> visualizeVectors_;
+
+    // monitors external transform change of objects during mouse moving
+    std::vector<boost::signals2::scoped_connection> connections_;
+    bool changingXfFromMouseMove_{ false }; // true only during setXf called from onMouseMove_
 };
 
 }


### PR DESCRIPTION
* History action changing objects' transformations is added on first actual change, and not at the end.
* The user is able to press Ctrl-Z during mouse movement to return to the position from which the movement started. The dragging is stopped as well.
* `cancel()` does return transformations. Please use undo for that.
* No clamping of shifts any more.