### PR TITLE
ci(emscripten): multi-stage Dockerfile to drop source tree from final image

### DIFF
--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -1,7 +1,67 @@
+# syntax=docker/dockerfile:1.6
+
+# Multi-stage build:
+#   builder: heavy thirdparty work for all three Emscripten variants.
+#   final:   runtime image containing only the installed artifacts.
+#
+# The builder stage is discarded at push time, so the MeshLib source tree
+# (COPY . .), thirdparty_build/ scratch, builder-only apt packages, and any
+# other incidental build residue never land in the pushed image. Only the
+# three /usr/local/lib/emscripten* install trees cross the stage boundary.
+#
+# Install paths are preserved, so build-test-emscripten.yml needs no changes.
+
+## ============================================================================
+## Stage 1: builder
+## ============================================================================
+FROM emscripten/emsdk:4.0.10-arm64 AS builder
+
+# Minimal apt set required by ./scripts/build_thirdparty.sh.
+# No firefox/xvfb/dbus here — those are test-runtime only, not build deps.
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -qqy && \
+    apt-get install -qqy --no-install-recommends \
+        git pkg-config ninja-build gettext && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /home/MeshLib
+
+# Full source tree (including submodules checked out by actions/checkout) is
+# needed to run the thirdparty build scripts. This layer is only in the
+# builder stage and does NOT propagate to the final image.
+COPY . .
+
+ENV MR_STATE=DOCKER_BUILD
+ENV MR_EMSCRIPTEN=ON
+
+# Stage the three installs under /opt/meshlib-thirdparty so the COPY --from=
+# in the final stage is unambiguous about what to pick up.
+RUN ./scripts/build_thirdparty.sh && \
+    ./scripts/cmake_install.sh /opt/meshlib-thirdparty/emscripten && \
+    rm -rf bin include lib share thirdparty_build
+
+ENV MR_EMSCRIPTEN_SINGLE=ON
+RUN ./scripts/build_thirdparty.sh && \
+    ./scripts/cmake_install.sh /opt/meshlib-thirdparty/emscripten-single && \
+    rm -rf bin include lib share thirdparty_build
+
+ENV MR_EMSCRIPTEN_SINGLE=OFF
+ENV MR_EMSCRIPTEN_WASM64=ON
+RUN ./scripts/build_thirdparty.sh && \
+    ./scripts/cmake_install.sh /opt/meshlib-thirdparty/emscripten-wasm64 && \
+    rm -rf bin include lib share thirdparty_build
+
+
+## ============================================================================
+## Stage 2: final runtime image
+## ============================================================================
 FROM emscripten/emsdk:4.0.10-arm64
 
-# Update and install req
-# install yaru-theme-icon to fix `Icon 'dialog-warning' not present in theme Yaru: 'glib warning'` while testing
+# Full runtime apt set. Same as pre-multi-stage master, except the x86_64
+# AWS CLI install was already dropped upstream.
+# yaru-theme-icon fixes `Icon 'dialog-warning' not present in theme Yaru:
+# 'glib warning'` during testing.
 RUN export DEBIAN_FRONTEND=noninteractive; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections; \
@@ -20,35 +80,11 @@ Pin-Priority: 1001\
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-## prepare thirdparty
-RUN mkdir /home/MeshLib
-WORKDIR "/home/MeshLib"
-
-#copy files
-COPY . .
-
-#build thirdparty
-ENV MR_STATE=DOCKER_BUILD
-ENV MR_EMSCRIPTEN=ON
-RUN ./scripts/build_thirdparty.sh && \
-    ./scripts/cmake_install.sh /usr/local/lib/emscripten && \
-    rm -rf bin include lib share thirdparty_build
-
-ENV MR_EMSCRIPTEN_SINGLE=ON
-RUN ./scripts/build_thirdparty.sh && \
-    ./scripts/cmake_install.sh /usr/local/lib/emscripten-single && \
-    rm -rf bin include lib share thirdparty_build
-
-ENV MR_EMSCRIPTEN_SINGLE=OFF
-ENV MR_EMSCRIPTEN_WASM64=ON
-RUN ./scripts/build_thirdparty.sh && \
-    ./scripts/cmake_install.sh /usr/local/lib/emscripten-wasm64 && \
-    rm -rf bin include lib share thirdparty_build
-
-ENV MR_EMSCRIPTEN_WASM64=OFF
-
-WORKDIR "/home/"
-RUN rm -rf MeshLib
+# Pull only the compiled thirdparty trees from the builder. Target paths
+# match what build-test-emscripten.yml's matrix.thirdparty-dir already expects.
+COPY --from=builder /opt/meshlib-thirdparty/emscripten        /usr/local/lib/emscripten
+COPY --from=builder /opt/meshlib-thirdparty/emscripten-single /usr/local/lib/emscripten-single
+COPY --from=builder /opt/meshlib-thirdparty/emscripten-wasm64 /usr/local/lib/emscripten-wasm64
 
 # Setup non-root user (use 1001 to play nicely with actions/checkout@v4)
 # https://github.com/actions/checkout/issues/1014


### PR DESCRIPTION
## What

Rewrites \`docker/emscriptenDockerfile\` as a two-stage build.

**Builder stage:** \`emsdk\` + a minimal apt set (\`git pkg-config ninja-build gettext\`) + \`COPY . .\` + the three existing sequential thirdparty builds, with installs redirected to \`/opt/meshlib-thirdparty/{emscripten,emscripten-single,emscripten-wasm64}\`.

**Final stage:** \`emsdk\` + the full runtime apt set (firefox, xvfb, dbus-x11, yaru-theme-icon, ninja-build, gettext, …) + three \`COPY --from=builder\` commands for just the install trees into \`/usr/local/lib/emscripten{,-single,-wasm64}\`, then the existing non-root user setup.

Install paths match what \`build-test-emscripten.yml\`'s \`matrix.thirdparty-dir\` already expects. No workflow changes needed.

## What ends up NOT in the pushed image anymore

- **Full MeshLib source tree baked in via \`COPY . .\`** — this was the big hidden cost. The layer remained in image history even after the later \`rm -rf MeshLib\`, because Docker layers are additive.
- \`thirdparty_build/\` scratch residue from the three build cycles.
- Builder-only apt packages (anything not also installed in the final stage).

Everything consumers actually use at job time (emsdk, firefox/xvfb for headless tests, ninja/pkg-config for MeshLib build, the three thirdparty install trees, user 1001) is still present.

## Measured impact

Run 24587477086 (this PR) vs master baseline 24556124466:

| Metric | Master (\`latest\`) | This PR | Δ |
|---|---:|---:|---:|
| Image size (Docker Hub, compressed) | 1517 MB | **1044 MB** | **−473 MB (−31%)** |
| \`Initialize containers\`, Singlethreaded | ~164 s | **57 s** | **−107 s (−65%)** |
| \`Initialize containers\`, Multithreaded | ~177 s | **57 s** | **−120 s (−68%)** |
| \`Initialize containers\`, Multithreaded-64Bit | ~162 s | **56 s** | **−106 s (−65%)** |
| Sum across 3 emscripten jobs | ~503 s | **170 s** | **−333 s (−66%)** |

Variance is tight (56-57 s across the three matrix jobs), suggesting the number is real rather than noise. Layer-count drops from 14 to 10, and the dominant single-layer extraction shrinks from ~35-40 s (the old thirdparty-install layers) to ~18 s.

## Related PRs

- **#5925** (GHCR mirror) — closed; measured ~0% init improvement; premise (Docker Hub network as bottleneck) was wrong.
- **#5927** (split image into per-variant) — closed; measured ~4% size reduction; the three thirdparty install trees compressed to ~35 MB each, not ~500 MB as I projected.

## Ops / rollout

The first CI run of this PR touches \`docker/emscriptenDockerfile\`, matching \`config.yml\`'s \`linux-changes\` paths-filter, so \`prepare-images.yml\` rebuilt and pushed the new image as \`meshlib/meshlib-emscripten-arm64:ci-emscripten-multistage-dockerfile\`. Emscripten jobs in the same run pulled that tag successfully.

After merge, the normal \`need_linux_image_rebuild\` path will push a new \`:latest\` on the next relevant change; until then, \`:latest\` remains the combined-image version (no regression).

## Rollback

Single-file revert of \`docker/emscriptenDockerfile\` restores the current single-stage Dockerfile. No registry or workflow cleanup required.

## Follow-up candidates (not in this PR)

- Apply the same multi-stage pattern to \`docker/rockylinux8-vcpkgDockerfile\` if measurement shows a similar layer-history weight from \`COPY . .\` there. Current vcpkg consumer init is ~80-110 s, so the ceiling is lower than it was for emscripten.
- The \`need_linux_image_rebuild\` output in \`config.yml\` has an intermittent bug where \`linux-changes=true\` doesn't propagate into the rebuild gate (observed in earlier runs on a different PR branch). This PR's run happened to hit the working path. Worth investigating separately.