### PR TITLE
MultiwayICP: independent mode improvements

### DIFF
--- a/source/MRMesh/MRMultiwayICP.cpp
+++ b/source/MRMesh/MRMultiwayICP.cpp
@@ -841,8 +841,7 @@ bool MultiwayICP::doIteration_( bool p2pl )
 bool MultiwayICP::p2ptIter_()
 {
     MR_TIMER;
-    using FullSizeBool = uint8_t;
-    Vector<FullSizeBool, ObjId> valid( objs_.size() );
+    Vector<std::optional<AffineXf3d>, ObjId> updXf( objs_.size() );
     ParallelFor( objs_, [&] ( ObjId objId )
     {
         ICPElementId id( objId.get() );
@@ -864,45 +863,45 @@ bool MultiwayICP::p2ptIter_()
             }
         }
 
-        AffineXf3f res;
+        AffineXf3d res;
         switch ( prop_.icpMode )
         {
         default:
             assert( false );
             [[fallthrough]];
         case ICPMode::RigidScale:
-            res = AffineXf3f( p2pt.findBestRigidScaleXf() );
+            res = p2pt.findBestRigidScaleXf();
             break;
         case ICPMode::AnyRigidXf:
-            res = AffineXf3f( p2pt.findBestRigidXf() );
+            res = p2pt.findBestRigidXf();
             break;
         case ICPMode::OrthogonalAxis:
-            res = AffineXf3f( p2pt.findBestRigidXfOrthogonalRotationAxis( Vector3d{ prop_.fixedRotationAxis } ) );
+            res = p2pt.findBestRigidXfOrthogonalRotationAxis( Vector3d{ prop_.fixedRotationAxis } );
             break;
         case ICPMode::FixedAxis:
-            res = AffineXf3f( p2pt.findBestRigidXfFixedRotationAxis( Vector3d{ prop_.fixedRotationAxis } ) );
+            res = p2pt.findBestRigidXfFixedRotationAxis( Vector3d{ prop_.fixedRotationAxis } );
             break;
         case ICPMode::TranslationOnly:
-            res = AffineXf3f( Matrix3f(), Vector3f( p2pt.findBestTranslation() ) );
+            res = AffineXf3d( Matrix3d(), p2pt.findBestTranslation() );
             break;
         }
         if ( std::isnan( res.b.x ) ) //nan check
-        {
-            valid[objId] = FullSizeBool( false );
             return;
-        }
-        objs_[objId].xf = res * objs_[objId].xf;
-        valid[objId] = FullSizeBool( true );
+        updXf[objId] = res;
     } );
-
-    return std::all_of( valid.vec_.begin(), valid.vec_.end(), [] ( auto v ) { return bool( v ); } );
+    if ( !std::all_of( updXf.vec_.begin(), updXf.vec_.end(), [] ( const auto& v ) { return v.has_value(); } ) )
+        return false;
+    // fix position of last object, and move all others relative to it
+    const auto fixLastXf = updXf.back()->inverse();
+    for ( ObjId objId( 0 ); objId + 1 < objs_.size(); ++objId )
+        objs_[objId].xf = AffineXf3f( fixLastXf * *updXf[objId] * AffineXf3d( objs_[objId].xf ) );
+    return true;
 }
 
 bool MultiwayICP::p2plIter_()
 {
     MR_TIMER;
-    using FullSizeBool = uint8_t;
-    Vector<FullSizeBool, ObjId> valid( objs_.size() );
+    Vector<std::optional<AffineXf3d>, ObjId> updXf( objs_.size() );
     ParallelFor( objs_, [&] ( ObjId objId )
     {
         ICPElementId id( objId.get() );
@@ -929,10 +928,7 @@ bool MultiwayICP::p2plIter_()
             }
         }
         if ( activeCount <= 0 )
-        {
-            valid[objId] = FullSizeBool( false );
             return;
-        }
         centroidRef /= float( activeCount * 2 );
 
         PointToPlaneAligningTransform p2pl;
@@ -955,16 +951,18 @@ bool MultiwayICP::p2plIter_()
 
         AffineXf3d res = getAligningXf( p2pl, prop_.icpMode, prop_.p2plAngleLimit, prop_.p2plScaleLimit, prop_.fixedRotationAxis );
         if ( std::isnan( res.b.x ) ) //nan check
-        {
-            valid[objId] = FullSizeBool( false );
             return;
-        }
         const AffineXf3d subCentroid{ Matrix3d(), Vector3d( -centroidRef ) };
         const AffineXf3d addCentroid{ Matrix3d(), Vector3d(  centroidRef ) };
-        objs_[objId].xf = AffineXf3f( addCentroid * res * subCentroid * AffineXf3d( objs_[objId].xf ) );
-        valid[objId] = FullSizeBool( true );
+        updXf[objId] = addCentroid * res * subCentroid;
     } );
-    return std::all_of( valid.vec_.begin(), valid.vec_.end(), [] ( auto v ) { return bool( v ); } );
+    if ( !std::all_of( updXf.vec_.begin(), updXf.vec_.end(), [] ( const auto& v ) { return v.has_value(); } ) )
+        return false;
+    // fix position of last object, and move all others relative to it
+    const auto fixLastXf = updXf.back()->inverse();
+    for ( ObjId objId( 0 ); objId + 1 < objs_.size(); ++objId )
+        objs_[objId].xf = AffineXf3f( fixLastXf * *updXf[objId] * AffineXf3d( objs_[objId].xf ) );
+    return true;
 }
 
 bool MultiwayICP::multiwayIter_( bool p2pl )

--- a/source/MRMesh/MRMultiwayICP.h
+++ b/source/MRMesh/MRMultiwayICP.h
@@ -62,8 +62,10 @@ struct MultiwayICPSamplingParameters
     /// sampling size of each object, 0 has special meaning "take all valid points"
     float samplingVoxelSize = 0;
 
-    /// size of maximum icp group to work with
-    /// if number of objects exceeds this value, icp is applied in cascade mode
+    /// size of maximum icp group to work with;
+    /// if the number of objects exceeds this value, icp is applied in cascade mode;
+    /// maxGroupSize = 1 means that every object is moved independently on half distance to the previous position of all other objects;
+    /// maxGroupSize = 0 means that a big system of equations for all objects is solved (force no cascading)
     int maxGroupSize = 64;
 
     enum class CascadeMode

--- a/source/MRTest/MRMultiwayICPTests.cpp
+++ b/source/MRTest/MRMultiwayICPTests.cpp
@@ -18,12 +18,12 @@ TEST( MRMesh, MultiwayICPTorus )
 
     const auto xf = AffineXf3f( Matrix3f::rotation( axis, 0.2f ), trans );
 
-    auto run = [&] ( ICPMethod method, float eps )
+    auto run = [&] ( ICPMethod method, int maxGroupSize, float eps )
     {
         ICPObjects objs;
         objs.push_back( { torusMove, xf } );
         objs.push_back( { torusRef, AffineXf3f{} } );
-        MultiwayICP icp( objs, MultiwayICPSamplingParameters{} );
+        MultiwayICP icp( objs, MultiwayICPSamplingParameters{ .maxGroupSize = maxGroupSize } );
 
         ICPProperties props
         {
@@ -40,14 +40,17 @@ TEST( MRMesh, MultiwayICPTorus )
         EXPECT_LT( newXf.b.length(), eps );
     };
 
-    std::cout << "running Point-to-Plane method\n";
-    run( ICPMethod::PointToPlane, 1e-6f );
+    for ( int maxGroupSize : { 0, 1 } )
+    {
+        std::cout << "running Point-to-Plane method, maxGroupSize=" << maxGroupSize << "\n";
+        run( ICPMethod::PointToPlane, maxGroupSize, 1e-6f );
 
-    std::cout << "running Point-to-Point method\n";
-    run( ICPMethod::PointToPoint, 1e-3f );
+        std::cout << "running Point-to-Point method, maxGroupSize=" << maxGroupSize << "\n";
+        run( ICPMethod::PointToPoint, maxGroupSize, 1e-3f );
 
-    std::cout << "running Combined method\n";
-    run( ICPMethod::Combined, 1e-6f );
+        std::cout << "running Combined method, maxGroupSize=" << maxGroupSize << "\n";
+        run( ICPMethod::Combined, maxGroupSize, 1e-6f );
+    }
 }
 
 } //namespace MR


### PR DESCRIPTION
* Explain special values of `MultiwayICPSamplingParameters::maxGroupSize` in the comment.
* `MultiwayICP::p2ptIter_()` and `MultiwayICP::p2plIter_()` fix transformation of the last object (as other methods do), and compute transformations in `double`-precision.
* `TEST( MRMesh, MultiwayICPTorus )` verifies independent mode as well.