### PR TITLE
Speedup marchingCubes

### DIFF
--- a/source/MRVoxels/MRMarchingCubes.cpp
+++ b/source/MRVoxels/MRMarchingCubes.cpp
@@ -773,7 +773,6 @@ Expected<TriMesh> VolumeMesher::finalize()
         {
             const BitSet* layerInvalids[2] = { &invalids_[loc.pos.z], &invalids_[loc.pos.z+1] };
             const BitSet* layerLowerIso[2] = { &lowerIso_[loc.pos.z], &lowerIso_[loc.pos.z+1] };
-            const VoxelId layerFirstVoxelId[2] = { indexer_.toVoxelId( { 0, 0, loc.pos.z } ), indexer_.toVoxelId( { 0, 0, loc.pos.z + 1 } ) };
             for ( loc.pos.y = 0; loc.pos.y + 1 < indexer_.dims().y; ++loc.pos.y )
             {
                 loc.pos.x = 0;


### PR DESCRIPTION
 - cache layerBits vales to eliminate `getBit` usage
 - fast check for fully invalid voxels

Before:
```
[13/02/26 14:50:38.045] [info]         5      50.970      50.718                MR::`anonymous-namespace'::VolumeMesher::finalize
[13/02/26 14:50:38.045] [info]         5       0.141       0.141                    MR::SeparationPointStorage::getTriangulation
```

After
```
[16/02/26 18:55:43.699] [info]         5      24.436      24.179                MR::`anonymous-namespace'::VolumeMesher::finalize
[16/02/26 18:55:43.699] [info]         5       0.144       0.144                    MR::SeparationPointStorage::getTriangulation
```

50.970 -> 24.436 sec 