### PR TITLE
several improvements

### DIFF
--- a/source/MRMesh/MRGridSampling.h
+++ b/source/MRMesh/MRGridSampling.h
@@ -12,11 +12,13 @@ namespace MR
 
 /// performs sampling of mesh vertices;
 /// subdivides mesh bounding box on voxels of approximately given size and returns at most one vertex per voxel;
+/// if voxelSize<=0 then returns all region vertices as samples;
 /// returns std::nullopt if it was terminated by the callback
 MRMESH_API std::optional<VertBitSet> verticesGridSampling( const MeshPart& mp, float voxelSize, const ProgressCallback & cb = {} );
 
 /// performs sampling of cloud points;
 /// subdivides point cloud bounding box on voxels of approximately given size and returns at most one point per voxel;
+/// if voxelSize<=0 then returns all valid points as samples;
 /// returns std::nullopt if it was terminated by the callback
 MRMESH_API std::optional<VertBitSet> pointGridSampling( const PointCloudPart& pcp, float voxelSize, const ProgressCallback & cb = {} );
 
@@ -46,6 +48,7 @@ using MultiObjsSamples = std::vector<ObjVertId>;
 
 /// performs sampling of several models respecting their world transformations
 /// subdivides models bounding box on voxels of approximately given size and returns at most one point per voxel;
+/// if voxelSize<=0 then returns all points from all models as samples;
 /// returns std::nullopt if it was terminated by the callback
 MRMESH_API std::optional<MultiObjsSamples> multiModelGridSampling( const Vector<ModelPointsData, ObjId>& models, float voxelSize, const ProgressCallback& cb = {} );
 

--- a/source/MRMesh/MRMultiwayICP.cpp
+++ b/source/MRMesh/MRMultiwayICP.cpp
@@ -406,12 +406,12 @@ Vector<AffineXf3f, ObjId> MultiwayICP::calculateTransformationsFixFirst( const P
     /// apply the same (updateXf) to all objects to restore transformation of first object,
     /// and make relative position of others the same
     assert( res[ObjId( 0 )] == objs_[ObjId( 0 )].xf );
-    const auto updateXf = xf0 * res[ObjId( 0 )].inverse();
+    const auto updateXf = AffineXf3d( xf0 ) * AffineXf3d( res[ObjId( 0 )].inverse() );
     res[ObjId( 0 )] = objs_[ObjId( 0 )].xf = xf0;
     for ( int i = 1; i < objs_.size(); ++i )
     {
         assert( res[ObjId( i )] == objs_[ObjId( i )].xf );
-        res[ObjId( i )] = objs_[ObjId( i )].xf = updateXf * res[ObjId( i )];
+        res[ObjId( i )] = objs_[ObjId( i )].xf = AffineXf3f( updateXf * AffineXf3d( res[ObjId( i )] ) );
     }
 
     return res;

--- a/source/MRTest/MRGridSamplingTests.cpp
+++ b/source/MRTest/MRGridSamplingTests.cpp
@@ -1,0 +1,17 @@
+#include <MRMesh/MRGridSampling.h>
+#include <MRMesh/MRMakeSphereMesh.h>
+#include <MRMesh/MRGTest.h>
+
+namespace MR
+{
+
+TEST( MRMesh, GridSampling )
+{
+    auto sphereMesh = makeUVSphere();
+    auto numVerts = sphereMesh.topology.numValidVerts();
+    auto samples = verticesGridSampling( sphereMesh, 0.5f );
+    auto sampleCount = samples->count();
+    EXPECT_LE( sampleCount, numVerts );
+}
+
+} // namespace MR

--- a/source/MRTest/MRMultiwayICPTests.cpp
+++ b/source/MRTest/MRMultiwayICPTests.cpp
@@ -10,8 +10,8 @@ namespace MR
 
 TEST( MRMesh, MultiwayICPTorus )
 {
-    auto torusRef = makeTorus( 2.5f, 0.7f, 48, 48 );
-    auto torusMove = torusRef;
+    // all objects have same shape but different transformations
+    const auto torus = makeTorus( 2.5f, 0.7f, 48, 48 );
 
     auto axis = Vector3f( 1, 0, 0 );
     auto trans = Vector3f( 0, 0.2f, 0.105f );
@@ -21,23 +21,28 @@ TEST( MRMesh, MultiwayICPTorus )
     auto run = [&] ( ICPMethod method, int maxGroupSize, float eps )
     {
         ICPObjects objs;
-        objs.push_back( { torusMove, xf } );
-        objs.push_back( { torusRef, AffineXf3f{} } );
+        objs.push_back( { torus, xf } );
+        objs.push_back( { torus, xf.inverse() } );
+        objs.push_back( { torus, AffineXf3f{} } );
         MultiwayICP icp( objs, MultiwayICPSamplingParameters{ .maxGroupSize = maxGroupSize } );
 
         ICPProperties props
         {
             .method = method,
-            .iterLimit = 20
+            .iterLimit = 30
         };
         icp.setParams( props );
         auto newXfs = icp.calculateTransformations();
-        EXPECT_EQ( newXfs[ObjId( 1 )], AffineXf3f{} );
+        EXPECT_EQ( newXfs[ObjId( 2 )], AffineXf3f{} );
         std::cout << icp.getStatusInfo() << '\n';
 
-        auto newXf = newXfs[ObjId( 0 )];
-        EXPECT_LT( ( newXf.A - Matrix3f::identity() ).norm(), eps );
-        EXPECT_LT( newXf.b.length(), eps );
+        auto newXf0 = newXfs[ObjId( 0 )];
+        EXPECT_LT( ( newXf0.A - Matrix3f::identity() ).norm(), eps );
+        EXPECT_LT( newXf0.b.length(), eps );
+
+        auto newXf1 = newXfs[ObjId( 1 )];
+        EXPECT_LT( ( newXf1.A - Matrix3f::identity() ).norm(), eps );
+        EXPECT_LT( newXf1.b.length(), eps );
     };
 
     for ( int maxGroupSize : { 0, 1 } )

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="MRExampleTest.cpp" />
     <ClCompile Include="MRExtractIsolinesTests.cpp" />
     <ClCompile Include="MRFeaturesTests.cpp" />
+    <ClCompile Include="MRGridSamplingTests.cpp" />
     <ClCompile Include="MRICPTests.cpp" />
     <ClCompile Include="MRLaplacianTests.cpp" />
     <ClCompile Include="MRMarchingCubesTests.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -148,6 +148,9 @@
     <ClCompile Include="MRMultiwayICPTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRGridSamplingTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />


### PR DESCRIPTION
1. Comment behavior of `MRGridSampling` functions in case of `voxelSize<=0`. 
2. Support the case of `voxelSize<=0` in the function `multiModelGridSampling` as in the others.
3. Move grid-sampling test from `MRMesh` to `MRTest`.
4. `MultiwayICP::calculateTransformationsFixFirst` perfroms calculations in `double` precision.
5. `TEST( MRMesh, MultiwayICPTorus )` works with 3 objects instead of 2.