### PR TITLE
ci: retry submodule fetch on transient github.com 500s

### DIFF
--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -75,13 +75,14 @@ jobs:
           # related issue: https://github.com/actions/checkout/issues/1779
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          git submodule update --init --depth 1 \
+          # Retried via retry.sh: submodule endpoints occasionally 500.
+          bash scripts/retry.sh -- git submodule update --init --depth 1 \
             thirdparty/imgui \
             thirdparty/parallel-hashmap \
             thirdparty/mrbind-pybind11 \
             thirdparty/mrbind
           # mrbind needs deps/cppdecl; recurse only there
-          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
+          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install thirdparty libs
         run: |

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -115,7 +115,8 @@ jobs:
           # related issue: https://github.com/actions/checkout/issues/1779
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          git submodule update --init --depth 1 \
+          # Retried via retry.sh: submodule endpoints occasionally 500.
+          bash scripts/retry.sh -- git submodule update --init --depth 1 \
             thirdparty/imgui \
             thirdparty/mrbind-pybind11 \
             thirdparty/mrbind \
@@ -123,7 +124,7 @@ jobs:
             thirdparty/nlohmann-json \
             thirdparty/cpp-httplib
           # mrbind needs deps/cppdecl; recurse only there
-          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
+          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install MRBind
         if: ${{ inputs.mrbind || inputs.mrbind_c }}

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -78,7 +78,8 @@ jobs:
         run: |
           # Selective init -- parent Checkout drops submodules:true.
           # https://github.com/actions/checkout/issues/1779
-          git submodule update --init --depth 1 \
+          # Retried via retry.sh: submodule endpoints occasionally 500.
+          bash scripts/retry.sh -- git submodule update --init --depth 1 \
             thirdparty/imgui \
             thirdparty/eigen \
             thirdparty/parallel-hashmap \
@@ -96,7 +97,7 @@ jobs:
             thirdparty/mrbind \
             thirdparty/mrbind-pybind11
           # mrbind needs deps/cppdecl; recurse only there
-          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
+          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Setup Homebrew prefix and resolve compiler paths
         id: setup

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -93,14 +93,15 @@ jobs:
           # related issue: https://github.com/actions/checkout/issues/1779
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory '*'
-          git submodule update --init --depth 1 \
+          # Retried via retry.sh: submodule endpoints occasionally 500.
+          bash scripts/retry.sh -- git submodule update --init --depth 1 \
             thirdparty/imgui \
             thirdparty/eigen \
             thirdparty/parallel-hashmap \
             thirdparty/mrbind-pybind11 \
             thirdparty/mrbind
           # mrbind needs deps/cppdecl; recurse only there
-          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
+          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install thirdparty libs
         run: |

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -72,14 +72,15 @@ jobs:
           # related issue: https://github.com/actions/checkout/issues/1779
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory '*'
-          git submodule update --init --depth 1 \
+          # Retried via retry.sh: submodule endpoints occasionally 500.
+          bash scripts/retry.sh -- git submodule update --init --depth 1 \
             thirdparty/imgui \
             thirdparty/eigen \
             thirdparty/parallel-hashmap \
             thirdparty/mrbind-pybind11 \
             thirdparty/mrbind
           # mrbind needs deps/cppdecl; recurse only there
-          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
+          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install thirdparty libs
         run: |

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -49,17 +49,29 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
 
     steps:
-      # Wrap checkout in a retry loop. GitHub's submodule endpoints occasionally
-      # serve HTTP 500s for 30-60s (see run 24845654039); actions/checkout@v6
-      # retries submodule clones once, which isn't enough for a sustained blip.
       - name: Checkout
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/checkout@v6
         with:
-          action: actions/checkout@v6
-          attempt_limit: 3
-          attempt_delay: 30000 # milliseconds
-          with: |
-            submodules: true
+          # Fetched explicitly below with a retry loop. GitHub's submodule
+          # endpoints occasionally serve HTTP 500s for ~30-60s (see run
+          # 24845654039), and actions/checkout's built-in retry only tries
+          # each submodule twice, which wasn't enough for that blip.
+          submodules: false
+
+      - name: Checkout submodules (with retries)
+        shell: bash
+        run: |
+          for i in 1 2 3; do
+            if git -c protocol.version=2 submodule update --init --force --depth=1; then
+              break
+            fi
+            if [ "$i" = "3" ]; then
+              echo "::error::submodule update failed after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::submodule update attempt $i failed — retrying in 30s"
+            sleep 30
+          done
 
       - name: Checkout third-party submodules
         run: |

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -58,7 +58,7 @@ jobs:
           # Selective init -- parent Checkout drops submodules:true.
           # https://github.com/actions/checkout/issues/1779
           # Retried via retry.sh: submodule endpoints occasionally 500.
-          bash scripts/retry.sh -- git -c protocol.version=2 submodule update --init --depth 1 \
+          bash scripts/retry.sh -- git submodule update --init --depth 1 \
             thirdparty/imgui \
             thirdparty/eigen \
             thirdparty/parallel-hashmap \

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -54,10 +54,10 @@ jobs:
 
       - name: Checkout third-party submodules
         shell: bash
-        # Selective init -- parent Checkout drops submodules:true.
-        # https://github.com/actions/checkout/issues/1779
-        # Retried via retry.sh: submodule endpoints occasionally 500.
         run: |
+          # Selective init -- parent Checkout drops submodules:true.
+          # https://github.com/actions/checkout/issues/1779
+          # Retried via retry.sh: submodule endpoints occasionally 500.
           bash scripts/retry.sh -- git -c protocol.version=2 submodule update --init --force --depth=1 \
             thirdparty/imgui \
             thirdparty/eigen \
@@ -70,6 +70,7 @@ jobs:
             thirdparty/cpp-httplib \
             thirdparty/mrbind \
             thirdparty/mrbind-pybind11
+          # mrbind needs deps/cppdecl; recurse only there
           bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --force --depth=1 deps/cppdecl
 
       - name: Get AWS instance type

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -58,7 +58,7 @@ jobs:
           # Selective init -- parent Checkout drops submodules:true.
           # https://github.com/actions/checkout/issues/1779
           # Retried via retry.sh: submodule endpoints occasionally 500.
-          bash scripts/retry.sh -- git -c protocol.version=2 submodule update --init --force --depth=1 \
+          bash scripts/retry.sh -- git -c protocol.version=2 submodule update --init --depth=1 \
             thirdparty/imgui \
             thirdparty/eigen \
             thirdparty/parallel-hashmap \
@@ -71,7 +71,7 @@ jobs:
             thirdparty/mrbind \
             thirdparty/mrbind-pybind11
           # mrbind needs deps/cppdecl; recurse only there
-          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --force --depth=1 deps/cppdecl
+          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth=1 deps/cppdecl
 
       - name: Get AWS instance type
         uses: ./.github/actions/get-aws-instance-type

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -58,7 +58,7 @@ jobs:
           # Selective init -- parent Checkout drops submodules:true.
           # https://github.com/actions/checkout/issues/1779
           # Retried via retry.sh: submodule endpoints occasionally 500.
-          bash scripts/retry.sh -- git -c protocol.version=2 submodule update --init --depth=1 \
+          bash scripts/retry.sh -- git -c protocol.version=2 submodule update --init --depth 1 \
             thirdparty/imgui \
             thirdparty/eigen \
             thirdparty/parallel-hashmap \
@@ -71,7 +71,7 @@ jobs:
             thirdparty/mrbind \
             thirdparty/mrbind-pybind11
           # mrbind needs deps/cppdecl; recurse only there
-          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth=1 deps/cppdecl
+          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Get AWS instance type
         uses: ./.github/actions/get-aws-instance-type

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -56,34 +56,21 @@ jobs:
         shell: bash
         # Selective init -- parent Checkout drops submodules:true.
         # https://github.com/actions/checkout/issues/1779
-        # Wrapped in a retry loop because GitHub's submodule endpoints
-        # occasionally serve HTTP 500s for ~30-60s (see run 24845654039),
-        # and actions/checkout's built-in retry only tries each submodule
-        # twice, which wasn't enough for that blip.
+        # Retried via retry.sh: submodule endpoints occasionally 500.
         run: |
-          for i in 1 2 3; do
-            if git -c protocol.version=2 submodule update --init --force --depth=1 \
-                thirdparty/imgui \
-                thirdparty/eigen \
-                thirdparty/parallel-hashmap \
-                thirdparty/expected \
-                thirdparty/OpenCTM-git \
-                thirdparty/laz-perf \
-                thirdparty/fastmcpp \
-                thirdparty/nlohmann-json \
-                thirdparty/cpp-httplib \
-                thirdparty/mrbind \
-                thirdparty/mrbind-pybind11 \
-                && git -C thirdparty/mrbind submodule update --init --force --depth=1 deps/cppdecl; then
-              break
-            fi
-            if [ "$i" = "3" ]; then
-              echo "::error::submodule update failed after 3 attempts"
-              exit 1
-            fi
-            echo "::warning::submodule update attempt $i failed — retrying in 30s"
-            sleep 30
-          done
+          bash scripts/retry.sh -- git -c protocol.version=2 submodule update --init --force --depth=1 \
+            thirdparty/imgui \
+            thirdparty/eigen \
+            thirdparty/parallel-hashmap \
+            thirdparty/expected \
+            thirdparty/OpenCTM-git \
+            thirdparty/laz-perf \
+            thirdparty/fastmcpp \
+            thirdparty/nlohmann-json \
+            thirdparty/cpp-httplib \
+            thirdparty/mrbind \
+            thirdparty/mrbind-pybind11
+          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --force --depth=1 deps/cppdecl
 
       - name: Get AWS instance type
         uses: ./.github/actions/get-aws-instance-type

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -49,10 +49,17 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
 
     steps:
+      # Wrap checkout in a retry loop. GitHub's submodule endpoints occasionally
+      # serve HTTP 500s for 30-60s (see run 24845654039); actions/checkout@v6
+      # retries submodule clones once, which isn't enough for a sustained blip.
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          submodules: true
+          action: actions/checkout@v6
+          attempt_limit: 3
+          attempt_delay: 30000 # milliseconds
+          with: |
+            submodules: true
 
       - name: Checkout third-party submodules
         run: |

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -107,13 +107,14 @@ jobs:
           git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/mrbind-pybind11
           git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/mrbind
           git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/mrbind/deps/cppdecl
-          git submodule update --init --depth 1 \
+          # Retried via retry.sh: submodule endpoints occasionally 500.
+          bash scripts/retry.sh -- git submodule update --init --depth 1 \
             thirdparty/imgui \
             thirdparty/parallel-hashmap \
             thirdparty/mrbind-pybind11 \
             thirdparty/mrbind
           # mrbind needs deps/cppdecl; recurse only there
-          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
+          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install mrbind
         # Also print the amount of RAM. If there's not enough RAM, building MRBind bindings can fail. Not doing it in that step, because OOM fails can erase logs from the current step.

--- a/.github/workflows/update-docs-manual.yml
+++ b/.github/workflows/update-docs-manual.yml
@@ -46,14 +46,15 @@ jobs:
           # related issue: https://github.com/actions/checkout/issues/1779
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory '*'
-          git submodule update --init --depth 1 \
+          # Retried via retry.sh: submodule endpoints occasionally 500.
+          bash scripts/retry.sh -- git submodule update --init --depth 1 \
             thirdparty/imgui \
             thirdparty/eigen \
             thirdparty/parallel-hashmap \
             thirdparty/mrbind-pybind11 \
             thirdparty/mrbind
           # mrbind needs deps/cppdecl; recurse only there
-          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
+          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install thirdparty libs
         run: |


### PR DESCRIPTION
## Summary

Submodule clones over github.com periodically fail with HTTP 500 in CI. Captured in [run 24845654039](https://github.com/MeshInspector/MeshLib/actions/runs/24845654039/job/72731902483) on Windows:

```
error: RPC failed; HTTP 500 curl 22 The requested URL returned error: 500
fatal: expected 'packfile'
fatal: clone of 'https://github.com/AcademySoftwareFoundation/openvdb' into submodule path 'thirdparty/openvdb/v9/openvdb' failed
```

Six different third-party submodules failed inside ~25 s on that run (openvdb, parallel-hashmap, tinygltf, tinyxml2, zlib-ng, openvdb/v10) — pure github.com flakes, not infra on our side. The hit was on Windows but the same risk exists on every workflow that does `git submodule update --init` for our third-party tree.

`actions/checkout@v6` does have built-in retry logic, but it only retries each submodule once and that wasn't enough to ride out the ~25 s spike.

## Change

Wrap the existing selective `git submodule update` calls in `scripts/retry.sh` — the 3x/30s retry helper master already ships and that the Rocky vcpkg Dockerfiles already use:

```yaml
- name: Checkout third-party submodules
  run: |
    # Selective init -- parent Checkout drops submodules:true.
    # https://github.com/actions/checkout/issues/1779
    # Retried via retry.sh: submodule endpoints occasionally 500.
    bash scripts/retry.sh -- git submodule update --init --depth 1 \
      thirdparty/imgui \
      ...
    # mrbind needs deps/cppdecl; recurse only there
    bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
```

Three attempts with a 30 s cooldown — enough to ride out the ~25 s github.com 500 spike observed in the failing run. Only behavioral delta vs master ([#5992](https://github.com/MeshInspector/MeshLib/pull/5992) for the selective-list pattern itself) is the `retry.sh` wrapper; the submodule lists, `--init --depth 1`, and the cppdecl recursion are all unchanged.

## Scope

All 8 workflows that do a "Checkout third-party submodules" step:

- `build-test-windows.yml` (the originally-failing one)
- `build-test-macos.yml`
- `build-test-ubuntu-x64.yml`
- `build-test-ubuntu-arm64.yml`
- `build-test-linux-vcpkg.yml`
- `build-test-emscripten.yml`
- `pip-build.yml` *(workflow_dispatch / release — not exercised by PR CI)*
- `update-docs-manual.yml` *(workflow_dispatch only — not exercised by PR CI)*

Each gets the same two-line edit (one `# Retried via retry.sh: ...` comment, two `bash scripts/retry.sh --` prefixes). Wrapper form is identical across all 8.

## Why not `Wandalen/wretry.action`

An earlier attempt on this PR wrapped the whole `actions/checkout` step in `Wandalen/wretry.action@v3.8.0`. It triggered a `startup_failure` — the workflow parser refused to schedule any job. Root cause appears to be that `wretry.action`'s outer composite-action layer dispatches to an inner `_js_action` running `node20`, but `actions/checkout@v6` uses `node24`; the handoff doesn't work and the whole workflow is rejected before any step runs. `wretry.action` is thinly maintained and has an open issue ([#193](https://github.com/Wandalen/wretry.action/issues/193)) with no ETA for a fix, so an in-workflow retry via `scripts/retry.sh` is the right trade.

## Test plan

- [x] Full CI matrix on `cbefd973` — [run 25015648390](https://github.com/MeshInspector/MeshLib/actions/runs/25015648390) all green:
  - windows 4/4, macos 3/3, ubuntu-x64 3/3, ubuntu-arm64 2/2, linux-vcpkg 4/4, emscripten 3/3 (19/19 build-test legs).
  - First-attempt success on every leg — `retry.sh` warnings silent (i.e. no submodule needed a retry on this run; the wrapper is a no-op on the happy path).
- [x] Earlier windows-only commit `a9cfc67a` validated the wrapper in isolation — [run 25009155998](https://github.com/MeshInspector/MeshLib/actions/runs/25009155998), 4/4 windows legs green.
- [ ] `pip-build.yml` and `update-docs-manual.yml` aren't reached by PR CI; their edits are identical two-line copies of the verified pattern.
- [ ] If a future CI run hits a github.com 500 during submodule fetch, retries kick in and the job still succeeds.
