### PR TITLE
Introduce Flat Patch

### DIFF
--- a/source/MRMesh/MRMeshMetrics.cpp
+++ b/source/MRMesh/MRMeshMetrics.cpp
@@ -344,4 +344,72 @@ FillHoleMetric getMinAreaMetric( const Mesh& mesh )
     return metric;
 }
 
+FillHoleMetric getCloseSurfaceFillMetric( const Mesh& mesh, const Mesh& closeSurface )
+{
+    FillHoleMetric metric;
+    closeSurface.getAABBTree(); // ensure the tree is constructed
+    metric.triangleMetric = [&mesh, &closeSurface] ( VertId a, VertId b, VertId c )
+    {
+        Vector3f center = ( mesh.points[a] + mesh.points[b] + mesh.points[c] ) / 3.0f;
+        return findProjection( center, closeSurface ).distSq;
+    };
+    return metric;
+}
+
+FillHoleMetric mixMetrics( const FillHoleMetric& f, const FillHoleMetric& g, const FillCombineMetric& mix /*= {} */ )
+{
+    FillHoleMetric res;
+    // using [=] copy capture to ensure f,g,op lifetime during filling
+    if ( f.triangleMetric || g.triangleMetric )
+    {
+        res.triangleMetric = [=] ( VertId a, VertId b, VertId c )->double
+        {
+            auto fRes = f.triangleMetric ? f.triangleMetric( a, b, c ) : 0.0;
+            auto gRes = g.triangleMetric ? g.triangleMetric( a, b, c ) : 0.0;
+            if ( f.triangleMetric && g.triangleMetric )
+            {
+                return mix ? mix( fRes, gRes ) : fRes + gRes;
+            }
+            else if ( f.triangleMetric )
+                return fRes;
+            else
+                return gRes;
+        };
+    }
+    if ( f.edgeMetric || g.edgeMetric )
+    {
+        res.edgeMetric = [=] ( VertId a, VertId b, VertId l, VertId r )->double
+        {
+            auto fRes = f.edgeMetric ? f.edgeMetric( a, b, l, r ) : 0.0;
+            auto gRes = g.edgeMetric ? g.edgeMetric( a, b, l, r ) : 0.0;
+            if ( f.edgeMetric && g.edgeMetric )
+            {
+                return mix ? mix( fRes, gRes ) : fRes + gRes;
+            }
+            else if ( f.edgeMetric )
+                return fRes;
+            else
+                return gRes;
+        };
+    }
+    if ( f.combineMetric || g.combineMetric )
+    {
+        res.combineMetric = [=] ( double a, double b )->double
+        {
+            auto fRes = f.combineMetric ? f.combineMetric( a, b ) : 0.0;
+            auto gRes = g.combineMetric ? g.combineMetric( a, b ) : 0.0;
+            if ( f.combineMetric && g.combineMetric )
+            {
+                return mix ? mix( fRes, gRes ) : fRes + gRes;
+            }
+            else if ( f.combineMetric )
+                return fRes;
+            else
+                return gRes;
+        };
+    }
+
+    return res;
+}
+
 }

--- a/source/MRMesh/MRMeshMetrics.cpp
+++ b/source/MRMesh/MRMeshMetrics.cpp
@@ -347,7 +347,6 @@ FillHoleMetric getMinAreaMetric( const Mesh& mesh )
 FillHoleMetric getCloseSurfaceFillMetric( const Mesh& mesh, const Mesh& closeSurface )
 {
     FillHoleMetric metric;
-    closeSurface.getAABBTree(); // ensure the tree is constructed
     metric.triangleMetric = [&mesh, &closeSurface] ( VertId a, VertId b, VertId c )
     {
         Vector3f center = ( mesh.points[a] + mesh.points[b] + mesh.points[c] ) / 3.0f;

--- a/source/MRMesh/MRMeshMetrics.h
+++ b/source/MRMesh/MRMeshMetrics.h
@@ -51,15 +51,18 @@ MRMESH_API double calcCombinedFillMetric( const Mesh & mesh, const FaceBitSet & 
 
 /// This metric minimizes the sum of circumcircle radii for all triangles in the triangulation.
 /// It is rather fast to calculate, and it results in typically good triangulations.
+/// The metric is linear (measured in meters)
 MRMESH_API FillHoleMetric getCircumscribedMetric( const Mesh& mesh );
 
 /// Same as getCircumscribedFillMetric, but with extra penalty for the triangles having
 /// normals looking in the opposite side of plane containing left of (e).
+/// The metric is linear (measured in meters)
 MRMESH_API FillHoleMetric getPlaneFillMetric( const Mesh& mesh, EdgeId e );
 
 /// Similar to getPlaneFillMetric with extra penalty for the triangles having
 /// normals looking in the opposite side of plane containing left of (e),
 /// but the metric minimizes the sum of circumcircle radius times aspect ratio for all triangles in the triangulation.
+/// The metric is linear (measured in meters)
 MRMESH_API FillHoleMetric getPlaneNormalizedFillMetric( const Mesh& mesh, EdgeId e );
 
 /// This metric minimizes the sum of triangleMetric for all triangles in the triangulation
@@ -67,23 +70,28 @@ MRMESH_API FillHoleMetric getPlaneNormalizedFillMetric( const Mesh& mesh, EdgeId
 /// Where\n
 /// triangleMetric is proportional to triangle aspect ratio\n
 /// edgeMetric is proportional to ( 1 - dihedralAngleCos )
+/// The metric is non-dimensional
 MRMESH_API FillHoleMetric getComplexStitchMetric( const Mesh& mesh );
 
 /// Simple metric minimizing the sum of all edge lengths
+/// The metric is linear (measured in meters)
 MRMESH_API FillHoleMetric getEdgeLengthFillMetric( const Mesh& mesh );
 
 /// Forbids connecting vertices from the same hole \n
 /// Simple metric minimizing edge length
+/// The metric is linear (measured in meters)
 MRMESH_API FillHoleMetric getEdgeLengthStitchMetric( const Mesh& mesh );
 
 /// Forbids connecting vertices from the same hole \n
 /// penalize for large area and face normal deviation from upDir \n
 /// All new faces should be parallel to given direction
+/// The metric is power 4 measure (measured in meters^4)
 MRMESH_API FillHoleMetric getVerticalStitchMetric( const Mesh& mesh, const Vector3f& upDir );
 
 /// Forbids connecting vertices from the same hole \n
 /// penalize for long edges and its deviation from upDir \n
 /// All new faces should be parallel to given direction
+/// The metric is quadratic (measured in meters^2)
 MRMESH_API FillHoleMetric getVerticalStitchMetricEdgeBased( const Mesh& mesh, const Vector3f& upDir );
 
 /// This metric minimizes the sum of triangleMetric for all triangles in the triangulation
@@ -91,13 +99,16 @@ MRMESH_API FillHoleMetric getVerticalStitchMetricEdgeBased( const Mesh& mesh, co
 /// Where\n
 /// triangleMetric is proportional to weighted triangle area and triangle aspect ratio\n
 /// edgeMetric grows with angle between triangles as ( ( 1 - cos( x ) ) / ( 1 + cos( x ) ) ) ^ 4.
+/// The metric is non-dimensional
 MRMESH_API FillHoleMetric getComplexFillMetric( const Mesh& mesh, EdgeId e );
 
 /// This metric minimizes summary projection of new edges to plane normal, (try do produce edges parallel to plane)
+/// The metric is linear (measured in meters)
 MRMESH_API FillHoleMetric getParallelPlaneFillMetric( const Mesh& mesh, EdgeId e, const Plane3f* plane = nullptr );
 
 /// This metric minimizes the maximal dihedral angle between the faces in the triangulation
 /// and on its boundary
+/// The metric is radial (measured in radians)
 MRMESH_API FillHoleMetric getMaxDihedralAngleMetric( const Mesh& mesh );
 
 /// This metric consists of two parts
@@ -106,6 +117,7 @@ MRMESH_API FillHoleMetric getMaxDihedralAngleMetric( const Mesh& mesh );
 /// 2) for each edge: square root of double total area of triangles to its left and right
 ///    times the factor depending extensionally on absolute dihedral angle between left and right triangles,
 ///    this makes visually triangulated surface as smooth as possible.
+/// The metric is linear (measured in meters)
 /// For planar holes it is the same as getCircumscribedMetric.
 MRMESH_API FillHoleMetric getUniversalMetric( const Mesh& mesh );
 
@@ -113,8 +125,20 @@ MRMESH_API FillHoleMetric getUniversalMetric( const Mesh& mesh );
 MRMESH_API FillHoleMetric getMinTriAngleMetric( const Mesh& mesh );
 
 /// This metric is for triangulation construction with minimal summed area of triangles.
+/// The metric is quadratic (measured in meters^2)
 /// Warning: this metric can produce degenerated triangles
 MRMESH_API FillHoleMetric getMinAreaMetric( const Mesh& mesh );
+
+/// This metric penalize new triangles for getting far from `closeSurface` by projecting candidate face center on `closeSurfce`.
+/// While slower - it can produce better quality results for patching
+/// The metric is quadratic (measured in meters^2)
+MRMESH_API FillHoleMetric getCloseSurfaceFillMetric( const Mesh& mesh, const Mesh& closeSurface );
+
+/// Compose two metrics together:
+/// return metrics are `mix(f.metric,g.metric)`.
+/// Default `mix` is sum
+/// \note It is recommended to both metrics to be in same measure e.g. both meters or both meters^2 etc. So scaling input meshes won't lead to different results.
+MRMESH_API FillHoleMetric mixMetrics( const FillHoleMetric& f, const FillHoleMetric& g, const FillCombineMetric& mix = {} );
 
 /// \}
 

--- a/source/MRMesh/MRMeshMetrics.h
+++ b/source/MRMesh/MRMeshMetrics.h
@@ -51,18 +51,18 @@ MRMESH_API double calcCombinedFillMetric( const Mesh & mesh, const FaceBitSet & 
 
 /// This metric minimizes the sum of circumcircle radii for all triangles in the triangulation.
 /// It is rather fast to calculate, and it results in typically good triangulations.
-/// The metric is linear (measured in meters)
+/// It is measured in length units.
 MRMESH_API FillHoleMetric getCircumscribedMetric( const Mesh& mesh );
 
 /// Same as getCircumscribedFillMetric, but with extra penalty for the triangles having
 /// normals looking in the opposite side of plane containing left of (e).
-/// The metric is linear (measured in meters)
+/// It is measured in length units.
 MRMESH_API FillHoleMetric getPlaneFillMetric( const Mesh& mesh, EdgeId e );
 
 /// Similar to getPlaneFillMetric with extra penalty for the triangles having
 /// normals looking in the opposite side of plane containing left of (e),
 /// but the metric minimizes the sum of circumcircle radius times aspect ratio for all triangles in the triangulation.
-/// The metric is linear (measured in meters)
+/// It is measured in length units.
 MRMESH_API FillHoleMetric getPlaneNormalizedFillMetric( const Mesh& mesh, EdgeId e );
 
 /// This metric minimizes the sum of triangleMetric for all triangles in the triangulation
@@ -70,28 +70,28 @@ MRMESH_API FillHoleMetric getPlaneNormalizedFillMetric( const Mesh& mesh, EdgeId
 /// Where\n
 /// triangleMetric is proportional to triangle aspect ratio\n
 /// edgeMetric is proportional to ( 1 - dihedralAngleCos )
-/// The metric is non-dimensional
+/// It is unitless.
 MRMESH_API FillHoleMetric getComplexStitchMetric( const Mesh& mesh );
 
 /// Simple metric minimizing the sum of all edge lengths
-/// The metric is linear (measured in meters)
+/// It is measured in length units.
 MRMESH_API FillHoleMetric getEdgeLengthFillMetric( const Mesh& mesh );
 
 /// Forbids connecting vertices from the same hole \n
 /// Simple metric minimizing edge length
-/// The metric is linear (measured in meters)
+/// It is measured in length units.
 MRMESH_API FillHoleMetric getEdgeLengthStitchMetric( const Mesh& mesh );
 
 /// Forbids connecting vertices from the same hole \n
 /// penalize for large area and face normal deviation from upDir \n
 /// All new faces should be parallel to given direction
-/// The metric is power 4 measure (measured in meters^4)
+/// It is measured in power 4 length units (e.g. meters^4).
 MRMESH_API FillHoleMetric getVerticalStitchMetric( const Mesh& mesh, const Vector3f& upDir );
 
 /// Forbids connecting vertices from the same hole \n
 /// penalize for long edges and its deviation from upDir \n
 /// All new faces should be parallel to given direction
-/// The metric is quadratic (measured in meters^2)
+/// It is measured in squared length units.
 MRMESH_API FillHoleMetric getVerticalStitchMetricEdgeBased( const Mesh& mesh, const Vector3f& upDir );
 
 /// This metric minimizes the sum of triangleMetric for all triangles in the triangulation
@@ -99,16 +99,16 @@ MRMESH_API FillHoleMetric getVerticalStitchMetricEdgeBased( const Mesh& mesh, co
 /// Where\n
 /// triangleMetric is proportional to weighted triangle area and triangle aspect ratio\n
 /// edgeMetric grows with angle between triangles as ( ( 1 - cos( x ) ) / ( 1 + cos( x ) ) ) ^ 4.
-/// The metric is non-dimensional
+/// It is unitless.
 MRMESH_API FillHoleMetric getComplexFillMetric( const Mesh& mesh, EdgeId e );
 
 /// This metric minimizes summary projection of new edges to plane normal, (try do produce edges parallel to plane)
-/// The metric is linear (measured in meters)
+/// It is measured in length units.
 MRMESH_API FillHoleMetric getParallelPlaneFillMetric( const Mesh& mesh, EdgeId e, const Plane3f* plane = nullptr );
 
 /// This metric minimizes the maximal dihedral angle between the faces in the triangulation
 /// and on its boundary
-/// The metric is radial (measured in radians)
+/// It is measured in angle units.
 MRMESH_API FillHoleMetric getMaxDihedralAngleMetric( const Mesh& mesh );
 
 /// This metric consists of two parts
@@ -117,7 +117,7 @@ MRMESH_API FillHoleMetric getMaxDihedralAngleMetric( const Mesh& mesh );
 /// 2) for each edge: square root of double total area of triangles to its left and right
 ///    times the factor depending extensionally on absolute dihedral angle between left and right triangles,
 ///    this makes visually triangulated surface as smooth as possible.
-/// The metric is linear (measured in meters)
+/// It is measured in length units.
 /// For planar holes it is the same as getCircumscribedMetric.
 MRMESH_API FillHoleMetric getUniversalMetric( const Mesh& mesh );
 
@@ -125,13 +125,13 @@ MRMESH_API FillHoleMetric getUniversalMetric( const Mesh& mesh );
 MRMESH_API FillHoleMetric getMinTriAngleMetric( const Mesh& mesh );
 
 /// This metric is for triangulation construction with minimal summed area of triangles.
-/// The metric is quadratic (measured in meters^2)
+/// It is measured in squared length units.
 /// Warning: this metric can produce degenerated triangles
 MRMESH_API FillHoleMetric getMinAreaMetric( const Mesh& mesh );
 
-/// This metric penalize new triangles for getting far from `closeSurface` by projecting candidate face center on `closeSurfce`.
+/// This metric penalizes new triangles for getting far from `closeSurface` by projecting candidate face center on `closeSurfce`.
 /// While slower - it can produce better quality results for patching
-/// The metric is quadratic (measured in meters^2)
+/// It is measured in squared length units.
 MRMESH_API FillHoleMetric getCloseSurfaceFillMetric( const Mesh& mesh, const Mesh& closeSurface );
 
 /// Compose two metrics together:

--- a/source/MRViewer/MRSurfaceManipulationWidget.cpp
+++ b/source/MRViewer/MRSurfaceManipulationWidget.cpp
@@ -404,19 +404,35 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
             {
                 .triangulateParams =
                 {
-                    .metric = getUniversalMetric( *newMesh ),
                     .multipleEdgesResolveMode = FillHoleParams::MultipleEdgesResolveMode::Strong
                 },
                 .subdivideSettings =
                 {
                     .maxEdgeLen = 0.0f // to use 'patchMesh' default
                 },
+                .smoothCurvature = !settings_.flatPatch,
                 .smoothSettings =
                 {
                     .edgeWeights = settings_.edgeWeights,
                     .vmass = settings_.vmass
                 }
             };
+            Mesh patchRefMesh;
+            if ( !settings_.flatPatch )
+            {
+                settings.triangulateParams.metric = getUniversalMetric( *newMesh );
+            }
+            else
+            {
+                patchRefMesh.addMeshPart( { *newMesh,&delFaces } );
+                settings.triangulateParams.metric = mixMetrics(
+                    getCircumscribedMetric( *newMesh ), getCloseSurfaceFillMetric( *newMesh, patchRefMesh ),
+                    [] ( double a, double b )->double
+                    {
+                        return a + 100.0 * std::sqrt( b );
+                    } );
+                //settings.triangulateParams.maxPolygonSubdivisions = 100;
+            }
             settings.subdivideSettings.onEdgeSplit = [&] ( EdgeId e1, EdgeId e )
             {
                 if ( newFaceSelection.test( newMesh->topology.left( e ) ) )

--- a/source/MRViewer/MRSurfaceManipulationWidget.cpp
+++ b/source/MRViewer/MRSurfaceManipulationWidget.cpp
@@ -410,7 +410,7 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
                 {
                     .maxEdgeLen = 0.0f // to use 'patchMesh' default
                 },
-                .smoothCurvature = !settings_.flatPatch,
+                .smoothCurvature = !settings_.mimicPatch,
                 .smoothSettings =
                 {
                     .edgeWeights = settings_.edgeWeights,
@@ -418,7 +418,7 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
                 }
             };
             Mesh patchRefMesh;
-            if ( !settings_.flatPatch )
+            if ( !settings_.mimicPatch )
             {
                 settings.triangulateParams.metric = getUniversalMetric( *newMesh );
             }
@@ -431,7 +431,6 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
                     {
                         return a + 100.0 * std::sqrt( b );
                     } );
-                //settings.triangulateParams.maxPolygonSubdivisions = 100;
             }
             settings.subdivideSettings.onEdgeSplit = [&] ( EdgeId e1, EdgeId e )
             {

--- a/source/MRViewer/MRSurfaceManipulationWidget.h
+++ b/source/MRViewer/MRSurfaceManipulationWidget.h
@@ -54,7 +54,7 @@ public:
         VertexMass vmass = VertexMass::NeiArea; ///< vertex weights for Laplacian and Patch
         bool laplacianBasedAddRemove = false; ///< if true in Add/Remove modes, the modification will be done using Laplacian solver, where the closest vertices will be attracted toward mouse cursor to form ideal ridges or grooves
         bool subdivideGrooves = false; ///< if true in Add/Remove modes, changed parts of mesh will be subdivided on mouse up
-        bool flatPatch = false; ///M if true in Patch mode mixes `CloseSurfaceFillMetric` and disables smoothing
+        bool mimicPatch = false; /// if true in Patch mode mixes `CloseSurfaceFillMetric` and disables smoothing
     };
 
     /// initialize widget according ObjectMesh

--- a/source/MRViewer/MRSurfaceManipulationWidget.h
+++ b/source/MRViewer/MRSurfaceManipulationWidget.h
@@ -54,6 +54,7 @@ public:
         VertexMass vmass = VertexMass::NeiArea; ///< vertex weights for Laplacian and Patch
         bool laplacianBasedAddRemove = false; ///< if true in Add/Remove modes, the modification will be done using Laplacian solver, where the closest vertices will be attracted toward mouse cursor to form ideal ridges or grooves
         bool subdivideGrooves = false; ///< if true in Add/Remove modes, changed parts of mesh will be subdivided on mouse up
+        bool flatPatch = false; ///M if true in Patch mode mixes `CloseSurfaceFillMetric` and disables smoothing
     };
 
     /// initialize widget according ObjectMesh


### PR DESCRIPTION
 - add `mixMetrics` to mix two fill/stitch metric together
 - add `getCloseSurfaceMetric` to prioritize close surface triangulation
 - add `flatPatch` option in `SurfaceManipulationWidget` to preserve sharp angles
<img height="220" alt="image" src="https://github.com/user-attachments/assets/a24a1496-077a-4e2d-a557-b7fc2c4ae217" /> => <img height="220" alt="image" src="https://github.com/user-attachments/assets/99aa8707-620f-48b3-84e5-f4b015fc1ba9" />
