### PR TITLE
ci(windows): add DLL-not-found diagnostic steps

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -111,29 +111,11 @@ jobs:
         working-directory: C:\vcpkg
         run: C:\vcpkg\vcpkg.exe integrate install
 
-      # Diagnostic step: inventory the vcpkg installed tree so DLL-not-found
-      # failures later in the build can be traced back to whether the DLL was
-      # (a) never installed, (b) installed under an unexpected name, or
-      # (c) installed fine but not copied to the build output.
       - name: Diagnostic — vcpkg installed tree
         if: ${{ always() }}
         shell: pwsh
         continue-on-error: true
-        run: |
-          $triplet = "${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}"
-          Write-Host "=== Triplet: $triplet ==="
-          foreach ($sub in 'bin','debug\bin','lib','debug\lib') {
-            $dir = "C:\vcpkg\installed\$triplet\$sub"
-            Write-Host ""
-            Write-Host "--- $dir ---"
-            if (Test-Path $dir) {
-              Get-ChildItem $dir -File -ErrorAction SilentlyContinue |
-                Select-Object Name, @{N='SizeKB';E={[int]($_.Length/1KB)}} |
-                Sort-Object Name | Format-Table -AutoSize
-            } else {
-              Write-Host "(directory not present)"
-            }
-          }
+        run: ./scripts/diagnostics/windows-vcpkg-tree.ps1 -Triplet "${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}"
 
       - name: Restore CUDA Cache
         uses: actions/cache@v5
@@ -237,51 +219,12 @@ jobs:
           call "${{matrix.vc-path}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
           call ./scripts/mrbind/generate_win.bat -B --trace MODE=none VS_MODE=${{matrix.config}}
 
-      # Diagnostic step: before launching MeshViewer.exe, dump the state the
-      # Windows loader will actually see. Prints the DLLs present next to the
-      # .exe, the import tables of the key binaries (so we know which DLL
-      # names the loader wants), and the PATH at launch. Lets DLL-not-found
-      # failures self-diagnose from the CI log.
       - name: Diagnostic — output bin DLL inventory + MRMesh imports
         if: ${{ always() }}
         shell: pwsh
         continue-on-error: true
         working-directory: source\x64\${{ matrix.config }}
-        run: |
-          Write-Host "=== DLLs / EXEs in $(Get-Location) ==="
-          Get-ChildItem . -File -Include *.dll,*.exe -Recurse -ErrorAction SilentlyContinue |
-            Select-Object Name, @{N='SizeKB';E={[int]($_.Length/1KB)}} |
-            Sort-Object Name | Format-Table -AutoSize
-
-          # Locate dumpbin.exe via the VC path hint passed in via matrix, then
-          # fall back to whatever is on PATH (Visual Studio Integration step
-          # earlier populates MSBuild PATH, not VC bin).
-          $vcpath  = '${{ matrix.vc-path }}'
-          $dumpbin = (Get-ChildItem "$vcpath\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" -ErrorAction SilentlyContinue |
-                      Select-Object -First 1).FullName
-          if (-not $dumpbin) {
-            $dumpbin = (Get-Command dumpbin.exe -ErrorAction SilentlyContinue).Source
-          }
-
-          if ($dumpbin) {
-            Write-Host ""
-            Write-Host "Using dumpbin at: $dumpbin"
-            foreach ($target in 'MeshViewer.exe','MRMesh.dll','MRTest.exe') {
-              if (Test-Path $target) {
-                Write-Host ""
-                Write-Host "=== Import table of $target (dumpbin /dependents) ==="
-                & $dumpbin /dependents $target |
-                  Where-Object { $_ -match '\.dll$' } |
-                  ForEach-Object { "  " + $_.Trim() }
-              }
-            }
-          } else {
-            Write-Warning "dumpbin.exe not found; skipping import-table dump"
-          }
-
-          Write-Host ""
-          Write-Host "=== PATH at diagnostic step ==="
-          $env:PATH -split ';' | ForEach-Object { "  $_" }
+        run: ${{ github.workspace }}\scripts\diagnostics\windows-bin-imports.ps1 -VcPath "${{ matrix.vc-path }}"
 
       - name: Run Start-and-Exit Tests
         timeout-minutes: 3

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -111,6 +111,30 @@ jobs:
         working-directory: C:\vcpkg
         run: C:\vcpkg\vcpkg.exe integrate install
 
+      # Diagnostic step: inventory the vcpkg installed tree so DLL-not-found
+      # failures later in the build can be traced back to whether the DLL was
+      # (a) never installed, (b) installed under an unexpected name, or
+      # (c) installed fine but not copied to the build output.
+      - name: Diagnostic — vcpkg installed tree
+        if: ${{ always() }}
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          $triplet = "${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}"
+          Write-Host "=== Triplet: $triplet ==="
+          foreach ($sub in 'bin','debug\bin','lib','debug\lib') {
+            $dir = "C:\vcpkg\installed\$triplet\$sub"
+            Write-Host ""
+            Write-Host "--- $dir ---"
+            if (Test-Path $dir) {
+              Get-ChildItem $dir -File -ErrorAction SilentlyContinue |
+                Select-Object Name, @{N='SizeKB';E={[int]($_.Length/1KB)}} |
+                Sort-Object Name | Format-Table -AutoSize
+            } else {
+              Write-Host "(directory not present)"
+            }
+          }
+
       - name: Restore CUDA Cache
         uses: actions/cache@v5
         id: cuda-cache
@@ -212,6 +236,52 @@ jobs:
         run: |
           call "${{matrix.vc-path}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
           call ./scripts/mrbind/generate_win.bat -B --trace MODE=none VS_MODE=${{matrix.config}}
+
+      # Diagnostic step: before launching MeshViewer.exe, dump the state the
+      # Windows loader will actually see. Prints the DLLs present next to the
+      # .exe, the import tables of the key binaries (so we know which DLL
+      # names the loader wants), and the PATH at launch. Lets DLL-not-found
+      # failures self-diagnose from the CI log.
+      - name: Diagnostic — output bin DLL inventory + MRMesh imports
+        if: ${{ always() }}
+        shell: pwsh
+        continue-on-error: true
+        working-directory: source\x64\${{ matrix.config }}
+        run: |
+          Write-Host "=== DLLs / EXEs in $(Get-Location) ==="
+          Get-ChildItem . -File -Include *.dll,*.exe -Recurse -ErrorAction SilentlyContinue |
+            Select-Object Name, @{N='SizeKB';E={[int]($_.Length/1KB)}} |
+            Sort-Object Name | Format-Table -AutoSize
+
+          # Locate dumpbin.exe via the VC path hint passed in via matrix, then
+          # fall back to whatever is on PATH (Visual Studio Integration step
+          # earlier populates MSBuild PATH, not VC bin).
+          $vcpath  = '${{ matrix.vc-path }}'
+          $dumpbin = (Get-ChildItem "$vcpath\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" -ErrorAction SilentlyContinue |
+                      Select-Object -First 1).FullName
+          if (-not $dumpbin) {
+            $dumpbin = (Get-Command dumpbin.exe -ErrorAction SilentlyContinue).Source
+          }
+
+          if ($dumpbin) {
+            Write-Host ""
+            Write-Host "Using dumpbin at: $dumpbin"
+            foreach ($target in 'MeshViewer.exe','MRMesh.dll','MRTest.exe') {
+              if (Test-Path $target) {
+                Write-Host ""
+                Write-Host "=== Import table of $target (dumpbin /dependents) ==="
+                & $dumpbin /dependents $target |
+                  Where-Object { $_ -match '\.dll$' } |
+                  ForEach-Object { "  " + $_.Trim() }
+              }
+            }
+          } else {
+            Write-Warning "dumpbin.exe not found; skipping import-table dump"
+          }
+
+          Write-Host ""
+          Write-Host "=== PATH at diagnostic step ==="
+          $env:PATH -split ';' | ForEach-Object { "  $_" }
 
       - name: Run Start-and-Exit Tests
         timeout-minutes: 3

--- a/scripts/diagnostics/windows-bin-imports.ps1
+++ b/scripts/diagnostics/windows-bin-imports.ps1
@@ -1,0 +1,45 @@
+# Before launching MeshViewer.exe, dump the state the Windows loader will
+# actually see. Prints the DLLs present in the current directory, the
+# import tables of the key binaries (so we know which DLL names the loader
+# wants), and the PATH at launch. Lets DLL-not-found failures self-diagnose
+# from the CI log.
+#
+# Run from the directory containing MeshViewer.exe / MRMesh.dll / MRTest.exe.
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$VcPath
+)
+
+Write-Host "=== DLLs / EXEs in $(Get-Location) ==="
+Get-ChildItem . -File -Include *.dll,*.exe -Recurse -ErrorAction SilentlyContinue |
+    Select-Object Name, @{N='SizeKB';E={[int]($_.Length/1KB)}} |
+    Sort-Object Name | Format-Table -AutoSize
+
+# Locate dumpbin.exe via the VC path hint, then fall back to whatever is on
+# PATH (Visual Studio Integration step earlier populates MSBuild PATH, not
+# VC bin).
+$dumpbin = (Get-ChildItem "$VcPath\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" -ErrorAction SilentlyContinue |
+            Select-Object -First 1).FullName
+if (-not $dumpbin) {
+    $dumpbin = (Get-Command dumpbin.exe -ErrorAction SilentlyContinue).Source
+}
+
+if ($dumpbin) {
+    Write-Host ""
+    Write-Host "Using dumpbin at: $dumpbin"
+    foreach ($target in 'MeshViewer.exe','MRMesh.dll','MRTest.exe') {
+        if (Test-Path $target) {
+            Write-Host ""
+            Write-Host "=== Import table of $target (dumpbin /dependents) ==="
+            & $dumpbin /dependents $target |
+                Where-Object { $_ -match '\.dll$' } |
+                ForEach-Object { "  " + $_.Trim() }
+        }
+    }
+} else {
+    Write-Warning "dumpbin.exe not found; skipping import-table dump"
+}
+
+Write-Host ""
+Write-Host "=== PATH at diagnostic step ==="
+$env:PATH -split ';' | ForEach-Object { "  $_" }

--- a/scripts/diagnostics/windows-vcpkg-tree.ps1
+++ b/scripts/diagnostics/windows-vcpkg-tree.ps1
@@ -1,0 +1,22 @@
+# Inventory the vcpkg installed tree so DLL-not-found failures later in the
+# build can be traced back to whether the DLL was (a) never installed,
+# (b) installed under an unexpected name, or (c) installed fine but not
+# copied to the build output.
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Triplet
+)
+
+Write-Host "=== Triplet: $Triplet ==="
+foreach ($sub in 'bin', 'debug\bin', 'lib', 'debug\lib') {
+    $dir = "C:\vcpkg\installed\$Triplet\$sub"
+    Write-Host ""
+    Write-Host "--- $dir ---"
+    if (Test-Path $dir) {
+        Get-ChildItem $dir -File -ErrorAction SilentlyContinue |
+            Select-Object Name, @{N='SizeKB';E={[int]($_.Length/1KB)}} |
+            Sort-Object Name | Format-Table -AutoSize
+    } else {
+        Write-Host "(directory not present)"
+    }
+}


### PR DESCRIPTION
## Summary

Add two unconditional diagnostic steps to `build-test-windows.yml` so that `STATUS_DLL_NOT_FOUND` failures at MRTest / MeshViewer launch become self-diagnosing from the CI log.

## Motivation

PR #5959 (zlib-ng) run [24802707812](https://github.com/MeshInspector/MeshLib/actions/runs/24802707812) failed on the `msvc-2019 Debug CMake x64-windows-meshlib-iterator-debug` leg with

```
##[error]Process completed with exit code -1073741515.
```

That's `0xC0000135` = `STATUS_DLL_NOT_FOUND`: MeshViewer.exe couldn't find a DLL at launch and the Windows loader aborted *before* main(). The log contained **zero** information about which DLL was missing. The same run succeeded on three other Windows triplets, implicating the iterator-debug triplet's DLL-copy chain, but diagnosis required reading vcpkg install logs from memory and guessing DLL-name conventions. This PR makes that data explicit on every Windows build, so the next occurrence of this failure mode identifies the root cause without needing to re-run CI or SSH to a runner.

## The steps

Both diagnostic bodies live in `scripts/diagnostics/*.ps1`; the workflow just invokes them.

### 1. After `Vcpkg integrate install` — vcpkg install tree inventory

```yaml
- name: Diagnostic — vcpkg installed tree
  if: ${{ always() }}
  shell: pwsh
  continue-on-error: true
  run: ./scripts/diagnostics/windows-vcpkg-tree.ps1 -Triplet "${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}"
```

`scripts/diagnostics/windows-vcpkg-tree.ps1` lists every file under `C:\vcpkg\installed\<triplet>\{bin,debug\bin,lib,debug\lib}`. Answers: *did vcpkg install the package, and under what filenames?* (e.g. distinguishing `libz-ng.dll` vs `libz-ngd.dll`, or `libz-ng.lib` vs `zlib-ng.lib`.)

### 2. Right before `Run Start-and-Exit Tests` — output bin inventory + import tables + PATH

```yaml
- name: Diagnostic — output bin DLL inventory + MRMesh imports
  if: ${{ always() }}
  shell: pwsh
  continue-on-error: true
  working-directory: source\x64\${{ matrix.config }}
  run: ${{ github.workspace }}\scripts\diagnostics\windows-bin-imports.ps1 -VcPath "${{ matrix.vc-path }}"
```

`scripts/diagnostics/windows-bin-imports.ps1` does three things in cwd:
- lists all `.dll` / `.exe` next to MeshViewer.exe (did applocal copy succeed?)
- runs `dumpbin /dependents` on MeshViewer.exe, MRMesh.dll, MRTest.exe (which DLL names does the loader want?)
- prints `$env:PATH` entry-by-entry (is the vcpkg install dir in the loader's search path?)

Cross-referencing these with step 1's vcpkg tree makes the diagnosis unambiguous: if the DLL exists in vcpkg's tree, is named what the loader wants, but isn't in the output dir and vcpkg's bin isn't on PATH — it's an applocal-copy problem. If the DLL name in the import table doesn't match what vcpkg installed — it's a naming-convention issue. If the DLL is entirely missing from vcpkg's tree — it's an install-time problem.

## Safety

- **`if: always()`** — runs even when preceding steps failed. That's when you need it most; a Build step that crashed pre-link still has a partial output dir we'd want to inspect.
- **`continue-on-error: true`** — a bug in the diagnostic step itself (e.g. dumpbin not found, pwsh syntax regression) can't turn a green run red.
- **Unconditional on all Windows legs** — no `if: matrix.foo ==` gating. Cheap enough to always run (~30 lines when healthy), and having the healthy-leg output makes diff-diagnosis trivial when one leg regresses.

## Cost

~30 lines of pwsh output per Windows job when everything works; ~100 lines when a DLL is missing. Negligible relative to the multi-GB Windows CI logs already emitted.

## Scope

Three files:
- `.github/workflows/build-test-windows.yml` — two new steps, one `run:` line each.
- `scripts/diagnostics/windows-vcpkg-tree.ps1` — new, vcpkg install-tree inventory.
- `scripts/diagnostics/windows-bin-imports.ps1` — new, output-dir DLL inventory + dumpbin imports + PATH dump.

No source changes, no behavioural change to the actual build/test pipeline.

## Labels

Windows-only change → can reasonably be gated with `disable-build-*` labels for the other platforms, but the hook that *triggers* image rebuilds on `thirdparty/` path changes doesn't fire here (nothing under `thirdparty/` is touched), so other platforms will run naturally without unnecessary image rebuild cost. Leaving no labels applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)