### PR TITLE
Propagate mimic patch to other functions

### DIFF
--- a/source/MRMesh/MRFixSelfIntersections.cpp
+++ b/source/MRMesh/MRFixSelfIntersections.cpp
@@ -153,7 +153,7 @@ Expected<void> fix( Mesh& mesh, const Settings& settings )
     if ( res->none() )
         return {};
 
-    expand( mesh.topology, *res, settings.maxExpand );
+    expand( mesh.topology, *res, std::max( settings.maxExpand, 1 ) );
 
     Settings currentSettings = settings;
     if ( currentSettings.subdivideEdgeLen < FLT_MAX )
@@ -187,7 +187,8 @@ Expected<void> fix( Mesh& mesh, const Settings& settings )
     if ( !res.has_value() )
         return unexpected( res.error() );
 
-    expand( mesh.topology, *res, settings.maxExpand );
+    if ( settings.maxExpand > 0 )
+        expand( mesh.topology, *res, settings.maxExpand );
 
     if ( settings.method == Settings::Method::Relax )
     {
@@ -204,6 +205,9 @@ Expected<void> fix( Mesh& mesh, const Settings& settings )
     else
     {
         auto boundaryEdges = mesh.topology.findLeftBdEdges();
+        Mesh patchRefMesh;
+        if ( settings.mimicPatch )
+            patchRefMesh.addMeshPart( { mesh,&*res } );
         mesh.topology.deleteFaces( *res );
         mesh.topology.deleteFaces( findHoleComplicatingFaces( mesh ) );
         mesh.invalidateCaches();
@@ -230,8 +234,22 @@ Expected<void> fix( Mesh& mesh, const Settings& settings )
             // Fill hole
             // MultipleEdgesResolveMode::Simple should be enough after deleting findHoleComplicatingFaces(...)
             // But if multiple edges appear often, could be changed to MultipleEdgesResolveMode::Strong
-            fillHole( mesh, holes[i].front(), {.metric = getMinAreaMetric(mesh),
-                .multipleEdgesResolveMode = FillHoleParams::MultipleEdgesResolveMode::Simple });
+            FillHoleParams fhParams;
+            if ( settings.mimicPatch )
+            {
+                fhParams.metric = mixMetrics(
+                    getMinAreaMetric( mesh ), getCloseSurfaceFillMetric( mesh, patchRefMesh ),
+                    [] ( double a, double b )->double
+                    {
+                        return a + 1000.0 * b;
+                    } );
+            }
+            else
+            {
+                fhParams.metric = getMinAreaMetric( mesh );
+            }
+            fhParams.multipleEdgesResolveMode = FillHoleParams::MultipleEdgesResolveMode::Simple;
+            fillHole( mesh, holes[i].front(), fhParams );
 
             if ( !reportProgress( sp, float( i + 1 ) / float( holes.size() ) ) )
                 return unexpectedOperationCanceled();

--- a/source/MRMesh/MRFixSelfIntersections.h
+++ b/source/MRMesh/MRFixSelfIntersections.h
@@ -30,6 +30,8 @@ struct Settings
     /// Edge length for subdivision of holes covers (0.0f means auto)
     /// FLT_MAX to disable subdivision
     float subdivideEdgeLen = 0.0f;
+    /// trying to stay close to initial surface when patching
+    bool mimicPatch = false;
     /// Callback function
     ProgressCallback callback = {};
 };

--- a/source/MRMesh/MRFixSelfIntersections.h
+++ b/source/MRMesh/MRFixSelfIntersections.h
@@ -25,7 +25,7 @@ struct Settings
     Method method = Method::Relax;
     /// Maximum relax iterations
     int relaxIterations = 5;
-    /// Maximum expand count (edge steps from self-intersecting faces), should be > 0
+    /// Maximum expand count (edge steps from self-intersecting faces), should be >= 0
     int maxExpand = 3;
     /// Edge length for subdivision of holes covers (0.0f means auto)
     /// FLT_MAX to disable subdivision

--- a/source/MRMesh/MRMeshFixer.cpp
+++ b/source/MRMesh/MRMeshFixer.cpp
@@ -250,20 +250,32 @@ Expected<void> fixMeshDegeneracies( Mesh& mesh, const FixMeshDegeneraciesParams&
     {
         .triangulateParams =
         {
-            .metric = getUniversalMetric( mesh ),
             .multipleEdgesResolveMode = FillHoleParams::MultipleEdgesResolveMode::Strong,
         },
         .subdivideSettings =
         {
             .maxEdgeLen = 0.0f, // to use default from `patchMesh`
             .maxEdgeSplits = 20'000,
-        },
-        .smoothCurvature = true,
-        .smoothSettings =
-        {
-            .edgeWeights = EdgeWeights::Unit // use unit weights to avoid potential laplacian degeneration (which leads to nan coords)
         }
     };
+    Mesh patchRefMesh;
+    if ( params.mimicPatch )
+    {
+        patchRefMesh.addMeshPart( { mesh,&*regRes } );
+        psettings.triangulateParams.metric = mixMetrics(
+                getCircumscribedMetric( mesh ), getCloseSurfaceFillMetric( mesh, patchRefMesh ),
+                [] ( double a, double b )->double
+                {
+                    return a + 100.0 * std::sqrt( b );
+                } );
+        psettings.smoothCurvature = false;
+    }
+    else
+    {
+        psettings.triangulateParams.metric = getUniversalMetric( mesh );
+        psettings.smoothCurvature = true;
+        psettings.smoothSettings.edgeWeights = EdgeWeights::Unit; // use unit weights to avoid potential laplacian degeneration (which leads to nan coords)
+    }
 
     auto newFaces = patchMesh( mesh, *regRes, psettings );
 

--- a/source/MRMesh/MRMeshFixer.h
+++ b/source/MRMesh/MRMeshFixer.h
@@ -66,6 +66,10 @@ struct FixMeshDegeneraciesParams
         RemeshPatch ///< if both decimation and subdivision does not succeed, removes degenerate areas and fills occurred holes
     } mode{ Mode::Remesh };
 
+    /// trying to stay close to initial surface when patching
+    /// also disables smoothing on patch
+    bool mimicPatch = false;
+
     ProgressCallback cb;
 };
 


### PR DESCRIPTION
 - add `mimic` option to self-intersection fixer
 - add `mimic` option to degeneracies fixer
 - allow zero expand for self-intersection fixer