### PR TITLE
Revert disabling mangling of windows runtime for pip/nuget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ source/MRDotNetTest/obj/*
 /include
 /out/build/
 .cache
+venv/*
+wheelhouse/*

--- a/scripts/nuget_patch/fake_whl_helper.py
+++ b/scripts/nuget_patch/fake_whl_helper.py
@@ -42,7 +42,9 @@ def patch_whl(out_dir,libs_dir):
                     # Another option is to use --no-mangle "msvcp140.dll;vcruntime140_1.dll;vcruntime140.dll"
                     # to pack these dlls with original names and let system solve conflicts on import
                     # https://stackoverflow.com/questions/78817088/vsruntime-dlls-conflict-after-delvewheel-repair
-                    "--no-dll", "msvcp140.dll;vcruntime140_1.dll;vcruntime140.dll",
+                    # UPDATE:
+                    #  no longer needed due to https://github.com/adang1345/delvewheel/issues/49 fix with https://github.com/adang1345/delvewheel/commit/42a52cdcc15d424b030a94cb4b51a6b72e4a3d92
+                    #"--no-dll", "msvcp140.dll;vcruntime140_1.dll;vcruntime140.dll",
 
                     "--add-path",libs_dir, # path where input dependencies are located
 

--- a/scripts/wheel/build_wheel.py
+++ b/scripts/wheel/build_wheel.py
@@ -138,7 +138,9 @@ def build_wheel():
                 # Another option is to use --no-mangle "msvcp140.dll;vcruntime140_1.dll;vcruntime140.dll"
                 # to pack these dlls with original names and let system solve conflicts on import
                 # https://stackoverflow.com/questions/78817088/vsruntime-dlls-conflict-after-delvewheel-repair
-                "--no-dll", "msvcp140.dll;vcruntime140_1.dll;vcruntime140.dll",
+                # UPDATE:
+                #  no longer needed due to https://github.com/adang1345/delvewheel/issues/49 fix with https://github.com/adang1345/delvewheel/commit/42a52cdcc15d424b030a94cb4b51a6b72e4a3d92
+                #"--no-dll", "msvcp140.dll;vcruntime140_1.dll;vcruntime140.dll",
                 "--add-path", LIB_DIR,
                 # This is needed to catch our `pybind11nonlimitedapi_meshlib_3.X.dll` on Windows. Otherwise they don't get patched,
                 # and then can't find `pybind11nonlimitedapi_stubs.dll`, which does get patched.


### PR DESCRIPTION
Thanks to https://github.com/adang1345/delvewheel/commit/42a52cdcc15d424b030a94cb4b51a6b72e4a3d92 https://github.com/adang1345/delvewheel/issues/49 is fixed

allowing us to mangle runtime dlls