### PR TITLE
test_decimate.py: reduce thresholds

### DIFF
--- a/test_regression/test_algorithms/test_decimate.py
+++ b/test_regression/test_algorithms/test_decimate.py
@@ -111,9 +111,8 @@ def test_decimate(tmp_path, dec_params):
     with check:
         # Previously we had thresholds here equal to 0.01, but compare_meshes_similarity failed on Arm computers,
         # if MeshLib was built with Clang 12 (but not with Clang >= 14) or with GCC 14.
-        # Even verts_thresh=0.02 was not enough for Debug GCC11 Arm configuration.
         compare_meshes_similarity(mesh, ref_mesh,
-                                  verts_thresh=0.01, edges_thresh=0.01)
+                                  verts_thresh=0.02, edges_thresh=0.02)
     with check:
         self_col_tri = mrmeshpy.findSelfCollidingTriangles(mesh).size()
         assert self_col_tri == 0, f"Mesh should have no self-colliding triangles, actual value is {self_col_tri}"


### PR DESCRIPTION
After stop taking inline functions from python bindings, thresholds can be reduced. 