### PR TITLE
prolong open self-intersection contours to terminal vertices

### DIFF
--- a/source/MRMesh/MRIntersectionContour.h
+++ b/source/MRMesh/MRIntersectionContour.h
@@ -29,7 +29,7 @@ MRMESH_API ContinuousContours orderIntersectionContours( const MeshTopology& top
 /// Combines unordered input self-intersections (and flips orientation of some intersected edges) into ordered oriented contours with the properties:
 /// 1. Each contour is
 ///    a. either closed (then its first and last elements are equal),
-///    b. or open (then its first and last intersected edges are boundary edges).
+///    b. or open if terminal intersection is on mesh boundary or if self-intersection terminates in a vertex.
 /// 2. Next intersection in a contour is located to the left of the current intersected edge:
 ///    a. if the current and next intersected triangles are the same, then next intersected edge is either next( curr.edge ) or prev( curr.edge.sym() ).sym(),
 ///    b. otherwise next intersected triangle is left( curr.edge ) and next intersected edge is one of the edges having the current intersected triangle to the right.

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -133,6 +133,9 @@ public:
     void getTriVerts( FaceId f, ThreeVertIds & v ) const { getLeftTriVerts( edgeWithLeft( f ), v ); }
     [[nodiscard]] ThreeVertIds getTriVerts( FaceId f ) const { return getLeftTriVerts( edgeWithLeft( f ) ); }
 
+    /// return true if triangular face (f) has (v) as one of its vertices
+    [[nodiscard]] bool isTriVert( FaceId f, VertId v ) const { auto vs = getTriVerts( f ); return v == vs[0] || v == vs[1] || v == vs[2]; }
+
     /// returns three vertex ids for valid triangles, invalid triangles are skipped
     [[nodiscard]] MRMESH_API std::vector<ThreeVertIds> getAllTriVerts() const;
 

--- a/source/MRMesh/MROneMeshContours.cpp
+++ b/source/MRMesh/MROneMeshContours.cpp
@@ -489,7 +489,7 @@ void getOneMeshIntersectionContours( const Mesh& meshA, const Mesh& meshB, const
     MR_TIMER;
     assert( outA || outB || outPtsA );
     // addSelfyTerminalVerts is supported only if both meshes are actually the same without any relative transformation
-    assert( !addSelfyTerminalVerts || &meshA == &meshB && !rigidB2A );
+    assert( !addSelfyTerminalVerts || ( &meshA == &meshB && !rigidB2A ) );
 
     std::function<Vector3f( const Vector3f& coord, bool meshA )> getCoord;
 

--- a/source/MRMesh/MROneMeshContours.cpp
+++ b/source/MRMesh/MROneMeshContours.cpp
@@ -484,10 +484,12 @@ void subdivideLoneContours( Mesh& mesh, const OneMeshContours& contours, FaceHas
 
 void getOneMeshIntersectionContours( const Mesh& meshA, const Mesh& meshB, const ContinuousContours& contours,
     OneMeshContours* outA, OneMeshContours* outB,
-    const CoordinateConverters& converters, const AffineXf3f* rigidB2A, Contours3f* outPtsA )
+    const CoordinateConverters& converters, const AffineXf3f* rigidB2A, Contours3f* outPtsA, bool addSelfyTerminalVerts )
 {
     MR_TIMER;
     assert( outA || outB || outPtsA );
+    // addSelfyTerminalVerts is supported only if both meshes are actually the same without any relative transformation
+    assert( !addSelfyTerminalVerts || &meshA == &meshB && !rigidB2A );
 
     std::function<Vector3f( const Vector3f& coord, bool meshA )> getCoord;
 
@@ -519,6 +521,8 @@ void getOneMeshIntersectionContours( const Mesh& meshA, const Mesh& meshB, const
         OneMeshContour curA, curB;
         Contour3f ptsA;
         const auto& curInContour = contours[j];
+        if ( curInContour.empty() )
+            return;
         curA.closed = curB.closed = isClosed( curInContour );
         if ( outA )
             curA.intersections.resize( curInContour.size() );
@@ -567,6 +571,39 @@ void getOneMeshIntersectionContours( const Mesh& meshA, const Mesh& meshB, const
                 curB.intersections[i] = pntB;
             }
         } );
+        if ( !curA.closed && addSelfyTerminalVerts )
+        {
+            const auto & points = meshA.points;
+            const auto & topology = meshA.topology;
+            const auto i0 = curInContour.front();
+            if ( topology.right( i0.edge ) )
+            {
+                const auto v0 = topology.dest( topology.prev( i0.edge ) );
+                assert( topology.isTriVert( i0.tri(), v0 ) );
+                OneMeshIntersection o0{ .primitiveId = v0, .coordinate = points[v0] };
+                if ( !curA.intersections.empty() )
+                    curA.intersections.insert( curA.intersections.begin(), o0 );
+                if ( !ptsA.empty() )
+                    ptsA.insert( ptsA.begin(), o0.coordinate );
+                if ( !curB.intersections.empty() )
+                    curB.intersections.insert( curB.intersections.begin(), o0 );
+            }
+
+            const auto i1 = curInContour.back();
+            if ( topology.left( i1.edge ) )
+            {
+                const auto v1 = topology.dest( topology.next( i1.edge ) );
+                assert( topology.isTriVert( i1.tri(), v1 ) );
+                OneMeshIntersection o1{ .primitiveId = v1, .coordinate = points[v1] };
+                if ( !curA.intersections.empty() )
+                    curA.intersections.push_back( o1 );
+                if ( !ptsA.empty() )
+                    ptsA.push_back( o1.coordinate );
+                if ( !curB.intersections.empty() )
+                    curB.intersections.push_back( o1 );
+            }
+        }
+
         if ( outA )
             (*outA)[j] = std::move( curA );
         if ( outB )

--- a/source/MRMesh/MROneMeshContours.h
+++ b/source/MRMesh/MROneMeshContours.h
@@ -54,7 +54,8 @@ MRMESH_API void subdivideLoneContours( Mesh& mesh, const OneMeshContours& contou
 MRMESH_API void getOneMeshIntersectionContours( const Mesh& meshA, const Mesh& meshB, const ContinuousContours& contours,
     OneMeshContours* outA, OneMeshContours* outB,
     const CoordinateConverters& converters, const AffineXf3f* rigidB2A = nullptr,
-    Contours3f* outPtsA = nullptr );
+    Contours3f* outPtsA = nullptr,
+    bool addSelfyTerminalVerts = false ); ///< if true, then open self-intersection contours will be prolonged to terminal vertices
 
 // Converts ordered continuous self contours of single meshes to OneMeshContours
 // converters are required for better precision in case of degenerations


### PR DESCRIPTION
* Function `getOneMeshIntersectionContours` gets option to prolong open self-intersection contours to terminal vertices.
* Correct comment for `orderSelfIntersectionContours`.
* New function `bool MeshTopology::isTriVert( FaceId f, VertId v ) const`.
