### PR TITLE
TypedBitSet class template

### DIFF
--- a/source/MRMesh/MRBitSet.h
+++ b/source/MRMesh/MRBitSet.h
@@ -127,29 +127,29 @@ private:
 };
 
 /// container of bits representing specific indices (faces, verts or edges)
-template <typename T>
-class TaggedBitSet : public BitSet
+template <typename I>
+class TypedBitSet : public BitSet
 {
     using base = BitSet;
 public:
     using base::base;
-    using IndexType = Id<T>;
+    using IndexType = I;
 
-    /// copies all bits from another BitSet (or a descending class, e.g. TaggedBitSet<U>)
-    explicit TaggedBitSet( const BitSet & src ) : BitSet( src ) {}
+    /// copies all bits from another BitSet (or a descending class, e.g. TypedBitSet<U>)
+    explicit TypedBitSet( const BitSet & src ) : BitSet( src ) {}
 
-    /// moves all bits from another BitSet (or a descending class, e.g. TaggedBitSet<U>)
-    explicit TaggedBitSet( BitSet && src ) : BitSet( std::move( src ) ) {}
+    /// moves all bits from another BitSet (or a descending class, e.g. TypedBitSet<U>)
+    explicit TypedBitSet( BitSet && src ) : BitSet( std::move( src ) ) {}
 
-    TaggedBitSet & set( IndexType n, size_type len, bool val ) { base::set( n, len, val ); return * this; }
-    TaggedBitSet & set( IndexType n, bool val = true ) { base::set( n, val ); return * this; }
-    TaggedBitSet & set() { base::set(); return * this; }
-    TaggedBitSet & reset( IndexType n, size_type len ) { base::reset( n, len ); return * this; }
-    TaggedBitSet & reset( IndexType n ) { base::reset( n ); return * this; }
-    TaggedBitSet & reset() { base::reset(); return * this; }
-    TaggedBitSet & flip( IndexType n, size_type len ) { base::flip( n, len ); return * this; }
-    TaggedBitSet & flip( IndexType n ) { base::flip( n ); return * this; }
-    TaggedBitSet & flip() { base::flip(); return * this; }
+    TypedBitSet & set( IndexType n, size_type len, bool val ) { base::set( n, len, val ); return * this; }
+    TypedBitSet & set( IndexType n, bool val = true ) { base::set( n, val ); return * this; }
+    TypedBitSet & set() { base::set(); return * this; }
+    TypedBitSet & reset( IndexType n, size_type len ) { base::reset( n, len ); return * this; }
+    TypedBitSet & reset( IndexType n ) { base::reset( n ); return * this; }
+    TypedBitSet & reset() { base::reset(); return * this; }
+    TypedBitSet & flip( IndexType n, size_type len ) { base::flip( n, len ); return * this; }
+    TypedBitSet & flip( IndexType n ) { base::flip( n ); return * this; }
+    TypedBitSet & flip() { base::flip(); return * this; }
     [[nodiscard]] bool test( IndexType n ) const { return base::test( n ); }
     [[nodiscard]] bool test_set( IndexType n, bool val = true ) { return base::test_set( n, val ); }
 
@@ -163,27 +163,27 @@ public:
     /// returns the location of nth set bit (where the first bit corresponds to n=0) or IndexType(npos) if there are less bit set
     [[nodiscard]] IndexType nthSetBit( size_t n ) const { return IndexType( base::nthSetBit( n ) ); }
 
-    TaggedBitSet & operator &= ( const TaggedBitSet & b ) { base::operator &= ( b ); return * this; }
-    TaggedBitSet & operator |= ( const TaggedBitSet & b ) { base::operator |= ( b ); return * this; }
-    TaggedBitSet & operator ^= ( const TaggedBitSet & b ) { base::operator ^= ( b ); return * this; }
-    TaggedBitSet & operator -= ( const TaggedBitSet & b ) { base::operator -= ( b ); return * this; }
+    TypedBitSet & operator &= ( const TypedBitSet & b ) { base::operator &= ( b ); return * this; }
+    TypedBitSet & operator |= ( const TypedBitSet & b ) { base::operator |= ( b ); return * this; }
+    TypedBitSet & operator ^= ( const TypedBitSet & b ) { base::operator ^= ( b ); return * this; }
+    TypedBitSet & operator -= ( const TypedBitSet & b ) { base::operator -= ( b ); return * this; }
 
-    [[nodiscard]] friend TaggedBitSet operator & ( const TaggedBitSet & a, const TaggedBitSet & b ) { auto res{ a }; res &= b; return res; }
-    [[nodiscard]] friend TaggedBitSet operator | ( const TaggedBitSet & a, const TaggedBitSet & b ) { auto res{ a }; res |= b; return res; }
-    [[nodiscard]] friend TaggedBitSet operator ^ ( const TaggedBitSet & a, const TaggedBitSet & b ) { auto res{ a }; res ^= b; return res; }
-    [[nodiscard]] friend TaggedBitSet operator - ( const TaggedBitSet & a, const TaggedBitSet & b ) { auto res{ a }; res -= b; return res; }
+    [[nodiscard]] friend TypedBitSet operator & ( const TypedBitSet & a, const TypedBitSet & b ) { auto res{ a }; res &= b; return res; }
+    [[nodiscard]] friend TypedBitSet operator | ( const TypedBitSet & a, const TypedBitSet & b ) { auto res{ a }; res |= b; return res; }
+    [[nodiscard]] friend TypedBitSet operator ^ ( const TypedBitSet & a, const TypedBitSet & b ) { auto res{ a }; res ^= b; return res; }
+    [[nodiscard]] friend TypedBitSet operator - ( const TypedBitSet & a, const TypedBitSet & b ) { auto res{ a }; res -= b; return res; }
 
     /// subtracts b from this, considering that bits in b are shifted right on bShiftInBlocks*bits_per_block
-    TaggedBitSet & subtract( const TaggedBitSet & b, int bShiftInBlocks ) { base::subtract( b, bShiftInBlocks ); return * this; }
+    TypedBitSet & subtract( const TypedBitSet & b, int bShiftInBlocks ) { base::subtract( b, bShiftInBlocks ); return * this; }
 
     /// returns true if, for every bit that is set in this bitset, the corresponding bit in bitset a is also set. Otherwise this function returns false.
-    bool is_subset_of( const TaggedBitSet& a ) const { return base::is_subset_of( a ); }
+    bool is_subset_of( const TypedBitSet& a ) const { return base::is_subset_of( a ); }
 
     /// returns true if, for every bit that is set in this bitset, the corresponding bit in bitset a is also set and if this->count() < a.count(). Otherwise this function returns false.
-    bool is_proper_subset_of( const TaggedBitSet& a ) const { return base::is_proper_subset_of( a ); }
+    bool is_proper_subset_of( const TypedBitSet& a ) const { return base::is_proper_subset_of( a ); }
 
     /// returns true if, there is a bit which is set in this bitset, such that the corresponding bit in bitset a is also set. Otherwise this function returns false.
-    bool intersects( const TaggedBitSet & a ) const { return base::intersects( a ); }
+    bool intersects( const TypedBitSet & a ) const { return base::intersects( a ); }
 
     void autoResizeSet( IndexType pos, size_type len, bool val = true ) { base::autoResizeSet( pos, len, val ); }
     void autoResizeSet( IndexType pos, bool val = true ) { base::autoResizeSet( pos, val ); }
@@ -191,19 +191,19 @@ public:
 
     /// constructs another bit set from this where every set bit index is transformed using given map
     template <typename M>
-    [[nodiscard]] TaggedBitSet getMapping( const M & map ) const;
-    [[nodiscard]] TaggedBitSet getMapping( const Vector<IndexType, IndexType> & map ) const
+    [[nodiscard]] TypedBitSet getMapping( const M & map ) const;
+    [[nodiscard]] TypedBitSet getMapping( const Vector<IndexType, IndexType> & map ) const
         { return getMapping( [&map]( IndexType i ) { return map[i]; } ); }
-    [[nodiscard]] TaggedBitSet getMapping( const BMap<IndexType, IndexType> & map ) const
+    [[nodiscard]] TypedBitSet getMapping( const BMap<IndexType, IndexType> & map ) const
         { return getMapping( [&map]( IndexType i ) { return map.b[i]; }, map.tsize ); }
-    [[nodiscard]] TaggedBitSet getMapping( const HashMap<IndexType, IndexType> & map ) const
+    [[nodiscard]] TypedBitSet getMapping( const HashMap<IndexType, IndexType> & map ) const
         { return getMapping( [&map]( IndexType i ) { return getAt( map, i ); } ); }
     /// this is a faster version if the result size is known beforehand
     template <typename M>
-    [[nodiscard]] TaggedBitSet getMapping( const M & map, size_t resSize ) const;
-    [[nodiscard]] TaggedBitSet getMapping( const Vector<IndexType, IndexType> & map, size_t resSize ) const
+    [[nodiscard]] TypedBitSet getMapping( const M & map, size_t resSize ) const;
+    [[nodiscard]] TypedBitSet getMapping( const Vector<IndexType, IndexType> & map, size_t resSize ) const
         { return getMapping( [&map]( IndexType i ) { return map[i]; }, resSize ); }
-    [[nodiscard]] TaggedBitSet getMapping( const HashMap<IndexType, IndexType> & map, size_t resSize ) const
+    [[nodiscard]] TypedBitSet getMapping( const HashMap<IndexType, IndexType> & map, size_t resSize ) const
         { return getMapping( [&map]( IndexType i ) { return getAt( map, i ); }, resSize ); }
 
     /// returns the identifier of the back() element
@@ -223,34 +223,34 @@ public:
 
 /// compare that two bit sets have the same set bits (they can be equal even if sizes are distinct but last bits are off)
 [[nodiscard]] MRMESH_API bool operator == ( const BitSet & a, const BitSet & b );
-template <typename T>
-[[nodiscard]] inline bool operator == ( const TaggedBitSet<T> & a, const TaggedBitSet<T> & b )
+template <typename I>
+[[nodiscard]] inline bool operator == ( const TypedBitSet<I> & a, const TypedBitSet<I> & b )
     { return static_cast<const BitSet &>( a ) == static_cast<const BitSet &>( b ); }
 /// prohibit comparison of unrelated sets
 template <typename T, typename U>
-void operator == ( const TaggedBitSet<T> & a, const TaggedBitSet<U> & b ) = delete;
+void operator == ( const TypedBitSet<T> & a, const TypedBitSet<U> & b ) = delete;
 
-template <typename T>
-[[nodiscard]] inline std::function<bool( Id<T> )> makePredicate( const TaggedBitSet<T> * bitset )
+template <typename I>
+[[nodiscard]] inline std::function<bool( I )> makePredicate( const TypedBitSet<I> * bitset )
 {
-    std::function<bool( Id<T> )> res;
+    std::function<bool( I )> res;
     if ( bitset )
-        res = [bitset]( Id<T> id ) { return bitset->test( id ); };
+        res = [bitset]( I id ) { return bitset->test( id ); };
     return res;
 }
 
-template <typename T>
-[[nodiscard]] inline std::function<bool( Id<T> )> makePredicate( const TaggedBitSet<T> & bitset )
+template <typename I>
+[[nodiscard]] inline std::function<bool( I )> makePredicate( const TypedBitSet<I> & bitset )
     { return makePredicate( &bitset ); }
 
-template <typename T>
-[[nodiscard]] inline bool contains( const TaggedBitSet<T> * bitset, Id<T> id )
+template <typename I>
+[[nodiscard]] inline bool contains( const TypedBitSet<I> * bitset, I id )
 {
     return id.valid() && ( !bitset || bitset->test( id ) );
 }
 
-template <typename T>
-[[nodiscard]] inline bool contains( const TaggedBitSet<T> & bitset, Id<T> id )
+template <typename I>
+[[nodiscard]] inline bool contains( const TypedBitSet<I> & bitset, I id )
 {
     return id.valid() && bitset.test( id );
 }
@@ -309,18 +309,18 @@ template <typename T>
 [[nodiscard]] MR_BIND_IGNORE inline auto end( const BitSet & )
     { return SetBitIteratorT<BitSet>(); }
 
-template <typename T>
-[[nodiscard]] MR_BIND_IGNORE inline auto begin( const TaggedBitSet<T> & a )
-    { return SetBitIteratorT<TaggedBitSet<T>>(a); }
-template <typename T>
-[[nodiscard]] MR_BIND_IGNORE inline auto end( const TaggedBitSet<T> & )
-    { return SetBitIteratorT<TaggedBitSet<T>>(); }
+template <typename I>
+[[nodiscard]] MR_BIND_IGNORE inline auto begin( const TypedBitSet<I> & a )
+    { return SetBitIteratorT<TypedBitSet<I>>(a); }
+template <typename I>
+[[nodiscard]] MR_BIND_IGNORE inline auto end( const TypedBitSet<I> & )
+    { return SetBitIteratorT<TypedBitSet<I>>(); }
 
 /// creates a Vector where for each set bit of input bitset its sequential number starting from 0 is returned; and -1 for reset bits
-template <typename T>
-[[nodiscard]] Vector<int, Id<T>> makeVectorWithSeqNums( const TaggedBitSet<T> & bs )
+template <typename I>
+[[nodiscard]] Vector<int, I> makeVectorWithSeqNums( const TypedBitSet<I> & bs )
 {
-    Vector<int, Id<T>> res( bs.size(), -1 );
+    Vector<int, I> res( bs.size(), -1 );
     int n = 0;
     for ( auto v : bs )
         res[v] = n++;
@@ -328,32 +328,32 @@ template <typename T>
 }
 
 /// creates a HashMap where for each set bit of input bitset its sequential number starting from 0 is returned
-template <typename T>
-[[nodiscard]] HashMap<Id<T>, int> makeHashMapWithSeqNums( const TaggedBitSet<T> & bs )
+template <typename I>
+[[nodiscard]] HashMap<I, int> makeHashMapWithSeqNums( const TypedBitSet<I> & bs )
 {
-    HashMap<Id<T>, int> res;
+    HashMap<I, int> res;
     int n = 0;
     for ( auto v : bs )
         res[v] = n++;
     return res;
 }
 
-template <typename T>
+template <typename I>
 template <typename M>
-[[nodiscard]] TaggedBitSet<T> TaggedBitSet<T>::getMapping( const M & map ) const
+[[nodiscard]] TypedBitSet<I> TypedBitSet<I>::getMapping( const M & map ) const
 {
-    TaggedBitSet<T> res;
+    TypedBitSet<I> res;
     for ( auto b : *this )
         if ( auto mapped = map( b ) )
             res.autoResizeSet( mapped );
     return res;
 }
 
-template <typename T>
+template <typename I>
 template <typename M>
-[[nodiscard]] TaggedBitSet<T> TaggedBitSet<T>::getMapping( const M & map, size_t resSize ) const
+[[nodiscard]] TypedBitSet<I> TypedBitSet<I>::getMapping( const M & map, size_t resSize ) const
 {
-    TaggedBitSet<T> res;
+    TypedBitSet<I> res;
     if ( !any() )
         return res;
     res.resize( resSize );

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -138,20 +138,23 @@ using EdgeLoops = std::vector<EdgeLoop>;
 
 class MRMESH_CLASS BitSet;
 
-MR_CANONICAL_TYPEDEFS( (template <typename T> class MRMESH_CLASS), TaggedBitSet,
-    ( FaceBitSet,           TaggedBitSet<FaceTag>           )
-    ( VertBitSet,           TaggedBitSet<VertTag>           )
-    ( EdgeBitSet,           TaggedBitSet<EdgeTag>           )
-    ( UndirectedEdgeBitSet, TaggedBitSet<UndirectedEdgeTag> )
-    ( PixelBitSet,          TaggedBitSet<PixelTag>          )
-    ( VoxelBitSet,          TaggedBitSet<VoxelTag>          )
-    ( RegionBitSet,         TaggedBitSet<RegionTag>         )
-    ( NodeBitSet,           TaggedBitSet<NodeTag>           )
-    ( ObjBitSet,            TaggedBitSet<ObjTag>            )
-    ( TextureBitSet,        TaggedBitSet<TextureTag>        )
-    ( GraphVertBitSet,      TaggedBitSet<GraphVertTag>      )
-    ( GraphEdgeBitSet,      TaggedBitSet<GraphEdgeTag>      )
+MR_CANONICAL_TYPEDEFS( (template <typename I> class MRMESH_CLASS), TypedBitSet,
+    ( FaceBitSet,           TypedBitSet<FaceId>           )
+    ( VertBitSet,           TypedBitSet<VertId>           )
+    ( EdgeBitSet,           TypedBitSet<EdgeId>           )
+    ( UndirectedEdgeBitSet, TypedBitSet<UndirectedEdgeId> )
+    ( PixelBitSet,          TypedBitSet<PixelId>          )
+    ( VoxelBitSet,          TypedBitSet<VoxelId>          )
+    ( RegionBitSet,         TypedBitSet<RegionId>         )
+    ( NodeBitSet,           TypedBitSet<NodeId>           )
+    ( ObjBitSet,            TypedBitSet<ObjId>            )
+    ( TextureBitSet,        TypedBitSet<TextureId>        )
+    ( GraphVertBitSet,      TypedBitSet<GraphVertId>      )
+    ( GraphEdgeBitSet,      TypedBitSet<GraphEdgeId>      )
 )
+
+template<typename T>
+using TaggedBitSet = TypedBitSet<Id<T>>;
 
 MR_CANONICAL_TYPEDEFS( (template <typename T> class MRMESH_CLASS), SetBitIteratorT,
     ( SetBitIterator,               SetBitIteratorT<BitSet>               )


### PR DESCRIPTION
* Define primary `template <typename I>class TypedBitSet : public BitSet`
* And make type alias `template<typename T> using TaggedBitSet = TypedBitSet<Id<T>>`
* Without it, it was hard to get the typed BitSet knowing only `Id` and not the tag