### PR TITLE
telemetry signal on PLY loading

### DIFF
--- a/source/MRMesh/MRLinesLoad.cpp
+++ b/source/MRMesh/MRLinesLoad.cpp
@@ -139,7 +139,8 @@ Expected<Polyline3> fromPly( std::istream& in, const LinesLoadSettings& settings
         .edges = &edges,
         .colors = settings.colors,
         // suppose that reading is 10% of progress and building polyline is 90% of progress
-        .callback = subprogress( settings.callback, 0.0f, 0.1f )
+        .callback = subprogress( settings.callback, 0.0f, 0.1f ),
+        .telemetrySignal = settings.telemetrySignal
     };
     auto maybePoints = loadPly( in, params );
     if ( !maybePoints )

--- a/source/MRMesh/MRLinesLoadSettings.h
+++ b/source/MRMesh/MRLinesLoadSettings.h
@@ -10,6 +10,7 @@ struct LinesLoadSettings
 {
     VertColors* colors = nullptr;    ///< optional load artifact: per-vertex color map
     ProgressCallback callback;       ///< callback for set progress and stop process
+    bool telemetrySignal = true;     ///< permit telemetry signal about loading
 };
 
 } //namespace MR

--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -488,7 +488,8 @@ Expected<Mesh> fromBinaryStl( std::istream& in, const MeshLoadSettings& settings
     if ( !reportProgress( settings.callback , 1.0f ) )
         return unexpectedOperationCanceled();
 
-    TelemetrySignal( std::string( "STL head " ) + header );
+    if ( settings.telemetrySignal )
+        TelemetrySignal( std::string( "STL head " ) + header );
 
     return res;
 }
@@ -585,7 +586,8 @@ Expected<Mesh> fromASCIIStl( std::istream& in, const MeshLoadSettings& settings 
     if ( settings.duplicatedVertexCount )
         *settings.duplicatedVertexCount = int( dups.size() );
 
-    TelemetrySignal( "STL ASCII" + header );
+    if ( settings.telemetrySignal )
+        TelemetrySignal( "STL ASCII" + header );
 
     return res;
 }
@@ -608,7 +610,8 @@ static Expected<Mesh> fromPly( std::istream& in, const MeshLoadSettings& setting
         .texture = settings.texture,
         .dir = dir,
         // suppose that reading is 10% of progress and building mesh is 90% of progress
-        .callback = subprogress( settings.callback, 0.0f, 0.1f )
+        .callback = subprogress( settings.callback, 0.0f, 0.1f ),
+        .telemetrySignal = settings.telemetrySignal
     };
     auto maybePoints = loadPly( in, params );
     if ( !maybePoints )

--- a/source/MRMesh/MRMeshLoadSettings.h
+++ b/source/MRMesh/MRMeshLoadSettings.h
@@ -19,6 +19,7 @@ struct MeshLoadSettings
     int* duplicatedVertexCount = nullptr; ///< optional output: counter of duplicated vertices (that created for resolve non-manifold geometry)
     AffineXf3f* xf = nullptr;        ///< optional output: transform for the loaded mesh to improve precision of vertex coordinates
     ProgressCallback callback;       ///< callback for set progress and stop process
+    bool telemetrySignal = true;     ///< permit telemetry signal about loading
 };
 
 } //namespace MR

--- a/source/MRMesh/MRObjectLinesHolder.cpp
+++ b/source/MRMesh/MRObjectLinesHolder.cpp
@@ -302,7 +302,7 @@ Expected<void> ObjectLinesHolder::deserializeModel_( const std::filesystem::path
     if ( modelPath.empty() )
         return {};
 
-    auto res = LinesLoad::fromAnySupportedFormat( modelPath, { .colors = &vertsColorMap_, .callback = progressCb } );
+    auto res = LinesLoad::fromAnySupportedFormat( modelPath, { .colors = &vertsColorMap_, .callback = progressCb, .telemetrySignal = false } );
     if ( !res.has_value() )
         return unexpected( res.error() );
 

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -270,7 +270,7 @@ Expected<void> ObjectMeshHolder::deserializeModel_( const std::filesystem::path&
         if ( modelPath.empty() )
             return unexpected( "No mesh file found: " + utf8string( path ) );
     }
-    auto res = MeshLoad::fromAnySupportedFormat( modelPath, { .colors = &data_.vertColors, .callback = progressCb } );
+    auto res = MeshLoad::fromAnySupportedFormat( modelPath, { .colors = &data_.vertColors, .callback = progressCb, .telemetrySignal = false } );
     if ( !res.has_value() )
         return unexpected( res.error() );
 

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -328,6 +328,7 @@ Expected<void> ObjectPointsHolder::deserializeModel_( const std::filesystem::pat
     auto res = PointsLoad::fromAnySupportedFormat( modelPath, {
         .colors = &vertsColorMap_,
         .callback = progressCb,
+        .telemetrySignal = false
     } );
     if ( !res.has_value() )
         return unexpected( std::move( res.error() ) );

--- a/source/MRMesh/MRPly.cpp
+++ b/source/MRMesh/MRPly.cpp
@@ -6,6 +6,7 @@
 #include "MRStringConvert.h"
 #include "MRImageLoad.h"
 #include "MRMeshTexture.h"
+#include "MRTelemetry.h"
 #include "MRTimer.h"
 
 namespace MR
@@ -27,41 +28,56 @@ Expected<VertCoords> loadPly( std::istream& in, const PlyLoadParams& params )
     const auto posEnd = reader.get_end_pos();
     const float streamSize = float( posEnd - posStart );
 
+    std::string signalString = "PLY";
     for ( int i = 0; reader.has_element(); reader.next_element(), ++i )
     {
         if ( reader.element_is(miniply::kPLYVertexElement) && reader.load_element() )
         {
+            signalString += " V";
             auto numVerts = reader.num_rows();
             if ( reader.find_pos( indecies ) )
             {
                 Timer t( "extractPoints" );
+                signalString += 'P';
                 res.resize( numVerts );
                 reader.extract_properties( indecies, 3, miniply::PLYPropertyType::Float, res.data() );
                 gotVerts = true;
             }
-            if ( params.normals && reader.find_normal( indecies ) )
+            if ( reader.find_normal( indecies ) )
             {
-                Timer t( "extractNormals" );
-                params.normals->resize( numVerts );
-                reader.extract_properties( indecies, 3, miniply::PLYPropertyType::Float, params.normals->data() );
-            }
-            if ( params.colors && reader.find_color( indecies ) )
-            {
-                Timer t( "extractVertColors" );
-                std::vector<unsigned char> colorsBuffer( 3 * numVerts );
-                reader.extract_properties( indecies, 3, miniply::PLYPropertyType::UChar, colorsBuffer.data() );
-                params.colors->resize( numVerts );
-                for ( VertId v{ 0 }; v < res.size(); ++v )
+                signalString += 'N';
+                if ( params.normals )
                 {
-                    int ind = 3 * v;
-                    ( *params.colors )[v] = Color( colorsBuffer[ind], colorsBuffer[ind + 1], colorsBuffer[ind + 2] );
+                    Timer t( "extractNormals" );
+                    params.normals->resize( numVerts );
+                    reader.extract_properties( indecies, 3, miniply::PLYPropertyType::Float, params.normals->data() );
                 }
             }
-            if ( params.uvCoords && reader.find_texcoord( indecies ) )
+            if ( reader.find_color( indecies ) )
             {
-                Timer t( "extractUVs" );
-                params.uvCoords->resize( numVerts );
-                reader.extract_properties( indecies, 2, miniply::PLYPropertyType::Float, params.uvCoords->data() );
+                signalString += 'C';
+                if ( params.colors )
+                {
+                    Timer t( "extractVertColors" );
+                    std::vector<unsigned char> colorsBuffer( 3 * numVerts );
+                    reader.extract_properties( indecies, 3, miniply::PLYPropertyType::UChar, colorsBuffer.data() );
+                    params.colors->resize( numVerts );
+                    for ( VertId v{ 0 }; v < res.size(); ++v )
+                    {
+                        int ind = 3 * v;
+                        ( *params.colors )[v] = Color( colorsBuffer[ind], colorsBuffer[ind + 1], colorsBuffer[ind + 2] );
+                    }
+                }
+            }
+            if ( reader.find_texcoord( indecies ) )
+            {
+                signalString += "UV";
+                if ( params.uvCoords )
+                {
+                    Timer t( "extractUVs" );
+                    params.uvCoords->resize( numVerts );
+                    reader.extract_properties( indecies, 2, miniply::PLYPropertyType::Float, params.uvCoords->data() );
+                }
             }
 
             const float progress = float( in.tellg() - posStart ) / streamSize;
@@ -71,98 +87,139 @@ Expected<VertCoords> loadPly( std::istream& in, const PlyLoadParams& params )
         }
 
         const auto posLast = in.tellg();
-        if ( params.tris && reader.element_is(miniply::kPLYFaceElement) && reader.load_element() && reader.find_indices(indecies) )
+        if ( reader.element_is(miniply::kPLYFaceElement) && reader.load_element() && reader.find_indices(indecies) )
         {
-            bool polys = reader.requires_triangulation( indecies[0] );
-            if ( polys && !gotVerts )
-                return unexpected( std::string( "PLY file open: need vertex positions to triangulate faces" ) );
-
-            Triangulation tris;
-            if (polys)
+            const size_t numRows( reader.num_rows() );
+            const bool polys = reader.requires_triangulation( indecies[0] );
+            signalString += polys ? " POLY" : " TRI";
+            if ( params.tris )
             {
-                Timer t( "extractTriangles" );
-                auto numIndices = reader.num_triangles( indecies[0] );
-                tris.resize( numIndices );
-                reader.extract_triangles( indecies[0], &res.front().x, (std::uint32_t)res.size(), miniply::PLYPropertyType::Int, tris.data() );
-            }
-            else
-            {
-                Timer t( "extractTriples" );
-                auto numIndices = reader.num_rows();
-                tris.resize( numIndices );
-                reader.extract_list_property( indecies[0], miniply::PLYPropertyType::Int, tris.data() );
-            }
-
-            if ( params.faceColors && reader.find_color( indecies ) )
-            {
-                Timer t( "extractFaceColors" );
-                std::vector<unsigned char> colorsBuffer( 3 * tris.size() );
-                reader.extract_properties( indecies, 3, miniply::PLYPropertyType::UChar, colorsBuffer.data() );
-                params.faceColors->resize( tris.size() );
-                for ( FaceId f{ 0 }; f < tris.size(); ++f )
+                Triangulation tris;
+                if (polys)
                 {
-                    int ind = 3 * f;
-                    ( *params.faceColors )[f] = Color( colorsBuffer[ind], colorsBuffer[ind + 1], colorsBuffer[ind + 2] );
+                    Timer t( "extractTriangles" );
+                    if ( !gotVerts )
+                    {
+                        signalString += " ENOVC";
+                        if ( params.telemetrySignal )
+                            TelemetrySignal( signalString );
+                        return unexpected( std::string( "PLY file open: need vertex positions to triangulate faces" ) );
+                    }
+                    auto numIndices = reader.num_triangles( indecies[0] );
+                    tris.resize( numIndices );
+                    reader.extract_triangles( indecies[0], &res.front().x, (std::uint32_t)res.size(), miniply::PLYPropertyType::Int, tris.data() );
+                }
+                else
+                {
+                    Timer t( "extractTriples" );
+                    tris.resize( numRows );
+                    reader.extract_list_property( indecies[0], miniply::PLYPropertyType::Int, tris.data() );
+                }
+                *params.tris = std::move( tris );
+            }
+
+            if ( reader.find_color( indecies ) )
+            {
+                signalString += 'C';
+                if ( params.faceColors )
+                {
+                    Timer t( "extractFaceColors" );
+                    std::vector<unsigned char> colorsBuffer( 3 * numRows );
+                    reader.extract_properties( indecies, 3, miniply::PLYPropertyType::UChar, colorsBuffer.data() );
+                    params.faceColors->resize( numRows );
+                    for ( FaceId f{ 0 }; f < numRows; ++f )
+                    {
+                        int ind = 3 * f;
+                        ( *params.faceColors )[f] = Color( colorsBuffer[ind], colorsBuffer[ind + 1], colorsBuffer[ind + 2] );
+                    }
                 }
             }
-            if ( params.triCornerUvCoords && reader.find_properties( indecies, 1, "texcoord" ) )
+            if ( reader.find_properties( indecies, 1, "texcoord" ) )
             {
-                Timer t( "extractFaceUVs" );
-                // the number of float-values in the property
-                const auto propSize = reader.sum_of_list_counts( indecies[0] );
-                // round upward to allocate not smaller amount of space
-                static_assert( sizeof( params.triCornerUvCoords->front() ) == 6 * sizeof( float ) );
-                params.triCornerUvCoords->resize( ( propSize + 5 ) / 6 );
-                reader.extract_list_property( indecies[0], miniply::PLYPropertyType::Float, params.triCornerUvCoords->data() );
+                signalString += "UV";
+                if ( params.triCornerUvCoords )
+                {
+                    Timer t( "extractFaceUVs" );
+                    // the number of float-values in the property
+                    const auto propSize = reader.sum_of_list_counts( indecies[0] );
+                    // round upward to allocate not smaller amount of space
+                    static_assert( sizeof( params.triCornerUvCoords->front() ) == 6 * sizeof( float ) );
+                    params.triCornerUvCoords->resize( ( propSize + 5 ) / 6 );
+                    reader.extract_list_property( indecies[0], miniply::PLYPropertyType::Float, params.triCornerUvCoords->data() );
+                }
             }
 
             const auto posCurrent = in.tellg();
             // suppose  that reading is 10% of progress and building mesh is 90% of progress
             if ( !reportProgress( params.callback, ( float( posLast ) + ( posCurrent - posLast ) * 0.1f - posStart ) / streamSize ) )
                 return unexpectedOperationCanceled();
-            *params.tris = std::move( tris );
         }
 
-        if ( params.edges && reader.element_is( "edge" ) && reader.load_element() && reader.find_properties( indecies, 2, "vertex1", "vertex2" ) )
+        if ( reader.element_is( "edge" ) && reader.load_element() && reader.find_properties( indecies, 2, "vertex1", "vertex2" ) )
         {
-            auto numEdges = reader.num_rows();
-            Edges es( numEdges );
-            static_assert( sizeof( es.front() ) == 8 );
-            if ( reader.extract_properties( indecies, 2, miniply::PLYPropertyType::Int, es.data() ) )
-                *params.edges = std::move( es );
+            signalString += " EDGE";
+            if ( params.edges )
+            {
+                auto numEdges = reader.num_rows();
+                Edges es( numEdges );
+                static_assert( sizeof( es.front() ) == 8 );
+                if ( reader.extract_properties( indecies, 2, miniply::PLYPropertyType::Int, es.data() ) )
+                    *params.edges = std::move( es );
+            }
         }
     }
 
     if ( !reader.valid() )
+    {
+        signalString += " EREAD";
+        if ( params.telemetrySignal )
+            TelemetrySignal( signalString );
         return unexpected( std::string( "PLY file read or parse error" ) );
+    }
 
     if ( !gotVerts )
-         return unexpected( std::string( "PLY file does not contain vertices" ) );
-
-    if ( params.texture )
     {
-        for ( const auto& comment : reader.comments() )
+        signalString += " ENOVC";
+        if ( params.telemetrySignal )
+            TelemetrySignal( signalString );
+        return unexpected( std::string( "PLY file does not contain vertices" ) );
+    }
+
+    auto textureToLoad = params.texture;
+    for ( const auto& comment : reader.comments() )
+    {
+        if ( !comment.starts_with( "TextureFile" ) )
         {
-            if ( !comment.starts_with( "TextureFile" ) )
-                continue;
-            int n = 11;
-            while ( n < comment.size() && ( comment[n] == ' ' || comment[n] == '\t' ) )
-                ++n;
-            const auto texFile = params.dir / asU8String( comment.substr( n ) );
-            std::error_code ec;
-            if ( !is_regular_file( texFile, ec ) )
-                break;
+            if ( params.telemetrySignal )
+                TelemetrySignal( "PLY comment " + comment );
+            continue;
+        }
+        signalString += " TEX";
+        int n = 11;
+        while ( n < comment.size() && ( comment[n] == ' ' || comment[n] == '\t' ) )
+            ++n;
+        const auto texFile = params.dir / asU8String( comment.substr( n ) );
+        std::error_code ec;
+        if ( !is_regular_file( texFile, ec ) )
+        {
+            signalString += '-';
+            continue;
+        }
+        if ( textureToLoad )
+        {
             if ( auto image = ImageLoad::fromAnySupportedFormat( texFile ) )
             {
-                params.texture->resolution = std::move( image->resolution );
-                params.texture->pixels = std::move( image->pixels );
-                params.texture->filter = FilterType::Linear;
-                params.texture->wrap = WrapType::Clamp;
+                textureToLoad->resolution = std::move( image->resolution );
+                textureToLoad->pixels = std::move( image->pixels );
+                textureToLoad->filter = FilterType::Linear;
+                textureToLoad->wrap = WrapType::Clamp;
             }
-            break;
+            textureToLoad = nullptr; // load the first texture only
         }
     }
 
+    if ( params.telemetrySignal )
+        TelemetrySignal( signalString );
     return res;
 }
 

--- a/source/MRMesh/MRPly.h
+++ b/source/MRMesh/MRPly.h
@@ -24,6 +24,7 @@ struct PlyLoadParams
 
     std::filesystem::path dir;       ///< directory to load texture files from
     ProgressCallback callback;       ///< callback for set progress and stop process
+    bool telemetrySignal = true;     ///< permit telemetry signal about loading
 };
 
 [[nodiscard]] MRMESH_API Expected<VertCoords> loadPly( std::istream& in, const PlyLoadParams& params );

--- a/source/MRMesh/MRPointsLoad.cpp
+++ b/source/MRMesh/MRPointsLoad.cpp
@@ -217,7 +217,8 @@ Expected<PointCloud> fromPly( std::istream& in, const PointsLoadSettings& settin
     {
         .colors = settings.colors,
         .normals = &res.normals,
-        .callback = settings.callback
+        .callback = settings.callback,
+        .telemetrySignal = settings.telemetrySignal
     };
     auto maybePoints = loadPly( in, params );
     if ( !maybePoints )

--- a/source/MRMesh/MRPointsLoadSettings.h
+++ b/source/MRMesh/MRPointsLoadSettings.h
@@ -11,6 +11,7 @@ struct PointsLoadSettings
     VertColors* colors = nullptr; ///< points where to load point color map
     AffineXf3f* outXf = nullptr; ///< transform for the loaded point cloud
     ProgressCallback callback; ///< callback for set progress and stop process
+    bool telemetrySignal = true; ///< permit telemetry signal about loading
 };
 
 } // namespace MR


### PR DESCRIPTION
* emit signals on successful and erroneous PLY loading;
* the signal can be turned off by `telemetrySignal` option in `PlyLoadParams`, `PointsLoadSettings`, `LinesLoadSettings`, `MeshLoadSettings`;
* and it is turned off during model loading in objects.