### PR TITLE
repro: Windows vcpkg fresh install fails on blosc/msys2-pkgconf 404 (do not merge)

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -91,7 +91,12 @@ jobs:
         uses: actions/cache@v5
         id: vcpkg-cache
         with:
-          key: vcpkg-cache-${{ matrix.vcpkg-version }}
+          # Repro PR: cache key with a unique suffix so the existing cached
+          # vcpkg tree is NOT used. This forces a fresh `vcpkg install` of
+          # all ports in requirements/windows.txt, which surfaces the
+          # msys2 mingw-w64-x86_64-pkgconf 1~2.2.0-1 download 404 inside
+          # upstream blosc's `vcpkg_fixup_pkgconfig()` call. Do NOT merge.
+          key: vcpkg-cache-${{ matrix.vcpkg-version }}-repro-blosc-msys2-2026-04-20
           path: |
             C:\vcpkg\*
 


### PR DESCRIPTION
## Purpose

Minimal reproduction PR (branched from current master, no overlay changes) demonstrating that a **fresh** Windows vcpkg install fails in `blosc:x64-windows-meshlib` with a 404 download error during `vcpkg_fixup_pkgconfig()`.

**Do not merge.** This PR exists only to isolate the failure on master (not on a feature branch) and confirm that it is independent of any other in-flight changes.

## What the PR changes

A single line in `.github/workflows/build-test-windows.yml`:

```diff
-          key: vcpkg-cache-${{ matrix.vcpkg-version }}
+          key: vcpkg-cache-${{ matrix.vcpkg-version }}-repro-blosc-msys2-2026-04-20
```

The new cache key has never been populated, so `actions/cache` will produce a cold miss on the first run of this PR. `install.bat` then runs `vcpkg install ...` against an empty `C:\vcpkg\installed\`, and every port in `requirements/windows.txt` (plus transitive deps) is built from scratch — which is the trigger for the bug.

## What to expect in CI

- `windows-build-test` matrix legs should fail in the `Update vcpkg packages` step, with output shaped like:

  ```
  -- Fixing pkgconfig file: C:/vcpkg/packages/blosc_x64-windows-meshlib/lib/pkgconfig/blosc.pc
  -- Downloading https://mirror.msys2.org/.../mingw-w64-x86_64-pkgconf-1~2.2.0-1-any.pkg.tar.zst ...
  error: Missing msys2-mingw-w64-x86_64-pkgconf-1~2.2.0-1-any.pkg.tar.zst
  error: https://mirror.msys2.org/.../mingw-w64-x86_64-pkgconf-1~2.2.0-1-any.pkg.tar.zst: failed: status code 404
  error: https://repo.msys2.org/.../mingw-w64-x86_64-pkgconf-1~2.2.0-1-any.pkg.tar.zst: failed: status code 404
  error: https://mirror.yandex.ru/...:                                                    failed: status code 404
  error: https://mirrors.tuna.tsinghua.edu.cn/...:                                        failed: status code 404
  error: https://mirrors.ustc.edu.cn/...:                                                 failed: status code 404
  error: https://mirror.selfnet.de/...:                                                   failed: status code 404
  error: building blosc:x64-windows-meshlib failed with: BUILD_FAILED
  ```

- Non-Windows matrix legs are disabled via labels (`disable-build-macos`, `disable-build-ubuntu-x64`, `disable-build-ubuntu-arm64`, `disable-build-linux-vcpkg`, `disable-build-emscripten`) so the CI surface is just the three Windows matrix legs.

## Root cause (from the zlib-ng PR investigation, run 24653463132)

- `blosc`'s upstream vcpkg portfile calls `vcpkg_fixup_pkgconfig()` which invokes `vcpkg_acquire_msys(PKGCONFIG)` → downloads a specific pinned version of `mingw-w64-x86_64-pkgconf` (currently `1~2.2.0-1`).
- msys2 mirrors retain only the latest version of each package in their live repos. Older versions that vcpkg still pins are pruned from every mirror, producing hard 404s.
- Stale vcpkg pin × msys2 pruning = fresh installs 404. Cached installs work because the download step is skipped.

## Why master itself doesn't show this

Master's Windows vcpkg cache is a consistent hit every run (cache key is just `vcpkg-cache-${{ matrix.vcpkg-version }}`, nothing varies between runs). No port ever rebuilds, `vcpkg_fixup_pkgconfig()` is never re-invoked, and the 404 never fires. Any change that busts the cache will expose this — including PR [#5932](https://github.com/MeshInspector/MeshLib/pull/5932) (zlib-ng overlay) and PR [#5934](https://github.com/MeshInspector/MeshLib/pull/5934) (principled cache-key invalidation on overlay changes).

## Possible paths forward (not proposed here, for discussion)

1. **Bump Windows matrix `vcpkg-version` pins** past the broken pkgconf pin. A newer vcpkg release that pins a still-available pkgconf solves the root cause.
2. **Overlay the blosc port** (and any other port calling `vcpkg_fixup_pkgconfig()`) to skip the call on Windows. Whack-a-mole.
3. **Pre-download the msys2 pkgconf package** into a private mirror / S3 asset store and point vcpkg at it via `x-asset-sources`. Robust but operationally heavier.
4. **Upstream fix** — a vcpkg issue filed at microsoft/vcpkg to update the pkgconf pin. Passive.