### PR TITLE
WebResponseCallback type alias

### DIFF
--- a/source/MRViewer/MRViewer.vcxproj
+++ b/source/MRViewer/MRViewer.vcxproj
@@ -315,6 +315,7 @@
     <ClInclude Include="MRRenderClickableRect.h" />
     <ClInclude Include="MRUIQualityControl.h" />
     <ClInclude Include="MRItemEnabledPerViewport.h" />
+    <ClInclude Include="MRWebResponseCallback.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(ProjectDir)..\.editorconfig" />

--- a/source/MRViewer/MRViewer.vcxproj.filters
+++ b/source/MRViewer/MRViewer.vcxproj.filters
@@ -963,6 +963,9 @@
     <ClInclude Include="MRItemEnabledPerViewport.h">
       <Filter>RibbonMenu</Filter>
     </ClInclude>
+    <ClInclude Include="MRWebResponseCallback.h">
+      <Filter>Requests</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="$(ProjectDir)..\.editorconfig" />

--- a/source/MRViewer/MRViewerFwd.h
+++ b/source/MRViewer/MRViewerFwd.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "exports.h"
 #include <MRMesh/MRMeshFwd.h>
+#include <json/forwards.h>
 #include <functional>
 
 namespace MR
@@ -67,6 +68,9 @@ using StatePlugin = StateListenerPlugin<>;
 class HistoryStore;
 
 using ViewerEventCallback = std::function<void()>;
+
+class MRVIEWER_CLASS WebRequest;
+using WebResponseCallback = std::function<void( const Json::Value& response )>;
 
 struct PointOnObject;
 

--- a/source/MRViewer/MRViewerFwd.h
+++ b/source/MRViewer/MRViewerFwd.h
@@ -3,7 +3,6 @@
 #include "config.h"
 #include "exports.h"
 #include <MRMesh/MRMeshFwd.h>
-#include <json/forwards.h>
 #include <functional>
 
 namespace MR
@@ -70,7 +69,6 @@ class HistoryStore;
 using ViewerEventCallback = std::function<void()>;
 
 class MRVIEWER_CLASS WebRequest;
-using WebResponseCallback = std::function<void( const Json::Value& response )>;
 
 struct PointOnObject;
 

--- a/source/MRViewer/MRWebRequest.h
+++ b/source/MRViewer/MRWebRequest.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "MRMesh/MRMeshFwd.h"
 #if defined( __EMSCRIPTEN__ ) || !defined( MRMESH_NO_CPR )
-#include "MRViewerFwd.h"
+#include "MRWebResponseCallback.h"
 #include "MRMesh/MRExpected.h"
 #include <unordered_map>
 #include <string>

--- a/source/MRViewer/MRWebRequest.h
+++ b/source/MRViewer/MRWebRequest.h
@@ -3,7 +3,6 @@
 #if defined( __EMSCRIPTEN__ ) || !defined( MRMESH_NO_CPR )
 #include "MRViewerFwd.h"
 #include "MRMesh/MRExpected.h"
-#include <json/forwards.h>
 #include <unordered_map>
 #include <string>
 #include <functional>
@@ -76,7 +75,7 @@ public:
     // set log name
     MRVIEWER_API void setLogName( std::string logName );
 
-    using ResponseCallback = std::function<void( const Json::Value& response )>;
+    using ResponseCallback = MR::WebResponseCallback;
 
     /// send request, calling callback on answer,
     /// if async then callback is called in next frame after getting response

--- a/source/MRViewer/MRWebResponseCallback.h
+++ b/source/MRViewer/MRWebResponseCallback.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "MRViewerFwd.h"
+#include <json/forwards.h>
+
+namespace MR
+{
+
+using WebResponseCallback = std::function<void( const Json::Value& response )>;
+
+} //namespace MR


### PR DESCRIPTION
Introduce new header `MRViewer\MRWebResponseCallback.h` with type alias `WebResponseCallback` to minimize inclusions of the header `MRViewer\MRWebRequest.h`