### PR TITLE
ci(windows): fix CUDA cache key + path to avoid full reinstall

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -115,8 +115,16 @@ jobs:
         uses: actions/cache@v5
         id: cuda-cache
         with:
-          key: cuda-${{matrix.CUDA-VERSION}}
-          path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA*
+          # Key version bumped (-v2) to invalidate the existing entries — the
+          # prior restore consistently warned "Failed to restore" and fell
+          # through to a 16-minute choco reinstall, even though the server
+          # reported a cache hit. Path tightened from the trailing-star glob
+          # (C:\...\CUDA* — which also captured "CUDA Samples", "CUDA SDK" and
+          # every toolkit version directory present on the runner) down to
+          # the exact per-version directory, so each cache entry maps to
+          # exactly one toolkit version and the restore is deterministic.
+          key: cuda-toolkit-${{ matrix.CUDA-VERSION }}-v2
+          path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ matrix.CUDA-MAJOR }}.${{ matrix.CUDA-MINOR }}
 
       - name: Install CUDA
         if: ${{ steps.cuda-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -115,14 +115,6 @@ jobs:
         uses: actions/cache@v5
         id: cuda-cache
         with:
-          # Key version bumped (-v2) to invalidate the existing entries — the
-          # prior restore consistently warned "Failed to restore" and fell
-          # through to a 16-minute choco reinstall, even though the server
-          # reported a cache hit. Path tightened from the trailing-star glob
-          # (C:\...\CUDA* — which also captured "CUDA Samples", "CUDA SDK" and
-          # every toolkit version directory present on the runner) down to
-          # the exact per-version directory, so each cache entry maps to
-          # exactly one toolkit version and the restore is deterministic.
           key: cuda-toolkit-${{ matrix.CUDA-VERSION }}-v2
           path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ matrix.CUDA-MAJOR }}.${{ matrix.CUDA-MINOR }}
 


### PR DESCRIPTION
## Problem

The Windows vcpkg `Install CUDA` step was eating 16–17 minutes per matrix leg because `actions/cache@v5`'s restore failed mid-stream even when the server reported a cache hit:

```
Cache hit for: cuda-12.0.1.52833
##[warning]Failed to restore:
Cache not found for input keys: cuda-12.0.1.52833
choco install cuda --version=12.0.1.52833 --confirm
Downloading cuda_12.0.1_528.33_windows.exe (3.43 GB)
Installing cuda...
cuda has been installed.         ← 16 minutes later
```

(Seen on run [24768907515](https://github.com/MeshInspector/MeshLib/actions/runs/24768907515/job/72470031519).)

## Root cause

```yaml
key:  cuda-${{ matrix.CUDA-VERSION }}
path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA*
```

The trailing-star glob matched every CUDA-related directory on the runner: all installed toolkit versions (`v11.4`, `v12.0`, …) plus siblings like `CUDA Samples` and `CUDA SDK`. Which files ended up in the cache depended on which matrix leg saved it first, and whatever was saved then failed `actions/cache`'s content verification on subsequent restores — hence the persistent "Failed to restore" warning.

## Fix

Tighten the path to one version per cache entry, bump the key to invalidate the existing corrupt entries:

```yaml
key:  cuda-toolkit-${{ matrix.CUDA-VERSION }}-v2
path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ matrix.CUDA-MAJOR }}.${{ matrix.CUDA-MINOR }}
```

Each cache entry now maps to exactly one toolkit version. No other changes.

## Verified on CI

Two runs on this branch prove the fix works.

**Run 1** — [`24773007640`](https://github.com/MeshInspector/MeshLib/actions/runs/24773007640) — new `-v2` key, expected miss:

```
  key: cuda-toolkit-12.0.1.52833-v2
  Cache not found for input keys: cuda-toolkit-12.0.1.52833-v2
  choco install cuda --version=12.0.1.52833 --confirm
  cuda has been installed.           ← 13 min, saved under the new key
```

**Run 2** — [`24774870654`](https://github.com/MeshInspector/MeshLib/actions/runs/24774870654) — on top of run 1's saved cache:

```
  key: cuda-toolkit-12.0.1.52833-v2
  Cache hit for: cuda-toolkit-12.0.1.52833-v2
  Cache restored from key: cuda-toolkit-12.0.1.52833-v2     ← 27 s
  # (Install CUDA step skipped by if: cache-hit != 'true')
```

No `##[warning]Failed to restore` on either run — the silent-hit-that-falls-back-to-reinstall behaviour is gone.

Per-leg savings between run 1 (cold) and run 2 (warm):

| Matrix leg | Run 1 | Run 2 | Δ |
|---|---:|---:|---:|
| msvc-2019 Debug CMake (CUDA 11.4) | 34 m 44 s | 22 m 33 s | −12 m |
| msvc-2022 Release CMake (CUDA 12.0) | 1 h 2 m 55 s | 52 m 5 s | −11 m |
| msvc-2022 Debug MSBuild (CUDA 12.0) | 45 m 30 s | 36 m 0 s | −9.5 m |
| msvc-2019 Release CMake (CUDA 11.4) | 54 m 31 s | 47 m 3 s | −7.5 m |

Aligned with the expected ~10–16 min of CUDA install collapsing into a ~30 s restore (remaining variance comes from vcpkg install, compile, and test steps that vary run-to-run).

## Cost

First Windows run after this merges pays the install cost once per CUDA version (4 legs → 2 distinct `-v2` caches saved, since msvc-2019 uses CUDA 11.4 and msvc-2022 uses CUDA 12.0). Every subsequent run hits the cache in ~20–30 s.

## Not in this PR

- Installing only the CUDA components MRCuda actually uses (~17 min → ~3–4 min even on cold cache) — a follow-up if restore failures reappear after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
