### PR TITLE
UI TestEngine: precise modal-blocked detection (fix #5961 regression)

### DIFF
--- a/source/MRViewer/MRUITestEngine.cpp
+++ b/source/MRViewer/MRUITestEngine.cpp
@@ -36,13 +36,27 @@ bool imGuiContextSaysDisabled()
     return g && ( g->CurrentItemFlags & ImGuiItemFlags_Disabled ) != 0;
 }
 
+// If a blocking modal popup is currently open and the widget being submitted is *outside* that
+// modal's window tree (walking ImGui's ParentWindow chain), returns a view of the modal's window
+// name. Otherwise returns empty (no modal open, or the widget is inside the modal).
+// The returned view is valid only while ImGui state is untouched (i.e. during the same callback).
+std::string_view imGuiBlockingModalName()
+{
+    ImGuiWindow* topModal = ImGui::GetTopMostPopupModal();
+    if ( !topModal )
+        return {};
+    for ( ImGuiWindow* w = ImGui::GetCurrentWindow(); w; w = w->ParentWindow )
+        if ( w == topModal )
+            return {};
+    return topModal->Name ? std::string_view{ topModal->Name } : std::string_view{ "<unnamed>" };
+}
+
 // Produce the effective disabled-reason string to store on an entry, given caller-supplied attrs.
 // - If caller passed a reason, use it verbatim (takes precedence).
 // - Else if ImGui says the widget is drawn under BeginDisabled, use a generic fallback so the
 //   entry is still marked disabled even though the caller didn't know why.
-// - Else, if a blocking modal popup is open and the widget is drawn outside it (walking the
-//   ParentWindow chain), return "blocked by modal '<name>'" — the widget can't receive input
-//   while the modal is on top.
+// - Else, if a blocking modal popup is open and the widget is drawn outside it, return
+//   "blocked by modal '<name>'" — the widget can't receive input while the modal is on top.
 // - Else empty (entry accepts input).
 std::string effectiveDisabledReason( const EntryAttributes& attrs )
 {
@@ -50,20 +64,8 @@ std::string effectiveDisabledReason( const EntryAttributes& attrs )
         return std::string( attrs.disabledReason );
     if ( imGuiContextSaysDisabled() )
         return "drawn inside ImGui::BeginDisabled";
-    if ( ImGuiWindow* topModal = ImGui::GetTopMostPopupModal() )
-    {
-        bool insideTopModal = false;
-        for ( ImGuiWindow* w = ImGui::GetCurrentWindow(); w; w = w->ParentWindow )
-        {
-            if ( w == topModal )
-            {
-                insideTopModal = true;
-                break;
-            }
-        }
-        if ( !insideTopModal )
-            return fmt::format( "blocked by modal '{}'", topModal->Name ? topModal->Name : "<unnamed>" );
-    }
+    if ( const auto modal = imGuiBlockingModalName(); !modal.empty() )
+        return fmt::format( "blocked by modal '{}'", modal );
     return {};
 }
 

--- a/source/MRViewer/MRUITestEngine.cpp
+++ b/source/MRViewer/MRUITestEngine.cpp
@@ -40,13 +40,30 @@ bool imGuiContextSaysDisabled()
 // - If caller passed a reason, use it verbatim (takes precedence).
 // - Else if ImGui says the widget is drawn under BeginDisabled, use a generic fallback so the
 //   entry is still marked disabled even though the caller didn't know why.
+// - Else, if a blocking modal popup is open and the widget is drawn outside it (walking the
+//   ParentWindow chain), return "blocked by modal '<name>'" — the widget can't receive input
+//   while the modal is on top.
 // - Else empty (entry accepts input).
-std::string_view effectiveDisabledReason( const EntryAttributes& attrs )
+std::string effectiveDisabledReason( const EntryAttributes& attrs )
 {
     if ( !attrs.disabledReason.empty() )
-        return attrs.disabledReason;
+        return std::string( attrs.disabledReason );
     if ( imGuiContextSaysDisabled() )
         return "drawn inside ImGui::BeginDisabled";
+    if ( ImGuiWindow* topModal = ImGui::GetTopMostPopupModal() )
+    {
+        bool insideTopModal = false;
+        for ( ImGuiWindow* w = ImGui::GetCurrentWindow(); w; w = w->ParentWindow )
+        {
+            if ( w == topModal )
+            {
+                insideTopModal = true;
+                break;
+            }
+        }
+        if ( !insideTopModal )
+            return fmt::format( "blocked by modal '{}'", topModal->Name ? topModal->Name : "<unnamed>" );
+    }
     return {};
 }
 
@@ -110,8 +127,7 @@ std::optional<T> detail::createValueLow( std::string_view name, std::optional<Bo
     if ( !entry )
         entry = &iter->second.value.emplace<ValueEntry>();
 
-    const auto reason = effectiveDisabledReason( attrs );
-    entry->disabledReason.assign( reason.data(), reason.size() );
+    entry->disabledReason = effectiveDisabledReason( attrs );
 
     std::optional<T> ret;
 
@@ -184,8 +200,7 @@ bool createButton( std::string_view name, const EntryAttributes& attrs )
     if ( !button )
         button = &iter->second.value.emplace<ButtonEntry>();
 
-    const auto reason = effectiveDisabledReason( attrs );
-    button->disabledReason.assign( reason.data(), reason.size() );
+    button->disabledReason = effectiveDisabledReason( attrs );
 
     iter->second.visitedOnThisFrame = true;
 

--- a/source/MRViewer/MRUITestEngineControl.cpp
+++ b/source/MRViewer/MRUITestEngineControl.cpp
@@ -2,10 +2,7 @@
 
 #include "MRMesh/MRMeshFwd.h"
 #include "MRPch/MRFmt.h"
-#include "MRViewer/MRImGui.h"
 #include "MRViewer/MRUITestEngine.h"
-
-#include <imgui_internal.h>
 
 #include <algorithm>
 #include <span>
@@ -71,42 +68,14 @@ static std::string_view entryDisabledReason( const TestEngine::Entry& entry )
     }, entry.value );
 }
 
-// Heuristic: "blocked" is set only on root-level (top-level) entries when any blocking popup is open.
-// The TestEngine tree is independent of ImGui's window/popup structure, so we can't do a precise
-// "is this entry occluded by that popup" check without extra bookkeeping. Mark top-level entries
-// as blocked so agents know a modal is intercepting input; entries inside `pushTree` groups (which
-// typically *are* the dialog contents) are left unmarked.
-static bool rootLevelBlocked()
-{
-    return ImGui::IsPopupOpen( "", ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel );
-}
-
-// Best-effort extraction of the topmost open popup's window name (for the blocking-modal status).
-// Returns empty if no popup is open or the name can't be determined. Callers must only use the
-// returned view while still on the GUI thread (ImGui owns the string).
-static std::string_view topBlockingModalName()
-{
-    ImGuiContext* g = ImGui::GetCurrentContext();
-    if ( !g || g->OpenPopupStack.empty() )
-        return {};
-    // The most recently opened popup is at the back of the stack.
-    const ImGuiPopupData& top = g->OpenPopupStack.back();
-    if ( top.Window && top.Window->Name )
-        return top.Window->Name;
-    return {};
-}
-
-// Compose the single user-facing status string. `disabledReason` is the widget's own reason
-// (non-empty when the widget was drawn greyed out); `blockingModal` is the topmost blocking
-// popup's name (non-empty when a modal is on top of this entry). The widget's own disable
-// takes precedence over modal occlusion (the widget is literally greyed out; the modal is
-// incidental).
-static std::string composeStatus( std::string_view disabledReason, std::string_view blockingModal )
+// Compose the single user-facing status string from the entry's `disabledReason`.
+// The reason covers every disable source — caller-supplied requirements, ImGui::BeginDisabled
+// auto-detect, and "blocked by modal '<name>'" (all formatted at registration time in
+// `MRUITestEngine.cpp:effectiveDisabledReason`).
+static std::string composeStatus( std::string_view disabledReason )
 {
     if ( !disabledReason.empty() )
         return fmt::format( "disabled: {}", disabledReason );
-    if ( !blockingModal.empty() )
-        return fmt::format( "disabled: blocked by modal '{}'", blockingModal );
     return "available";
 }
 
@@ -117,14 +86,11 @@ Expected<std::vector<TypedEntry>> listEntries( const std::vector<std::string>& p
         return unexpected( groupEx.error() );
     const auto& group = **groupEx;
 
-    const std::string_view blockingModal = ( path.empty() && rootLevelBlocked() ) ? topBlockingModalName() : std::string_view{};
-
     std::vector<TypedEntry> ret;
     ret.reserve( group.elems.size() );
 
     for ( const auto& elem : group.elems )
     {
-        const std::string_view disabledReason = entryDisabledReason( elem.second );
         ret.push_back( {
             .name = elem.first,
             .type = std::visit( MR::overloaded{
@@ -140,7 +106,7 @@ Expected<std::vector<TypedEntry>> listEntries( const std::vector<std::string>& p
                 },
                 []( const TestEngine::GroupEntry& ) { return EntryType::group; },
             }, elem.second.value ),
-            .status = composeStatus( disabledReason, blockingModal ),
+            .status = composeStatus( entryDisabledReason( elem.second ) ),
         } );
     }
     return ret;
@@ -165,13 +131,8 @@ Expected<void> pressButton( const std::vector<std::string>& path )
         return unexpected( buttonEx.error() );
 
     const std::string_view disabledReason = ( *buttonEx )->disabledReason;
-    // Root-level entries are considered unreachable when a blocking popup is open on top of them.
-    const bool isBlocked = disabledReason.empty() && path.size() == 1 && rootLevelBlocked();
-    if ( !disabledReason.empty() || isBlocked )
-    {
-        const std::string_view blockingModal = isBlocked ? topBlockingModalName() : std::string_view{};
-        return unexpected( fmt::format( "pressButton {}: {}", pathToString( path ), composeStatus( disabledReason, blockingModal ) ) );
-    }
+    if ( !disabledReason.empty() )
+        return unexpected( fmt::format( "pressButton {}: {}", pathToString( path ), composeStatus( disabledReason ) ) );
 
     ( *buttonEx )->simulateClick = true;
 
@@ -290,12 +251,8 @@ Expected<void> writeValue( const std::vector<std::string>& path, T value )
     const auto& entry = **entryEx;
 
     const std::string_view disabledReason = entry.disabledReason;
-    const bool isBlocked = disabledReason.empty() && path.size() == 1 && rootLevelBlocked();
-    if ( !disabledReason.empty() || isBlocked )
-    {
-        const std::string_view blockingModal = isBlocked ? topBlockingModalName() : std::string_view{};
-        return unexpected( fmt::format( "writeValue {}: {}", pathToString( path ), composeStatus( disabledReason, blockingModal ) ) );
-    }
+    if ( !disabledReason.empty() )
+        return unexpected( fmt::format( "writeValue {}: {}", pathToString( path ), composeStatus( disabledReason ) ) );
 
     auto writeValueOfCorrectType = [&entry, &path]( auto fixedValue ) -> Expected<void>
     {


### PR DESCRIPTION
## Summary

Replaces the overbroad `rootLevelBlocked()` heuristic in `UI::TestEngine::Control` with a per-widget check done at registration time. Fixes the test_ui regression [`ubuntu22-arm64 build-test` on MeshInspectorCode#7242](https://github.com/MeshInspector/MeshInspectorCode/actions/runs/24833399981/job/72690748398).

## The regression

PR #5961 added `status` reporting and typed errors from `pressButton`/`writeValue` for disabled-or-blocked widgets. The "blocked by modal" branch used `ImGui::IsPopupOpen("", AnyPopupId | AnyPopupLevel)` — true whenever any popup is open *anywhere*. It flagged **every** root-level entry, including buttons that actually lived **inside** the modal. Test scenarios pressing modal-own buttons like `Don't Save` on the `New scene` confirmation dialog hit a typed error instead of being simulated, Python propagated, MeshInspector terminated with exit 6:

```
[error] RuntimeError: pressButton Don't Save: disabled: blocked by modal 'New scene##new scene'
terminate called without an active exception
```

`test_all_scens.py::test_all_scenarios[main_set/features/select/qase_regression]` all fail as a result.

## Why the heuristic was wrong

The `UI::TestEngine` tree (`pushTree`/`popTree`) is independent of ImGui's window/popup structure. MeshInspector's `New scene` confirmation dialog registers its `Don't Save` button via `createButton(...)` without a surrounding `pushTree`, so the button sits at the TestEngine root. A global "any popup open" test can't distinguish "at root *behind* the modal" from "at root *inside* the modal."

## The fix

Do the check **at widget registration time** (where `ImGui::GetCurrentWindow()` is valid) and fold the result into the existing `disabledReason` string on the internal entry. A widget whose current window is not in the topmost blocking modal's ancestor chain gets `disabledReason = "blocked by modal '<name>'"` for that frame; widgets inside the modal (or with no modal open) get an empty reason. `listEntries`, `pressButton`, `writeValue`, and `composeStatus` already consume `disabledReason` — no per-caller changes needed.

Concretely:

- **`MRUITestEngine.cpp` :: `effectiveDisabledReason`** — return type bumped from `std::string_view` to `std::string`; after the caller-reason and `BeginDisabled` auto-detect branches, falls back to checking `ImGui::GetTopMostPopupModal()` and walking the current window's `ParentWindow` chain. If the widget is outside the modal, format `"blocked by modal '<name>'"`.
- **`MRUITestEngineControl.cpp`** — `rootLevelBlocked()` and `topBlockingModalName()` deleted; `composeStatus` collapses to a single `std::string_view disabledReason` input; `listEntries`/`pressButton`/`writeValue` drop the `blockingModal` branch and the `path.size() == 1` special case (the per-entry reason now carries all needed info).
- **No header changes**, no API surface change. `ButtonEntry::disabledReason` and `ValueEntry::disabledReason` already store `std::string`. MCP `status` and Python `UiEntry.status` produce the same three shapes as before: `"available"` | `"disabled: <reason>"` | `"disabled: blocked by modal '<name>'"`.

Secondary improvement: switches from `IsPopupOpen(AnyPopupId|AnyPopupLevel)` to `GetTopMostPopupModal()`, so non-modal popups (tooltips, `BeginPopup` without `_Modal`) no longer count as blockers.

## Test plan

Verified live via MCP against Debug build:

- [x] Root with no modal — every entry `"available"`.
- [x] `RibbonSceneButtons/*` with empty scene — `"disabled: <ribbon requirement>"` (unchanged — the requirement-based path isn't touched).
- [x] Open Toolbar Customize popup → root entries BEHIND the modal (`##Cube`, `Create Object`, `Watch Video`, `Information`, `Show on Startup`) report `"disabled: blocked by modal 'Toolbar Customize'"`.
- [x] Same scenario → entries INSIDE the modal (`Toolbar Customize/##About`, `Toolbar Customize/Reset to default`, etc.) report `"available"`.
- [x] `pressButton(["Toolbar Customize", "Reset to default"])` (inside modal) returns `{}` — no typed error.
- [x] `pressButton(["Toolbar", "##ToolbarCustomizeBtn"])` (behind modal) returns `"pressButton .../...: disabled: blocked by modal 'Toolbar Customize'"` — correct typed error on a widget NOT in the modal, at any path depth.

The CI-regression case (`Don't Save` inside `New scene##new scene`) is the symmetric "inside-modal at root" path: the widget's current window == the top modal → `disabledReason` stays empty → `status: "available"` → `pressButton` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)