### PR TITLE
extractAllPaths function

### DIFF
--- a/source/MRMesh/MRRegionBoundary.cpp
+++ b/source/MRMesh/MRRegionBoundary.cpp
@@ -74,7 +74,7 @@ EdgeId extractPath( const MeshTopology& topology, EdgeId e, EdgeBitSet& edges, E
     }
 }
 
-EdgeId extractBackPath( const MeshTopology& topology, EdgeId e, EdgeBitSet& edges, EdgePath* outBackPath, Turn turn )
+EdgeId extractOppositePath( const MeshTopology& topology, EdgeId e, EdgeBitSet& edges, EdgePath* outPath, Turn turn )
 {
     std::function<EdgeId( EdgeId )> prev;
     if ( turn == Turn::Leftmost )
@@ -85,16 +85,16 @@ EdgeId extractBackPath( const MeshTopology& topology, EdgeId e, EdgeBitSet& edge
     for ( ;; )
     {
         // search for next edge in the path
-        for ( auto e1 = prev( e );; e1 = prev( e1 ) )
+        for ( auto e1 = prev( e.sym() );; e1 = prev( e1 ) )
         {
-            if ( e1 == e )
+            if ( e1 == e.sym() )
                 return e; // nothing found after full round
 
             if ( edges.test_set( e1.sym(), false ) )
             {
-                if ( outBackPath )
-                    outBackPath->push_back( e1 );
-                e = e1.sym();
+                if ( outPath )
+                    outPath->push_back( e1 );
+                e = e1;
                 break;
             }
         }
@@ -141,7 +141,7 @@ std::vector<EdgePath> extractAllPaths( const MeshTopology& topology, EdgeBitSet 
         if ( topology.org( path.front() ) != topology.dest( path.back() ) )
         {
             // not closed path was extracted, track backward as well
-            extractBackPath( topology, e, edges, &backPath, turn );
+            extractOppositePath( topology, e.sym(), edges, &backPath, turn );
             assert( isEdgePath( topology, backPath ) );
             assert ( backPath.empty() || topology.org( path.front() ) == topology.org( backPath.front() ) );
             reverse( backPath );

--- a/source/MRMesh/MRRegionBoundary.cpp
+++ b/source/MRMesh/MRRegionBoundary.cpp
@@ -74,6 +74,33 @@ EdgeId extractPath( const MeshTopology& topology, EdgeId e, EdgeBitSet& edges, E
     }
 }
 
+EdgeId extractBackPath( const MeshTopology& topology, EdgeId e, EdgeBitSet& edges, EdgePath* outBackPath, Turn turn )
+{
+    std::function<EdgeId( EdgeId )> prev;
+    if ( turn == Turn::Leftmost )
+        prev = [&] ( EdgeId e ) { return topology.next( e ); };
+    else
+        prev = [&] ( EdgeId e ) { return topology.prev( e ); };
+
+    for ( ;; )
+    {
+        // search for next edge in the path
+        for ( auto e1 = prev( e );; e1 = prev( e1 ) )
+        {
+            if ( e1 == e )
+                return e; // nothing found after full round
+
+            if ( edges.test_set( e1.sym(), false ) )
+            {
+                if ( outBackPath )
+                    outBackPath->push_back( e1 );
+                e = e1.sym();
+                break;
+            }
+        }
+    }
+}
+
 std::vector<EdgeLoop> extractAllLoops( const MeshTopology& topology, EdgeBitSet & edges, Turn turn )
 {
     MR_TIMER;
@@ -86,7 +113,7 @@ std::vector<EdgeLoop> extractAllLoops( const MeshTopology& topology, EdgeBitSet 
         if ( !path.empty() && topology.org( path.front() ) == topology.dest( path.back() ) )
         {
             // a closed loop was extracted;
-            // do not move to keep allocated memory in path
+            // do not move to keep allocated memory in path, and res optimally packed
             res.push_back( path );
         }
         else
@@ -98,6 +125,35 @@ std::vector<EdgeLoop> extractAllLoops( const MeshTopology& topology, EdgeBitSet 
         path.clear();
     }
     edges = std::move( pathEdges );
+    return res;
+}
+
+std::vector<EdgePath> extractAllPaths( const MeshTopology& topology, EdgeBitSet & edges, Turn turn )
+{
+    MR_TIMER;
+    EdgePath path, backPath;
+    std::vector<EdgeLoop> res;
+    for ( auto e : edges )
+    {
+        extractPath( topology, e, edges, &path, turn );
+        assert( !path.empty() );
+        assert( isEdgePath( topology, path ) );
+        if ( topology.org( path.front() ) != topology.dest( path.back() ) )
+        {
+            // not closed path was extracted, track backward as well
+            extractBackPath( topology, e, edges, &backPath, turn );
+            assert( isEdgePath( topology, backPath ) );
+            assert ( backPath.empty() || topology.org( path.front() ) == topology.org( backPath.front() ) );
+            reverse( backPath );
+            path.insert( path.begin(), backPath.begin(), backPath.end() );
+            assert( isEdgePath( topology, path ) );
+        }
+        // do not move to keep allocated memory in path, and res optimally packed
+        res.push_back( path );
+        path.clear();
+        backPath.clear();
+    }
+    assert( edges.none() );
     return res;
 }
 

--- a/source/MRMesh/MRRegionBoundary.h
+++ b/source/MRMesh/MRRegionBoundary.h
@@ -22,18 +22,30 @@ namespace MR
 [[nodiscard]] MR_BIND_IGNORE inline EdgeLoop trackRightBoundaryLoop( const MeshTopology & topology, const FaceBitSet & region, EdgeId e0, Turn turn = Turn::Rightmost )
     { return trackRightBoundaryLoop( topology, e0, &region, turn ); }
 
-/// track the path of edges with set bits in (edges) starting from (e0);
+/// tracks the path of edges with set bits in (edges) starting from (e0);
 /// \return the last edge of the path or invalid edge if e0's bit in (edge) was reset;
 /// if at some reached vertex there are two or more edges originate with set bits in (edges),
 /// the path selects the leftmost or the rightmost option depending on \param turn;
 /// the bits in (edges) for tracked path edges are reset
 MRMESH_API EdgeId extractPath( const MeshTopology& topology, EdgeId e0, EdgeBitSet& edges, EdgePath* outPath, Turn turn );
 
-/// tracks are returns all closed loops of edges from the given bit set;
+/// tracks the path of edges, where each path's edge (e) had set for e.sym() in (edges), starting from (but not including) e0.sym();
+/// \return oppositely oriented the last edge of the backward path or e0 if backward path is empty;
+/// \param turn is treated as for forward paths, so the actual selection is reversed;
+/// the bits in (edges) for tracked path edges are reset
+MRMESH_API EdgeId extractBackPath( const MeshTopology& topology, EdgeId e0, EdgeBitSet& edges, EdgePath* outBackPath, Turn turn );
+
+/// tracks and returns all closed loops of edges from the given bit set;
 /// if at some reached vertex there are two or more edges originate with set bits in (edges),
 /// the path selects the leftmost or the rightmost option depending on \param turn;
 /// the bits corresponding to loops are reset in (edges), and to remaining not-closed paths are kept
 [[nodiscard]] MRMESH_API std::vector<EdgeLoop> extractAllLoops( const MeshTopology& topology, EdgeBitSet & edges, Turn turn );
+
+/// tracks and returns all closed and not-closed paths of edges from the given bit set;
+/// if at some reached vertex there are two or more edges originate with set bits in (edges),
+/// the path selects the leftmost or the rightmost option depending on \param turn;
+/// on return all bits in (edges) are reset
+[[nodiscard]] MRMESH_API std::vector<EdgePath> extractAllPaths( const MeshTopology& topology, EdgeBitSet & edges, Turn turn );
 
 /// returns all region boundary loops;
 /// every loop has region faces on the left, and not-region faces or holes on the right

--- a/source/MRMesh/MRRegionBoundary.h
+++ b/source/MRMesh/MRRegionBoundary.h
@@ -29,11 +29,11 @@ namespace MR
 /// the bits in (edges) for tracked path edges are reset
 MRMESH_API EdgeId extractPath( const MeshTopology& topology, EdgeId e0, EdgeBitSet& edges, EdgePath* outPath, Turn turn );
 
-/// tracks the path of edges, where each path's edge (e) had set for e.sym() in (edges), starting from (but not including) e0.sym();
-/// \return oppositely oriented the last edge of the backward path or e0 if backward path is empty;
+/// tracks the path of oppositely oriented edges to the edges with set bits in (edges), starting from (but not including) e0;
+/// \return the last edge of the path or e0 if backward path is empty;
 /// \param turn is treated as for forward paths, so the actual selection is reversed;
-/// the bits in (edges) for tracked path edges are reset
-MRMESH_API EdgeId extractBackPath( const MeshTopology& topology, EdgeId e0, EdgeBitSet& edges, EdgePath* outBackPath, Turn turn );
+/// the bits in (edges) for the opposites of tracked path edges are reset
+MRMESH_API EdgeId extractOppositePath( const MeshTopology& topology, EdgeId e0, EdgeBitSet& edges, EdgePath* outPath, Turn turn );
 
 /// tracks and returns all closed loops of edges from the given bit set;
 /// if at some reached vertex there are two or more edges originate with set bits in (edges),


### PR DESCRIPTION
* New `extractAllPaths` function in addition for existed `extractAllLoops` function that can track full not closed paths as well.
* New `extractOppositePath` function that is used inside `extractAllPaths`.
