### PR TITLE
Simplify drag_drop logic

### DIFF
--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -1270,7 +1270,7 @@ bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList, con
             if ( auto cn = commonClassName( result.scene->children() ) )
                 undoName += " as " + *cn;
 
-            if ( options.forceReplaceScene || ( result.loadedFiles.size() == 1 && ( !result.isSceneConstructed || wasEmptyScene ) ) )
+            if ( options.forceReplaceScene || wasEmptyScene )
             {
                 {
                     // the scene is taken as is from a single file, replace the current scene with it


### PR DESCRIPTION
Objects dropped to scene tree will be always **added** independently of format
Objects dropped to 3d view will always **replace** current scene 