### PR TITLE
Save Scene As: suggest old name by default

### DIFF
--- a/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
@@ -800,14 +800,23 @@ void SaveSceneAsMenuItem::saveScene_( const std::filesystem::path& savePath )
 
 void SaveSceneAsMenuItem::saveSceneAs_()
 {
-    std::string defFileName;
-    if ( auto obj = getDepthFirstObject( &SceneRoot::get(), ObjectSelectivityType::Selectable ) )
-        defFileName = obj->name();
+    FileParameters params{ .filters = SceneSave::getFilters() };
+    auto savePath = SceneRoot::getScenePath();
+    if ( savePath.empty() )
+    {
+        if ( auto obj = getDepthFirstObject( &SceneRoot::get(), ObjectSelectivityType::Selectable ) )
+            params.fileName = obj->name();
+    }
+    else
+    {
+        params.baseFolder = savePath.parent_path();
+        params.fileName = utf8string( savePath.stem() );
+    }
     saveFileDialogAsync( [&] ( const std::filesystem::path& savePath )
     {
         if ( !savePath.empty() )
             saveScene_( savePath );
-    }, { .fileName = defFileName, .filters = SceneSave::getFilters() } );
+    }, params );
 }
 
 bool SaveSceneAsMenuItem::action()


### PR DESCRIPTION
Save Scene As
* if the scene already have a name, suggests old name and old folder in File dialog;
* otherwise it suggests the name of the first object, and last used folder.