### PR TITLE
LoadOBJ: simplify triangulation

### DIFF
--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -829,7 +829,7 @@ Expected<std::vector<MeshLoad::NamedMesh>> loadModelsFromObj(
     bool colorChecked = false;
     bool hasColors = false;
 
-    Expected<MtlLibrary> mtl; // all materials
+    Expected<MtlLibrary> mtl = unexpected( "absent" ); // all materials
 
     std::string parseError;
 


### PR DESCRIPTION
Fill triangulation vector in single pass without intermediate data structures. 

This shall decrease memory consumption.