### PR TITLE
Boost.Multiprecision: switch to unchecked integers

### DIFF
--- a/source/MRMesh/MRHighPrecision.h
+++ b/source/MRMesh/MRHighPrecision.h
@@ -10,8 +10,8 @@ namespace MR
 /// \ingroup MathGroup
 /// \{
 
-using HighPrecisionInt = boost::multiprecision::checked_int128_t;
-using HighHighPrecisionInt = boost::multiprecision::checked_int256_t;
+using HighPrecisionInt = boost::multiprecision::int128_t;
+using HighHighPrecisionInt = boost::multiprecision::int256_t;
 
 using Vector2hp = Vector2<HighPrecisionInt>;
 using Vector3hp = Vector3<HighPrecisionInt>;


### PR DESCRIPTION
Use not-throwing long integer types from Boost: https://www.boost.org/doc/libs/latest/libs/multiprecision/doc/html/boost_multiprecision/tut/ints/cpp_int.html

Motivation:
* not all target platforms support exceptions,
* exception-free code is expected to be faster.

The user is responsible to have all values in range.