### PR TITLE
Support several objects in ImGuiMenu::drawTransform_

### DIFF
--- a/source/MRViewer/ImGuiMenu.cpp
+++ b/source/MRViewer/ImGuiMenu.cpp
@@ -2705,75 +2705,149 @@ void ImGuiMenu::drawTagInformation_( const std::vector<std::shared_ptr<Object>>&
     ImGui::PopStyleColor();
 }
 
+void ImGuiMenu::drawMixedTransformField_( const char* labelId, int columns, const char* trailingLabel )
+{
+    // Long-dash (em-dash) rendered in a read-only box per column; used when selected objects
+    // have differing transforms, so the field communicates "values differ" and cannot be edited.
+    static const std::string kDash = "\xE2\x80\x94";
+    const float w = getSceneInfoItemWidth_( columns );
+    for ( int i = 0; i < columns; ++i )
+    {
+        if ( i )
+            ImGui::SameLine( 0, ImGui::GetStyle().ItemInnerSpacing.x );
+        const std::string label = ( i == columns - 1 && trailingLabel && *trailingLabel )
+            ? fmt::format( "{}##{}{}", trailingLabel, labelId, i )
+            : fmt::format( "##{}{}", labelId, i );
+        UI::inputTextCenteredReadOnly( label.c_str(), kDash, w );
+    }
+}
+
+std::shared_ptr<CombinedHistoryAction> ImGuiMenu::makeObjectsXfHistoryAction_(
+    const std::string& name,
+    const std::vector<std::shared_ptr<Object>>& objs ) const
+{
+    std::vector<std::shared_ptr<HistoryAction>> subs;
+    subs.reserve( objs.size() );
+    for ( const auto& o : objs )
+        subs.push_back( std::make_shared<ChangeXfAction>( name, o ) );
+    return std::make_shared<CombinedHistoryAction>( name, subs );
+}
+
+void ImGuiMenu::applyXfToObjects_(
+    const AffineXf3f& xf,
+    const std::vector<std::shared_ptr<Object>>& objs )
+{
+    for ( const auto& o : objs )
+        o->setXf( xf );
+}
+
 float ImGuiMenu::drawTransform_()
 {
-    const auto& selected = SceneCache::getAllObjects<Object, ObjectSelectivityType::Selected>();
+    // Use topmost-selected objects so that when a parent and its child are both selected,
+    // only the parent is edited — otherwise applying the same xf to both would move the
+    // child twice (once through its own xf, once through the parent's cascade).
+    const auto& selected = SceneCache::getAllTopmostObjects<Object, ObjectSelectivityType::Selected>();
+
+    // Hide the panel if nothing is selected or any selected object is locked —
+    // a generalisation of the original single-object `!selected[0]->isLocked()` gate.
+    const bool canShow = !selected.empty()
+        && std::none_of( selected.begin(), selected.end(),
+            []( const auto& o ){ return o->isLocked(); } );
+    if ( !canShow )
+    {
+        transformBlockShown_ = false;
+        return 0.f;
+    }
 
     auto& style = ImGui::GetStyle();
 
-    float resultHeight_ = 0.f;
-    if ( selected.size() == 1 && !selected[0]->isLocked() )
+    // Fix up the scene-list scroll on the frame the transform block first appears, so the
+    // selected row stays in view as the properties panel grows by the block's height.
+    if ( !transformBlockShown_ )
     {
-        if ( !selectionChangedToSingleObj_ )
-        {
-            selectionChangedToSingleObj_ = true;
-            sceneObjectsList_->setNextFrameFixScroll();
-        }
-        resultHeight_ = ImGui::GetTextLineHeight() + style.FramePadding.y * 2 + style.ItemSpacing.y;
-        bool openedContext = false;
-        if ( drawCollapsingHeaderTransform_() )
-        {
-            openedContext = drawTransformContextMenu_( selected[0] );
-            const float transformHeight = ( ImGui::GetTextLineHeight() + style.FramePadding.y * 2 ) * 3 + style.ItemSpacing.y * 2;
-            resultHeight_ += transformHeight + style.ItemSpacing.y;
-            ImGui::BeginChild( "SceneTransform", ImVec2( 0, transformHeight ) );
-            auto& data = *selected.front();
+        transformBlockShown_ = true;
+        sceneObjectsList_->setNextFrameFixScroll();
+    }
 
-            auto xf = data.xf();
-            Matrix3f q, r;
+    // When transforms differ across the selection, we display "—" in the fields, do not
+    // enter the editing path, and do not open the context menu — its Copy/Paste/Reset
+    // operations assume a single shared xf to read from and write back to.
+    const AffineXf3f& xf0 = selected.front()->xf();
+    const bool allSame = std::all_of( selected.begin() + 1, selected.end(),
+        [&]( const auto& o ){ return o->xf() == xf0; } );
+
+    float resultHeight_ = ImGui::GetTextLineHeight() + style.FramePadding.y * 2 + style.ItemSpacing.y;
+    bool openedContext = false;
+    if ( drawCollapsingHeaderTransform_() )
+    {
+        openedContext = drawTransformContextMenu_( selected );
+        const float transformHeight = ( ImGui::GetTextLineHeight() + style.FramePadding.y * 2 ) * 3 + style.ItemSpacing.y * 2;
+        resultHeight_ += transformHeight + style.ItemSpacing.y;
+        ImGui::BeginChild( "SceneTransform", ImVec2( 0, transformHeight ) );
+
+        auto xf = xf0;
+        Matrix3f q, r;
+        Vector3f euler;
+        Vector3f scale;
+        if ( allSame )
+        {
             decomposeMatrix3( xf.A, q, r );
+            euler = ( 180 / PI_F ) * q.toEulerAngles();
+            scale = Vector3f{ r.x.x, r.y.y, r.z.z };
+        }
 
-            auto euler = ( 180 / PI_F ) * q.toEulerAngles();
-            Vector3f scale{ r.x.x, r.y.y, r.z.z };
+        bool inputDeactivated = false;
+        bool inputChanged = false;
 
-            bool inputDeactivated = false;
-            bool inputChanged = false;
+        ImGui::PushItemWidth( getSceneInfoItemWidth_( 3 ) );
+        if ( !allSame )
+        {
+            // Mixed: render "—" in the same column layout the drag widgets would use.
+            drawMixedTransformField_( "scaleMixed", uniformScale_ ? 1 : 3 );
+            ImGui::SameLine( 0, uniformScale_
+                ? ImGui::GetStyle().ItemSpacing.x
+                : ImGui::GetStyle().ItemInnerSpacing.x );
+        }
+        else if ( uniformScale_ )
+        {
+            float midScale = ( scale.x + scale.y + scale.z ) / 3.0f;
+            ImGui::SetNextItemWidth( getSceneInfoItemWidth_() );
+            inputChanged = UI::drag<NoUnit>( "##scaleX", midScale, midScale * 0.01f, 1e-3f, 1e+6f );
+            if ( inputChanged )
+                scale.x = scale.y = scale.z = midScale;
+            inputDeactivated = inputDeactivated || ImGui::IsItemDeactivatedAfterEdit();
+            ImGui::SameLine();
+        }
+        else
+        {
+            inputChanged = UI::drag<NoUnit>( "##scaleX", scale.x, scale.x * 0.01f, 1e-3f, 1e+6f );
+            inputDeactivated = inputDeactivated || ImGui::IsItemDeactivatedAfterEdit();
+            ImGui::SameLine( 0, ImGui::GetStyle().ItemInnerSpacing.x );
+            inputChanged = UI::drag<NoUnit>( "##scaleY", scale.y, scale.y * 0.01f, 1e-3f, 1e+6f ) || inputChanged;
+            inputDeactivated = inputDeactivated || ImGui::IsItemDeactivatedAfterEdit();
+            ImGui::SameLine( 0, ImGui::GetStyle().ItemInnerSpacing.x );
+            inputChanged = UI::drag<NoUnit>( "##scaleZ", scale.z, scale.z * 0.01f, 1e-3f, 1e+6f ) || inputChanged;
+            inputDeactivated = inputDeactivated || ImGui::IsItemDeactivatedAfterEdit();
+            ImGui::SameLine( 0, ImGui::GetStyle().ItemInnerSpacing.x );
+        }
 
-            ImGui::PushItemWidth( getSceneInfoItemWidth_( 3 ) );
-            if ( uniformScale_ )
-            {
-                float midScale = ( scale.x + scale.y + scale.z ) / 3.0f;
-                ImGui::SetNextItemWidth( getSceneInfoItemWidth_() );
-                inputChanged = UI::drag<NoUnit>( "##scaleX", midScale, midScale * 0.01f, 1e-3f, 1e+6f );
-                if ( inputChanged )
-                    scale.x = scale.y = scale.z = midScale;
-                inputDeactivated = inputDeactivated || ImGui::IsItemDeactivatedAfterEdit();
-                ImGui::SameLine();
-            }
-            else
-            {
-                inputChanged = UI::drag<NoUnit>( "##scaleX", scale.x, scale.x * 0.01f, 1e-3f, 1e+6f );
-                inputDeactivated = inputDeactivated || ImGui::IsItemDeactivatedAfterEdit();
-                ImGui::SameLine( 0, ImGui::GetStyle().ItemInnerSpacing.x );
-                inputChanged = UI::drag<NoUnit>( "##scaleY", scale.y, scale.y * 0.01f, 1e-3f, 1e+6f ) || inputChanged;
-                inputDeactivated = inputDeactivated || ImGui::IsItemDeactivatedAfterEdit();
-                ImGui::SameLine( 0, ImGui::GetStyle().ItemInnerSpacing.x );
-                inputChanged = UI::drag<NoUnit>( "##scaleZ", scale.z, scale.z * 0.01f, 1e-3f, 1e+6f ) || inputChanged;
-                inputDeactivated = inputDeactivated || ImGui::IsItemDeactivatedAfterEdit();
-                ImGui::SameLine( 0, ImGui::GetStyle().ItemInnerSpacing.x );
-            }
+        auto ctx = ImGui::GetCurrentContext();
+        assert( ctx );
+        auto window = ctx->CurrentWindow;
+        assert( window );
+        auto diff = ImGui::GetStyle().FramePadding.y - cCheckboxPadding * UI::scale();
+        ImGui::SetCursorPosY( ImGui::GetCursorPosY() + diff );
+        UI::checkbox( _tr( "Uni-scale" ), &uniformScale_ );
+        window->DC.CursorPosPrevLine.y -= diff;
+        UI::setTooltipIfHovered( _tr( "Selects between uniform scaling or separate scaling along each axis" ) );
+        ImGui::PopItemWidth();
 
-            auto ctx = ImGui::GetCurrentContext();
-            assert( ctx );
-            auto window = ctx->CurrentWindow;
-            assert( window );
-            auto diff = ImGui::GetStyle().FramePadding.y - cCheckboxPadding * UI::scale();
-            ImGui::SetCursorPosY( ImGui::GetCursorPosY() + diff );
-            UI::checkbox( _tr( "Uni-scale" ), &uniformScale_ );
-            window->DC.CursorPosPrevLine.y -= diff;
-            UI::setTooltipIfHovered( _tr( "Selects between uniform scaling or separate scaling along each axis" ) );
-            ImGui::PopItemWidth();
-
+        if ( !allSame )
+        {
+            drawMixedTransformField_( "rotationMixed", 3, _tr( "Rotation XYZ" ) );
+        }
+        else
+        {
             ImGui::SetNextItemWidth( getSceneInfoItemWidth_() );
             bool rotationChanged = UI::drag<AngleUnit>( _tr( "Rotation XYZ" ), euler, invertedRotation_ ? -0.1f : 0.1f, -360.f, 360.f, { .sourceUnit = AngleUnit::degrees } );
             bool rotationDeactivatedAfterEdit = ImGui::IsItemDeactivatedAfterEdit();
@@ -2806,7 +2880,14 @@ float ImGuiMenu::drawTransform_()
             euler.y = std::clamp( euler.y, -90.0f + 2.0f * cZenithEps, 90.0f - 2.0f * cZenithEps );
             if ( inputChanged )
                 xf.A = Matrix3f::rotationFromEuler( ( PI_F / 180 ) * euler ) * Matrix3f::scale( scale );
+        }
 
+        if ( !allSame )
+        {
+            drawMixedTransformField_( "translationMixed", 3, _tr( "Translation" ) );
+        }
+        else
+        {
             const auto trSpeed = ( selectionLocalBox_.valid() && selectionLocalBox_.diagonal() > std::numeric_limits<float>::epsilon() ) ? 0.003f * selectionLocalBox_.diagonal() : 0.003f;
 
             ImGui::SetNextItemWidth( getSceneInfoItemWidth_() );
@@ -2824,24 +2905,21 @@ float ImGuiMenu::drawTransform_()
             if ( xfHistUpdated_ )
                 xfHistUpdated_ = !inputDeactivated;
 
-            if ( xf != data.xf() && !xfHistUpdated_ )
+            if ( xf != xf0 && !xfHistUpdated_ )
             {
-                AppendHistory<ChangeXfAction>( _t( "Manual Change Transform" ), selected[0] );
+                // One combined history entry per drag, regardless of how many objects
+                // were selected — so Ctrl+Z reverts them all in one step.
+                AppendHistory( makeObjectsXfHistoryAction_( _t( "Manual Change Transform" ), selected ) );
                 xfHistUpdated_ = true;
             }
-            data.setXf( xf );
-            ImGui::EndChild();
-            if ( !openedContext )
-                openedContext = drawTransformContextMenu_( selected[0] );
+            applyXfToObjects_( xf, selected );
         }
+        ImGui::EndChild();
         if ( !openedContext )
-            drawTransformContextMenu_( selected[0] );
+            openedContext = drawTransformContextMenu_( selected );
     }
-    else
-    {
-        if ( selectionChangedToSingleObj_ )
-            selectionChangedToSingleObj_ = false;
-    }
+    if ( !openedContext )
+        drawTransformContextMenu_( selected );
 
     return resultHeight_;
 }

--- a/source/MRViewer/ImGuiMenu.h
+++ b/source/MRViewer/ImGuiMenu.h
@@ -24,6 +24,7 @@ class MeshModifier;
 struct UiRenderManager;
 class SceneObjectsListDrawer;
 class ObjectComparableWithReference;
+class CombinedHistoryAction;
 
 enum class SelectedTypesMask
 {
@@ -132,8 +133,10 @@ protected:
       Quad // left lower vp, left upper vp, right lower vp, right upper vp
   } viewportConfig_{ Single };
 
-  // flag to correctly update scroll on transform window appearing
-  bool selectionChangedToSingleObj_{ false };
+  // Tracks whether the transform block is currently being drawn in the scene info panel.
+  // On the false→true transition (i.e. the block just appeared) the scene-list scroll is
+  // fixed up so the selected row stays in view as the properties panel grows.
+  bool transformBlockShown_{ false };
   // menu will change objects' colors in this viewport
   ViewportId selectedViewport_ = {};
 
@@ -410,7 +413,27 @@ protected:
 
     MRVIEWER_API float drawTransform_();
 
-    MRVIEWER_API virtual bool drawTransformContextMenu_( const std::shared_ptr<Object>& /*selected*/ ) { return false; }
+    // Draws a read-only row of long-dashes ("—") matching the column layout of `UI::drag`;
+    // used in drawTransform_ when the selection's transforms are not all equal.
+    // `trailingLabel`, if non-null, is shown to the right of the last column (matches the
+    // label rendering of the editable `UI::drag` widgets).
+    MRVIEWER_API void drawMixedTransformField_( const char* labelId, int columns, const char* trailingLabel = nullptr );
+
+    // Builds one ChangeXfAction per object and wraps them in a single CombinedHistoryAction,
+    // so a multi-object transform edit goes into the history as a single undoable step.
+    MRVIEWER_API std::shared_ptr<CombinedHistoryAction> makeObjectsXfHistoryAction_(
+        const std::string& name,
+        const std::vector<std::shared_ptr<Object>>& objs ) const;
+
+    // Applies the same transform to every object in objs.
+    MRVIEWER_API void applyXfToObjects_(
+        const AffineXf3f& xf,
+        const std::vector<std::shared_ptr<Object>>& objs );
+
+    // Context menu for the transform panel. Invoked for the whole selection — caller guarantees
+    // all passed objects share the same xf, so Copy/Save read from the first and Paste/Load/Reset
+    // apply to every object under one combined history entry.
+    MRVIEWER_API virtual bool drawTransformContextMenu_( const std::vector<std::shared_ptr<Object>>& /*selected*/ ) { return false; }
 
     // A virtual function for drawing of the dialog with shortcuts. It can be overriden in the inherited classes
     MRVIEWER_API virtual void drawShortcutsWindow_();

--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -46,6 +46,7 @@
 #include <MRPch/MRWasm.h>
 #include "MRGladGlfw.h"
 #include "MRImGuiMultiViewport.h"
+#include "MRMesh/MRCombinedHistoryAction.h"
 #include <imgui_internal.h> // needed here to fix items dialogs windows positions
 #include <misc/freetype/imgui_freetype.h> // for proper font loading
 #include <regex>
@@ -1848,18 +1849,21 @@ bool RibbonMenu::drawCollapsingHeaderTransform_()
     UI::setTooltipIfHovered( _tr( "Open Transform Data context menu." ) );
     iconsFont.pushFont();
 
-    const auto& selectedObjectsCache = SceneCache::getAllObjects<const Object, ObjectSelectivityType::Selected>();
-    if ( numButtons >= 2.0f && selectedObjectsCache.size() == 1 && selectedObjectsCache.front()->xf() != AffineXf3f() )
+    // Reset / Apply write to every topmost-selected object (matching drawTransform_), so the
+    // header buttons stay in sync with the main transform panel. The availability check for
+    // "Apply Transform" still uses the full selected set — that's the ribbon item's own domain.
+    const auto& topmostSelected = SceneCache::getAllTopmostObjects<Object, ObjectSelectivityType::Selected>();
+    const bool anyNonIdentity = std::any_of( topmostSelected.begin(), topmostSelected.end(),
+        []( const auto& o ){ return o->xf() != AffineXf3f(); } );
+    if ( numButtons >= 2.0f && !topmostSelected.empty() && anyNonIdentity )
     {
-        auto obj = std::const_pointer_cast< Object >( selectedObjectsCache.front() );
-        assert( obj );
         contextBtnPos.x -= smallBtnSize.x;
         ImGui::SetCursorPos( contextBtnPos );
 
         if ( ImGui::Button( "\xef\x80\x8d", smallBtnSize ) ) // X(cross) icon for reset
         {
-            AppendHistory<ChangeXfAction>( _t( "Reset Transform" ), obj );
-            obj->setXf( AffineXf3f() );
+            AppendHistory( makeObjectsXfHistoryAction_( _t( "Reset Transform" ), topmostSelected ) );
+            applyXfToObjects_( AffineXf3f(), topmostSelected );
         }
         iconsFont.popFont();
         UI::setTooltipIfHovered( _tr( "Resets transform value to identity." ) );
@@ -1868,7 +1872,7 @@ bool RibbonMenu::drawCollapsingHeaderTransform_()
         auto item = RibbonSchemaHolder::schema().items.find( "Apply Transform" );
         bool drawApplyBtn = numButtons >=3.0f &&
             item != RibbonSchemaHolder::schema().items.end() &&
-            item->second.item->isAvailable( selectedObjectsCache ).empty();
+            item->second.item->isAvailable( SceneCache::getAllObjects<const Object, ObjectSelectivityType::Selected>() ).empty();
 
         if ( drawApplyBtn )
         {
@@ -1888,10 +1892,22 @@ bool RibbonMenu::drawCollapsingHeaderTransform_()
     return res;
 }
 
-bool RibbonMenu::drawTransformContextMenu_( const std::shared_ptr<Object>& selected )
+bool RibbonMenu::drawTransformContextMenu_( const std::vector<std::shared_ptr<Object>>& selected )
 {
     if ( !ImGui::BeginPopupContextItem( cTransformContextName ) )
         return false;
+
+    assert( !selected.empty() );
+
+    // When selected objects share a common xf we can read it for Copy / Save-to-file;
+    // when they differ, those read-the-xf buttons are disabled but write-to-all buttons
+    // (Paste / Load / Reset / Apply) still work because they don't need a shared source value.
+    const auto& startXf = selected.front()->xf();
+    const bool allSame = std::all_of( selected.begin() + 1, selected.end(),
+        [&]( const auto& o ){ return o->xf() == startXf; } );
+    // Reset / Apply are offered whenever at least one object has a non-identity xf to undo.
+    const bool anyNonIdentity = std::any_of( selected.begin(), selected.end(),
+        []( const auto& o ){ return o->xf() != AffineXf3f(); } );
 
     auto buttonSize = 100.0f * UI::scale();
 
@@ -1917,13 +1933,20 @@ bool RibbonMenu::drawTransformContextMenu_( const std::shared_ptr<Object>& selec
         return Transform{ xf, uniformScale };
     };
 
+    // Write the same xf to every selected object under one combined history entry — so Ctrl+Z
+    // reverts a Paste/Load/Reset across all objects in a single step.
+    auto applyXfToAll = [&]( const AffineXf3f& xf, const std::string& actionName )
+    {
+        AppendHistory( makeObjectsXfHistoryAction_( actionName, selected ) );
+        applyXfToObjects_( xf, selected );
+    };
+
     RibbonFontHolder semiBoldFont( RibbonFontManager::FontType::SemiBold );
     ImGui::Text( "%s", _tr( "Transform Data" ) );
     semiBoldFont.popFont();
 
-    const auto& startXf = selected->xf();
 #if !defined( __EMSCRIPTEN__ )
-    if ( UI::button( _tr( "Copy" ), Vector2f( buttonSize, 0 ) ) )
+    if ( UI::button( _tr( "Copy" ), /*active=*/allSame, Vector2f( buttonSize, 0 ) ) )
     {
         Json::Value root;
         serializeTransform( root, { startXf, uniformScale_ } );
@@ -1949,8 +1972,7 @@ bool RibbonMenu::drawTransformContextMenu_( const std::shared_ptr<Object>& selec
             {
                 if ( UI::button( _tr( "Paste" ), Vector2f( buttonSize, 0 ) ) )
                 {
-                    AppendHistory<ChangeXfAction>( _t( "Paste Transform" ), selected );
-                    selected->setXf( tr->xf );
+                    applyXfToAll( tr->xf, _t( "Paste Transform" ) );
                     uniformScale_ = tr->uniformScale;
                     ImGui::CloseCurrentPopup();
                 }
@@ -1958,7 +1980,7 @@ bool RibbonMenu::drawTransformContextMenu_( const std::shared_ptr<Object>& selec
         }
     }
 
-    if ( UI::button( _tr( "Save to file" ), Vector2f( buttonSize, 0 ) ) )
+    if ( UI::button( _tr( "Save to file" ), /*active=*/allSame, Vector2f( buttonSize, 0 ) ) )
     {
         auto filename = saveFileDialog( {
             .fileName = "Transform",
@@ -1989,8 +2011,7 @@ bool RibbonMenu::drawTransformContextMenu_( const std::shared_ptr<Object>& selec
             {
                 if ( auto tr = deserializeTransform( *root ) )
                 {
-                    AppendHistory<ChangeXfAction>( _t( "Load Transform from File" ), selected );
-                    selected->setXf( tr->xf );
+                    applyXfToAll( tr->xf, _t( "Load Transform from File" ) );
                     uniformScale_ = tr->uniformScale;
                 }
                 else
@@ -2008,7 +2029,7 @@ bool RibbonMenu::drawTransformContextMenu_( const std::shared_ptr<Object>& selec
         ImGui::CloseCurrentPopup();
     }
 
-    if ( startXf != AffineXf3f() )
+    if ( anyNonIdentity )
     {
         auto item = RibbonSchemaHolder::schema().items.find( "Apply Transform" );
         if ( item != RibbonSchemaHolder::schema().items.end() &&
@@ -2022,8 +2043,7 @@ bool RibbonMenu::drawTransformContextMenu_( const std::shared_ptr<Object>& selec
 
         if ( UI::button( _tr( "Reset" ), Vector2f( buttonSize, 0 ) ) )
         {
-            AppendHistory<ChangeXfAction>( _t( "Reset Transform (context menu)" ), selected );
-            selected->setXf( AffineXf3f() );
+            applyXfToAll( AffineXf3f(), _t( "Reset Transform (context menu)" ) );
             ImGui::CloseCurrentPopup();
         }
         UI::setTooltipIfHovered( _tr( "Resets transform value to identity." ) );

--- a/source/MRViewer/MRRibbonMenu.h
+++ b/source/MRViewer/MRRibbonMenu.h
@@ -201,7 +201,7 @@ protected:
     MRVIEWER_API virtual void drawRibbonSceneInformation_( const std::vector<std::shared_ptr<Object>>& selected );
 
     MRVIEWER_API virtual bool drawCollapsingHeaderTransform_() override;
-    MRVIEWER_API virtual bool drawTransformContextMenu_( const std::shared_ptr<Object>& selected ) override;
+    MRVIEWER_API virtual bool drawTransformContextMenu_( const std::vector<std::shared_ptr<Object>>& selected ) override;
 
     MRVIEWER_API virtual void addRibbonItemShortcut_( const std::string& itemName, const ShortcutKey& key, ShortcutCategory category );
 

--- a/source/MRViewer/MRSceneCache.h
+++ b/source/MRViewer/MRSceneCache.h
@@ -24,6 +24,11 @@ public:
     template <typename ObjectType, ObjectSelectivityType SelectivityType>
     static const ObjectList<ObjectType>& getAllObjects();
 
+    // analog getTopmostObjects<ObjectType>( &SceneRoot::get(), SelectivityType ) but use cached data
+    // reference copy is valid until invalidateAll() is called
+    template <typename ObjectType, ObjectSelectivityType SelectivityType>
+    static const ObjectList<ObjectType>& getAllTopmostObjects();
+
 private:
     MRVIEWER_API static SceneCache& instance_();
     SceneCache() = default;
@@ -37,6 +42,12 @@ private:
     };
     template <typename ObjectType, ObjectSelectivityType SelectivityType>
     struct MRVIEWER_CLASS VectorHolder : BasicVectorHolder
+    {
+        ObjectList<ObjectType> value;
+    };
+    // distinct holder type so the topmost query gets its own cache slot (keyed by typeid)
+    template <typename ObjectType, ObjectSelectivityType SelectivityType>
+    struct MRVIEWER_CLASS TopmostVectorHolder : BasicVectorHolder
     {
         ObjectList<ObjectType> value;
     };
@@ -54,6 +65,25 @@ const SceneCache::ObjectList<ObjectType>& SceneCache::getAllObjects()
     {
         auto dataList = std::make_shared<ResultType>();
         dataList->value = getAllObjectsInTree<ObjectType>( &SceneRoot::get(), SelectivityType );
+        cachedVec = dataList;
+    }
+    assert( cachedVec );
+    auto resPtr = dynamic_pointer_cast< ResultType >( cachedVec );
+    assert( resPtr );
+    return resPtr->value;
+}
+
+template <typename ObjectType, ObjectSelectivityType SelectivityType>
+const SceneCache::ObjectList<ObjectType>& SceneCache::getAllTopmostObjects()
+{
+    using ResultType = TopmostVectorHolder<ObjectType, SelectivityType>;
+    const auto typeIndex = std::type_index( typeid( ResultType ) );
+    auto& cachedData = instance_().cachedData_;
+    auto& cachedVec = cachedData[typeIndex];
+    if ( !cachedVec )
+    {
+        auto dataList = std::make_shared<ResultType>();
+        dataList->value = getTopmostObjects<ObjectType>( &SceneRoot::get(), SelectivityType );
         cachedVec = dataList;
     }
     assert( cachedVec );


### PR DESCRIPTION
## Summary

- The transform properties panel (`ImGuiMenu::drawTransform_`) and the small Reset / Apply / context-menu buttons on its header now operate over the whole selection instead of short-circuiting on multi-selection.
- When the selected objects share the same xf, edits are written to every object under a single `CombinedHistoryAction`, so Ctrl+Z reverts the multi-object edit in one step.
- When the selected objects' xfs differ, the scale / rotation / translation rows render read-only em-dashes (`—`) and cannot be edited. The context menu is still available — Copy / Save-to-file are disabled in that case, but Paste / Load / Reset / Apply remain enabled (they only write).

## Details

- **Selection source** — new `SceneCache::getAllTopmostObjects<T, S>()` alongside `getAllObjects`, used so that a parent-plus-child selection is not moved twice through the parent's cascade. Reusable by other panels.
- **Helpers** — two small protected helpers on `ImGuiMenu` (reused by `RibbonMenu`):
  - `makeObjectsXfHistoryAction_` — one `ChangeXfAction` per object wrapped in a single `CombinedHistoryAction`.
  - `applyXfToObjects_` — `setXf` loop.
- **Mixed-state rendering** — new `drawMixedTransformField_` renders `—` via `UI::inputTextCenteredReadOnly` in the same column layout the editable `UI::drag` widgets would use (with the trailing "Rotation XYZ" / "Translation" label preserved).
- **Context menu signature** — `drawTransformContextMenu_` now takes `const std::vector<std::shared_ptr<Object>>&` instead of a single object; `RibbonMenu`'s Copy/Save are gated on `allSame`, Apply/Reset on `anyNonIdentity`.
- **Scroll-fix flag renamed** — `selectionChangedToSingleObj_` → `transformBlockShown_`, simplified to trigger the scene-list scroll fix on the "block just appeared" transition (it used to trigger only on the N→1 boundary).

## Test plan

- [x] Single-object regression: select one mesh; edit scale / rotation / translation; one undo step per drag release.
- [x] Multi-object, identical xf: duplicate an object, select both; panel shows the shared values; drag any axis; both move together; one Ctrl+Z reverts both (single "Manual Change Transform" entry in History).
- [x] Multi-object, differing xf: select meshes at different positions; every numeric field shows `—`; fields are non-interactive; Uni-scale checkbox still flips the layout between 1 and 3 dashes.
- [x] Context menu (right-click header) in mixed case: Copy and Save-to-file greyed out; Paste, Load, Reset, Apply remain clickable and act on every selected object under one undo step.
- [x] Header buttons in multi-selection: Reset / Apply icons show when any selected object has a non-identity xf; Reset produces a single combined undo entry.
- [x] Parent-plus-child selection: only the parent is edited (via `getAllTopmostObjects`); the child is not moved twice through its parent's cascade.
- [ ] Locked object in selection: the entire transform panel hides, matching today's single-object lock behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)