### PR TITLE
optimize BitSet::test for MSVC

### DIFF
--- a/source/MRMesh/MRBitSet.h
+++ b/source/MRMesh/MRBitSet.h
@@ -59,7 +59,7 @@ public:
     [[nodiscard]] bool uncheckedTestSet( IndexType n, bool val = true ) { assert( n < size() ); bool b = uncheckedTest( n ); if ( b != val ) set( n, val ); return b; }
 
     // all bits after size() we silently consider as not-set
-    [[nodiscard]] bool test( IndexType n ) const { return n < size() ? uncheckedTest( n ) : false; } // return n < size() && uncheckedTest( n ); was compiled with conditional jump by MSVC
+    [[nodiscard]] bool test( IndexType n ) const { return n < size() ? uncheckedTest( n ) : false; } // return n < size() && uncheckedTest( n ); was compiled with extra conditional jump inside uncheckedTest() by MSVC
     [[nodiscard]] bool test_set( IndexType n, bool val = true ) { return ( val || n < size() ) ? uncheckedTestSet( n, val ) : false; }
 
     MRMESH_API BitSet & set( IndexType n, size_type len, bool val );


### PR DESCRIPTION
Previous implementation of `BitSet::test` was optimized very badly in MSVC with two conditional jumps. Now only one jump remains.