### PR TITLE
Move cylinder approximator definition out of header file

### DIFF
--- a/source/MRMesh/MRCylinderApproximator.cpp
+++ b/source/MRMesh/MRCylinderApproximator.cpp
@@ -1,0 +1,337 @@
+#include "MRCylinderApproximator.h"
+#include "MRConstants.h"
+#include "MRCylinder3.h"
+#include "MRToFromEigen.h"
+#include "MRVector.h"
+#include "MRPch/MRSpdlog.h"
+#include "MRPch/MRTBB.h"
+
+namespace MR
+{
+
+template <typename T>
+Cylinder3Approximation<T>::Cylinder3Approximation()
+{
+    reset();
+}
+
+template <typename T>
+void Cylinder3Approximation<T>::reset()
+{
+    thetaResolution_ = 0;
+    phiResolution_ = 0;
+    precomputedMu_.setZero();
+    precomputedF0_.setZero();
+    precomputedF1_.setZero();
+    precomputedF2_.setZero();
+    normalizedPoints_.clear();
+}
+
+template <typename T>
+T Cylinder3Approximation<T>::solveGeneral( const std::vector<Vector3<T>>& points, Cylinder3<T>& cylinder, size_t theta,
+    size_t phi, bool isMultithread )
+{
+    thetaResolution_ = theta;
+    phiResolution_ = phi;
+    isMultithread_ = isMultithread;
+    fitter_ = CylinderFitterType::HemisphereSearchFit;
+    assert( thetaResolution_ > 0 );
+    assert( phiResolution_ > 0 );
+    auto result = solve( points, cylinder );
+    reset();
+    return result;
+}
+
+template <typename T>
+T Cylinder3Approximation<T>::solveSpecificAxis( const std::vector<Vector3<T>>& points, Cylinder3<T>& cylinder,
+    Vector3<T> const& cylinderAxis )
+{
+    baseCylinderAxis_ = MR::toEigen( cylinderAxis.normalized() );
+    fitter_ = CylinderFitterType::SpecificAxisFit;
+    assert( baseCylinderAxis_.isZero() == false ); //  "The cylinder axis must be nonzero."
+    auto result = solve( points, cylinder );
+    reset();
+    return result;
+}
+
+template <typename T>
+T Cylinder3Approximation<T>::solve( const std::vector<Vector3<T>>& points, Cylinder3<T>& cylinder )
+{
+    if ( points.size() < 6 )
+    {
+        spdlog::warn( "Cylinder3Approximation :: Too low point for cylinder approximation count=" + std::to_string( points.size() ) );
+        return -1;
+    }
+    assert( points.size() >= 6 ); // "At least 6 points needs for correct fitting requires ."
+
+    normalizedPoints_.clear();
+    cylinder = Cylinder3<T>();
+    Vector3<T> avgPoint;
+    Eigen::Vector<T, 3> bestPC;
+    Eigen::Vector<T, 3> bestW; // cylinder main axis
+    T rootSquare = 0;
+    T error = 0;
+
+    //For significant increase speed, we make a preliminary calculation based on the initial data.
+    updatePrecomputeParams( points, avgPoint );
+
+    // Listing 16. page 38.
+    if ( fitter_ == CylinderFitterType::HemisphereSearchFit )
+    {
+        if ( isMultithread_ )
+            error = fitCylindeHemisphereMultiThreaded( bestPC, bestW, rootSquare );
+
+        else
+            error = fitCylindeHemisphereSingleThreaded( bestPC, bestW, rootSquare );
+    }
+    else if ( fitter_ == CylinderFitterType::SpecificAxisFit )
+    {
+        error = SpecificAxisFit( bestPC, bestW, rootSquare );
+    }
+    else
+    {
+        spdlog::warn( "Cylinder3Approximation :: unsupported fitter" );
+        assert( false ); // unsupported fitter
+        return -1;
+    }
+
+    assert( rootSquare >= 0 );
+
+    cylinder.center() = fromEigen( bestPC ) + avgPoint;
+    cylinder.direction() = ( fromEigen( bestW ) ).normalized();
+    cylinder.radius = std::sqrt( rootSquare );
+
+    // Calculate a max. possible length of a cylinder covered by dataset.
+    // Project point on a main cylinder axis
+    T hmin = std::numeric_limits<T>::max();
+    T hmax = -std::numeric_limits<T>::max();
+
+    for ( size_t i = 0; i < points.size(); ++i )
+    {
+        T h = MR::dot( cylinder.direction(), points[i] - cylinder.center() );
+        hmin = std::min( h, hmin );
+        hmax = std::max( h, hmax );
+    }
+    T hmid = ( hmin + hmax ) / 2;
+
+    // Very tiny correct a cylinder center.
+    cylinder.center() = cylinder.center() + hmid * cylinder.direction();
+    cylinder.length = hmax - hmin;
+
+    assert( cylinder.length >= 0 );
+
+    return error;
+}
+
+template <typename T>
+void Cylinder3Approximation<T>::updatePrecomputeParams( const std::vector<Vector3<T>>& points, Vector3<T>& average )
+{
+    // Listing 15. page 37.
+    normalizedPoints_.resize( points.size() );
+
+    // calculate avg point of dataset
+    average = Vector3<T>{};
+    for ( size_t i = 0; i < points.size(); ++i )
+        average += points[i];
+    average = average / static_cast< T > ( points.size() );
+
+    // normalize points and store it.
+    for ( size_t i = 0; i < points.size(); ++i )
+        normalizedPoints_[i] = toEigen( points[i] - average );
+
+    const Eigen::Vector<T, 6> zeroEigenVector6{ 0, 0, 0, 0, 0, 0 };
+    std::vector<Eigen::Vector<T, 6>> products( normalizedPoints_.size(), zeroEigenVector6 );
+    precomputedMu_ = zeroEigenVector6;
+
+    for ( size_t i = 0; i < normalizedPoints_.size(); ++i )
+    {
+        products[i][0] = normalizedPoints_[i][0] * normalizedPoints_[i][0];
+        products[i][1] = normalizedPoints_[i][0] * normalizedPoints_[i][1];
+        products[i][2] = normalizedPoints_[i][0] * normalizedPoints_[i][2];
+        products[i][3] = normalizedPoints_[i][1] * normalizedPoints_[i][1];
+        products[i][4] = normalizedPoints_[i][1] * normalizedPoints_[i][2];
+        products[i][5] = normalizedPoints_[i][2] * normalizedPoints_[i][2];
+        precomputedMu_[0] += products[i][0];
+        precomputedMu_[1] += 2 * products[i][1];
+        precomputedMu_[2] += 2 * products[i][2];
+        precomputedMu_[3] += products[i][3];
+        precomputedMu_[4] += 2 * products[i][4];
+        precomputedMu_[5] += products[i][5];
+    }
+    precomputedMu_ = precomputedMu_ / points.size();
+
+    precomputedF0_.setZero();
+    precomputedF1_.setZero();
+    precomputedF2_.setZero();
+    for ( size_t i = 0; i < normalizedPoints_.size(); ++i )
+    {
+        Eigen::Vector<T, 6> delta{};
+        delta[0] = products[i][0] - precomputedMu_[0];
+        delta[1] = 2 * products[i][1] - precomputedMu_[1];
+        delta[2] = 2 * products[i][2] - precomputedMu_[2];
+        delta[3] = products[i][3] - precomputedMu_[3];
+        delta[4] = 2 * products[i][4] - precomputedMu_[4];
+        delta[5] = products[i][5] - precomputedMu_[5];
+        precomputedF0_( 0, 0 ) += products[i][0];
+        precomputedF0_( 0, 1 ) += products[i][1];
+        precomputedF0_( 0, 2 ) += products[i][2];
+        precomputedF0_( 1, 1 ) += products[i][3];
+        precomputedF0_( 1, 2 ) += products[i][4];
+        precomputedF0_( 2, 2 ) += products[i][5];
+        precomputedF1_ = precomputedF1_ + normalizedPoints_[i] * delta.transpose();
+        precomputedF2_ += delta * delta.transpose();
+    }
+    precomputedF0_ = precomputedF0_ / static_cast < T > ( points.size() );
+    precomputedF0_( 1, 0 ) = precomputedF0_( 0, 1 );
+    precomputedF0_( 2, 0 ) = precomputedF0_( 0, 2 );
+    precomputedF0_( 2, 1 ) = precomputedF0_( 1, 2 );
+    precomputedF1_ = precomputedF1_ / static_cast < T > ( points.size() );
+    precomputedF2_ = precomputedF2_ / static_cast < T > ( points.size() );
+}
+
+template <typename T>
+T Cylinder3Approximation<T>::G( const Eigen::Vector<T, 3>& W, Eigen::Vector<T, 3>& PC, T& rsqr ) const
+{
+    Eigen::Matrix<T, 3, 3> P = Eigen::Matrix<T, 3, 3>::Identity() - ( W * W.transpose() ); // P = I - W * W^T
+
+    Eigen::Matrix<T, 3, 3> S;
+    S << 0, -W[2], W[1],
+        W[2], 0, -W[0],
+        -W[1], W[0], 0;
+
+    Eigen::Matrix<T, 3, 3> A = P * precomputedF0_ * P;
+    Eigen::Matrix<T, 3, 3> hatA = -( S * A * S );
+    Eigen::Matrix<T, 3, 3> hatAA = hatA * A;
+    T trace = hatAA.trace();
+    if ( trace == 0 )
+    {
+        // cannot divide on zero, return maximum error
+        PC.setZero();
+        return std::numeric_limits<T>::max();
+    }
+    Eigen::Matrix<T, 3, 3> Q = hatA / trace;
+    Eigen::Vector<T, 6> pVec{ P( 0, 0 ), P( 0, 1 ), P( 0, 2 ), P( 1, 1 ), P( 1, 2 ), P( 2, 2 ) };
+    Eigen::Vector<T, 3> alpha = precomputedF1_ * pVec;
+    Eigen::Vector<T, 3> beta = Q * alpha;
+    T error = ( pVec.dot( precomputedF2_ * pVec ) - 4 * alpha.dot( beta ) + 4 * beta.dot( precomputedF0_ * beta ) ) / static_cast< T >( normalizedPoints_.size() );
+
+    // some times appears floating points calculation errors. Error is a non negative value by default, so, make it positive.
+    // absolute value (instead of error=0) is used to avoid collisions for near-null values and subsequent ambiguous work, since this code can be used in parallel algorithms
+    if ( error < 0 )
+        error = std::abs( error );
+
+    PC = beta;
+    rsqr = std::max( T(0), pVec.dot( precomputedMu_ ) + beta.dot( beta ) ); // the value can slightly below zero due to rounding-errors
+
+    return error;
+}
+
+template <typename T>
+T Cylinder3Approximation<T>::fitCylindeHemisphereSingleThreaded( Eigen::Vector<T, 3>& PC, Eigen::Vector<T, 3>& W,
+    T& resultedRootSquare ) const
+{
+    T const theraStep = static_cast< T >( 2 * PI ) / thetaResolution_;
+    T const phiStep = static_cast< T >( PI2 ) / phiResolution_;
+
+    // problem in list. 16. => start from pole.
+    W = { 0, 0, 1 };
+    T minError = G( W, PC, resultedRootSquare );
+
+    for ( size_t j = 1; j <= phiResolution_; ++j )
+    {
+        T phi = phiStep * j; //  [0 .. pi/2]
+        T cosPhi = std::cos( phi );
+        T sinPhi = std::sin( phi );
+        for ( size_t i = 0; i < thetaResolution_; ++i )
+        {
+            T theta = theraStep * i; //  [0 .. 2*pi)
+            T cosTheta = std::cos( theta );
+            T sinTheta = std::sin( theta );
+            Eigen::Vector<T, 3> currW{ cosTheta * sinPhi, sinTheta * sinPhi, cosPhi };
+            Eigen::Vector<T, 3> currPC{};
+            T rsqr;
+            T error = G( currW, currPC, rsqr );
+            if ( error < minError )
+            {
+                minError = error;
+                resultedRootSquare = rsqr;
+                W = currW;
+                PC = currPC;
+            }
+        }
+    }
+
+    return minError;
+}
+
+template <typename T>
+T Cylinder3Approximation<T>::fitCylindeHemisphereMultiThreaded( Eigen::Vector<T, 3>& PC, Eigen::Vector<T, 3>& W,
+    T& resultedRootSquare ) const
+{
+    T const theraStep = static_cast< T >( 2 * PI ) / thetaResolution_;
+    T const phiStep = static_cast< T >( PI2 ) / phiResolution_;
+
+    // problem in list. 16. => start from pole.
+    W = { 0, 0, 1 };
+    T minError = G( W, PC, resultedRootSquare );
+
+    std::vector<BestHemisphereStoredData> storedData;
+    storedData.resize( phiResolution_ + 1 ); //  [0 .. pi/2] +1 for include upper bound
+
+    tbb::parallel_for( tbb::blocked_range<size_t>( size_t( 0 ), phiResolution_ + 1 ),
+        [&] ( const tbb::blocked_range<size_t>& range )
+        {
+            for ( size_t j = range.begin(); j < range.end(); ++j )
+            {
+
+                T phi = phiStep * j; // [0 .. pi/2]
+                T cosPhi = std::cos( phi );
+                T sinPhi = std::sin( phi );
+                for ( size_t i = 0; i < thetaResolution_; ++i )
+                {
+
+                    T theta = theraStep * i; // [0 .. 2*pi)
+                    T cosTheta = std::cos( theta );
+                    T sinTheta = std::sin( theta );
+                    Eigen::Vector<T, 3> currW{ cosTheta * sinPhi, sinTheta * sinPhi, cosPhi };
+                    Eigen::Vector<T, 3> currPC{};
+                    T rsqr;
+                    T error = G( currW, currPC, rsqr );
+
+                    if ( error < storedData[j].error )
+                    {
+                        storedData[j].error = error;
+                        storedData[j].rootSquare = rsqr;
+                        storedData[j].W = currW;
+                        storedData[j].PC = currPC;
+                    }
+                }
+            }
+        }
+    );
+
+    for ( size_t i = 0; i <= phiResolution_; ++i )
+    {
+        if ( storedData[i].error < minError )
+        {
+            minError = storedData[i].error;
+            resultedRootSquare = storedData[i].rootSquare;
+            W = storedData[i].W;
+            PC = storedData[i].PC;
+        }
+    }
+
+    return minError;
+}
+
+template <typename T>
+T Cylinder3Approximation<T>::SpecificAxisFit( Eigen::Vector<T, 3>& PC, Eigen::Vector<T, 3>& W, T& resultedRootSquare )
+{
+    W = baseCylinderAxis_;
+    return G( W, PC, resultedRootSquare );
+}
+
+template class Cylinder3Approximation<float>;
+template class Cylinder3Approximation<double>;
+
+} // namespace MR

--- a/source/MRMesh/MRCylinderApproximator.h
+++ b/source/MRMesh/MRCylinderApproximator.h
@@ -1,33 +1,19 @@
 #pragma once
 
 #include "MRMeshFwd.h"
-#include "MRCylinder3.h"
-#include "MRVector.h"
-#include "MRMatrix.h"
-#include "MRPch/MRTBB.h"
-#include "MRToFromEigen.h"
-#include "MRConstants.h"
-#include "MRLog.h"
 
-#ifdef _MSC_VER
-#pragma warning(push)
+#include "MRPch/MRSuppressWarning.h"
+
+MR_SUPPRESS_WARNING_PUSH
+#if defined( _MSC_VER )
 #pragma warning(disable:5054)  //operator '&': deprecated between enumerations of different types
 #pragma warning(disable:4127)  //C4127. "Consider using 'if constexpr' statement instead"
-#elif defined(__clang__)
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
+#elif defined( __clang__ )
+#elif defined( __GNUC__ )
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
-
 #include <Eigen/Eigenvalues>
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#elif defined(__clang__)
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-
+MR_SUPPRESS_WARNING_POP
 
 // https://www.geometrictools.com/Documentation/LeastSquaresFitting.pdf
 
@@ -36,9 +22,7 @@ namespace MR
 template <typename T>
 class Cylinder3Approximation
 {
-
 private:
-
     enum class CylinderFitterType
     {
         // The algorithm implimentation needs an initial approximation to refine the cylinder axis.
@@ -81,258 +65,30 @@ private:
     Eigen::Matrix <T, 6, 6>  precomputedF2_ = {};
 
 public:
-    Cylinder3Approximation()
-    {
-        reset();
-    };
+    Cylinder3Approximation();
 
-    void reset()
-    {
-        thetaResolution_ = 0;
-        phiResolution_ = 0;
-        precomputedMu_.setZero();
-        precomputedF0_.setZero();
-        precomputedF1_.setZero();
-        precomputedF2_.setZero();
-        normalizedPoints_.clear();
-    };
+    void reset();
     // Solver for CylinderFitterType::HemisphereSearchFit type
     // thetaResolution_, phiResolution_  must be positive and as large as it posible. Price is CPU time. (~ 100 gives good results).
-    T solveGeneral( const std::vector<MR::Vector3<T>>& points, Cylinder3<T>& cylinder, size_t theta = 180, size_t phi = 90, bool isMultithread = true )
-    {
-        thetaResolution_ = theta;
-        phiResolution_ = phi;
-        isMultithread_ = isMultithread;
-        fitter_ = CylinderFitterType::HemisphereSearchFit;
-        assert( thetaResolution_ > 0 );
-        assert( phiResolution_ > 0 );
-        auto result = solve( points, cylinder );
-        reset();
-        return result;
-    };
+    T solveGeneral( const std::vector<MR::Vector3<T>>& points, Cylinder3<T>& cylinder, size_t theta = 180, size_t phi = 90, bool isMultithread = true );
 
     // Solver for CylinderFitterType::SpecificAxisFit type
     // Simplet way in case of we already know clinder axis
-    T solveSpecificAxis( const std::vector<MR::Vector3<T>>& points, Cylinder3<T>& cylinder, MR::Vector3<T> const& cylinderAxis )
-    {
+    T solveSpecificAxis( const std::vector<MR::Vector3<T>>& points, Cylinder3<T>& cylinder, MR::Vector3<T> const& cylinderAxis );
 
-        baseCylinderAxis_ = MR::toEigen( cylinderAxis.normalized() );
-        fitter_ = CylinderFitterType::SpecificAxisFit;
-        assert( baseCylinderAxis_.isZero() == false ); //  "The cylinder axis must be nonzero."
-        auto result = solve( points, cylinder );
-        reset();
-        return result;
-    };
 private:
     // main solver.
-    T solve( const std::vector<MR::Vector3<T>>& points, Cylinder3<T>& cylinder )
-    {
-        if ( points.size() < 6 )
-        {
-            Logger::warn( "Cylinder3Approximation :: Too low point for cylinder approximation count=" + std::to_string( points.size() ) );
-            return -1;
-        }
-        assert( points.size() >= 6 ); // "At least 6 points needs for correct fitting requires ."
+    T solve( const std::vector<MR::Vector3<T>>& points, Cylinder3<T>& cylinder );
 
-        normalizedPoints_.clear();
-        cylinder = Cylinder3<T>();
-        Vector3<T> avgPoint;
-        Eigen::Vector<T, 3> bestPC;
-        Eigen::Vector<T, 3> bestW; // cylinder main axis
-        T rootSquare = 0;
-        T error = 0;
-
-        //For significant increase speed, we make a preliminary calculation based on the initial data.
-        updatePrecomputeParams( points, avgPoint );
-
-        // Listing 16. page 38.
-        if ( fitter_ == CylinderFitterType::HemisphereSearchFit )
-        {
-            if ( isMultithread_ )
-                error = fitCylindeHemisphereMultiThreaded( bestPC, bestW, rootSquare );
-
-            else
-                error = fitCylindeHemisphereSingleThreaded( bestPC, bestW, rootSquare );
-        }
-        else if ( fitter_ == CylinderFitterType::SpecificAxisFit )
-        {
-            error = SpecificAxisFit( bestPC, bestW, rootSquare );
-        }
-        else
-        {
-            Logger::warn( "Cylinder3Approximation :: unsupported fitter" );
-            assert( false ); // unsupported fitter
-            return -1;
-        }
-
-        assert( rootSquare >= 0 );
-
-        cylinder.center() = fromEigen( bestPC ) + avgPoint;
-        cylinder.direction() = ( fromEigen( bestW ) ).normalized();
-        cylinder.radius = std::sqrt( rootSquare );
-
-        // Calculate a max. possible length of a cylinder covered by dataset.
-        // Project point on a main cylinder axis
-        T hmin = std::numeric_limits<T>::max();
-        T hmax = -std::numeric_limits<T>::max();
-
-        for ( size_t i = 0; i < points.size(); ++i )
-        {
-            T h = MR::dot( cylinder.direction(), points[i] - cylinder.center() );
-            hmin = std::min( h, hmin );
-            hmax = std::max( h, hmax );
-        }
-        T hmid = ( hmin + hmax ) / 2;
-
-        // Very tiny correct a cylinder center.
-        cylinder.center() = cylinder.center() + hmid * cylinder.direction();
-        cylinder.length = hmax - hmin;
-
-        assert( cylinder.length >= 0 );
-
-        return error;
-    }
-
-    void updatePrecomputeParams( const std::vector <MR::Vector3<T>>& points, Vector3<T>& average )
-    {
-        // Listing 15. page 37.
-        normalizedPoints_.resize( points.size() );
-
-        // calculate avg point of dataset
-        average = Vector3<T>{};
-        for ( size_t i = 0; i < points.size(); ++i )
-            average += points[i];
-        average = average / static_cast< T > ( points.size() );
-
-        // normalize points and store it.
-        for ( size_t i = 0; i < points.size(); ++i )
-            normalizedPoints_[i] = toEigen( points[i] - average );
-
-        const Eigen::Vector<T, 6> zeroEigenVector6{ 0, 0, 0, 0, 0, 0 };
-        std::vector<Eigen::Vector<T, 6>> products( normalizedPoints_.size(), zeroEigenVector6 );
-        precomputedMu_ = zeroEigenVector6;
-
-        for ( size_t i = 0; i < normalizedPoints_.size(); ++i )
-        {
-            products[i][0] = normalizedPoints_[i][0] * normalizedPoints_[i][0];
-            products[i][1] = normalizedPoints_[i][0] * normalizedPoints_[i][1];
-            products[i][2] = normalizedPoints_[i][0] * normalizedPoints_[i][2];
-            products[i][3] = normalizedPoints_[i][1] * normalizedPoints_[i][1];
-            products[i][4] = normalizedPoints_[i][1] * normalizedPoints_[i][2];
-            products[i][5] = normalizedPoints_[i][2] * normalizedPoints_[i][2];
-            precomputedMu_[0] += products[i][0];
-            precomputedMu_[1] += 2 * products[i][1];
-            precomputedMu_[2] += 2 * products[i][2];
-            precomputedMu_[3] += products[i][3];
-            precomputedMu_[4] += 2 * products[i][4];
-            precomputedMu_[5] += products[i][5];
-        }
-        precomputedMu_ = precomputedMu_ / points.size();
-
-        precomputedF0_.setZero();
-        precomputedF1_.setZero();
-        precomputedF2_.setZero();
-        for ( size_t i = 0; i < normalizedPoints_.size(); ++i )
-        {
-            Eigen::Vector<T, 6> delta{};
-            delta[0] = products[i][0] - precomputedMu_[0];
-            delta[1] = 2 * products[i][1] - precomputedMu_[1];
-            delta[2] = 2 * products[i][2] - precomputedMu_[2];
-            delta[3] = products[i][3] - precomputedMu_[3];
-            delta[4] = 2 * products[i][4] - precomputedMu_[4];
-            delta[5] = products[i][5] - precomputedMu_[5];
-            precomputedF0_( 0, 0 ) += products[i][0];
-            precomputedF0_( 0, 1 ) += products[i][1];
-            precomputedF0_( 0, 2 ) += products[i][2];
-            precomputedF0_( 1, 1 ) += products[i][3];
-            precomputedF0_( 1, 2 ) += products[i][4];
-            precomputedF0_( 2, 2 ) += products[i][5];
-            precomputedF1_ = precomputedF1_ + normalizedPoints_[i] * delta.transpose();
-            precomputedF2_ += delta * delta.transpose();
-        }
-        precomputedF0_ = precomputedF0_ / static_cast < T > ( points.size() );
-        precomputedF0_( 1, 0 ) = precomputedF0_( 0, 1 );
-        precomputedF0_( 2, 0 ) = precomputedF0_( 0, 2 );
-        precomputedF0_( 2, 1 ) = precomputedF0_( 1, 2 );
-        precomputedF1_ = precomputedF1_ / static_cast < T > ( points.size() );
-        precomputedF2_ = precomputedF2_ / static_cast < T > ( points.size() );
-    }
+    void updatePrecomputeParams( const std::vector <MR::Vector3<T>>& points, Vector3<T>& average );
 
     // Core minimization function.
     // Functional that needs to be minimized to obtain the optimal value of W (i.e. the cylinder axis)
     // General definition is formula 94, but for speed up we use formula 99.
     // https://www.geometrictools.com/Documentation/LeastSquaresFitting.pdf
-    T G( const Eigen::Vector<T, 3>& W, Eigen::Vector<T, 3>& PC, T& rsqr ) const
-    {
-        Eigen::Matrix<T, 3, 3> P = Eigen::Matrix<T, 3, 3>::Identity() - ( W * W.transpose() ); // P = I - W * W^T
+    T G( const Eigen::Vector<T, 3>& W, Eigen::Vector<T, 3>& PC, T& rsqr ) const;
 
-        Eigen::Matrix<T, 3, 3> S;
-        S << 0, -W[2], W[1],
-            W[2], 0, -W[0],
-            -W[1], W[0], 0;
-
-        Eigen::Matrix<T, 3, 3> A = P * precomputedF0_ * P;
-        Eigen::Matrix<T, 3, 3> hatA = -( S * A * S );
-        Eigen::Matrix<T, 3, 3> hatAA = hatA * A;
-        T trace = hatAA.trace();
-        if ( trace == 0 )
-        {
-            // cannot divide on zero, return maximum error
-            PC.setZero();
-            return std::numeric_limits<T>::max();
-        }
-        Eigen::Matrix<T, 3, 3> Q = hatA / trace;
-        Eigen::Vector<T, 6> pVec{ P( 0, 0 ), P( 0, 1 ), P( 0, 2 ), P( 1, 1 ), P( 1, 2 ), P( 2, 2 ) };
-        Eigen::Vector<T, 3> alpha = precomputedF1_ * pVec;
-        Eigen::Vector<T, 3> beta = Q * alpha;
-        T error = ( pVec.dot( precomputedF2_ * pVec ) - 4 * alpha.dot( beta ) + 4 * beta.dot( precomputedF0_ * beta ) ) / static_cast< T >( normalizedPoints_.size() );
-
-        // some times appears floating points calculation errors. Error is a non negative value by default, so, make it positive.
-        // absolute value (instead of error=0) is used to avoid collisions for near-null values and subsequent ambiguous work, since this code can be used in parallel algorithms
-        if ( error < 0 )
-            error = std::abs( error );
-
-        PC = beta;
-        rsqr = std::max( T(0), pVec.dot( precomputedMu_ ) + beta.dot( beta ) ); // the value can slightly below zero due to rounding-errors
-
-        return error;
-    }
-
-    T fitCylindeHemisphereSingleThreaded( Eigen::Vector<T, 3>& PC, Eigen::Vector<T, 3>& W, T& resultedRootSquare ) const
-    {
-        T const theraStep = static_cast< T >( 2 * PI ) / thetaResolution_;
-        T const phiStep = static_cast< T >( PI2 ) / phiResolution_;
-
-        // problem in list. 16. => start from pole.
-        W = { 0, 0, 1 };
-        T minError = G( W, PC, resultedRootSquare );
-
-        for ( size_t j = 1; j <= phiResolution_; ++j )
-        {
-            T phi = phiStep * j; //  [0 .. pi/2]
-            T cosPhi = std::cos( phi );
-            T sinPhi = std::sin( phi );
-            for ( size_t i = 0; i < thetaResolution_; ++i )
-            {
-                T theta = theraStep * i; //  [0 .. 2*pi)
-                T cosTheta = std::cos( theta );
-                T sinTheta = std::sin( theta );
-                Eigen::Vector<T, 3> currW{ cosTheta * sinPhi, sinTheta * sinPhi, cosPhi };
-                Eigen::Vector<T, 3> currPC{};
-                T rsqr;
-                T error = G( currW, currPC, rsqr );
-                if ( error < minError )
-                {
-                    minError = error;
-                    resultedRootSquare = rsqr;
-                    W = currW;
-                    PC = currPC;
-                }
-            }
-        }
-
-        return minError;
-    }
+    T fitCylindeHemisphereSingleThreaded( Eigen::Vector<T, 3>& PC, Eigen::Vector<T, 3>& W, T& resultedRootSquare ) const;
 
     class BestHemisphereStoredData
     {
@@ -343,69 +99,12 @@ private:
         Eigen::Vector<T, 3> PC;
     };
 
-    T fitCylindeHemisphereMultiThreaded( Eigen::Vector<T, 3>& PC, Eigen::Vector<T, 3>& W, T& resultedRootSquare ) const
-    {
-        T const theraStep = static_cast< T >( 2 * PI ) / thetaResolution_;
-        T const phiStep = static_cast< T >( PI2 ) / phiResolution_;
+    T fitCylindeHemisphereMultiThreaded( Eigen::Vector<T, 3>& PC, Eigen::Vector<T, 3>& W, T& resultedRootSquare ) const;
 
-        // problem in list. 16. => start from pole.
-        W = { 0, 0, 1 };
-        T minError = G( W, PC, resultedRootSquare );
-
-        std::vector<BestHemisphereStoredData> storedData;
-        storedData.resize( phiResolution_ + 1 ); //  [0 .. pi/2] +1 for include upper bound
-
-        tbb::parallel_for( tbb::blocked_range<size_t>( size_t( 0 ), phiResolution_ + 1 ),
-                           [&] ( const tbb::blocked_range<size_t>& range )
-        {
-            for ( size_t j = range.begin(); j < range.end(); ++j )
-            {
-
-                T phi = phiStep * j; // [0 .. pi/2]
-                T cosPhi = std::cos( phi );
-                T sinPhi = std::sin( phi );
-                for ( size_t i = 0; i < thetaResolution_; ++i )
-                {
-
-                    T theta = theraStep * i; // [0 .. 2*pi)
-                    T cosTheta = std::cos( theta );
-                    T sinTheta = std::sin( theta );
-                    Eigen::Vector<T, 3> currW{ cosTheta * sinPhi, sinTheta * sinPhi, cosPhi };
-                    Eigen::Vector<T, 3> currPC{};
-                    T rsqr;
-                    T error = G( currW, currPC, rsqr );
-
-                    if ( error < storedData[j].error )
-                    {
-                        storedData[j].error = error;
-                        storedData[j].rootSquare = rsqr;
-                        storedData[j].W = currW;
-                        storedData[j].PC = currPC;
-                    }
-                }
-            }
-        }
-        );
-
-        for ( size_t i = 0; i <= phiResolution_; ++i )
-        {
-            if ( storedData[i].error < minError )
-            {
-                minError = storedData[i].error;
-                resultedRootSquare = storedData[i].rootSquare;
-                W = storedData[i].W;
-                PC = storedData[i].PC;
-            }
-        }
-
-        return minError;
-    };
-
-    T SpecificAxisFit( Eigen::Vector<T, 3>& PC, Eigen::Vector<T, 3>& W, T& resultedRootSquare )
-    {
-        W = baseCylinderAxis_;
-        return G( W, PC, resultedRootSquare );
-    };
+    T SpecificAxisFit( Eigen::Vector<T, 3>& PC, Eigen::Vector<T, 3>& W, T& resultedRootSquare );
 };
+
+extern template class MRMESH_API Cylinder3Approximation<float>;
+extern template class MRMESH_API Cylinder3Approximation<double>;
 
 }

--- a/source/MRMesh/MRCylinderObject.cpp
+++ b/source/MRMesh/MRCylinderObject.cpp
@@ -2,6 +2,7 @@
 #include "MRCylinderObject.h"
 #include "MRMatrix3.h"
 #include "MRCylinder.h"
+#include "MRCylinder3.h"
 #include "MRMesh.h"
 #include "MRObjectFactory.h"
 #include "MRPch/MRJson.h"
@@ -169,79 +170,6 @@ FeatureObjectProjectPointResult CylinderObject::projectPoint( const Vector3f& po
     Vector3f projection = K + normal * radius;
 
     return FeatureObjectProjectPointResult{ projection + center, normal };
-}
-
-TEST( MRMesh, CylinderApproximation )
-{
-    float originalRadius = 1.5f;
-    float originalLength = 10.0f;
-    float startAngle = 0.0f;
-    float archSize = PI_F / 1.5f;
-    int  resolution = 100;
-
-    AffineXf3f testXf;
-    Vector3f center{ 1,2,3 };
-    Vector3f direction = ( Vector3f{ 3,2,1 } ).normalized();
-
-    testXf = AffineXf3f::translation( { 1,2,3 } );
-    testXf.A = Matrix3f::rotation( Vector3f::plusZ(), direction ) * Matrix3f::scale( { originalRadius , originalRadius  ,originalLength } );
-
-    std::vector<Vector3f> points;
-
-    float angleStep = archSize / resolution;
-    float zStep = 1.0f / resolution;
-    for ( int i = 0; i < resolution; ++i )
-    {
-        float angle = startAngle + i * angleStep;
-        float z = i * zStep - 0.5f;
-        points.emplace_back( testXf( Vector3f{ cosf( angle )  , sinf( angle ) , z } ) );
-        points.emplace_back( testXf( Vector3f{ cosf( angle )  , sinf( angle ) ,  -z } ) );
-    }
-
-    /////////////////////////////
-    // General multithread test
-    /////////////////////////////
-
-    Cylinder3<float> result;
-    auto fit = Cylinder3Approximation<float>();
-    auto approximationRMS = fit.solveGeneral( points, result, phiResolution, thetaResolution, true );
-    std::cout << "multi thread center: " << result.center() << " direction:" << result.direction() << " length:" << result.length << " radius:" << result.radius << " error:" << approximationRMS << std::endl;
-
-    EXPECT_LE( approximationRMS, 0.1f );
-    EXPECT_NEAR( result.radius, originalRadius, 0.1f );
-    EXPECT_NEAR( result.length, originalLength, 0.1f );
-    EXPECT_LE( ( result.center() - center ).length(), 0.1f );
-    EXPECT_GT( dot( direction, result.direction() ), 0.9f );
-
-    ///////////////////////////////////////
-    // Compare single thread vs multithread
-    ///////////////////////////////////////
-
-    Cylinder3<float> resultST;
-    auto approximationRMS_ST = fit.solveGeneral( points, resultST, phiResolution, thetaResolution, false );
-    std::cout << "single thread center: " << result.center() << " direction:" << result.direction() << " length:" << result.length << " radius:" << result.radius << " error:" << approximationRMS << std::endl;
-
-    EXPECT_NEAR( approximationRMS, approximationRMS_ST, 0.01f );
-    EXPECT_NEAR( result.radius, resultST.radius, 0.01f );
-    EXPECT_NEAR( result.length, resultST.length, 0.01f );
-    EXPECT_LE( ( result.center() - resultST.center() ).length(), 0.01f );
-    EXPECT_GT( dot( resultST.direction(), result.direction() ), 0.99f );
-
-    //////////////////////////////////////////
-    // Test usage with SpecificAxisFit (SAF)
-    //////////////////////////////////////////
-
-    Cylinder3<float> resultSAF;
-    Vector3f noice{ 0.002f , -0.003f , 0.01f };
-
-    auto approximationRMS_SAF = fit.solveSpecificAxis( points, resultSAF, direction + noice );
-    std::cout << "SpecificAxisFit center: " << resultSAF.center() << " direction:" << resultSAF.direction() << " length:" << resultSAF.length << " radius:" << resultSAF.radius << " error:" << approximationRMS_SAF << std::endl;
-
-    EXPECT_LE( approximationRMS_SAF, 0.1f );
-    EXPECT_NEAR( resultSAF.radius, originalRadius, 0.1f );
-    EXPECT_NEAR( resultSAF.length, originalLength, 0.1f );
-    EXPECT_LE( ( resultSAF.center() - center ).length(), 0.1f );
-    EXPECT_GT( dot( direction, resultSAF.direction() ), 0.9f );
 }
 
 } // namespace MR

--- a/source/MRMesh/MRLog.cpp
+++ b/source/MRMesh/MRLog.cpp
@@ -12,36 +12,6 @@ Logger& Logger::instance()
     return theLogger;
 }
 
-void Logger::trace( std::string_view msg )
-{
-    instance().logger_->trace( msg );
-}
-
-void Logger::debug( std::string_view msg )
-{
-    instance().logger_->debug( msg );
-}
-
-void Logger::info( std::string_view msg )
-{
-    instance().logger_->info( msg );
-}
-
-void Logger::warn( std::string_view msg )
-{
-    instance().logger_->warn( msg );
-}
-
-void Logger::error( std::string_view msg )
-{
-    instance().logger_->error( msg );
-}
-
-void Logger::critical( std::string_view msg )
-{
-    instance().logger_->critical( msg );
-}
-
 const std::shared_ptr<spdlog::logger>& Logger::getSpdLogger() const
 {
     return logger_;

--- a/source/MRMesh/MRLog.h
+++ b/source/MRMesh/MRLog.h
@@ -24,15 +24,6 @@ class MR_BIND_IGNORE Logger
 public:
     MRMESH_API static Logger& instance();
 
-    /// simple methods to log messages
-    /// for more optimal methods use getSpdLogger()
-    MRMESH_API static void trace( std::string_view msg );
-    MRMESH_API static void debug( std::string_view msg );
-    MRMESH_API static void info( std::string_view msg );
-    MRMESH_API static void warn( std::string_view msg );
-    MRMESH_API static void error( std::string_view msg );
-    MRMESH_API static void critical( std::string_view msg );
-
     /// store this pointer if need to prolong logger life time (necessary to log something from destructors)
     MRMESH_API const std::shared_ptr<spdlog::logger>& getSpdLogger() const;
 

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -710,6 +710,7 @@
     <ClCompile Include="MROffsetVerts.cpp" />
     <ClCompile Include="MRTripleFaceIntersections.cpp" />
     <ClCompile Include="MREndMill.cpp" />
+    <ClCompile Include="MRCylinderApproximator.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MRPch\MRPch.vcxproj">

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -2189,6 +2189,9 @@
     <ClCompile Include="MREndMill.cpp">
       <Filter>Source Files\Gcode</Filter>
     </ClCompile>
+    <ClCompile Include="MRCylinderApproximator.cpp">
+      <Filter>Source Files\Math</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />

--- a/source/MRTest/MRCylinderApproximation.cpp
+++ b/source/MRTest/MRCylinderApproximation.cpp
@@ -1,0 +1,90 @@
+#include "MRMesh/MRCylinder3.h"
+#include "MRMesh/MRCylinderApproximator.h"
+
+#include "MRMesh/MRGTest.h"
+
+namespace
+{
+
+constexpr int phiResolution = 180;
+constexpr int thetaResolution = 180;
+
+} // namespace
+
+namespace MR
+{
+
+TEST( MRMesh, CylinderApproximation )
+{
+    float originalRadius = 1.5f;
+    float originalLength = 10.0f;
+    float startAngle = 0.0f;
+    float archSize = PI_F / 1.5f;
+    int  resolution = 100;
+
+    AffineXf3f testXf;
+    Vector3f center{ 1,2,3 };
+    Vector3f direction = ( Vector3f{ 3,2,1 } ).normalized();
+
+    testXf = AffineXf3f::translation( { 1,2,3 } );
+    testXf.A = Matrix3f::rotation( Vector3f::plusZ(), direction ) * Matrix3f::scale( { originalRadius , originalRadius  ,originalLength } );
+
+    std::vector<Vector3f> points;
+
+    float angleStep = archSize / resolution;
+    float zStep = 1.0f / resolution;
+    for ( int i = 0; i < resolution; ++i )
+    {
+        float angle = startAngle + i * angleStep;
+        float z = i * zStep - 0.5f;
+        points.emplace_back( testXf( Vector3f{ cosf( angle )  , sinf( angle ) , z } ) );
+        points.emplace_back( testXf( Vector3f{ cosf( angle )  , sinf( angle ) ,  -z } ) );
+    }
+
+    /////////////////////////////
+    // General multithread test
+    /////////////////////////////
+
+    Cylinder3<float> result;
+    auto fit = Cylinder3Approximation<float>();
+    auto approximationRMS = fit.solveGeneral( points, result, phiResolution, thetaResolution, true );
+    std::cout << "multi thread center: " << result.center() << " direction:" << result.direction() << " length:" << result.length << " radius:" << result.radius << " error:" << approximationRMS << std::endl;
+
+    EXPECT_LE( approximationRMS, 0.1f );
+    EXPECT_NEAR( result.radius, originalRadius, 0.1f );
+    EXPECT_NEAR( result.length, originalLength, 0.1f );
+    EXPECT_LE( ( result.center() - center ).length(), 0.1f );
+    EXPECT_GT( dot( direction, result.direction() ), 0.9f );
+
+    ///////////////////////////////////////
+    // Compare single thread vs multithread
+    ///////////////////////////////////////
+
+    Cylinder3<float> resultST;
+    auto approximationRMS_ST = fit.solveGeneral( points, resultST, phiResolution, thetaResolution, false );
+    std::cout << "single thread center: " << result.center() << " direction:" << result.direction() << " length:" << result.length << " radius:" << result.radius << " error:" << approximationRMS << std::endl;
+
+    EXPECT_NEAR( approximationRMS, approximationRMS_ST, 0.01f );
+    EXPECT_NEAR( result.radius, resultST.radius, 0.01f );
+    EXPECT_NEAR( result.length, resultST.length, 0.01f );
+    EXPECT_LE( ( result.center() - resultST.center() ).length(), 0.01f );
+    EXPECT_GT( dot( resultST.direction(), result.direction() ), 0.99f );
+
+    //////////////////////////////////////////
+    // Test usage with SpecificAxisFit (SAF)
+    //////////////////////////////////////////
+
+    Cylinder3<float> resultSAF;
+    Vector3f noice{ 0.002f , -0.003f , 0.01f };
+
+    auto approximationRMS_SAF = fit.solveSpecificAxis( points, resultSAF, direction + noice );
+    std::cout << "SpecificAxisFit center: " << resultSAF.center() << " direction:" << resultSAF.direction() << " length:" << resultSAF.length << " radius:" << resultSAF.radius << " error:" << approximationRMS_SAF << std::endl;
+
+    EXPECT_LE( approximationRMS_SAF, 0.1f );
+    EXPECT_NEAR( resultSAF.radius, originalRadius, 0.1f );
+    EXPECT_NEAR( resultSAF.length, originalLength, 0.1f );
+    EXPECT_LE( ( resultSAF.center() - center ).length(), 0.1f );
+    EXPECT_GT( dot( direction, resultSAF.direction() ), 0.9f );
+}
+
+} // namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -46,6 +46,7 @@
     <ClCompile Include="MRZlib.cpp" />
     <ClCompile Include="MRProgressCallback.cpp" />
     <ClCompile Include="MRConvexHull.cpp" />
+    <ClCompile Include="MRCylinderApproximation.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\thirdparty\pybind11nonlimitedapi_stubs.vcxproj">

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -112,6 +112,9 @@
     <ClCompile Include="MRPrecisePredicatesTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRCylinderApproximation.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />


### PR DESCRIPTION
- Remove obsolete Logger methods.
- Move cylinder approximation test to MRTest to check the extern template visibility.