### PR TITLE
Optimize precise predicates 2D

### DIFF
--- a/source/MRMesh/MRDivRound.h
+++ b/source/MRMesh/MRDivRound.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "MRMeshFwd.h"
+
+namespace MR
+{
+
+/// computes division n/d with rounding of the result to the nearest integer, all signs of n and d are supported
+/// https://stackoverflow.com/a/18067292/7325599
+template <class T>
+inline T divRound( T n, T d )
+{
+    return ((n < 0) == (d < 0)) ? ((n + d/2)/d) : ((n - d/2)/d);
+}
+
+/// computes division n/d with rounding of each components to the nearest integer, all signs of n and d are supported
+template <class T>
+Vector2<T> divRound( const Vector2<T>& n, T d )
+{
+    return
+    {
+        divRound( n.x, d ),
+        divRound( n.y, d )
+    };
+}
+
+/// computes division n/d with rounding of each components to the nearest integer, all signs of n and d are supported
+template <class T>
+Vector3<T> divRound( const Vector3<T>& n, T d )
+{
+    return
+    {
+        divRound( n.x, d ),
+        divRound( n.y, d ),
+        divRound( n.z, d )
+    };
+}
+
+/// computes division n/d with rounding of each components to the nearest integer, all signs of n and d are supported
+template <class T>
+Vector4<T> divRound( const Vector4<T>& n, T d )
+{
+    return
+    {
+        divRound( n.x, d ),
+        divRound( n.y, d ),
+        divRound( n.z, d ),
+        divRound( n.w, d )
+    };
+}
+
+} //namespace MR

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -11,6 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="MRDivRound.h" />
     <ClInclude Include="MRFastInt128.h" />
     <ClInclude Include="MRMapOrHashMap.h" />
     <ClInclude Include="MRAABBTreeBase.h" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1340,6 +1340,9 @@
     <ClInclude Include="MRSparsePolynomial.h">
       <Filter>Source Files\Math</Filter>
     </ClInclude>
+    <ClInclude Include="MRDivRound.h">
+      <Filter>Source Files\Math</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRParallelProgressReporter.cpp">

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -2,6 +2,7 @@
 #include "MRHighPrecision.h"
 #include "MRVector2.h"
 #include "MRBox.h"
+#include "MRDivRound.h"
 #include <optional>
 
 namespace MR
@@ -198,24 +199,6 @@ static std::optional<Vector3i> findTwoSegmentsIntersection( const Vector3i& ai, 
     return Vector3i( Vector3d( abdS * Vector3i128{ ci } + abcS * Vector3i128{ di } ) / double( abcS + abdS ) );
 }
 
-/// https://stackoverflow.com/a/18067292/7325599
-template <class T>
-T divRoundClosest( T n, T d )
-{
-    return ((n < 0) == (d < 0)) ? ((n + d/2)/d) : ((n - d/2)/d);
-}
-
-template <class T>
-Vector3<T> divRoundClosest( const Vector3<T>& n, T d )
-{
-    return
-    {
-        divRoundClosest( n.x, d ),
-        divRoundClosest( n.y, d ),
-        divRoundClosest( n.z, d )
-    };
-}
-
 Vector3f findTriangleSegmentIntersectionPrecise( 
     const Vector3f& a, const Vector3f& b, const Vector3f& c, 
     const Vector3f& d, const Vector3f& e, 
@@ -234,7 +217,7 @@ Vector3f findTriangleSegmentIntersectionPrecise(
         abce = -abce;
     auto sum = abcd + abce;
     if ( sum != 0 )
-        return converters.toFloat( Vector3i{ divRoundClosest( abcd * Vector3i128fast{ ei } + abce * Vector3i128fast{ di }, sum ) } );
+        return converters.toFloat( Vector3i{ divRound( abcd * Vector3i128fast{ ei } + abce * Vector3i128fast{ di }, sum ) } );
     // rare case when `sum == 0` 
     // suggest finding middle point of edge segment laying inside triangle
     Vector3i64 sumVec;

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -1,7 +1,9 @@
 #include <MRMesh/MRPrecisePredicates2.h>
 #include <MRMesh/MRPrecisePredicates3.h>
+#include <MRMesh/MRBox.h>
 #include <MRMesh/MRGTest.h>
 #include <algorithm>
+#include <climits>
 
 namespace MR
 {
@@ -315,6 +317,17 @@ TEST( MRMesh, PrecisePredicates3FullDegen )
         }
     }
     while ( std::next_permutation( vs.begin(), vs.end(), []( const auto & l, const auto & r ) { return l.id < r.id; } ) );
+}
+
+TEST( MRMesh, getToIntConverter )
+{
+    auto toInt = getToIntConverter( Box3d( {0,0,-1.0}, {0,0,1.0} ) );
+    auto i0 = toInt( { 0,0,-1.f } );
+    auto i1 = toInt( { 0,0, 1.f } );
+    // check that sum and difference of any two points can be computed in integer without overflow
+    EXPECT_LE( -i0.z, INT_MAX / 2 );
+    EXPECT_LE(  i1.z, INT_MAX / 2 );
+    EXPECT_GT( i1.z - i0.z, 0 );
 }
 
 } //namespace MR


### PR DESCRIPTION
1. Performs computation with the lowest integer type enough to represent all possible values (e.g. changes Int128->Int64)
2. Replace Int128 -> FastInt128 and Vector2i128 -> Vector2i128fast
3. Avoid double arithmetic, instead use `divRound` function moved in public header
4. Add test that sum and difference of any two points can be computed in integer without overflow