### PR TITLE
Add transform(Vector) overloads for Mesh, Polyline, and PointCloud

### DIFF
--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -255,6 +255,17 @@ void Mesh::transform( const AffineXf3f& xf, const VertBitSet* region )
     invalidateCaches();
 }
 
+void Mesh::transform( const Vector3f& shift, const VertBitSet* region )
+{
+    MR_TIMER;
+
+    BitSetParallelFor( topology.getVertIds( region ), [&] ( const VertId v )
+    {
+        points[v] += shift;
+    } );
+    invalidateCaches();
+}
+
 VertId Mesh::addPoint( const Vector3f & pos )
 {
     VertId v = topology.addVertId();

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -353,6 +353,10 @@ struct [[nodiscard]] Mesh
     /// \snippet cpp-examples/MeshModification.dox.cpp MeshTransform
     MRMESH_API void transform( const AffineXf3f& xf, const VertBitSet* region = nullptr );
 
+    /// applies given shift to specified vertices
+    /// if region is nullptr, all valid mesh vertices are used
+    MRMESH_API void transform( const Vector3f& shift, const VertBitSet* region = nullptr );
+
     /// creates new point and assigns given position to it
     MRMESH_API VertId addPoint( const Vector3f & pos );
 

--- a/source/MRMesh/MRPointCloud.cpp
+++ b/source/MRMesh/MRPointCloud.cpp
@@ -68,6 +68,17 @@ void PointCloud::transform( const AffineXf3f& xf, const VertBitSet* region )
     } );
 }
 
+void PointCloud::transform( const Vector3f& shift, const VertBitSet* region )
+{
+    MR_TIMER;
+    invalidateCaches();
+
+    BitSetParallelFor( getVertIds( region ), [&] ( const VertId v )
+    {
+        points[v] += shift;
+    } );
+}
+
 void PointCloud::addPartByMask( const PointCloud& from, const VertBitSet& fromVerts, const CloudPartMapping& outMap, const VertNormals * extNormals )
 {
     MR_TIMER;

--- a/source/MRMesh/MRPointCloud.h
+++ b/source/MRMesh/MRPointCloud.h
@@ -64,6 +64,10 @@ struct PointCloud
     /// if region is nullptr, all valid points are modified
     MRMESH_API void transform( const AffineXf3f& xf, const VertBitSet* region = nullptr );
 
+    /// applies given shift to specified points (normals are not changed);
+    /// if region is nullptr, all valid points are modified
+    MRMESH_API void transform( const Vector3f& shift, const VertBitSet* region = nullptr );
+
     /// returns all valid point ids sorted lexicographically by their coordinates (optimal for uniform sampling)
     [[nodiscard]] MRMESH_API std::vector<VertId> getLexicographicalOrder() const;
 

--- a/source/MRMesh/MRPolyline.cpp
+++ b/source/MRMesh/MRPolyline.cpp
@@ -330,6 +330,20 @@ void Polyline<V>::transform( const AffineXf<V> & xf )
 }
 
 template<typename V>
+void Polyline<V>::transform( const V & shift )
+{
+    MR_TIMER;
+    VertId lastValidVert = topology.lastValidVert();
+
+    ParallelFor( 0_v, lastValidVert + 1, [&] ( VertId v )
+    {
+        if ( topology.hasVert( v ) )
+            points[v] += shift;
+    } );
+    invalidateCaches();
+}
+
+template<typename V>
 EdgeId Polyline<V>::splitEdge( EdgeId e, const V & newVertPos )
 {
     EdgeId newe = topology.splitEdge( e );

--- a/source/MRMesh/MRPolyline.h
+++ b/source/MRMesh/MRPolyline.h
@@ -118,6 +118,9 @@ public:
     /// applies given transformation to all valid polyline vertices
     MRMESH_API void transform( const AffineXf<V> & xf );
 
+    /// applies given shift to all valid polyline vertices
+    MRMESH_API void transform( const V & shift );
+
     /// split given edge on two parts:
     /// dest(returned-edge) = org(e) - newly created vertex,
     /// org(returned-edge) = org(e-before-split),


### PR DESCRIPTION
## Summary

- Add `transform(const Vector3f& shift)` overloads to `Mesh`, `PointCloud`, and `Polyline<V>` that perform translation by simple vector addition instead of constructing a full `AffineXf` matrix
- `Mesh` and `PointCloud` overloads accept an optional `region` parameter (matching existing `transform(AffineXf3f)`)
- `Polyline` overload applies to all valid vertices (matching existing `transform(AffineXf<V>)`)
- Normals are not modified for `PointCloud` shift (correct for pure translation)

## Test plan

- [ ] Verify compilation on all platforms (CI)
- [ ] Verify that `mesh.transform(vec)` produces the same result as `mesh.transform(AffineXf3f::translation(vec))`

🤖 Generated with [Claude Code](https://claude.com/claude-code)