### PR TITLE
MRZlib: optional properties output (CRC-32 + sizes) on raw compress

### DIFF
--- a/source/MRMesh/MRZlib.cpp
+++ b/source/MRMesh/MRZlib.cpp
@@ -75,6 +75,10 @@ Expected<void> zlibCompressStream( std::istream& in, std::ostream& out, const Zl
         deflateEnd( &stream );
     };
 
+    const bool collect = params.properties && params.rawDeflate;
+    if ( collect )
+        *params.properties = {};
+
     while ( !in.eof() )
     {
         in.read( inChunk.data(), inChunk.size() );
@@ -83,6 +87,13 @@ Expected<void> zlibCompressStream( std::istream& in, std::ostream& out, const Zl
         stream.next_in = reinterpret_cast<uint8_t*>( inChunk.data() );
         stream.avail_in = (unsigned)in.gcount();
         assert( stream.avail_in <= (unsigned)inChunk.size() );
+
+        if ( collect )
+        {
+            // reuse the already-typed pointers zlib needs — no new casts.
+            params.properties->crc32 = (uint32_t)crc32( params.properties->crc32, stream.next_in, stream.avail_in );
+            params.properties->uncompressedSize += stream.avail_in;
+        }
 
         const auto flush = in.eof() ? Z_FINISH : Z_NO_FLUSH;
         do
@@ -94,9 +105,12 @@ Expected<void> zlibCompressStream( std::istream& in, std::ostream& out, const Zl
                 return unexpected( zlibToString( ret ) );
 
             assert( stream.avail_out <= (unsigned)outChunk.size() );
-            out.write( outChunk.data(), (unsigned)outChunk.size() - stream.avail_out );
+            const unsigned written = (unsigned)outChunk.size() - stream.avail_out;
+            out.write( outChunk.data(), written );
             if ( out.bad() )
                 return unexpected( "I/O error" );
+            if ( collect )
+                params.properties->compressedSize += written;
         }
         while ( stream.avail_out == 0 );
     }

--- a/source/MRMesh/MRZlib.cpp
+++ b/source/MRMesh/MRZlib.cpp
@@ -75,9 +75,8 @@ Expected<void> zlibCompressStream( std::istream& in, std::ostream& out, const Zl
         deflateEnd( &stream );
     };
 
-    const bool collect = params.properties && params.rawDeflate;
-    if ( collect )
-        *params.properties = {};
+    if ( params.stats )
+        *params.stats = {};
 
     while ( !in.eof() )
     {
@@ -88,11 +87,10 @@ Expected<void> zlibCompressStream( std::istream& in, std::ostream& out, const Zl
         stream.avail_in = (unsigned)in.gcount();
         assert( stream.avail_in <= (unsigned)inChunk.size() );
 
-        if ( collect )
+        if ( params.stats )
         {
-            // reuse the already-typed pointers zlib needs — no new casts.
-            params.properties->crc32 = (uint32_t)crc32( params.properties->crc32, stream.next_in, stream.avail_in );
-            params.properties->uncompressedSize += stream.avail_in;
+            params.stats->crc32 = (uint32_t)crc32( params.stats->crc32, stream.next_in, stream.avail_in );
+            params.stats->uncompressedSize += stream.avail_in;
         }
 
         const auto flush = in.eof() ? Z_FINISH : Z_NO_FLUSH;
@@ -109,8 +107,8 @@ Expected<void> zlibCompressStream( std::istream& in, std::ostream& out, const Zl
             out.write( outChunk.data(), written );
             if ( out.bad() )
                 return unexpected( "I/O error" );
-            if ( collect )
-                params.properties->compressedSize += written;
+            if ( params.stats )
+                params.stats->compressedSize += written;
         }
         while ( stream.avail_out == 0 );
     }

--- a/source/MRMesh/MRZlib.h
+++ b/source/MRMesh/MRZlib.h
@@ -3,6 +3,7 @@
 #include "MRMeshFwd.h"
 #include "MRExpected.h"
 
+#include <cstdint>
 #include <iostream>
 
 namespace MR
@@ -17,12 +18,25 @@ struct ZlibParams
     bool rawDeflate = false;
 };
 
+/// populated by zlibCompressStream (see ZlibCompressParams::properties)
+struct ZlibCompressProperties
+{
+    uint32_t crc32 = 0;            ///< CRC-32 of the uncompressed input
+    size_t uncompressedSize = 0;   ///< total bytes read from the input stream
+    size_t compressedSize = 0;     ///< total bytes written to the output stream
+};
+
 /// parameters for zlibCompressStream (adds a compression level on top of ZlibParams)
 struct ZlibCompressParams : ZlibParams
 {
     /// compression level: 0 = no compression, 1 = the fastest but the most inefficient,
     /// 9 = the most efficient but the slowest; -1 = zlib's default
     int level = -1;
+
+    /// Optional output. Populated only when non-null and `rawDeflate` is true —
+    /// the zlib wrapper already carries Adler-32 inline, so this metadata is
+    /// collected for the raw/ZIP path only.
+    ZlibCompressProperties* properties = nullptr;
 };
 
 /**

--- a/source/MRMesh/MRZlib.h
+++ b/source/MRMesh/MRZlib.h
@@ -18,8 +18,9 @@ struct ZlibParams
     bool rawDeflate = false;
 };
 
-/// populated by zlibCompressStream (see ZlibCompressParams::properties)
-struct ZlibCompressProperties
+/// statistics gathered during compression: CRC-32 of the uncompressed input and
+/// the total numbers of bytes read from / written to the streams
+struct ZlibCompressStats
 {
     uint32_t crc32 = 0;            ///< CRC-32 of the uncompressed input
     size_t uncompressedSize = 0;   ///< total bytes read from the input stream
@@ -33,10 +34,9 @@ struct ZlibCompressParams : ZlibParams
     /// 9 = the most efficient but the slowest; -1 = zlib's default
     int level = -1;
 
-    /// Optional output. Populated only when non-null and `rawDeflate` is true —
-    /// the zlib wrapper already carries Adler-32 inline, so this metadata is
-    /// collected for the raw/ZIP path only.
-    ZlibCompressProperties* properties = nullptr;
+    /// optional output; if non-null, the pointed-to object is populated with
+    /// CRC-32 of the input and the uncompressed / compressed byte totals
+    ZlibCompressStats* stats = nullptr;
 };
 
 /**

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -61,7 +61,7 @@
     <ClCompile Include="MRMeshVoxelsConverter.cpp" />
     <ClCompile Include="MRTriMathTests.cpp" />
     <ClCompile Include="MRVolumeToMeshByPartsTests.cpp" />
-    <ClCompile Include="MRZlib.cpp" />
+    <ClCompile Include="MRZlibTests.cpp" />
     <ClCompile Include="MRProgressCallback.cpp" />
     <ClCompile Include="MRConvexHull.cpp" />
     <ClCompile Include="MRCylinderApproximation.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -16,7 +16,7 @@
     <ClCompile Include="MRTriangleIntersectionTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="MRZlib.cpp">
+    <ClCompile Include="MRZlibTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="MRPolylineTrimWithPlane.cpp">

--- a/source/MRTest/MRZlib.cpp
+++ b/source/MRTest/MRZlib.cpp
@@ -1,8 +1,23 @@
 #include <MRMesh/MRGTest.h>
 #include <MRMesh/MRZlib.h>
 
+#include <cstdint>
+
 namespace
 {
+
+/// independent CRC-32 reference (PKZIP polynomial 0xedb88320, init 0xffffffff, final xor 0xffffffff)
+uint32_t crc32Ref( const unsigned char* data, size_t len )
+{
+    uint32_t crc = 0xffffffffu;
+    for ( size_t i = 0; i < len; ++i )
+    {
+        crc ^= data[i];
+        for ( int k = 0; k < 8; ++k )
+            crc = ( crc & 1u ) ? ( crc >> 1 ) ^ 0xedb88320u : ( crc >> 1 );
+    }
+    return ~crc;
+}
 
 constexpr unsigned char cInput[] = {
     0xe1, 0x83, 0x9b, 0xe1, 0x83, 0x94, 0xe1, 0x83, 0xaa, 0xe1, 0x83, 0xae,
@@ -117,3 +132,58 @@ INSTANTIATE_TEST_SUITE_P( MRMesh, ZlibDecompressTestFixture, testing::Values(
     ZlibDecompressParameters { cRawLevel1,     sizeof( cRawLevel1 ),     cInput, sizeof( cInput ), true  },
     ZlibDecompressParameters { cRawLevel9,     sizeof( cRawLevel9 ),     cInput, sizeof( cInput ), true  }
 ) );
+
+TEST( MRMesh, ZlibCompressPropertiesRaw )
+{
+    const std::string inputStr( reinterpret_cast<const char*>( cInput ), sizeof( cInput ) );
+
+    for ( int level : { 1, 9 } )
+    {
+        const size_t expectedCompSize = ( level == 1 ) ? sizeof( cRawLevel1 ) : sizeof( cRawLevel9 );
+
+        MR::ZlibCompressProperties props;
+        std::istringstream in( inputStr );
+        std::ostringstream out;
+        auto res = MR::zlibCompressStream( in, out,
+            MR::ZlibCompressParams{ { .rawDeflate = true }, level, &props } );
+        EXPECT_TRUE( res.has_value() );
+
+        EXPECT_EQ( props.crc32, crc32Ref( cInput, sizeof( cInput ) ) );
+        EXPECT_EQ( props.uncompressedSize, sizeof( cInput ) );
+        EXPECT_EQ( props.compressedSize, expectedCompSize );
+        EXPECT_EQ( out.str().size(), expectedCompSize );
+    }
+}
+
+TEST( MRMesh, ZlibCompressPropertiesEmpty )
+{
+    MR::ZlibCompressProperties props;
+    std::istringstream in;            // empty input
+    std::ostringstream out;
+    auto res = MR::zlibCompressStream( in, out,
+        MR::ZlibCompressParams{ { .rawDeflate = true }, /*level*/ -1, &props } );
+    EXPECT_TRUE( res.has_value() );
+
+    EXPECT_EQ( props.crc32, 0u );
+    EXPECT_EQ( props.uncompressedSize, 0u );
+    // raw deflate still emits a terminator block for Z_FINISH on empty input;
+    // pin whatever zlib actually wrote.
+    EXPECT_EQ( props.compressedSize, out.str().size() );
+    EXPECT_GT( props.compressedSize, 0u );
+}
+
+TEST( MRMesh, ZlibCompressPropertiesIgnoredInWrappedMode )
+{
+    MR::ZlibCompressProperties sentinel{ .crc32 = 0xDEADBEEFu, .uncompressedSize = 999, .compressedSize = 888 };
+    const std::string inputStr( reinterpret_cast<const char*>( cInput ), sizeof( cInput ) );
+    std::istringstream in( inputStr );
+    std::ostringstream out;
+    auto res = MR::zlibCompressStream( in, out,
+        MR::ZlibCompressParams{ { .rawDeflate = false }, /*level*/ -1, &sentinel } );
+    EXPECT_TRUE( res.has_value() );
+
+    // wrapped mode leaves properties untouched
+    EXPECT_EQ( sentinel.crc32, 0xDEADBEEFu );
+    EXPECT_EQ( sentinel.uncompressedSize, 999u );
+    EXPECT_EQ( sentinel.compressedSize, 888u );
+}

--- a/source/MRTest/MRZlibTests.cpp
+++ b/source/MRTest/MRZlibTests.cpp
@@ -133,57 +133,51 @@ INSTANTIATE_TEST_SUITE_P( MRMesh, ZlibDecompressTestFixture, testing::Values(
     ZlibDecompressParameters { cRawLevel9,     sizeof( cRawLevel9 ),     cInput, sizeof( cInput ), true  }
 ) );
 
-TEST( MRMesh, ZlibCompressPropertiesRaw )
+TEST( MRMesh, ZlibCompressStats )
 {
     const std::string inputStr( reinterpret_cast<const char*>( cInput ), sizeof( cInput ) );
+    const uint32_t expectedCrc = crc32Ref( cInput, sizeof( cInput ) );
 
-    for ( int level : { 1, 9 } )
+    struct Case { bool rawDeflate; int level; size_t expectedCompSize; };
+    const Case cases[] = {
+        { true,  1, sizeof( cRawLevel1 ) },
+        { true,  9, sizeof( cRawLevel9 ) },
+        { false, 1, sizeof( cWrappedLevel1 ) },
+        { false, 9, sizeof( cWrappedLevel9 ) },
+    };
+
+    for ( const auto& c : cases )
     {
-        const size_t expectedCompSize = ( level == 1 ) ? sizeof( cRawLevel1 ) : sizeof( cRawLevel9 );
-
-        MR::ZlibCompressProperties props;
+        MR::ZlibCompressStats stats;
         std::istringstream in( inputStr );
         std::ostringstream out;
         auto res = MR::zlibCompressStream( in, out,
-            MR::ZlibCompressParams{ { .rawDeflate = true }, level, &props } );
+            MR::ZlibCompressParams{ { .rawDeflate = c.rawDeflate }, c.level, &stats } );
         EXPECT_TRUE( res.has_value() );
 
-        EXPECT_EQ( props.crc32, crc32Ref( cInput, sizeof( cInput ) ) );
-        EXPECT_EQ( props.uncompressedSize, sizeof( cInput ) );
-        EXPECT_EQ( props.compressedSize, expectedCompSize );
-        EXPECT_EQ( out.str().size(), expectedCompSize );
+        EXPECT_EQ( stats.crc32, expectedCrc );
+        EXPECT_EQ( stats.uncompressedSize, sizeof( cInput ) );
+        EXPECT_EQ( stats.compressedSize, c.expectedCompSize );
+        EXPECT_EQ( out.str().size(), c.expectedCompSize );
     }
 }
 
-TEST( MRMesh, ZlibCompressPropertiesEmpty )
+TEST( MRMesh, ZlibCompressStatsEmpty )
 {
-    MR::ZlibCompressProperties props;
-    std::istringstream in;            // empty input
-    std::ostringstream out;
-    auto res = MR::zlibCompressStream( in, out,
-        MR::ZlibCompressParams{ { .rawDeflate = true }, /*level*/ -1, &props } );
-    EXPECT_TRUE( res.has_value() );
+    for ( bool rawDeflate : { false, true } )
+    {
+        MR::ZlibCompressStats stats;
+        std::istringstream in;            // empty input
+        std::ostringstream out;
+        auto res = MR::zlibCompressStream( in, out,
+            MR::ZlibCompressParams{ { .rawDeflate = rawDeflate }, /*level*/ -1, &stats } );
+        EXPECT_TRUE( res.has_value() );
 
-    EXPECT_EQ( props.crc32, 0u );
-    EXPECT_EQ( props.uncompressedSize, 0u );
-    // raw deflate still emits a terminator block for Z_FINISH on empty input;
-    // pin whatever zlib actually wrote.
-    EXPECT_EQ( props.compressedSize, out.str().size() );
-    EXPECT_GT( props.compressedSize, 0u );
-}
-
-TEST( MRMesh, ZlibCompressPropertiesIgnoredInWrappedMode )
-{
-    MR::ZlibCompressProperties sentinel{ .crc32 = 0xDEADBEEFu, .uncompressedSize = 999, .compressedSize = 888 };
-    const std::string inputStr( reinterpret_cast<const char*>( cInput ), sizeof( cInput ) );
-    std::istringstream in( inputStr );
-    std::ostringstream out;
-    auto res = MR::zlibCompressStream( in, out,
-        MR::ZlibCompressParams{ { .rawDeflate = false }, /*level*/ -1, &sentinel } );
-    EXPECT_TRUE( res.has_value() );
-
-    // wrapped mode leaves properties untouched
-    EXPECT_EQ( sentinel.crc32, 0xDEADBEEFu );
-    EXPECT_EQ( sentinel.uncompressedSize, 999u );
-    EXPECT_EQ( sentinel.compressedSize, 888u );
+        EXPECT_EQ( stats.crc32, 0u );
+        EXPECT_EQ( stats.uncompressedSize, 0u );
+        // deflate emits at least a terminator block for Z_FINISH on empty input;
+        // pin whatever zlib actually wrote.
+        EXPECT_EQ( stats.compressedSize, out.str().size() );
+        EXPECT_GT( stats.compressedSize, 0u );
+    }
 }


### PR DESCRIPTION
## Why

Step 2 toward parallelizing `MR::compressZip`. libzip's trust-source fast path ([zip_close.c:561](thirdparty/libzip/lib/zip_close.c#L561)) requires the source to report `COMP_METHOD | CRC | SIZE` valid in its `ZIP_SOURCE_STAT` response. The parallel pre-compression workers need `zlibCompressStream` to hand back that metadata.

## What

- New `ZlibCompressStats { uint32_t crc32; size_t uncompressedSize; size_t compressedSize; }`.
- `ZlibCompressParams` gains an optional `ZlibCompressStats* stats` pointer — populated whenever it's non-null, in both raw and zlib-wrapped modes. The zlib wrapper carries Adler-32 inline, but a caller may still want CRC-32 for external checksums.
- No return-type changes; both overloads still return `Expected<void>`.
- Collection reuses the `stream.next_in` / `stream.avail_in` that zlib already needs, so no new `reinterpret_cast`. Writing through the pointer under a `const ZlibCompressParams&` is fine — only the pointer is const.

## Tests

- Parameterized over `{raw, wrapped} × {level 1, 9}`: CRC matches an independent `crc32Ref` (PKZIP polynomial); `uncompressedSize` equals input length; `compressedSize` equals the known canned-vector size for that mode/level.
- Empty input, both modes: CRC and uncompressed size stay 0; compressed size equals whatever zlib emitted for `Z_FINISH` on empty input.
- MRTest's `MRZlib.cpp` renamed to `MRZlibTests.cpp` (separates from the production file of the same name).

## Test plan

- [ ] `MRTest` passes `ZlibCompressStats`, `ZlibCompressStatsEmpty`.
- [ ] Existing round-trip fixtures (`ZlibCompressTestFixture`, `ZlibDecompressTestFixture`) unchanged.
- [ ] Build green across all CI platforms.