### PR TITLE
test: round-trip decompressZip check in CompressManySmallFilesToZip

### DIFF
--- a/source/MRTest/MRZipCompressTests.cpp
+++ b/source/MRTest/MRZipCompressTests.cpp
@@ -194,6 +194,50 @@ TEST( MRMesh, CompressManySmallFilesToZip )
 
     // Sanity envelope: same bound as the sphere test.
     EXPECT_LT( zipSize, totalInput * 2u );
+
+    // Round-trip: decompress the archive into a fresh temp folder and verify
+    // every original file comes back byte-for-byte. Catches subtle regressions
+    // in the compressZip -> decompressZip path that the size envelope above
+    // would miss (entry truncation, wrong method byte, CRC-vs-data mismatch,
+    // off-by-one in a local file header, etc.).
+    UniqueTemporaryFolder roundtripFolder;
+    ASSERT_TRUE( bool( roundtripFolder ) );
+    const auto decompressRes = decompressZip( zipPath, roundtripFolder );
+    ASSERT_TRUE( decompressRes.has_value() ) << decompressRes.error();
+
+    auto readAllBytes = []( const std::filesystem::path& p ) -> std::vector<char>
+    {
+        std::ifstream in( p, std::ios::binary | std::ios::ate );
+        if ( !in )
+            return {};
+        const std::streamoff sz = in.tellg();
+        in.seekg( 0 );
+        std::vector<char> buf( sz < 0 ? 0 : size_t( sz ) );
+        if ( !buf.empty() )
+            in.read( buf.data(), std::streamsize( buf.size() ) );
+        return buf;
+    };
+
+    int verified = 0;
+    const std::filesystem::path srcRoot = srcFolder;
+    const std::filesystem::path rtRoot  = roundtripFolder;
+    for ( const auto& entry : std::filesystem::recursive_directory_iterator{ srcRoot } )
+    {
+        if ( !entry.is_regular_file( ec ) )
+            continue;
+        const auto rel = std::filesystem::relative( entry.path(), srcRoot, ec );
+        const auto dst = rtRoot / rel;
+        ASSERT_TRUE( std::filesystem::exists( dst, ec ) )
+            << "missing in roundtrip: " << rel.generic_string();
+        const auto origBytes = readAllBytes( entry.path() );
+        const auto rtBytes   = readAllBytes( dst );
+        ASSERT_EQ( origBytes.size(), rtBytes.size() )
+            << "size mismatch: " << rel.generic_string();
+        EXPECT_EQ( origBytes, rtBytes )
+            << "content mismatch: " << rel.generic_string();
+        ++verified;
+    }
+    EXPECT_EQ( verified, numBinaryFiles + numJsonFiles );
 }
 
 } // namespace MR

--- a/source/MRTest/MRZipCompressTests.cpp
+++ b/source/MRTest/MRZipCompressTests.cpp
@@ -1,3 +1,4 @@
+#include <MRMesh/MRDirectory.h>
 #include <MRMesh/MRGTest.h>
 #include <MRMesh/MRMakeSphereMesh.h>
 #include <MRMesh/MRMesh.h>
@@ -221,7 +222,7 @@ TEST( MRMesh, CompressManySmallFilesToZip )
     int verified = 0;
     const std::filesystem::path srcRoot = srcFolder;
     const std::filesystem::path rtRoot  = roundtripFolder;
-    for ( const auto& entry : std::filesystem::recursive_directory_iterator{ srcRoot } )
+    for ( auto entry : DirectoryRecursive{ srcRoot, ec } )
     {
         if ( !entry.is_regular_file( ec ) )
             continue;


### PR DESCRIPTION
## Summary

Extend `TEST( MRMesh, CompressManySmallFilesToZip )` with a round-trip check: after compressing the 20 `.bin` + 20 `.json` source files to `many.zip`, decompress the archive into a fresh temp folder and verify every original file is recovered byte-for-byte.

## Why

The existing size-envelope check (`EXPECT_LT( zipSize, totalInput * 2u )`) only proves the zip exists and isn't pathological in size. It does not prove the archive actually decodes, let alone decodes to the originals. The kinds of regressions that have surfaced on `compressZip` in recent work would slip past a size-only check:

- wrong general-purpose bit flag / method byte on an entry (archive looks fine, entry reads as wrong size)
- CRC mismatch vs. the compressed payload (valid deflate stream, wrong CRC → reader rejects)
- off-by-one in a local file header size or extra-field length
- entry truncation during the final flush

The round-trip compare catches all of these without needing a second reader (7-Zip / Python `zipfile`) in the CI path.

## What the check does

- Decompresses `many.zip` into a new `UniqueTemporaryFolder`
- Walks `srcFolder` with `DirectoryRecursive` (same style as `MRZip.cpp::compressZip`); for each regular file, mirrors the relative path into the decompressed tree
- Asserts the decompressed file exists, has identical size, and has identical bytes
- Asserts that exactly `numBinaryFiles + numJsonFiles` entries (default 40) were actually visited — a silently-empty iteration fails loudly

## What it doesn't do

- Sphere test is untouched. That test saves a single `.mrmesh` via `MeshSave::toMrmesh`, which MeshLib's own loader already round-trips under separate mesh-IO tests.
- No new dependencies — `std::ifstream` for the byte compare, `DirectoryRecursive` (already used in `MRZip.cpp`) for the walk.

## CI measurements

Full matrix green on run [`24773463735`](https://github.com/MeshInspector/MeshLib/actions/runs/24773463735) (all 28 jobs). Example from the macOS x64 Release leg:

```
[ RUN      ] MRMesh.CompressManySmallFilesToZip
[info] many-files input:   120000 binary + 120000 json = 240000 bytes
[info] many.zip size:      157342 bytes
[info] many.zip compression time: 0.00848868s sec
[       OK ] MRMesh.CompressManySmallFilesToZip (44 ms)
```

44 ms end-to-end vs. the pre-change baseline of ~10–20 ms — decompress + per-file byte compare of 40 × 6 KB = 240 KB adds roughly 25 ms on a hot macOS runner. Below the noise floor for the MRTest run as a whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
