### PR TITLE
build(win): flatten ObjectFileName in fastmcpp.vcxproj to enable /MP parallelism

### DIFF
--- a/source/fastmcpp/fastmcpp.vcxproj
+++ b/source/fastmcpp/fastmcpp.vcxproj
@@ -15,7 +15,7 @@
          on basename. MSBuild's ClCompile task batches items with identical
          metadata into one CL.exe invocation; having one big batch lets CL's
          /MP parallelize across all of these files at once. Previously each
-         source subdirectory had its own ObjectFileName (e.g. $(IntDir)server\),
+         source subdirectory had its own ObjectFileName (e.g. $(IntDir)server/),
          which forced MSBuild to serialize ~11 separate CL invocations. -->
     <ClCompile Include="..\..\thirdparty\fastmcpp\src\app.cpp" />
     <ClCompile Include="..\..\thirdparty\fastmcpp\src\proxy.cpp" />

--- a/source/fastmcpp/fastmcpp.vcxproj
+++ b/source/fastmcpp/fastmcpp.vcxproj
@@ -11,121 +11,66 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <!-- ObjectFileName is deliberately omitted on all files that don't collide
+         on basename. MSBuild's ClCompile task batches items with identical
+         metadata into one CL.exe invocation; having one big batch lets CL's
+         /MP parallelize across all of these files at once. Previously each
+         source subdirectory had its own ObjectFileName (e.g. $(IntDir)server\),
+         which forced MSBuild to serialize ~11 separate CL invocations. -->
     <ClCompile Include="..\..\thirdparty\fastmcpp\src\app.cpp" />
     <ClCompile Include="..\..\thirdparty\fastmcpp\src\proxy.cpp" />
     <ClCompile Include="..\..\thirdparty\fastmcpp\src\types.cpp" />
     <ClCompile Include="..\..\thirdparty\fastmcpp\src\settings.cpp" />
     <ClCompile Include="..\..\thirdparty\fastmcpp\src\telemetry.cpp" />
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\client\client.cpp">
-      <ObjectFileName>$(IntDir)client\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\client\sampling_handlers.cpp">
-      <ObjectFileName>$(IntDir)client\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\client\transports.cpp">
-      <ObjectFileName>$(IntDir)client\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\internal\process.cpp">
-      <ObjectFileName>$(IntDir)internal\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\mcp\handler.cpp">
-      <ObjectFileName>$(IntDir)mcp\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\mcp\tasks.cpp">
-      <ObjectFileName>$(IntDir)mcp\</ObjectFileName>
-    </ClCompile>
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\client\client.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\client\sampling_handlers.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\client\transports.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\internal\process.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\mcp\handler.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\mcp\tasks.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\prompts\prompt.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\filesystem_provider.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\openapi_provider.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\skills_provider.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\namespace.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\prompts_as_tools.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\resources_as_tools.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\tool_transform.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\version_filter.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\visibility.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\resources\resource.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\resources\template.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\context.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\elicitation.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\http_server.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\middleware.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\ping_middleware.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\response_limiting_middleware.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\sampling.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\security_middleware.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\server.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\sse_server.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\stdio_server.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\streamable_http_server.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\tools\tool.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\util\json_schema_type.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\util\json_schema.cpp" />
+    <ClCompile Include="..\..\thirdparty\fastmcpp\src\util\schema_build.cpp" />
+    <!-- manager.cpp exists in three subdirectories (prompts/, resources/,
+         tools/). If we let them all default to $(IntDir)manager.obj they
+         would overwrite each other. Instead, give each a unique explicit
+         object filename so the outputs don't collide. These three files
+         end up in their own single-file CL.exe invocations (MSBuild can't
+         batch them with the main group because their ObjectFileName values
+         differ) — not ideal for parallelism but only 3 files out of ~40. -->
     <ClCompile Include="..\..\thirdparty\fastmcpp\src\prompts\manager.cpp">
-      <ObjectFileName>$(IntDir)prompts\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\prompts\prompt.cpp">
-      <ObjectFileName>$(IntDir)prompts\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\filesystem_provider.cpp">
-      <ObjectFileName>$(IntDir)providers\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\openapi_provider.cpp">
-      <ObjectFileName>$(IntDir)providers\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\skills_provider.cpp">
-      <ObjectFileName>$(IntDir)providers\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\namespace.cpp">
-      <ObjectFileName>$(IntDir)providers\transforms\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\prompts_as_tools.cpp">
-      <ObjectFileName>$(IntDir)providers\transforms\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\resources_as_tools.cpp">
-      <ObjectFileName>$(IntDir)providers\transforms\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\tool_transform.cpp">
-      <ObjectFileName>$(IntDir)providers\transforms\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\version_filter.cpp">
-      <ObjectFileName>$(IntDir)providers\transforms\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\providers\transforms\visibility.cpp">
-      <ObjectFileName>$(IntDir)providers\transforms\</ObjectFileName>
+      <ObjectFileName>$(IntDir)prompts_manager.obj</ObjectFileName>
     </ClCompile>
     <ClCompile Include="..\..\thirdparty\fastmcpp\src\resources\manager.cpp">
-      <ObjectFileName>$(IntDir)resources\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\resources\resource.cpp">
-      <ObjectFileName>$(IntDir)resources\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\resources\template.cpp">
-      <ObjectFileName>$(IntDir)resources\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\context.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\elicitation.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\http_server.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\middleware.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\ping_middleware.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\response_limiting_middleware.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\sampling.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\security_middleware.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\server.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\sse_server.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\stdio_server.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\server\streamable_http_server.cpp">
-      <ObjectFileName>$(IntDir)server\</ObjectFileName>
+      <ObjectFileName>$(IntDir)resources_manager.obj</ObjectFileName>
     </ClCompile>
     <ClCompile Include="..\..\thirdparty\fastmcpp\src\tools\manager.cpp">
-      <ObjectFileName>$(IntDir)tools\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\tools\tool.cpp">
-      <ObjectFileName>$(IntDir)tools\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\util\json_schema_type.cpp">
-      <ObjectFileName>$(IntDir)util\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\util\json_schema.cpp">
-      <ObjectFileName>$(IntDir)util\</ObjectFileName>
-    </ClCompile>
-    <ClCompile Include="..\..\thirdparty\fastmcpp\src\util\schema_build.cpp">
-      <ObjectFileName>$(IntDir)util\</ObjectFileName>
+      <ObjectFileName>$(IntDir)tools_manager.obj</ObjectFileName>
     </ClCompile>
   </ItemGroup>
   <PropertyGroup Label="Globals">


### PR DESCRIPTION
## Problem

In the most recent Windows Debug MSBuild run (see [job 72120606524](https://github.com/MeshInspector/MeshLib/actions/runs/24665079803/job/72120606524)), the \`fastmcpp\` project took ~4 min 35 s to compile. Extracted from the log, fastmcpp's ClCompile produced **11 separate CL.exe invocations**, each with a different \`/Fo\` output directory:

```
12:21:40   /Fo".../fastmcpp/x64/Debug/\"               5 files  (src/)
12:22:41   /Fo".../fastmcpp/x64/Debug/client/\"        3 files
12:23:05   /Fo".../fastmcpp/x64/Debug/internal/\"      1 file
12:23:11   /Fo".../fastmcpp/x64/Debug/mcp/\"           2 files
12:23:39   /Fo".../fastmcpp/x64/Debug/prompts/\"       2 files
12:23:49   /Fo".../fastmcpp/x64/Debug/providers/\"     3 files
12:24:15   /Fo".../fastmcpp/x64/Debug/providers/transforms/\"  6 files
12:24:45   /Fo".../fastmcpp/x64/Debug/resources/\"     3 files
12:24:59   /Fo".../fastmcpp/x64/Debug/server/\"       12 files
12:26:01   /Fo".../fastmcpp/x64/Debug/tools/\"         2 files
12:26:08   /Fo".../fastmcpp/x64/Debug/util/\"          3 files
```

MSBuild batches \`<ClCompile>\` items into CL.exe invocations based on matching metadata. \`fastmcpp.vcxproj\` set \`<ObjectFileName>$(IntDir)<subdir>\</ObjectFileName>\` per source subdirectory, so each subdirectory got its own invocation, and those invocations ran **serially**. Even though \`/MP\` was set on each, parallelism within one invocation is capped at the file count of its subdirectory (1-12), and the invocations do not overlap.

Other projects in the solution (OpenCTM, imgui, laz-perf, …) don't have this issue: their files have no per-file \`<ObjectFileName>\` override, so MSBuild emits a single CL.exe invocation per project and /MP parallelizes across all the files at once.

## Fix

Edit \`source/fastmcpp/fastmcpp.vcxproj\`:

1. **Remove \`<ObjectFileName>\` from 39 of the 42 source files.** These all have unique basenames, so without an override they share empty metadata and MSBuild batches them into **one** CL.exe invocation. \`/MP\` then parallelizes across all 39 files simultaneously.

2. **Keep a per-file \`<ObjectFileName>\` on the 3 \`manager.cpp\` files** (in \`src/prompts/\`, \`src/resources/\`, \`src/tools/\`). Without an override they would all default to \`$(IntDir)manager.obj\` and overwrite each other. Instead, give each a unique explicit obj name:
    - \`prompts/manager.cpp\` → \`$(IntDir)prompts_manager.obj\`
    - \`resources/manager.cpp\` → \`$(IntDir)resources_manager.obj\`
    - \`tools/manager.cpp\` → \`$(IntDir)tools_manager.obj\`

    Each has a unique \`<ObjectFileName>\` value, so MSBuild can't batch them with the main group or with each other — they run as 3 single-file CL invocations. That's fine, only 3 files total.

Net: **4 CL.exe invocations instead of 11**, with the big invocation containing 39 files that all compile in parallel.

## No behavioral change

- No source file is added, removed, or renamed.
- The produced \`fastmcpp.lib\` contains the same object files (same basenames, just in a flatter output layout: almost all in \`\$(IntDir)\`, 3 manager objects with a subdir-prefixed name).
- Warning flags, include paths, preprocessor defines, and link options are unchanged.

## Measurement status

**Not measured yet.** Expected to roughly halve the fastmcpp ClCompile wall time. Actual impact depends on how well \`/MP\` scales on the GitHub Windows runner (typically 4 cores) across a 39-file batch vs 11 small batches. CI on this PR is the proof.

## Scope of this PR's CI run

Non-Windows builds are disabled via labels (\`disable-build-macos\`, \`disable-build-ubuntu-x64\`, \`disable-build-ubuntu-arm64\`, \`disable-build-linux-vcpkg\`, \`disable-build-emscripten\`) so only the three \`windows-build-test\` matrix legs run. fastmcpp is only compiled on Windows via this vcxproj; Linux uses CMake and is unaffected either way, but running it would cost CI minutes for no additional information.

## Rollback

Single-file revert of \`source/fastmcpp/fastmcpp.vcxproj\`.