### PR TITLE
test: loop compress + round-trip over CompressZipSettings levels 0..9

### DIFF
--- a/source/MRTest/MRZipCompressTests.cpp
+++ b/source/MRTest/MRZipCompressTests.cpp
@@ -177,35 +177,6 @@ TEST( MRMesh, CompressManySmallFilesToZip )
     spdlog::info( "many-files input:   {} binary + {} json = {} bytes",
         totalBinaryBytes, totalJsonBytes, totalInput );
 
-    // Compress to a zip in a separate temp folder.
-    UniqueTemporaryFolder dstFolder;
-    ASSERT_TRUE( bool( dstFolder ) );
-    const std::filesystem::path zipPath = dstFolder / "many.zip";
-
-    Timer t( "t" );
-    const auto compressRes = compressZip( zipPath, srcFolder );
-    const auto sec = t.secondsPassed();
-    ASSERT_TRUE( compressRes.has_value() ) << compressRes.error();
-    std::error_code ec;
-    ASSERT_TRUE( std::filesystem::exists( zipPath, ec ) );
-    const auto zipSize = std::filesystem::file_size( zipPath, ec );
-    EXPECT_GT( zipSize, 0u );
-    spdlog::info( "many.zip size:      {} bytes", zipSize );
-    spdlog::info( "many.zip compression time: {} sec", sec );
-
-    // Sanity envelope: same bound as the sphere test.
-    EXPECT_LT( zipSize, totalInput * 2u );
-
-    // Round-trip: decompress the archive into a fresh temp folder and verify
-    // every original file comes back byte-for-byte. Catches subtle regressions
-    // in the compressZip -> decompressZip path that the size envelope above
-    // would miss (entry truncation, wrong method byte, CRC-vs-data mismatch,
-    // off-by-one in a local file header, etc.).
-    UniqueTemporaryFolder roundtripFolder;
-    ASSERT_TRUE( bool( roundtripFolder ) );
-    const auto decompressRes = decompressZip( zipPath, roundtripFolder );
-    ASSERT_TRUE( decompressRes.has_value() ) << decompressRes.error();
-
     auto readAllBytes = []( const std::filesystem::path& p ) -> std::vector<char>
     {
         std::ifstream in( p, std::ios::binary | std::ios::ate );
@@ -219,26 +190,68 @@ TEST( MRMesh, CompressManySmallFilesToZip )
         return buf;
     };
 
-    int verified = 0;
+    std::error_code ec;
     const std::filesystem::path srcRoot = srcFolder;
-    const std::filesystem::path rtRoot  = roundtripFolder;
-    for ( auto entry : DirectoryRecursive{ srcRoot, ec } )
+
+    // Exercise every compression level accepted by CompressZipSettings:
+    // 0 is documented as "use default level"; 1..9 span fastest -> best-ratio.
+    // For each level: compress the source tree, then decompress into a fresh
+    // temp folder and verify every file round-trips byte-for-byte. Catches
+    // level-dependent wiring bugs (wrong general-purpose bit flag for the
+    // entry, mis-encoded compression-method/level byte, store-mode fallthrough
+    // on a compressible payload, etc.) that a single-level run would miss.
+    for ( int level = 0; level <= 9; ++level )
     {
-        if ( !entry.is_regular_file( ec ) )
-            continue;
-        const auto rel = std::filesystem::relative( entry.path(), srcRoot, ec );
-        const auto dst = rtRoot / rel;
-        ASSERT_TRUE( std::filesystem::exists( dst, ec ) )
-            << "missing in roundtrip: " << rel.generic_string();
-        const auto origBytes = readAllBytes( entry.path() );
-        const auto rtBytes   = readAllBytes( dst );
-        ASSERT_EQ( origBytes.size(), rtBytes.size() )
-            << "size mismatch: " << rel.generic_string();
-        EXPECT_EQ( origBytes, rtBytes )
-            << "content mismatch: " << rel.generic_string();
-        ++verified;
+        UniqueTemporaryFolder dstFolder;
+        ASSERT_TRUE( bool( dstFolder ) ) << "level " << level;
+        const std::filesystem::path zipPath = dstFolder / "many.zip";
+
+        CompressZipSettings settings;
+        settings.compressionLevel = level;
+
+        Timer t( "t" );
+        const auto compressRes = compressZip( zipPath, srcFolder, settings );
+        const auto sec = t.secondsPassed();
+        ASSERT_TRUE( compressRes.has_value() )
+            << "level " << level << ": " << compressRes.error();
+        ASSERT_TRUE( std::filesystem::exists( zipPath, ec ) ) << "level " << level;
+        const auto zipSize = std::filesystem::file_size( zipPath, ec );
+        EXPECT_GT( zipSize, 0u ) << "level " << level;
+        spdlog::info( "level {}: many.zip size: {} bytes, compression time: {} sec",
+            level, zipSize, sec );
+
+        // Sanity envelope: same bound as the sphere test.
+        EXPECT_LT( zipSize, totalInput * 2u ) << "level " << level;
+
+        // Round-trip: decompress into a fresh folder and compare every file's
+        // bytes. Built per-iteration so each level gets an independent target
+        // tree, with no cross-level contamination.
+        UniqueTemporaryFolder roundtripFolder;
+        ASSERT_TRUE( bool( roundtripFolder ) ) << "level " << level;
+        const auto decompressRes = decompressZip( zipPath, roundtripFolder );
+        ASSERT_TRUE( decompressRes.has_value() )
+            << "level " << level << ": " << decompressRes.error();
+
+        int verified = 0;
+        const std::filesystem::path rtRoot = roundtripFolder;
+        for ( auto entry : DirectoryRecursive{ srcRoot, ec } )
+        {
+            if ( !entry.is_regular_file( ec ) )
+                continue;
+            const auto rel = std::filesystem::relative( entry.path(), srcRoot, ec );
+            const auto dst = rtRoot / rel;
+            ASSERT_TRUE( std::filesystem::exists( dst, ec ) )
+                << "level " << level << ": missing in roundtrip: " << rel.generic_string();
+            const auto origBytes = readAllBytes( entry.path() );
+            const auto rtBytes   = readAllBytes( dst );
+            ASSERT_EQ( origBytes.size(), rtBytes.size() )
+                << "level " << level << ": size mismatch: " << rel.generic_string();
+            EXPECT_EQ( origBytes, rtBytes )
+                << "level " << level << ": content mismatch: " << rel.generic_string();
+            ++verified;
+        }
+        EXPECT_EQ( verified, numBinaryFiles + numJsonFiles ) << "level " << level;
     }
-    EXPECT_EQ( verified, numBinaryFiles + numJsonFiles );
 }
 
 } // namespace MR


### PR DESCRIPTION
## Summary

Extend `TEST( MRMesh, CompressManySmallFilesToZip )` to iterate every documented value of `CompressZipSettings::compressionLevel`:

- `0` = use default level (libzip falls through to `ZIP_CM_DEFAULT`)
- `1..9` = explicit levels passed to `zip_set_file_compression`

For each of the 10 levels the test now:

1. Builds a fresh `UniqueTemporaryFolder` for the output zip.
2. Compresses `srcFolder` → `many.zip` with `settings.compressionLevel = level`.
3. Logs per-level `zipSize` and `compressionTime` via `spdlog::info`.
4. Asserts the size envelope `zipSize < totalInput * 2` (unchanged bound).
5. Decompresses into a second fresh `UniqueTemporaryFolder`.
6. Walks `srcFolder` with `DirectoryRecursive`, mirrors each path into the roundtrip tree, and compares bytes with `EXPECT_EQ`.
7. Asserts that all `numBinaryFiles + numJsonFiles` (default 40) files were actually verified.

## Why

The single-level run merged in #5958 only exercised `compressionLevel = 0` (default). Level-dependent wiring bugs that a default-level pass would miss:

- wrong general-purpose bit flag bits 1–2 for the entry (spec encodes the four-level category there)
- a level value leaking into the wrong PKZIP field
- store-mode fallthrough on a level where deflate is expected
- libzip's `zip_set_file_compression` being silently ignored because of an earlier `ZIP_CM_DEFAULT` path

Any of those would still produce a zip that passes the size envelope but fails on readback at exactly the one level that hits the bug.

## Cost

Input generation (40 files × 6000 bytes = 240 KB) is still a one-time setup outside the loop. `readAllBytes`, `DirectoryRecursive` walk, and temp folders are reused across iterations — each compress + decompress + compare was ~40 ms on macOS x64 Release in #5958's verification run, so 10 levels ≈ 0.4 s added to the Unit Tests step.

The per-level log lines also give a size-vs-speed curve for the `compressZip` path on every matrix leg, which will show up clearly in `spdlog::info` output and is useful baseline data for any future backend-swap PR.

## No production code changes

Source change is one file (`source/MRTest/MRZipCompressTests.cpp`, +59/−46). The sphere test and the input-generation logic are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
