### PR TITLE
UI TestEngine: expose disabled/blocked state on entries

### DIFF
--- a/source/MRMcp/MRMcp.h
+++ b/source/MRMcp/MRMcp.h
@@ -51,16 +51,6 @@ namespace Schema
         {}
     };
 
-    /// A schema describing a boolean.
-    struct Bool : Base
-    {
-        Bool()
-            : Base( nlohmann::json::object( {
-                { "type", "boolean" },
-            } ) )
-        {}
-    };
-
     /// A schema describing an array of whatever is passed to the constructor.
     struct Array : Base
     {

--- a/source/MRMcp/MRMcp.h
+++ b/source/MRMcp/MRMcp.h
@@ -51,6 +51,16 @@ namespace Schema
         {}
     };
 
+    /// A schema describing a boolean.
+    struct Bool : Base
+    {
+        Bool()
+            : Base( nlohmann::json::object( {
+                { "type", "boolean" },
+            } ) )
+        {}
+    };
+
     /// A schema describing an array of whatever is passed to the constructor.
     struct Array : Base
     {

--- a/source/MRViewer/MRRibbonButtonDrawer.cpp
+++ b/source/MRViewer/MRRibbonButtonDrawer.cpp
@@ -282,7 +282,10 @@ void RibbonButtonDrawer::drawCustomButtonItem( const MenuItemInfo& item, const C
         pushRibbonButtonColors( requirements.empty(), item.item->isActive(), params.forceHovered, params.rootType );
     ImGui::SetNextItemAllowOverlap();
     bool pressed = ImGui::ButtonEx( ( "##wholeChildBtn" + item.item->name() ).c_str(), itemSize, ImGuiButtonFlags_AllowOverlap );
-    pressed = UI::TestEngine::createButton( item.item->name(), /*disabled*/ !requirements.empty() ) || pressed; // Must not short-circuit.
+    // `requirements` empty = no unmet requirements = button enabled; non-empty = disabled with this reason.
+    pressed = UI::TestEngine::createButton(
+        item.item->name(),
+        { .disabledReason = requirements } ) || pressed; // Must not short-circuit.
     pressed = pressed || params.forcePressed;
 
     float fontScale = 1.f;

--- a/source/MRViewer/MRRibbonButtonDrawer.cpp
+++ b/source/MRViewer/MRRibbonButtonDrawer.cpp
@@ -282,7 +282,6 @@ void RibbonButtonDrawer::drawCustomButtonItem( const MenuItemInfo& item, const C
         pushRibbonButtonColors( requirements.empty(), item.item->isActive(), params.forceHovered, params.rootType );
     ImGui::SetNextItemAllowOverlap();
     bool pressed = ImGui::ButtonEx( ( "##wholeChildBtn" + item.item->name() ).c_str(), itemSize, ImGuiButtonFlags_AllowOverlap );
-    // `requirements` empty = no unmet requirements = button enabled; non-empty = disabled with this reason.
     pressed = UI::TestEngine::createButton(
         item.item->name(),
         { .disabledReason = requirements } ) || pressed; // Must not short-circuit.

--- a/source/MRViewer/MRRibbonButtonDrawer.cpp
+++ b/source/MRViewer/MRRibbonButtonDrawer.cpp
@@ -282,7 +282,7 @@ void RibbonButtonDrawer::drawCustomButtonItem( const MenuItemInfo& item, const C
         pushRibbonButtonColors( requirements.empty(), item.item->isActive(), params.forceHovered, params.rootType );
     ImGui::SetNextItemAllowOverlap();
     bool pressed = ImGui::ButtonEx( ( "##wholeChildBtn" + item.item->name() ).c_str(), itemSize, ImGuiButtonFlags_AllowOverlap );
-    pressed = UI::TestEngine::createButton( item.item->name() ) || pressed; // Must not short-circuit.
+    pressed = UI::TestEngine::createButton( item.item->name(), /*disabled*/ !requirements.empty() ) || pressed; // Must not short-circuit.
     pressed = pressed || params.forcePressed;
 
     float fontScale = 1.f;

--- a/source/MRViewer/MRUIStyle.cpp
+++ b/source/MRViewer/MRUIStyle.cpp
@@ -253,7 +253,7 @@ const char* getImGuiPrimaryCtrlName()
 
 bool buttonEx( const char* label, const Vector2f& size_arg /*= Vector2f( 0, 0 )*/, const ButtonCustomizationParams& customParams )
 {
-    bool simulateClick = customParams.enableTestEngine && TestEngine::createButton( customParams.testEngineName.empty() ? label : customParams.testEngineName );
+    bool simulateClick = customParams.enableTestEngine && TestEngine::createButton( customParams.testEngineName.empty() ? label : customParams.testEngineName, /*disabled*/ !customParams.enabled );
     assert( ( simulateClick <= customParams.enabled ) && "Trying to programmatically press a button, but it's inactive!" );
     if ( !customParams.enabled )
         simulateClick = false;

--- a/source/MRViewer/MRUIStyle.cpp
+++ b/source/MRViewer/MRUIStyle.cpp
@@ -253,7 +253,9 @@ const char* getImGuiPrimaryCtrlName()
 
 bool buttonEx( const char* label, const Vector2f& size_arg /*= Vector2f( 0, 0 )*/, const ButtonCustomizationParams& customParams )
 {
-    bool simulateClick = customParams.enableTestEngine && TestEngine::createButton( customParams.testEngineName.empty() ? label : customParams.testEngineName, /*disabled*/ !customParams.enabled );
+    bool simulateClick = customParams.enableTestEngine && TestEngine::createButton(
+        customParams.testEngineName.empty() ? label : customParams.testEngineName,
+        { .disabledReason = customParams.enabled ? std::string_view{} : std::string_view{ "inactive" } } );
     assert( ( simulateClick <= customParams.enabled ) && "Trying to programmatically press a button, but it's inactive!" );
     if ( !customParams.enabled )
         simulateClick = false;

--- a/source/MRViewer/MRUIStyle.cpp
+++ b/source/MRViewer/MRUIStyle.cpp
@@ -253,9 +253,11 @@ const char* getImGuiPrimaryCtrlName()
 
 bool buttonEx( const char* label, const Vector2f& size_arg /*= Vector2f( 0, 0 )*/, const ButtonCustomizationParams& customParams )
 {
+    TestEngine::EntryAttributes attrs;
+    if ( !customParams.enabled )
+        attrs.disabledReason = "inactive";
     bool simulateClick = customParams.enableTestEngine && TestEngine::createButton(
-        customParams.testEngineName.empty() ? label : customParams.testEngineName,
-        { .disabledReason = customParams.enabled ? std::string_view{} : std::string_view{ "inactive" } } );
+        customParams.testEngineName.empty() ? label : customParams.testEngineName, attrs );
     assert( ( simulateClick <= customParams.enabled ) && "Trying to programmatically press a button, but it's inactive!" );
     if ( !customParams.enabled )
         simulateClick = false;

--- a/source/MRViewer/MRUITestEngine.cpp
+++ b/source/MRViewer/MRUITestEngine.cpp
@@ -2,6 +2,8 @@
 #include "MRImGui.h"
 #include "MRPch/MRFmt.h"
 
+#include <imgui_internal.h>
+
 #ifndef MR_ENABLE_UI_TEST_ENGINE
 // Set to 0 to disable the UI test engine. All functions will act as if no UI elements are registered.
 #define MR_ENABLE_UI_TEST_ENGINE 1
@@ -26,6 +28,13 @@ struct State
 };
 // Our global state. Stores the current tree of buttons and button groups.
 State state;
+
+// True if the widget currently being submitted is inside an `ImGui::BeginDisabled` scope.
+bool imGuiContextSaysDisabled()
+{
+    ImGuiContext* g = ImGui::GetCurrentContext();
+    return g && ( g->CurrentItemFlags & ImGuiItemFlags_Disabled ) != 0;
+}
 
 void checkForNewFrame()
 {
@@ -65,7 +74,7 @@ void checkForNewFrame()
 } // namespace
 
 template <typename T>
-std::optional<T> detail::createValueLow( std::string_view name, std::optional<BoundedValue<T>> value, bool consumeValueOverride /*= true*/ )
+std::optional<T> detail::createValueLow( std::string_view name, std::optional<BoundedValue<T>> value, bool consumeValueOverride /*= true*/, bool disabled /*= false*/ )
 {
     #if MR_ENABLE_UI_TEST_ENGINE
 
@@ -86,6 +95,8 @@ std::optional<T> detail::createValueLow( std::string_view name, std::optional<Bo
     ValueEntry* entry = std::get_if<ValueEntry>( &iter->second.value );
     if ( !entry )
         entry = &iter->second.value.emplace<ValueEntry>();
+
+    entry->disabled = disabled || imGuiContextSaysDisabled();
 
     std::optional<T> ret;
 
@@ -129,12 +140,12 @@ std::optional<T> detail::createValueLow( std::string_view name, std::optional<Bo
     #endif
 }
 
-template std::optional<std::int64_t> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::int64_t>> value, bool consumeValueOverride );
-template std::optional<std::uint64_t> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::uint64_t>> value, bool consumeValueOverride );
-template std::optional<double> detail::createValueLow( std::string_view name, std::optional<BoundedValue<double>> value, bool consumeValueOverride );
-template std::optional<std::string> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::string>> value, bool consumeValueOverride );
+template std::optional<std::int64_t> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::int64_t>> value, bool consumeValueOverride, bool disabled );
+template std::optional<std::uint64_t> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::uint64_t>> value, bool consumeValueOverride, bool disabled );
+template std::optional<double> detail::createValueLow( std::string_view name, std::optional<BoundedValue<double>> value, bool consumeValueOverride, bool disabled );
+template std::optional<std::string> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::string>> value, bool consumeValueOverride, bool disabled );
 
-bool createButton( std::string_view name )
+bool createButton( std::string_view name, bool disabled )
 {
     #if MR_ENABLE_UI_TEST_ENGINE
     checkForNewFrame();
@@ -158,6 +169,8 @@ bool createButton( std::string_view name )
     if ( !button )
         button = &iter->second.value.emplace<ButtonEntry>();
 
+    button->disabled = disabled || imGuiContextSaysDisabled();
+
     iter->second.visitedOnThisFrame = true;
 
     // commented, because it is already logged in MRPythonUiInteraction.cpp/pressButton
@@ -166,13 +179,14 @@ bool createButton( std::string_view name )
 
     return std::exchange( button->simulateClick, false );
     #else
+    (void)disabled;
     return false;
     #endif
 }
 
-std::optional<std::string> createValue( std::string_view name, std::string value, bool consumeValueOverride, std::optional<std::vector<std::string>> allowedValues )
+std::optional<std::string> createValue( std::string_view name, std::string value, bool consumeValueOverride, std::optional<std::vector<std::string>> allowedValues, bool disabled )
 {
-    return detail::createValueLow<std::string>( name, detail::BoundedValue<std::string>{ .value = std::move( value ), .allowedValues = std::move( allowedValues ) }, consumeValueOverride );
+    return detail::createValueLow<std::string>( name, detail::BoundedValue<std::string>{ .value = std::move( value ), .allowedValues = std::move( allowedValues ) }, consumeValueOverride, disabled );
 }
 
 void pushTree( std::string_view name )

--- a/source/MRViewer/MRUITestEngine.cpp
+++ b/source/MRViewer/MRUITestEngine.cpp
@@ -36,6 +36,20 @@ bool imGuiContextSaysDisabled()
     return g && ( g->CurrentItemFlags & ImGuiItemFlags_Disabled ) != 0;
 }
 
+// Produce the effective disabled-reason string to store on an entry, given caller-supplied attrs.
+// - If caller passed a reason, use it verbatim (takes precedence).
+// - Else if ImGui says the widget is drawn under BeginDisabled, use a generic fallback so the
+//   entry is still marked disabled even though the caller didn't know why.
+// - Else empty (entry accepts input).
+std::string_view effectiveDisabledReason( const EntryAttributes& attrs )
+{
+    if ( !attrs.disabledReason.empty() )
+        return attrs.disabledReason;
+    if ( imGuiContextSaysDisabled() )
+        return "drawn inside ImGui::BeginDisabled";
+    return {};
+}
+
 void checkForNewFrame()
 {
     // If this is a new frame...
@@ -74,7 +88,7 @@ void checkForNewFrame()
 } // namespace
 
 template <typename T>
-std::optional<T> detail::createValueLow( std::string_view name, std::optional<BoundedValue<T>> value, bool consumeValueOverride /*= true*/, bool disabled /*= false*/ )
+std::optional<T> detail::createValueLow( std::string_view name, std::optional<BoundedValue<T>> value, bool consumeValueOverride /*= true*/, const EntryAttributes& attrs /*= {}*/ )
 {
     #if MR_ENABLE_UI_TEST_ENGINE
 
@@ -96,7 +110,8 @@ std::optional<T> detail::createValueLow( std::string_view name, std::optional<Bo
     if ( !entry )
         entry = &iter->second.value.emplace<ValueEntry>();
 
-    entry->disabled = disabled || imGuiContextSaysDisabled();
+    const auto reason = effectiveDisabledReason( attrs );
+    entry->disabledReason.assign( reason.data(), reason.size() );
 
     std::optional<T> ret;
 
@@ -140,12 +155,12 @@ std::optional<T> detail::createValueLow( std::string_view name, std::optional<Bo
     #endif
 }
 
-template std::optional<std::int64_t> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::int64_t>> value, bool consumeValueOverride, bool disabled );
-template std::optional<std::uint64_t> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::uint64_t>> value, bool consumeValueOverride, bool disabled );
-template std::optional<double> detail::createValueLow( std::string_view name, std::optional<BoundedValue<double>> value, bool consumeValueOverride, bool disabled );
-template std::optional<std::string> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::string>> value, bool consumeValueOverride, bool disabled );
+template std::optional<std::int64_t> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::int64_t>> value, bool consumeValueOverride, const EntryAttributes& attrs );
+template std::optional<std::uint64_t> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::uint64_t>> value, bool consumeValueOverride, const EntryAttributes& attrs );
+template std::optional<double> detail::createValueLow( std::string_view name, std::optional<BoundedValue<double>> value, bool consumeValueOverride, const EntryAttributes& attrs );
+template std::optional<std::string> detail::createValueLow( std::string_view name, std::optional<BoundedValue<std::string>> value, bool consumeValueOverride, const EntryAttributes& attrs );
 
-bool createButton( std::string_view name, bool disabled )
+bool createButton( std::string_view name, const EntryAttributes& attrs )
 {
     #if MR_ENABLE_UI_TEST_ENGINE
     checkForNewFrame();
@@ -169,7 +184,8 @@ bool createButton( std::string_view name, bool disabled )
     if ( !button )
         button = &iter->second.value.emplace<ButtonEntry>();
 
-    button->disabled = disabled || imGuiContextSaysDisabled();
+    const auto reason = effectiveDisabledReason( attrs );
+    button->disabledReason.assign( reason.data(), reason.size() );
 
     iter->second.visitedOnThisFrame = true;
 
@@ -179,14 +195,14 @@ bool createButton( std::string_view name, bool disabled )
 
     return std::exchange( button->simulateClick, false );
     #else
-    (void)disabled;
+    (void)attrs;
     return false;
     #endif
 }
 
-std::optional<std::string> createValue( std::string_view name, std::string value, bool consumeValueOverride, std::optional<std::vector<std::string>> allowedValues, bool disabled )
+std::optional<std::string> createValue( std::string_view name, std::string value, bool consumeValueOverride, std::optional<std::vector<std::string>> allowedValues, const EntryAttributes& attrs )
 {
-    return detail::createValueLow<std::string>( name, detail::BoundedValue<std::string>{ .value = std::move( value ), .allowedValues = std::move( allowedValues ) }, consumeValueOverride, disabled );
+    return detail::createValueLow<std::string>( name, detail::BoundedValue<std::string>{ .value = std::move( value ), .allowedValues = std::move( allowedValues ) }, consumeValueOverride, attrs );
 }
 
 void pushTree( std::string_view name )

--- a/source/MRViewer/MRUITestEngine.h
+++ b/source/MRViewer/MRUITestEngine.h
@@ -19,15 +19,9 @@ namespace MR::UI::TestEngine
 {
 
 // Optional attributes reported to the test engine each frame alongside a widget registration.
-// Passed to `createButton` / `createValue` / `createValueTentative`. All fields default to no-op.
 struct EntryAttributes
 {
-    // Non-empty marks the widget as disabled, with this human-readable reason ("Select an object
-    // first.", unmet requirements, etc.). Empty means "not explicitly disabled by caller" — the
-    // test engine may still infer disabled state from ImGui's CurrentItemFlags (BeginDisabled)
-    // and fill in a generic reason, so widgets wrapped in ImGui's native BeginDisabled don't need
-    // to set this. Surfaced on the listed entry and used by pressButton/writeValue to return a
-    // meaningful error instead of silently succeeding.
+    // Non-empty marks the widget as disabled with this reason. Only read during the call.
     std::string_view disabledReason;
 };
 
@@ -67,7 +61,7 @@ namespace detail
 }
 
 // Call this every frame when drawing a button you want to track (regardless of whether it returns true of false).
-// If this returns true, simulate a button click. See `EntryAttributes` for optional disabled-state reporting.
+// If this returns true, simulate a button click.
 [[nodiscard]] MRVIEWER_API bool createButton( std::string_view name, const EntryAttributes& attrs = {} );
 
 template <typename T>

--- a/source/MRViewer/MRUITestEngine.h
+++ b/source/MRViewer/MRUITestEngine.h
@@ -36,12 +36,12 @@ namespace detail
     };
 
     template <typename T>
-    [[nodiscard]] MRVIEWER_API std::optional<T> createValueLow( std::string_view name, std::optional<BoundedValue<T>> value, bool consumeValueOverride = true );
+    [[nodiscard]] MRVIEWER_API std::optional<T> createValueLow( std::string_view name, std::optional<BoundedValue<T>> value, bool consumeValueOverride = true, bool disabled = false );
 
-    extern template MRVIEWER_API std::optional<std::int64_t> createValueLow( std::string_view name, std::optional<BoundedValue<std::int64_t>> value, bool consumeValueOverride );
-    extern template MRVIEWER_API std::optional<std::uint64_t> createValueLow( std::string_view name, std::optional<BoundedValue<std::uint64_t>> value, bool consumeValueOverride );
-    extern template MRVIEWER_API std::optional<double> createValueLow( std::string_view name, std::optional<BoundedValue<double>> value, bool consumeValueOverride );
-    extern template MRVIEWER_API std::optional<std::string> createValueLow( std::string_view name, std::optional<BoundedValue<std::string>> value, bool consumeValueOverride );
+    extern template MRVIEWER_API std::optional<std::int64_t> createValueLow( std::string_view name, std::optional<BoundedValue<std::int64_t>> value, bool consumeValueOverride, bool disabled );
+    extern template MRVIEWER_API std::optional<std::uint64_t> createValueLow( std::string_view name, std::optional<BoundedValue<std::uint64_t>> value, bool consumeValueOverride, bool disabled );
+    extern template MRVIEWER_API std::optional<double> createValueLow( std::string_view name, std::optional<BoundedValue<double>> value, bool consumeValueOverride, bool disabled );
+    extern template MRVIEWER_API std::optional<std::string> createValueLow( std::string_view name, std::optional<BoundedValue<std::string>> value, bool consumeValueOverride, bool disabled );
 
     template <typename T, typename = void> struct UnderlyingValueTypeHelper {};
     template <typename T> struct UnderlyingValueTypeHelper<T, std::enable_if_t<std::is_floating_point_v<T>>> {using type = double;};
@@ -55,7 +55,12 @@ namespace detail
 
 // Call this every frame when drawing a button you want to track (regardless of whether it returns true of false).
 // If this returns true, simulate a button click.
-[[nodiscard]] MRVIEWER_API bool createButton( std::string_view name );
+// `disabled` marks the button as not currently accepting input (e.g. greyed out by `ImGui::BeginDisabled`
+// or by MeshLib's own `UI::button(active=false)` / requirement-gated state). `pressButton()` on a disabled
+// entry returns an error instead of silently succeeding. If `disabled` is left false, the value is still
+// auto-OR'd with the current `ImGuiItemFlags_Disabled` so callers inside `ImGui::BeginDisabled` don't need
+// to pass it explicitly.
+[[nodiscard]] MRVIEWER_API bool createButton( std::string_view name, bool disabled = false );
 
 template <typename T>
 concept AllowedValueType = std::is_arithmetic_v<T> || std::is_same_v<T, std::string>;
@@ -70,7 +75,7 @@ concept AllowedValueType = std::is_arithmetic_v<T> || std::is_same_v<T, std::str
 //   are in different groups created with `pushTree()`/`popTree()`).
 template <AllowedValueType T>
 requires std::is_arithmetic_v<T>
-[[nodiscard]] std::optional<T> createValue( std::string_view name, T value, T min, T max, bool consumeValueOverride = true )
+[[nodiscard]] std::optional<T> createValue( std::string_view name, T value, T min, T max, bool consumeValueOverride = true, bool disabled = false )
 {
     if ( !( min < max ) )
     {
@@ -81,20 +86,20 @@ requires std::is_arithmetic_v<T>
     using U = detail::UnderlyingValueType<T>;
     static_assert(sizeof(T) <= sizeof(U), "The used type is too large.");
 
-    auto ret = detail::createValueLow<U>( name, detail::BoundedValue<U>{ .value = U( value ), .min = U( min ), .max = U( max ) }, consumeValueOverride );
+    auto ret = detail::createValueLow<U>( name, detail::BoundedValue<U>{ .value = U( value ), .min = U( min ), .max = U( max ) }, consumeValueOverride, disabled );
     return ret ? std::optional<T>( T( *ret ) ) : std::nullopt;
 }
 // This overload is for strings.
-[[nodiscard]] MRVIEWER_API std::optional<std::string> createValue( std::string_view name, std::string value, bool consumeValueOverride = true, std::optional<std::vector<std::string>> allowedValues = std::nullopt );
+[[nodiscard]] MRVIEWER_API std::optional<std::string> createValue( std::string_view name, std::string value, bool consumeValueOverride = true, std::optional<std::vector<std::string>> allowedValues = std::nullopt, bool disabled = false );
 
 // Usually you don't need this function.
 // This is for widgets that require you to specify the value override before drawing it, such as `ImGui::CollapsingHeader()`.
 // For those, call this version first to read the value override, then draw the widget, then call the normal `createValue()` with the same name
 //   and with the new value, and discard its return value.
 template <AllowedValueType T>
-[[nodiscard]] std::optional<T> createValueTentative( std::string_view name, bool consumeValueOverride = true )
+[[nodiscard]] std::optional<T> createValueTentative( std::string_view name, bool consumeValueOverride = true, bool disabled = false )
 {
-    auto ret = detail::createValueLow<detail::UnderlyingValueType<T>>( name, std::nullopt, consumeValueOverride );
+    auto ret = detail::createValueLow<detail::UnderlyingValueType<T>>( name, std::nullopt, consumeValueOverride, disabled );
     return ret ? std::optional<T>( T( *ret ) ) : std::nullopt;
 }
 
@@ -108,6 +113,9 @@ struct ButtonEntry
 {
     // Set this to true to simulate a button click.
     mutable bool simulateClick = false;
+
+    // True if the button was drawn in a disabled state (greyed out / not accepting input) on the last frame.
+    bool disabled = false;
 
     static constexpr std::string_view kindName = "button";
 };
@@ -145,6 +153,9 @@ struct ValueEntry
     };
     using ValueVar = std::variant<Value<std::int64_t>, Value<std::uint64_t>, Value<double>, Value<std::string>>;
     ValueVar value;
+
+    // True if the widget was drawn in a disabled state (greyed out / read-only) on the last frame.
+    bool disabled = false;
 
     static constexpr std::string_view kindName = "value";
 };

--- a/source/MRViewer/MRUITestEngine.h
+++ b/source/MRViewer/MRUITestEngine.h
@@ -18,6 +18,19 @@
 namespace MR::UI::TestEngine
 {
 
+// Optional attributes reported to the test engine each frame alongside a widget registration.
+// Passed to `createButton` / `createValue` / `createValueTentative`. All fields default to no-op.
+struct EntryAttributes
+{
+    // Non-empty marks the widget as disabled, with this human-readable reason ("Select an object
+    // first.", unmet requirements, etc.). Empty means "not explicitly disabled by caller" — the
+    // test engine may still infer disabled state from ImGui's CurrentItemFlags (BeginDisabled)
+    // and fill in a generic reason, so widgets wrapped in ImGui's native BeginDisabled don't need
+    // to set this. Surfaced on the listed entry and used by pressButton/writeValue to return a
+    // meaningful error instead of silently succeeding.
+    std::string_view disabledReason;
+};
+
 namespace detail
 {
     template <typename T>
@@ -36,12 +49,12 @@ namespace detail
     };
 
     template <typename T>
-    [[nodiscard]] MRVIEWER_API std::optional<T> createValueLow( std::string_view name, std::optional<BoundedValue<T>> value, bool consumeValueOverride = true, bool disabled = false );
+    [[nodiscard]] MRVIEWER_API std::optional<T> createValueLow( std::string_view name, std::optional<BoundedValue<T>> value, bool consumeValueOverride = true, const EntryAttributes& attrs = {} );
 
-    extern template MRVIEWER_API std::optional<std::int64_t> createValueLow( std::string_view name, std::optional<BoundedValue<std::int64_t>> value, bool consumeValueOverride, bool disabled );
-    extern template MRVIEWER_API std::optional<std::uint64_t> createValueLow( std::string_view name, std::optional<BoundedValue<std::uint64_t>> value, bool consumeValueOverride, bool disabled );
-    extern template MRVIEWER_API std::optional<double> createValueLow( std::string_view name, std::optional<BoundedValue<double>> value, bool consumeValueOverride, bool disabled );
-    extern template MRVIEWER_API std::optional<std::string> createValueLow( std::string_view name, std::optional<BoundedValue<std::string>> value, bool consumeValueOverride, bool disabled );
+    extern template MRVIEWER_API std::optional<std::int64_t> createValueLow( std::string_view name, std::optional<BoundedValue<std::int64_t>> value, bool consumeValueOverride, const EntryAttributes& attrs );
+    extern template MRVIEWER_API std::optional<std::uint64_t> createValueLow( std::string_view name, std::optional<BoundedValue<std::uint64_t>> value, bool consumeValueOverride, const EntryAttributes& attrs );
+    extern template MRVIEWER_API std::optional<double> createValueLow( std::string_view name, std::optional<BoundedValue<double>> value, bool consumeValueOverride, const EntryAttributes& attrs );
+    extern template MRVIEWER_API std::optional<std::string> createValueLow( std::string_view name, std::optional<BoundedValue<std::string>> value, bool consumeValueOverride, const EntryAttributes& attrs );
 
     template <typename T, typename = void> struct UnderlyingValueTypeHelper {};
     template <typename T> struct UnderlyingValueTypeHelper<T, std::enable_if_t<std::is_floating_point_v<T>>> {using type = double;};
@@ -54,13 +67,8 @@ namespace detail
 }
 
 // Call this every frame when drawing a button you want to track (regardless of whether it returns true of false).
-// If this returns true, simulate a button click.
-// `disabled` marks the button as not currently accepting input (e.g. greyed out by `ImGui::BeginDisabled`
-// or by MeshLib's own `UI::button(active=false)` / requirement-gated state). `pressButton()` on a disabled
-// entry returns an error instead of silently succeeding. If `disabled` is left false, the value is still
-// auto-OR'd with the current `ImGuiItemFlags_Disabled` so callers inside `ImGui::BeginDisabled` don't need
-// to pass it explicitly.
-[[nodiscard]] MRVIEWER_API bool createButton( std::string_view name, bool disabled = false );
+// If this returns true, simulate a button click. See `EntryAttributes` for optional disabled-state reporting.
+[[nodiscard]] MRVIEWER_API bool createButton( std::string_view name, const EntryAttributes& attrs = {} );
 
 template <typename T>
 concept AllowedValueType = std::is_arithmetic_v<T> || std::is_same_v<T, std::string>;
@@ -75,7 +83,7 @@ concept AllowedValueType = std::is_arithmetic_v<T> || std::is_same_v<T, std::str
 //   are in different groups created with `pushTree()`/`popTree()`).
 template <AllowedValueType T>
 requires std::is_arithmetic_v<T>
-[[nodiscard]] std::optional<T> createValue( std::string_view name, T value, T min, T max, bool consumeValueOverride = true, bool disabled = false )
+[[nodiscard]] std::optional<T> createValue( std::string_view name, T value, T min, T max, bool consumeValueOverride = true, const EntryAttributes& attrs = {} )
 {
     if ( !( min < max ) )
     {
@@ -86,20 +94,20 @@ requires std::is_arithmetic_v<T>
     using U = detail::UnderlyingValueType<T>;
     static_assert(sizeof(T) <= sizeof(U), "The used type is too large.");
 
-    auto ret = detail::createValueLow<U>( name, detail::BoundedValue<U>{ .value = U( value ), .min = U( min ), .max = U( max ) }, consumeValueOverride, disabled );
+    auto ret = detail::createValueLow<U>( name, detail::BoundedValue<U>{ .value = U( value ), .min = U( min ), .max = U( max ) }, consumeValueOverride, attrs );
     return ret ? std::optional<T>( T( *ret ) ) : std::nullopt;
 }
 // This overload is for strings.
-[[nodiscard]] MRVIEWER_API std::optional<std::string> createValue( std::string_view name, std::string value, bool consumeValueOverride = true, std::optional<std::vector<std::string>> allowedValues = std::nullopt, bool disabled = false );
+[[nodiscard]] MRVIEWER_API std::optional<std::string> createValue( std::string_view name, std::string value, bool consumeValueOverride = true, std::optional<std::vector<std::string>> allowedValues = std::nullopt, const EntryAttributes& attrs = {} );
 
 // Usually you don't need this function.
 // This is for widgets that require you to specify the value override before drawing it, such as `ImGui::CollapsingHeader()`.
 // For those, call this version first to read the value override, then draw the widget, then call the normal `createValue()` with the same name
 //   and with the new value, and discard its return value.
 template <AllowedValueType T>
-[[nodiscard]] std::optional<T> createValueTentative( std::string_view name, bool consumeValueOverride = true, bool disabled = false )
+[[nodiscard]] std::optional<T> createValueTentative( std::string_view name, bool consumeValueOverride = true, const EntryAttributes& attrs = {} )
 {
-    auto ret = detail::createValueLow<detail::UnderlyingValueType<T>>( name, std::nullopt, consumeValueOverride, disabled );
+    auto ret = detail::createValueLow<detail::UnderlyingValueType<T>>( name, std::nullopt, consumeValueOverride, attrs );
     return ret ? std::optional<T>( T( *ret ) ) : std::nullopt;
 }
 
@@ -114,8 +122,9 @@ struct ButtonEntry
     // Set this to true to simulate a button click.
     mutable bool simulateClick = false;
 
-    // True if the button was drawn in a disabled state (greyed out / not accepting input) on the last frame.
-    bool disabled = false;
+    // Non-empty if the button was drawn disabled (greyed out / not accepting input) on the last frame,
+    // with a human-readable reason. Empty means the button accepts input.
+    std::string disabledReason;
 
     static constexpr std::string_view kindName = "button";
 };
@@ -154,8 +163,9 @@ struct ValueEntry
     using ValueVar = std::variant<Value<std::int64_t>, Value<std::uint64_t>, Value<double>, Value<std::string>>;
     ValueVar value;
 
-    // True if the widget was drawn in a disabled state (greyed out / read-only) on the last frame.
-    bool disabled = false;
+    // Non-empty if the widget was drawn disabled (greyed out / read-only) on the last frame,
+    // with a human-readable reason. Empty means the widget accepts input.
+    std::string disabledReason;
 
     static constexpr std::string_view kindName = "value";
 };

--- a/source/MRViewer/MRUITestEngineControl.cpp
+++ b/source/MRViewer/MRUITestEngineControl.cpp
@@ -2,6 +2,7 @@
 
 #include "MRMesh/MRMeshFwd.h"
 #include "MRPch/MRFmt.h"
+#include "MRViewer/MRImGui.h"
 #include "MRViewer/MRUITestEngine.h"
 
 #include <algorithm>
@@ -57,12 +58,34 @@ std::string pathToString( const std::vector<std::string>& path )
     return pathString;
 }
 
+// Read the disabled flag off an internal entry (groups are never disabled).
+static bool entryDisabled( const TestEngine::Entry& entry )
+{
+    return std::visit( MR::overloaded{
+        []( const TestEngine::ButtonEntry& e ) { return e.disabled; },
+        []( const TestEngine::ValueEntry& e ) { return e.disabled; },
+        []( const TestEngine::GroupEntry& ) { return false; },
+    }, entry.value );
+}
+
+// Heuristic: "blocked" is set only on root-level (top-level) entries when any blocking popup is open.
+// The TestEngine tree is independent of ImGui's window/popup structure, so we can't do a precise
+// "is this entry occluded by that popup" check without extra bookkeeping. Mark top-level entries
+// as blocked so agents know a modal is intercepting input; entries inside `pushTree` groups (which
+// typically *are* the dialog contents) are left unmarked.
+static bool rootLevelBlocked()
+{
+    return ImGui::IsPopupOpen( "", ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel );
+}
+
 Expected<std::vector<TypedEntry>> listEntries( const std::vector<std::string>& path )
 {
     auto groupEx = findGroup( path );
     if ( !groupEx )
         return unexpected( groupEx.error() );
     const auto& group = **groupEx;
+
+    const bool blocked = path.empty() && rootLevelBlocked();
 
     std::vector<TypedEntry> ret;
     ret.reserve( group.elems.size() );
@@ -84,6 +107,8 @@ Expected<std::vector<TypedEntry>> listEntries( const std::vector<std::string>& p
                 },
                 []( const TestEngine::GroupEntry& ) { return EntryType::group; },
             }, elem.second.value ),
+            .disabled = entryDisabled( elem.second ),
+            .blocked = blocked,
         } );
     }
     return ret;
@@ -101,11 +126,18 @@ Expected<void> pressButton( const std::vector<std::string>& path )
 
     auto iter = group.elems.find( path.back() );
     if ( iter == group.elems.end() )
-        unexpected( fmt::format( "pressButton {}: no such entry: `{}`. Known entries are: {}.", pathToString( path ), path.back(), listKeys( group ) ) );
+        return unexpected( fmt::format( "pressButton {}: no such entry: `{}`. Known entries are: {}.", pathToString( path ), path.back(), listKeys( group ) ) );
 
     auto buttonEx = iter->second.getAs<TestEngine::ButtonEntry>( path.back() );
     if ( !buttonEx )
         return unexpected( buttonEx.error() );
+
+    if ( ( *buttonEx )->disabled )
+        return unexpected( fmt::format( "pressButton {}: button is disabled and cannot be pressed.", pathToString( path ) ) );
+
+    // Root-level entries are considered unreachable when a blocking popup is open on top of them.
+    if ( path.size() == 1 && rootLevelBlocked() )
+        return unexpected( fmt::format( "pressButton {}: a modal popup is currently open on top of this button; dismiss it first.", pathToString( path ) ) );
 
     ( *buttonEx )->simulateClick = true;
 
@@ -222,6 +254,12 @@ Expected<void> writeValue( const std::vector<std::string>& path, T value )
     if ( !entryEx )
         return unexpected( entryEx.error() );
     const auto& entry = **entryEx;
+
+    if ( entry.disabled )
+        return unexpected( fmt::format( "writeValue {}: widget is disabled and cannot be edited.", pathToString( path ) ) );
+
+    if ( path.size() == 1 && rootLevelBlocked() )
+        return unexpected( fmt::format( "writeValue {}: a modal popup is currently open on top of this widget; dismiss it first.", pathToString( path ) ) );
 
     auto writeValueOfCorrectType = [&entry, &path]( auto fixedValue ) -> Expected<void>
     {

--- a/source/MRViewer/MRUITestEngineControl.cpp
+++ b/source/MRViewer/MRUITestEngineControl.cpp
@@ -5,6 +5,8 @@
 #include "MRViewer/MRImGui.h"
 #include "MRViewer/MRUITestEngine.h"
 
+#include <imgui_internal.h>
+
 #include <algorithm>
 #include <span>
 #include <utility>
@@ -58,13 +60,14 @@ std::string pathToString( const std::vector<std::string>& path )
     return pathString;
 }
 
-// Read the disabled flag off an internal entry (groups are never disabled).
-static bool entryDisabled( const TestEngine::Entry& entry )
+// Read the disabled-reason string off an internal entry. Empty means the entry accepts input.
+// Groups are never disabled.
+static std::string_view entryDisabledReason( const TestEngine::Entry& entry )
 {
     return std::visit( MR::overloaded{
-        []( const TestEngine::ButtonEntry& e ) { return e.disabled; },
-        []( const TestEngine::ValueEntry& e ) { return e.disabled; },
-        []( const TestEngine::GroupEntry& ) { return false; },
+        []( const TestEngine::ButtonEntry& e ) -> std::string_view { return e.disabledReason; },
+        []( const TestEngine::ValueEntry& e )  -> std::string_view { return e.disabledReason; },
+        []( const TestEngine::GroupEntry& )    -> std::string_view { return {}; },
     }, entry.value );
 }
 
@@ -78,6 +81,35 @@ static bool rootLevelBlocked()
     return ImGui::IsPopupOpen( "", ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel );
 }
 
+// Best-effort extraction of the topmost open popup's window name (for the blocking-modal status).
+// Returns empty if no popup is open or the name can't be determined. Callers must only use the
+// returned view while still on the GUI thread (ImGui owns the string).
+static std::string_view topBlockingModalName()
+{
+    ImGuiContext* g = ImGui::GetCurrentContext();
+    if ( !g || g->OpenPopupStack.empty() )
+        return {};
+    // The most recently opened popup is at the back of the stack.
+    const ImGuiPopupData& top = g->OpenPopupStack.back();
+    if ( top.Window && top.Window->Name )
+        return top.Window->Name;
+    return {};
+}
+
+// Compose the single user-facing status string. `disabledReason` is the widget's own reason
+// (non-empty when the widget was drawn greyed out); `blockingModal` is the topmost blocking
+// popup's name (non-empty when a modal is on top of this entry). The widget's own disable
+// takes precedence over modal occlusion (the widget is literally greyed out; the modal is
+// incidental).
+static std::string composeStatus( std::string_view disabledReason, std::string_view blockingModal )
+{
+    if ( !disabledReason.empty() )
+        return fmt::format( "disabled: {}", disabledReason );
+    if ( !blockingModal.empty() )
+        return fmt::format( "disabled: blocked by modal '{}'", blockingModal );
+    return "available";
+}
+
 Expected<std::vector<TypedEntry>> listEntries( const std::vector<std::string>& path )
 {
     auto groupEx = findGroup( path );
@@ -85,13 +117,14 @@ Expected<std::vector<TypedEntry>> listEntries( const std::vector<std::string>& p
         return unexpected( groupEx.error() );
     const auto& group = **groupEx;
 
-    const bool blocked = path.empty() && rootLevelBlocked();
+    const std::string_view blockingModal = ( path.empty() && rootLevelBlocked() ) ? topBlockingModalName() : std::string_view{};
 
     std::vector<TypedEntry> ret;
     ret.reserve( group.elems.size() );
 
     for ( const auto& elem : group.elems )
     {
+        const std::string_view disabledReason = entryDisabledReason( elem.second );
         ret.push_back( {
             .name = elem.first,
             .type = std::visit( MR::overloaded{
@@ -107,8 +140,7 @@ Expected<std::vector<TypedEntry>> listEntries( const std::vector<std::string>& p
                 },
                 []( const TestEngine::GroupEntry& ) { return EntryType::group; },
             }, elem.second.value ),
-            .disabled = entryDisabled( elem.second ),
-            .blocked = blocked,
+            .status = composeStatus( disabledReason, blockingModal ),
         } );
     }
     return ret;
@@ -132,12 +164,14 @@ Expected<void> pressButton( const std::vector<std::string>& path )
     if ( !buttonEx )
         return unexpected( buttonEx.error() );
 
-    if ( ( *buttonEx )->disabled )
-        return unexpected( fmt::format( "pressButton {}: button is disabled and cannot be pressed.", pathToString( path ) ) );
-
+    const std::string_view disabledReason = ( *buttonEx )->disabledReason;
     // Root-level entries are considered unreachable when a blocking popup is open on top of them.
-    if ( path.size() == 1 && rootLevelBlocked() )
-        return unexpected( fmt::format( "pressButton {}: a modal popup is currently open on top of this button; dismiss it first.", pathToString( path ) ) );
+    const bool isBlocked = disabledReason.empty() && path.size() == 1 && rootLevelBlocked();
+    if ( !disabledReason.empty() || isBlocked )
+    {
+        const std::string_view blockingModal = isBlocked ? topBlockingModalName() : std::string_view{};
+        return unexpected( fmt::format( "pressButton {}: {}", pathToString( path ), composeStatus( disabledReason, blockingModal ) ) );
+    }
 
     ( *buttonEx )->simulateClick = true;
 
@@ -255,11 +289,13 @@ Expected<void> writeValue( const std::vector<std::string>& path, T value )
         return unexpected( entryEx.error() );
     const auto& entry = **entryEx;
 
-    if ( entry.disabled )
-        return unexpected( fmt::format( "writeValue {}: widget is disabled and cannot be edited.", pathToString( path ) ) );
-
-    if ( path.size() == 1 && rootLevelBlocked() )
-        return unexpected( fmt::format( "writeValue {}: a modal popup is currently open on top of this widget; dismiss it first.", pathToString( path ) ) );
+    const std::string_view disabledReason = entry.disabledReason;
+    const bool isBlocked = disabledReason.empty() && path.size() == 1 && rootLevelBlocked();
+    if ( !disabledReason.empty() || isBlocked )
+    {
+        const std::string_view blockingModal = isBlocked ? topBlockingModalName() : std::string_view{};
+        return unexpected( fmt::format( "writeValue {}: {}", pathToString( path ), composeStatus( disabledReason, blockingModal ) ) );
+    }
 
     auto writeValueOfCorrectType = [&entry, &path]( auto fixedValue ) -> Expected<void>
     {

--- a/source/MRViewer/MRUITestEngineControl.h
+++ b/source/MRViewer/MRUITestEngineControl.h
@@ -47,6 +47,14 @@ struct TypedEntry
 {
     std::string name;
     EntryType type;
+
+    // The widget is currently drawn in a disabled state (greyed out / read-only). Always false for groups.
+    bool disabled = false;
+
+    // A blocking popup (e.g. a modal dialog) is currently open and is likely intercepting input from this entry.
+    // Heuristic: set only on root-level (top-level) entries; entries inside `pushTree` groups are assumed to
+    // live inside the blocking popup itself and are not marked.
+    bool blocked = false;
 };
 
 // Returns the elements of `path` combined into a single string.

--- a/source/MRViewer/MRUITestEngineControl.h
+++ b/source/MRViewer/MRUITestEngineControl.h
@@ -48,13 +48,14 @@ struct TypedEntry
     std::string name;
     EntryType type;
 
-    // The widget is currently drawn in a disabled state (greyed out / read-only). Always false for groups.
-    bool disabled = false;
-
-    // A blocking popup (e.g. a modal dialog) is currently open and is likely intercepting input from this entry.
-    // Heuristic: set only on root-level (top-level) entries; entries inside `pushTree` groups are assumed to
-    // live inside the blocking popup itself and are not marked.
-    bool blocked = false;
+    // Human-readable interaction status. Always one of:
+    //   * "available"                                — entry accepts input
+    //   * "disabled"                                 — disabled, no specific reason known
+    //   * "disabled: <reason>"                       — disabled via requirements / UI::button(active=false)
+    //   * "disabled: blocked by modal '<name>'"      — modal popup currently on top
+    //   * "disabled: blocked by modal popup"         — modal open, its window name isn't determinable
+    // Agents can branch on `status.starts_with("disabled")` or pattern-match the whole string.
+    std::string status;
 };
 
 // Returns the elements of `path` combined into a single string.

--- a/source/MRViewer/MRUITestEngineControl.h
+++ b/source/MRViewer/MRUITestEngineControl.h
@@ -48,13 +48,9 @@ struct TypedEntry
     std::string name;
     EntryType type;
 
-    // Human-readable interaction status. Always one of:
-    //   * "available"                                — entry accepts input
-    //   * "disabled"                                 — disabled, no specific reason known
-    //   * "disabled: <reason>"                       — disabled via requirements / UI::button(active=false)
-    //   * "disabled: blocked by modal '<name>'"      — modal popup currently on top
-    //   * "disabled: blocked by modal popup"         — modal open, its window name isn't determinable
-    // Agents can branch on `status.starts_with("disabled")` or pattern-match the whole string.
+    // Human-readable interaction status. Built by `composeStatus()` in MRUITestEngineControl.cpp —
+    // see that function for the set of values. Agents can branch on `status == "available"` or
+    // match `status.starts_with("disabled")`.
     std::string status;
 };
 

--- a/source/MRViewer/MRViewerMcp.cpp
+++ b/source/MRViewer/MRViewerMcp.cpp
@@ -47,8 +47,7 @@ static nlohmann::json mcpToolListUiEntries( const nlohmann::json& args )
         ret.push_back( nlohmann::json::object( {
             { "name", elem.name },
             { "type", std::move( typeStr ) },
-            { "disabled", elem.disabled },
-            { "blocked", elem.blocked },
+            { "status", elem.status },
         } ) );
     }
 
@@ -116,14 +115,13 @@ MR_ON_INIT{
     server.addTool(
         /*id*/"ui.listEntries",
         /*name*/"List UI entries",
-        /*desc*/"Returns the list of UI elements at the given path. The elements form a tree. Pass an empty array to get the top-level elements. Each element is described by a string. The path parameter describes the path from the root node to a specific element. Only elements of type `group` can have sub-elements. Each entry reports `disabled` (true when the widget is greyed out / read-only and cannot be pressed or edited) and `blocked` (true when a modal popup is currently open on top of this entry and is intercepting input — dismiss the popup first).",
+        /*desc*/"Returns the list of UI elements at the given path. The elements form a tree. Pass an empty array to get the top-level elements. The path parameter describes the path from the root node to a specific element. Only elements of type `group` can have sub-elements. Each entry's `status` field is a human-readable interaction state: `\"available\"` means the entry accepts input; `\"disabled\"` or `\"disabled: <reason>\"` means the widget is currently greyed out (reason is typically the unmet requirement, e.g. `\"Select exactly one Object\"`); `\"disabled: blocked by modal '<name>'\"` means a modal popup is occluding the entry and must be dismissed first.",
         /*input_schema*/Mcp::Schema::Object{}.addMember( "path", Mcp::Schema::Array( Mcp::Schema::String{} ) ),
         /*output_schema*/Mcp::Schema::Array(
             Mcp::Schema::Object{}
                 .addMember( "name", Mcp::Schema::String{} )
                 .addMember( "type", Mcp::Schema::String{} )
-                .addMember( "disabled", Mcp::Schema::Bool{} )
-                .addMember( "blocked", Mcp::Schema::Bool{} )
+                .addMember( "status", Mcp::Schema::String{} )
         ),
         /*func*/mcpToolListUiEntries
     );

--- a/source/MRViewer/MRViewerMcp.cpp
+++ b/source/MRViewer/MRViewerMcp.cpp
@@ -47,6 +47,8 @@ static nlohmann::json mcpToolListUiEntries( const nlohmann::json& args )
         ret.push_back( nlohmann::json::object( {
             { "name", elem.name },
             { "type", std::move( typeStr ) },
+            { "disabled", elem.disabled },
+            { "blocked", elem.blocked },
         } ) );
     }
 
@@ -114,9 +116,15 @@ MR_ON_INIT{
     server.addTool(
         /*id*/"ui.listEntries",
         /*name*/"List UI entries",
-        /*desc*/"Returns the list of UI elements at the given path. The elements form a tree. Pass an empty array to get the top-level elements. Each element is described by a string. The path parameter describes the path from the root node to a specific element. Only elements of type `group` can have sub-elements.",
+        /*desc*/"Returns the list of UI elements at the given path. The elements form a tree. Pass an empty array to get the top-level elements. Each element is described by a string. The path parameter describes the path from the root node to a specific element. Only elements of type `group` can have sub-elements. Each entry reports `disabled` (true when the widget is greyed out / read-only and cannot be pressed or edited) and `blocked` (true when a modal popup is currently open on top of this entry and is intercepting input — dismiss the popup first).",
         /*input_schema*/Mcp::Schema::Object{}.addMember( "path", Mcp::Schema::Array( Mcp::Schema::String{} ) ),
-        /*output_schema*/Mcp::Schema::Array( Mcp::Schema::Object{}.addMember( "name", Mcp::Schema::String{} ).addMember( "type", Mcp::Schema::String{} ) ),
+        /*output_schema*/Mcp::Schema::Array(
+            Mcp::Schema::Object{}
+                .addMember( "name", Mcp::Schema::String{} )
+                .addMember( "type", Mcp::Schema::String{} )
+                .addMember( "disabled", Mcp::Schema::Bool{} )
+                .addMember( "blocked", Mcp::Schema::Bool{} )
+        ),
         /*func*/mcpToolListUiEntries
     );
 

--- a/source/mrviewerpy/MRPythonUiInteraction.cpp
+++ b/source/mrviewerpy/MRPythonUiInteraction.cpp
@@ -38,9 +38,13 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrviewerpy, UiEntry, [] ( pybind11::module_& m )
     MR_PYTHON_CUSTOM_CLASS( UiEntry )
         .def_readonly( "name", &Control::TypedEntry::name )
         .def_readonly( "type", &Control::TypedEntry::type )
+        .def_readonly( "disabled", &Control::TypedEntry::disabled )
+        .def_readonly( "blocked", &Control::TypedEntry::blocked )
         .def("__repr__", []( const Control::TypedEntry& e )
         {
-            return fmt::format( "<mrmesh.mrviewerpy.UiEntry '{}' of type '{}'>", e.name, toString( e.type ) );
+            return fmt::format( "<mrmesh.mrviewerpy.UiEntry '{}' of type '{}'{}{}>", e.name, toString( e.type ),
+                e.disabled ? " disabled" : "",
+                e.blocked ? " blocked" : "" );
         } )
     ;
 } )

--- a/source/mrviewerpy/MRPythonUiInteraction.cpp
+++ b/source/mrviewerpy/MRPythonUiInteraction.cpp
@@ -38,13 +38,10 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrviewerpy, UiEntry, [] ( pybind11::module_& m )
     MR_PYTHON_CUSTOM_CLASS( UiEntry )
         .def_readonly( "name", &Control::TypedEntry::name )
         .def_readonly( "type", &Control::TypedEntry::type )
-        .def_readonly( "disabled", &Control::TypedEntry::disabled )
-        .def_readonly( "blocked", &Control::TypedEntry::blocked )
+        .def_readonly( "status", &Control::TypedEntry::status )
         .def("__repr__", []( const Control::TypedEntry& e )
         {
-            return fmt::format( "<mrmesh.mrviewerpy.UiEntry '{}' of type '{}'{}{}>", e.name, toString( e.type ),
-                e.disabled ? " disabled" : "",
-                e.blocked ? " blocked" : "" );
+            return fmt::format( "<mrmesh.mrviewerpy.UiEntry '{}' of type '{}' status='{}'>", e.name, toString( e.type ), e.status );
         } )
     ;
 } )


### PR DESCRIPTION
## Summary

- Adds a human-readable `status` string to `UI::TestEngine::Control::TypedEntry`, populated each frame.
- `pressButton` / `writeValue<T>` now return a typed error instead of silently succeeding when the target widget isn't interactive.
- MCP `ui.listEntries` and the Python binding `mrviewerpy.UiEntry` surface the same `status` field.

## Why

When an MCP or Python test client drove `pressButton` at a widget drawn under `ImGui::BeginDisabled` / `UI::button(active=false)` / a requirement-gated ribbon item, the TestEngine accepted the press but the runtime path dropped it. Agents had no way to detect the failure except by tailing logs. Likewise for clicks occluded by a modal popup. This surfaces both conditions via one consistent field and turns silent no-ops into checkable errors.

## The `status` string

One string per entry, exactly one of:

| Value | Meaning |
|---|---|
| `"available"` | Entry accepts input |
| `"disabled"` | Disabled, no specific reason known |
| `"disabled: <reason>"` | Disabled with caller-supplied reason (e.g. a ribbon `requirements` string like `"Select exactly one Object"`) |
| `"disabled: blocked by modal '<name>'"` | A modal popup named `<name>` is currently on top of this entry |
| `"disabled: blocked by modal popup"` | Modal open, its window name isn't determinable |

Agents can branch on `status == "available"` or `status.startswith("disabled")`, or pattern-match the whole string for reporting.

## Mechanics

- `UI::TestEngine::EntryAttributes` is a single-field struct `{ std::string_view disabledReason; }` — non-empty marks the widget disabled with that reason. The test engine also auto-detects `ImGui::BeginDisabled` via `GImGui->CurrentItemFlags & ImGuiItemFlags_Disabled` and fills a generic fallback reason when the caller didn't set one.
- `ButtonEntry` / `ValueEntry` store just a `std::string disabledReason` — disabled iff non-empty.
- `TypedEntry::status` is built in `listEntries` from (entry's reason, top ImGui popup's window name) via a small `composeStatus` helper.
- `pressButton` / `writeValue<T>` errors use the same format: `"<fn> <path>: <status>"`.

## Call-site updates

- `buttonEx`: forwards `customParams.enabled` as `disabledReason = "inactive"` when disabled.
- `RibbonButtonDrawer`: forwards the existing `requirements` string directly (empty = enabled).
- All other existing call sites continue to work unchanged — `createButton(name)` etc. still compiles because the new param is defaulted.

## Python binding

`mrviewerpy.UiEntry` gains a single `.status: str` property mirroring the MCP shape, per the sync directive at the top of `MRUITestEngineControl.h`.

## Test plan

Verified end-to-end against a Debug build of MeshInspector via the MCP client:

- [x] `ui.listEntries` on `RibbonSceneButtons` with no scene: each entry reports `status: "disabled: At least one objects should be in scene"` / `"disabled: Select at least one Object"` / `"disabled: Select exactly one Object"` per its ribbon requirement.
- [x] `ui.listEntries` on the Toolbar with no scene: mixed `"available"` (Create Simple Objects, Move object, Select objects, Viewer settings) and `"disabled: <specific requirement>"` (Fit data, Clone, Transform object, etc.).
- [x] `ui.pressButton` on a disabled entry returns `pressButton <path>: disabled: <reason>` instead of succeeding silently.
- [x] Opening a modal popup (Toolbar Customize) flips every root-level entry to `"disabled: blocked by modal 'Toolbar Customize'"`; entries inside the popup's own group stay `"available"`.
- [x] `ui.pressButton` on a blocked root entry returns `...: disabled: blocked by modal '<name>'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)