### PR TITLE
optimize segmentIntersectionOrder function

### DIFF
--- a/source/MRMesh/MRSparsePolynomial.h
+++ b/source/MRMesh/MRSparsePolynomial.h
@@ -31,6 +31,9 @@ public:
     /// constructs polynomial c0 + c1*x^d1 + c2*x^d2
     SparsePolynomial( C c0, D d1, C c1, D d2, C c2 );
 
+    /// sets coefficient for given degree to zero
+    void setZeroCoeff( D d ) { map_.erase( d ); }
+
     /// returns true if no single polynomial coefficient is defined
     [[nodiscard]] bool empty() const { return map_.empty(); }
 


### PR DESCRIPTION
1. First compute integer value of the function, and if its not zero return immediately (fast happy path).
2. Compute polynomial of epsilon only overwise (much slower).
3. Only item 1 is computed in 128 bit arithmetic, for coefficients in item 2, 64 bits are enough.