### PR TITLE
makeThickMesh improvements for complex cases

### DIFF
--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1809,7 +1809,7 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
             auto e = fromContour[j];
             auto e1 = thisContour[j];
             assert( !left( e1 ) );
-            assert( ( flipOrientation && !from.left( e ) ) || ( !flipOrientation && !from.right( e ) ) );
+            assert( ( flipOrientation && !from.isLeftInRegion( e, fromFaces0 ) ) || ( !flipOrientation && !from.isLeftInRegion( e.sym(), fromFaces0 ) ) );
             setVmap( from.org( e ), org( e1 ) );
             setVmap( from.dest( e ), dest( e1 ) );
             assert( !getAt( emap, e.undirected() ) );


### PR DESCRIPTION
* duplicate boundary vertices as necessary so that every vertex must be on at most one hole boundary to have unique mapping on the vertices after `makeDegenerateBandAroundHole`.
* avoid the situation when all vertices of a connected component have `stabilizer=0` and the system of equations is underdetermined.
* correct `assert` in `MeshTopology::addPartByMask`, requiring that stitched edges do not have neighbor triangles in copied region (but can have neighbor triangles outside of copied region).