### PR TITLE
BitSet::is_subset_of supports arguments of different size

### DIFF
--- a/source/MRMesh/MRBitSet.cpp
+++ b/source/MRMesh/MRBitSet.cpp
@@ -83,65 +83,17 @@ size_t BitSet::nthSetBit( size_t n ) const
     return npos;
 }
 
-TEST(MRMesh, BitSet) 
+bool BitSet::is_subset_of( const BitSet& a ) const
 {
-    BitSet bs0(4);
-    bs0.set(0);
-    bs0.set(2);
+    // base implementation does not support bitsets of different sizes
+    const auto commonBlocks = std::min( num_blocks(), a.num_blocks() );
+    for ( size_type i = 0; i < commonBlocks; ++i )
+        if ( m_bits[i] & ~a.m_bits[i] )
+            return false;
+    // this is subset of (a) if consider common bits only
 
-    EXPECT_EQ( bs0.nthSetBit( 0 ), 0 );
-    EXPECT_EQ( bs0.nthSetBit( 1 ), 2 );
-    EXPECT_EQ( bs0.nthSetBit( 2 ), BitSet::npos );
-
-    BitSet bs1(3);
-    bs1.set(1);
-    bs1.set(2);
-
-    EXPECT_TRUE(  end( bs1 ) == std::find_if( begin( bs1 ), end( bs1 ), []( size_t i ) { return i == 0; } ) );
-    EXPECT_FALSE( end( bs1 ) == std::find_if( begin( bs1 ), end( bs1 ), []( size_t i ) { return i == 1; } ) );
-
-    EXPECT_EQ( BitSet( bs0 & bs1 ).count(), 1 );
-    EXPECT_EQ( BitSet( bs0 | bs1 ).count(), 3 );
-    EXPECT_EQ( BitSet( bs0 - bs1 ).count(), 1 );
-    EXPECT_EQ( BitSet( bs1 - bs0 ).count(), 1 );
-    EXPECT_EQ( BitSet( bs0 ^ bs1 ).count(), 2 );
-
-    EXPECT_EQ( BitSet( BitSet( bs0 ) &= bs1 ).count(), 1 );
-    EXPECT_EQ( BitSet( BitSet( bs0 ) |= bs1 ).count(), 3 );
-    EXPECT_EQ( BitSet( BitSet( bs0 ) -= bs1 ).count(), 1 );
-    EXPECT_EQ( BitSet( BitSet( bs1 ) -= bs0 ).count(), 1 );
-    EXPECT_EQ( BitSet( BitSet( bs0 ) ^= bs1 ).count(), 2 );
-
-    EXPECT_EQ( bs0.find_last(), size_t( 2 ) );
-    BitSet bs2( 5 );
-    EXPECT_EQ( bs2.find_last(), size_t( -1 ) );
-}
-
-TEST(MRMesh, TaggedBitSet) 
-{
-    VertBitSet bs0( 3 );
-    bs0.set( VertId( 0 ) );
-    bs0.set( VertId( 2 ) );
-
-    VertBitSet bs1( 4 );
-    bs1.set( VertId( 1 ) );
-    bs1.set( VertId( 2 ) );
-
-    EXPECT_EQ( bs1.nthSetBit( 0 ), 1_v );
-    EXPECT_EQ( bs1.nthSetBit( 1 ), 2_v );
-    EXPECT_EQ( bs1.nthSetBit( 2 ), VertId{} );
-
-    EXPECT_EQ( VertBitSet( bs0 & bs1 ).count(), 1 );
-    EXPECT_EQ( VertBitSet( bs0 | bs1 ).count(), 3 );
-    EXPECT_EQ( VertBitSet( bs0 - bs1 ).count(), 1 );
-    EXPECT_EQ( VertBitSet( bs1 - bs0 ).count(), 1 );
-    EXPECT_EQ( VertBitSet( bs0 ^ bs1 ).count(), 2 );
-
-    EXPECT_EQ( VertBitSet( VertBitSet( bs0 ) &= bs1 ).count(), 1 );
-    EXPECT_EQ( VertBitSet( VertBitSet( bs0 ) |= bs1 ).count(), 3 );
-    EXPECT_EQ( VertBitSet( VertBitSet( bs0 ) -= bs1 ).count(), 1 );
-    EXPECT_EQ( VertBitSet( VertBitSet( bs1 ) -= bs0 ).count(), 1 );
-    EXPECT_EQ( VertBitSet( VertBitSet( bs0 ) ^= bs1 ).count(), 2 );
+    return size() <= a.size() // this has no more bits than (a)
+        || find_next( a.size() - 1 ) > size(); // or all additional bits of this are off
 }
 
 } //namespace MR

--- a/source/MRMesh/MRBitSet.h
+++ b/source/MRMesh/MRBitSet.h
@@ -22,7 +22,8 @@ namespace MR
  * \{
  */
 
-/// container of bits
+/// std::vector<bool> like container  (random-access, size_t - index type, bool - value type)
+/// with all bits after size() considered off during testing
 class BitSet : public boost::dynamic_bitset<std::uint64_t>
 {
 public:
@@ -69,6 +70,12 @@ public:
 
     /// returns the location of nth set bit (where the first bit corresponds to n=0) or npos if there are less bit set
     [[nodiscard]] MRMESH_API size_t nthSetBit( size_t n ) const;
+
+    /// returns true if, for every bit that is set in this bitset, the corresponding bit in bitset a is also set. Otherwise this function returns false.
+    [[nodiscard]] MRMESH_API bool is_subset_of( const BitSet& a ) const;
+
+    /// returns true if, for every bit that is set in this bitset, the corresponding bit in bitset a is also set and if this->count() < a.count(). Otherwise this function returns false.
+    bool is_proper_subset_of( const BitSet& a ) const = delete; // base implementation does not support bitsets of different sizes
 
     /// doubles reserved memory until resize(newSize) can be done without reallocation
     void resizeWithReserve( size_t newSize )
@@ -127,7 +134,8 @@ private:
     using base::m_num_bits;
 };
 
-/// container of bits representing specific indices (faces, verts or edges)
+/// Vector<bool, I> like container (random-access, I - index type, bool - value type)
+/// with all bits after size() considered off during testing
 template <typename I>
 class TypedBitSet : public BitSet
 {
@@ -179,13 +187,10 @@ public:
     TypedBitSet & subtract( const TypedBitSet & b, int bShiftInBlocks ) { base::subtract( b, bShiftInBlocks ); return * this; }
 
     /// returns true if, for every bit that is set in this bitset, the corresponding bit in bitset a is also set. Otherwise this function returns false.
-    bool is_subset_of( const TypedBitSet& a ) const { return base::is_subset_of( a ); }
-
-    /// returns true if, for every bit that is set in this bitset, the corresponding bit in bitset a is also set and if this->count() < a.count(). Otherwise this function returns false.
-    bool is_proper_subset_of( const TypedBitSet& a ) const { return base::is_proper_subset_of( a ); }
+    [[nodiscard]] bool is_subset_of( const TypedBitSet& a ) const { return base::is_subset_of( a ); }
 
     /// returns true if, there is a bit which is set in this bitset, such that the corresponding bit in bitset a is also set. Otherwise this function returns false.
-    bool intersects( const TypedBitSet & a ) const { return base::intersects( a ); }
+    [[nodiscard]] bool intersects( const TypedBitSet & a ) const { return base::intersects( a ); }
 
     void autoResizeSet( IndexType pos, size_type len, bool val = true ) { base::autoResizeSet( pos, len, val ); }
     void autoResizeSet( IndexType pos, bool val = true ) { base::autoResizeSet( pos, val ); }

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -217,7 +217,7 @@ public:
     [[nodiscard]] const VertBitSet & getVertIds( const VertBitSet * region ) const
     {
         assert( region || updateValids_ ); // region shall be either given on input or maintained in validVerts_
-        assert( !updateValids_ || !region || ( *region - validVerts_ ).none() ); // if region is given and all valid vertices are known, then region must be a subset of them
+        assert( !updateValids_ || !region || region->is_subset_of( validVerts_ ) ); // if region is given and all valid vertices are known, then region must be a subset of them
         return region ? *region : validVerts_;
     }
 
@@ -283,7 +283,7 @@ public:
     [[nodiscard]] const FaceBitSet & getFaceIds( const FaceBitSet * region ) const
     {
         assert( region || updateValids_ ); // region shall be either given on input or maintained in validFaces_
-        assert( !updateValids_ || !region || ( *region - validFaces_ ).none() ); // if region is given and all valid faces are known, then region must be a subset of them
+        assert( !updateValids_ || !region || region->is_subset_of( validFaces_ ) ); // if region is given and all valid faces are known, then region must be a subset of them
         return region ? *region : validFaces_;
     }
 

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -602,7 +602,7 @@ size_t ObjectMeshHolder::numSelectedFaces() const
         numSelectedFaces_ = data_.selectedFaces.count();
 #ifndef NDEBUG
         // check that there are no selected invalid faces
-        assert( !data_.mesh || !( data_.selectedFaces - data_.mesh->topology.getValidFaces() ).any() );
+        assert( !data_.mesh || data_.selectedFaces.is_subset_of( data_.mesh->topology.getValidFaces() ) );
 #endif
     }
 
@@ -616,7 +616,7 @@ size_t ObjectMeshHolder::numSelectedEdges() const
         numSelectedEdges_ = data_.selectedEdges.count();
 #ifndef NDEBUG
         // check that there are no selected invalid edges
-        assert( !data_.mesh || !( data_.selectedEdges - data_.mesh->topology.findNotLoneUndirectedEdges() ).any() );
+        assert( !data_.mesh || data_.selectedEdges.is_subset_of( data_.mesh->topology.findNotLoneUndirectedEdges() ) );
 #endif
     }
 
@@ -630,7 +630,7 @@ size_t ObjectMeshHolder::numCreaseEdges() const
         numCreaseEdges_ = data_.creases.count();
 #ifndef NDEBUG
         // check that there are no invalid edges among creases
-        assert( !data_.mesh || !( data_.creases - data_.mesh->topology.findNotLoneUndirectedEdges() ).any() );
+        assert( !data_.mesh || data_.creases.is_subset_of( data_.mesh->topology.findNotLoneUndirectedEdges() ) );
 #endif
     }
 

--- a/source/MRMesh/MRRectIndexer.cpp
+++ b/source/MRMesh/MRRectIndexer.cpp
@@ -104,9 +104,9 @@ TEST( MRMesh, ExpandShrinkPixels )
 
     auto storeMask = mask;
     expandPixelMask( mask, indexer );
-    EXPECT_FALSE( ( mask - refMask ).any() );
+    EXPECT_TRUE( mask.is_subset_of( refMask ) );
     shrinkPixelMask( mask, indexer );
-    EXPECT_FALSE( ( mask - storeMask ).any() );
+    EXPECT_TRUE( mask.is_subset_of( storeMask ) );
 }
 
 } //namespace MR

--- a/source/MRTest/MRBitSetTests.cpp
+++ b/source/MRTest/MRBitSetTests.cpp
@@ -1,0 +1,79 @@
+#include <MRMesh/MRBitSet.h>
+#include <MRMesh/MRGTest.h>
+
+namespace MR
+{
+
+TEST(MRMesh, BitSet)
+{
+    BitSet bs0(4);
+    bs0.set(0);
+    bs0.set(2);
+
+    EXPECT_EQ( bs0.nthSetBit( 0 ), 0 );
+    EXPECT_EQ( bs0.nthSetBit( 1 ), 2 );
+    EXPECT_EQ( bs0.nthSetBit( 2 ), BitSet::npos );
+
+    BitSet bs1(3);
+    bs1.set(1);
+    bs1.set(2);
+
+    EXPECT_TRUE(  end( bs1 ) == std::find_if( begin( bs1 ), end( bs1 ), []( size_t i ) { return i == 0; } ) );
+    EXPECT_FALSE( end( bs1 ) == std::find_if( begin( bs1 ), end( bs1 ), []( size_t i ) { return i == 1; } ) );
+
+    EXPECT_EQ( BitSet( bs0 & bs1 ).count(), 1 );
+    EXPECT_EQ( BitSet( bs0 | bs1 ).count(), 3 );
+    EXPECT_EQ( BitSet( bs0 - bs1 ).count(), 1 );
+    EXPECT_EQ( BitSet( bs1 - bs0 ).count(), 1 );
+    EXPECT_EQ( BitSet( bs0 ^ bs1 ).count(), 2 );
+
+    EXPECT_EQ( BitSet( BitSet( bs0 ) &= bs1 ).count(), 1 );
+    EXPECT_EQ( BitSet( BitSet( bs0 ) |= bs1 ).count(), 3 );
+    EXPECT_EQ( BitSet( BitSet( bs0 ) -= bs1 ).count(), 1 );
+    EXPECT_EQ( BitSet( BitSet( bs1 ) -= bs0 ).count(), 1 );
+    EXPECT_EQ( BitSet( BitSet( bs0 ) ^= bs1 ).count(), 2 );
+
+    EXPECT_EQ( bs0.find_last(), size_t( 2 ) );
+    BitSet bs2( 5 );
+    EXPECT_EQ( bs2.find_last(), size_t( -1 ) );
+
+    EXPECT_FALSE( bs1.is_subset_of( bs0 ) );
+    EXPECT_FALSE( bs0.is_subset_of( bs1 ) );
+    BitSet bs3 = bs0;
+    EXPECT_TRUE( bs3.is_subset_of( bs0 ) );
+    bs3.resize( 5 );
+    EXPECT_TRUE( bs3.is_subset_of( bs0 ) );
+    EXPECT_TRUE( bs0.is_subset_of( bs3 ) );
+    bs3.set( 4 );
+    EXPECT_FALSE( bs3.is_subset_of( bs0 ) );
+    EXPECT_TRUE( bs0.is_subset_of( bs3 ) );
+}
+
+TEST(MRMesh, TaggedBitSet)
+{
+    VertBitSet bs0( 3 );
+    bs0.set( VertId( 0 ) );
+    bs0.set( VertId( 2 ) );
+
+    VertBitSet bs1( 4 );
+    bs1.set( VertId( 1 ) );
+    bs1.set( VertId( 2 ) );
+
+    EXPECT_EQ( bs1.nthSetBit( 0 ), 1_v );
+    EXPECT_EQ( bs1.nthSetBit( 1 ), 2_v );
+    EXPECT_EQ( bs1.nthSetBit( 2 ), VertId{} );
+
+    EXPECT_EQ( VertBitSet( bs0 & bs1 ).count(), 1 );
+    EXPECT_EQ( VertBitSet( bs0 | bs1 ).count(), 3 );
+    EXPECT_EQ( VertBitSet( bs0 - bs1 ).count(), 1 );
+    EXPECT_EQ( VertBitSet( bs1 - bs0 ).count(), 1 );
+    EXPECT_EQ( VertBitSet( bs0 ^ bs1 ).count(), 2 );
+
+    EXPECT_EQ( VertBitSet( VertBitSet( bs0 ) &= bs1 ).count(), 1 );
+    EXPECT_EQ( VertBitSet( VertBitSet( bs0 ) |= bs1 ).count(), 3 );
+    EXPECT_EQ( VertBitSet( VertBitSet( bs0 ) -= bs1 ).count(), 1 );
+    EXPECT_EQ( VertBitSet( VertBitSet( bs1 ) -= bs0 ).count(), 1 );
+    EXPECT_EQ( VertBitSet( VertBitSet( bs0 ) ^= bs1 ).count(), 2 );
+}
+
+} //namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -14,6 +14,7 @@
     <ClCompile Include="MRAABBTreePointsTests.cpp" />
     <ClCompile Include="MRBestFitTests.cpp" />
     <ClCompile Include="MRBezierTests.cpp" />
+    <ClCompile Include="MRBitSetTests.cpp" />
     <ClCompile Include="MRBoxTests.cpp" />
     <ClCompile Include="MRChunkIterator.cpp" />
     <ClCompile Include="MRContoursCutTests.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -121,6 +121,9 @@
     <ClCompile Include="MRMeshMeshDistanceTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRBitSetTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />


### PR DESCRIPTION
* `BitSet::is_subset_of` supports arguments of different size unlike `boost` implementation
* `x.is_subset_of(y)` is used in all places instead of slower `(x-y).none()`, which makes a temporary bitset
* `BitSet::is_proper_subset_of` to be supported later and now prohibited for use
* tests for `BitSet` moved in `MRTest`
* more comments