### PR TITLE
Bambu 3mf: read default filament color

### DIFF
--- a/source/MRIOExtras/MR3mf.cpp
+++ b/source/MRIOExtras/MR3mf.cpp
@@ -749,7 +749,7 @@ Expected<void> Node::loadMesh_( ThreeMFLoader& loader, const tinyxml2::XMLElemen
     VertColors vColorMap;
     initDefaultFillament_( loader );
     std::optional<Color> baseFilament;
-    if ( defaultFillamentId_ >= 0 && defaultFillamentId_ < loader.filamentColors_.size() )
+    if ( defaultFillamentId_ < loader.filamentColors_.size() )
         baseFilament = loader.filamentColors_[defaultFillamentId_];
     bool allTrisHaveConstColors = true;
     bool someTrisHaveNotBgColor = !bgColor.has_value();


### PR DESCRIPTION
For 3mf files saved with filament colors, read default filament from `model_settings.config` file