### PR TITLE
VisualObject: reset dirty flags if no render object

### DIFF
--- a/source/MRMesh/MRVisualObject.cpp
+++ b/source/MRMesh/MRVisualObject.cpp
@@ -263,7 +263,10 @@ bool VisualObject::render( const ModelRenderParams& params ) const
 {
     setupRenderObject_();
     if ( !renderObj_ )
+    {
+        resetDirty();
         return false;
+    }
 
     return renderObj_->render( params );
 }


### PR DESCRIPTION
Otherwise `VisualObject` without any model will lead to never ending redrawing.