### PR TITLE
ci: split emscripten image into 3 per-variant images

### DIFF
--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -18,23 +18,29 @@ jobs:
     timeout-minutes: 40
     runs-on: ubuntu-24.04-arm
     container:
-      image: meshlib/meshlib-emscripten-arm64:${{ inputs.docker_image_tag }}
+      # Three separate per-variant images are built by prepare-images.yml
+      # (see emscripten-image-build-upload). Each job pulls only the variant
+      # it needs, roughly halving the container-init time.
+      image: meshlib/meshlib-emscripten-arm64-${{ matrix.image-variant }}:${{ inputs.docker_image_tag }}
     strategy:
       fail-fast: false
       matrix:
         config: [Singlethreaded, Multithreaded, Multithreaded-64Bit]
         include:
           - config: Singlethreaded
+            image-variant: single
             target_name: emscripten-singlethreaded
             package_name: emscripten-singlethreaded
             thirdparty-dir: emscripten-single
             aws-dir: RMISingle
           - config: Multithreaded
+            image-variant: multi
             target_name: emscripten
             package_name: emscripten-multithreaded
             thirdparty-dir: emscripten
             aws-dir: RMI
           - config: Multithreaded-64Bit
+            image-variant: wasm64
             target_name: emscripten-wasm64
             package_name: emscripten-multithreaded-64bit
             thirdparty-dir: emscripten-wasm64

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -41,11 +41,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [ ubuntu22, ubuntu24, emscripten ]
+        distro: [ ubuntu22, ubuntu24 ]
         arch: [ x64, arm64 ]
-        exclude:
-          - distro: emscripten
-            arch: x64
         include:
           - arch: x64
             image-suffix: ''
@@ -96,6 +93,59 @@ jobs:
         run: docker build -f ./docker/${{ env.dockerfile }} -t ${{ env.image }} . --progress=plain
 
       - name: Push Linux image
+        run: docker push ${{ env.image }}
+
+      - name: Remove unused Docker data
+        run: docker system prune --force --all --volumes
+
+  emscripten-image-build-upload:
+    # Build the three Emscripten thirdparty variants (multi, single, wasm64) as
+    # independent images in parallel. Each consumer job pulls only its variant,
+    # which is ~40-50% of the previous combined image and cuts the
+    # "Initialize containers" step accordingly (extraction was the dominant cost).
+    if: ${{ inputs.need_linux_image_rebuild }}
+    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [ multi, single, wasm64 ]
+    runs-on: ubuntu-24.04-arm
+    env:
+      image: meshlib/meshlib-emscripten-arm64-${{ matrix.variant }}:${{ inputs.docker_image_tag }}
+    steps:
+      - name: Work-around possible permission issues
+        shell: bash
+        run: |
+          # NOTE: {GITHUB_WORKSPACE} != {{ github.workspace }}
+          # Related issue: https://github.com/actions/runner/issues/2058
+          if test -d $GITHUB_WORKSPACE && test -n "$(find ${GITHUB_WORKSPACE} -user root)" ; then
+            mv ${GITHUB_WORKSPACE} ${GITHUB_WORKSPACE}_${RANDOM}
+            mkdir ${GITHUB_WORKSPACE}
+          fi
+
+      - name: Remove unused Docker data
+        run: docker system prune --force --all --volumes
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: meshlib
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Emscripten image
+        run: |
+          docker build \
+            -f ./docker/emscriptenDockerfile \
+            --build-arg VARIANT=${{ matrix.variant }} \
+            -t ${{ env.image }} \
+            . --progress=plain
+
+      - name: Push Emscripten image
         run: docker push ${{ env.image }}
 
       - name: Remove unused Docker data

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -1,5 +1,13 @@
 FROM emscripten/emsdk:4.0.10-arm64
 
+# Which thirdparty variant to build into this image. Built and pushed as three
+# separate images (-single, -multi, -wasm64) by prepare-images.yml; each CI job
+# pulls only the variant it needs, keeping the image ~40-50% smaller and the
+# "Initialize containers" step proportionally faster.
+#
+# Valid values: multi | single | wasm64
+ARG VARIANT=multi
+
 # Update and install req
 # install yaru-theme-icon to fix `Icon 'dialog-warning' not present in theme Yaru: 'glib warning'` while testing
 RUN export DEBIAN_FRONTEND=noninteractive; \
@@ -27,25 +35,24 @@ WORKDIR "/home/MeshLib"
 #copy files
 COPY . .
 
-#build thirdparty
+# Build only the thirdparty variant requested by the VARIANT build-arg.
+# Each image ends up with exactly one /usr/local/lib/emscripten{,-single,-wasm64}
+# tree, and matching env defaults so downstream scripts don't need to know
+# which variant is installed.
 ENV MR_STATE=DOCKER_BUILD
 ENV MR_EMSCRIPTEN=ON
-RUN ./scripts/build_thirdparty.sh && \
-    ./scripts/cmake_install.sh /usr/local/lib/emscripten && \
-    rm -rf bin include lib share thirdparty_build
-
-ENV MR_EMSCRIPTEN_SINGLE=ON
-RUN ./scripts/build_thirdparty.sh && \
-    ./scripts/cmake_install.sh /usr/local/lib/emscripten-single && \
-    rm -rf bin include lib share thirdparty_build
-
-ENV MR_EMSCRIPTEN_SINGLE=OFF
-ENV MR_EMSCRIPTEN_WASM64=ON
-RUN ./scripts/build_thirdparty.sh && \
-    ./scripts/cmake_install.sh /usr/local/lib/emscripten-wasm64 && \
-    rm -rf bin include lib share thirdparty_build
-
-ENV MR_EMSCRIPTEN_WASM64=OFF
+ARG VARIANT
+RUN case "${VARIANT}" in \
+      multi)  INSTALL_DIR=/usr/local/lib/emscripten;        SINGLE=OFF; WASM64=OFF ;; \
+      single) INSTALL_DIR=/usr/local/lib/emscripten-single; SINGLE=ON;  WASM64=OFF ;; \
+      wasm64) INSTALL_DIR=/usr/local/lib/emscripten-wasm64; SINGLE=OFF; WASM64=ON  ;; \
+      *) echo "Unknown VARIANT='${VARIANT}' (expected multi|single|wasm64)" >&2; exit 1 ;; \
+    esac \
+ && export MR_EMSCRIPTEN_SINGLE="${SINGLE}" \
+ && export MR_EMSCRIPTEN_WASM64="${WASM64}" \
+ && ./scripts/build_thirdparty.sh \
+ && ./scripts/cmake_install.sh "${INSTALL_DIR}" \
+ && rm -rf bin include lib share thirdparty_build
 
 # install aws cli
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
## Why

The current \`meshlib-emscripten-arm64\` image bundles all three thirdparty variants (multi, single, wasm64) into one ~1.76 GB image. Every matrix job pulls and extracts all three even though it uses only one. On \`ubuntu-24.04-arm\` runners, extraction is sequential and dominates the \`Initialize containers\` step (~180 s), making the bundled image the slowest CI container to initialize by a wide margin.

Per the post-mortem on PR #5925: the registry switch alone couldn't move the needle because the bottleneck was layer extraction, not network transfer. This PR targets the actual bottleneck.

## What

Parametrize the Dockerfile with a \`VARIANT\` build-arg and produce three independent images:

- \`meshlib-emscripten-arm64-multi\`
- \`meshlib-emscripten-arm64-single\`
- \`meshlib-emscripten-arm64-wasm64\`

Each contains exactly one \`/usr/local/lib/emscripten{,-single,-wasm64}\` tree. Downstream paths in \`build-test-emscripten.yml\` (\`thirdparty-dir\` matrix entries, \`cmake_install\` locations, \`Create Package\` copy) need no changes - only the \`container.image:\` line and a new \`image-variant\` matrix field.

### Files changed

- **\`docker/emscriptenDockerfile\`** - replace three sequential thirdparty builds with a single \`case/esac\` block driven by \`ARG VARIANT\`. Default is \`multi\` so local \`docker build\` still works.
- **\`.github/workflows/prepare-images.yml\`** - drop emscripten from \`linux-image-build-upload\` (now ubuntu22/24 only) and add a dedicated \`emscripten-image-build-upload\` job with a 3-entry variant matrix. All three images build in parallel on separate ARM64 runners instead of sequentially on one.
- **\`.github/workflows/build-test-emscripten.yml\`** - matrix gains an \`image-variant\` field (\`single|multi|wasm64\`) mapped 1:1 to the three \`config\` entries; \`container.image\` picks the correct per-variant image.

## Expected impact

| Metric | Before | Expected | Mechanism |
|---|---|---|---|
| Image size (compressed) | ~1.76 GB | ~0.9-1.1 GB | 1 thirdparty layer instead of 3 |
| \`Initialize containers\` | ~180 s | ~90-120 s | ~⅓ fewer bytes to extract, 1 large layer instead of 3 |
| \`prepare-images\` wall time | 3 builds sequential in 1 job | 3 builds parallel in 3 jobs | matrix fan-out |
| Storage on Docker Hub | 1 image × ~1.76 GB | 3 images × ~0.9-1.1 GB ≈ 3 GB | base layers dedup across the 3 images in Docker's blob store but not in displayed sizes |

## Ops / rollout

- **First rebuild creates the 3 new images.** Until then, any PR referencing the new names will fail with \`manifest unknown\`. Standard path: merge + bump \`docker_image_tag\` or run \`prepare-images.yml\` manually with \`need_linux_image_rebuild: true\`.
- **Old \`meshlib-emscripten-arm64\` image is no longer produced** by this workflow. It remains on Docker Hub indefinitely (nothing deletes it); safe to purge later via Docker Hub UI.
- **Rollback:** reverting this commit restores the combined-image flow without touching registries.

## Orthogonal to PR #5925

This PR branches from \`master\` and does not include the GHCR mirror changes. If #5925 lands first, the GHCR push pattern is trivially copyable to the new \`emscripten-image-build-upload\` job. If this lands first, #5925's approach extends cleanly.

## Follow-ups (not in this PR)

- The \`awscli-exe-linux-x86_64.zip\` install in the Dockerfile downloads an **x86_64** binary on an **arm64** image (\`docker/emscriptenDockerfile:51\`). That binary won't run - either drop it or switch to the aarch64 URL. Worth a separate small PR.
- Same split pattern could be applied to vcpkg images if we ever observe similar extraction pain on rockylinux8 images.