### PR TITLE
Fix: Copy static-lib files when building thirdparty libs on Mac in Emscripten mode.

### DIFF
--- a/scripts/build_thirdparty.sh
+++ b/scripts/build_thirdparty.sh
@@ -147,10 +147,10 @@ popd
 
 # copy libs (some of them are handled by their `cmake --install`, but some are not)
 echo "Copying thirdparty libs.."
-if [[ $OSTYPE == 'darwin'* ]]; then
-  LIB_SUFFIX="*.dylib"
-elif [ "${MR_EMSCRIPTEN}" = "ON" ]; then
+if [ "${MR_EMSCRIPTEN}" = "ON" ]; then
   LIB_SUFFIX="*.a"
+elif [[ $OSTYPE == 'darwin'* ]]; then
+  LIB_SUFFIX="*.dylib"
 else
   LIB_SUFFIX="*.so"
 fi


### PR DESCRIPTION
1. When need to copy static files, first determine whether it is emscripten.
2. I listed the lib files  in **thirdparty_build**, only the static library file **liblazperf_s.a** needs to be copied separately, but it doesn't seem to matter if it is not copied.

Fix :https://github.com/MeshInspector/MeshLib/issues/5047