### PR TITLE
Hide extra overloads of `trackLeftBoundaryLoop()` and `trackRightBoun…

### DIFF
--- a/source/MRMesh/MRRegionBoundary.h
+++ b/source/MRMesh/MRRegionBoundary.h
@@ -11,13 +11,15 @@ namespace MR
 /// returns closed loop of region boundary starting from given region boundary edge (region faces on the left, and not-region faces or holes on the right);
 /// if more than two boundary edges connect in one vertex, then the function makes the most abrupt turn to right
 [[nodiscard]] MRMESH_API EdgeLoop trackLeftBoundaryLoop( const MeshTopology & topology, EdgeId e0, const FaceBitSet * region = nullptr );
-[[nodiscard]] inline EdgeLoop trackLeftBoundaryLoop( const MeshTopology & topology, const FaceBitSet & region, EdgeId e0 )
+// This is skipped in the bindings to get nicer overload names in C.
+[[nodiscard]] MR_BIND_IGNORE inline EdgeLoop trackLeftBoundaryLoop( const MeshTopology & topology, const FaceBitSet & region, EdgeId e0 )
     { return trackLeftBoundaryLoop( topology, e0, &region ); }
 
 /// returns closed loop of region boundary starting from given region boundary edge (region faces on the right, and not-region faces or holes on the left);
 /// if more than two boundary edges connect in one vertex, then the function makes the most abrupt turn to left
 [[nodiscard]] MRMESH_API EdgeLoop trackRightBoundaryLoop( const MeshTopology & topology, EdgeId e0, const FaceBitSet * region = nullptr );
-[[nodiscard]] inline EdgeLoop trackRightBoundaryLoop( const MeshTopology & topology, const FaceBitSet & region, EdgeId e0 )
+// This is skipped in the bindings to get nicer overload names in C.
+[[nodiscard]] MR_BIND_IGNORE inline EdgeLoop trackRightBoundaryLoop( const MeshTopology & topology, const FaceBitSet & region, EdgeId e0 )
     { return trackRightBoundaryLoop( topology, e0, &region ); }
 
 /// track the path of edges with set bits in (edges) starting from (e0);

--- a/source/MRTestC2/MRMeshBoolean.c
+++ b/source/MRTestC2/MRMeshBoolean.c
@@ -130,7 +130,7 @@ void testBooleanMultipleEdgePropogationSort( void )
         const MR_MeshTopology* meshATopology = MR_Mesh_Get_topology( meshA );
         MR_std_vector_MR_EdgeId* meshAHoles = MR_MeshTopology_findHoleRepresentiveEdges( meshATopology, NULL );
 
-        MR_std_vector_MR_EdgeId* border = MR_trackRightBoundaryLoop_MR_EdgeId( meshATopology, *MR_std_vector_MR_EdgeId_at( meshAHoles, 0 ), NULL );
+        MR_std_vector_MR_EdgeId* border = MR_trackRightBoundaryLoop( meshATopology, *MR_std_vector_MR_EdgeId_at( meshAHoles, 0 ), NULL );
 
         MR_std_vector_std_vector_MR_EdgeId* borderVec = MR_std_vector_std_vector_MR_EdgeId_DefaultConstruct();
         MR_std_vector_std_vector_MR_EdgeId_push_back( borderVec, MR_PassBy_Move, border );


### PR DESCRIPTION
…daryLoop()` from bindings, to get better C function names for those.