### PR TITLE
ci(regression-tests): drop --quiet on aws s3 sync

### DIFF
--- a/.github/actions/python-regression-tests/action.yml
+++ b/.github/actions/python-regression-tests/action.yml
@@ -68,12 +68,12 @@ runs:
     - name: Copy autotest data from S3 Tests
       if: ${{ runner.os != 'Windows' }}
       shell: bash
-      run: aws s3 sync ${{ inputs.autotest_data_s3_url }} test_data --delete --no-sign-request --size-only --quiet
+      run: aws s3 sync ${{ inputs.autotest_data_s3_url }} test_data --delete --no-sign-request --size-only
 
     - name: Copy autotest data from S3 Tests (Windows)
       if: ${{ runner.os == 'Windows' }}
       shell: powershell
-      run: aws s3 sync ${{ inputs.autotest_data_s3_url }} test_data --delete --no-sign-request --size-only --quiet
+      run: aws s3 sync ${{ inputs.autotest_data_s3_url }} test_data --delete --no-sign-request --size-only
 
     - name: Python Regression Tests
       if: ${{ runner.os != 'Windows' }}


### PR DESCRIPTION
## Summary

Drop `--quiet` from both `aws s3 sync` invocations in `.github/actions/python-regression-tests/action.yml` (bash path for macOS/Linux, powershell path for Windows).

## Why

`--quiet` silences all per-object output *and* the normal error stream when the command fails. When the sync exits non-zero we currently see only:

```
##[error]Process completed with exit code 1.
```

— a blank step body with no hint of what went wrong. Observed on macOS arm64 Debug in run [24821677923](https://github.com/MeshInspector/MeshLib/actions/runs/24821677923/job/72647687854): the step exited 1 three seconds after a successful OIDC authentication and a successful cache restore, with nothing visible to distinguish between:

- a transient S3 5xx / network hiccup
- an IAM permission change
- a bucket rename or TLS issue
- DNS flake
- a signed-vs-unsigned request mismatch

…turning every flaky-infrastructure failure into a multi-minute dig through AWS support docs and other runs' logs.

## Cost of removing `--quiet`

Small. Our `--size-only` sync against `s3://data-autotest/test_data_2025-05-13` copies a ~50 MB tree with only *updated* objects printed (not re-scanned). Steady-state output on a matching cache is a handful of lines if anything; on a fresh fetch it's one line per object (bounded by the file count in that test-data snapshot). No secret leakage — bucket is public and unsigned.

## Benefit

When S3 glitches again (which it will), the error stream is right there in the step log, and we save a CI-log round-trip for every future flake on this path.

## No functional change on success

The only behavioural difference is what the step prints; exit code / files synced are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
