### PR TITLE
Use `GeodesicPath` in bend functions

### DIFF
--- a/source/MRMesh/MRAlignContoursToMesh.h
+++ b/source/MRMesh/MRAlignContoursToMesh.h
@@ -62,7 +62,7 @@ struct BendContoursAlongCurveParams
 MRMESH_API Expected<Mesh> bendContoursAlongCurve( const Contours2f& contours, const CurveFunc& curve, const BendContoursAlongCurveParams& params );
 
 /// Converts contours in thick mesh, and deforms it along given surface path: start->path->end
-MRMESH_API Expected<Mesh> bendContoursAlongSurfacePath( const Contours2f& contours, const Mesh& mesh, const MeshTriPoint & start, const SurfacePath& path, const MeshTriPoint & end,
+MRMESH_API Expected<Mesh> bendContoursAlongSurfacePath( const Contours2f& contours, const Mesh& mesh, const GeodesicPath& path,
     const BendContoursAlongCurveParams& params );
 
 /// Converts contours in thick mesh, and deforms it along given surface path
@@ -86,7 +86,7 @@ MRMESH_API Expected<CurveFunc> curveFromPoints( const CurvePoints& cp, float * o
 MRMESH_API Expected<CurveFunc> curveFromPoints( CurvePoints&& cp, float* outCurveLen = nullptr );
 
 /// converts polyline given as a number of MeshTriPoint/MeshEdgePoint into CurvePoints
-[[nodiscard]] MRMESH_API CurvePoints meshPathCurvePoints( const Mesh& mesh, const MeshTriPoint & start, const SurfacePath& path, const MeshTriPoint & end );
+[[nodiscard]] MRMESH_API CurvePoints meshPathCurvePoints( const Mesh& mesh, const GeodesicPath& path );
 [[nodiscard]] MRMESH_API CurvePoints meshPathCurvePoints( const Mesh& mesh, const SurfacePath& path );
 
 /// given a planar mesh with boundary on input located in plane XY, packs and extends it along Z on zOffset (along -Z if zOffset is negative) to make a volumetric closed mesh

--- a/source/MRSymbolMesh/MRAlignTextToMesh.cpp
+++ b/source/MRSymbolMesh/MRAlignTextToMesh.cpp
@@ -134,30 +134,19 @@ Expected<Mesh> bendTextAlongCurve( const CurveFunc& curve, const BendTextAlongCu
         } );
 }
 
-Expected<Mesh> bendTextAlongCurve( const CurvePoints& cp, const BendTextAlongCurveParams& params0 )
+Expected<Mesh> bendTextAlongCurve( const CurvePoints& cp, const BendTextAlongCurveParams& params )
 {
     MR_TIMER;
-
-    float curveLen = 0;
-    auto maybeCurveFunc = curveFromPoints( cp, &curveLen );
+    auto maybeCurveFunc = curveFromPoints( cp );
     if ( !maybeCurveFunc )
         return unexpected( std::move( maybeCurveFunc.error() ) );
-    assert( curveLen > 0 );
-
-    BendTextAlongCurveParams params = params0;
-    if ( !params.stretch )
-    {
-        // pivotCurveTime from relative [0,1] into actual [0,len]
-        params.pivotCurveTime *= curveLen;
-    }
-
     return bendTextAlongCurve( *maybeCurveFunc, params );
 }
 
 Expected<Mesh> bendTextAlongSurfacePath( const Mesh& mesh,
-    const MeshTriPoint & start, const SurfacePath& path, const MeshTriPoint & end, const BendTextAlongCurveParams& params )
+    const GeodesicPath& path, const BendTextAlongCurveParams& params )
 {
-    return bendTextAlongCurve( meshPathCurvePoints( mesh, start, path, end ), params );
+    return bendTextAlongCurve( meshPathCurvePoints( mesh, path ), params );
 }
 
 Expected<Mesh> bendTextAlongSurfacePath( const Mesh& mesh,

--- a/source/MRSymbolMesh/MRAlignTextToMesh.h
+++ b/source/MRSymbolMesh/MRAlignTextToMesh.h
@@ -80,7 +80,7 @@ MRSYMBOLMESH_API Expected<Mesh> bendTextAlongCurve( const CurvePoints& curve, co
 
 /// Creates symbol mesh and deforms it along given surface path: start->path->end
 MRSYMBOLMESH_API Expected<Mesh> bendTextAlongSurfacePath( const Mesh& mesh,
-    const MeshTriPoint & start, const SurfacePath& path, const MeshTriPoint & end, const BendTextAlongCurveParams& params );
+    const GeodesicPath& path, const BendTextAlongCurveParams& params );
 
 /// Creates symbol mesh and deforms it along given surface path
 MRSYMBOLMESH_API Expected<Mesh> bendTextAlongSurfacePath( const Mesh& mesh,

--- a/source/MRTest/MRBendTextAlongCurveTests.cpp
+++ b/source/MRTest/MRBendTextAlongCurveTests.cpp
@@ -44,13 +44,15 @@ TEST( MRMesh, BendTextAlongCurve )
     EXPECT_TRUE( maybeText.has_value() );
     EXPECT_GT( maybeText->topology.numValidFaces(), 0 );
 
-    const auto start = findProjection( { 0, 0, 1 }, sphere ).mtp;
-    const auto end = findProjection( { 0, 0, -1 }, sphere ).mtp;
-    auto maybePath = computeGeodesicPath( sphere, start, end );
+    GeodesicPath path;
+    path.start = findProjection( { 0, 0, 1 }, sphere ).mtp;
+    path.end = findProjection( { 0, 0, -1 }, sphere ).mtp;
+    auto maybePath = computeGeodesicPath( sphere, path.start, path.end );
     EXPECT_TRUE( maybePath.has_value() );
     EXPECT_GT( maybePath->size(), 0 );
+    path.mids = std::move( *maybePath );
 
-    maybeText = bendTextAlongSurfacePath( sphere, start, *maybePath, end,
+    maybeText = bendTextAlongSurfacePath( sphere, path,
         BendTextAlongCurveParams{
             .symbolMesh = s,
             .fontHeight = 0.1f,


### PR DESCRIPTION
also fix bug with `stretch=false` for text bending