### PR TITLE
Fix Build.Net

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Build .NET
         if:   ${{ env.BUILD_C_SHARP == 'true' }}
-        run: msbuild -m source\MeshLibDotNet.sln -p:Configuration=${{ matrix.config }}
+        run: msbuild -m source\MeshLibDotNet.sln -p:Configuration=${{ matrix.config }} -t:restore -t:build
 
       - name: Build .NET examples
         if:   ${{ env.BUILD_C_SHARP == 'true' }}


### PR DESCRIPTION
This hopefully resolves
> error NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version 9.0.300 of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.