### PR TITLE
ci(ubuntu22): drop the apt.kitware.com CMake upgrade step

### DIFF
--- a/cmake/Modules/ConfigureCuda.cmake
+++ b/cmake/Modules/ConfigureCuda.cmake
@@ -11,12 +11,7 @@ IF(NOT CUDAToolkit_FOUND AND NOT CUDA_FOUND)
       # For our VS2022 CI:
       set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH")
     ELSE()
-      # CMake's NVCC flag-table entry for C++20 was added in the CMake 3.25.2
-      # patch release (gated on NVCC >= 12.0); earlier 3.25.x / 3.24 / 3.22
-      # etc. fail at CUDA project detection with "does not know the compile
-      # flags to use to enable it." Ubuntu 22.04 jammy ships 3.22.x through
-      # apt, well below the threshold, so fall back to C++17 there. MeshLib's
-      # CUDA code compiles cleanly under either standard.
+      # https://cmake.org/cmake/help/latest/release/3.25.html#id2
       IF(CMAKE_VERSION VERSION_LESS 3.25.2)
         set(CMAKE_CUDA_STANDARD 17)
       ELSE()

--- a/cmake/Modules/ConfigureCuda.cmake
+++ b/cmake/Modules/ConfigureCuda.cmake
@@ -11,13 +11,13 @@ IF(NOT CUDAToolkit_FOUND AND NOT CUDA_FOUND)
       # For our VS2022 CI:
       set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH")
     ELSE()
-      # CMake's NVCC flag-table entry for C++20 was added in CMake 3.26 (gated
-      # on NVCC >= 12.0). On older CMake -- notably Ubuntu 22.04 jammy's
-      # apt-supplied 3.22 -- using CUDA_STANDARD=20 fails at CUDA project
-      # detection with "does not know the compile flags to use to enable it".
-      # Fall back to C++17 in that case; MeshLib's CUDA code compiles under
-      # either standard.
-      IF(CMAKE_VERSION VERSION_LESS 3.26)
+      # CMake's NVCC flag-table entry for C++20 was added in the CMake 3.25.2
+      # patch release (gated on NVCC >= 12.0); earlier 3.25.x / 3.24 / 3.22
+      # etc. fail at CUDA project detection with "does not know the compile
+      # flags to use to enable it." Ubuntu 22.04 jammy ships 3.22.x through
+      # apt, well below the threshold, so fall back to C++17 there. MeshLib's
+      # CUDA code compiles cleanly under either standard.
+      IF(CMAKE_VERSION VERSION_LESS 3.25.2)
         set(CMAKE_CUDA_STANDARD 17)
       ELSE()
         set(CMAKE_CUDA_STANDARD 20)

--- a/cmake/Modules/ConfigureCuda.cmake
+++ b/cmake/Modules/ConfigureCuda.cmake
@@ -11,7 +11,17 @@ IF(NOT CUDAToolkit_FOUND AND NOT CUDA_FOUND)
       # For our VS2022 CI:
       set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH")
     ELSE()
-      set(CMAKE_CUDA_STANDARD 20)
+      # CMake's NVCC flag-table entry for C++20 was added in CMake 3.26 (gated
+      # on NVCC >= 12.0). On older CMake -- notably Ubuntu 22.04 jammy's
+      # apt-supplied 3.22 -- using CUDA_STANDARD=20 fails at CUDA project
+      # detection with "does not know the compile flags to use to enable it".
+      # Fall back to C++17 in that case; MeshLib's CUDA code compiles under
+      # either standard.
+      IF(CMAKE_VERSION VERSION_LESS 3.26)
+        set(CMAKE_CUDA_STANDARD 17)
+      ELSE()
+        set(CMAKE_CUDA_STANDARD 20)
+      ENDIF()
       find_package(CUDAToolkit 12 REQUIRED)
     ENDIF()
     set(CMAKE_CUDA_STANDARD_REQUIRED ON)

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -68,20 +68,6 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-# update cmake
-RUN apt remove --purge --auto-remove -y cmake \
- && apt update \
- && apt install -y software-properties-common lsb-release \
- && apt clean all \
- && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
- && apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" \
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 42D5A192B819C5DA \
- && apt update \
- && apt install -y kitware-archive-keyring \
- && rm /etc/apt/trusted.gpg.d/kitware.gpg \
- && apt update \
- && apt install -y cmake
-
 RUN ./scripts/install_thirdparty.sh && \
     echo '/usr/local/lib' | tee -a  /etc/ld.so.conf && \
     sudo ldconfig


### PR DESCRIPTION
## Summary

Two-file change that replaces the apt.kitware.com CMake-upgrade step on Ubuntu 22.04 with a CMake-version-aware fallback in `ConfigureCuda.cmake`:

- **`docker/ubuntu22Dockerfile`** — delete the `apt remove cmake → apt-add-repository apt.kitware.com → apt install cmake` block entirely. Image now uses Ubuntu 22.04 jammy's apt-supplied CMake 3.22 directly, matching `docker/ubuntu24Dockerfile`'s existing pattern (which ships 3.28 and never needed an upgrade).
- **`cmake/Modules/ConfigureCuda.cmake`** — gate `CMAKE_CUDA_STANDARD` on the running CMake version so CUDA20 is only requested when CMake actually supports the `-std=c++20` flag for NVCC:

```cmake
ELSE()
  IF(CMAKE_VERSION VERSION_LESS 3.25.2)
    set(CMAKE_CUDA_STANDARD 17)
  ELSE()
    set(CMAKE_CUDA_STANDARD 20)
  ENDIF()
  find_package(CUDAToolkit 12 REQUIRED)
ENDIF()
```

## Why 3.25.2

CMake's NVCC flag table entry for `-std=c++20` was backported into the **CMake 3.25.2** patch release (gated on `CUDA_COMPILER_VERSION >= 12.0`). Earlier 3.25.x / 3.24 / 3.22 / … refuse with

```
Target "cmTC_*" requires the language dialect "CUDA20" (with compiler
extensions), but CMake does not know the compile flags to use to enable it.
Call Stack:
  source/MRCuda/CMakeLists.txt:4 (project)
```

Verified at the source by reading [`Modules/Compiler/NVIDIA-CUDA.cmake @ v3.25.2`](https://raw.githubusercontent.com/Kitware/CMake/v3.25.2/Modules/Compiler/NVIDIA-CUDA.cmake):

```cmake
if (NOT CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.0)
  set(CMAKE_CUDA20_STANDARD_COMPILE_OPTION "-std=c++20")
  set(CMAKE_CUDA20_EXTENSION_COMPILE_OPTION "-std=c++20")
endif()
```

Cross-checked with the [3.25 release notes](https://cmake.org/cmake/help/latest/release/3.25.html#id2):

> CUDA language level 20 (corresponding to C++20) is now supported with NVCC 12.0 and above.

Ubuntu 22.04 jammy ships CMake 3.22 via apt, well below this threshold; hence the historical Dockerfile upgrade. Falling back to CUDA17 on that specific environment — and only that one — is the minimum change that restores a clean install.

## Per-platform effect

| Environment | CMake version | CUDA_STANDARD before | CUDA_STANDARD after |
|---|---|---|---|
| Ubuntu 22.04 apt | 3.22 | 20 (would silently fail without Kitware upgrade) | **17** (fallback) |
| Ubuntu 24.04 apt | 3.28 | 20 | 20 (unchanged) |
| macOS Homebrew | latest | 20 | 20 (unchanged) |
| Rocky Linux vcpkg | vcpkg toolchain | 20 | 20 (unchanged) |
| Emscripten Docker | recent Kitware apt | 20 | 20 (unchanged) |
| Windows | any | 17 (separately pinned on line 6 for a different reason) | 17 (unchanged) |

Only Ubuntu 22.04 flips CUDA standard. Every other leg keeps CUDA20 as before.

## Why not just keep the upgrade

Two separate exploration PRs close in favour of this one:

- [#5962](https://github.com/MeshInspector/MeshLib/pull/5962) swapped apt.kitware.com → GitHub Releases tarball (`cmake-4.3.2-linux-<arch>.tar.gz`). Works, but installs CMake 4.3.2 we don't functionally need (MeshLib's real floor is 3.22, not 3.28 or 4.x — only the NVCC+C++20 combination needed ≥ 3.25.2).
- [#5965](https://github.com/MeshInspector/MeshLib/pull/5965) wraps the existing Kitware recipe in a retry loop. Works, but keeps the single-origin dependency on a repo that's been repeatedly flaky ([Dec 2024 outage](https://discourse.cmake.org/t/kitware-apt-repo-down/13184), connection-refused on arm64 runners).

Dropping the upgrade entirely and falling back to C++17 on the one environment that needs it is the smallest durable change.

## Verified on CI — run [24828203407](https://github.com/MeshInspector/MeshLib/actions/runs/24828203407)

All four Ubuntu 22.04 matrix legs:

| Job | Duration | Status |
|---|---|---|
| `prepare-image / linux-image-build-upload (ubuntu22, x64)` | 14 m 03 s | ✓ |
| `prepare-image / linux-image-build-upload (ubuntu22, arm64)` | 22 m 49 s | ✓ |
| `ubuntu-arm64-build-test (ubuntu22, Release)` | 25 m 04 s | ✓ |
| `ubuntu-x64-build-test (ubuntu22, Release, GCC-12)` | 43 m 32 s | ✓ |

Specifically verified on that run:

- [x] **0 references to `apt.kitware.com` or `kitware-archive-keyring`** in the ubuntu22 image-build log — the step is fully gone.
- [x] **CUDA 12.6.85 identified, no `does not know the compile flags` error** — the CUDA17 fallback fired silently and MRCuda configured cleanly against Ubuntu's CMake 3.22.
- [x] **All 283 unit tests passed**, including `CompressSphereToZip` and `CompressManySmallFilesToZip` — nothing downstream regressed from dropping CUDA20 to CUDA17 in MRCuda.

The other matrix legs (Ubuntu 24.04, macOS, Windows, linux-vcpkg, Emscripten) are all on CMake ≥ 3.25.2 and continue to use CUDA20 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
