### PR TITLE
Nesting: add nesting functionality

### DIFF
--- a/source/MRIOExtras/MRIOExtras.vcxproj
+++ b/source/MRIOExtras/MRIOExtras.vcxproj
@@ -35,6 +35,7 @@
     <ClCompile Include="MRIOExtras.cpp" />
     <ClCompile Include="MRJpeg.cpp" />
     <ClCompile Include="MRLas.cpp" />
+    <ClCompile Include="MRNesting3mfExport.cpp" />
     <ClCompile Include="MRPdf.cpp" />
     <ClCompile Include="MRPng.cpp" />
     <ClCompile Include="MRStep.cpp" />
@@ -52,6 +53,7 @@
     <ClInclude Include="MRIOExtras.h" />
     <ClInclude Include="MRJpeg.h" />
     <ClInclude Include="MRLas.h" />
+    <ClInclude Include="MRNesting3mfExport.h" />
     <ClInclude Include="MRPdf.h" />
     <ClInclude Include="MRPng.h" />
     <ClInclude Include="MRStep.h" />

--- a/source/MRIOExtras/MRNesting3mfExport.cpp
+++ b/source/MRIOExtras/MRNesting3mfExport.cpp
@@ -1,0 +1,475 @@
+#include "MRNesting3mfExport.h"
+#ifndef MRIOEXTRAS_NO_XML
+#include "MRMesh/MRUniqueTemporaryFolder.h"
+#include "MRMesh/MRStringConvert.h"
+#include "MRMesh/MRId.h"
+#include "MRMesh/MRProgressCallback.h"
+#include "MRMesh/MRParallelFor.h"
+#include "MRMesh/MRPlane3.h"
+#include "MRMesh/MRMesh.h"
+#include "MRMesh/MRExtractIsolines.h"
+#include "MRMesh/MRPolylineDecimate.h"
+#include "MRMesh/MRPolyline.h"
+#include "MRMesh/MRZip.h"
+#include "MRMesh/MRImage.h"
+#include "MRMesh/MRImageSave.h"
+#include "MRPch/MRFmt.h"
+#include "MRPch/MRTBB.h"
+#include "MRMesh/MR2to3.h"
+#include <tinyxml2.h>
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+
+#include <filesystem>
+
+namespace
+{
+std::string generateUUID()
+{
+    boost::uuids::random_generator generator;
+    boost::uuids::uuid u = generator();
+    return boost::uuids::to_string( u );
+}
+}
+
+namespace MR::Nesting
+{
+
+using Slices2D = std::vector<std::pair<Contours2f, float>>;
+
+static Slices2D prepareSlices( const MeshXf& mesh, const Box3f& worldBox, float step, bool decimate )
+{
+    if ( !mesh.mesh )
+        return {};
+    auto invXf = mesh.xf.inverse();
+    auto minDist = worldBox.min.z;
+    auto maxDist = worldBox.max.z - minDist;
+    int numSlices = 1; // one empty slice at the end
+    for ( auto dist = step * 0.5f; dist <= maxDist; dist += step )
+        ++numSlices;
+
+    Slices2D res;
+    res.resize( numSlices );
+
+    ParallelFor( res, [&] ( size_t i )
+    {
+        auto& [slices, ztop] = res[i];
+        ztop = ( i + 1 ) * step;
+
+        auto plane = transformed( -Plane3f( Vector3f::plusZ(), minDist + ztop - step * 0.5f ), invXf ).normalized();
+        auto sections = extractPlaneSections( *mesh.mesh, plane );
+        if ( sections.empty() )
+            return;
+
+        if ( decimate )
+        {
+            Contours3f conts;
+            Polyline3 polyline;
+            for ( const auto& section : sections )
+                polyline.addFromSurfacePath( *mesh.mesh, section );
+            DecimatePolylineSettings3 pds;
+            pds.maxError = 0.5f * step;
+            decimatePolyline( polyline, pds );
+            conts = polyline.contours();
+            slices.resize( conts.size() );
+
+            for ( int si = 0; si < conts.size(); ++si )
+            {
+                auto& sliceI = slices[si];
+                const auto& contI = conts[si];
+                sliceI.resize( contI.size() );
+                for ( int sj = 0; sj < contI.size(); ++sj )
+                    sliceI[sj] = to2dim( mesh.xf( contI[sj] ) - worldBox.min );
+            }
+        }
+        else
+        {
+            for ( int si = 0; si < sections.size(); ++si )
+            {
+                auto& sliceI = slices[si];
+                const auto& sectionI = sections[si];
+                sliceI.resize( sectionI.size() );
+                for ( int sj = 0; sj < sectionI.size(); ++sj )
+                    sliceI[sj] = to2dim( mesh.xf( mesh.mesh->edgePoint( sectionI[sj] ) ) - worldBox.min );
+            }
+        }
+    } );
+    return res;
+}
+
+void save2dModelFile( const std::filesystem::path& path, const Slices2D& slices )
+{
+    if ( slices.empty() )
+        return;
+
+    tinyxml2::XMLDocument slicesDoc;
+    auto decl = slicesDoc.NewDeclaration();
+    slicesDoc.LinkEndChild( decl );
+    auto model = slicesDoc.NewElement( "model" );
+    model->SetAttribute( "xmlns", "http://schemas.microsoft.com/3dmanufacturing/core/2015/02" );
+    model->SetAttribute( "xmlns:s", "http://schemas.microsoft.com/3dmanufacturing/slice/2015/07" );
+    model->SetAttribute( "xmlns:p", "http://schemas.microsoft.com/3dmanufacturing/production/2015/06" );
+    model->SetAttribute( "unit", "millimeter" );
+    model->SetAttribute( "xml:lang", "en-US" );
+    auto resources = model->InsertNewChildElement( "resources" );
+    auto slicestack = resources->InsertNewChildElement( "s:slicestack" );
+    slicestack->SetAttribute( "id", 1 );
+    auto tempStr = fmt::format( "{:.3f}", 0.0f );
+    slicestack->SetAttribute( "zbottom", tempStr.c_str() );
+
+    for ( int i = 0; i < slices.size(); ++i )
+    {
+        const auto& [zSlices, ztop] = slices[i];
+        auto slice = slicestack->InsertNewChildElement( "s:slice" );
+        tempStr = fmt::format( "{:.3f}", ztop );
+        slice->SetAttribute( "ztop", tempStr.c_str() );
+        if ( !zSlices.empty() )
+        {
+            auto vertices = slice->InsertNewChildElement( "s:vertices" );
+
+            for ( const auto& zSlice : zSlices )
+            {
+                for ( int si = 0; si + 1 < zSlice.size(); ++si )
+                {
+                    auto coord = zSlice[si];
+
+                    auto vertex = vertices->InsertNewChildElement( "s:vertex" );
+                    tempStr = fmt::format( "{:.3f}", coord.x );
+                    vertex->SetAttribute( "x", tempStr.c_str() );
+                    tempStr = fmt::format( "{:.3f}", coord.y );
+                    vertex->SetAttribute( "y", tempStr.c_str() );
+                    vertices->LinkEndChild( vertex );
+                }
+            }
+            slice->LinkEndChild( vertices );
+            int numV = -1;
+            for ( const auto& zSlice : zSlices )
+            {
+                auto polygon = slice->InsertNewChildElement( "s:polygon" );
+                auto startV = ++numV;
+                polygon->SetAttribute( "startv", startV );
+                for ( int si = 1; si < zSlice.size(); ++si )
+                {
+                    auto segment = polygon->InsertNewChildElement( "s:segment" );
+                    if ( si + 1 < zSlice.size() )
+                        segment->SetAttribute( "v2", ++numV );
+                    else
+                        segment->SetAttribute( "v2", startV );
+                    polygon->LinkEndChild( segment );
+                }
+                slice->LinkEndChild( polygon );
+            }
+        }
+        slicestack->LinkEndChild( slice );
+    }
+
+    resources->LinkEndChild( slicestack );
+    model->LinkEndChild( resources );
+    model->LinkEndChild( model->InsertNewChildElement( "build" ) );
+    slicesDoc.LinkEndChild( model );
+    auto slPath = utf8string( path );
+    slicesDoc.SaveFile( slPath.c_str() );
+}
+
+Expected<void> exportNesting3mf( const std::filesystem::path& path, const Nesting3mfParams& params )
+{
+    if ( params.zStep <= 0 )
+    {
+        assert( false );
+        return unexpected( "Negative slice step" );
+    }
+    UniqueTemporaryFolder saveDir;
+    std::filesystem::path dir = saveDir;
+
+    std::error_code ec;
+    if ( !std::filesystem::is_directory( dir, ec ) && !std::filesystem::create_directories( dir, ec ) )
+        return unexpected( systemToUtf8( ec.message() ) );
+    auto dir2d = dir / "2D";
+    auto dir3d = dir / "3D";
+    auto dirRels = dir / "_rels";
+    auto dir3dRels = dir3d / "_rels";
+    auto dirMeta = dir / "Metadata";
+    auto dirThumb = dir / "Thumbnails";
+    if ( !std::filesystem::is_directory( dir2d, ec ) && !std::filesystem::create_directories( dir2d, ec ) )
+        return unexpected( systemToUtf8( ec.message() ) );
+    if ( !std::filesystem::is_directory( dir3d, ec ) && !std::filesystem::create_directories( dir3d, ec ) )
+        return unexpected( systemToUtf8( ec.message() ) );
+    if ( !std::filesystem::is_directory( dirRels, ec ) && !std::filesystem::create_directories( dirRels, ec ) )
+        return unexpected( systemToUtf8( ec.message() ) );
+    if ( !std::filesystem::is_directory( dir3dRels, ec ) && !std::filesystem::create_directories( dir3dRels, ec ) )
+        return unexpected( systemToUtf8( ec.message() ) );
+    if ( params.image && !std::filesystem::is_directory( dirMeta, ec ) && !std::filesystem::create_directories( dirMeta, ec ) )
+        return unexpected( systemToUtf8( ec.message() ) );
+    if ( params.meshImages && !std::filesystem::is_directory( dirThumb, ec ) && !std::filesystem::create_directories( dirThumb, ec ) )
+        return unexpected( systemToUtf8( ec.message() ) );
+
+    // [Content_Types].xml
+    {
+        tinyxml2::XMLDocument contentType;
+        auto decl = contentType.NewDeclaration("xml version=\"1.0\"");
+        contentType.LinkEndChild( decl );
+
+        auto* type = contentType.NewElement( "Types" );
+        type->SetAttribute( "xmlns", "http://schemas.openxmlformats.org/package/2006/content-types" );
+        auto el = type->InsertNewChildElement( "Default" );
+        el->SetAttribute( "Extension", "rels" );
+        el->SetAttribute( "ContentType", "application/vnd.openxmlformats-package.relationships+xml" );
+        type->LinkEndChild( el );
+        el = type->InsertNewChildElement( "Default" );
+        el->SetAttribute( "Extension", "model" );
+        el->SetAttribute( "ContentType", "application/vnd.ms-package.3dmanufacturing-3dmodel+xml" );
+        type->LinkEndChild( el );
+        if ( params.image )
+        {
+            el = type->InsertNewChildElement( "Default" );
+            el->SetAttribute( "Extension", "png" );
+            el->SetAttribute( "ContentType", "image/png" );
+            type->LinkEndChild( el );
+        }
+        contentType.LinkEndChild( type );
+        auto ctPath = utf8string( dir / "[Content_Types].xml" );
+        contentType.SaveFile( ctPath.c_str() );
+    }
+
+    if ( !reportProgress( params.cb, 0.05f ) )
+        return unexpectedOperationCanceled();
+
+    Vector<Box3f, ObjId> worldBoxes( params.meshes.size() );
+    auto keepGoing = ParallelFor( params.meshes, [&] ( ObjId oid )
+    {
+        if ( !params.meshes[oid].mesh )
+            return;
+        worldBoxes[oid] = params.meshes[oid].mesh->computeBoundingBox( &params.meshes[oid].xf );
+    }, subprogress( params.cb, 0.05f, 0.1f ) );
+
+    if ( !keepGoing )
+        return unexpectedOperationCanceled();
+
+    std::vector<std::string> uuids( params.meshes.size() );
+    for ( int i = 0; i < uuids.size(); ++i )
+        uuids[i] = generateUUID();
+
+    // Thumbnails
+    if ( params.meshImages )
+    {
+        auto sb = subprogress( params.cb, 0.1f, 0.15f );
+        if ( params.meshImages->size() != params.meshes.size() )
+            return unexpected( "Invalid number of one by one screenshots" );
+        for ( int i = 0; i < params.meshes.size(); ++i )
+        {
+            auto saveRes = ImageSave::toAnySupportedFormat( ( *params.meshImages )[i], dirThumb / ( uuids[i] + ".png" ) );
+            if ( !saveRes.has_value() )
+                return unexpected( "Cannot save screenshot: " + saveRes.error() );
+            if ( !reportProgress( sb, float( i + 1 ) / float( params.meshes.size() ) ) )
+                return unexpectedOperationCanceled();
+        }
+    }
+
+    // 2D
+    {
+        auto sb = subprogress( params.cb, 0.15f, 0.4f );
+        tbb::task_group tg;
+
+        Slices2D slicesSave, slicesBuffer;
+        if ( !params.meshes.empty() )
+            slicesBuffer = prepareSlices( params.meshes[ObjId( 0 )], worldBoxes[ObjId( 0 )], params.zStep, params.decimateSlices );
+        for ( ObjId i( 0 ); i < params.meshes.size(); ++i )
+        {
+            tg.wait();
+            std::swap( slicesSave, slicesBuffer ); // get prepared slices buffer
+            if ( i + 1 < params.meshes.size() )
+            {
+                // prepare next object slices in parallel while saving this object slices
+                tg.run( [&] ()
+                {
+                    slicesBuffer = prepareSlices( params.meshes[i + 1], worldBoxes[i + 1], params.zStep, params.decimateSlices );
+                } );
+            }
+            auto slPath = utf8string( dir / "2D" / ( uuids[i] + ".model" ) );
+            save2dModelFile( slPath, slicesSave );
+            if ( !reportProgress( sb, float( i + 1 ) / float( params.meshes.size() ) ) )
+                return unexpectedOperationCanceled();
+        }
+    }
+
+    std::string tempStr;
+    // 3D
+    {
+        tinyxml2::XMLDocument buildDoc;
+        auto decl = buildDoc.NewDeclaration();
+        buildDoc.LinkEndChild( decl );
+        auto model = buildDoc.NewElement( "model" );
+        model->SetAttribute( "xmlns", "http://schemas.microsoft.com/3dmanufacturing/core/2015/02" );
+        model->SetAttribute( "xmlns:s", "http://schemas.microsoft.com/3dmanufacturing/slice/2015/07" );
+        model->SetAttribute( "xmlns:p", "http://schemas.microsoft.com/3dmanufacturing/production/2015/06" );
+        model->SetAttribute( "unit", "millimeter" );
+        model->SetAttribute( "xml:lang", "en-US" );
+        auto resources = model->InsertNewChildElement( "resources" );
+        for ( ObjId i( 0 ); i < params.meshes.size(); ++i )
+        {
+            auto slicestack = resources->InsertNewChildElement( "s:slicestack" );
+            slicestack->SetAttribute( "id", int( i + 1 ) );
+            tempStr = fmt::format( "{:.3f}",  0.0f );
+            slicestack->SetAttribute( "zbottom", tempStr.c_str() );
+            auto sliceref = slicestack->InsertNewChildElement( "s:sliceref" );
+            sliceref->SetAttribute( "slicestackid", 1 );
+            auto slicepath = "/2D/" + uuids[i] + ".model";
+            sliceref->SetAttribute( "slicepath", slicepath.c_str() );
+            slicestack->LinkEndChild( sliceref );
+            resources->LinkEndChild( slicestack );
+        }
+
+        for ( ObjId i( 0 ); i < params.meshes.size(); ++i )
+        {
+            auto object = resources->InsertNewChildElement( "object" );
+            object->SetAttribute( "id", int( i + 1 + params.meshes.size() ) );
+            auto name = std::to_string( int( i + 1 ) ) + "_printable.model";
+            if ( params.meshNames )
+                name = ( *params.meshNames )[int( i )];
+            object->SetAttribute( "name", name.c_str() );
+            auto thumbnail = "/Thumbnails/" + uuids[i] + ".png";
+            object->SetAttribute( "thumbnail", thumbnail.c_str() );
+            object->SetAttribute( "s:slicestackid", int( i + 1 ) );
+            object->SetAttribute( "p:UUID", uuids[i].c_str() );
+            auto mesh = object->InsertNewChildElement( "mesh" );
+            auto vertices = mesh->InsertNewChildElement( "vertices" );
+            constexpr uint8_t cOrder[8] = { 0,2,3,1,4,6,7,5 };
+            for ( auto ord : cOrder )
+            {
+                auto pos = worldBoxes[i].corner( Vector3b( bool( ord & 1 ), bool( ord & 2 ), bool( ord & 4 ) ) ) - worldBoxes[i].min;
+                auto vert = vertices->InsertNewChildElement( "vertex" );
+                tempStr = fmt::format( "{:.3f}",  pos.x );
+                vert->SetAttribute( "x", tempStr.c_str() );
+                tempStr = fmt::format( "{:.3f}",  pos.y );
+                vert->SetAttribute( "y", tempStr.c_str() );
+                tempStr = fmt::format( "{:.3f}",  pos.z );
+                vert->SetAttribute( "z", tempStr.c_str() );
+                vertices->LinkEndChild( vert );
+            }
+            mesh->LinkEndChild( vertices );
+            auto triangles = mesh->InsertNewChildElement( "triangles" );
+            constexpr ThreeVertIds cTris[12] = {
+                {VertId( 0 ),VertId( 1 ),VertId( 2 )},
+                {VertId( 0 ),VertId( 2 ),VertId( 3 )},
+                {VertId( 4 ),VertId( 7 ),VertId( 6 )},
+                {VertId( 4 ),VertId( 6 ),VertId( 5 )},
+                {VertId( 0 ),VertId( 4 ),VertId( 5 )},
+                {VertId( 0 ),VertId( 5 ),VertId( 1 )},
+                {VertId( 1 ),VertId( 5 ),VertId( 6 )},
+                {VertId( 1 ),VertId( 6 ),VertId( 2 )},
+                {VertId( 2 ),VertId( 6 ),VertId( 7 )},
+                {VertId( 2 ),VertId( 7 ),VertId( 3 )},
+                {VertId( 3 ),VertId( 7 ),VertId( 4 )},
+                {VertId( 3 ),VertId( 4 ),VertId( 0 )}
+            };
+            for ( const auto& triV : cTris )
+            {
+                auto tri = triangles->InsertNewChildElement( "triangle" );
+                tri->SetAttribute( "v1", int( triV[0] ) );
+                tri->SetAttribute( "v2", int( triV[1] ) );
+                tri->SetAttribute( "v3", int( triV[2] ) );
+                triangles->LinkEndChild( tri );
+            }
+            mesh->LinkEndChild( triangles );
+            object->LinkEndChild( mesh );
+            resources->LinkEndChild( object );
+        }
+        model->LinkEndChild( resources );
+        auto build = model->InsertNewChildElement( "build" );
+        auto tempUUID = generateUUID();
+        build->SetAttribute( "p:UUID", tempUUID.c_str() );
+        for ( ObjId i( 0 ); i < params.meshes.size(); ++i )
+        {
+            auto item = build->InsertNewChildElement( "item" );
+            item->SetAttribute( "objectid", int( i + 1 + params.meshes.size() ) );
+            std::string transformStr = "1.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000 1.0000 ";
+            transformStr += 
+                fmt::format( "{:.4f}",  worldBoxes[i].min.x ) + " " + 
+                fmt::format( "{:.4f}",  worldBoxes[i].min.y ) + " " + 
+                fmt::format( "{:.4f}",  worldBoxes[i].min.z );
+            item->SetAttribute( "transform", transformStr.c_str() );
+            tempUUID = generateUUID();
+            item->SetAttribute( "p:UUID", tempUUID.c_str() );
+            build->LinkEndChild( item );
+        }
+        model->LinkEndChild( build );
+        buildDoc.LinkEndChild( model );
+        auto bdPath = utf8string( dir / "3D" / "3dmodel.model" );
+        buildDoc.SaveFile( bdPath.c_str() );
+    }
+
+    if ( !reportProgress( params.cb, 0.4f ) )
+        return unexpectedOperationCanceled();
+
+    // image
+    if ( params.image )
+    {
+        auto imageSaveRes = ImageSave::toAnySupportedFormat( *params.image, dirMeta / "thumbnail.png" );
+        if ( !imageSaveRes.has_value() )
+            return unexpected( std::move( imageSaveRes.error() ) );
+    }
+
+    if ( !reportProgress( params.cb, 0.45f ) )
+        return unexpectedOperationCanceled();
+    // rels
+    {
+        tinyxml2::XMLDocument rootRels;
+        auto decl = rootRels.NewDeclaration( "xml version=\"1.0\"" );
+        rootRels.LinkEndChild( decl );
+        auto rels = rootRels.NewElement( "Relationships" );
+        rels->SetAttribute( "xmlns", "http://schemas.openxmlformats.org/package/2006/relationships" );
+        auto rel = rels->InsertNewChildElement( "Relationship" );
+        rel->SetAttribute( "Target", "/3D/3dmodel.model" );
+        rel->SetAttribute( "Id", "rel0" );
+        rel->SetAttribute( "Type", "http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel" );
+        rels->LinkEndChild( rel );
+        if ( params.image )
+        {
+            rel = rels->InsertNewChildElement( "Relationship" );
+            rel->SetAttribute( "Target", "/Metadata/thumbnail.png" );
+            rel->SetAttribute( "Id", "rel1" );
+            rel->SetAttribute( "Type", "http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail" );
+            rels->LinkEndChild( rel );
+        }
+        rootRels.LinkEndChild( rels );
+        auto rootRelsPath = utf8string( dirRels / ".rels" );
+        rootRels.SaveFile( rootRelsPath.c_str() );
+
+        tinyxml2::XMLDocument rels3d;
+        decl = rels3d.NewDeclaration( "xml version=\"1.0\"" );
+        rels3d.LinkEndChild( decl );
+        rels = rels3d.NewElement( "Relationships" );
+        rels->SetAttribute( "xmlns", "http://schemas.openxmlformats.org/package/2006/relationships" );
+        for ( int i = 0; i < params.meshes.size(); ++i )
+        {
+            rel = rels->InsertNewChildElement( "Relationship" );
+            std::string slicestackName = "/2D/" + uuids[i] + ".model";
+            rel->SetAttribute( "Target", slicestackName.c_str() );
+            std::string relId = "rel" + std::to_string( 2 * i + 1 );
+            rel->SetAttribute( "Id", relId.c_str() );
+            rel->SetAttribute( "Type", "http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel" );
+            rels->LinkEndChild( rel );
+
+            rel = rels->InsertNewChildElement( "Relationship" );
+            std::string thumbnailsName = "/Thumbnails/" + uuids[i] + ".png";
+            rel->SetAttribute( "Target", thumbnailsName.c_str() );
+            relId = "rel" + std::to_string( 2 * i + 2 );
+            rel->SetAttribute( "Id", relId.c_str() );
+            rel->SetAttribute( "Type", "http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail" );
+            rels->LinkEndChild( rel );
+        }
+        rels3d.LinkEndChild( rels );
+        auto rels3dPath = utf8string( dir3dRels / "3dmodel.model.rels" );
+        rels3d.SaveFile( rels3dPath.c_str() );
+    }
+
+    if ( !reportProgress( params.cb, 0.5f ) )
+        return unexpectedOperationCanceled();
+
+    return compressZip( path, dir, { .compressionLevel = 2, .cb = subprogress( params.cb, 0.5f, 1.0f ) } );
+}
+
+}
+#endif

--- a/source/MRIOExtras/MRNesting3mfExport.h
+++ b/source/MRIOExtras/MRNesting3mfExport.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "config.h"
+#ifndef MRIOEXTRAS_NO_XML
+#include "exports.h"
+
+#include "MRMesh/MRMeshFwd.h"
+#include "MRMesh/MRNestingStructures.h"
+#include "MRMesh/MRExpected.h"
+#include "MRMesh/MRVector.h"
+
+#include <filesystem>
+
+namespace MR
+{
+
+namespace Nesting
+{
+
+struct Nesting3mfParams
+{
+    /// nested meshes with their transforms into nest
+    Vector<MeshXf, ObjId> meshes;
+
+    /// slicing step
+    float zStep = 1.0f;
+
+    /// if set: decimate slices
+    bool decimateSlices{ true };
+
+    /// optional image of all meshes in nest
+    const Image* image = nullptr;
+
+    /// optional screen shots of each mesh one by one
+    const std::vector<Image>* meshImages{ nullptr };
+
+    /// optional names of each mesh one by one
+    const std::vector<std::string>* meshNames{ nullptr };
+
+    ProgressCallback cb;
+};
+
+/// exports slicestack 3mf file based on placed meshes
+MRIOEXTRAS_API Expected<void> exportNesting3mf( const std::filesystem::path& path, const Nesting3mfParams& params );
+
+}
+
+}
+#endif

--- a/source/MRMesh/MRBoxNesting.cpp
+++ b/source/MRMesh/MRBoxNesting.cpp
@@ -1,0 +1,672 @@
+#include "MRBoxNesting.h"
+#include "MRMesh/MRBox.h"
+#include "MRMesh/MRVector2.h"
+#include "MRMesh/MRVector4.h"
+#include "MRMesh/MRId.h"
+#include "MRMesh/MRVector.h"
+#include "MRMesh/MR2to3.h"
+#include "MRMesh/MRTimer.h"
+#include "MRMesh/MRParallelFor.h"
+#include "MRMesh/MRBestFit.h"
+#include "MRMesh/MRMesh.h"
+#include "MRMesh/MRMeshPart.h"
+#include <queue>
+
+namespace
+{
+constexpr float cSafeExpansion = 1.01f;
+}
+
+namespace MR
+{
+
+namespace Nesting
+{
+
+struct PlacedSocket
+{
+    int parentSocketId = -1; // -1 means root box
+    Vector3i pos;
+    Box3f box;
+    ObjId objId;
+    bool rotated{ false };
+};
+
+struct QueueNode
+{
+    int socketId = -1;
+    double cost = -DBL_MAX;
+    int numObjs{ 0 };
+
+    friend bool operator <( const QueueNode& a, const QueueNode& b )
+    {
+        return std::tie( a.numObjs, a.cost ) < std::tie( b.numObjs, b.cost );
+    }
+};
+
+class BoxNester
+{
+public:
+    BoxNester( const Vector<Vector3f, ObjId>& sizes, const BoxNestingParams& params );
+
+    /// suggest that all objs has box.min at zero
+    Vector<NestingResult, ObjId> run();
+private:
+    BoxNestingParams params_;
+    Vector<Vector3f, ObjId> sizes_;
+    Vector<ObjId, ObjId> sortMapNew2Old_;
+
+    std::vector<PlacedSocket> socketTree_;
+    std::priority_queue<QueueNode> candidatesQ_;
+
+    double calcCost_( const PlacedSocket& leafSocket ) const;
+    bool isPlacementValid_( const PlacedSocket& socket ) const;
+
+    bool testPreNested_( const Box3f& curBox ) const;
+    bool addCustomToQ_( int parentSocketId, ObjId parentObjId, int& iterNumber );
+
+    void init_();
+    bool addCandidateCorners_( int parentSocketId, ObjId parentObjId, const Box3f& parentBox, int& iterNumber );
+    bool addSingleCorner_( int parentSocketId, ObjId parentObjId, const Vector3f& pos, uint8_t cornerId, int& iterNumber );
+    void addToQ_( PlacedSocket&& socket );
+
+    // takenOrientationId: 8 possible orientations (4 corners * 2 flips, see comment in `calcBox_` function)
+    PlacedSocket createSocket_( int parentSocketId, ObjId oId, const Vector3f& cornerPos, uint8_t applicationCornerId, uint8_t takenOrientationId );
+    void addInterval_( Box3f& box, uint8_t thisCorner, uint8_t parentCorner );
+    Box3f calcBox_( const Vector3f& pos, const Vector3f& size, uint8_t takenOrientation ) const;
+
+    const PlacedSocket* processQ_();
+};
+
+Box3f BoxNester::calcBox_( const Vector3f& pos, const Vector3f& sizeP, uint8_t takenOrientation ) const
+{
+    auto size = sizeP;
+    if ( takenOrientation % 2 == 1 )
+        std::swap( size.x, size.y );
+
+    Box3f box;
+    auto applicationCornerId = takenOrientation / 2;
+    for ( int i = 0; i < 3; ++i )
+    {
+        bool posMax = bool( applicationCornerId & ( 1 << i ) );
+        box.min[i] = posMax ? pos[i] - size[i] : pos[i];
+        box.max[i] = posMax ? pos[i] : pos[i] + size[i];
+    }
+    return box;
+}
+
+bool BoxNester::isPlacementValid_( const PlacedSocket& socket ) const
+{
+    if ( !params_.baseParams.nest.insignificantlyExpanded().contains( socket.box ) )
+        return false;
+
+    Vector3f expansion = Vector3f::diagonal( params_.baseParams.minInterval * 0.9f );
+    auto curBox = socket.box.expanded( expansion );
+
+    auto pSocketId = socket.parentSocketId;
+    while ( pSocketId != -1 )
+    {
+        const auto& pSocket = socketTree_[pSocketId];
+        if ( pSocket.box.intersects( curBox ) )
+            return false;
+        pSocketId = pSocket.parentSocketId;
+    }
+    return testPreNested_( curBox );
+}
+
+bool BoxNester::testPreNested_( const Box3f& curBox ) const
+{
+    if ( !params_.options.preNestedVolumes )
+        return true;
+    for ( const auto& box : *params_.options.preNestedVolumes )
+        if ( box.intersects( curBox ) )
+            return false;
+    return true;
+}
+
+bool BoxNester::addCustomToQ_( int parentSocketId, ObjId parentObjId, int& iterNumber )
+{
+    if ( !params_.options.additinalSocketCorners )
+        return true;
+    for ( auto [pos, corner] : *params_.options.additinalSocketCorners )
+    {
+        if ( !addSingleCorner_( parentSocketId, parentObjId, pos, corner, iterNumber ) )
+            return false;
+    }
+    return true;
+}
+
+void BoxNester::addToQ_( PlacedSocket&& socket )
+{
+    if ( !isPlacementValid_( socket ) )
+        return;
+    int id = int( socketTree_.size() );
+    socketTree_.push_back( std::move( socket ) );
+    candidatesQ_.push( { id, calcCost_( socketTree_.back() ),socketTree_.back().objId } );
+}
+
+Nesting::PlacedSocket BoxNester::createSocket_( int parentSocketId, ObjId oId, const Vector3f& cornerPos, uint8_t applicationCornerId, uint8_t takenOrientationId )
+{
+    PlacedSocket socket{
+        .parentSocketId = parentSocketId,
+        .box = calcBox_( cornerPos,sizes_[oId],takenOrientationId ),
+        .objId = oId,
+        .rotated = ( takenOrientationId % 2 == 1 )
+    };
+    addInterval_( socket.box, takenOrientationId / 2, applicationCornerId );
+    return socket;
+}
+
+void BoxNester::addInterval_( Box3f& box, uint8_t thisCorner, uint8_t parentCorner )
+{
+    auto xorCorner = thisCorner ^ parentCorner;
+    Vector3f addition;
+    for ( int i = 0; i < 3; ++i )
+    {
+        uint8_t bit = 1 << i;
+        if ( bool( xorCorner & bit ) )
+            addition[i] += ( bool( parentCorner & bit ) ? params_.baseParams.minInterval : -params_.baseParams.minInterval );
+    }
+    box.min += addition;
+    box.max += addition;
+}
+
+void BoxNester::init_()
+{
+    PlacedSocket rootSocket = createSocket_( -1, ObjId( 0 ), params_.baseParams.nest.min, 0, 0 );
+    addToQ_( std::move( rootSocket ) );
+
+    auto nestSize = params_.baseParams.nest.size();
+    if ( std::abs( nestSize.x - nestSize.y ) > params_.baseParams.minInterval && params_.options.allowRotation ) // if nest's sides are not equal try both rotations of obj
+    {
+        rootSocket = createSocket_( -1, ObjId( 0 ), params_.baseParams.nest.min, 0, 1 );
+        addToQ_( std::move( rootSocket ) );
+    }
+
+    int numIters = 0;
+    addCustomToQ_( -1, ObjId(), numIters );
+}
+
+bool BoxNester::addCandidateCorners_( int parentSocketId, ObjId topSocketObjId, const Box3f& box, int& iter )
+{
+    uint8_t maxCornerId = params_.options.allow3dNesting ? 8 : 4;
+    for ( uint8_t ac = 0; ac < maxCornerId; ++ac )
+    {
+        Vector3b cornerId;
+        for ( uint8_t i = 0; i < 3; ++i )
+            cornerId[i] = bool( ac & ( 1 << i ) );
+        Vector3f corner = box.corner( cornerId );
+        if ( !addSingleCorner_( parentSocketId, topSocketObjId, corner, ac, iter ) )
+            return false;
+    }
+    return true;
+}
+
+bool BoxNester::addSingleCorner_( int parentSocketId, ObjId topSocketObjId, const Vector3f& corner, uint8_t ac, int& iter )
+{
+    uint8_t maxCornerId = params_.options.allow3dNesting ? 8 : 4;
+    for ( uint8_t tc = 0; tc < maxCornerId; ++tc )
+    {
+        if ( params_.options.checkLessCombinations )
+        {
+            if ( tc != 0 )
+                continue; // only allow 0b000 application
+            if ( ac != 0b001 && ac != 0b010 && ac != 0b100 )
+                continue; // only allow 0b001, 0b010, 0b100 corners
+        }
+        addToQ_( createSocket_( parentSocketId, topSocketObjId + 1, corner, ac, 2 * tc ) );
+        if ( ++iter > params_.options.iterationLimit )
+            return false;
+        if ( params_.options.allowRotation )
+        {
+            addToQ_( createSocket_( parentSocketId, topSocketObjId + 1, corner, ac, 2 * tc + 1 ) );
+            if ( ++iter > params_.options.iterationLimit )
+                return false;
+        }
+    }
+    return true;
+}
+
+BoxNester::BoxNester( const Vector<Vector3f, ObjId>& sizes, const BoxNestingParams& params ) :
+    params_{ params }
+{
+    if ( !params_.options.priorityMetric )
+        params_.options.priorityMetric = getNestPostionMinPriorityMetric( params_.baseParams.nest );
+
+    std::vector<std::pair<Vector3f, ObjId>> forSort( sizes.size() );
+    sizes_.resize( sizes.size() );
+    sortMapNew2Old_.resize( sizes.size() );
+    for ( int i = 0; i < sizes.size(); ++i )
+    {
+        forSort[i] = { sizes[ObjId( i )],ObjId( i ) };
+    }
+    if ( params_.options.volumeBasedOrder )
+    {
+        std::sort( forSort.begin(), forSort.end(), [] ( const auto& l, const auto& r )
+        {
+            return l.first.x * l.first.y * l.first.z > r.first.x * r.first.y * r.first.z;
+        } );
+    }
+    else
+    {
+        // Use same size for all models if no sort
+        /*
+        auto it = std::min_element( forSort.begin(), forSort.end(), [] ( const auto& l, const auto& r )
+        {
+            return l.first.x * l.first.y * l.first.z > r.first.x * r.first.y * r.first.z;
+        } );
+        if ( it != forSort.end() )
+            for ( auto& [s, _] : forSort )
+                s = it->first;
+        */
+    }
+    for ( int i = 0; i < sizes.size(); ++i )
+    {
+        sizes_[ObjId( i )] = forSort[i].first;
+        sortMapNew2Old_[ObjId( i )] = forSort[i].second;
+    }
+}
+
+Vector<NestingResult, ObjId> BoxNester::run()
+{
+    init_();
+    auto lastSocket = processQ_();
+
+    float expansionShiftCompensation = 1.0f;
+    if ( params_.options.expansionFactor )
+    {
+        // we expand sizes by expansionFactor*1.01 so we need to compensate it back in rotation case
+        expansionShiftCompensation = float( 1.0 / ( params_.options.expansionFactor->y * cSafeExpansion ) );
+    }
+
+    Vector<NestingResult, ObjId> result( sizes_.size() );
+    while ( lastSocket )
+    {
+        auto& res = result[sortMapNew2Old_[lastSocket->objId]];
+        res.nested = true;
+        const auto& box = lastSocket->box;
+        if ( !lastSocket->rotated )
+        {
+            res.xf = AffineXf3f::translation( box.min );
+        }
+        else
+        {
+            res.xf = AffineXf3f::translation( box.min ) *
+                AffineXf3f::translation( Vector3f( sizes_[lastSocket->objId].y * expansionShiftCompensation, 0, 0 ) ) *
+                AffineXf3f::linear( Matrix3f::rotation( Vector3f::plusX(), Vector3f::plusY() ) );
+        }
+
+        if ( lastSocket->parentSocketId != -1 )
+            lastSocket = &socketTree_[lastSocket->parentSocketId];
+        else
+            lastSocket = nullptr;
+    }
+    return result;
+}
+
+double BoxNester::calcCost_( const PlacedSocket& leafSocket ) const
+{
+    if ( !params_.options.priorityMetric )
+    {
+        assert( false );
+        return 0.0;
+    }
+
+    params_.options.priorityMetric->init( leafSocket.box );
+    const PlacedSocket* socket = &leafSocket;
+    while ( socket )
+    {
+        params_.options.priorityMetric->addNested( socket->box );
+        socket = socket->parentSocketId == -1 ? nullptr : &socketTree_[socket->parentSocketId];
+    }
+    if ( params_.options.preNestedVolumes )
+    {
+        for ( const auto& box : *params_.options.preNestedVolumes )
+        {
+            params_.options.priorityMetric->addNested( box );
+        }
+    }
+    return params_.options.priorityMetric->complete();
+}
+
+/*
+Vector3i BoxNester::calcPos_( const Vector3i& parentPos, uint8_t pc, uint8_t tc )
+{
+    Vector3i pos = parentPos;
+    for ( uint8_t i = 0; i < 3; ++i )
+    {
+        uint8_t bit = 1 << i;
+        bool bitPV = bool( pc & bit );
+        bool bitTV = bool( tc & bit );
+        if ( !bitPV && bitTV )
+            --pos[i];
+        else if ( bitPV && !bitTV )
+            ++pos[i];
+    }
+    return pos;
+}
+*/
+
+const PlacedSocket* BoxNester::processQ_()
+{
+    QueueNode minQueueNode;
+    int iter = 0;
+    bool stopIterating = false;
+    while ( !candidatesQ_.empty() && !stopIterating )
+    {
+        auto top = candidatesQ_.top();
+        candidatesQ_.pop();
+        auto topSocketObjId = socketTree_[top.socketId].objId;
+        if ( topSocketObjId == sizes_.backId() )
+            return &socketTree_[top.socketId]; // found result
+        if ( minQueueNode < top )
+            minQueueNode = top;
+
+        auto parentId = top.socketId;
+        while ( parentId != -1 && !stopIterating )
+        {
+            auto box = socketTree_[parentId].box;
+            stopIterating = !addCandidateCorners_( top.socketId, topSocketObjId, box, iter );
+            parentId = socketTree_[parentId].parentSocketId;
+        }
+        if ( !stopIterating )
+            stopIterating = !addCustomToQ_( top.socketId, topSocketObjId, iter );
+    }
+    if ( !candidatesQ_.empty() )
+    {
+        auto top = candidatesQ_.top();
+        candidatesQ_.pop();
+        if ( minQueueNode < top )
+            minQueueNode = top;
+    }
+    if ( minQueueNode.socketId == -1 )
+        return nullptr; // no result found
+    return &socketTree_[minQueueNode.socketId]; // return best found
+}
+
+void calcToDenseXfAndDenseXYSize( const MeshXf& m, AffineXf3f& outXf, Vector3f& outSize, bool allowRotation )
+{
+    if ( !m.mesh )
+    {
+        assert( false );
+        return;
+    }
+    AffineXf3f toDenseXf = m.xf;
+    if ( allowRotation )
+    {
+        PointAccumulator pa;
+        accumulateFaceCenters( pa, *m.mesh, &m.xf );
+        Matrix3f resBasis;
+
+        Vector3d centroid;
+        Matrix3d eigenvectors;
+        Vector3d eigenvalues;
+        pa.getCenteredCovarianceEigen( centroid, eigenvectors, eigenvalues );
+
+        auto zComp2dLengthSq = to2dim( eigenvectors.z * eigenvalues.z ).lengthSq();
+        auto yComp2dLengthSq = to2dim( eigenvectors.y * eigenvalues.y ).lengthSq();
+
+        resBasis.x = Vector3f( zComp2dLengthSq >= yComp2dLengthSq ? eigenvectors.z : eigenvectors.y );
+        resBasis.x.z = 0.0f;
+        resBasis.x = resBasis.x.normalized();
+        resBasis.y = cross( resBasis.z, resBasis.x );
+        resBasis = resBasis.transposed(); // fromPlaneXf
+
+        auto toPlaneXf = AffineXf3f::linear( resBasis ).inverse();
+        toDenseXf = toPlaneXf * toDenseXf;
+    }
+    auto denseBox = m.mesh->computeBoundingBox( &toDenseXf );
+    outXf = AffineXf3f::translation( -denseBox.min ) * toDenseXf;
+    outSize = denseBox.size();
+}
+
+std::shared_ptr<IBoxNestingPriority> getNestPostionMinPriorityMetric( const Box3f& nest )
+{
+    class NestPositionMinPriority : public IBoxNestingPriority
+    {
+    public:
+        NestPositionMinPriority( float quantSize, int maxQuants, float maxVolume ) : quantSize_{ quantSize }, maxQuants_{ maxQuants }, maxVolume_{ maxVolume }
+        {
+        };
+        virtual void init( const Box3f& thisBox ) override
+        {
+            pos_ = Vector3i( thisBox.min / quantSize_ );
+            commonBox_ = thisBox;
+        }
+        virtual void addNested( const Box3f& box ) override
+        {
+            commonBox_.include( box );
+        }
+        virtual double complete() const override
+        {
+            size_t res =
+                size_t( maxQuants_ - pos_.z ) * maxQuants_ * maxQuants_ +
+                size_t( maxQuants_ - pos_.y ) * maxQuants_ +
+                size_t( maxQuants_ - pos_.x );
+            return double( res ) + double( maxVolume_ - commonBox_.volume() ) / maxVolume_;
+        }
+    private:
+        float quantSize_ = 1.0f;
+        int maxQuants_{ 20 };
+        float maxVolume_{ 0.0f };
+        Vector3i pos_;
+        Box3f commonBox_;
+    };
+    auto nestSize = nest.size();
+    return std::make_shared<NestPositionMinPriority>( std::max( { nestSize.x,nestSize.y,nestSize.z } ) / 20.0f, 20, nest.volume() );
+}
+
+std::shared_ptr<IBoxNestingPriority> getNeighborigDensityPriorityMetric( const Box3f& nest, float neighborhood )
+{
+    class NestNeighborDensityPriority : public IBoxNestingPriority
+    {
+    public:
+        NestNeighborDensityPriority( const Box3f& nest, float neighborhood ) :nest_{ nest }, neighborhood_{ neighborhood }
+        {
+        }
+        virtual void init( const Box3f& thisBox ) override
+        {
+            for ( int i = 0; i < 6; ++i )
+            {
+                int coord = i / 2;
+                if ( i % 2 == 0 )
+                {
+                    outerBoxes_[i].min = thisBox.min;
+                    outerBoxes_[i].min[coord] -= neighborhood_;
+                    outerBoxes_[i].max = thisBox.max;
+                    outerBoxes_[i].max[coord] = thisBox.min[coord];
+                }
+                else
+                {
+                    outerBoxes_[i].min = thisBox.min;
+                    outerBoxes_[i].min[coord] = thisBox.max[coord];
+                    outerBoxes_[i].max = thisBox.max;
+                    outerBoxes_[i].max[coord] += neighborhood_;
+                }
+            }
+
+            for ( int i = 0; i < 6; ++i )
+            {
+                outerBoxVolume_[i] = outerBoxes_[i].volume();
+                auto nestInter = outerBoxes_[i].intersection( nest_ );
+                sumNeigboringIntersectionVolume_[i] = nestInter.valid() ? ( outerBoxVolume_[i] - nestInter.volume() ) : 0.0;
+            }
+        }
+        virtual void addNested( const Box3f& box ) override
+        {
+            for ( int i = 0; i < 6; ++i )
+            {
+                auto inter = outerBoxes_[i].intersection( box );
+                if ( inter.valid() )
+                    sumNeigboringIntersectionVolume_[i] += inter.volume();
+            }
+        }
+        virtual double complete() const override
+        {
+            constexpr int cOrder[6] = { 4, 2, 0, 1, 3, 5 }; // ordered sum: -Z -Y -X +X +Y +Z
+            double resCost = sumNeigboringIntersectionVolume_[cOrder[0]] / outerBoxVolume_[cOrder[0]];
+            double nextWeightMultiplier = 1.0;
+            for ( int i = 1; i < 6; ++i )
+            {
+                int prevCoord = cOrder[i - 1];
+                double prevFillRatio = sumNeigboringIntersectionVolume_[prevCoord] / outerBoxVolume_[prevCoord];
+                if ( prevFillRatio < 1.0 )
+                    nextWeightMultiplier *= prevFillRatio;
+                int thisCoord = cOrder[i];
+                resCost += nextWeightMultiplier * sumNeigboringIntersectionVolume_[thisCoord] / outerBoxVolume_[thisCoord];
+            }
+            return resCost;
+        }
+    private:
+        Box3f outerBoxes_[6];
+        double sumNeigboringIntersectionVolume_[6] = { 0.0,0.0,0.0,0.0,0.0,0.0 };
+        double outerBoxVolume_[6] = { 0.0,0.0,0.0,0.0,0.0,0.0 };
+
+        Box3f nest_;
+        float neighborhood_{ 0.0f };
+    };
+    return std::make_shared<NestNeighborDensityPriority>( nest, neighborhood );
+}
+
+Expected<void> fillNestingSocketCorneres( const std::vector<Box3f>& nestedBoxes, std::vector<BoxNestingCorner>& outCorners, const ProgressCallback& cb )
+{
+    MR_TIMER;
+    struct BoxOrder
+    {
+        std::vector<BoxNestingCorner>* localStorage{ nullptr };
+        int begin = 0;
+        int end = 0;
+    };
+
+    tbb::enumerable_thread_specific<std::vector<BoxNestingCorner>> tls;
+    std::vector<BoxOrder> order( nestedBoxes.size() ); // needed to have deterministic result vector
+    auto keepGoing = ParallelFor( 0, int( nestedBoxes.size() ), tls, [&] ( int i, std::vector<BoxNestingCorner>& local )
+    {
+        BoxOrder thisOrder;
+        thisOrder.localStorage = &local;
+        thisOrder.begin = int( local.size() );
+        const auto& thisBox = nestedBoxes[i];
+        std::array<Vector3f, 8> corners
+        {
+            thisBox.corner( Vector3b( false,false,false ) ),
+            thisBox.corner( Vector3b( true,false,false ) ),
+            thisBox.corner( Vector3b( false,true,false ) ),
+            thisBox.corner( Vector3b( true,true,false ) ),
+            thisBox.corner( Vector3b( false,false,true ) ),
+            thisBox.corner( Vector3b( true,false,true ) ),
+            thisBox.corner( Vector3b( false,true,true ) ),
+            thisBox.corner( Vector3b( true,true,true ) )
+        };
+        uint8_t cornerInsideBitMask = 0b00000000; // for each corner 0 means outside other box, 1 means inside
+        // classify corners as "inside/outside"
+        for ( uint8_t c = 0; c < 8; ++c )
+        {
+            for ( int j = 0; j < nestedBoxes.size(); ++j )
+            {
+                if ( i == j )
+                    continue;
+                if ( nestedBoxes[j].contains( corners[c] ) )
+                {
+                    cornerInsideBitMask |= ( 1 << c );
+                    break;
+                }
+            }
+        }
+        // add simple outside corners
+        for ( uint8_t c = 0; c < 8; ++c )
+        {
+            if ( bool( cornerInsideBitMask & ( 1 << c ) ) )
+                continue; // do nothing if inside
+            local.emplace_back( BoxNestingCorner{ .pos = corners[c],.bitMask = c } );
+        }
+        // add corners of intersections
+        for ( uint8_t edgeI = 0; edgeI < 12; ++edgeI )
+        {
+            uint8_t mainAxisId = edgeI / 4; // 0-x, 1-y, 2-z
+            uint8_t subAxes = edgeI % 4;
+            uint8_t secAxisId = subAxes / 2;
+            uint8_t lastAxisId = subAxes % 2;
+            uint8_t minCornerId = 0;
+            if ( mainAxisId == 2 )
+                minCornerId |= ( secAxisId << 1 );
+            else
+                minCornerId |= ( secAxisId << 2 );
+
+            if ( mainAxisId == 0 )
+                minCornerId |= ( lastAxisId << 1 );
+            else
+                minCornerId |= ( lastAxisId << 0 );
+            uint8_t maxCornerId = minCornerId + ( 1 << mainAxisId );
+            bool minInside = bool( cornerInsideBitMask & ( 1 << minCornerId ) );
+            bool maxInside = bool( cornerInsideBitMask & ( 1 << maxCornerId ) );
+            if ( minInside == maxInside )
+                continue; // nothing to add, both corners from one side
+
+            // find furthest intersection and add to output
+            BoxNestingCorner outCorner;
+            outCorner.pos = minInside ? corners[minCornerId] : corners[maxCornerId];
+            outCorner.bitMask = minInside ? minCornerId : maxCornerId;
+            for ( int j = 0; j < nestedBoxes.size(); ++j )
+            {
+                if ( j == i )
+                    continue;
+                if ( minInside )
+                    outCorner.pos[mainAxisId] = std::max( nestedBoxes[j].max[mainAxisId], outCorner.pos[mainAxisId] );
+                else
+                    outCorner.pos[mainAxisId] = std::min( nestedBoxes[j].min[mainAxisId], outCorner.pos[mainAxisId] );
+            }
+            local.emplace_back( std::move( outCorner ) );
+        }
+        thisOrder.end = int( local.size() );
+        order[i] = thisOrder;
+    }, subprogress( cb, 0.0f, 0.9f ) );
+
+    if ( !keepGoing )
+        return unexpectedOperationCanceled();
+
+    for ( const auto& o : order )
+        outCorners.insert( outCorners.end(), o.localStorage->begin() + o.begin, o.localStorage->begin() + o.end );
+
+    if ( !reportProgress( cb, 1.0f ) )
+        return unexpectedOperationCanceled();
+    return {};
+}
+
+Expected<Vector<NestingResult, ObjId>> boxNesting( const Vector<MeshXf, ObjId>& meshes, const BoxNestingParams& params )
+{
+    MR_TIMER;
+
+    // 1. Find XY dense boxes for all
+    Vector<AffineXf3f, ObjId> toDenseXfs( meshes.size() );
+    Vector<Vector3f, ObjId> sizes( meshes.size() );
+    auto keepGoing = ParallelFor( toDenseXfs, [&] ( ObjId oId )
+    {
+        calcToDenseXfAndDenseXYSize( meshes[oId], toDenseXfs[oId], sizes[oId], params.options.allowRotation );
+        if ( params.options.expansionFactor )
+        {
+            auto expandedSize = mult( sizes[oId], *params.options.expansionFactor * cSafeExpansion );
+            sizes[oId] = expandedSize;
+        }
+    }, subprogress( params.options.cb, 0.0f, 0.5f ) );
+    if ( !keepGoing )
+        return unexpectedOperationCanceled();
+
+    // 2. Find best nesting
+    Nesting::BoxNester nester( sizes, params );
+    auto res = nester.run();
+    if ( !reportProgress( params.options.cb, 0.75f ) )
+        return unexpectedOperationCanceled();
+
+    // 3. Compose result xf
+    keepGoing = ParallelFor( res, [&] ( ObjId oId )
+    {
+        res[oId].xf = res[oId].xf * toDenseXfs[oId];
+    }, subprogress( params.options.cb, 0.75f, 1.0f ) );
+    if ( !keepGoing )
+        return unexpectedOperationCanceled();
+    return res;
+}
+
+}
+
+}

--- a/source/MRMesh/MRBoxNesting.h
+++ b/source/MRMesh/MRBoxNesting.h
@@ -1,0 +1,92 @@
+#pragma once
+#include "MRNestingStructures.h"
+#include "MRMesh/MRVector.h"
+#include "MRMesh/MRId.h"
+#include "MRMesh/MRExpected.h"
+
+namespace MR
+{
+
+namespace Nesting
+{
+
+struct BoxNestingCorner
+{
+    /// Vector3f - corner position
+    Vector3f pos;
+    /// corner mask 0bZYX (0b000 - lower left corner, 0b111 - upper right)
+    uint8_t bitMask{ 0 };
+};
+
+/// class to override box nesting metrics
+class MRMESH_CLASS IBoxNestingPriority
+{
+public:
+    virtual ~IBoxNestingPriority() = default;
+
+    /// init priority calculation with box of placed object 
+    virtual void init( const Box3f& thisBox ) = 0;
+
+    /// accumulate priority by one of already nested boxes
+    virtual void addNested( const Box3f& box ) = 0;
+
+    /// finalize priority and return the value (more - better)
+    virtual double complete() const = 0;
+};
+
+/// priority metric that minimizes position of new object by Z->Y->X coordinate in nest
+MRMESH_API std::shared_ptr<IBoxNestingPriority> getNestPostionMinPriorityMetric( const Box3f& nest );
+
+/// priority metric that maximizes density of placement in local neighborhood
+MRMESH_API std::shared_ptr<IBoxNestingPriority> getNeighborigDensityPriorityMetric( const Box3f& nest, float neighborhood );
+
+struct BoxNestingOptions
+{
+    /// if true allows placing objects over the bottom plane
+    bool allow3dNesting{ true };
+
+    /// set false to keep original XY orientation
+    bool allowRotation{ false };
+
+    /// if true - nests objects in the order of decreasing volume, otherwise nest in the input order
+    bool volumeBasedOrder = true;
+
+    /// reduces nesting candidate options for speedup
+    bool checkLessCombinations{ false };
+
+    /// limit maximum number of tries, not to freeze for too long in this function
+    int iterationLimit = 10'000'000;
+
+    /// metric to calculate priority for candidates placement
+    /// if not set - default `getNestPostionMinPriorityMetric` is used
+    std::shared_ptr<IBoxNestingPriority> priorityMetric;
+
+    /// optional input expansion of boxes (useful to compensate shrinkage of material)
+    const Vector3f* expansionFactor{ nullptr };
+
+    /// if not-nullptr contains boxes that are fixed in the nest and should not be intersected by floating (input) meshes
+    const std::vector<Box3f>* preNestedVolumes{ nullptr };
+
+    /// user might force these sockets to be considered as corners for placing candidates
+    const std::vector<BoxNestingCorner>* additinalSocketCorners{ nullptr };
+
+    /// callback indicating progress of the nesting
+    ProgressCallback cb;
+};
+
+/// fills `outCorners` based on `nestedBoxes` corners \n
+/// also adding corners in intersections of `nestedBoxes`
+MRMESH_API Expected<void> fillNestingSocketCorneres( const std::vector<Box3f>& nestedBoxes, std::vector<BoxNestingCorner>& outCorners, const ProgressCallback& cb = {} );
+
+struct BoxNestingParams
+{
+    NestingBaseParams baseParams;
+    BoxNestingOptions options;
+};
+
+/// finds best positions of input meshes to fit the nest (checks them by contacting box corners)
+MRMESH_API Expected<Vector<NestingResult, ObjId>> boxNesting( const Vector<MeshXf, ObjId>& meshes, const BoxNestingParams& params );
+
+}
+
+}

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MRAlignContoursToMesh.h" />
+    <ClInclude Include="MRBoxNesting.h" />
     <ClInclude Include="MRCurve.h" />
     <ClInclude Include="MRDivRound.h" />
     <ClInclude Include="MRFastInt128.h" />
@@ -156,6 +157,7 @@
     <ClInclude Include="MRMultiwayAligningTransform.h" />
     <ClInclude Include="MRMultiwayICP.h" />
     <ClInclude Include="MRMutexOwner.h" />
+    <ClInclude Include="MRNestingStructures.h" />
     <ClInclude Include="MRNormalDenoising.h" />
     <ClInclude Include="MRNormalsToPoints.h" />
     <ClInclude Include="MRObjectMeshData.h" />
@@ -446,6 +448,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRAlignContoursToMesh.cpp" />
+    <ClCompile Include="MRBoxNesting.cpp" />
     <ClCompile Include="MRChangeMeshDataAction.cpp" />
     <ClCompile Include="MRDirMax.cpp" />
     <ClCompile Include="MRDirMaxBruteForce.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -100,6 +100,9 @@
     <Filter Include="Source Files\Algorithms">
       <UniqueIdentifier>{435d3e5d-8726-43e7-be69-b9d4c1799c95}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Nesting">
+      <UniqueIdentifier>{f891eaa8-8411-45b7-8b9d-38cece180034}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MRMeshFwd.h">
@@ -1392,6 +1395,12 @@
     <ClInclude Include="MRMeshDivideWithPlane.h">
       <Filter>Source Files\MeshAlgorithm</Filter>
     </ClInclude>
+    <ClInclude Include="MRNestingStructures.h">
+      <Filter>Source Files\Nesting</Filter>
+    </ClInclude>
+    <ClInclude Include="MRBoxNesting.h">
+      <Filter>Source Files\Nesting</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRParallelProgressReporter.cpp">
@@ -2287,6 +2296,9 @@
     </ClCompile>
     <ClCompile Include="MRMeshDivideWithPlane.cpp">
       <Filter>Source Files\MeshAlgorithm</Filter>
+    </ClCompile>
+    <ClCompile Include="MRBoxNesting.cpp">
+      <Filter>Source Files\Nesting</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/source/MRMesh/MRNestingStructures.h
+++ b/source/MRMesh/MRNestingStructures.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "MRMesh/MRMeshFwd.h"
+#include "MRMesh/MRAffineXf3.h"
+#include "MRMesh/MRBox.h"
+
+namespace MR
+{
+
+namespace Nesting
+{
+
+struct NestingResult
+{
+    /// best found xf for this object (might be equal with input xf if no good nesting was found)
+    AffineXf3f xf;
+
+    /// false - means that this object does not fit the nest
+    bool nested{ false };
+};
+
+struct MeshXf
+{
+    /// input mesh - should not be nullptr
+    const Mesh* mesh{ nullptr };
+    /// input mesh world transformation before nesting
+    AffineXf3f xf;
+};
+
+struct NestingBaseParams
+{
+    /// available nest
+    Box3f nest;
+
+    /// minimum space among meshes in the nest
+    float minInterval{ 0.01f };
+};
+
+}
+
+}

--- a/source/MRVoxels/MRSequentialNester.cpp
+++ b/source/MRVoxels/MRSequentialNester.cpp
@@ -1,0 +1,133 @@
+#include "MRSequentialNester.h"
+#include "MRMesh/MRAffineXf.h"
+#include "MRMesh/MRMesh.h"
+#include "MRMesh/MRProgressCallback.h"
+#include "MRMesh/MRTimer.h"
+
+namespace MR
+{
+
+namespace Nesting
+{
+
+SequentialNester::SequentialNester( const NestingBaseParams& params, float voxelSize ) :
+    baseParams_{ params },
+    tetrisOptions_{ .voxelSize = voxelSize,.nestVoxelsCache = &voxelsCache_,.nestDimensionsCache = &dimensionsCache_,.occupiedVoxelsCache = &occupiedVoxelsCache_ }
+{
+}
+
+Expected<NestingResult> SequentialNester::nestMesh( const MeshXf& meshXf, const BoxNestingOptions& options, const std::vector<OutEdge>* densificationSequence )
+{
+    auto res = nestMeshes( { meshXf }, options, densificationSequence );
+    if ( !res.has_value() )
+        return unexpected( std::move( res.error() ) );
+    if ( res->empty() )
+    {
+        assert( false );
+        return {};
+    }
+    return ( *res )[ObjId( 0 )];
+}
+
+Expected<Vector<NestingResult, ObjId>> SequentialNester::nestMeshes( const Vector<MeshXf, ObjId>& meshes, const BoxNestingOptions& options, const std::vector<OutEdge>* densificationSequence )
+{
+    MR_TIMER;
+    BoxNestingParams bnParams;
+    bnParams.baseParams = baseParams_;
+    bnParams.options = options;
+    bnParams.options.preNestedVolumes = &nestedBoxesCache_;
+    bnParams.options.additinalSocketCorners = &addBoxCornersCache_;
+
+    bool doTetris = ( !densificationSequence || !densificationSequence->empty() ) && tetrisOptions_.voxelSize > 0;
+
+    bnParams.options.cb = subprogress( options.cb, 0.0f, doTetris ? 0.3f : 0.9f );
+
+    auto boxNestingRes = boxNesting( meshes, bnParams );
+    if ( !boxNestingRes.has_value() )
+        return boxNestingRes;
+
+    int numPlaced = 0;
+    for ( const auto& r : *boxNestingRes )
+        if ( r.nested )
+            ++numPlaced;
+
+    if ( numPlaced == 0 )
+        return boxNestingRes;
+
+    Vector<MeshXf, ObjId> nestedMeshes;
+    if ( doTetris )
+        nestedMeshes.resize( numPlaced );
+
+    auto prevNestedSize = nestedBoxesCache_.size();
+    nestedBoxesCache_.resize( prevNestedSize + numPlaced );
+    auto* nestedBoxes = nestedBoxesCache_.data() + prevNestedSize;
+
+    ObjId no( 0 );
+    for ( ObjId io( 0 ); io < meshes.size(); ++io )
+    {
+        if ( !( *boxNestingRes )[io].nested )
+            continue;
+        if ( doTetris )
+            nestedMeshes[no] = meshes[io];
+        const auto& resXf = ( *boxNestingRes )[io].xf;
+        nestedBoxes[no] = meshes[io].mesh->computeBoundingBox( &resXf ); // nested box before densification
+        if ( options.expansionFactor )
+        {
+            AffineXf3f scaleXf = AffineXf3f::xfAround( Matrix3f::scale( *options.expansionFactor ), nestedBoxes[no].min );
+            nestedBoxes[no].max = scaleXf( nestedBoxes[no].max );
+            if ( doTetris )
+                nestedMeshes[no].xf = scaleXf * resXf;
+        }
+        else
+        {
+            if ( doTetris )
+                nestedMeshes[no].xf = resXf;
+        }
+        ++no;
+    }
+
+    if ( doTetris )
+    {
+        TetrisDensifyParams tdParams;
+        tdParams.baseParams = baseParams_;
+        tdParams.options = tetrisOptions_;
+        if ( densificationSequence )
+            tdParams.options.densificationSequence = *densificationSequence;
+        else
+            tdParams.options.densificationSequence = { OutEdge::MinusZ,OutEdge::MinusY,OutEdge::MinusX,
+                                                       OutEdge::MinusZ,OutEdge::MinusY,OutEdge::MinusX,
+                                                       OutEdge::MinusZ };
+        tdParams.options.cb = subprogress( options.cb, 0.3f, 0.8f );
+
+        auto tetrisDensifyRes = tetrisNestingDensify( nestedMeshes, tdParams );
+
+        if ( !tetrisDensifyRes.has_value() )
+            return unexpected( std::move( tetrisDensifyRes.error() ) );
+
+        no = ObjId( 0 );
+        for ( ObjId io( 0 ); io < meshes.size(); ++io )
+        {
+            if ( !( *boxNestingRes )[io].nested )
+                continue;
+            const auto& resXf = ( *tetrisDensifyRes )[no];
+            ( *boxNestingRes )[io].xf = resXf * ( *boxNestingRes )[io].xf;
+            nestedBoxes[no].min += resXf.b;
+            nestedBoxes[no].max += resXf.b;
+            nestedBoxes[no].intersect( baseParams_.nest );
+            ++no;
+        }
+        if ( !reportProgress( options.cb, 0.9f ) )
+            return unexpectedOperationCanceled();
+    }
+    addBoxCornersCache_.clear();
+
+    auto updateCornersRes = fillNestingSocketCorneres( nestedBoxesCache_, addBoxCornersCache_, subprogress( options.cb, 0.9f, 1.0f ) );
+    if ( !updateCornersRes.has_value() )
+        return unexpected( std::move( updateCornersRes.error() ) );
+
+    return boxNestingRes;
+}
+
+}
+
+}

--- a/source/MRVoxels/MRSequentialNester.h
+++ b/source/MRVoxels/MRSequentialNester.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "MRMesh/MRBoxNesting.h"
+#include "MRTetrisNesting.h"
+#include "MRMesh/MRBitSet.h"
+
+namespace MR
+{
+
+namespace Nesting
+{
+
+/// class to add meshes to nest sequentially 
+class MRVOXELS_CLASS SequentialNester
+{
+public:
+    /// if voxelSize > 0 peform densification on each addition
+    MRVOXELS_API SequentialNester( const NestingBaseParams& params, float voxelSize );
+
+    /// tries to add single mesh to the nest
+    /// returns true if mesh is nested, false otherwise (can be canceled)
+    MRVOXELS_API Expected<NestingResult> nestMesh( const MeshXf& meshXf, const BoxNestingOptions& options, const std::vector<OutEdge>* densificationSequence = nullptr );
+
+    /// tries to add multiple mesh to the nest
+    /// returns bitset of nested meshes (can be canceled)
+    MRVOXELS_API Expected<Vector<NestingResult, ObjId>> nestMeshes( const Vector<MeshXf, ObjId>& meshes, const BoxNestingOptions& options, const std::vector<OutEdge>* densificationSequence = nullptr );
+private:
+    NestingBaseParams baseParams_;
+    TetrisDensifyOptions tetrisOptions_;
+
+    Vector<ObjId, VoxelId> voxelsCache_;
+    Vector3i dimensionsCache_;
+    VoxelBitSet occupiedVoxelsCache_;
+
+    std::vector<Box3f> nestedBoxesCache_;
+    std::vector<BoxNestingCorner> addBoxCornersCache_;
+};
+
+}
+
+}

--- a/source/MRVoxels/MRTetrisNesting.cpp
+++ b/source/MRVoxels/MRTetrisNesting.cpp
@@ -1,0 +1,477 @@
+#include "MRTetrisNesting.h"
+#include "MRMesh/MRBitSet.h"
+#include "MRVoxels/MRDistanceVolumeParams.h"
+#include "MRMesh/MRParallelFor.h"
+#include "MRMesh/MRUnionFind.h"
+#include "MRMesh/MRBitSetParallelFor.h"
+#include "MRMesh/MRMesh.h"
+#include "MRMesh/MRBox.h"
+#include "MRVoxels/MRCalcDims.h"
+#include "MRVoxels/MRMeshToDistanceVolume.h"
+#include "MRVoxels/MRVoxelsVolume.h"
+#include "MRVoxels/MRVoxelsSave.h"
+#include <limits>
+
+namespace MR
+{
+
+namespace Nesting
+{
+
+class GroupTag;
+using GId = Id<GroupTag>;
+
+struct GroupsInfo
+{
+    Vector<GId, ObjId> o2gId;
+    Vector<ObjBitSet, GId> groups;
+};
+
+// we use int16_t, so we don't expect large shifts
+class MinShiftsMatrix
+{
+public:
+    MinShiftsMatrix( size_t numObjs ) : numObjs_{ numObjs }
+    {
+        minShifts_.resize( numObjs_ * numObjs_, std::numeric_limits<int16_t>::max() );
+    }
+
+    size_t numObjects() const
+    {
+        return numObjs_;
+    }
+
+    int16_t get( GId a, GId b ) const
+    {
+        return minShifts_[a * numObjs_ + b];
+    }
+    int16_t& get( GId a, GId b )
+    {
+        return minShifts_[a * numObjs_ + b];
+    }
+
+    void setMin( GId a, GId b, int16_t val )
+    {
+        auto& ownval = get( a, b );
+        if ( val < ownval )
+            ownval = val;
+    }
+
+    void mergeOther( const MinShiftsMatrix& other )
+    {
+        assert( other.numObjs_ == numObjs_ );
+        for ( int i = 0; i < minShifts_.size(); ++i )
+            minShifts_[i] = std::min( minShifts_[i], other.minShifts_[i] );
+    }
+
+    Vector<int16_t, GId> process()
+    {
+        Vector<int16_t, GId> shifts( numObjs_, 0 );
+        bool shiftsAdded = true;
+        while ( shiftsAdded )
+        {
+            shiftsAdded = false;
+            for ( GId a( 0 ); a < numObjs_; ++a )
+            {
+                auto ms = findMinShift_( a );
+                if ( ms == std::numeric_limits<int16_t>::max() || ms == 0 )
+                    continue;
+                shift_( a, ms );
+                shifts[a] += ms;
+                shiftsAdded = true;
+            }
+        }
+        return shifts;
+    }
+private:
+    int16_t findMinShift_( GId a ) const
+    {
+        int16_t minVal = std::numeric_limits<int16_t>::max();
+        for ( GId b( 0 ); b < numObjs_; ++b )
+        {
+            auto val = get( a, b );
+            if ( val < minVal )
+                minVal = val;
+        }
+        return minVal;
+    }
+
+    void shift_( GId a, int16_t val )
+    {
+        for ( GId b( 0 ); b < numObjs_; ++b )
+        {
+            auto& ownval = get( a, b );
+            if ( ownval != std::numeric_limits<int16_t>::max() )
+                ownval -= val;
+        }
+        for ( GId b( 0 ); b < numObjs_; ++b )
+        {
+            auto& ownval = get( b, a );
+            if ( a != b && ownval != std::numeric_limits<int16_t>::max() )
+                ownval += val;
+        }
+    }
+
+    std::vector<int16_t> minShifts_;
+    size_t numObjs_{ 0 };
+};
+
+static std::pair<GroupsInfo, MinShiftsMatrix> convergeShiftsMatrix( MinShiftsMatrix&& sm, const GroupsInfo* optPrevLayerGroup = nullptr )
+{
+    UnionFind<ObjId> uf;
+    uf.reset( sm.numObjects() );
+    for ( int a = 0; a < sm.numObjects(); ++a )
+    {
+        for ( int b = 0; b < sm.numObjects(); ++b )
+        {
+            if ( sm.get( GId( a ), GId( b ) ) == 0 )
+            {
+                uf.unite( ObjId( a ), ObjId( b ) );
+            }
+        }
+    }
+
+    GroupsInfo resG;
+    resG.o2gId.resize( sm.numObjects() );
+    for ( ObjId a( 0 ); a < sm.numObjects(); ++a )
+    {
+        auto& agId = resG.o2gId[a];
+        if ( !agId )
+        {
+            agId = GId( resG.groups.size() );
+            resG.groups.emplace_back();
+        }
+        resG.groups[agId].autoResizeSet( a );
+        for ( ObjId b( a + 1 ); b < sm.numObjects(); ++b )
+        {
+            if ( !uf.united( a, b ) )
+                continue;
+            resG.o2gId[b] = agId;
+            resG.groups[agId].autoResizeSet( b );
+        }
+    }
+
+    MinShiftsMatrix resM( resG.groups.size() );
+    for ( GId ag( 0 ); ag < resM.numObjects(); ++ag )
+    {
+        for ( GId bg( 0 ); bg < resM.numObjects(); ++bg )
+        {
+            int16_t minVal = std::numeric_limits<int16_t>::max();
+            for ( auto a : resG.groups[ag] )
+            {
+                if ( ag != bg )
+                {
+                    for ( auto b : resG.groups[bg] )
+                    {
+                        minVal = std::min( minVal, sm.get( GId( int( a ) ), GId( int( b ) ) ) );
+                    }
+                }
+                else
+                    minVal = std::min( minVal, sm.get( GId( int( a ) ), GId( int( a ) ) ) );
+            }
+            resM.setMin( ag, bg, minVal );
+        }
+    }
+
+    if ( optPrevLayerGroup )
+    {
+        // update groups to gave bitsets of original objects instead of bitsets of prev layer groups
+        ObjBitSet accumBitSet;
+        for ( auto& group : resG.groups )
+        {
+            accumBitSet.reset();
+            for ( auto gId : group )
+            {
+                accumBitSet |= optPrevLayerGroup->groups[optPrevLayerGroup->o2gId[gId]];
+            }
+            group = accumBitSet;
+        }
+    }
+    return std::make_pair( std::move( resG ), std::move( resM ) );
+}
+
+struct TetrisBlock
+{
+    VoxelBitSet objectVoxels;
+    Vector3i dims;
+    Vector3i position;
+};
+
+class TetrisDensifier
+{
+public:
+    TetrisDensifier( const Vector<MeshXf, ObjId>& meshes, const TetrisDensifyParams& params );
+
+    Expected<Vector<AffineXf3f, ObjId>> run();
+private:
+    TetrisDensifyParams params_;
+
+    Vector<TetrisBlock, ObjId> tetrisBlocks_;
+
+    Vector<ObjId, VoxelId> nestVoxels_;
+    Vector3i nestDims_;
+
+    void buildBlocks_( const Vector<MeshXf, ObjId>& meshes );
+    bool fillNest_( const ProgressCallback& cb );
+    MinShiftsMatrix calcInitShifts_( OutEdge dir ) const;
+    Vector<int16_t, ObjId> calcResShifts_( MinShiftsMatrix&& sm ) const;
+};
+
+TetrisDensifier::TetrisDensifier( const Vector<MeshXf, ObjId>& meshes, const TetrisDensifyParams& params ) :
+    params_{ params }
+{
+    auto dims = Vector3i( params_.baseParams.nest.size() / params_.options.voxelSize ) + Vector3i::diagonal( 1 );
+    if ( params_.options.nestDimensionsCache )
+    {
+        if ( *params_.options.nestDimensionsCache != Vector3i() )
+            dims = *params_.options.nestDimensionsCache; // if not zero - take input dimensions
+        else
+            *params_.options.nestDimensionsCache = dims; // if zero - output calculated to `caches`
+    }
+    if ( params_.options.nestVoxelsCache )
+    {
+        nestVoxels_ = std::move( *params_.options.nestVoxelsCache ); // move it into class for further usage
+    }
+
+    nestDims_ = dims;
+    buildBlocks_( meshes );
+}
+
+Expected<Vector<AffineXf3f, ObjId>> TetrisDensifier::run()
+{
+    MR_TIMER;
+
+    auto sb = subprogress( params_.options.cb, 0.5f, 1.0f );
+    Vector<AffineXf3f, ObjId> combinedShifts( tetrisBlocks_.size() );
+    int numSteps = int( params_.options.densificationSequence.size() );
+    for ( int i = 0; i < numSteps; ++i )
+    {
+        OutEdge dir = params_.options.densificationSequence[i];
+
+        if ( !fillNest_( subprogress( sb, float( i ) / float( numSteps ), float( i + 1 ) / float( numSteps ) ) ) )
+            return unexpectedOperationCanceled();
+
+        // debug output voxels
+#if 0
+        static int numSave = 0;
+        {
+            SimpleVolume sv;
+            sv.data.resize( nestVoxels_.size() );
+            ParallelFor( nestVoxels_, [&] ( VoxelId v )
+            {
+                sv.data[v] = float( int( nestVoxels_[v] ) );
+            } );
+            sv.dims = nestDims_;
+            sv.voxelSize = Vector3f::diagonal( params_.options.voxelSize );
+            ( void ) VoxelsSave::toRawAutoname( sv, "D:\\WORK\\MODELS\\Nesting\\DEBUG\\" + std::to_string( ++numSave ) + "_vox.raw" );
+        }
+#endif
+
+
+        auto shifts = calcResShifts_( calcInitShifts_( dir ) );
+        for ( ObjId o( 0 ); o < combinedShifts.size(); ++o )
+        {
+            auto addShift = neiPosDelta[int( dir )] * int( shifts[o] );
+            tetrisBlocks_[o].position += addShift;
+            combinedShifts[o].b += Vector3f( addShift ) * params_.options.voxelSize;
+        }
+    }
+
+    // output occupied voxels
+    if ( params_.options.occupiedVoxelsCache )
+    {
+        params_.options.occupiedVoxelsCache->resize( nestVoxels_.size() );
+        BitSetParallelForAll( *params_.options.occupiedVoxelsCache, [&] ( VoxelId vid )
+        {
+            params_.options.occupiedVoxelsCache->set( vid, bool( nestVoxels_[vid] ) );
+        } );
+    }
+    // output nest voxels
+    if ( params_.options.nestVoxelsCache )
+        *params_.options.nestVoxelsCache = std::move( nestVoxels_ ); // return it for possible subsequent calls
+
+    return combinedShifts;
+}
+
+void TetrisDensifier::buildBlocks_( const Vector<MeshXf, ObjId>& meshes )
+{
+    MR_TIMER;
+    tetrisBlocks_.resize( meshes.size() );
+    ParallelFor( meshes, [&] ( ObjId oId )
+    {
+        if ( !meshes[oId].mesh )
+            return;
+        auto box = meshes[oId].mesh->computeBoundingBox( &meshes[oId].xf );
+        box = box.expanded( Vector3f::diagonal( params_.baseParams.minInterval ) );
+        auto [org, dims] = calcOriginAndDimensions( box, params_.options.voxelSize );
+        tetrisBlocks_[oId].position = Vector3i( ( org - params_.baseParams.nest.min ) / params_.options.voxelSize );
+        org = params_.baseParams.nest.min + Vector3f( tetrisBlocks_[oId].position ) * params_.options.voxelSize;
+
+        CloseToMeshVolumeParams tParams;
+        // half min interval, so two objects together have 0.5+0.5=1
+        tParams.closeDist = std::max( 0.5f * params_.baseParams.minInterval, params_.options.voxelSize * std::sqrt( 3.0f ) * 0.5f ); // half voxel diagonal for small intervals
+        tParams.meshToWorld = &meshes[oId].xf;
+        tParams.vol.dimensions = dims;
+        tParams.vol.origin = org;
+        tParams.vol.voxelSize = Vector3f::diagonal( params_.options.voxelSize );
+
+        auto res = makeCloseToMeshVolume( *meshes[oId].mesh, tParams );
+        if ( !res.has_value() )
+        {
+            assert( false );
+            return;
+        }
+        tetrisBlocks_[oId].dims = dims;
+        tetrisBlocks_[oId].objectVoxels = std::move( res->data );
+    }, subprogress( params_.options.cb, 0.0f, 0.5f ) );
+}
+
+bool TetrisDensifier::fillNest_( const ProgressCallback& cb )
+{
+    MR_TIMER;
+    if ( !reportProgress( cb, 0.0f ) )
+        return false;
+
+    if ( nestVoxels_.empty() )
+    {
+        nestVoxels_.resize( size_t( nestDims_.z ) * nestDims_.y * nestDims_.x, ObjId() );
+    }
+    else
+    {
+        std::fill( nestVoxels_.vec_.begin(), nestVoxels_.vec_.end(), ObjId() );
+    }
+
+    if ( !reportProgress( cb, 0.1f ) )
+        return false;
+
+    auto sb2 = subprogress( cb, 0.1f, 0.9f );
+
+    auto nestIndexer = VolumeIndexer( nestDims_ );
+    for ( ObjId o( 0 ); o < tetrisBlocks_.size(); ++o )
+    {
+        auto localIndexer = VolumeIndexer( tetrisBlocks_[o].dims );
+        BitSetParallelFor( tetrisBlocks_[o].objectVoxels, [&] ( VoxelId v )
+        {
+            auto nestPos = localIndexer.toPos( v ) + tetrisBlocks_[o].position;
+            if ( nestPos.x < 0 || nestPos.x >= nestDims_.x ||
+                 nestPos.y < 0 || nestPos.y >= nestDims_.y ||
+                 nestPos.z < 0 || nestPos.z >= nestDims_.z )
+                return;
+            nestVoxels_[nestIndexer.toVoxelId( nestPos )] = o;
+        } );
+        if ( !reportProgress( sb2, float( int( o ) + 1 ) / float( tetrisBlocks_.size() ) ) )
+            return false;
+    }
+
+    // fill external second to improve "slide-ability"
+    auto invalidObjId = ObjId( tetrisBlocks_.size() );
+    if ( params_.options.occupiedVoxelsCache && params_.options.occupiedVoxelsCache->any() )
+    {
+        BitSetParallelFor( *params_.options.occupiedVoxelsCache, [&] ( VoxelId vid )
+        {
+            nestVoxels_[vid] = invalidObjId;
+        } );
+    }
+#if 0 // at one point we decided that there is no need in safe layers
+    else
+    {
+        int numSafeLayers = int( params_.baseParams.minInterval * 0.5f / params_.options.voxelSize );
+        Vector3i safeDims = nestDims_ - Vector3i::diagonal( numSafeLayers );
+        VolumeIndexer indexer( nestDims_ );
+        ParallelFor( nestVoxels_, [&] ( VoxelId vid )
+        {
+            auto pos = indexer.toPos( vid );
+            if ( pos.x < numSafeLayers || pos.y < numSafeLayers || pos.z < numSafeLayers ||
+                 pos.x >= safeDims.x || pos.y >= safeDims.y || pos.z >= safeDims.z )
+                nestVoxels_[vid] = invalidObjId;
+        } );
+    }
+#endif
+    if ( !reportProgress( cb, 1.0f ) )
+        return false;
+
+    return true;
+}
+
+MinShiftsMatrix TetrisDensifier::calcInitShifts_( OutEdge dir ) const
+{
+    MR_TIMER;
+    VolumeIndexer indexer( nestDims_ );
+    size_t numobjs = tetrisBlocks_.size();
+    auto invalidObjId = ObjId( numobjs );
+    tbb::enumerable_thread_specific<MinShiftsMatrix> shiftsTLS( numobjs );
+    ParallelFor( nestVoxels_, shiftsTLS, [&] ( VoxelId voxel, MinShiftsMatrix& tls )
+    {
+        auto thisObjId = nestVoxels_[voxel];
+        if ( !thisObjId || thisObjId == invalidObjId )
+            return;
+        VoxelId nextVox = voxel;
+        ObjId nextObjId;
+        int16_t shift = 0;
+        for ( ;; )
+        {
+            nextVox = indexer.getNeighbor( nextVox, dir );
+            if ( !nextVox )
+                break;
+            nextObjId = nestVoxels_[nextVox];
+            if ( !nextObjId )
+                ++shift; // free space
+            else if ( nextObjId == thisObjId )
+                return; // same object
+            else // other object
+                break;
+        }
+        if ( !nextObjId || nextObjId == invalidObjId )
+            nextObjId = thisObjId; // this means nest wall or cache->occupiedVoxel
+        tls.setMin( GId( int( thisObjId ) ), GId( int( nextObjId ) ), shift );
+    } );
+    MinShiftsMatrix res( numobjs );
+    for ( const auto& shiftTLS : shiftsTLS )
+        res.mergeOther( shiftTLS );
+    return res;
+}
+
+Vector<int16_t, ObjId> TetrisDensifier::calcResShifts_( MinShiftsMatrix&& sm ) const
+{
+    MR_TIMER;
+    size_t numobjs = tetrisBlocks_.size();
+
+    Vector<int16_t, ObjId> res( numobjs, 0 );
+
+    auto gsm = convergeShiftsMatrix( std::move( sm ), nullptr );
+
+    for ( ;; )
+    {
+        bool atLeastOneChanged = false;
+        auto gShifts = gsm.second.process();
+        for ( GId i( 0 ); i < gShifts.size(); ++i )
+        {
+            auto shift = gShifts[i];
+            if ( shift == 0 )
+                continue;
+            atLeastOneChanged = true;
+            for ( auto objId : gsm.first.groups[i] )
+                res[objId] += shift;
+        }
+        if ( !atLeastOneChanged )
+            break;
+        gsm = convergeShiftsMatrix( std::move( gsm.second ), &gsm.first );
+    }
+    return res;
+}
+
+Expected<Vector<AffineXf3f, ObjId>> tetrisNestingDensify( const Vector<MeshXf, ObjId>& meshes, const TetrisDensifyParams& params )
+{
+    MR_TIMER;
+    if ( params.options.densificationSequence.empty() )
+    {
+        assert( false );
+        return unexpected( "Empty densification sequence" );
+    }
+    Nesting::TetrisDensifier td( meshes, params );
+    return td.run();
+}
+
+}
+
+}

--- a/source/MRVoxels/MRTetrisNesting.h
+++ b/source/MRVoxels/MRTetrisNesting.h
@@ -1,0 +1,42 @@
+#pragma once
+#include "MRVoxelsFwd.h"
+#include "MRMesh/MRNestingStructures.h"
+#include "MRMesh/MRVector.h"
+#include "MRMesh/MRId.h"
+#include "MRMesh/MRExpected.h"
+#include "MRMesh/MRVolumeIndexer.h"
+
+
+namespace MR
+{
+
+namespace Nesting
+{
+
+struct TetrisDensifyOptions
+{
+    /// size of block for tetris box
+    float voxelSize{ 0.0f };
+
+    /// tetris box will be densify in these directions one by one
+    std::vector<OutEdge> densificationSequence = { OutEdge::MinusZ,OutEdge::MinusY,OutEdge::MinusX };
+
+    ProgressCallback cb;
+
+    Vector<ObjId, VoxelId>* nestVoxelsCache{ nullptr }; ///< [in/out] pre-allocated voxels vector (to speedup allocation)
+    Vector3i* nestDimensionsCache{ nullptr }; ///< [in/out] dimensions of the nest (complimentary to voxels data)
+    VoxelBitSet* occupiedVoxelsCache{ nullptr }; ///< [in/out] voxels that blocks movement of floating (input) meshes (to provide input and output occupancy status)
+};
+
+struct TetrisDensifyParams
+{
+    NestingBaseParams baseParams;
+    TetrisDensifyOptions options;
+};
+
+/// make nested meshes more compact by representing them via voxels and pushing to nest zero
+MRVOXELS_API Expected<Vector<AffineXf3f, ObjId>> tetrisNestingDensify( const Vector<MeshXf, ObjId>& meshes, const TetrisDensifyParams& params );
+
+}
+
+}

--- a/source/MRVoxels/MRVoxels.vcxproj
+++ b/source/MRVoxels/MRVoxels.vcxproj
@@ -38,8 +38,10 @@
     <ClCompile Include="MRRebuildMesh.cpp" />
     <ClCompile Include="MRScalarConvert.cpp" />
     <ClCompile Include="MRScanHelpers.cpp" />
+    <ClCompile Include="MRSequentialNester.cpp" />
     <ClCompile Include="MRSweptVolume.cpp" />
     <ClCompile Include="MRTeethMaskToDirectionVolume.cpp" />
+    <ClCompile Include="MRTetrisNesting.cpp" />
     <ClCompile Include="MRToolPath.cpp" />
     <ClCompile Include="MRVDBConversions.cpp" />
     <ClCompile Include="MRVolumeSegment.cpp" />
@@ -80,8 +82,10 @@
     <ClInclude Include="MRRebuildMesh.h" />
     <ClInclude Include="MRScalarConvert.h" />
     <ClInclude Include="MRScanHelpers.h" />
+    <ClInclude Include="MRSequentialNester.h" />
     <ClInclude Include="MRSweptVolume.h" />
     <ClInclude Include="MRTeethMaskToDirectionVolume.h" />
+    <ClInclude Include="MRTetrisNesting.h" />
     <ClInclude Include="MRToolPath.h" />
     <ClInclude Include="MRVDBConversions.h" />
     <ClInclude Include="MRVDBFloatGrid.h" />


### PR DESCRIPTION
 - add `BoxNesting`: nest objects based by their bounding boxes
 - add `TetrisDensify`: pack nested objects based on their "filled voxels" tetris-like densification
 - add `SequentialNester`: class that allows to nest objects sequentially by groups (using `BoxNesting` and optionally `TetrisDensification`)
 - add `exportNesting3mf`: function to export slicestacks in `3mf` format, used by some printers

(Code moved from MeshInspector)