### PR TITLE
Topology::lastNotLoneUndirectedEdge function

### DIFF
--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -88,10 +88,10 @@ bool MeshTopology::isLoneEdge( EdgeId a ) const
     return true;
 }
 
-EdgeId MeshTopology::lastNotLoneEdge() const
+UndirectedEdgeId MeshTopology::lastNotLoneUndirectedEdge() const
 {
     assert( edges_.size() % 2 == 0 );
-    for ( EdgeId i{ (int)edges_.size() - 1 }; i.valid(); ----i ) // one decrement returns sym-edge
+    for ( UndirectedEdgeId i{ (int)undirectedEdgeSize() - 1 }; i.valid(); --i )
     {
         if ( !isLoneEdge( i ) )
             return i;

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -23,8 +23,11 @@ public:
     /// checks whether the edge is disconnected from all other edges and disassociated from all vertices and faces (as if after makeEdge)
     [[nodiscard]] MRMESH_API bool isLoneEdge( EdgeId a ) const;
 
+    /// returns last not lone undirected edge id, or invalid id if no such edge exists
+    [[nodiscard]] MRMESH_API UndirectedEdgeId lastNotLoneUndirectedEdge() const;
+
     /// returns last not lone edge id, or invalid id if no such edge exists
-    [[nodiscard]] MRMESH_API EdgeId lastNotLoneEdge() const;
+    [[nodiscard]] EdgeId lastNotLoneEdge() const { auto ue = lastNotLoneUndirectedEdge(); return ue ? EdgeId( ue ) + 1 : EdgeId(); }
 
     /// remove all lone edges from given set
     MRMESH_API void excludeLoneEdges( UndirectedEdgeBitSet & edges ) const;

--- a/source/MRMesh/MRPolylineComponents.cpp
+++ b/source/MRMesh/MRPolylineComponents.cpp
@@ -86,7 +86,7 @@ std::pair<std::vector<UndirectedEdgeBitSet>, int> getAllComponents( const Polyli
     MR_TIMER;
     auto unionFindStruct = getUnionFindStructure( topology );
     const auto& allRoots = unionFindStruct.roots();
-    UndirectedEdgeBitSet region( topology.lastNotLoneEdge() + 1 );
+    UndirectedEdgeBitSet region( topology.lastNotLoneUndirectedEdge() + 1 );
     for ( auto e : undirectedEdges( topology ) )
         region.set( e );
     auto [uniqueRootsMap, componentsCount] = getUniqueRootIds( allRoots, region );
@@ -146,7 +146,7 @@ UndirectedEdgeBitSet getLargestComponent( const Polyline<V>& polyline )
     auto& topology = polyline.topology;
     auto unionFindStruct = getUnionFindStructure( topology );
 
-    UndirectedEdgeBitSet region( topology.lastNotLoneEdge() + 1 );
+    UndirectedEdgeBitSet region( topology.lastNotLoneUndirectedEdge() + 1 );
     for ( auto e : undirectedEdges( topology ) )
         region.set( e );
 
@@ -168,7 +168,7 @@ UndirectedEdgeBitSet getLargestComponent( const Polyline<V>& polyline )
         }
     }
 
-    UndirectedEdgeBitSet maxLengthComponent( topology.lastNotLoneEdge() + 1 );
+    UndirectedEdgeBitSet maxLengthComponent( topology.lastNotLoneUndirectedEdge() + 1 );
     for ( auto e : region )
     {
         auto index = uniqueRootsMap[e];

--- a/source/MRMesh/MRPolylineTopology.cpp
+++ b/source/MRMesh/MRPolylineTopology.cpp
@@ -160,10 +160,10 @@ bool PolylineTopology::isLoneEdge( EdgeId a ) const
     return true;
 }
 
-EdgeId PolylineTopology::lastNotLoneEdge() const
+UndirectedEdgeId PolylineTopology::lastNotLoneUndirectedEdge() const
 {
     assert( edges_.size() % 2 == 0 );
-    for ( EdgeId i{ (int)edges_.size() - 1 }; i.valid(); ----i ) // one decrement returns sym-edge
+    for ( UndirectedEdgeId i{ (int)undirectedEdgeSize() - 1 }; i.valid(); --i )
     {
         if ( !isLoneEdge( i ) )
             return i;

--- a/source/MRMesh/MRPolylineTopology.h
+++ b/source/MRMesh/MRPolylineTopology.h
@@ -48,8 +48,11 @@ public:
     /// checks whether the edge is disconnected from all other edges and disassociated from all vertices (as if after makeEdge)
     [[nodiscard]] MRMESH_API bool isLoneEdge( EdgeId a ) const;
 
+    /// returns last not lone undirected edge id, or invalid id if no such edge exists
+    [[nodiscard]] MRMESH_API UndirectedEdgeId lastNotLoneUndirectedEdge() const;
+
     /// returns last not lone edge id, or invalid id if no such edge exists
-    [[nodiscard]] MRMESH_API EdgeId lastNotLoneEdge() const;
+    [[nodiscard]] EdgeId lastNotLoneEdge() const { auto ue = lastNotLoneUndirectedEdge(); return ue ? EdgeId( ue ) + 1 : EdgeId(); }
 
     /// returns the number of half-edge records including lone ones
     [[nodiscard]] size_t edgeSize() const { return edges_.size(); }

--- a/source/MRMesh/MRPolylineTrimWithPlane.cpp
+++ b/source/MRMesh/MRPolylineTrimWithPlane.cpp
@@ -33,7 +33,7 @@ UndirectedEdgeBitSet subdividePolylineWithPlane( Polyline3& polyline, const Plan
 
 std::vector<VertPair> findSegmentEndVertices( const Polyline3& polyline, const EdgeBitSet& orgEdges )
 {
-    const size_t numEdges = polyline.topology.lastNotLoneEdge().undirected() + 1;
+    const size_t numEdges = polyline.topology.lastNotLoneUndirectedEdge() + 1;
     UndirectedEdgeBitSet visited( numEdges );
 
     std::vector<VertPair> result;
@@ -100,7 +100,7 @@ void trimWithPlane( Polyline3& polyline, const Plane3f& plane, const DividePolyl
 
     if ( params.otherPart )
     {
-        const size_t numEdges = polyline.topology.lastNotLoneEdge().undirected() + 1;
+        const size_t numEdges = polyline.topology.lastNotLoneUndirectedEdge() + 1;
         UndirectedEdgeBitSet otherPartEdges( numEdges );
         for ( auto ue : undirectedEdges( polyline.topology ) )
         {


### PR DESCRIPTION
* Introduce new `MeshTopology::lastNotLoneUndirectedEdge` and `PolylineTopology::lastNotLoneUndirectedEdge` functions
* Implement existing `MeshTopology::lastNotLoneEdge` and `PolylineTopology::lastNotLoneEdge` functions via new ones
* Fix incorrect usage of `lastNotLoneEdge` functions