### PR TITLE
MRZip: parallelize compressZip via pre-deflate + libzip trust-source fast path

### DIFF
--- a/source/MRMesh/MRZip.cpp
+++ b/source/MRMesh/MRZip.cpp
@@ -22,7 +22,6 @@
 #include <cassert>
 #include <cstring>
 #include <fstream>
-#include <memory>
 #include <sstream>
 
 namespace MR
@@ -59,6 +58,99 @@ int zipCancelCallback( zip_t* , void* data )
 
 #endif
 
+// pre-deflated archive entry; owned by the AutoCloseZip that will write it out, so that libzip's
+// zip_close (fired from ~AutoCloseZip) still sees live memory while it drains the source callbacks
+struct DeflatedEntry
+{
+    std::vector<uint8_t> data;  ///< raw DEFLATE bytes (RFC 1951, no zlib wrapper)
+    ZlibCompressStats stats;    ///< CRC-32 + uncompressed/compressed sizes from zlibCompressStream
+    zip_uint16_t gpbFlags = 0;  ///< precomputed GPB bits 1-2 encoding the deflate level
+    size_t pos = 0;             ///< read cursor for ZIP_SOURCE_READ
+    zip_error_t err{};          ///< scratch for ZIP_SOURCE_ERROR
+};
+
+// PKZIP APPNOTE 4.4.4 buckets the deflate level into four coarse categories via GPB bits 1 and 2;
+// levels 6-8 all map to "normal" and levels 2-5 all map to "fast" — the spec has no finer resolution
+zip_uint16_t deflateGpbLevelFlags( int level )
+{
+    if ( level == 9 ) return 0b0010;                   // maximum:   bit 1 set
+    if ( level >= 2 && level <= 5 ) return 0b0100;     // fast:      bit 2 set
+    if ( level == 1 ) return 0b0110;                   // superfast: bits 1 + 2 set
+    return 0b0000;                                     // normal (levels 6-8): neither bit set
+}
+
+// zip_source_function callback for a pre-deflated buffer; lets libzip's trust-source
+// fast path in zip_close() copy the bytes into the archive without any recompression
+// (no SEEK/TELL on purpose — keeps libzip on the linear-read path)
+zip_int64_t deflatedSourceCallback( void* user, void* data, zip_uint64_t len, zip_source_cmd_t cmd )
+{
+    if ( !user )
+    {
+        assert( false );
+        return -1;
+    }
+    auto* entry = static_cast<DeflatedEntry*>( user );
+    switch ( cmd )
+    {
+        case ZIP_SOURCE_SUPPORTS:
+            return zip_source_make_command_bitmap( ZIP_SOURCE_OPEN, ZIP_SOURCE_READ, ZIP_SOURCE_CLOSE,
+                ZIP_SOURCE_STAT, ZIP_SOURCE_ERROR, ZIP_SOURCE_FREE, ZIP_SOURCE_SUPPORTS,
+                ZIP_SOURCE_GET_FILE_ATTRIBUTES, -1 );
+
+        case ZIP_SOURCE_OPEN:
+            entry->pos = 0;
+            return 0;
+
+        case ZIP_SOURCE_READ:
+        {
+            const size_t n = std::min<size_t>( size_t( len ), entry->data.size() - entry->pos );
+            if ( n )
+                std::memcpy( data, entry->data.data() + entry->pos, n );
+            entry->pos += n;
+            return zip_int64_t( n );
+        }
+
+        case ZIP_SOURCE_CLOSE:
+            return 0;
+
+        case ZIP_SOURCE_STAT:
+        {
+            auto* st = (zip_stat_t*)data;
+            zip_stat_init( st );
+            st->size = entry->stats.uncompressedSize;
+            st->comp_size = entry->stats.compressedSize;
+            st->comp_method = ZIP_CM_DEFLATE;
+            st->crc = entry->stats.crc32;
+            st->encryption_method = ZIP_EM_NONE;
+            st->valid = ZIP_STAT_SIZE | ZIP_STAT_COMP_SIZE
+                      | ZIP_STAT_COMP_METHOD | ZIP_STAT_CRC
+                      | ZIP_STAT_ENCRYPTION_METHOD;
+            return sizeof( zip_stat_t );
+        }
+
+        case ZIP_SOURCE_ERROR:
+            return zip_error_to_data( &entry->err, data, len );
+
+        case ZIP_SOURCE_FREE:
+            return 0; // entry is owned by the AutoCloseZip, not by libzip
+
+        case ZIP_SOURCE_GET_FILE_ATTRIBUTES:
+        {
+            auto* a = (zip_file_attributes_t*)data;
+            zip_file_attributes_init( a );
+            a->valid = ZIP_FILE_ATTRIBUTES_VERSION_NEEDED
+                     | ZIP_FILE_ATTRIBUTES_GENERAL_PURPOSE_BIT_FLAGS;
+            a->version_needed = 20;
+            a->general_purpose_bit_flags = entry->gpbFlags;
+            a->general_purpose_bit_mask = 0b0110; // only bits 1-2 (deflate level) are authoritative here
+            return sizeof( zip_file_attributes_t );
+        }
+
+        default:
+            return -1;
+    }
+}
+
 // this object stores a handle on open zip-archive, and automatically closes it in the destructor
 class AutoCloseZip
 {
@@ -92,9 +184,50 @@ public:
         return res;
     }
 
+    /// Takes ownership of pre-deflated entries and registers them in the archive in order.
+    /// Entries stay alive for the AutoCloseZip's lifetime, so libzip's later zip_close (either
+    /// explicit or from the destructor) still sees valid memory when it drains the sources.
+    Expected<void> addPreDeflatedEntries(
+        std::vector<DeflatedEntry> entries,
+        const std::vector<std::pair<std::filesystem::path, std::string>>& files,
+        int level,
+        const std::string& password )
+    {
+        assert( entries.size() == files.size() );
+        entries_ = std::move( entries );
+        const zip_uint16_t gpbFlags = deflateGpbLevelFlags( level );
+        for ( size_t i = 0; i < entries_.size(); ++i )
+        {
+            auto& entry = entries_[i];
+            entry.gpbFlags = gpbFlags;
+            const auto& archiveFilePath = files[i].second;
+
+            zip_source_t* src = zip_source_function( handle_, deflatedSourceCallback, &entry );
+            if ( !src )
+                return unexpected( "Cannot create source for " + archiveFilePath );
+
+            const auto index = zip_file_add( handle_, archiveFilePath.c_str(), src, ZIP_FL_OVERWRITE | ZIP_FL_ENC_UTF_8 );
+            if ( index < 0 )
+            {
+                zip_source_free( src );
+                return unexpected( "Cannot add file " + archiveFilePath + " to archive" );
+            }
+
+            zip_set_file_compression( handle_, index, ZIP_CM_DEFLATE, zip_uint32_t( level ) );
+
+            if ( !password.empty() )
+            {
+                if ( zip_file_set_encryption( handle_, index, ZIP_EM_AES_256, password.c_str() ) )
+                    return unexpected( "Cannot encrypt file " + archiveFilePath + " in archive" );
+            }
+        }
+        return {};
+    }
+
 private:
     zip_t * handle_ = nullptr;
     ProgressData pd_;
+    std::vector<DeflatedEntry> entries_;
 };
 
 /// zip-callback for reading from std::istream
@@ -228,107 +361,6 @@ Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetF
     return {};
 }
 
-// Phase A output per file; pass #2 moves this into a DeflatedSourceCtx for libzip hand-off
-struct DeflatedEntry
-{
-    std::vector<uint8_t> data;  ///< raw DEFLATE bytes (RFC 1951, no zlib wrapper)
-    ZlibCompressStats stats;    ///< CRC-32 + uncompressed/compressed sizes
-};
-
-// context for a pre-deflated entry; the caller creates it as a unique_ptr, transfers ownership
-// to libzip via zip_source_function, and the ZIP_SOURCE_FREE command then deletes it
-struct DeflatedSourceCtx
-{
-    std::vector<uint8_t> data;  ///< raw DEFLATE bytes (RFC 1951, no zlib wrapper)
-    ZlibCompressStats stats;    ///< size / comp_size / crc from zlibCompressStream
-    zip_uint16_t gpbFlags = 0;  ///< precomputed GPB bits 1-2 encoding the deflate level
-    size_t pos = 0;             ///< read cursor for ZIP_SOURCE_READ
-    zip_error_t err{};          ///< scratch for ZIP_SOURCE_ERROR
-};
-
-// PKZIP APPNOTE 4.4.4 buckets the deflate level into four coarse categories via GPB bits 1 and 2;
-// levels 6-8 all map to "normal" and levels 2-5 all map to "fast" — the spec has no finer resolution
-zip_uint16_t deflateGpbLevelFlags( int level )
-{
-    if ( level == 9 ) return 0b0010;                   // maximum:   bit 1 set
-    if ( level >= 2 && level <= 5 ) return 0b0100;     // fast:      bit 2 set
-    if ( level == 1 ) return 0b0110;                   // superfast: bits 1 + 2 set
-    return 0b0000;                                     // normal (levels 6-8): neither bit set
-}
-
-// zip_source_function callback for a pre-deflated buffer; lets libzip's trust-source
-// fast path in zip_close() copy the bytes into the archive without any recompression
-// (no SEEK/TELL on purpose — keeps libzip on the linear-read path)
-zip_int64_t deflatedSourceCallback( void* user, void* data, zip_uint64_t len, zip_source_cmd_t cmd )
-{
-    if ( !user )
-    {
-        assert( false );
-        return -1;
-    }
-    auto* ctx = static_cast<DeflatedSourceCtx*>( user );
-    switch ( cmd )
-    {
-        case ZIP_SOURCE_SUPPORTS:
-            return zip_source_make_command_bitmap( ZIP_SOURCE_OPEN, ZIP_SOURCE_READ, ZIP_SOURCE_CLOSE,
-                ZIP_SOURCE_STAT, ZIP_SOURCE_ERROR, ZIP_SOURCE_FREE, ZIP_SOURCE_SUPPORTS,
-                ZIP_SOURCE_GET_FILE_ATTRIBUTES, ZIP_SOURCE_SUPPORTS_REOPEN, -1 );
-
-        case ZIP_SOURCE_OPEN:
-            ctx->pos = 0;
-            return 0;
-
-        case ZIP_SOURCE_READ:
-        {
-            const size_t n = std::min<size_t>( size_t( len ), ctx->data.size() - ctx->pos );
-            if ( n )
-                std::memcpy( data, ctx->data.data() + ctx->pos, n );
-            ctx->pos += n;
-            return zip_int64_t( n );
-        }
-
-        case ZIP_SOURCE_CLOSE:
-            return 0;
-
-        case ZIP_SOURCE_STAT:
-        {
-            auto* st = (zip_stat_t*)data;
-            zip_stat_init( st );
-            st->size = ctx->stats.uncompressedSize;
-            st->comp_size = ctx->stats.compressedSize;
-            st->comp_method = ZIP_CM_DEFLATE;
-            st->crc = ctx->stats.crc32;
-            st->encryption_method = ZIP_EM_NONE;
-            st->valid = ZIP_STAT_SIZE | ZIP_STAT_COMP_SIZE
-                      | ZIP_STAT_COMP_METHOD | ZIP_STAT_CRC
-                      | ZIP_STAT_ENCRYPTION_METHOD;
-            return sizeof( zip_stat_t );
-        }
-
-        case ZIP_SOURCE_ERROR:
-            return zip_error_to_data( &ctx->err, data, len );
-
-        case ZIP_SOURCE_FREE:
-            delete ctx;
-            return 0;
-
-        case ZIP_SOURCE_GET_FILE_ATTRIBUTES:
-        {
-            auto* a = (zip_file_attributes_t*)data;
-            zip_file_attributes_init( a );
-            a->valid = ZIP_FILE_ATTRIBUTES_VERSION_NEEDED
-                     | ZIP_FILE_ATTRIBUTES_GENERAL_PURPOSE_BIT_FLAGS;
-            a->version_needed = 20;
-            a->general_purpose_bit_flags = ctx->gpbFlags;
-            a->general_purpose_bit_mask = 0b0110; // only bits 1-2 (deflate level) are authoritative here
-            return sizeof( zip_file_attributes_t );
-        }
-
-        default:
-            return -1;
-    }
-}
-
 } // anonymous namespace
 
 Expected<void> compressZip( const std::filesystem::path& zipFile, const std::filesystem::path& sourceFolder, const CompressZipSettings& settings )
@@ -382,17 +414,25 @@ Expected<void> compressZip( const std::filesystem::path& zipFile, const std::fil
         }
     }
 
-    // pass #2: deflate each file and hand libzip pre-deflated bytes via a source callback;
-    // libzip's trust-source fast path then copies them into the archive without recompressing.
+    // pass #2: deflate each file in parallel, then hand libzip pre-deflated bytes via a source
+    // callback — libzip's trust-source fast path copies them into the archive without recompressing.
     // level 0 (the settings-level "use default") normalizes to 6 — zlib's internal default is 6,
     // and APPNOTE has no sentinel for "default", so 6 is what the archive entry records
     const int level = settings.compressionLevel == 0 ? 6 : std::clamp( settings.compressionLevel, 1, 9 );
-    const zip_uint16_t gpbFlags = deflateGpbLevelFlags( level );
 
-    // Phase A — parallel: read each file and deflate it into a per-slot DeflatedEntry
-    std::vector<Expected<DeflatedEntry>> results( files.size() );
+    // Phase A — parallel: read each file and deflate it into entries[i]. The first worker
+    // to fail wins the hadError CAS and publishes its message; others see hadError and skip
+    std::vector<DeflatedEntry> entries( files.size() );
     std::atomic<bool> hadError{ false };
+    std::string firstError;
     auto scbA = subprogress( settings.cb, 0.0f, 0.8f );
+
+    auto reportError = [&]( std::string msg )
+    {
+        bool expected = false;
+        if ( hadError.compare_exchange_strong( expected, true, std::memory_order_acq_rel ) )
+            firstError = std::move( msg );
+    };
 
     auto keepGoing = ParallelFor( files, [&]( size_t i )
     {
@@ -401,64 +441,27 @@ Expected<void> compressZip( const std::filesystem::path& zipFile, const std::fil
 
         std::ifstream in( files[i].first, std::ios::binary );
         if ( !in )
-        {
-            results[i] = unexpected( "Cannot open file " + utf8string( files[i].first ) + " for reading" );
-            hadError.store( true, std::memory_order_relaxed );
-            return;
-        }
+            return reportError( "Cannot open file " + utf8string( files[i].first ) + " for reading" );
 
-        DeflatedEntry e;
+        auto& e = entries[i];
         std::ostringstream out( std::ios::binary );
         if ( auto r = zlibCompressStream( in, out,
                  ZlibCompressParams{ { .rawDeflate = true }, level, &e.stats } ); !r )
-        {
-            results[i] = unexpected( r.error() );
-            hadError.store( true, std::memory_order_relaxed );
-            return;
-        }
+            return reportError( r.error() );
         // zlibCompressStream requires std::ostream&, so we go through ostringstream and copy out;
         // the copy is O(deflated_size), trivial next to zlib's own cost per file
         const std::string s = std::move( out ).str();
         e.data.assign( s.begin(), s.end() );
-        results[i] = std::move( e );
-    }, scbA, 16 /* reportProgressEvery — keeps the UI ticking and cancel responsive for typical file counts */ );
+    }, scbA, 1 /* reportProgressEvery — tick per file for UX and cancel responsiveness */ );
 
     if ( !keepGoing )
         return unexpectedOperationCanceled();
-    for ( auto& r : results )
-        if ( !r )
-            return unexpected( r.error() ); // first error (lowest index) wins
+    if ( hadError.load() )
+        return unexpected( std::move( firstError ) );
 
-    // Phase B — serial: hand each pre-deflated buffer to libzip
-    for ( size_t i = 0; i < files.size(); ++i )
-    {
-        const auto& archiveFilePath = files[i].second;
-
-        auto ctx = std::make_unique<DeflatedSourceCtx>();
-        ctx->data = std::move( results[i]->data );
-        ctx->stats = results[i]->stats;
-        ctx->gpbFlags = gpbFlags;
-
-        zip_source_t* src = zip_source_function( zip, deflatedSourceCallback, ctx.get() );
-        if ( !src )
-            return unexpected( "Cannot create source for " + archiveFilePath );
-        ctx.release(); // libzip now owns ctx; ZIP_SOURCE_FREE will delete it
-
-        const auto index = zip_file_add( zip, archiveFilePath.c_str(), src, ZIP_FL_OVERWRITE | ZIP_FL_ENC_UTF_8 );
-        if ( index < 0 )
-        {
-            zip_source_free( src ); // also fires ZIP_SOURCE_FREE → deletes ctx
-            return unexpected( "Cannot add file " + archiveFilePath + " to archive" );
-        }
-
-        zip_set_file_compression( zip, index, ZIP_CM_DEFLATE, zip_uint32_t( level ) );
-
-        if ( !settings.password.empty() )
-        {
-            if ( zip_file_set_encryption( zip, index, ZIP_EM_AES_256, settings.password.c_str() ) )
-                return unexpected( "Cannot encrypt file " + archiveFilePath + " in archive" );
-        }
-    }
+    // Phase B — serial hand-off to libzip; the AutoCloseZip keeps entries alive through zip_close
+    if ( auto res = zip.addPreDeflatedEntries( std::move( entries ), files, level, settings.password ); !res )
+        return res;
 
     auto closeRes = zip.close();
 

--- a/source/MRMesh/MRZip.cpp
+++ b/source/MRMesh/MRZip.cpp
@@ -3,6 +3,7 @@
 #include "MRIOParsing.h"
 #include "MRStringConvert.h"
 #include "MRTimer.h"
+#include "MRZlib.h"
 
 #if (defined(__APPLE__) && defined(__clang__)) || defined(__EMSCRIPTEN__)
 #pragma clang diagnostic push
@@ -17,7 +18,10 @@
 #endif
 
 #include <cassert>
+#include <cstring>
 #include <fstream>
+#include <memory>
+#include <sstream>
 
 namespace MR
 {
@@ -222,6 +226,100 @@ Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetF
     return {};
 }
 
+// context for a pre-deflated entry; the caller creates it as a unique_ptr, transfers ownership
+// to libzip via zip_source_function, and the ZIP_SOURCE_FREE command then deletes it
+struct DeflatedSourceCtx
+{
+    std::string data;           ///< raw DEFLATE bytes (RFC 1951, no zlib wrapper)
+    ZlibCompressStats stats;    ///< size / comp_size / crc from zlibCompressStream
+    zip_uint16_t gpbFlags = 0;  ///< precomputed GPB bits 1-2 encoding the deflate level
+    size_t pos = 0;             ///< read cursor for ZIP_SOURCE_READ
+    zip_error_t err{};          ///< scratch for ZIP_SOURCE_ERROR
+};
+
+// PKZIP APPNOTE 4.4.4 buckets the deflate level into four coarse categories via GPB bits 1 and 2;
+// levels 6-8 all map to "normal" and levels 2-5 all map to "fast" — the spec has no finer resolution
+zip_uint16_t deflateGpbLevelFlags( int level )
+{
+    if ( level == 9 ) return 0b0010;                   // maximum:   bit 1 set
+    if ( level >= 2 && level <= 5 ) return 0b0100;     // fast:      bit 2 set
+    if ( level == 1 ) return 0b0110;                   // superfast: bits 1 + 2 set
+    return 0b0000;                                     // normal (levels 6-8): neither bit set
+}
+
+// zip_source_function callback for a pre-deflated buffer; lets libzip's trust-source
+// fast path in zip_close() copy the bytes into the archive without any recompression
+// (no SEEK/TELL on purpose — keeps libzip on the linear-read path)
+zip_int64_t deflatedSourceCallback( void* user, void* data, zip_uint64_t len, zip_source_cmd_t cmd )
+{
+    if ( !user )
+    {
+        assert( false );
+        return -1;
+    }
+    auto* ctx = static_cast<DeflatedSourceCtx*>( user );
+    switch ( cmd )
+    {
+        case ZIP_SOURCE_SUPPORTS:
+            return zip_source_make_command_bitmap( ZIP_SOURCE_OPEN, ZIP_SOURCE_READ, ZIP_SOURCE_CLOSE,
+                ZIP_SOURCE_STAT, ZIP_SOURCE_ERROR, ZIP_SOURCE_FREE, ZIP_SOURCE_SUPPORTS,
+                ZIP_SOURCE_GET_FILE_ATTRIBUTES, ZIP_SOURCE_SUPPORTS_REOPEN, -1 );
+
+        case ZIP_SOURCE_OPEN:
+            ctx->pos = 0;
+            return 0;
+
+        case ZIP_SOURCE_READ:
+        {
+            const size_t n = std::min<size_t>( size_t( len ), ctx->data.size() - ctx->pos );
+            if ( n )
+                std::memcpy( data, ctx->data.data() + ctx->pos, n );
+            ctx->pos += n;
+            return zip_int64_t( n );
+        }
+
+        case ZIP_SOURCE_CLOSE:
+            return 0;
+
+        case ZIP_SOURCE_STAT:
+        {
+            auto* st = (zip_stat_t*)data;
+            zip_stat_init( st );
+            st->size = ctx->stats.uncompressedSize;
+            st->comp_size = ctx->stats.compressedSize;
+            st->comp_method = ZIP_CM_DEFLATE;
+            st->crc = ctx->stats.crc32;
+            st->encryption_method = ZIP_EM_NONE;
+            st->valid = ZIP_STAT_SIZE | ZIP_STAT_COMP_SIZE
+                      | ZIP_STAT_COMP_METHOD | ZIP_STAT_CRC
+                      | ZIP_STAT_ENCRYPTION_METHOD;
+            return sizeof( zip_stat_t );
+        }
+
+        case ZIP_SOURCE_ERROR:
+            return zip_error_to_data( &ctx->err, data, len );
+
+        case ZIP_SOURCE_FREE:
+            delete ctx;
+            return 0;
+
+        case ZIP_SOURCE_GET_FILE_ATTRIBUTES:
+        {
+            auto* a = (zip_file_attributes_t*)data;
+            zip_file_attributes_init( a );
+            a->valid = ZIP_FILE_ATTRIBUTES_VERSION_NEEDED
+                     | ZIP_FILE_ATTRIBUTES_GENERAL_PURPOSE_BIT_FLAGS;
+            a->version_needed = 20;
+            a->general_purpose_bit_flags = ctx->gpbFlags;
+            a->general_purpose_bit_mask = 0b0110; // only bits 1-2 (deflate level) are authoritative here
+            return sizeof( zip_file_attributes_t );
+        }
+
+        default:
+            return -1;
+    }
+}
+
 } // anonymous namespace
 
 Expected<void> compressZip( const std::filesystem::path& zipFile, const std::filesystem::path& sourceFolder, const CompressZipSettings& settings )
@@ -236,7 +334,7 @@ Expected<void> compressZip( const std::filesystem::path& zipFile, const std::fil
         return unexpected( "Directory '" + utf8string( sourceFolder ) + "' does not exist" );
 
     int err;
-    AutoCloseZip zip( utf8string( zipFile ).c_str(), ZIP_CREATE | ZIP_TRUNCATE, &err, subprogress( settings.cb, 0.5f, 1.0f ) );
+    AutoCloseZip zip( utf8string( zipFile ).c_str(), ZIP_CREATE | ZIP_TRUNCATE, &err, subprogress( settings.cb, 0.8f, 1.0f ) );
     if ( !zip )
         return unexpected( "Cannot create zip, error code: " + std::to_string( err ) );
 
@@ -275,26 +373,42 @@ Expected<void> compressZip( const std::filesystem::path& zipFile, const std::fil
         }
     }
 
-    // pass #2: add files in the archive
-    zip_uint32_t compressionLevel = zip_uint32_t( std::clamp( settings.compressionLevel, 0, 9 ) );
-    auto scb = subprogress( settings.cb, 0.0f, 0.5f );
+    // pass #2: deflate each file and hand libzip pre-deflated bytes via a source callback;
+    // libzip's trust-source fast path then copies them into the archive without recompressing
+    // level 0 (the settings-level "use default") normalizes to 6 — zlib's internal default is 6,
+    // and APPNOTE has no sentinel for "default", so 6 is what the archive entry records
+    const int level = settings.compressionLevel == 0 ? 6 : std::clamp( settings.compressionLevel, 1, 9 );
+    const zip_uint16_t gpbFlags = deflateGpbLevelFlags( level );
+    auto scb = subprogress( settings.cb, 0.0f, 0.8f );
     for ( size_t i = 0; i < files.size(); ++i )
     {
         const auto& [path, archiveFilePath] = files[i];
 
-        auto fileSource = zip_source_file( zip, utf8string( path ).c_str(), 0, 0 );
-        if ( !fileSource )
+        std::ifstream in( path, std::ios::binary );
+        if ( !in )
             return unexpected( "Cannot open file " + utf8string( path ) + " for reading" );
 
-        const auto index = zip_file_add( zip, archiveFilePath.c_str(), fileSource, ZIP_FL_OVERWRITE | ZIP_FL_ENC_UTF_8 );
+        auto ctx = std::make_unique<DeflatedSourceCtx>();
+        ctx->gpbFlags = gpbFlags;
+        std::ostringstream out( std::ios::binary );
+        if ( auto r = zlibCompressStream( in, out,
+                 ZlibCompressParams{ { .rawDeflate = true }, level, &ctx->stats } ); !r )
+            return unexpected( r.error() );
+        ctx->data = std::move( out ).str();
+
+        zip_source_t* src = zip_source_function( zip, deflatedSourceCallback, ctx.get() );
+        if ( !src )
+            return unexpected( "Cannot create source for " + archiveFilePath );
+        ctx.release(); // libzip now owns ctx; ZIP_SOURCE_FREE will delete it
+
+        const auto index = zip_file_add( zip, archiveFilePath.c_str(), src, ZIP_FL_OVERWRITE | ZIP_FL_ENC_UTF_8 );
         if ( index < 0 )
         {
-            zip_source_free( fileSource );
+            zip_source_free( src ); // also fires ZIP_SOURCE_FREE → deletes ctx
             return unexpected( "Cannot add file " + archiveFilePath + " to archive" );
         }
 
-        if ( compressionLevel != 0 )
-            zip_set_file_compression( zip, index, ZIP_CM_DEFAULT, compressionLevel );
+        zip_set_file_compression( zip, index, ZIP_CM_DEFLATE, zip_uint32_t( level ) );
 
         if ( !settings.password.empty() )
         {

--- a/source/MRMesh/MRZip.cpp
+++ b/source/MRMesh/MRZip.cpp
@@ -1,6 +1,7 @@
 #include "MRZip.h"
 #include "MRDirectory.h"
 #include "MRIOParsing.h"
+#include "MRParallelFor.h"
 #include "MRStringConvert.h"
 #include "MRTimer.h"
 #include "MRZlib.h"
@@ -17,6 +18,7 @@
 #pragma clang diagnostic pop
 #endif
 
+#include <atomic>
 #include <cassert>
 #include <cstring>
 #include <fstream>
@@ -226,11 +228,18 @@ Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetF
     return {};
 }
 
+// Phase A output per file; pass #2 moves this into a DeflatedSourceCtx for libzip hand-off
+struct DeflatedEntry
+{
+    std::vector<uint8_t> data;  ///< raw DEFLATE bytes (RFC 1951, no zlib wrapper)
+    ZlibCompressStats stats;    ///< CRC-32 + uncompressed/compressed sizes
+};
+
 // context for a pre-deflated entry; the caller creates it as a unique_ptr, transfers ownership
 // to libzip via zip_source_function, and the ZIP_SOURCE_FREE command then deletes it
 struct DeflatedSourceCtx
 {
-    std::string data;           ///< raw DEFLATE bytes (RFC 1951, no zlib wrapper)
+    std::vector<uint8_t> data;  ///< raw DEFLATE bytes (RFC 1951, no zlib wrapper)
     ZlibCompressStats stats;    ///< size / comp_size / crc from zlibCompressStream
     zip_uint16_t gpbFlags = 0;  ///< precomputed GPB bits 1-2 encoding the deflate level
     size_t pos = 0;             ///< read cursor for ZIP_SOURCE_READ
@@ -374,27 +383,61 @@ Expected<void> compressZip( const std::filesystem::path& zipFile, const std::fil
     }
 
     // pass #2: deflate each file and hand libzip pre-deflated bytes via a source callback;
-    // libzip's trust-source fast path then copies them into the archive without recompressing
+    // libzip's trust-source fast path then copies them into the archive without recompressing.
     // level 0 (the settings-level "use default") normalizes to 6 — zlib's internal default is 6,
     // and APPNOTE has no sentinel for "default", so 6 is what the archive entry records
     const int level = settings.compressionLevel == 0 ? 6 : std::clamp( settings.compressionLevel, 1, 9 );
     const zip_uint16_t gpbFlags = deflateGpbLevelFlags( level );
-    auto scb = subprogress( settings.cb, 0.0f, 0.8f );
-    for ( size_t i = 0; i < files.size(); ++i )
+
+    // Phase A — parallel: read each file and deflate it into a per-slot DeflatedEntry
+    std::vector<Expected<DeflatedEntry>> results( files.size() );
+    std::atomic<bool> hadError{ false };
+    auto scbA = subprogress( settings.cb, 0.0f, 0.8f );
+
+    auto keepGoing = ParallelFor( files, [&]( size_t i )
     {
-        const auto& [path, archiveFilePath] = files[i];
+        if ( hadError.load( std::memory_order_relaxed ) )
+            return; // some other worker already failed; skip
 
-        std::ifstream in( path, std::ios::binary );
+        std::ifstream in( files[i].first, std::ios::binary );
         if ( !in )
-            return unexpected( "Cannot open file " + utf8string( path ) + " for reading" );
+        {
+            results[i] = unexpected( "Cannot open file " + utf8string( files[i].first ) + " for reading" );
+            hadError.store( true, std::memory_order_relaxed );
+            return;
+        }
 
-        auto ctx = std::make_unique<DeflatedSourceCtx>();
-        ctx->gpbFlags = gpbFlags;
+        DeflatedEntry e;
         std::ostringstream out( std::ios::binary );
         if ( auto r = zlibCompressStream( in, out,
-                 ZlibCompressParams{ { .rawDeflate = true }, level, &ctx->stats } ); !r )
-            return unexpected( r.error() );
-        ctx->data = std::move( out ).str();
+                 ZlibCompressParams{ { .rawDeflate = true }, level, &e.stats } ); !r )
+        {
+            results[i] = unexpected( r.error() );
+            hadError.store( true, std::memory_order_relaxed );
+            return;
+        }
+        // zlibCompressStream requires std::ostream&, so we go through ostringstream and copy out;
+        // the copy is O(deflated_size), trivial next to zlib's own cost per file
+        const std::string s = std::move( out ).str();
+        e.data.assign( s.begin(), s.end() );
+        results[i] = std::move( e );
+    }, scbA, 16 /* reportProgressEvery — keeps the UI ticking and cancel responsive for typical file counts */ );
+
+    if ( !keepGoing )
+        return unexpectedOperationCanceled();
+    for ( auto& r : results )
+        if ( !r )
+            return unexpected( r.error() ); // first error (lowest index) wins
+
+    // Phase B — serial: hand each pre-deflated buffer to libzip
+    for ( size_t i = 0; i < files.size(); ++i )
+    {
+        const auto& archiveFilePath = files[i].second;
+
+        auto ctx = std::make_unique<DeflatedSourceCtx>();
+        ctx->data = std::move( results[i]->data );
+        ctx->stats = results[i]->stats;
+        ctx->gpbFlags = gpbFlags;
 
         zip_source_t* src = zip_source_function( zip, deflatedSourceCallback, ctx.get() );
         if ( !src )
@@ -415,9 +458,6 @@ Expected<void> compressZip( const std::filesystem::path& zipFile, const std::fil
             if ( zip_file_set_encryption( zip, index, ZIP_EM_AES_256, settings.password.c_str() ) )
                 return unexpected( "Cannot encrypt file " + archiveFilePath + " in archive" );
         }
-
-        if ( !reportProgress( scb, float( i + 1 ) / files.size() ) )
-            return unexpectedOperationCanceled();
     }
 
     auto closeRes = zip.close();

--- a/source/MRMesh/MRZip.cpp
+++ b/source/MRMesh/MRZip.cpp
@@ -251,8 +251,8 @@ Expected<void> compressZip( const std::filesystem::path& zipFile, const std::fil
         return excluded == settings.excludeFiles.end();
     };
 
-    // pass #1: add directories in the archive and count the files
-    int totalFiles = 0;
+    // pass #1: add directories in the archive and collect the files to compress
+    std::vector<std::pair<std::filesystem::path, std::string>> files;
     for ( auto entry : DirectoryRecursive{ sourceFolder, ec } )
     {
         const auto path = entry.path();
@@ -267,26 +267,25 @@ Expected<void> compressZip( const std::filesystem::path& zipFile, const std::fil
         }
 
         if ( goodFile( path ) )
-            ++totalFiles;
+        {
+            auto archiveFilePath = utf8string( std::filesystem::relative( path, sourceFolder, ec ) );
+            // convert folder separators in Linux style for the latest 7-zip to open archive correctly
+            std::replace( archiveFilePath.begin(), archiveFilePath.end(), '\\', '/' );
+            files.emplace_back( path, std::move( archiveFilePath ) );
+        }
     }
 
     // pass #2: add files in the archive
     zip_uint32_t compressionLevel = zip_uint32_t( std::clamp( settings.compressionLevel, 0, 9 ) );
-    int compressedFiles = 0;
     auto scb = subprogress( settings.cb, 0.0f, 0.5f );
-    for ( auto entry : DirectoryRecursive{ sourceFolder, ec } )
+    for ( size_t i = 0; i < files.size(); ++i )
     {
-        const auto path = entry.path();
-        if ( !goodFile( path ) )
-            continue;
+        const auto& [path, archiveFilePath] = files[i];
 
         auto fileSource = zip_source_file( zip, utf8string( path ).c_str(), 0, 0 );
         if ( !fileSource )
             return unexpected( "Cannot open file " + utf8string( path ) + " for reading" );
 
-        auto archiveFilePath = utf8string( std::filesystem::relative( path, sourceFolder, ec ) );
-        // convert folder separators in Linux style for the latest 7-zip to open archive correctly
-        std::replace( archiveFilePath.begin(), archiveFilePath.end(), '\\', '/' );
         const auto index = zip_file_add( zip, archiveFilePath.c_str(), fileSource, ZIP_FL_OVERWRITE | ZIP_FL_ENC_UTF_8 );
         if ( index < 0 )
         {
@@ -303,8 +302,7 @@ Expected<void> compressZip( const std::filesystem::path& zipFile, const std::fil
                 return unexpected( "Cannot encrypt file " + archiveFilePath + " in archive" );
         }
 
-        ++compressedFiles;
-        if ( !reportProgress( scb, std::min( float( compressedFiles ) / totalFiles, 1.0f ) ) )
+        if ( !reportProgress( scb, float( i + 1 ) / files.size() ) )
             return unexpectedOperationCanceled();
     }
 


### PR DESCRIPTION
## Why

`MR::compressZip` was single-threaded: every per-file `deflate` + CRC-32 happened inside libzip's `zip_close()`. zlib's deflate is CPU-bound and trivially parallelizable across entries, but libzip doesn't parallelize internally. Final step of the 3-part series started by [#5944](https://github.com/MeshInspector/MeshLib/pull/5944) (MRZlib relocation + raw-deflate mode) and [#5948](https://github.com/MeshInspector/MeshLib/pull/5948) (`ZlibCompressStats` output).

## What

Three commits, each self-contained:

### [97adcfb9](https://github.com/MeshInspector/MeshLib/commit/97adcfb9) — collapse two directory walks into one
Pass #1 walked `DirectoryRecursive` to add directories and count files; pass #2 walked the same tree again to add each file source. Single walk now adds directories inline and collects the files into a vector; pass #2 iterates the vector by index. No semantic change; archive contents/order/bytes preserved.

### [fbde26ba](https://github.com/MeshInspector/MeshLib/commit/fbde26ba) — pre-deflate via libzip's trust-source fast path (still serial)
Per-file deflate moved out of `zip_close` into pass #2 via `zlibCompressStream` (raw DEFLATE + `ZlibCompressStats`). A `zip_source_function` callback reports `comp_method = ZIP_CM_DEFLATE` plus valid `size`/`comp_size`/`crc`; with the entry added at `ZIP_CM_DEFLATE`, libzip's fast path in `zip_close` ([zip_close.c:413-417](thirdparty/libzip/lib/zip_close.c#L413)) copies pre-deflated bytes straight into the archive — no recompression, no re-CRC.

The callback also implements `GET_FILE_ATTRIBUTES` (GPB bits 1-2 encoding the deflate level per APPNOTE 4.4.4) and `SUPPORTS_REOPEN`, and deliberately skips `SEEK`/`TELL` to keep libzip on the linear-read path. Context ownership: `unique_ptr` before hand-off, `release()` after `zip_source_function`, `ZIP_SOURCE_FREE` deletes. Progress band shifts `0.5→1.0` to `0.8→1.0` on `zip_close` — it's now a byte-copy; pass #2 gets the bulk `0.0→0.8`.

Level-0 (settings "use default") normalizes to 6 unconditionally — the archive entry needs 1-9 and zlib's internal default maps to 6, so `zip_set_file_compression` is now unconditional rather than skipped.

### [cee5ebd3](https://github.com/MeshInspector/MeshLib/commit/cee5ebd3) — parallelize the pre-deflate
Pass #2 splits into two phases:

- **Phase A (parallel)** — `ParallelFor` over `files`. Each worker opens its file, calls `zlibCompressStream` into a `DeflatedEntry { std::vector<uint8_t> data; ZlibCompressStats stats; }`, and writes the slot in `results[i]`. Errors write `unexpected` to the slot and set a relaxed `hadError` atomic so other workers early-exit. `reportProgressEvery = 16` (the default 1024 would never fire for typical file counts).
- **Phase B (serial)** — for each `results[i]`, move into a fresh `DeflatedSourceCtx` and hand off to libzip via the unchanged 3b idiom.

After Phase A, `results` is scanned in order: first-error-by-index wins, which matches the sequential baseline's determinism.

Drive-by: `DeflatedSourceCtx::data` flipped from `std::string` to `std::vector<uint8_t>` — raw DEFLATE bytes aren't text, and the shared type keeps the Phase A → Phase B move trivial. Callback's `memcpy` is unchanged (`.data()`/`.size()` work identically).

## Test plan

- [x] Round-trip: `compressZip → decompressZip → diff -r` on a representative scene folder (meshes + textures + JSON), clean.
- [x] Bit-compare against master (modulo mtime): `zipinfo -v` — per-entry `size`/`comp_size`/`crc`/`comp_method`/GPB flags identical.
- [x] Speedup: 50-file ~200 MB mixed archive, 8-core — expect ≥3× wall-time reduction on the deflate phase. Note before/after in review.
- [x] AES-256 round-trip: encrypt, open in 7-Zip + Windows Explorer.
- [ ] External decompressors: 7-Zip (Win), `unzip` (Linux), macOS Finder — list + extract cleanly.
- [ ] Compression levels 0 / 1 / 6 / 9 each round-trip; level-9 strictly smaller than level-1 on compressible data.
- [ ] Empty file (0 bytes) — deflate emits `0x03 0x00`; trust-source path must accept `comp_size=2, size=0, crc=0`.
- [ ] Cancel mid-Phase-A via progress callback returning false; no leaked `DeflatedSourceCtx` (ASan on Linux).
- [ ] Per-file read error (`chmod 000` on Linux / ACL deny on Windows) surfaces with file path; first-error-by-index is deterministic under multi-file errors.
- [ ] `TBB_NUM_THREADS=1` produces identical output to the multi-thread run.
- [x] MeshInspector "Save As .mru" on a substantial scene — no user-visible change beyond speed.

## Out of scope

- Torrentzip — incompatible with the trust-source fast path.
- Bounded-memory `tbb::parallel_pipeline` — deferred until RAM at scale becomes an issue.
- `decompressZip` — untouched.