### PR TITLE
OBJ loading fix

### DIFF
--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -462,6 +462,8 @@ Expected<MeshLoad::NamedMesh> loadSingleModelFromObj(
     }
     if ( firstVert < 0 )
         firstVert = int( points.size() ) - firstVert;
+    else
+        --firstVert;
     if ( firstVert < 0 || firstVert >= points.size() )
         return unexpected( "Out of bounds Vertex ID in OBJ-file" );
     haveColors = firstVert < colors.size();


### PR DESCRIPTION
The OBJ loader fails if the first vertex of the first face is equal to the number of points.

It seems the check at the beginning of  `loadSingleModelFromObj`  assumes that `firstVert` is zero-indexed:

```C++
    if ( firstVert < 0 || firstVert >= points.size() )
        return unexpected( "Out of bounds Vertex ID in OBJ-file" );
```

The fix is therefore to decrement `firstVert`, similar to what's done for `repr.vId` inside the loop.

This should hopefully fix #5184 although I haven't actually tested it yet.