### PR TITLE
move signals in parent classes

### DIFF
--- a/source/MRMesh/MRObjectLines.cpp
+++ b/source/MRMesh/MRObjectLines.cpp
@@ -45,32 +45,10 @@ std::shared_ptr< Polyline3 > ObjectLines::updatePolyline( std::shared_ptr< Polyl
     return polyline;
 }
 
-void ObjectLines::setDirtyFlags( uint32_t mask, bool invalidateCaches )
-{
-    ObjectLinesHolder::setDirtyFlags( mask, invalidateCaches );
-
-    if ( mask & DIRTY_POSITION || mask & DIRTY_PRIMITIVES )
-    {
-        if ( polyline_ )
-        {
-            linesChangedSignal( mask );
-        }
-    }
-}
-
 void ObjectLines::swapBase_( Object& other )
 {
     if ( auto otherLines = other.asType<ObjectLines>() )
         std::swap( *this, *otherLines );
-    else
-        assert( false );
-}
-
-void ObjectLines::swapSignals_( Object& other )
-{
-    ObjectLinesHolder::swapSignals_( other );
-    if ( auto otherLines = other.asType<ObjectLines>() )
-        std::swap( linesChangedSignal, otherLines->linesChangedSignal );
     else
         assert( false );
 }

--- a/source/MRMesh/MRObjectLines.h
+++ b/source/MRMesh/MRObjectLines.h
@@ -32,25 +32,16 @@ public:
 
     virtual const std::shared_ptr<Polyline3>& varPolyline() { return polyline_; }
 
-    MRMESH_API virtual void setDirtyFlags( uint32_t mask, bool invalidateCaches = true ) override;
-
     /// \note this ctor is public only for std::make_shared used inside clone()
     ObjectLines( ProtectedStruct, const ObjectLines& obj ) : ObjectLines( obj ) {}
 
     MRMESH_API virtual std::vector<std::string> getInfoLines() const override;
-
-    /// signal about lines changing, triggered in setDirtyFlag
-    using LinesChangedSignal = Signal<void( uint32_t mask )>;
-    LinesChangedSignal linesChangedSignal;
 
 protected:
     ObjectLines( const ObjectLines& other ) = default;
 
     /// swaps this object with other
     MRMESH_API virtual void swapBase_( Object& other ) override;
-    /// swaps signals, used in `swap` function to return back signals after `swapBase_`
-    /// pls call Parent::swapSignals_ first when overriding this function
-    MRMESH_API virtual void swapSignals_( Object& other ) override;
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 };

--- a/source/MRMesh/MRObjectLinesHolder.cpp
+++ b/source/MRMesh/MRObjectLinesHolder.cpp
@@ -70,6 +70,14 @@ void ObjectLinesHolder::setDirtyFlags( uint32_t mask, bool invalidateCaches )
         if ( invalidateCaches && polyline_ )
             polyline_->invalidateCaches();
     }
+
+    if ( mask & DIRTY_POSITION || mask & DIRTY_PRIMITIVES )
+    {
+        if ( polyline_ )
+        {
+            linesChangedSignal( mask );
+        }
+    }
 }
 
 void ObjectLinesHolder::setDashPattern( const DashPattern& pattern, ViewportId id /*= {} */ )
@@ -100,6 +108,15 @@ void ObjectLinesHolder::swapBase_( Object& other )
 {
     if ( auto otherLines = other.asType<ObjectLinesHolder>() )
         std::swap( *this, *otherLines );
+    else
+        assert( false );
+}
+
+void ObjectLinesHolder::swapSignals_( Object& other )
+{
+    VisualObject::swapSignals_( other );
+    if ( auto otherLines = other.asType<ObjectLinesHolder>() )
+        std::swap( linesChangedSignal, otherLines->linesChangedSignal );
     else
         assert( false );
 }

--- a/source/MRMesh/MRObjectLinesHolder.h
+++ b/source/MRMesh/MRObjectLinesHolder.h
@@ -107,11 +107,19 @@ public:
     /// reset basic object colors to their default values from the current theme
     MRMESH_API void resetFrontColor() override;
 
+    /// signal about lines changing, triggered in setDirtyFlag
+    using LinesChangedSignal = Signal<void( uint32_t mask )>;
+    LinesChangedSignal linesChangedSignal;
+
 protected:
     ObjectLinesHolder( const ObjectLinesHolder& other ) = default;
 
     /// swaps this object with other
     MRMESH_API virtual void swapBase_( Object& other ) override;
+
+    /// swaps signals, used in `swap` function to return back signals after `swapBase_`
+    /// pls call Parent::swapSignals_ first when overriding this function
+    MRMESH_API virtual void swapSignals_( Object& other ) override;
 
     /// we serialize polyline as text so separate polyline serialization and base fields serialization
     /// serializeBaseFields_ serializes Parent fields and base fields of ObjectLinesHolder

--- a/source/MRMesh/MRObjectMesh.cpp
+++ b/source/MRMesh/MRObjectMesh.cpp
@@ -157,31 +157,10 @@ std::shared_ptr<Object> ObjectMesh::shallowClone() const
     return res;
 }
 
-void ObjectMesh::setDirtyFlags( uint32_t mask, bool invalidateCaches )
-{
-    ObjectMeshHolder::setDirtyFlags( mask, invalidateCaches );
-    if ( mask & DIRTY_POSITION || mask & DIRTY_FACE)
-    {
-        if ( data_.mesh )
-        {
-            meshChangedSignal( mask );
-        }
-    }
-}
-
 void ObjectMesh::swapBase_( Object& other )
 {
     if ( auto otherMesh = other.asType<ObjectMesh>() )
         std::swap( *this, *otherMesh );
-    else
-        assert( false );
-}
-
-void ObjectMesh::swapSignals_( Object& other )
-{
-    ObjectMeshHolder::swapSignals_( other );
-    if ( auto otherMesh = other.asType<ObjectMesh>() )
-        std::swap( meshChangedSignal, otherMesh->meshChangedSignal );
     else
         assert( false );
 }

--- a/source/MRMesh/MRObjectMesh.h
+++ b/source/MRMesh/MRObjectMesh.h
@@ -38,8 +38,6 @@ public:
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;
 
-    MRMESH_API virtual void setDirtyFlags( uint32_t mask, bool invalidateCaches = true ) override;
-
     /// \note this ctor is public only for std::make_shared used inside clone()
     ObjectMesh( ProtectedStruct, const ObjectMesh& obj ) : ObjectMesh( obj ) {}
 
@@ -48,18 +46,11 @@ public:
     /// it is inefficient to call this function for many rays, because it computes world-to-local xf every time
     MRMESH_API MeshIntersectionResult worldRayIntersection( const Line3f& worldRay, const FaceBitSet* region = nullptr ) const;
 
-    /// signal about mesh changing, triggered in setDirtyFlag
-    using MeshChangedSignal = Signal<void( uint32_t mask )>;
-    MeshChangedSignal meshChangedSignal;
-
 protected:
     ObjectMesh( const ObjectMesh& other ) = default;
 
     /// swaps this object with other
     MRMESH_API virtual void swapBase_( Object& other ) override;
-    /// swaps signals, used in `swap` function to return back signals after `swapBase_`
-    /// pls call Parent::swapSignals_ first when overriding this function
-    MRMESH_API virtual void swapSignals_( Object& other ) override;
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 };

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -785,6 +785,14 @@ void ObjectMeshHolder::setDirtyFlags( uint32_t mask, bool invalidateCaches )
         if ( invalidateCaches && data_.mesh )
             data_.mesh->invalidateCaches();
     }
+
+    if ( mask & DIRTY_POSITION || mask & DIRTY_FACE)
+    {
+        if ( data_.mesh )
+        {
+            meshChangedSignal( mask );
+        }
+    }
 }
 
 void ObjectMeshHolder::setCreases( UndirectedEdgeBitSet creases )
@@ -820,6 +828,7 @@ void ObjectMeshHolder::swapSignals_( Object& other )
         std::swap( faceSelectionChangedSignal, otherMesh->faceSelectionChangedSignal );
         std::swap( edgeSelectionChangedSignal, otherMesh->edgeSelectionChangedSignal );
         std::swap( creasesChangedSignal, otherMesh->creasesChangedSignal );
+        std::swap( meshChangedSignal, otherMesh->meshChangedSignal );
     }
     else
         assert( false );

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -265,6 +265,10 @@ public:
     SelectionChangedSignal edgeSelectionChangedSignal;
     SelectionChangedSignal creasesChangedSignal;
 
+    /// signal about mesh changing, triggered in setDirtyFlag
+    using MeshChangedSignal = Signal<void( uint32_t mask )>;
+    MeshChangedSignal meshChangedSignal;
+
 protected:
     ObjectMeshData data_;
 

--- a/source/MRMesh/MRObjectPoints.cpp
+++ b/source/MRMesh/MRObjectPoints.cpp
@@ -71,18 +71,6 @@ std::vector<std::string> ObjectPoints::getInfoLines() const
     return res;
 }
 
-void ObjectPoints::setDirtyFlags( uint32_t mask, bool invalidateCaches )
-{
-    ObjectPointsHolder::setDirtyFlags( mask, invalidateCaches );
-    if ( points_ )
-    {
-        if ( mask & DIRTY_POSITION || mask & DIRTY_FACE )
-            pointsChangedSignal( mask );
-        if ( mask & DIRTY_RENDER_NORMALS )
-            normalsChangedSignal( mask );
-    }
-}
-
 std::shared_ptr<Object> ObjectPoints::clone() const
 {
     auto res = std::make_shared<ObjectPoints>( ProtectedStruct{}, *this );
@@ -111,18 +99,6 @@ void ObjectPoints::swapBase_( Object& other )
 {
     if ( auto otherPoints = other.asType<ObjectPoints>() )
         std::swap( *this, *otherPoints );
-    else
-        assert( false );
-}
-
-void ObjectPoints::swapSignals_( Object& other )
-{
-    ObjectPointsHolder::swapSignals_( other );
-    if ( auto otherPoints = other.asType<ObjectPoints>() )
-    {
-        std::swap( pointsChangedSignal, otherPoints->pointsChangedSignal );
-        std::swap( normalsChangedSignal, otherPoints->normalsChangedSignal );
-    }
     else
         assert( false );
 }

--- a/source/MRMesh/MRObjectPoints.h
+++ b/source/MRMesh/MRObjectPoints.h
@@ -40,21 +40,11 @@ public:
 
     MRMESH_API virtual std::vector<std::string> getInfoLines() const override;
 
-    MRMESH_API virtual void setDirtyFlags( uint32_t mask, bool invalidateCaches = true ) override;
-
-    /// signal about points or normals changing, triggered in setDirtyFlag
-    using ChangedSignal = Signal<void( uint32_t mask )>;
-    ChangedSignal pointsChangedSignal;
-    ChangedSignal normalsChangedSignal;
-
 protected:
     ObjectPoints( const ObjectPoints& other ) = default;
 
     /// swaps this object with other
     MRMESH_API virtual void swapBase_( Object& other ) override;
-    /// swaps signals, used in `swap` function to return back signals after `swapBase_`
-    /// pls call Parent::swapSignals_ first when overriding this function
-    MRMESH_API virtual void swapSignals_( Object& other ) override;
 
     MRMESH_API virtual void serializeFields_( Json::Value& root ) const override;
 };

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -77,8 +77,15 @@ void ObjectPointsHolder::setDirtyFlags( uint32_t mask, bool invalidateCaches )
         if ( invalidateCaches && points_ )
             points_->invalidateCaches();
     }
-}
 
+    if ( points_ )
+    {
+        if ( mask & DIRTY_POSITION || mask & DIRTY_FACE )
+            pointsChangedSignal( mask );
+        if ( mask & DIRTY_RENDER_NORMALS )
+            normalsChangedSignal( mask );
+    }
+}
 
 void ObjectPointsHolder::swapSignals_( Object& other )
 {
@@ -86,6 +93,8 @@ void ObjectPointsHolder::swapSignals_( Object& other )
     if ( auto otherPoints = other.asType<ObjectPointsHolder>() )
     {
         std::swap( pointsSelectionChangedSignal, otherPoints->pointsSelectionChangedSignal );
+        std::swap( pointsChangedSignal, otherPoints->pointsChangedSignal );
+        std::swap( normalsChangedSignal, otherPoints->normalsChangedSignal );
     }
     else
         assert( false );

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -155,6 +155,11 @@ public:
     /// signal about render discretization changing, triggered in setRenderDiscretization
     Signal<void()> renderDiscretizationChangedSignal;
 
+    /// signal about points or normals changing, triggered in setDirtyFlag
+    using ChangedSignal = Signal<void( uint32_t mask )>;
+    ChangedSignal pointsChangedSignal;
+    ChangedSignal normalsChangedSignal;
+
 protected:
     VertBitSet selectedPoints_;
     mutable std::optional<size_t> numValidPoints_;


### PR DESCRIPTION
* `meshChangedSignal` moved from `ObjectMesh` into `ObjectMeshHolder`
* `pointsChangedSignal` and `normalsChangedSignal` moved from `ObjectPoints` into `ObjectPointsHolder`
* `linesChangedSignal` moved from `ObjectLines` into `ObjectLinesHolder`