### PR TITLE
getVectorConverters: add overload and respect region

### DIFF
--- a/source/MRMesh/MRMeshCollidePrecise.cpp
+++ b/source/MRMesh/MRMeshCollidePrecise.cpp
@@ -574,10 +574,19 @@ std::vector<EdgeTri> findSelfCollidingEdgeTrisPrecise( const MeshPart& mp, Conve
 
 CoordinateConverters getVectorConverters( const MeshPart& a, const MeshPart& b, const AffineXf3f* rigidB2A )
 {
-    Box3d bb;
-    bb.include( Box3d( a.mesh.computeBoundingBox() ) );
-    Box3f bMeshBox = b.mesh.computeBoundingBox( rigidB2A );
-    bb.include( Box3d( bMeshBox ) );
+    MR_TIMER;
+    Box3d bb( a.mesh.computeBoundingBox( a.region ) );
+    bb.include( Box3d( b.mesh.computeBoundingBox( b.region, rigidB2A ) ) );
+    CoordinateConverters res;
+    res.toInt = getToIntConverter( bb );
+    res.toFloat = getToFloatConverter( bb );
+    return res;
+}
+
+CoordinateConverters getVectorConverters( const MeshPart& a )
+{
+    MR_TIMER;
+    Box3d bb( a.mesh.computeBoundingBox( a.region ) );
     CoordinateConverters res;
     res.toInt = getToIntConverter( bb );
     res.toFloat = getToFloatConverter( bb );

--- a/source/MRMesh/MRMeshCollidePrecise.h
+++ b/source/MRMesh/MRMeshCollidePrecise.h
@@ -93,6 +93,11 @@ MRMESH_API std::vector<EdgeTri> findCollidingEdgeTrisPrecise(
     ConvertToIntVector conv, const AffineXf3f * rigidB2A = nullptr );
 
 /**
+ * \brief creates simple converters from Vector3f to Vector3i and back in mesh part area range
+ */
+MRMESH_API CoordinateConverters getVectorConverters( const MeshPart& a );
+
+/**
  * \brief creates simple converters from Vector3f to Vector3i and back in mesh parts area range
  * \param rigidB2A rigid transformation from B-mesh space to A mesh space, nullptr considered as identity transformation
  */

--- a/source/MRTest/MRContoursCutTests.cpp
+++ b/source/MRTest/MRContoursCutTests.cpp
@@ -67,7 +67,7 @@ TEST( MRMesh, MeshCollidePrecise )
     auto meshB = makeTorus( 1.1f, 0.5f, 8, 8 );
     meshB.transform( AffineXf3f::linear( Matrix3f::rotation( Vector3f::plusZ(), Vector3f { 0.1f, 0.8f, 0.2f } ) ) );
 
-    const auto conv = getVectorConverters( meshA, meshB );
+    auto conv = getVectorConverters( meshA, meshB );
 
     const auto intersections = findCollidingEdgeTrisPrecise( meshA, meshB, conv.toInt );
     EXPECT_EQ( intersections.size(), 152 );
@@ -140,6 +140,7 @@ TEST( MRMesh, MeshCollidePrecise )
     // same for self-intersections
     auto mergedMesh = meshA;
     mergedMesh.addMesh( meshB );
+    conv = getVectorConverters( mergedMesh );
     const auto selfIntersections = findSelfCollidingEdgeTrisPrecise( mergedMesh, conv.toInt );
     EXPECT_EQ( selfIntersections.size(), 152 );
 


### PR DESCRIPTION
1. Previously regions of `MeshPart` were ignored.
2. Add overload with one mesh for self-intersections finding.