### PR TITLE
optimize MeshTopology::addPart function

### DIFF
--- a/source/MRTest/MRMeshTopologyTests.cpp
+++ b/source/MRTest/MRMeshTopologyTests.cpp
@@ -1,0 +1,31 @@
+#include <MRMesh/MRMeshTopology.h>
+#include <MRMesh/MRGTest.h>
+
+namespace MR
+{
+
+TEST( MRMesh, splitEdge )
+{
+    MeshTopology topology;
+    EdgeId a = topology.makeEdge();
+    EdgeId b = topology.makeEdge();
+    EdgeId c = topology.makeEdge();
+    EdgeId d = topology.makeEdge();
+    topology.splice( b, a.sym() );
+    topology.splice( c, b.sym() );
+    topology.splice( d, c.sym() );
+    topology.splice( a, d.sym() );
+    EXPECT_TRUE( topology.isLeftQuad( a ) );
+    EXPECT_TRUE( topology.isLeftQuad( a.sym() ) );
+    topology.setLeft( a, topology.addFaceId() );
+    EdgeId a0 = topology.splitEdge( a );
+    EXPECT_TRUE( topology.isLeftTri( a0 ) );
+    EXPECT_TRUE( topology.isLeftQuad( a ) );
+    EXPECT_EQ( topology.getLeftDegree( a.sym() ), 5 );
+    EdgeId a1 = topology.splitEdge( a.sym() );
+    EXPECT_TRUE( topology.isLeftTri( a1.sym() ) );
+    EXPECT_TRUE( topology.isLeftQuad( a ) );
+    EXPECT_EQ( topology.getLeftDegree( a.sym() ), 6 );
+}
+
+} //namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="MRMeshIntersectTests.cpp" />
     <ClCompile Include="MRMeshLoadSaveTest.cpp" />
     <ClCompile Include="MRMeshTests.cpp" />
+    <ClCompile Include="MRMeshTopologyTests.cpp" />
     <ClCompile Include="MRNaNTest.cpp" />
     <ClCompile Include="MRPdfTests.cpp" />
     <ClCompile Include="MRPointCloudVariadicOffsetTests.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -91,6 +91,9 @@
     <ClCompile Include="MRContoursCutTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRMeshTopologyTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />


### PR DESCRIPTION
* If `rearrangeTriangles == false`, the call is forwarded to better optimized `addPartByMask` function.
* If `rearrangeTriangles == true`, we use `tbb::parallel_sort` now for better performance.

Also the test moved into `MRTest` project.