### PR TITLE
SurfaceManipulationWidget avoids mesh metrics computation while the user holds mouse down

### DIFF
--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -763,8 +763,22 @@ size_t ObjectMeshHolder::numHandles() const
 
 void ObjectMeshHolder::setDirtyFlags( uint32_t mask, bool invalidateCaches )
 {
-    VisualObject::setDirtyFlags( mask, invalidateCaches );
+    invalidateMetricsCache( mask );
+    setDirtyFlagsFast( mask );
 
+    if ( invalidateCaches && ( mask & DIRTY_POSITION || mask & DIRTY_FACE ) && data_.mesh )
+        data_.mesh->invalidateCaches();
+}
+
+void ObjectMeshHolder::setDirtyFlagsFast( uint32_t mask )
+{
+    VisualObject::setDirtyFlags( mask );
+    if ( ( mask & DIRTY_POSITION || mask & DIRTY_FACE ) && data_.mesh )
+        meshChangedSignal( mask );
+}
+
+void ObjectMeshHolder::invalidateMetricsCache( uint32_t mask )
+{
     if ( mask & DIRTY_FACE )
     {
         numHoles_.reset();
@@ -782,16 +796,6 @@ void ObjectMeshHolder::setDirtyFlags( uint32_t mask, bool invalidateCaches )
         selectedArea_.reset();
         volume_.reset();
         avgEdgeLen_.reset();
-        if ( invalidateCaches && data_.mesh )
-            data_.mesh->invalidateCaches();
-    }
-
-    if ( mask & DIRTY_POSITION || mask & DIRTY_FACE)
-    {
-        if ( data_.mesh )
-        {
-            meshChangedSignal( mask );
-        }
     }
 }
 

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -64,6 +64,14 @@ public:
 
     MRMESH_API virtual void setDirtyFlags( uint32_t mask, bool invalidateCaches = true ) override;
 
+    /// this is a faster version of setDirtyFlags(), which does not invalidate metrics cache (area, volume, ...);
+    /// the user is responsible for calling invalidateMetricsCache( mask ) or setDirtyFlags( mask ) at the end of mesh editing;
+    /// DANGER: all cached values returned until then can be outdated
+    MRMESH_API virtual void setDirtyFlagsFast( uint32_t mask );
+
+    /// invalidates same caches with mesh metrics (area, volume, ...) as by setDirtyFlags( mask )
+    MRMESH_API virtual void invalidateMetricsCache( uint32_t mask );
+
     const FaceBitSet& getSelectedFaces() const { return data_.selectedFaces; }
     MRMESH_API virtual void selectFaces( FaceBitSet newSelection );
     /// returns colors of selected triangles

--- a/source/MRViewer/MRSurfaceManipulationWidget.h
+++ b/source/MRViewer/MRSurfaceManipulationWidget.h
@@ -122,6 +122,7 @@ protected:
     void changeSurface_();
     void updateUVmap_( bool set, bool wholeMesh = false );
     void updateRegion_( const Vector2f& mousePos );
+    void invalidateMetricsCache_();
     void abortEdit_();
     /// Laplacian
     void laplacianPickVert_( const PointOnFace& pick );


### PR DESCRIPTION
* Information pane will show old area and volume for meshes being edited until the user releases the mouse.
* New methods introduced: `ObjectMeshHolder::setDirtyFlagsFast` and `ObjectMeshHolder::invalidateMetricsCache` to support it.