### PR TITLE
findTwoLineSegmClosestPoints functions

### DIFF
--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -241,6 +241,7 @@
     <ClInclude Include="MRRigidXf3.h" />
     <ClInclude Include="MRSaveSettings.h" />
     <ClInclude Include="MRSceneLoad.h" />
+    <ClInclude Include="MRTwoLineSegmDist.h" />
     <ClInclude Include="MRSeparationPoint.h" />
     <ClInclude Include="MRSharedThreadSafeOwner.h" />
     <ClInclude Include="MRSolarRadiation.h" />
@@ -667,6 +668,7 @@
     <ClCompile Include="MRTerrainTriangulation.cpp" />
     <ClCompile Include="MRTunnelDetector.cpp" />
     <ClCompile Include="MRTupleBindings.cpp" />
+    <ClCompile Include="MRTwoLineSegmDist.cpp" />
     <ClCompile Include="MRUniformSampling.cpp" />
     <ClCompile Include="MRUniqueThreadSafeOwner.cpp" />
     <ClCompile Include="MRQuadraticForm.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1383,6 +1383,9 @@
       <Filter>Source Files\Basic</Filter>
     </ClInclude>
     <ClInclude Include="MRFunctional.h" />
+    <ClInclude Include="MRTwoLineSegmDist.h">
+      <Filter>Source Files\Math</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRParallelProgressReporter.cpp">
@@ -2270,6 +2273,9 @@
     </ClCompile>
     <ClCompile Include="MRParallelFor.cpp" />
     <ClCompile Include="MRBitSetParallelFor.cpp" />
+    <ClCompile Include="MRTwoLineSegmDist.cpp">
+      <Filter>Source Files\Math</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />

--- a/source/MRMesh/MRMeshDelone.cpp
+++ b/source/MRMesh/MRMeshDelone.cpp
@@ -7,7 +7,7 @@
 #include "MRTriMath.h"
 #include "MRVector2.h"
 #include "MRReducePath.h"
-#include "MRTriDist.h"
+#include "MRTwoLineSegmDist.h"
 #include "MREdgeLengthMesh.h"
 
 namespace MR
@@ -118,10 +118,11 @@ bool checkDeloneQuadrangleInMesh( const MeshTopology & topology, const VertCoord
 
     if ( deviationSqAfterFlip || settings.maxDeviationAfterFlip < FLT_MAX )
     {
-        Vector3f vec, closestOnAC, closestOnBD;
-        segPoints( vec, closestOnAC, closestOnBD,
-            ap, cp - ap,   // first diagonal segment
-            bp, dp - bp ); // second diagonal segment
+        const auto sd = findTwoLineSegmClosestPoints(
+            { ap, cp },   // first diagonal segment
+            { bp, dp } ); // second diagonal segment
+        const auto closestOnAC = sd.a;
+        const auto closestOnBD = sd.b;
         const auto distSq = ( closestOnAC - closestOnBD ).lengthSq();
         if ( deviationSqAfterFlip )
             *deviationSqAfterFlip = distSq;

--- a/source/MRMesh/MRTriDist.h
+++ b/source/MRMesh/MRTriDist.h
@@ -63,13 +63,7 @@ inline float triDist( Vector3f & p, Vector3f & q, const std::array<Vector3f, 3> 
     return triDist( p, q, s.data(), t.data() );
 }
 
-
-
-/// Returns closest points between an segment pair.
-MRMESH_API void segPoints(
-          // if both closest points are in segment endpoints, then directed from closest point 1 to closest point 2,
-          // if both closest points are inner to the segments, then its orthogonal to both segments and directed from 1 to 2,
-          // otherwise it is orthogonal to the segment with inner closest point and rotated toward/away the other closest point in endpoint
+[[deprecated( "Use findTwoLineSegmClosestPoints() instead" )]] MRMESH_API void segPoints(
           Vector3f & VEC,
           Vector3f & X, Vector3f & Y,             // closest points
           const Vector3f & P, const Vector3f & A, // seg 1 origin, vector

--- a/source/MRMesh/MRTwoLineSegmDist.cpp
+++ b/source/MRMesh/MRTwoLineSegmDist.cpp
@@ -1,0 +1,135 @@
+#include "MRTwoLineSegmDist.h"
+
+namespace MR
+{
+
+namespace
+{
+
+// Implemented from an algorithm described in
+//
+// Vladimir J. Lumelsky,
+// On fast computation of distance between line segments.
+// In Information Processing Letters, no. 21, pages 55-61, 1985.
+template<class T>
+TwoLineSegmClosestPoints<T> findTwoLineSegmDistanceT( const LineSegm3<T>& a, const LineSegm3<T>& b )
+{
+    TwoLineSegmClosestPoints<T> res;
+
+    const auto adir = a.dir();
+    const auto bdir = b.dir();
+
+    const auto aa = dot( adir, adir );
+    const auto bb = dot( bdir, bdir );
+    const auto ab = dot( adir, bdir );
+    const auto denom = aa * bb - ab * ab;
+
+           auto d = b.a - a.a;
+    const auto ad = dot( adir, d );
+    const auto bd = dot( bdir, d );
+
+    // compute t for the closest point on ray a to ray b
+    // t parameterizes ray a
+    auto t = ( ad * bb - bd * ab ) / denom;
+
+    // clamp result so t is on the segment a.a,adir
+
+    if ( ( t < 0 ) || std::isnan( t ) ) t = 0; else if ( t > 1 ) t = 1;
+
+    // find u for point on ray b closest to point ad t
+    // u parameterizes ray b
+    auto u = ( t * ab - bd ) / bb;
+
+    // if u is on segment b.a,bdir, t and u correspond to
+    // closest points, otherwise, clamp u, recompute and
+    // clamp t
+
+    if ( ( u <= 0 ) || std::isnan( u ) )
+    {
+        res.b = b.a;
+
+        t = ad / aa;
+
+        if ( ( t <= 0 ) || std::isnan( t ) )
+        {
+            res.a = a.a;
+            res.dir = b.a - a.a;
+        }
+        else if ( t >= 1 )
+        {
+            res.a = a.a + adir;
+            res.dir = b.a - res.a;
+        }
+        else
+        {
+            res.a = a.a + adir * t;
+            auto tmp = cross( d, adir );
+            res.dir = cross( adir, tmp );
+        }
+    }
+    else if ( u >= 1 )
+    {
+        res.b = b.a + bdir;
+
+        t = ( ab + ad ) / aa;
+
+        if ( ( t <= 0 ) || std::isnan( t ) )
+        {
+            res.a = a.a;
+            res.dir = res.b - a.a;
+        }
+        else if ( t >= 1 )
+        {
+            res.a = a.a + adir;
+            res.dir = res.b - res.a;
+        }
+        else
+        {
+            res.a = a.a + adir * t;
+            d = res.b - a.a;
+            auto tmp = cross( d, adir );
+            res.dir = cross( adir, tmp );
+        }
+    }
+    else
+    {
+        res.b = b.a + bdir * u;
+
+        if ( ( t <= 0 ) || std::isnan( t ) )
+        {
+            res.a = a.a;
+            auto tmp = cross( d, bdir );
+            res.dir = cross( bdir, tmp );
+        }
+        else if ( t >= 1 )
+        {
+            res.a = a.a + adir;
+            d = b.a - res.a;
+            auto tmp = cross( d, bdir );
+            res.dir = cross( bdir, tmp );
+        }
+        else
+        {
+            res.a = a.a + adir * t;
+            res.dir = cross( adir, bdir );
+            if ( dot( res.dir, d ) < 0 )
+                res.dir = -res.dir;
+        }
+    }
+
+    return res;
+}
+
+} // anonymous namespace
+
+TwoLineSegmClosestPointsf findTwoLineSegmClosestPoints( const LineSegm3f& a, const LineSegm3f& b )
+{
+    return findTwoLineSegmDistanceT( a, b );
+}
+
+TwoLineSegmClosestPointsd findTwoLineSegmClosestPoints( const LineSegm3d& a, const LineSegm3d& b )
+{
+    return findTwoLineSegmDistanceT( a, b );
+}
+
+} //namespace MR

--- a/source/MRMesh/MRTwoLineSegmDist.h
+++ b/source/MRMesh/MRTwoLineSegmDist.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "MRVector3.h"
+#include "MRLineSegm.h"
+
+namespace MR
+{
+
+template<class T>
+struct TwoLineSegmClosestPoints
+{
+    /// the closest points each from its respective segment
+    Vector3<T> a, b;
+
+    // if both closest points are in segment endpoints, then directed from closest point a to closest point b,
+    // if both closest points are inner to the segments, then its orthogonal to both segments and directed from a to b,
+    // otherwise it is orthogonal to the segment with inner closest point and rotated toward/away the other closest point in endpoint
+    Vector3<T> dir;
+};
+using TwoLineSegmClosestPointsf = TwoLineSegmClosestPoints<float>;
+using TwoLineSegmClosestPointsd = TwoLineSegmClosestPoints<double>;
+
+/// computes the closest points on two line segments
+[[nodiscard]] MRMESH_API TwoLineSegmClosestPointsf findTwoLineSegmClosestPoints( const LineSegm3f& a, const LineSegm3f& b );
+[[nodiscard]] MRMESH_API TwoLineSegmClosestPointsd findTwoLineSegmClosestPoints( const LineSegm3d& a, const LineSegm3d& b );
+
+} // namespace MR


### PR DESCRIPTION
Deprecate `segPoints` function, and introduce instead two `findTwoLineSegmClosestPoints` functions for `float` and `double` precisions with more convenient interface.
