### PR TITLE
SaveSettings: renaming of two fields for more clarity

### DIFF
--- a/source/MRIOExtras/MRCtm.cpp
+++ b/source/MRIOExtras/MRCtm.cpp
@@ -243,7 +243,7 @@ Expected<void> toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOption
         ctmVertexPrecision( context, options.vertexPrecision );
         break;
     }
-    ctmRearrangeTriangles( context, options.rearrangeTriangles ? 1 : 0 );
+    ctmRearrangeTriangles( context, options.packPrimitives ? 1 : 0 );
     ctmCompressionLevel( context, options.compressionLevel );
 
     const VertRenumber vertRenumber( mesh.topology.getValidVerts(), options.onlyValidPoints );
@@ -252,7 +252,7 @@ Expected<void> toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOption
 
     std::vector<CTMuint> aIndices;
     const auto fLast = mesh.topology.lastValidFace();
-    const auto numSaveFaces = options.rearrangeTriangles ? mesh.topology.numValidFaces() : int( fLast + 1 );
+    const auto numSaveFaces = options.packPrimitives ? mesh.topology.numValidFaces() : int( fLast + 1 );
     aIndices.reserve( numSaveFaces * 3 );
     for ( FaceId f{0}; f <= fLast; ++f )
     {
@@ -263,7 +263,7 @@ Expected<void> toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOption
             for ( int i = 0; i < 3; ++i )
                 aIndices.push_back( vertRenumber( v[i] ) );
         }
-        else if ( !options.rearrangeTriangles )
+        else if ( !options.packPrimitives )
         {
             for ( int i = 0; i < 3; ++i )
                 aIndices.push_back( 0 );

--- a/source/MRIOExtras/MRCtm.cpp
+++ b/source/MRIOExtras/MRCtm.cpp
@@ -246,7 +246,7 @@ Expected<void> toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOption
     ctmRearrangeTriangles( context, options.rearrangeTriangles ? 1 : 0 );
     ctmCompressionLevel( context, options.compressionLevel );
 
-    const VertRenumber vertRenumber( mesh.topology.getValidVerts(), options.saveValidOnly );
+    const VertRenumber vertRenumber( mesh.topology.getValidVerts(), options.onlyValidPoints );
     const int numPoints = vertRenumber.sizeVerts();
     const VertId lastVertId = mesh.topology.lastValidVert();
 
@@ -284,7 +284,7 @@ Expected<void> toCtm( const Mesh & mesh, std::ostream & out, const CtmSaveOption
         colors4f.reserve( aVertexCount );
         for ( VertId i{ 0 }; i <= lastVertId; ++i )
         {
-            if ( options.saveValidOnly && !mesh.topology.hasVert( i ) )
+            if ( options.onlyValidPoints && !mesh.topology.hasVert( i ) )
                 continue;
             colors4f.push_back( Vector4f( ( *options.colors )[i] ) );
         }
@@ -422,8 +422,8 @@ Expected<void> toCtm( const PointCloud& cloud, std::ostream& out, const CtmSaveP
 {
     MR_TIMER;
 
-    if ( (  options.saveValidOnly && !cloud.validPoints.any() ) ||
-         ( !options.saveValidOnly && cloud.points.empty() ) )
+    if ( (  options.onlyValidPoints && !cloud.validPoints.any() ) ||
+         ( !options.onlyValidPoints && cloud.points.empty() ) )
         return unexpected( "Cannot save empty point cloud in CTM format" );
     // the only fake triangle with point #0 in all 3 vertices
     std::vector<CTMuint> aIndices{ 0,0,0 };
@@ -436,14 +436,14 @@ Expected<void> toCtm( const PointCloud& cloud, std::ostream& out, const CtmSaveP
     ctmCompressionLevel( context, options.compressionLevel );
 
     const bool saveNormals = cloud.hasNormals();
-    CTMuint aVertexCount = CTMuint( options.saveValidOnly ? cloud.validPoints.count() : cloud.points.size() );
+    CTMuint aVertexCount = CTMuint( options.onlyValidPoints ? cloud.validPoints.count() : cloud.points.size() );
 
     VertCoords points;
     VertNormals normals;
     NormalXfMatrix normXf( options.xf );
-    if ( options.saveValidOnly || options.xf )
+    if ( options.onlyValidPoints || options.xf )
     {
-        if ( options.saveValidOnly )
+        if ( options.onlyValidPoints )
         {
             points.reserve( aVertexCount );
             for ( auto v : cloud.validPoints )
@@ -457,7 +457,7 @@ Expected<void> toCtm( const PointCloud& cloud, std::ostream& out, const CtmSaveP
 
         if ( saveNormals )
         {
-            if ( options.saveValidOnly )
+            if ( options.onlyValidPoints )
             {
                 normals.reserve( aVertexCount );
                 for ( auto v : cloud.validPoints )
@@ -487,7 +487,7 @@ Expected<void> toCtm( const PointCloud& cloud, std::ostream& out, const CtmSaveP
         colors4f.reserve( aVertexCount );
         for ( auto v = 0_v; v < cloud.points.size(); ++v )
         {
-            if ( options.saveValidOnly && !cloud.validPoints.test( v ) )
+            if ( options.onlyValidPoints && !cloud.validPoints.test( v ) )
                 continue;
             colors4f.push_back( Vector4f{ ( *options.colors )[v] } );
         }

--- a/source/MRMesh/MRLinesSave.h
+++ b/source/MRMesh/MRLinesSave.h
@@ -17,17 +17,17 @@ namespace LinesSave
 /// \{
 
 /// saves in .mrlines file;
-/// SaveSettings::saveValidOnly = true is ignored
+/// SaveSettings::onlyValidPoints = true is ignored
 MRMESH_API Expected<void> toMrLines( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings = {} );
 MRMESH_API Expected<void> toMrLines( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings = {} );
 
 /// saves in .pts file;
-/// SaveSettings::saveValidOnly = false is ignored
+/// SaveSettings::onlyValidPoints = false is ignored
 MRMESH_API Expected<void> toPts( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings = {} );
 MRMESH_API Expected<void> toPts( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings = {} );
 
 /// saves in .dxf file;
-/// SaveSettings::saveValidOnly = false is ignored
+/// SaveSettings::onlyValidPoints = false is ignored
 MRMESH_API Expected<void> toDxf( const Polyline3& polyline, const std::filesystem::path& file, const SaveSettings & settings = {} );
 MRMESH_API Expected<void> toDxf( const Polyline3& polyline, std::ostream& out, const SaveSettings & settings = {} );
 

--- a/source/MRMesh/MRMeshSave.cpp
+++ b/source/MRMesh/MRMeshSave.cpp
@@ -60,7 +60,7 @@ Expected<void> toOff( const Mesh& mesh, std::ostream& out, const SaveSettings & 
 {
     MR_TIMER;
 
-    const VertRenumber vertRenumber( mesh.topology.getValidVerts(), settings.saveValidOnly );
+    const VertRenumber vertRenumber( mesh.topology.getValidVerts(), settings.onlyValidPoints );
     const int numPoints = vertRenumber.sizeVerts();
     const VertId lastVertId = mesh.topology.lastValidVert();
     const int numPolygons = mesh.topology.numValidFaces();
@@ -69,7 +69,7 @@ Expected<void> toOff( const Mesh& mesh, std::ostream& out, const SaveSettings & 
     int numSaved = 0;
     for ( VertId i{ 0 }; i <= lastVertId; ++i )
     {
-        if ( settings.saveValidOnly && !mesh.topology.hasVert( i ) )
+        if ( settings.onlyValidPoints && !mesh.topology.hasVert( i ) )
             continue;
         auto saveVertex = [&]( auto && p )
         {
@@ -143,7 +143,7 @@ Expected<void> toObj( const Mesh & mesh, std::ostream & out, const SaveSettings 
     if ( settings.uvMap )
         out << fmt::format( "mtllib {}.mtl\n", settings.materialName );
 
-    const VertRenumber vertRenumber( mesh.topology.getValidVerts(), settings.saveValidOnly );
+    const VertRenumber vertRenumber( mesh.topology.getValidVerts(), settings.onlyValidPoints );
     const int numPoints = vertRenumber.sizeVerts();
     const VertId lastVertId = mesh.topology.lastValidVert();
 
@@ -151,7 +151,7 @@ Expected<void> toObj( const Mesh & mesh, std::ostream & out, const SaveSettings 
     auto sb = subprogress( settings.progress, 0.0f, settings.uvMap ? 0.35f : 0.5f );
     for ( VertId i{ 0 }; i <= lastVertId; ++i )
     {
-        if ( settings.saveValidOnly && !mesh.topology.hasVert( i ) )
+        if ( settings.onlyValidPoints && !mesh.topology.hasVert( i ) )
             continue;
 
         auto saveVertex = [&]( auto && p )
@@ -181,7 +181,7 @@ Expected<void> toObj( const Mesh & mesh, std::ostream & out, const SaveSettings 
         sb = subprogress( settings.progress, 0.35f, 0.7f );
         for ( VertId i{ 0 }; i <= lastVertId; ++i )
         {
-            if ( settings.saveValidOnly && !mesh.topology.hasVert( i ) )
+            if ( settings.onlyValidPoints && !mesh.topology.hasVert( i ) )
                 continue;
             const auto& uv = ( *settings.uvMap )[i];
             out << fmt::format( "vt {} {}\n", uv.x, uv.y );
@@ -372,7 +372,7 @@ Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings 
 {
     MR_TIMER;
 
-    const VertRenumber vertRenumber( mesh.topology.getValidVerts(), settings.saveValidOnly );
+    const VertRenumber vertRenumber( mesh.topology.getValidVerts(), settings.onlyValidPoints );
     const int numPoints = vertRenumber.sizeVerts();
     const VertId lastVertId = mesh.topology.lastValidVert();
     const bool saveColors = settings.colors && settings.colors->size() > lastVertId;
@@ -399,7 +399,7 @@ Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings 
     int numSaved = 0;
     for ( VertId i{ 0 }; i <= lastVertId; ++i )
     {
-        if ( settings.saveValidOnly && !mesh.topology.hasVert( i ) )
+        if ( settings.onlyValidPoints && !mesh.topology.hasVert( i ) )
             continue;
         const Vector3f p = applyFloat( settings.xf, mesh.points[i] );
         out.write( ( const char* )&p, 12 );

--- a/source/MRMesh/MRMeshSave.cpp
+++ b/source/MRMesh/MRMeshSave.cpp
@@ -383,7 +383,7 @@ Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings 
         out << "property uchar red\nproperty uchar green\nproperty uchar blue\n";
 
     const auto fLast = mesh.topology.lastValidFace();
-    const auto numSaveFaces = settings.rearrangeTriangles ? mesh.topology.numValidFaces() : int( fLast + 1 );
+    const auto numSaveFaces = settings.packPrimitives ? mesh.topology.numValidFaces() : int( fLast + 1 );
     out <<  "element face " << numSaveFaces << "\nproperty list uchar int vertex_indices\nend_header\n";
 
     static_assert( sizeof( Vector3f ) == 12, "wrong size of Vector3f" );
@@ -435,7 +435,7 @@ Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings 
             for ( int i = 0; i < 3; ++i )
                 tri.v[i] = vertRenumber( vs[i] );
         }
-        else if ( !settings.rearrangeTriangles )
+        else if ( !settings.packPrimitives )
             tri.v[0] = tri.v[1] = tri.v[2] = 0;
         else
             continue;

--- a/source/MRMesh/MRMeshSave.h
+++ b/source/MRMesh/MRMeshSave.h
@@ -18,7 +18,7 @@ namespace MeshSave
 /// \{
 
 /// saves in internal file format;
-/// SaveSettings::saveValidOnly = true is ignored
+/// SaveSettings::onlyValidPoints = true is ignored
 MRMESH_API Expected<void> toMrmesh( const Mesh & mesh, const std::filesystem::path & file,
                                                      const SaveSettings & settings = {} );
 MRMESH_API Expected<void> toMrmesh( const Mesh & mesh, std::ostream & out,
@@ -40,12 +40,12 @@ MRMESH_API Expected<void> toObj( const Mesh & mesh, const std::filesystem::path 
 MRMESH_API Expected<void> toObj( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
 
 /// saves in binary .stl file;
-/// SaveSettings::saveValidOnly = false is ignored
+/// SaveSettings::onlyValidPoints = false is ignored
 MRMESH_API Expected<void> toBinaryStl( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings = {} );
 MRMESH_API Expected<void> toBinaryStl( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
 
 /// saves in textual .stl file;
-/// SaveSettings::saveValidOnly = false is ignored
+/// SaveSettings::onlyValidPoints = false is ignored
 MRMESH_API Expected<void> toAsciiStl( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings & settings = {} );
 MRMESH_API Expected<void> toAsciiStl( const Mesh& mesh, std::ostream& out, const SaveSettings & settings = {} );
 

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -56,7 +56,7 @@ Expected<std::future<Expected<void>>> ObjectMeshHolder::serializeModel_( const s
 
     SaveSettings saveSettings;
     saveSettings.onlyValidPoints = false;
-    saveSettings.rearrangeTriangles = false;
+    saveSettings.packPrimitives = false;
     if ( !data_.vertColors.empty() )
         saveSettings.colors = &data_.vertColors;
     auto save = [mesh = data_.mesh, serializeFormat = serializeFormat_ ? serializeFormat_ : defaultSerializeMeshFormat(), path, saveSettings]()

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -55,7 +55,7 @@ Expected<std::future<Expected<void>>> ObjectMeshHolder::serializeModel_( const s
         return {};
 
     SaveSettings saveSettings;
-    saveSettings.saveValidOnly = false;
+    saveSettings.onlyValidPoints = false;
     saveSettings.rearrangeTriangles = false;
     if ( !data_.vertColors.empty() )
         saveSettings.colors = &data_.vertColors;

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -280,7 +280,7 @@ Expected<std::future<Expected<void>>> ObjectPointsHolder::serializeModel_( const
 
     SaveSettings saveSettings;
     saveSettings.onlyValidPoints = false;
-    saveSettings.rearrangeTriangles = false;
+    saveSettings.packPrimitives = false;
     if ( !vertsColorMap_.empty() )
         saveSettings.colors = &vertsColorMap_;
     auto save = [points = points_, serializeFormat = serializeFormat_ ? serializeFormat_ : defaultSerializePointsFormat(), path, saveSettings]()

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -279,7 +279,7 @@ Expected<std::future<Expected<void>>> ObjectPointsHolder::serializeModel_( const
         return std::async( getAsyncLaunchType(), []{ return Expected<void>{}; } );
 
     SaveSettings saveSettings;
-    saveSettings.saveValidOnly = false;
+    saveSettings.onlyValidPoints = false;
     saveSettings.rearrangeTriangles = false;
     if ( !vertsColorMap_.empty() )
         saveSettings.colors = &vertsColorMap_;

--- a/source/MRMesh/MRPointsSave.cpp
+++ b/source/MRMesh/MRPointsSave.cpp
@@ -51,13 +51,13 @@ Expected<void> toXyz( const PointCloud& points, const std::filesystem::path& fil
 Expected<void> toXyz( const PointCloud& cloud, std::ostream& out, const SaveSettings& settings )
 {
     MR_TIMER;
-    const size_t totalPoints = settings.saveValidOnly ? cloud.validPoints.count() : cloud.points.size();
+    const size_t totalPoints = settings.onlyValidPoints ? cloud.validPoints.count() : cloud.points.size();
     size_t numSaved = 0;
 
     NormalXfMatrix normXf( settings.xf );
     for ( auto v = 0_v; v < cloud.points.size(); ++v )
     {
-        if ( settings.saveValidOnly && !cloud.validPoints.test( v ) )
+        if ( settings.onlyValidPoints && !cloud.validPoints.test( v ) )
             continue;
         auto saveVertex = [&]( auto && p )
         {
@@ -93,13 +93,13 @@ Expected<void> toXyzn( const PointCloud& cloud, std::ostream& out, const SaveSet
     MR_TIMER;
     if ( !cloud.hasNormals() )
         return unexpected( std::string( "Point cloud does not have normal data" ) );
-    const size_t totalPoints = settings.saveValidOnly ? cloud.validPoints.count() : cloud.points.size();
+    const size_t totalPoints = settings.onlyValidPoints ? cloud.validPoints.count() : cloud.points.size();
     size_t numSaved = 0;
 
     NormalXfMatrix normXf( settings.xf );
     for ( auto v = 0_v; v < cloud.points.size(); ++v )
     {
-        if ( settings.saveValidOnly && !cloud.validPoints.test( v ) )
+        if ( settings.onlyValidPoints && !cloud.validPoints.test( v ) )
             continue;
         auto saveVertex = [&]( auto && p, auto && n )
         {
@@ -150,7 +150,7 @@ Expected<void> toPly( const PointCloud& points, const std::filesystem::path& fil
 Expected<void> toPly( const PointCloud& cloud, std::ostream& out, const SaveSettings& settings )
 {
     MR_TIMER;
-    const size_t totalPoints = settings.saveValidOnly ? cloud.validPoints.count() : cloud.points.size();
+    const size_t totalPoints = settings.onlyValidPoints ? cloud.validPoints.count() : cloud.points.size();
 
     out << "ply\nformat binary_little_endian 1.0\ncomment MeshInspector.com\n"
         "element vertex " << totalPoints << "\nproperty float x\nproperty float y\nproperty float z\n";
@@ -176,7 +176,7 @@ Expected<void> toPly( const PointCloud& cloud, std::ostream& out, const SaveSett
     size_t numSaved = 0;
     for ( auto v = 0_v; v < cloud.points.size(); ++v )
     {
-        if ( settings.saveValidOnly && !cloud.validPoints.test( v ) )
+        if ( settings.onlyValidPoints && !cloud.validPoints.test( v ) )
             continue;
         const Vector3f p = applyFloat( settings.xf, cloud.points[v] );
         out.write( ( const char* )&p, 12 );

--- a/source/MRMesh/MRSaveSettings.h
+++ b/source/MRMesh/MRSaveSettings.h
@@ -14,7 +14,7 @@ struct SaveSettings
 {
     /// true - save valid points/vertices only (pack them);
     /// false - save all points/vertices preserving their indices
-    bool saveValidOnly = true;
+    bool onlyValidPoints = true;
 
     /// whether to allow the pack or shuffle of triangles;
     /// if it is turned on, then ids of invalid triangles are reused by the following valid triangles

--- a/source/MRMesh/MRSaveSettings.h
+++ b/source/MRMesh/MRSaveSettings.h
@@ -16,12 +16,12 @@ struct SaveSettings
     /// false - save all points/vertices preserving their indices
     bool onlyValidPoints = true;
 
-    /// whether to allow the pack or shuffle of triangles;
-    /// if it is turned on, then ids of invalid triangles are reused by the following valid triangles
-    /// and higher compression (in .ctm format) can be reached but the order of triangles is changed;
-    /// if it is turned off then all triangles maintain their ids, and invalid triangles are saved as (0,0,0) vertex triples;
-    /// currently affects .ctm and .ply formats only
-    bool rearrangeTriangles = true;
+    /// whether to allow packing or shuffling of primitives (triangles in meshes or edges in polylines);
+    /// if packPrimitives=true, then ids of invalid primitives are reused by valid primitives
+    /// and higher compression (in .ctm format) can be reached if the order of triangles is changed;
+    /// if packPrimitives=false then all primitives maintain their ids, and invalid primitives are saved with all vertex ids equal to zero;
+    /// currently this flag affects the saving in .ctm and .ply formats only
+    bool packPrimitives = true;
 
     /// optional per-vertex color to save with the geometry
     const VertColors * colors = nullptr;

--- a/source/MRMeshC/MRMeshSave.cpp
+++ b/source/MRMeshC/MRMeshSave.cpp
@@ -19,7 +19,7 @@ void mrMeshSaveToAnySupportedFormat( const MRMesh* mesh_, const char* file, cons
     if ( settings_ )
     {
         settings.onlyValidPoints = settings_->onlyValidPoints;
-        settings.rearrangeTriangles = settings_->rearrangeTriangles;
+        settings.packPrimitives = settings_->packPrimitives;
         settings.progress = settings_->progress;
         vector_wrapper<Color>* wrapper = (vector_wrapper<Color>*)( settings_->colors );
         if ( wrapper )

--- a/source/MRMeshC/MRMeshSave.cpp
+++ b/source/MRMeshC/MRMeshSave.cpp
@@ -18,7 +18,7 @@ void mrMeshSaveToAnySupportedFormat( const MRMesh* mesh_, const char* file, cons
     SaveSettings settings;
     if ( settings_ )
     {
-        settings.saveValidOnly = settings_->saveValidOnly;
+        settings.onlyValidPoints = settings_->onlyValidPoints;
         settings.rearrangeTriangles = settings_->rearrangeTriangles;
         settings.progress = settings_->progress;
         vector_wrapper<Color>* wrapper = (vector_wrapper<Color>*)( settings_->colors );

--- a/source/MRMeshC/MRPointsSave.cpp
+++ b/source/MRMeshC/MRPointsSave.cpp
@@ -18,7 +18,7 @@ void mrPointsSaveToAnySupportedFormat( const MRPointCloud* pc_, const char* file
     if ( settings_ )
     {
         settings.onlyValidPoints = settings_->onlyValidPoints;
-        settings.rearrangeTriangles = settings_->rearrangeTriangles;
+        settings.packPrimitives = settings_->packPrimitives;
         settings.progress = settings_->progress;
         vector_wrapper<Color>* wrapper = (vector_wrapper<Color>*)( settings_->colors );
         if ( wrapper )

--- a/source/MRMeshC/MRPointsSave.cpp
+++ b/source/MRMeshC/MRPointsSave.cpp
@@ -17,7 +17,7 @@ void mrPointsSaveToAnySupportedFormat( const MRPointCloud* pc_, const char* file
     SaveSettings settings;
     if ( settings_ )
     {
-        settings.saveValidOnly = settings_->saveValidOnly;
+        settings.onlyValidPoints = settings_->onlyValidPoints;
         settings.rearrangeTriangles = settings_->rearrangeTriangles;
         settings.progress = settings_->progress;
         vector_wrapper<Color>* wrapper = (vector_wrapper<Color>*)( settings_->colors );

--- a/source/MRMeshC/MRSaveSettings.h
+++ b/source/MRMeshC/MRSaveSettings.h
@@ -10,9 +10,9 @@ typedef struct MRSaveSettings
     /// true - save valid points/vertices only (pack them);
     /// false - save all points/vertices preserving their indices
     bool onlyValidPoints;
-    /// if it is turned on, then higher compression ratios are reached but the order of triangles is changed;
-    /// currently affects .ctm format only
-    bool rearrangeTriangles;
+    /// if it is turned on, then higher compression ratios are reached but the order of primitives (triangles in meshes or edges in polylines) is changed;
+    /// currently this flag affects the saving in .ctm and .ply formats only
+    bool packPrimitives;
     /// optional per-vertex color to save with the geometry
     const MRVertColors* colors;
     /// to report save progress and cancel saving if user desires

--- a/source/MRMeshC/MRSaveSettings.h
+++ b/source/MRMeshC/MRSaveSettings.h
@@ -9,7 +9,7 @@ typedef struct MRSaveSettings
 {
     /// true - save valid points/vertices only (pack them);
     /// false - save all points/vertices preserving their indices
-    bool saveValidOnly;
+    bool onlyValidPoints;
     /// if it is turned on, then higher compression ratios are reached but the order of triangles is changed;
     /// currently affects .ctm format only
     bool rearrangeTriangles;


### PR DESCRIPTION
* `saveValidOnly` renamed in `onlyValidPoints` since it was not clear that it affects vertices/points only.
* `rearrangeTriangles` renamed in `packPrimitives` since for polylines it shall affect edges and not triangles, and since it always activates packing of primitives only sometimes their rearrangement.