### PR TITLE
unify parallel_hashmap includes

### DIFF
--- a/source/MRMesh/MRContoursCut.cpp
+++ b/source/MRMesh/MRContoursCut.cpp
@@ -17,7 +17,7 @@
 #include "MRMeshIntersect.h"
 #include "MRSurfacePath.h"
 #include "MRPch/MRSpdlog.h"
-#include <parallel_hashmap/phmap.h>
+#include "MRphmap.h"
 #include <numeric>
 
 namespace MR

--- a/source/MRMesh/MRIntersectionContour.cpp
+++ b/source/MRMesh/MRIntersectionContour.cpp
@@ -6,7 +6,7 @@
 #include "MRFillContour.h"
 #include "MRAffineXf3.h"
 #include "MRParallelFor.h"
-#include <parallel_hashmap/phmap.h>
+#include "MRphmap.h"
 #include <optional>
 
 namespace MR

--- a/source/MRMesh/MRLocalTriangulations.cpp
+++ b/source/MRMesh/MRLocalTriangulations.cpp
@@ -8,7 +8,7 @@
 #include "MRBox.h"
 #include "MRHeap.h"
 #include "MRBitSetParallelFor.h"
-#include <parallel_hashmap/phmap.h>
+#include "MRphmap.h"
 #include <algorithm>
 #include <cassert>
 #include <cfloat>

--- a/source/MRMesh/MRMeshComponents.cpp
+++ b/source/MRMesh/MRMeshComponents.cpp
@@ -8,7 +8,7 @@
 #include "MRRegionBoundary.h"
 #include "MREdgeIterator.h"
 #include "MRUnionFindParallel.h"
-#include <parallel_hashmap/phmap.h>
+#include "MRphmap.h"
 #include <climits>
 
 namespace MR

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -11,7 +11,7 @@
 #include "MRGTest.h"
 #include "MRParallelFor.h"
 #include "MRPch/MRSpdlog.h"
-#include <parallel_hashmap/phmap.h>
+#include "MRphmap.h"
 #include <queue>
 #include <functional>
 

--- a/source/MRMesh/MRPointCloudTriangulation.cpp
+++ b/source/MRMesh/MRPointCloudTriangulation.cpp
@@ -19,7 +19,7 @@
 #include "MRLocalTriangulations.h"
 #include "MRMeshFixer.h"
 #include "MREdgePaths.h"
-#include <parallel_hashmap/phmap.h>
+#include "MRphmap.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRTripleFaceIntersections.cpp
+++ b/source/MRMesh/MRTripleFaceIntersections.cpp
@@ -3,7 +3,7 @@
 #include "MRMeshTopology.h"
 #include "MRTimer.h"
 #include <MRPch/MRTBB.h>
-#include <parallel_hashmap/phmap.h>
+#include "MRphmap.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRphmap.h
+++ b/source/MRMesh/MRphmap.h
@@ -1,17 +1,7 @@
 #pragma once
 
 #include "MRMesh/MRMeshFwd.h"
-
-#if defined(__EMSCRIPTEN__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-builtins"
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#pragma clang diagnostic ignored "-Wshift-count-overflow"
-#endif
-#include <parallel_hashmap/phmap.h>
-#if defined(__EMSCRIPTEN__)
-#pragma clang diagnostic pop
-#endif
+#include "MRPch/MRHashMap.h"
 
 namespace MR
 {

--- a/source/MRPch/MRHashMap.h
+++ b/source/MRPch/MRHashMap.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#if defined(__EMSCRIPTEN__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-builtins"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wshift-count-overflow"
+#endif
+#include <parallel_hashmap/phmap.h>
+#if defined(__EMSCRIPTEN__)
+#pragma clang diagnostic pop
+#endif

--- a/source/MRPch/MRPch.h
+++ b/source/MRPch/MRPch.h
@@ -4,9 +4,7 @@
 #pragma warning(disable: 4820) //#pragma warning: N bytes padding added after data member
 
 #include "MREigen.h"
-
-#include <parallel_hashmap/phmap.h>
-
+#include "MRHashMap.h"
 #include "MRExpected.h"
 
 #pragma warning(push)

--- a/source/MRPch/MRPch.vcxproj
+++ b/source/MRPch/MRPch.vcxproj
@@ -22,6 +22,7 @@
     <ClInclude Include="MRExpected.h" />
     <ClInclude Include="MRFilesystem.h" />
     <ClInclude Include="MRFmt.h" />
+    <ClInclude Include="MRHashMap.h" />
     <ClInclude Include="MRWasm.h" />
     <ClInclude Include="MRAsyncLaunchType.h" />
     <ClInclude Include="MREigen.h" />

--- a/source/MRPch/MRPch.vcxproj.filters
+++ b/source/MRPch/MRPch.vcxproj.filters
@@ -17,6 +17,7 @@
     <ClInclude Include="MRWinapi.h" />
     <ClInclude Include="MRExpected.h" />
     <ClInclude Include="MREigenSparseCore.h" />
+    <ClInclude Include="MRHashMap.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRPch.cpp" />

--- a/source/MRVoxels/MRVoxelGraphCut.cpp
+++ b/source/MRVoxels/MRVoxelGraphCut.cpp
@@ -9,7 +9,7 @@
 #include "MRMesh/MRBox.h"
 #include "MRPch/MRSpdlog.h"
 #include "MRPch/MRTBB.h"
-#include <parallel_hashmap/phmap.h>
+#include "MRMesh/MRphmap.h"
 #include <array>
 #include <cfloat>
 

--- a/source/MRVoxels/MRVoxelPath.cpp
+++ b/source/MRVoxels/MRVoxelPath.cpp
@@ -4,8 +4,8 @@
 #include "MRVoxelsVolume.h"
 #include "MRMesh/MRVector3.h"
 #include "MRMesh/MRTimer.h"
+#include "MRMesh/MRphmap.h"
 #include <cfloat>
-#include <parallel_hashmap/phmap.h>
 #include <queue>
 #include <cmath>
 #include <filesystem>


### PR DESCRIPTION
Include `<parallel_hashmap/phmap.h>` not directly, but via our `<MRPch/MRHashMap.h>`, which suppresses warnings inside the library (and introduces later some fixes for ARM platform).