### PR TITLE
optimize MeshTopology::pack( const PackMapping & map )

### DIFF
--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -529,6 +529,26 @@ void MeshTopology::setLeft( EdgeId a, FaceId f )
     }
 }
 
+void MeshTopology::fillOrg_()
+{
+    MR_TIMER;
+    ParallelFor( edgePerVertex_, [&]( VertId v )
+    {
+        if ( auto e0 = edgePerVertex_[v] )
+            setOrg_( e0, v );
+    } );
+}
+
+void MeshTopology::fillLeft_()
+{
+    MR_TIMER;
+    ParallelFor( edgePerFace_, [&]( FaceId f )
+    {
+        if ( auto e0 = edgePerFace_[f] )
+            setLeft_( e0, f );
+    } );
+}
+
 bool MeshTopology::isInnerOrBdVertex( VertId v, const FaceBitSet * region ) const
 {
     for ( auto e : orgRing( *this, v ) )
@@ -993,26 +1013,6 @@ void MeshTopology::translate_( HalfEdgeRecord & r, HalfEdgeRecord & rsym,
         std::swap( rsym.prev, rsym.next );
         std::swap( r.left, rsym.left );
     }
-}
-
-void MeshTopology::fillOrg_()
-{
-    MR_TIMER;
-    ParallelFor( edgePerVertex_, [&]( VertId v )
-    {
-        if ( auto e0 = edgePerVertex_[v] )
-            setOrg_( e0, v );
-    } );
-}
-
-void MeshTopology::fillLeft_()
-{
-    MR_TIMER;
-    ParallelFor( edgePerFace_, [&]( FaceId f )
-    {
-        if ( auto e0 = edgePerFace_[f] )
-            setLeft_( e0, f );
-    } );
 }
 
 void MeshTopology::flipEdge( EdgeId e )

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -542,8 +542,14 @@ private:
     /// sets new origin to the full origin ring including this edge, without updating edgePerVertex_ table
     void setOrg_( EdgeId a, VertId v );
 
+    /// writes all valid edge_.org by calling setOrg_ for each valid edgePerVertex_
+    void fillOrg_();
+
     /// sets new left face to the full left ring including this edge, without updating edgePerFace_ table
     void setLeft_( EdgeId a, FaceId f );
+
+    /// writes all valid edge_.left by calling setLeft_ for each valid edgePerFace_
+    void fillLeft_();
 
     /// data of every half-edge, align to put whole record in one cache line
     struct alignas( 16 ) HalfEdgeRecord
@@ -584,12 +590,6 @@ private:
     int numValidFaces_ = 0; ///< the number of valid elements in edgePerFace_ or set bits in validFaces_
 
     bool updateValids_ = true; ///< if false, validVerts_, validFaces_, numValidVerts_, numValidFaces_ are not updated
-
-    /// computes valid edge_.org from edgePerVertex_ and edges_.next
-    void fillOrg_();
-
-    /// computes valid edge_.left from edgePerFace_ and edges_.next
-    void fillLeft_();
 };
 
 template <typename T>


### PR DESCRIPTION
The idea is to pack initially only `next` field of `edges_`, and then restore from it remaining fields: `prev`, `left` and `org`.

Thus peak memory consumption is reduced twofold:
* previously `tmp` has `map.e.tsize` records of `4 * sizeof(Id)` each,
* now `newNext` has two times more records but of `sizeof(Id)` each.

The performance is slightly higher as well.
