### PR TITLE
.github/actions/get-aws-instance-type: load instance life cycle

### DIFF
--- a/.github/actions/get-aws-instance-type/action.yml
+++ b/.github/actions/get-aws-instance-type/action.yml
@@ -46,8 +46,8 @@ runs:
             $InstanceType = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-type" -Headers @{ "X-aws-ec2-metadata-token" = $Token }
             $InstanceLifeCycle = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-life-cycle" -Headers @{ "X-aws-ec2-metadata-token" = $Token }
             # if not an EC2 instance
-            $InstanceType ??= "self-hosted"
-            $InstanceLifeCycle ??= "self-hosted"
+            if ($null -eq $InstanceType) { $InstanceType = "self-hosted" }
+            if ($null -eq $InstanceLifeCycle) { $InstanceType = "self-hosted" }
             # https://github.com/actions/runner-images/issues/5251#issuecomment-1071030822
             echo "AWS_INSTANCE_TYPE=$InstanceType" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
             echo "AWS_INSTANCE_LIFE_CYCLE=$InstanceLifeCycle" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/actions/get-aws-instance-type/action.yml
+++ b/.github/actions/get-aws-instance-type/action.yml
@@ -17,11 +17,6 @@ runs:
             -H "X-aws-ec2-metadata-token: $TOKEN" \
             "http://169.254.169.254/latest/meta-data/instance-type" 2>/dev/null || true)
           
-          # if not an EC2 instance
-          if test -z "$AWS_INSTANCE_TYPE" ; then
-            AWS_INSTANCE_TYPE="self-hosted"
-          fi
-
           echo "AWS_INSTANCE_TYPE=$AWS_INSTANCE_TYPE" >> $GITHUB_ENV
           echo $AWS_INSTANCE_TYPE
 
@@ -30,10 +25,6 @@ runs:
             -H "X-aws-ec2-metadata-token: $TOKEN" \
             "http://169.254.169.254/latest/meta-data/instance-life-cycle" 2>/dev/null || true)
           
-          if test -z "$AWS_INSTANCE_LIFE_CYCLE" ; then
-            AWS_INSTANCE_LIFE_CYCLE="self-hosted"
-          fi
-
           echo "AWS_INSTANCE_LIFE_CYCLE=$AWS_INSTANCE_LIFE_CYCLE" >> $GITHUB_ENV
           echo $AWS_INSTANCE_LIFE_CYCLE
 

--- a/.github/actions/get-aws-instance-type/action.yml
+++ b/.github/actions/get-aws-instance-type/action.yml
@@ -39,7 +39,6 @@ runs:
 
     - name: Get AWS instance type (Windows)
       if: ${{ runner.os == 'Windows' }}
-      shell: powershell
       run: |
         try {
             $Token = Invoke-RestMethod -Uri "http://169.254.169.254/latest/api/token" -Method PUT -Headers @{ "X-aws-ec2-metadata-token-ttl-seconds" = "10" }

--- a/.github/actions/get-aws-instance-type/action.yml
+++ b/.github/actions/get-aws-instance-type/action.yml
@@ -39,6 +39,7 @@ runs:
 
     - name: Get AWS instance type (Windows)
       if: ${{ runner.os == 'Windows' }}
+      shell: powershell
       run: |
         try {
             $Token = Invoke-RestMethod -Uri "http://169.254.169.254/latest/api/token" -Method PUT -Headers @{ "X-aws-ec2-metadata-token-ttl-seconds" = "10" }

--- a/.github/actions/get-aws-instance-type/action.yml
+++ b/.github/actions/get-aws-instance-type/action.yml
@@ -17,8 +17,25 @@ runs:
             -H "X-aws-ec2-metadata-token: $TOKEN" \
             "http://169.254.169.254/latest/meta-data/instance-type" 2>/dev/null || true)
           
+          # if not an EC2 instance
+          if test -z "$AWS_INSTANCE_TYPE" ; then
+            AWS_INSTANCE_TYPE="self-hosted"
+          fi
+
           echo "AWS_INSTANCE_TYPE=$AWS_INSTANCE_TYPE" >> $GITHUB_ENV
           echo $AWS_INSTANCE_TYPE
+
+          # spot or on-demand
+          AWS_INSTANCE_LIFE_CYCLE=$(curl -fsS --max-time 2 --connect-timeout 1 \
+            -H "X-aws-ec2-metadata-token: $TOKEN" \
+            "http://169.254.169.254/latest/meta-data/instance-life-cycle" 2>/dev/null || true)
+          
+          if test -z "$AWS_INSTANCE_LIFE_CYCLE" ; then
+            AWS_INSTANCE_LIFE_CYCLE="self-hosted"
+          fi
+
+          echo "AWS_INSTANCE_LIFE_CYCLE=$AWS_INSTANCE_LIFE_CYCLE" >> $GITHUB_ENV
+          echo $AWS_INSTANCE_LIFE_CYCLE
 
     - name: Get AWS instance type (Windows)
       if: ${{ runner.os == 'Windows' }}
@@ -27,8 +44,14 @@ runs:
         try {
             $Token = Invoke-RestMethod -Uri "http://169.254.169.254/latest/api/token" -Method PUT -Headers @{ "X-aws-ec2-metadata-token-ttl-seconds" = "10" }
             $InstanceType = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-type" -Headers @{ "X-aws-ec2-metadata-token" = $Token }
+            $InstanceLifeCycle = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-life-cycle" -Headers @{ "X-aws-ec2-metadata-token" = $Token }
+            # if not an EC2 instance
+            $InstanceType ??= "self-hosted"
+            $InstanceLifeCycle ??= "self-hosted"
             # https://github.com/actions/runner-images/issues/5251#issuecomment-1071030822
             echo "AWS_INSTANCE_TYPE=$InstanceType" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            echo "AWS_INSTANCE_LIFE_CYCLE=$InstanceLifeCycle" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
             Write-Output $InstanceType
+            Write-Output $InstanceLifeCycle
         } catch { Write-Warning -Message "Error returned! $_" }
         


### PR DESCRIPTION
sets `AWS_INSTANCE_LIFE_CYCLE=spot or on-demand` if executed on AWS runners.
