### PR TITLE
SurfaceManipulationWidget: VertexMass::NeiArea by default in Laplacian

### DIFF
--- a/source/MRViewer/MRSurfaceManipulationWidget.h
+++ b/source/MRViewer/MRSurfaceManipulationWidget.h
@@ -51,7 +51,7 @@ public:
         float sharpness = 50.f; ///< effect of force on points far from center editing area. [0 - 100]
         float relaxForceAfterEdit = 0.25f; ///< force of relaxing modified area after editing (add / remove) is complete. [0 - 0.5], 0 - not relax
         EdgeWeights edgeWeights = EdgeWeights::Cotan; ///< edge weights for Laplacian and Patch
-        VertexMass vmass = VertexMass::Unit; ///< vertex weights for Laplacian and Patch
+        VertexMass vmass = VertexMass::NeiArea; ///< vertex weights for Laplacian and Patch
     };
 
     /// initialize widget according ObjectMesh


### PR DESCRIPTION
This setting is much better for editing not uniform meshes.