### PR TITLE
Expected<Mesh> marchingCubes( const SimpleBinaryVolume& volume )

### DIFF
--- a/source/MRMesh/MRBitSet.h
+++ b/source/MRMesh/MRBitSet.h
@@ -214,6 +214,13 @@ public:
     [[nodiscard]] IndexType endId() const { return IndexType{ size() }; }
 };
 
+
+/// returns the amount of memory given BitSet occupies on heap
+[[nodiscard]] inline size_t heapBytes( const BitSet& bs )
+{
+    return bs.heapBytes();
+}
+
 /// compare that two bit sets have the same set bits (they can be equal even if sizes are distinct but last bits are off)
 [[nodiscard]] MRMESH_API bool operator == ( const BitSet & a, const BitSet & b );
 template <typename T>

--- a/source/MRMesh/MRBitSet.h
+++ b/source/MRMesh/MRBitSet.h
@@ -102,6 +102,7 @@ public:
 
     /// returns the amount of memory this object occupies on heap
     [[nodiscard]] size_t heapBytes() const { return capacity() / 8; }
+    [[nodiscard]] friend size_t heapBytes( const BitSet & bs ) { return bs.capacity() / 8; }
 
     /// returns the identifier of the back() element
     [[nodiscard]] IndexType backId() const { assert( !empty() ); return IndexType{ size() - 1 }; }
@@ -213,13 +214,6 @@ public:
     [[nodiscard]] static IndexType beginId() { return IndexType{ size_t( 0 ) }; }
     [[nodiscard]] IndexType endId() const { return IndexType{ size() }; }
 };
-
-
-/// returns the amount of memory given BitSet occupies on heap
-[[nodiscard]] inline size_t heapBytes( const BitSet& bs )
-{
-    return bs.heapBytes();
-}
 
 /// compare that two bit sets have the same set bits (they can be equal even if sizes are distinct but last bits are off)
 [[nodiscard]] MRMESH_API bool operator == ( const BitSet & a, const BitSet & b );

--- a/source/MRMesh/MRBitSet.h
+++ b/source/MRMesh/MRBitSet.h
@@ -102,7 +102,6 @@ public:
 
     /// returns the amount of memory this object occupies on heap
     [[nodiscard]] size_t heapBytes() const { return capacity() / 8; }
-    [[nodiscard]] friend size_t heapBytes( const BitSet & bs ) { return bs.capacity() / 8; }
 
     /// returns the identifier of the back() element
     [[nodiscard]] IndexType backId() const { assert( !empty() ); return IndexType{ size() - 1 }; }
@@ -214,6 +213,13 @@ public:
     [[nodiscard]] static IndexType beginId() { return IndexType{ size_t( 0 ) }; }
     [[nodiscard]] IndexType endId() const { return IndexType{ size() }; }
 };
+
+
+/// returns the amount of memory given BitSet occupies on heap
+[[nodiscard]] inline size_t heapBytes( const BitSet& bs )
+{
+    return bs.heapBytes();
+}
 
 /// compare that two bit sets have the same set bits (they can be equal even if sizes are distinct but last bits are off)
 [[nodiscard]] MRMESH_API bool operator == ( const BitSet & a, const BitSet & b );

--- a/source/MRMesh/MRHeapBytes.h
+++ b/source/MRMesh/MRHeapBytes.h
@@ -84,13 +84,6 @@ template<typename ...Ts>
     return cap + kWidth + cap * sizeof( typename phmap::flat_hash_map<Ts...>::slot_type );
 }
 
-/// returns the amount of memory given object occupies on heap
-template<typename T>
-[[nodiscard]] inline size_t heapBytes( const T& obj ) MR_REQUIRES_IF_SUPPORTED( requires{ obj.heapBytes(); } )
-{
-    return obj.heapBytes();
-}
-
 /// \}
 
 } // namespace MR

--- a/source/MRMesh/MRHeapBytes.h
+++ b/source/MRMesh/MRHeapBytes.h
@@ -84,6 +84,13 @@ template<typename ...Ts>
     return cap + kWidth + cap * sizeof( typename phmap::flat_hash_map<Ts...>::slot_type );
 }
 
+/// returns the amount of memory given object occupies on heap
+template<typename T>
+[[nodiscard]] inline size_t heapBytes( const T& obj ) MR_REQUIRES_IF_SUPPORTED( requires{ obj.heapBytes(); } )
+{
+    return obj.heapBytes();
+}
+
 /// \}
 
 } // namespace MR

--- a/source/MRVoxels/MRMarchingCubes.cpp
+++ b/source/MRVoxels/MRMarchingCubes.cpp
@@ -1059,6 +1059,8 @@ Expected<Mesh> marchingCubes( const FunctionVolume& volume, const MarchingCubesP
 
 Expected<TriMesh> marchingCubesAsTriMesh( const SimpleBinaryVolume& volume, const MarchingCubesParams& params /*= {} */ )
 {
+    if ( params.iso <= 0 || params.iso >= 1 )
+        return TriMesh{};
     return VolumeMesher::run( volume, params );
 }
 

--- a/source/MRVoxels/MRMarchingCubes.cpp
+++ b/source/MRVoxels/MRMarchingCubes.cpp
@@ -366,8 +366,8 @@ private:
 
     template<typename V, typename Positioner>
     void addPartBlock_( const V& volume, Positioner&& positioner, const BlockInfo& blockInfo );
-    template<typename V, typename Positioner>
-    void addBinaryPartBlock_( const V& volume, Positioner&& positioner, const BlockInfo& blockInfo );
+    template<typename Positioner>
+    void addBinaryPartBlock_( const SimpleBinaryVolume& volume, Positioner&& positioner, const BlockInfo& blockInfo );
 
 private:
     VolumeIndexer indexer_;
@@ -538,7 +538,7 @@ Expected<void> VolumeMesher::addPart_( const V& part, Positioner&& positioner )
                 blockInfo.myProgress = [&]( float ) { return keepGoing.load( std::memory_order_relaxed ); };
         }
 
-        if ( binary )
+        if constexpr ( binary )
             addBinaryPartBlock_( part, std::forward<Positioner>( positioner ), blockInfo );
         else
             addPartBlock_( part, std::forward<Positioner>( positioner ), blockInfo );
@@ -656,8 +656,8 @@ void VolumeMesher::addPartBlock_( const V& part, Positioner&& positioner, const 
     }
 }
 
-template<typename V, typename Positioner>
-void VolumeMesher::addBinaryPartBlock_( const V& part, Positioner&& positioner, const BlockInfo& blockInfo )
+template<typename Positioner>
+void VolumeMesher::addBinaryPartBlock_( const SimpleBinaryVolume& part, Positioner&& positioner, const BlockInfo& blockInfo )
 {
     MR_TIMER;
 
@@ -665,7 +665,7 @@ void VolumeMesher::addBinaryPartBlock_( const V& part, Positioner&& positioner, 
     const auto layerSize = indexer_.sizeXY();
     const auto partFirstId = layerSize * blockInfo.partFirstZ;
     const VolumeIndexer partIndexer( part.dims );
-    const VoxelsVolumeAccessor<V> acc( part );
+    const VoxelsVolumeAccessor<SimpleBinaryVolume> acc( part );
     /// grid point of this part with integer coordinates (0,0,0) will be shifted to this position in 3D space
     const Vector3f zeroPoint = params_.origin + mult( acc.shift() + Vector3f( 0, 0, (float)blockInfo.partFirstZ ), part.voxelSize );
 

--- a/source/MRVoxels/MRMarchingCubes.cpp
+++ b/source/MRVoxels/MRMarchingCubes.cpp
@@ -697,9 +697,8 @@ void VolumeMesher::addBinaryPartBlock_( const SimpleBinaryVolume& part, Position
 
                     auto nextCoords = coords;
                     nextCoords[n] += part.voxelSize[n];
-                    const float value = lower ? 0.0f : 1.0f;
-                    const float nextValue = nextLower ? 0.0f : 1.0f;
-                    Vector3f pos = positioner( coords, nextCoords, value, nextValue, params_.iso );
+                    Vector3f pos = lower ? positioner( coords, nextCoords, 0.f, 1.f, params_.iso )
+                                         : positioner( coords, nextCoords, 1.f, 0.f, params_.iso );
                     set[n] = block.nextVid();
                     block.coords.push_back( pos );
                     atLeastOneOk = true;

--- a/source/MRVoxels/MRMarchingCubes.cpp
+++ b/source/MRVoxels/MRMarchingCubes.cpp
@@ -464,16 +464,16 @@ Expected<void> VolumeMesher::addPart_( const V& part, Positioner&& positioner )
     constexpr bool binary = std::is_same_v<V, SimpleBinaryVolume>;
     if constexpr ( binary )
     {
-        const int fillFirstZ = partFirstZ;
+        int fillFirstZ = partFirstZ;
         if ( fillFirstZ )
             ++fillFirstZ; // skip already filled layer
         ParallelFor( fillFirstZ, fillFirstZ + part.dims.z, [&]( size_t z )
         {
             const auto layerSize = indexer_.sizeXY();
             BitSet layerLowerIso( layerSize );
-            const auto firstLayerId = ( z - partFirstZ ) * layerSize;
+            const auto firstLayerId = VoxelId( ( z - partFirstZ ) * layerSize );
             for ( size_t i = 0; i < layerSize; ++i )
-                layerLowerIso.set( i, !part.test( firstLayerId + i ) );
+                layerLowerIso.set( i, !part.data.test( firstLayerId + i ) );
             if ( layerLowerIso.any() )
                 lowerIso_[z] = std::move( layerLowerIso );
         } );

--- a/source/MRVoxels/MRMarchingCubes.h
+++ b/source/MRVoxels/MRMarchingCubes.h
@@ -73,6 +73,10 @@ MRVOXELS_API Expected<TriMesh> marchingCubesAsTriMesh( const VdbVolume& volume, 
 MRVOXELS_API Expected<Mesh> marchingCubes( const FunctionVolume& volume, const MarchingCubesParams& params = {} );
 MRVOXELS_API Expected<TriMesh> marchingCubesAsTriMesh( const FunctionVolume& volume, const MarchingCubesParams& params = {} );
 
+// makes Mesh from SimpleBinaryVolume with given settings using Marching Cubes algorithm
+MRVOXELS_API Expected<Mesh> marchingCubes( const SimpleBinaryVolume& volume, const MarchingCubesParams& params = {} );
+MRVOXELS_API Expected<TriMesh> marchingCubesAsTriMesh( const SimpleBinaryVolume& volume, const MarchingCubesParams& params = {} );
+
 /// converts volume split on parts by planes z=const into mesh,
 /// last z-layer of previous part must be repeated as first z-layer of next part
 /// usage:

--- a/source/MRVoxels/MRVoxelsFwd.h
+++ b/source/MRVoxels/MRVoxelsFwd.h
@@ -40,6 +40,7 @@ MR_CANONICAL_TYPEDEFS( (template <typename T> struct), MRVOXELS_CLASS VoxelsVolu
     ( FunctionVolumeU8, VoxelsVolume<VoxelValueGetter<uint8_t>> )
     ( SimpleVolume, VoxelsVolume<std::vector<float>> )
     ( SimpleVolumeU16, VoxelsVolume<std::vector<uint16_t>> )
+    ( SimpleBinaryVolume, VoxelsVolume<VoxelBitSet> )
 )
 
 namespace VoxelsLoad

--- a/source/MRVoxels/MRVoxelsVolume.h
+++ b/source/MRVoxels/MRVoxelsVolume.h
@@ -21,6 +21,12 @@ struct VoxelTraits<std::vector<T>>
     using ValueType = T;
 };
 
+template <>
+struct VoxelTraits<VoxelBitSet>
+{
+    using ValueType = bool;
+};
+
 template <typename T>
 struct VoxelTraits<VoxelValueGetter<T>>
 {


### PR DESCRIPTION
* New type introduced: `using SimpleBinaryVolume = VoxelsVolume<VoxelBitSet>`
* `marchingCubes` function overload optimized for that type added
* `MR::heapBytes( const BitSet& )` function added for general algorithms