### PR TITLE
propagate clipped-by-plane visual property on all subobjects

### DIFF
--- a/source/MRMesh/MRVisualObject.cpp
+++ b/source/MRMesh/MRVisualObject.cpp
@@ -72,6 +72,34 @@ AllVisualizeProperties VisualObject::getAllVisualizeProperties() const
     return res;
 }
 
+ViewportMask VisualObject::globalClippedByPlaneMask() const
+{
+    auto res = clipByPlane_;
+    auto parent = this->parent();
+    while ( parent )
+    {
+        if ( auto visParent = dynamic_cast<const VisualObject*>( parent ) )
+            res |= visParent->clipByPlane_;
+        parent = parent->parent();
+    }
+    return res;
+}
+
+void VisualObject::setGlobalClippedByPlane( bool on, ViewportMask viewportMask )
+{
+    setVisualizeProperty( on, VisualizeMaskType::ClippedByPlane, viewportMask );
+    if ( on )
+        return;
+
+    auto parent = this->parent();
+    while ( parent )
+    {
+        if ( auto visParent = dynamic_cast<VisualObject*>( parent ) )
+            visParent->setVisualizeProperty( on, VisualizeMaskType::ClippedByPlane, viewportMask );
+        parent = parent->parent();
+    }
+}
+
 const Color& VisualObject::getFrontColor( bool selected /*= true */, ViewportId viewportId /*= {} */ ) const
 {
     // Calling the getter in case it's overridden.

--- a/source/MRMesh/MRVisualObject.h
+++ b/source/MRMesh/MRVisualObject.h
@@ -155,6 +155,15 @@ public:
         setAllVisualizeProperties_( properties, counter );
     }
 
+    /// returns all viewports where this object or any of its parents is clipped by plane
+    [[nodiscard]] MRMESH_API ViewportMask globalClippedByPlaneMask() const;
+
+    /// returns true if this object or any of its parents is clipped by plane in any of given viewports
+    [[nodiscard]] bool globalClippedByPlane( ViewportMask viewportMask = ViewportMask::any() ) const { return !( globalClippedByPlaneMask() & viewportMask ).empty(); }
+
+    /// if false deactivates clipped-by-plane for this object and all of its parents, otherwise sets clipped-by-plane for this this object only
+    MRMESH_API void setGlobalClippedByPlane( bool on, ViewportMask viewportMask = ViewportMask::all() );
+
     /// shows/hides labels
     [[deprecated( "please use ObjectLabel mechanism instead" )]]
     MR_BIND_IGNORE void showLabels( bool on ) { return setVisualizeProperty( on, VisualizeMaskType::Labels, ViewportMask::all() ); }

--- a/source/MRViewer/MRRenderLabelObject.cpp
+++ b/source/MRViewer/MRRenderLabelObject.cpp
@@ -60,7 +60,7 @@ bool RenderLabelObject::render( const ModelRenderParams& renderParams )
 
     update_();
 
-    if ( objLabel_->getVisualizeProperty( VisualizeMaskType::ClippedByPlane, renderParams.viewportId ) )
+    if ( objLabel_->globalClippedByPlane( renderParams.viewportId ) )
     {
         Vector3f pos = renderParams.modelMatrix( objLabel_->getLabel().position );
         if ( dot( pos, renderParams.clipPlane.n ) > renderParams.clipPlane.d )

--- a/source/MRViewer/MRRenderLinesObject.cpp
+++ b/source/MRViewer/MRRenderLinesObject.cpp
@@ -131,7 +131,7 @@ void RenderLinesObject::render_( const ModelRenderParams& renderParams, bool poi
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "perVertColoring" ), objLines_->getColoringType() == ColoringType::VertsColorMap ) );
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "perLineColoring" ), objLines_->getColoringType() == ColoringType::LinesColorMap ) );
 
-    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objLines_->getVisualizeProperty( VisualizeMaskType::ClippedByPlane, renderParams.viewportId ) ) );
+    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objLines_->globalClippedByPlane( renderParams.viewportId ) ) );
     GL_EXEC( glUniform4f( glGetUniformLocation( shader, "clippingPlane" ),
         renderParams.clipPlane.n.x, renderParams.clipPlane.n.y,
         renderParams.clipPlane.n.z, renderParams.clipPlane.d ) );
@@ -186,7 +186,7 @@ void RenderLinesObject::renderPicker_( const ModelBaseRenderParams& parameters, 
         GL_EXEC( glUniform1f( glGetUniformLocation( shader, "width" ), objLines_->getLineWidth() ) );
     }
 
-    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objLines_->getVisualizeProperty( VisualizeMaskType::ClippedByPlane, parameters.viewportId ) ) );
+    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objLines_->globalClippedByPlane( parameters.viewportId ) ) );
     GL_EXEC( glUniform4f( glGetUniformLocation( shader, "clippingPlane" ),
         parameters.clipPlane.n.x, parameters.clipPlane.n.y,
         parameters.clipPlane.n.z, parameters.clipPlane.d ) );

--- a/source/MRViewer/MRRenderMeshObject.cpp
+++ b/source/MRViewer/MRRenderMeshObject.cpp
@@ -104,7 +104,7 @@ bool RenderMeshObject::render( const ModelRenderParams& renderParams )
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "perVertColoring" ), objMesh_->getColoringType() == ColoringType::VertsColorMap ) );
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "perFaceColoring" ), objMesh_->getColoringType() == ColoringType::FacesColorMap ) );
 
-    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objMesh_->getVisualizeProperty( VisualizeMaskType::ClippedByPlane, renderParams.viewportId ) ) );
+    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objMesh_->globalClippedByPlane( renderParams.viewportId ) ) );
     GL_EXEC( glUniform4f( glGetUniformLocation( shader, "clippingPlane" ),
         renderParams.clipPlane.n.x, renderParams.clipPlane.n.y,
         renderParams.clipPlane.n.z, renderParams.clipPlane.d ) );
@@ -189,7 +189,7 @@ void RenderMeshObject::renderPicker( const ModelBaseRenderParams& parameters, un
 
     GL_EXEC( glUniform1ui( glGetUniformLocation( shader, "primBucketSize" ), 3 ) );
 
-    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objMesh_->getVisualizeProperty( VisualizeMaskType::ClippedByPlane, parameters.viewportId ) ) );
+    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objMesh_->globalClippedByPlane( parameters.viewportId ) ) );
     GL_EXEC( glUniform4f( glGetUniformLocation( shader, "clippingPlane" ),
         parameters.clipPlane.n.x, parameters.clipPlane.n.y, parameters.clipPlane.n.z, parameters.clipPlane.d ) );
     GL_EXEC( glUniform1ui( glGetUniformLocation( shader, "uniGeomId" ), geomId ) );
@@ -273,7 +273,7 @@ void RenderMeshObject::renderEdges_( const ModelRenderParams& renderParams, bool
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "perVertColoring" ), false ) );
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "perLineColoring" ), false ) );
 
-    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objMesh_->getVisualizeProperty( VisualizeMaskType::ClippedByPlane, renderParams.viewportId ) ) );
+    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objMesh_->globalClippedByPlane( renderParams.viewportId ) ) );
     GL_EXEC( glUniform4f( glGetUniformLocation( shader, "clippingPlane" ),
         renderParams.clipPlane.n.x, renderParams.clipPlane.n.y, renderParams.clipPlane.n.z, renderParams.clipPlane.d ) );
 
@@ -322,7 +322,7 @@ void RenderMeshObject::renderMeshEdges_( const ModelRenderParams& renderParams, 
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "perVertColoring" ), false ) );
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "perLineColoring" ), false ) );
 
-    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objMesh_->getVisualizeProperty( VisualizeMaskType::ClippedByPlane, renderParams.viewportId ) ) );
+    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objMesh_->globalClippedByPlane( renderParams.viewportId ) ) );
     GL_EXEC( glUniform4f( glGetUniformLocation( shader, "clippingPlane" ),
         renderParams.clipPlane.n.x, renderParams.clipPlane.n.y, renderParams.clipPlane.n.z, renderParams.clipPlane.d ) );
 
@@ -358,7 +358,7 @@ void RenderMeshObject::renderMeshVerts_( const ModelRenderParams& renderParams, 
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "invertNormals" ), objMesh_->getVisualizeProperty( VisualizeMaskType::InvertedNormals, renderParams.viewportId ) ) );
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "perVertColoring" ), objMesh_->getColoringType() == ColoringType::VertsColorMap ) );
 
-    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objMesh_->getVisualizeProperty( VisualizeMaskType::ClippedByPlane, renderParams.viewportId ) ) );
+    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objMesh_->globalClippedByPlane( renderParams.viewportId ) ) );
     GL_EXEC( glUniform4f( glGetUniformLocation( shader, "clippingPlane" ),
         renderParams.clipPlane.n.x, renderParams.clipPlane.n.y,
         renderParams.clipPlane.n.z, renderParams.clipPlane.d ) );

--- a/source/MRViewer/MRRenderPointsObject.cpp
+++ b/source/MRViewer/MRRenderPointsObject.cpp
@@ -107,7 +107,7 @@ bool RenderPointsObject::render( const ModelRenderParams& renderParams )
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "invertNormals" ), objPoints_->getVisualizeProperty( VisualizeMaskType::InvertedNormals, renderParams.viewportId ) ) );
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "perVertColoring" ), objPoints_->getColoringType() == ColoringType::VertsColorMap ) );
 
-    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objPoints_->getVisualizeProperty( VisualizeMaskType::ClippedByPlane, renderParams.viewportId ) ) );
+    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objPoints_->globalClippedByPlane( renderParams.viewportId ) ) );
     GL_EXEC( glUniform4f( glGetUniformLocation( shader, "clippingPlane" ),
         renderParams.clipPlane.n.x, renderParams.clipPlane.n.y,
         renderParams.clipPlane.n.z, renderParams.clipPlane.d ) );
@@ -183,7 +183,7 @@ void RenderPointsObject::renderPicker( const ModelBaseRenderParams& parameters, 
 
     GL_EXEC( glUniform1ui( glGetUniformLocation( shader, "primBucketSize" ), 1 ) );
 
-    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objPoints_->getVisualizeProperty( VisualizeMaskType::ClippedByPlane, parameters.viewportId ) ) );
+    GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ), objPoints_->globalClippedByPlane( parameters.viewportId ) ) );
     GL_EXEC( glUniform4f( glGetUniformLocation( shader, "clippingPlane" ),
         parameters.clipPlane.n.x, parameters.clipPlane.n.y, parameters.clipPlane.n.z, parameters.clipPlane.d ) );
     GL_EXEC( glUniform1ui( glGetUniformLocation( shader, "uniGeomId" ), geomId ) );

--- a/source/MRViewer/MRRenderVolumeObject.cpp
+++ b/source/MRViewer/MRRenderVolumeObject.cpp
@@ -153,7 +153,7 @@ void RenderVolumeObject::render_( const ModelBaseRenderParams& renderParams, con
         GL_EXEC( glUniform1f( glGetUniformLocation( shader, "ambientStrength" ), ambient ) );
     }
     GL_EXEC( glUniform1i( glGetUniformLocation( shader, "useClippingPlane" ),
-        objVoxels_->getVisualizeProperty( VisualizeMaskType::ClippedByPlane, renderParams.viewportId ) ) );
+        objVoxels_->globalClippedByPlane( renderParams.viewportId ) ) );
     GL_EXEC( glUniform4f( glGetUniformLocation( shader, "clippingPlane" ),
         renderParams.clipPlane.n.x, renderParams.clipPlane.n.y,
         renderParams.clipPlane.n.z, renderParams.clipPlane.d ) );

--- a/source/MRViewer/MRSelectScreenLasso.cpp
+++ b/source/MRViewer/MRSelectScreenLasso.cpp
@@ -226,7 +226,7 @@ FaceBitSet findIncidentFaces( const Viewport& viewport, const BitSet& pixBs, con
 
         tbb::enumerable_thread_specific<std::vector<Line3fMesh>> tlsLineMeshes( std::cref( lineMeshes ) );
         const auto& clippingPlane = viewport.getParameters().clippingPlane;
-        const bool useClipping = obj.getVisualizeProperty( VisualizeMaskType::ClippedByPlane, viewport.id );
+        const bool useClipping = obj.globalClippedByPlane( viewport.id );
 
         auto isPointHidden = [&]( const Vector3f& point ) -> bool
         {
@@ -362,7 +362,7 @@ VertBitSet findVertsInViewportArea( const Viewport& viewport, const BitSet& pixB
             if ( dot( xf.A * normals[i], cameraDir ) < 0 )
                 verts.set( i, false );
         }
-        if ( onlyVisible && obj.getVisualizeProperty( VisualizeMaskType::ClippedByPlane, viewport.id ) &&
+        if ( onlyVisible && obj.globalClippedByPlane( viewport.id ) &&
             clippingPlane.distance( xf( pointCloud->points[i] ) ) > 0 )
         {
             verts.set( i, false );


### PR DESCRIPTION
If an object has activated clipped-by-plane visual property, then all its children in scene tree are rendered with clipping irrespective of their clipped-by-plane visual property.

New methods added in `VisualObject`:
```c++
    /// returns all viewports where this object or any of its parents is clipped by plane
    [[nodiscard]] MRMESH_API ViewportMask globalClippedByPlaneMask() const;

    /// returns true if this object or any of its parents is clipped by plane in any of given viewports
    [[nodiscard]] bool globalClippedByPlane( ViewportMask viewportMask = ViewportMask::any() ) const { return !( globalClippedByPlaneMask() & viewportMask ).empty(); }

    /// if false deactivates clipped-by-plane for this object and all of its parents, otherwise sets clipped-by-plane for this this object only
    MRMESH_API void setGlobalClippedByPlane( bool on, ViewportMask viewportMask = ViewportMask::all() );
```
