### PR TITLE
LoadObj: eliminate hash-map for vertex renumbering

### DIFF
--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -566,7 +566,7 @@ Expected<MeshLoad::NamedMesh> loadSingleModelFromObj(
     haveColors = firstVert < colors.size();
 
 
-    Timer timer( "prepare unique vertices" );
+    Timer timer( "prepare VertexRepr" );
 
     auto getVertexRepr = [&] ( size_t fId, int ind ) -> Expected<VertexRepr>
     {
@@ -627,48 +627,36 @@ Expected<MeshLoad::NamedMesh> loadSingleModelFromObj(
         }
     }, ctx );
 
+    if ( !error.empty() )
+        return unexpected( error );
+
     if ( !reportProgress( settings.callback, 0.2f ) )
         return unexpectedOperationCanceled();
 
-    if ( !error.empty() )
-        return unexpected( error );
+    timer.restart( "keep unique VertexRepr" );
 
     tbb::parallel_sort( orderedPoints.begin(), orderedPoints.end() );
 
     orderedPoints.erase( std::unique( orderedPoints.begin(), orderedPoints.end() ), orderedPoints.end() );
 
-    using ParallelIndicesMap = ParallelHashMap<VertexRepr, VertId, VertexReprHasher>;
-    ParallelIndicesMap map;
-    tbb::parallel_for( tbb::blocked_range<size_t>( 0, map.subcnt(), 1 ), [&] ( const tbb::blocked_range<size_t>& range )
-    {
-        for ( size_t mId = range.begin(); mId < range.end(); ++mId )
-        {
-            for ( size_t i = 0; i < orderedPoints.size(); ++i )
-            {
-                auto hash = map.hash( orderedPoints[i] );
-                if ( mId != map.subidx( hash ) )
-                    continue;
-                map.insert( { orderedPoints[i],VertId( i ) } );
-            }
-        }
-    } );
-
-    size_t numCoords = orderedPoints.size();
-    if ( numCoords == 0 )
+    size_t numOrderedPoints = orderedPoints.size();
+    if ( numOrderedPoints == 0 )
         return unexpected( "No vertex found in OBJ-file" );
+
+    if ( !reportProgress( settings.callback, 0.25f ) )
+        return unexpectedOperationCanceled();
+
+    timer.restart( "copy vertex attributes" );
+
+    MeshLoad::NamedMesh res;
+    VertCoords coords;
+    coords.resizeNoInit( numOrderedPoints );
+    res.colors.resize( haveColors ? coords.size() : 0 );
+    res.uvCoords.resize( haveUVs ? coords.size() : 0 );
 
     MinMax<int> minmaxV;
     minmaxV.min = orderedPoints.front().vId;
     minmaxV.max = orderedPoints.back().vId;
-    orderedPoints = {}; // reduce peak memory
-
-    if ( !reportProgress( settings.callback, 0.3f ) )
-        return unexpectedOperationCanceled();
-
-    MeshLoad::NamedMesh res;
-    VertCoords coords( numCoords );
-    res.colors.resize( haveColors ? coords.size() : 0 );
-    res.uvCoords.resize( haveUVs ? coords.size() : 0 );
 
     // set vertices and attributes first
     Vector3d pointOffset;
@@ -681,22 +669,18 @@ Expected<MeshLoad::NamedMesh> loadSingleModelFromObj(
         res.xf = AffineXf3f::translation( Vector3f( pointOffset ) );
     }
 
-    ParallelFor( size_t( 0 ), map.subcnt(), [&] ( size_t id )
+    ParallelFor( orderedPoints, [&] ( size_t i )
     {
-        map.with_submap( id, [&] ( const ParallelIndicesMap::EmbeddedSet& subset )
-        {
-            for ( const auto& [repr, vId] : subset )
-            {
-                coords[vId] = Vector3f( points[VertId( repr.vId )] - pointOffset );
-                if ( haveColors && repr.vId < colors.size() )
-                    res.colors[vId] = colors[repr.vId];
-                if ( haveUVs && repr.vtId < uvCoords.size() )
-                    res.uvCoords[vId] = uvCoords[repr.vtId];
-            }
-        } );
+        const auto & repr = orderedPoints[i];
+        VertId vId( i );
+        coords[vId] = Vector3f( points[VertId( repr.vId )] - pointOffset );
+        if ( haveColors && repr.vId < colors.size() )
+            res.colors[vId] = colors[repr.vId];
+        if ( haveUVs && repr.vtId < uvCoords.size() )
+            res.uvCoords[vId] = uvCoords[repr.vtId];
     } );
 
-    if ( !reportProgress( settings.callback, 0.4f ) )
+    if ( !reportProgress( settings.callback, 0.3f ) )
         return unexpectedOperationCanceled();
 
     timer.restart( "replace vertex ids" );
@@ -709,13 +693,15 @@ Expected<MeshLoad::NamedMesh> loadSingleModelFromObj(
         {
             auto repr = getVertexRepr( f, v );
             assert( repr.has_value() );
-            auto it = map.find( *repr );
-            assert( it != map.end() );
-            faces.getVert( f, v ) = it->second;
+            auto it = std::lower_bound( orderedPoints.begin(), orderedPoints.end(), *repr );
+            assert( it != orderedPoints.end() );
+            faces.getVert( f, v ) = VertId( it - orderedPoints.begin() );
         }
     } );
 
-    if ( !reportProgress( settings.callback, 0.45f ) )
+    orderedPoints = {}; // reduce peak memory
+
+    if ( !reportProgress( settings.callback, 0.4f ) )
         return unexpectedOperationCanceled();
 
     timer.restart( "prepare model triangulation" );


### PR DESCRIPTION
It save both memory consumption and time for the construction.

Instead hash-map, the binary search in already sorted array is used to locate an element.