### PR TITLE
better handling of human readable names of object classes

### DIFF
--- a/source/MRMesh/MRAngleMeasurementObject.h
+++ b/source/MRMesh/MRAngleMeasurementObject.h
@@ -18,11 +18,14 @@ public:
     constexpr static const char* TypeName() noexcept { return "AngleMeasurementObject"; }
     const char* typeName() const override { return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "Angle"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Angles"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     // For `std::make_shared()` in `clone()`.
     AngleMeasurementObject( ProtectedStruct, const AngleMeasurementObject& obj ) : AngleMeasurementObject( obj ) {}
-
-    std::string getClassName() const override { return "Angle"; }
-    std::string getClassNameInPlural() const override { return "Angles"; }
 
     MRMESH_API std::shared_ptr<Object> clone() const override;
     MRMESH_API std::shared_ptr<Object> shallowClone() const override;

--- a/source/MRMesh/MRCircleObject.h
+++ b/source/MRMesh/MRCircleObject.h
@@ -24,21 +24,18 @@ public:
     CircleObject( CircleObject&& ) noexcept = default;
     CircleObject& operator = ( CircleObject&& ) noexcept = default;
 
-    constexpr static const char* TypeName() noexcept
-    {
-        return "CircleObject";
-    }
-    virtual const char* typeName() const override
-    {
-        return TypeName();
-    }
+    constexpr static const char* TypeName() noexcept { return "CircleObject"; }
+    virtual const char* typeName() const override { return TypeName(); }
+
+    constexpr static const char* ClassName() noexcept { return "Circle"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Circles"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
 
     /// \note this ctor is public only for std::make_shared used inside clone()
     CircleObject( ProtectedStruct, const CircleObject& obj ) : CircleObject( obj )
     {}
-
-    std::string getClassName() const override { return "Circle"; }
-    std::string getClassNameInPlural() const override { return "Circles"; }
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;

--- a/source/MRMesh/MRConeObject.h
+++ b/source/MRMesh/MRConeObject.h
@@ -26,21 +26,18 @@ public:
     ConeObject( ConeObject&& ) noexcept = default;
     ConeObject& operator = ( ConeObject&& ) noexcept = default;
 
-    constexpr static const char* TypeName() noexcept
-    {
-        return "ConeObject";
-    }
-    virtual const char* typeName() const override
-    {
-        return TypeName();
-    }
+    constexpr static const char* TypeName() noexcept { return "ConeObject"; }
+    virtual const char* typeName() const override { return TypeName(); }
+
+    constexpr static const char* ClassName() noexcept { return "Cone"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Cones"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
 
     /// \note this ctor is public only for std::make_shared used inside clone()
     ConeObject( ProtectedStruct, const ConeObject& obj ) : ConeObject( obj )
     {}
-
-    std::string getClassName() const override { return "Cone"; }
-    std::string getClassNameInPlural() const override { return "Cones"; }
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;

--- a/source/MRMesh/MRCylinderObject.cpp
+++ b/source/MRMesh/MRCylinderObject.cpp
@@ -1,18 +1,16 @@
-#include "MRPch/MRSpdlog.h"
 #include "MRCylinderObject.h"
 #include "MRMatrix3.h"
 #include "MRCylinder.h"
 #include "MRCylinder3.h"
 #include "MRMesh.h"
 #include "MRObjectFactory.h"
-#include "MRPch/MRJson.h"
 #include "MRCylinderApproximator.h"
-#include "MRMeshFwd.h"
+#include "MRMeshNormals.h"
 #include "MRLine.h"
 #include "MRGTest.h"
-
+#include "MRPch/MRSpdlog.h"
+#include "MRPch/MRJson.h"
 #include <iostream>
-#include "MRMeshNormals.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRCylinderObject.h
+++ b/source/MRMesh/MRCylinderObject.h
@@ -25,21 +25,18 @@ public:
     CylinderObject( CylinderObject&& ) noexcept = default;
     CylinderObject& operator = ( CylinderObject&& ) noexcept = default;
 
-    constexpr static const char* TypeName() noexcept
-    {
-        return "CylinderObject";
-    }
-    virtual const char* typeName() const override
-    {
-        return TypeName();
-    }
+    constexpr static const char* TypeName() noexcept { return "CylinderObject"; }
+    virtual const char* typeName() const override { return TypeName(); }
+
+    constexpr static const char* ClassName() noexcept { return "Cylinder"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Cylinders"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
 
     /// \note this ctor is public only for std::make_shared used inside clone()
     CylinderObject( ProtectedStruct, const CylinderObject& obj ) : CylinderObject( obj )
     {}
-
-    std::string getClassName() const override { return "Cylinder"; }
-    std::string getClassNameInPlural() const override { return "Cylinders"; }
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;

--- a/source/MRMesh/MRDistanceMeasurementObject.h
+++ b/source/MRMesh/MRDistanceMeasurementObject.h
@@ -19,11 +19,14 @@ public:
     constexpr static const char* TypeName() noexcept { return "DistanceMeasurementObject"; }
     const char* typeName() const override { return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "Distance"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Distances"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     // For `std::make_shared()` in `clone()`.
     DistanceMeasurementObject( ProtectedStruct, const DistanceMeasurementObject& obj ) : DistanceMeasurementObject( obj ) {}
-
-    std::string getClassName() const override { return "Distance"; }
-    std::string getClassNameInPlural() const override { return "Distances"; }
 
     MRMESH_API std::shared_ptr<Object> clone() const override;
     MRMESH_API std::shared_ptr<Object> shallowClone() const override;

--- a/source/MRMesh/MRFeatureObject.h
+++ b/source/MRMesh/MRFeatureObject.h
@@ -93,12 +93,13 @@ class MRMESH_CLASS FeatureObject : public VisualObject
 {
 public:
     constexpr static const char* TypeName() noexcept { return "FeatureObject"; }
-
     virtual const char* typeName() const override { return TypeName(); }
 
-    virtual std::string getClassName() const override { return "Feature"; }
+    constexpr static const char* ClassName() noexcept { return "Feature"; }
+    virtual std::string className() const override { return ClassName(); }
 
-    virtual std::string getClassNameInPlural() const override { return "Features"; }
+    constexpr static const char* ClassNameInPlural() noexcept { return "Features"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
 
     /// Create and generate list of bounded getters and setters for the main properties of feature object, together with prop. name for display and edit into UI.
     virtual const std::vector<FeatureObjectSharedProperty>& getAllSharedProperties() const = 0;

--- a/source/MRMesh/MRLineObject.h
+++ b/source/MRMesh/MRLineObject.h
@@ -23,12 +23,15 @@ public:
     constexpr static const char* TypeName() noexcept { return "LineObject"; }
     virtual const char* typeName() const override { return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "Line"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Lines"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     /// \note this ctor is public only for std::make_shared used inside clone()
     LineObject( ProtectedStruct, const LineObject& obj ) : LineObject( obj )
     {}
-
-    std::string getClassName() const override { return "Line"; }
-    std::string getClassNameInPlural() const override { return "Lines"; }
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;

--- a/source/MRMesh/MRObject.cpp
+++ b/source/MRMesh/MRObject.cpp
@@ -528,7 +528,7 @@ std::vector<std::string> Object::getInfoLines() const
 {
     std::vector<std::string> res;
 
-    res.push_back( "type: " + getClassName() );
+    res.push_back( "class: " + className() );
     res.push_back( "mem: " + bytesString( heapBytes() ) );
     res.push_back( fmt::format( "tags: {}", tags_.size() ) );
     for ( const auto& tag : tags_ )

--- a/source/MRMesh/MRObject.h
+++ b/source/MRMesh/MRObject.h
@@ -70,6 +70,14 @@ public:
     constexpr static const char* TypeName() noexcept { return "Object"; }
     virtual const char* typeName() const { return TypeName(); }
 
+    /// return human readable name of subclass
+    constexpr static const char* ClassName() noexcept { return "Object"; }
+    virtual std::string className() const { return ClassName(); }
+
+    /// return human readable name of subclass in plural form
+    constexpr static const char* ClassNameInPlural() noexcept { return "Objects"; }
+    virtual std::string classNameInPlural() const { return ClassNameInPlural(); }
+
     template <typename T>
     T * asType() { return dynamic_cast<T*>( this ); }
     template <typename T>
@@ -213,12 +221,6 @@ public:
 
     /// return several info lines that can better describe object in the UI
     MRMESH_API virtual std::vector<std::string> getInfoLines() const;
-
-    /// return human readable name of subclass
-    virtual std::string getClassName() const { return "Object"; }
-
-    /// return human readable name of subclass in plural form
-    virtual std::string getClassNameInPlural() const { return "Objects"; }
 
     /// creates futures that save this object subtree:
     ///   models in the folder by given path and

--- a/source/MRMesh/MRObjectDistanceMap.h
+++ b/source/MRMesh/MRObjectDistanceMap.h
@@ -23,15 +23,18 @@ public:
     constexpr static const char* TypeName() noexcept { return "ObjectDistanceMap"; }
     virtual const char* typeName() const override { return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "Distance Map"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Distance Maps"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     MRMESH_API virtual void applyScale( float scaleFactor ) override;
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;
 
     MRMESH_API virtual std::vector<std::string> getInfoLines() const override;
-
-    std::string getClassName() const override { return "Distance Map"; }
-    std::string getClassNameInPlural() const override { return "Distance Maps"; }
 
     /// rebuilds the mesh;
     /// if it is executed in the rendering stream then you can set the needUpdateMesh = true

--- a/source/MRMesh/MRObjectGcode.h
+++ b/source/MRMesh/MRObjectGcode.h
@@ -20,6 +20,12 @@ public:
     constexpr static const char* TypeName() noexcept { return "ObjectGcode"; }
     virtual const char* typeName() const override { return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "G-code"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "G-codes"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;
 
@@ -39,9 +45,6 @@ public:
     ObjectGcode( ProtectedStruct, const ObjectGcode& obj ) : ObjectGcode( obj ) {}
 
     MRMESH_API virtual std::vector<std::string> getInfoLines() const override;
-
-    std::string getClassName() const override { return "G-code"; }
-    std::string getClassNameInPlural() const override { return "G-codes"; }
 
     // set drawing feedrate as gradient of brightness
     MRMESH_API void switchFeedrateGradient( bool isFeedrateGradientEnabled );

--- a/source/MRMesh/MRObjectLines.h
+++ b/source/MRMesh/MRObjectLines.h
@@ -17,6 +17,12 @@ public:
     constexpr static const char* TypeName() noexcept { return "ObjectLines"; }
     virtual const char* typeName() const override { return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "Polyline"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Polylines"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;
 
@@ -32,9 +38,6 @@ public:
     ObjectLines( ProtectedStruct, const ObjectLines& obj ) : ObjectLines( obj ) {}
 
     MRMESH_API virtual std::vector<std::string> getInfoLines() const override;
-
-    std::string getClassName() const override { return "Lines"; }
-    std::string getClassNameInPlural() const override { return "Lines"; }
 
     /// signal about lines changing, triggered in setDirtyFlag
     using LinesChangedSignal = Signal<void( uint32_t mask )>;

--- a/source/MRMesh/MRObjectMesh.h
+++ b/source/MRMesh/MRObjectMesh.h
@@ -18,6 +18,12 @@ public:
     constexpr static const char* TypeName() noexcept { return "ObjectMesh"; }
     virtual const char* typeName() const override { return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "Mesh"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Meshes"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     /// returns variable mesh, if const mesh is needed use `mesh()` instead
     virtual const std::shared_ptr< Mesh > & varMesh() { return data_.mesh; }
 
@@ -28,9 +34,6 @@ public:
     MRMESH_API virtual std::shared_ptr< Mesh > updateMesh( std::shared_ptr< Mesh > mesh );
 
     MRMESH_API virtual std::vector<std::string> getInfoLines() const override;
-
-    std::string getClassName() const override { return "Mesh"; }
-    std::string getClassNameInPlural() const override { return "Meshes"; }
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;

--- a/source/MRMesh/MRObjectPoints.h
+++ b/source/MRMesh/MRObjectPoints.h
@@ -18,6 +18,12 @@ public:
     constexpr static const char* TypeName() noexcept { return "ObjectPoints"; }
     virtual const char* typeName() const override { return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "Point Cloud"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Point Clouds"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     /// returns variable point cloud, if const point cloud is needed use `pointCloud()` instead
     virtual const std::shared_ptr<PointCloud>& varPointCloud() { return points_; }
 
@@ -33,9 +39,6 @@ public:
     ObjectPoints( ProtectedStruct, const ObjectPoints& obj ) : ObjectPoints( obj ) {}
 
     MRMESH_API virtual std::vector<std::string> getInfoLines() const override;
-
-    std::string getClassName() const override { return "Points"; }
-    std::string getClassNameInPlural() const override { return "Points"; }
 
     MRMESH_API virtual void setDirtyFlags( uint32_t mask, bool invalidateCaches = true ) override;
 

--- a/source/MRMesh/MRPlaneObject.h
+++ b/source/MRMesh/MRPlaneObject.h
@@ -19,21 +19,18 @@ public:
     PlaneObject( PlaneObject&& ) noexcept = default;
     PlaneObject& operator = ( PlaneObject&& ) noexcept = default;
 
-    constexpr static const char* TypeName() noexcept
-    {
-        return "PlaneObject";
-    }
-    virtual const char* typeName() const override
-    {
-        return TypeName();
-    }
+    constexpr static const char* TypeName() noexcept { return "PlaneObject"; }
+    virtual const char* typeName() const override { return TypeName(); }
+
+    constexpr static const char* ClassName() noexcept { return "Plane"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Planes"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
 
     /// \note this ctor is public only for std::make_shared used inside clone()
     PlaneObject( ProtectedStruct, const PlaneObject& obj ) : PlaneObject( obj )
     {}
-
-    std::string getClassName() const override { return "Plane"; }
-    std::string getClassNameInPlural() const override { return "Planes"; }
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;

--- a/source/MRMesh/MRPointObject.h
+++ b/source/MRMesh/MRPointObject.h
@@ -23,12 +23,15 @@ public:
     constexpr static const char* TypeName() noexcept { return "PointObject"; }
     virtual const char* typeName() const override { return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "Point"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Points"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     /// \note this ctor is public only for std::make_shared used inside clone()
     PointObject( ProtectedStruct, const PointObject& obj ) : PointObject( obj )
     {}
-
-    std::string getClassName() const override { return "Point"; }
-    std::string getClassNameInPlural() const override { return "Points"; }
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;

--- a/source/MRMesh/MRRadiusMeasurementObject.h
+++ b/source/MRMesh/MRRadiusMeasurementObject.h
@@ -19,11 +19,14 @@ public:
     constexpr static const char* TypeName() noexcept { return "RadiusMeasurementObject"; }
     const char* typeName() const override { return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "Radius"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Radii"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     // For `std::make_shared()` in `clone()`.
     RadiusMeasurementObject( ProtectedStruct, const RadiusMeasurementObject& obj ) : RadiusMeasurementObject( obj ) {}
-
-    std::string getClassName() const override { return "Radius"; }
-    std::string getClassNameInPlural() const override { return "Radii"; }
 
     MRMESH_API std::shared_ptr<Object> clone() const override;
     MRMESH_API std::shared_ptr<Object> shallowClone() const override;

--- a/source/MRMesh/MRSceneRoot.h
+++ b/source/MRMesh/MRSceneRoot.h
@@ -11,24 +11,41 @@ class MRMESH_CLASS SceneRootObject final : public Object
 {
 public:
     MRMESH_API SceneRootObject();
+
     SceneRootObject( SceneRootObject&& ) noexcept = default;
+
     SceneRootObject& operator = ( SceneRootObject&& ) noexcept = default;
+
     /// \note this ctor is public only for std::make_shared used inside clone()
     SceneRootObject( ProtectedStruct, const SceneRootObject& obj ) : SceneRootObject( obj ) {}
+
     constexpr static const char* TypeName() noexcept { return "RootObject"; }
-    constexpr static const char* RootName() noexcept { return "Root"; }
-    virtual std::string getClassName() const override { return "Root"; }
-    virtual std::string getClassNameInPlural() const override { return "Roots"; }
     virtual const char* typeName() const override { return TypeName(); }
+
+    constexpr static const char* ClassName() noexcept { return "Root"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Roots"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
+    constexpr static const char* RootName() noexcept { return "Root"; }
+
     virtual void setAncillary( bool ) override { Object::setAncillary( false ); }
+
     virtual bool select( bool ) override { return Object::select( false ); }
+
     virtual void setName( std::string ) override { Object::setName( SceneRootObject::RootName() ); }
+
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
+
     /// same as clone but returns correct type
     MRMESH_API std::shared_ptr<SceneRootObject> cloneRoot() const;
+
 protected:
     SceneRootObject( const SceneRootObject& other ) = default;
+
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
+
     MRMESH_API void deserializeFields_( const Json::Value& root ) override;
 };
 

--- a/source/MRMesh/MRSphereObject.h
+++ b/source/MRMesh/MRSphereObject.h
@@ -25,11 +25,14 @@ public:
     constexpr static const char* TypeName() noexcept { return "SphereObject"; }
     virtual const char* typeName() const override {return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "Sphere"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Spheres"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     /// \note this ctor is public only for std::make_shared used inside clone()
     SphereObject( ProtectedStruct, const SphereObject& obj ) : SphereObject( obj ) {}
-
-    std::string getClassName() const override { return "Sphere"; }
-    std::string getClassNameInPlural() const override { return "Spheres"; }
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;

--- a/source/MRMesh/MRVisualObject.cpp
+++ b/source/MRMesh/MRVisualObject.cpp
@@ -2,8 +2,6 @@
 #include "MRObjectFactory.h"
 #include "MRSerializer.h"
 #include "MRSceneColors.h"
-#include "MRMesh.h"
-#include "MRObjectMesh.h"
 #include "MRTimer.h"
 #include "MRHeapBytes.h"
 #include "MRStringConvert.h"

--- a/source/MRMesh/MRVisualObject.h
+++ b/source/MRMesh/MRVisualObject.h
@@ -127,8 +127,11 @@ public:
     constexpr static const char* TypeName() noexcept { return "VisualObject"; }
     virtual const char* typeName() const override { return TypeName(); }
 
-    std::string getClassName() const override { return "Visual Object"; }
-    std::string getClassNameInPlural() const override { return "Visual Objects"; }
+    constexpr static const char* ClassName() noexcept { return "Visual Object"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Visual Objects"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
 
     /// Returns true if this class supports the property `type`. Otherwise passing it to the functions below is illegal.
     [[nodiscard]] MRMESH_API virtual bool supportsVisualizeProperty( AnyVisualizeMaskEnum type ) const;

--- a/source/MRViewer/ImGuiMenu.cpp
+++ b/source/MRViewer/ImGuiMenu.cpp
@@ -1417,7 +1417,7 @@ float ImGuiMenu::drawSelectionInformation_()
 
     if ( selectedObjs.size() == 1 )
     {
-        UI::inputTextCenteredReadOnly( "Object Type", selectedObjs.front()->getClassName(), itemWidth, textColor, labelColor );
+        UI::inputTextCenteredReadOnly( "Object Type", selectedObjs.front()->className(), itemWidth, textColor, labelColor );
 
         drawTagInformation_( selectedObjs.front(), {
             .textColor = textColor,

--- a/source/MRViewer/MRSceneStateCheck.h
+++ b/source/MRViewer/MRSceneStateCheck.h
@@ -15,44 +15,18 @@ struct NoModelCheck {};
 template<typename ObjectT>
 std::string getNObjectsLine( unsigned n )
 {
-    std::string typeName = ObjectT::TypeName();
-    if ( typeName.starts_with( "Object" ) )
-    {
-        if ( !typeName.ends_with( "Object" ) )
-            typeName = typeName.substr( 6 );
-    }
-    else if ( typeName.ends_with( "Object" ) )
-        typeName = typeName.substr( 0, typeName.size() - 6 );
-
-    if ( typeName == "Points" )
-        typeName = "Point Cloud";
-    else if ( typeName == "Lines" )
-        typeName = "Polyline";
-    else if ( typeName == "Voxels" )
-        typeName = "Volume";
-    else if ( typeName == "Visual" )
-        typeName = "Visual Object";
-
-    if ( n != 1 )
-    {
-        if ( typeName.ends_with( "s" ) || typeName.ends_with( "sh" ) )
-            typeName += "es";
-        else
-            typeName += "s";
-    }
-
     switch ( n )
     {
     case 1:
-        return "one " + typeName;
+        return std::string( "one " ) + ObjectT::ClassName();
     case 2:
-        return "two " + typeName;
+        return std::string( "two " ) + ObjectT::ClassNameInPlural();
     case 3:
-        return "three " + typeName;
+        return std::string( "three " ) + ObjectT::ClassNameInPlural();
     case 4:
-        return "four " + typeName;
+        return std::string( "four " ) + ObjectT::ClassNameInPlural();
     default:
-        return std::to_string( n ) + " " + typeName;
+        return std::to_string( n ) + " " + ObjectT::ClassNameInPlural();
     }    
 }
 
@@ -67,7 +41,7 @@ std::string sceneSelectedExactly( const std::vector<std::shared_ptr<const Object
     {
         auto tObj = dynamic_cast<const ObjectT*>( obj.get() );
         if ( !tObj )
-            return std::string( "Selected object(s) must have type: " ) + ObjectT::TypeName();
+            return std::string( "Selected object(s) must be " ) + ObjectT::ClassName();
 
         if constexpr ( modelCheck )
             if ( !tObj->hasModel() )

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -1263,15 +1263,15 @@ static std::optional<std::string> commonClassName( const std::vector<std::shared
     if ( objs.empty() )
         return {};
 
-    auto cn = objs[0]->getClassName();
+    auto cn = objs[0]->className();
     if ( objs.size() == 1 )
         return cn;
 
     for ( int i = 1; i < objs.size(); ++i )
-        if ( cn != objs[i]->getClassName() )
+        if ( cn != objs[i]->className() )
             return {};
 
-    return objs[0]->getClassNameInPlural();
+    return objs[0]->classNameInPlural();
 }
 
 bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList, const FileLoadOptions & options )

--- a/source/MRVoxels/MRObjectVoxels.h
+++ b/source/MRVoxels/MRObjectVoxels.h
@@ -24,6 +24,12 @@ public:
     constexpr static const char* TypeName() noexcept { return "ObjectVoxels"; }
     virtual const char* typeName() const override { return TypeName(); }
 
+    constexpr static const char* ClassName() noexcept { return "Voxel Volume"; }
+    virtual std::string className() const override { return ClassName(); }
+
+    constexpr static const char* ClassNameInPlural() noexcept { return "Voxel Volumes"; }
+    virtual std::string classNameInPlural() const override { return ClassNameInPlural(); }
+
     MRVOXELS_API virtual void applyScale( float scaleFactor ) override;
 
     /// Returns iso surface, empty if iso value is not set
@@ -52,9 +58,6 @@ public:
     { return vdbVolume_.voxelSize; }
 
     MRVOXELS_API virtual std::vector<std::string> getInfoLines() const override;
-
-    std::string getClassName() const override { return "Voxels"; }
-    std::string getClassNameInPlural() const override { return "Voxels"; }
 
     /// Clears all internal data and then creates grid and calculates histogram (surface is not built, call \ref updateHistogramAndSurface)
     /// \param normalPlusGrad true means that iso-surface normals will be along gradient, false means opposite direction


### PR DESCRIPTION
1. To be similar to existing `Object::typeName()` and `Object::TypeName()`:

  * `Object::getClassName()` renamed in `Object::className()`
  * `Object::getClassNameInPlural()` renamed in `Object::classNameInPlural()`
  * new static functions `Object::ClassName()` and `Object::ClassNameInPlural()` introduced

3. Scene state checks implemented via `Object::ClassName()` and `Object::ClassNameInPlural()`

4. Some class names renamed to avoid ambiguity and to resemble more what was in scene state checks.