### PR TITLE
misc improvements

### DIFF
--- a/source/MRMesh/MRBitSet.h
+++ b/source/MRMesh/MRBitSet.h
@@ -24,10 +24,10 @@ namespace MR
 
 /// std::vector<bool> like container  (random-access, size_t - index type, bool - value type)
 /// with all bits after size() considered off during testing
-class BitSet : public boost::dynamic_bitset<std::uint64_t>
+class BitSet : public boost::dynamic_bitset<Uint64>
 {
 public:
-    using base = boost::dynamic_bitset<std::uint64_t>;
+    using base = boost::dynamic_bitset<Uint64>;
     using base::base;
     using IndexType = size_t;
 

--- a/source/MRMesh/MRDistanceMapLoad.cpp
+++ b/source/MRMesh/MRDistanceMapLoad.cpp
@@ -9,6 +9,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 
 namespace MR
 {

--- a/source/MRMesh/MRDistanceMapSave.cpp
+++ b/source/MRMesh/MRDistanceMapSave.cpp
@@ -7,6 +7,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 
 namespace MR
 {

--- a/source/MRMesh/MRLinesLoad.cpp
+++ b/source/MRMesh/MRLinesLoad.cpp
@@ -8,6 +8,7 @@
 #include "MRPly.h"
 #include "MRTimer.h"
 #include <fstream>
+#include <sstream>
 
 namespace MR
 {

--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -20,6 +20,7 @@
 
 #include <array>
 #include <future>
+#include <sstream>
 
 namespace MR
 {

--- a/source/MRMesh/MRMultiwayAligningTransform.cpp
+++ b/source/MRMesh/MRMultiwayAligningTransform.cpp
@@ -1,4 +1,5 @@
 #include "MRMultiwayAligningTransform.h"
+#include "MRphmap.h"
 #include "MRGTest.h"
 #include "MRTimer.h"
 

--- a/source/MRMesh/MRStreamOperators.h
+++ b/source/MRMesh/MRStreamOperators.h
@@ -6,11 +6,11 @@
 #include "MRMatrix3.h"
 #include "MRMatrix4.h"
 #include "MRPlane3.h"
-#include "MRBitSet.h"
 #include "MRTriPoint.h"
 #include "MRAffineXf3.h"
 #include "MRPointOnFace.h"
-
+#include <istream>
+#include <ostream>
 
 /**
  * \brief Overloaded operators for IO base structures (Vector, Matrix, Plane, AffineXf, ...)

--- a/source/MRMeshC/MRBitSet.cpp
+++ b/source/MRMeshC/MRBitSet.cpp
@@ -19,7 +19,7 @@ MRBitSet* mrBitSetCopy( const MRBitSet* bs_ )
     RETURN_NEW( bs );
 }
 
-const uint64_t* mrBitSetBlocks( const MRBitSet* bs_ )
+const Uint64* mrBitSetBlocks( const MRBitSet* bs_ )
 {
     ARG( bs );
     return bs.bits().data();

--- a/source/MRMeshC/MRBitSet.h
+++ b/source/MRMeshC/MRBitSet.h
@@ -11,7 +11,7 @@ MRMESHC_API MRBitSet* mrBitSetCopy( const MRBitSet* bs );
 MRMESHC_API MRBitSet* mrBitSetNew( size_t numBits, bool fillValue );
 
 /// gets read-only access to the underlying blocks of a bitset
-MRMESHC_API const uint64_t* mrBitSetBlocks( const MRBitSet* bs );
+MRMESHC_API const Uint64* mrBitSetBlocks( const MRBitSet* bs );
 
 /// gets count of the underlying blocks of a bitset
 MRMESHC_API size_t mrBitSetBlocksNum( const MRBitSet* bs );

--- a/source/MRMeshC/MRMeshFwd.h
+++ b/source/MRMeshC/MRMeshFwd.h
@@ -54,4 +54,22 @@ typedef struct MRSaveSettings MRSaveSettings;
 
 typedef bool (*MRProgressCallback)( float );
 
+#ifdef __cplusplus
+#define MRSTD std::
+#else
+#define MRSTD
+#endif
+
+#ifdef __APPLE__
+typedef MRSTD ptrdiff_t Int64;
+typedef MRSTD size_t Uint64;
+#ifdef __cplusplus
+static_assert(sizeof(Int64) == 8);
+static_assert(sizeof(Uint64) == 8);
+#endif
+#else //!__APPLE__
+typedef MRSTD int64_t Int64;
+typedef MRSTD uint64_t Uint64;
+#endif
+
 MR_EXTERN_C_END

--- a/source/MRPch/MRPch.h
+++ b/source/MRPch/MRPch.h
@@ -59,6 +59,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cassert>
 #include <cfloat>
 #include <chrono>
@@ -87,6 +88,7 @@
 #include <string>
 #include <thread>
 #include <tuple>
+#include <typeindex>
 #include <unordered_map>
 #include <variant>
 #include <vector>

--- a/source/MRTest/MRChunkIterator.cpp
+++ b/source/MRTest/MRChunkIterator.cpp
@@ -1,5 +1,5 @@
 #include "MRMesh/MRChunkIterator.h"
-
+#include "MRMesh/MRBitSet.h"
 #include "MRMesh/MRGTest.h"
 
 namespace MR

--- a/source/MRViewer/MRSceneCache.h
+++ b/source/MRViewer/MRSceneCache.h
@@ -4,6 +4,7 @@
 #include "MRMesh/MRSceneRoot.h"
 #include "exports.h"
 #include <unordered_map>
+#include <typeindex>
 
 namespace MR
 {

--- a/source/MRVoxels/MRDicom.cpp
+++ b/source/MRVoxels/MRDicom.cpp
@@ -25,6 +25,7 @@
 #include <gdcmTagKeywords.h>
 #pragma warning(pop)
 
+#include <variant>
 
 namespace MR
 {


### PR DESCRIPTION
* use `boost::dynamic_bitset` with `Uint64` template parameter instead of `std::uint64_t` for C-bindings consistency
* allow using `Uint64` in `MRMeshC`
* `MRStreamOperators.h`: remove `#include "MRBitSet.h"`
* add missed includes in other places