### PR TITLE
SurfaceManipulationWidged: move fixed points

### DIFF
--- a/source/MRViewer/MRSurfaceManipulationWidget.cpp
+++ b/source/MRViewer/MRSurfaceManipulationWidget.cpp
@@ -353,10 +353,7 @@ bool SurfaceManipulationWidget::onMouseDown_( MouseButton button, int modifiers 
 
             if ( settings_.laplacianBasedAddRemove
                 && ( settings_.workMode == WorkMode::Add || settings_.workMode == WorkMode::Remove ) )
-            {
-                fixedPickedVerts_.clear();
-                fixedPickedVerts_.resize( obj_->mesh()->points.size() );
-            }
+                fixedPickedVertsToDistSq_.clear();
 
             historyAction_ = std::make_shared<SmartChangeMeshPointsAction>( name, obj_ );
         }
@@ -644,21 +641,22 @@ void SurfaceManipulationWidget::changeSurface_()
     if ( settings_.laplacianBasedAddRemove )
     {
         // fix vertices near new pick points
-        bool newFixedVert = false;
+        bool changedAnyFixedVert = false;
         for ( const auto& p : pointsUnderMouse_ )
         {
+            bool changedThisFixedVert = false;
             auto v = mesh.getClosestVertex( p );
-            // do not change the position of already fixed vertex, otherwise
-            // it will result in appearance of very short edges with both ends fixed:
-            if ( !fixedPickedVerts_.test( v ) )
+            auto vDistSq = distanceSq( mesh.points[v], mesh.triPoint( p ) );
+            auto vIt = fixedPickedVertsToDistSq_.find( v );
+            if ( vIt == fixedPickedVertsToDistSq_.end() )
             {
                 bool fixedTri = false;
                 for ( EdgeId e : orgRing( mesh.topology, v ) )
                 {
                     if ( !mesh.topology.left( e ) )
                         continue;
-                    if ( fixedPickedVerts_.test( mesh.topology.dest( e ) )
-                      && fixedPickedVerts_.test( mesh.topology.dest( mesh.topology.next( e ) ) ) )
+                    if ( fixedPickedVertsToDistSq_.count( mesh.topology.dest( e ) ) > 0
+                      && fixedPickedVertsToDistSq_.count( mesh.topology.dest( mesh.topology.next( e ) ) ) > 0 )
                     {
                         fixedTri = true;
                         break;
@@ -666,24 +664,34 @@ void SurfaceManipulationWidget::changeSurface_()
                 }
                 if ( !fixedTri ) //otherwise a triangle appear with all vertices fixed
                 {
-                    fixedPickedVerts_.set( v );
+                    fixedPickedVertsToDistSq_.insert( { v, vDistSq } );
                     varMesh.points[v] = mesh.triPoint( p ) + normal * maxShift;
-                    newFixedVert = true;
-                    // all vertices around fixed vertices must be included in Laplacian free vertices to optimize surrounding triangles:
-                    for ( EdgeId e : orgRing( mesh.topology, v ) )
-                    {
-                        if ( auto d = mesh.topology.dest( e ); !unchangeableVerts_.test( d ) )
-                            singleEditingRegion_.set( d );
-                    }
+                    changedThisFixedVert = changedAnyFixedVert = true;
+                }
+            }
+            else if ( vIt->second > vDistSq )
+            {
+                // change position of previously fixed vertex if mouse cursor came closer to its location on stable mesh
+                vIt->second = vDistSq;
+                varMesh.points[v] = mesh.triPoint( p ) + normal * maxShift;
+                changedThisFixedVert = changedAnyFixedVert = true;
+            }
+            if ( changedThisFixedVert )
+            {
+                // all vertices around fixed vertices must be included in Laplacian free vertices to optimize surrounding triangles:
+                for ( EdgeId e : orgRing( mesh.topology, v ) )
+                {
+                    if ( auto d = mesh.topology.dest( e ); !unchangeableVerts_.test( d ) )
+                        singleEditingRegion_.set( d );
                 }
             }
         }
-        if ( !newFixedVert )
+        if ( !changedAnyFixedVert )
             return;
 
         initLaplacian_( RememberShape::No );
         // fix vertices near current and previous pick points
-        for ( auto v : fixedPickedVerts_ )
+        for ( auto& [v, dSq] : fixedPickedVertsToDistSq_ )
             laplacian_->fixVertex( v );
 
         laplacian_->apply();

--- a/source/MRViewer/MRSurfaceManipulationWidget.h
+++ b/source/MRViewer/MRSurfaceManipulationWidget.h
@@ -183,8 +183,9 @@ protected:
     std::unique_ptr<Laplacian> laplacian_;
 
     /// these are all vertices manually moved to be under mouse and lifted to material width since last mouse down
-    /// in laplacianBasedAddRemove mode not including the vertices around moved by the laplacian
-    VertBitSet fixedPickedVerts_;
+    /// in laplacianBasedAddRemove mode not including the vertices around moved by the laplacian;
+    /// mapped float value is the minimal distance from point under mouse to that vertex
+    HashMap<VertId, float> fixedPickedVertsToDistSq_;
 
     /// prior to add/remove/smooth/deform modification, this action is created and current mesh coordinate are copied here
     class SmartChangeMeshPointsAction;


### PR DESCRIPTION
In `laplacianBasedAddRemove` mode, move fixed points to the lifted location where the mouse cursor approached to the closest distance to that vertex.