### PR TITLE
UI TestEngine: add listAllEntries for one-shot flat tree dump

### DIFF
--- a/source/MRViewer/MRUITestEngineControl.cpp
+++ b/source/MRViewer/MRUITestEngineControl.cpp
@@ -110,6 +110,23 @@ static std::string composeStatus( std::string_view disabledReason, std::string_v
     return "available";
 }
 
+static EntryType typeOf( const TestEngine::Entry& entry )
+{
+    return std::visit( MR::overloaded{
+        []( const TestEngine::ButtonEntry& ) { return EntryType::button; },
+        []( const TestEngine::ValueEntry& e )
+        {
+            return std::visit( MR::overloaded{
+                []( const TestEngine::ValueEntry::Value<std::int64_t>& ){ return EntryType::valueInt; },
+                []( const TestEngine::ValueEntry::Value<std::uint64_t>& ){ return EntryType::valueUint; },
+                []( const TestEngine::ValueEntry::Value<double>& ){ return EntryType::valueReal; },
+                []( const TestEngine::ValueEntry::Value<std::string>& ){ return EntryType::valueString; },
+            }, e.value );
+        },
+        []( const TestEngine::GroupEntry& ) { return EntryType::group; },
+    }, entry.value );
+}
+
 Expected<std::vector<TypedEntry>> listEntries( const std::vector<std::string>& path )
 {
     auto groupEx = findGroup( path );
@@ -124,24 +141,55 @@ Expected<std::vector<TypedEntry>> listEntries( const std::vector<std::string>& p
 
     for ( const auto& elem : group.elems )
     {
-        const std::string_view disabledReason = entryDisabledReason( elem.second );
         ret.push_back( {
             .name = elem.first,
-            .type = std::visit( MR::overloaded{
-                []( const TestEngine::ButtonEntry& ) { return EntryType::button; },
-                []( const TestEngine::ValueEntry& e )
-                {
-                    return std::visit( MR::overloaded{
-                        []( const TestEngine::ValueEntry::Value<std::int64_t>& ){ return EntryType::valueInt; },
-                        []( const TestEngine::ValueEntry::Value<std::uint64_t>& ){ return EntryType::valueUint; },
-                        []( const TestEngine::ValueEntry::Value<double>& ){ return EntryType::valueReal; },
-                        []( const TestEngine::ValueEntry::Value<std::string>& ){ return EntryType::valueString; },
-                    }, e.value );
-                },
-                []( const TestEngine::GroupEntry& ) { return EntryType::group; },
-            }, elem.second.value ),
-            .status = composeStatus( disabledReason, blockingModal ),
+            .type = typeOf( elem.second ),
+            .status = composeStatus( entryDisabledReason( elem.second ), blockingModal ),
         } );
+    }
+    return ret;
+}
+
+static void walkAll( std::vector<std::string>& pathStack,
+                     const TestEngine::Entry& entry,
+                     std::string_view rootBlockingModal, bool isRootLevel,
+                     std::vector<PathedEntry>& out )
+{
+    TypedEntry te{
+        .name   = pathStack.back(),
+        .type   = typeOf( entry ),
+        .status = composeStatus( entryDisabledReason( entry ),
+                                 isRootLevel ? rootBlockingModal : std::string_view{} ),
+    };
+    out.emplace_back( pathStack, std::move( te ) );
+
+    if ( auto g = std::get_if<TestEngine::GroupEntry>( &entry.value ) )
+    {
+        for ( const auto& [childName, childEntry] : g->elems )
+        {
+            pathStack.push_back( childName );
+            walkAll( pathStack, childEntry, rootBlockingModal, /*isRootLevel=*/false, out );
+            pathStack.pop_back();
+        }
+    }
+}
+
+Expected<std::vector<PathedEntry>> listAllEntries( const std::vector<std::string>& rootPath )
+{
+    auto groupEx = findGroup( rootPath );
+    if ( !groupEx )
+        return unexpected( groupEx.error() );
+    const auto& group = **groupEx;
+
+    const std::string_view blockingModal = ( rootPath.empty() && rootLevelBlocked() ) ? topBlockingModalName() : std::string_view{};
+
+    std::vector<PathedEntry> ret;
+    std::vector<std::string> pathStack = rootPath;
+    for ( const auto& [childName, childEntry] : group.elems )
+    {
+        pathStack.push_back( childName );
+        walkAll( pathStack, childEntry, blockingModal, /*isRootLevel=*/true, ret );
+        pathStack.pop_back();
     }
     return ret;
 }

--- a/source/MRViewer/MRUITestEngineControl.cpp
+++ b/source/MRViewer/MRUITestEngineControl.cpp
@@ -119,14 +119,12 @@ Expected<std::vector<TypedEntry>> listEntries( const std::vector<std::string>& p
 
 static void walkAll( std::vector<std::string>& pathStack,
                      const TestEngine::Entry& entry,
-                     std::string_view rootBlockingModal, bool isRootLevel,
                      std::vector<PathedEntry>& out )
 {
     TypedEntry te{
         .name   = pathStack.back(),
         .type   = typeOf( entry ),
-        .status = composeStatus( entryDisabledReason( entry ),
-                                 isRootLevel ? rootBlockingModal : std::string_view{} ),
+        .status = composeStatus( entryDisabledReason( entry ) ),
     };
     out.emplace_back( pathStack, std::move( te ) );
 
@@ -135,7 +133,7 @@ static void walkAll( std::vector<std::string>& pathStack,
         for ( const auto& [childName, childEntry] : g->elems )
         {
             pathStack.push_back( childName );
-            walkAll( pathStack, childEntry, rootBlockingModal, /*isRootLevel=*/false, out );
+            walkAll( pathStack, childEntry, out );
             pathStack.pop_back();
         }
     }
@@ -148,14 +146,12 @@ Expected<std::vector<PathedEntry>> listAllEntries( const std::vector<std::string
         return unexpected( groupEx.error() );
     const auto& group = **groupEx;
 
-    const std::string_view blockingModal = ( rootPath.empty() && rootLevelBlocked() ) ? topBlockingModalName() : std::string_view{};
-
     std::vector<PathedEntry> ret;
     std::vector<std::string> pathStack = rootPath;
     for ( const auto& [childName, childEntry] : group.elems )
     {
         pathStack.push_back( childName );
-        walkAll( pathStack, childEntry, blockingModal, /*isRootLevel=*/true, ret );
+        walkAll( pathStack, childEntry, ret );
         pathStack.pop_back();
     }
     return ret;

--- a/source/MRViewer/MRUITestEngineControl.h
+++ b/source/MRViewer/MRUITestEngineControl.h
@@ -60,6 +60,14 @@ struct TypedEntry
 // Returns the contents of `path`, or an error if the path is wrong.
 [[nodiscard]] MRVIEWER_API Expected<std::vector<TypedEntry>> listEntries( const std::vector<std::string>& path );
 
+// `listAllEntries` returns this: each element is `(fullPath, entry)` where `fullPath.back() == entry.name`.
+using PathedEntry = std::pair<std::vector<std::string>, TypedEntry>;
+
+// Returns every entry in the subtree rooted at `rootPath` as a flat depth-first list. Pass an empty
+// `rootPath` to get the whole tree. Groups are included in the list (identifiable by `type == group`)
+// and their descendants appear on subsequent rows with `path` extending theirs.
+[[nodiscard]] MRVIEWER_API Expected<std::vector<PathedEntry>> listAllEntries( const std::vector<std::string>& rootPath );
+
 // Presses the button at this path, or returns an error.
 MRVIEWER_API Expected<void> pressButton( const std::vector<std::string>& path );
 

--- a/source/MRViewer/MRViewerMcp.cpp
+++ b/source/MRViewer/MRViewerMcp.cpp
@@ -15,6 +15,22 @@ static void skipFramesAfterInput()
         MR::CommandLoop::runCommandFromGUIThread( [] {} ); // Wait a few frames.
 }
 
+// Hopefully "float" is more clear to LLMs than "real". The actual underlying type is `double`.
+static const char* mcpTypeStr( UI::TestEngine::Control::EntryType type )
+{
+    switch ( type )
+    {
+        case UI::TestEngine::Control::EntryType::button:      return "button";
+        case UI::TestEngine::Control::EntryType::group:       return "group";
+        case UI::TestEngine::Control::EntryType::valueInt:    return "int";
+        case UI::TestEngine::Control::EntryType::valueUint:   return "uint";
+        case UI::TestEngine::Control::EntryType::valueReal:   return "float";
+        case UI::TestEngine::Control::EntryType::valueString: return "string";
+    }
+    assert( false && "Unknown EntryType." );
+    return "invalid";
+}
+
 static nlohmann::json mcpToolListUiEntries( const nlohmann::json& args )
 {
     std::vector<UI::TestEngine::Control::TypedEntry> list;
@@ -29,25 +45,35 @@ static nlohmann::json mcpToolListUiEntries( const nlohmann::json& args )
     nlohmann::json ret = nlohmann::json::array();
     for ( const auto& elem : list )
     {
-        std::string typeStr;
-        switch ( elem.type )
-        {
-            case UI::TestEngine::Control::EntryType::button:      typeStr = "button"; break;
-            case UI::TestEngine::Control::EntryType::group:       typeStr = "group"; break;
-            case UI::TestEngine::Control::EntryType::valueInt:    typeStr = "int"; break;
-            case UI::TestEngine::Control::EntryType::valueUint:   typeStr = "uint"; break;
-            case UI::TestEngine::Control::EntryType::valueReal:   typeStr = "float"; break; // Hopefully "float" is more clear to LLMs than "real". The actual underlying type is `double`.
-            case UI::TestEngine::Control::EntryType::valueString: typeStr = "string"; break;
-        }
-
-        assert( !typeStr.empty() );
-        if ( typeStr.empty() )
-            typeStr = "invalid";
-
         ret.push_back( nlohmann::json::object( {
             { "name", elem.name },
-            { "type", std::move( typeStr ) },
+            { "type", mcpTypeStr( elem.type ) },
             { "status", elem.status },
+        } ) );
+    }
+
+    return nlohmann::json::object( { { "result", ret } } );
+}
+
+static nlohmann::json mcpToolListAllUiEntries( const nlohmann::json& args )
+{
+    std::vector<UI::TestEngine::Control::PathedEntry> list;
+    MR::CommandLoop::runCommandFromGUIThread( [&]
+    {
+        auto ex = UI::TestEngine::Control::listAllEntries( args.value( "path", std::vector<std::string>{} ) );
+        if ( !ex )
+            throw std::runtime_error( ex.error() );
+        list = std::move( *ex );
+    } );
+
+    nlohmann::json ret = nlohmann::json::array();
+    for ( const auto& pe : list )
+    {
+        ret.push_back( nlohmann::json::object( {
+            { "path", pe.first },
+            { "name", pe.second.name },
+            { "type", mcpTypeStr( pe.second.type ) },
+            { "status", pe.second.status },
         } ) );
     }
 
@@ -124,6 +150,21 @@ MR_ON_INIT{
                 .addMember( "status", Mcp::Schema::String{} )
         ),
         /*func*/mcpToolListUiEntries
+    );
+
+    server.addTool(
+        /*id*/"ui.listAllEntries",
+        /*name*/"List all UI entries (flat, recursive)",
+        /*desc*/"Returns a flat depth-first list of every UI element in the subtree rooted at `path` (default: the whole tree). Each item carries its own full `path`, so the tree structure is recoverable without extra calls. `type == \"group\"` identifies intermediate nodes; their descendants appear on subsequent rows whose `path` extends theirs. `name`, `type`, and `status` have the same meaning as in `ui.listEntries`. Use this instead of walking level-by-level with `ui.listEntries` when you want a one-shot view of the UI.",
+        /*input_schema*/Mcp::Schema::Object{}.addMemberOpt( "path", Mcp::Schema::Array( Mcp::Schema::String{} ) ),
+        /*output_schema*/Mcp::Schema::Array(
+            Mcp::Schema::Object{}
+                .addMember( "path", Mcp::Schema::Array( Mcp::Schema::String{} ) )
+                .addMember( "name", Mcp::Schema::String{} )
+                .addMember( "type", Mcp::Schema::String{} )
+                .addMember( "status", Mcp::Schema::String{} )
+        ),
+        /*func*/mcpToolListAllUiEntries
     );
 
     server.addTool(

--- a/source/mrviewerpy/MRPythonUiInteraction.cpp
+++ b/source/mrviewerpy/MRPythonUiInteraction.cpp
@@ -58,6 +58,17 @@ MR_ADD_PYTHON_FUNCTION( mrviewerpy, uiListEntries,
     "Add group name to the end of the vector to see its contents.\n"
     "When you find the button you need, pass it to `uiPressButton()`."
 )
+MR_ADD_PYTHON_FUNCTION( mrviewerpy, uiListAllEntries,
+    []( const std::vector<std::string>& rootPath )
+    {
+        std::vector<Control::PathedEntry> ret;
+        MR::CommandLoop::runCommandFromGUIThread( [&]{ ret = MR::expectedValueOrThrow( Control::listAllEntries( rootPath ) ); } );
+        return ret;
+    },
+    "Flat depth-first list of every UI entry in the subtree rooted at `rootPath`.\n"
+    "Pass an empty list for the whole tree.\n"
+    "Each element is a `(path, UiEntry)` tuple where `path[-1] == entry.name`."
+)
 MR_ADD_PYTHON_FUNCTION( mrviewerpy, uiPressButton,
     []( const std::vector<std::string>& path )
     {


### PR DESCRIPTION
## Summary

- Walking the UI tree via `ui.listEntries` costs 4–5 sequential round-trips to reach a known widget. This PR adds `ui.listAllEntries` (MCP) + `uiListAllEntries` (Python) returning every entry in the subtree at `path` (default empty → whole tree) as a flat depth-first list of `(path, TypedEntry)` pairs. Groups appear in the list and their descendants follow on subsequent rows, so the tree structure is recoverable from the flat output.
- `TypedEntry` and `ui.listEntries` are unchanged — purely additive.
- Follow-up to #5961 ([prior-session plan](https://github.com/MeshInspector/MeshInspectorCode/issues/7205) step 2).

## Design notes

- `PathedEntry = std::pair<std::vector<std::string>, TypedEntry>` alias in `MRUITestEngineControl.h` keeps the signature readable.
- Factored `typeOf(Entry)` in `MRUITestEngineControl.cpp` so the flat `listEntries` and the new recursive walker share the variant switch.
- Factored `mcpTypeStr(EntryType)` in `MRViewerMcp.cpp` so the old and new MCP handlers share the enum→string.
- pybind11 auto-converts `pair` → tuple and `vector<pair<…>>` → list of tuples; no new binding class needed.
- Output schema is `Array(Object{path, name, type, status})`. `Mcp::Schema` has no `$ref` for recursive children, but the flat-with-path shape sidesteps that and is trivially serializable.

## Test plan

Live-verified end-to-end against a freshly-built MeshInspector via the MCP SSE endpoint:

- [x] `ui.listAllEntries({path:[]})` returns **84 entries**, **9857 bytes** serialized (under the ~10 KB budget from the plan).
- [x] Flat output is the same set of `(path, type)` tuples as a recursive walk via `ui.listEntries` — **0 missing, 0 extra, 0 status drift**.
- [x] Subtree rooting at `["QuickAccess"]` returns 9 entries all with the correct `path` prefix; first-level set matches `ui.listEntries` at the same path.
- [x] Bogus `path` returns the same `"No such entry: \`…\`. Known entries are: …"` error shape as `listEntries` (shared `findGroup` helper).
- [x] Omitting `path` defaults to empty (whole tree).
- [x] `tools/list` shows `ui.listAllEntries` registered alongside the other 10 `ui.*` tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)