### PR TITLE
getUniversalMetric() improvements

### DIFF
--- a/source/MRMesh/MRMeshMetrics.cpp
+++ b/source/MRMesh/MRMeshMetrics.cpp
@@ -275,12 +275,12 @@ FillHoleMetric getMaxDihedralAngleMetric( const Mesh& mesh )
     return metric;
 }
 
-FillHoleMetric getUniversalMetric( const Mesh& mesh, float circumFactor )
+FillHoleMetric getUniversalMetric( const Mesh& mesh )
 {
     FillHoleMetric metric;
-    metric.triangleMetric = [&points = mesh.points, circumFactor] ( VertId a, VertId b, VertId c )
+    metric.triangleMetric = [&points = mesh.points] ( VertId a, VertId b, VertId c )
     {
-        return circumcircleDiameter( points[a], points[b], points[c] ) * circumFactor;
+        return circumcircleDiameter( points[a], points[b], points[c] );
     };
     metric.edgeMetric = [&points = mesh.points] ( VertId a, VertId b, VertId l, VertId r ) -> double
     {

--- a/source/MRMesh/MRMeshMetrics.h
+++ b/source/MRMesh/MRMeshMetrics.h
@@ -94,14 +94,14 @@ MRMESH_API FillHoleMetric getParallelPlaneFillMetric( const Mesh& mesh, EdgeId e
 /// and on its boundary
 MRMESH_API FillHoleMetric getMaxDihedralAngleMetric( const Mesh& mesh );
 
-/// This metric minimizes the sum of
-/// 1) for each triangle: its circumcircle diameter times \p circumFactor,
+/// This metric consists of two parts
+/// 1) for each triangle: it is the circumcircle diameter,
 ///    this avoids the appearance of degenerate triangles;
-/// 2) for each edge: double total area of triangles to its left and right
+/// 2) for each edge: square root of double total area of triangles to its left and right
 ///    times the factor depending extensionally on absolute dihedral angle between left and right triangles,
 ///    this makes visually triangulated surface as smooth as possible.
 /// For planar holes it is the same as getCircumscribedMetric.
-MRMESH_API FillHoleMetric getUniversalMetric( const Mesh& mesh, float circumFactor = 1 );
+MRMESH_API FillHoleMetric getUniversalMetric( const Mesh& mesh );
 
 /// This metric maximizes the minimal angle among all faces in the triangulation
 MRMESH_API FillHoleMetric getMinTriAngleMetric( const Mesh& mesh );

--- a/source/MRMesh/MRMeshMetrics.h
+++ b/source/MRMesh/MRMeshMetrics.h
@@ -94,10 +94,14 @@ MRMESH_API FillHoleMetric getParallelPlaneFillMetric( const Mesh& mesh, EdgeId e
 /// and on its boundary
 MRMESH_API FillHoleMetric getMaxDihedralAngleMetric( const Mesh& mesh );
 
-/// This metric minimizes the maximal dihedral angle between the faces in the triangulation
-/// and on its boundary, and it avoids creating too degenerate triangles;
-///  for planar holes it is the same as getCircumscribedMetric
-MRMESH_API FillHoleMetric getUniversalMetric( const Mesh& mesh );
+/// This metric minimizes the sum of
+/// 1) for each triangle: its circumcircle diameter times \p circumFactor,
+///    this avoids the appearance of degenerate triangles;
+/// 2) for each edge: double total area of triangles to its left and right
+///    times the factor depending extensionally on absolute dihedral angle between left and right triangles,
+///    this makes visually triangulated surface as smooth as possible.
+/// For planar holes it is the same as getCircumscribedMetric.
+MRMESH_API FillHoleMetric getUniversalMetric( const Mesh& mesh, float circumFactor = 1 );
 
 /// This metric maximizes the minimal angle among all faces in the triangulation
 MRMESH_API FillHoleMetric getMinTriAngleMetric( const Mesh& mesh );


### PR DESCRIPTION
In universal metric for hole filling, the edge part is proportional not on edge's length but on square root of double total area of triangles to its left and right, cause the same angle for large triangles is much more visible than for small ones (even if shared edge's length is the same).