### PR TITLE
fix search rendering within header style scope

### DIFF
--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -560,9 +560,16 @@ void RibbonMenu::drawHeaderPannel_()
         summaryTabPannelSize += ( tabSizes[i] + cTabsInterval * menuScaling );
     }
 
-    auto backupPos = ImGui::GetCursorPos();
-    auto availWidth = drawHeaderHelpers_( summaryTabPannelSize, menuScaling );
-    ImGui::SetCursorPos( backupPos );
+    float availWidth = 0.0f;
+    {
+        auto backupPos = ImGui::GetCursorPos();
+        ImGui::PopStyleVar( 2 ); // draw helpers with default style
+        availWidth = drawHeaderHelpers_( summaryTabPannelSize, menuScaling );
+        // push header panel style back
+        ImGui::PushStyleVar( ImGuiStyleVar_TabRounding, cTabFrameRounding * menuScaling );
+        ImGui::PushStyleVar( ImGuiStyleVar_ItemSpacing, ImVec2( 0, 0 ) );
+        ImGui::SetCursorPos( backupPos );
+    }
 
     float scrollMax = summaryTabPannelSize - availWidth;
     bool needScroll = scrollMax > 0.0f;


### PR DESCRIPTION
Search result list got under header panel style scope after #4758, so we fix it by disabling additional styles for header helpers rendering