### PR TITLE
fix(emscripten): restore apt mirror swap in builder stage

### DIFF
--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -18,7 +18,10 @@ FROM emscripten/emsdk:4.0.10-arm64 AS builder
 
 # Minimal apt set required by ./scripts/build_thirdparty.sh.
 # No firefox/xvfb/dbus here — those are test-runtime only, not build deps.
+# The sed swap redirects ports.ubuntu.com to a faster mirror and must
+# run before the first apt-get update.
 RUN export DEBIAN_FRONTEND=noninteractive && \
+    sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list && \
     apt-get update -qqy && \
     apt-get install -qqy --no-install-recommends \
         git pkg-config ninja-build gettext && \

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -18,8 +18,6 @@ FROM emscripten/emsdk:4.0.10-arm64 AS builder
 
 # Minimal apt set required by ./scripts/build_thirdparty.sh.
 # No firefox/xvfb/dbus here — those are test-runtime only, not build deps.
-# The sed swap redirects ports.ubuntu.com to a faster mirror and must
-# run before the first apt-get update.
 RUN export DEBIAN_FRONTEND=noninteractive && \
     sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list && \
     apt-get update -qqy && \


### PR DESCRIPTION
## What

Restores the `sed -i` redirect of `ports.ubuntu.com` → `mirror.eu.ossplanet.net` in the **builder** stage of `docker/emscriptenDockerfile`. This was present before PR #5930 and dropped by that PR's multi-stage refactor.

## Before #5930

Master's single-stage Dockerfile had one `RUN` block doing:

```dockerfile
RUN export DEBIAN_FRONTEND=noninteractive; \
    ...
    sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list; \
    apt-get update -qqy \
 && apt-get install ...
```

The sed swap ran *before* the first `apt-get update`, so all apt traffic in the image went through the faster alternative mirror.

## After #5930 (current master)

The refactor kept the sed swap in the final stage's apt block but introduced a new minimal apt block in the builder stage without the swap:

```dockerfile
# builder stage
RUN export DEBIAN_FRONTEND=noninteractive && \
    apt-get update -qqy && \
    apt-get install -qqy --no-install-recommends \
        git pkg-config ninja-build gettext && ...
```

So the builder pulls `git`, `pkg-config`, `ninja-build`, and `gettext` from `ports.ubuntu.com` directly. Slower on every image rebuild; potentially unreliable from geo-restricted runners.

## Fix

Prepend the same `sed -i` to the builder's `RUN`, one new line:

```diff
 RUN export DEBIAN_FRONTEND=noninteractive && \
+    sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list && \
     apt-get update -qqy && \
     apt-get install -qqy --no-install-recommends \
         git pkg-config ninja-build gettext && ...
```

Final stage is unchanged — it already had the swap.

## Rollback

Revert this single-line commit.