### PR TITLE
MCP: tighten ui.* descriptions, document ## name semantics

### DIFF
--- a/source/MRViewer/MRViewerMcp.cpp
+++ b/source/MRViewer/MRViewerMcp.cpp
@@ -135,13 +135,28 @@ static nlohmann::json mcpToolWriteValue( const nlohmann::json& args )
     return nlohmann::json::object();
 }
 
+// Prepended to every path-accepting tool's `desc`. One place defines the vocabulary;
+// per-tool descs only say what the tool itself does.
+static constexpr std::string_view kPathSemantics =
+    "`path`: array of entry names from the root (empty = root). Whitespace-sensitive. "
+    "Names may contain `##<suffix>` — a hidden ImGui uniqueness marker; pass the name VERBATIM "
+    "as returned by `ui.listEntries` / `ui.listAllEntries`, do not strip `##<suffix>`.\n"
+    "`type`: `button` | `group` | `int` | `uint` | `float` | `string`.\n"
+    "`status`: `\"available\"` | `\"disabled: <reason>\"` (widget greyed out) | "
+    "`\"disabled: blocked by modal '<name>'\"` (dismiss the modal first).\n\n";
+
+static std::string withPreamble( std::string_view specific )
+{
+    return std::string( kPathSemantics ) + std::string( specific );
+}
+
 MR_ON_INIT{
     Mcp::Server& server = Mcp::getDefaultServer();
 
     server.addTool(
         /*id*/"ui.listEntries",
-        /*name*/"List UI entries",
-        /*desc*/"Returns the list of UI elements at the given path. The elements form a tree. Pass an empty array to get the top-level elements. The path parameter describes the path from the root node to a specific element. Only elements of type `group` can have sub-elements. Each entry's `status` field is a human-readable interaction state: `\"available\"` means the entry accepts input; `\"disabled\"` or `\"disabled: <reason>\"` means the widget is currently greyed out (reason is typically the unmet requirement, e.g. `\"Select exactly one Object\"`); `\"disabled: blocked by modal '<name>'\"` means a modal popup is occluding the entry and must be dismissed first.",
+        /*name*/"List UI entries (one level)",
+        /*desc*/withPreamble( "List the direct children of `path`. Use `ui.listAllEntries` to get the entire subtree in one call." ),
         /*input_schema*/Mcp::Schema::Object{}.addMember( "path", Mcp::Schema::Array( Mcp::Schema::String{} ) ),
         /*output_schema*/Mcp::Schema::Array(
             Mcp::Schema::Object{}
@@ -154,8 +169,8 @@ MR_ON_INIT{
 
     server.addTool(
         /*id*/"ui.listAllEntries",
-        /*name*/"List all UI entries (flat, recursive)",
-        /*desc*/"Returns a flat depth-first list of every UI element in the subtree rooted at `path` (default: the whole tree). Each item carries its own full `path`, so the tree structure is recoverable without extra calls. `type == \"group\"` identifies intermediate nodes; their descendants appear on subsequent rows whose `path` extends theirs. `name`, `type`, and `status` have the same meaning as in `ui.listEntries`. Use this instead of walking level-by-level with `ui.listEntries` when you want a one-shot view of the UI.",
+        /*name*/"List UI entries (full subtree)",
+        /*desc*/withPreamble( "Flat depth-first dump of every entry in the subtree at `path` (omit or empty = whole tree). Each row carries its own `path`, so tree structure is recoverable. Prefer this for first-contact exploration; use `ui.listEntries` for a single level after a state change." ),
         /*input_schema*/Mcp::Schema::Object{}.addMemberOpt( "path", Mcp::Schema::Array( Mcp::Schema::String{} ) ),
         /*output_schema*/Mcp::Schema::Array(
             Mcp::Schema::Object{}
@@ -169,26 +184,29 @@ MR_ON_INIT{
 
     server.addTool(
         /*id*/"ui.pressButton",
-        /*name*/"Press button",
-        /*desc*/"Presses the button at the given path.",
+        /*name*/"Click UI button",
+        /*desc*/withPreamble( "Click the button at `path` (must end in a `type == \"button\"` entry). Fails if `status` starts with `\"disabled\"`." ),
         /*input_schema*/Mcp::Schema::Object{}.addMember( "path", Mcp::Schema::Array( Mcp::Schema::String{} ) ),
         /*output_schema*/Mcp::Schema::Empty{},
         /*func*/mcpToolPressButton
     );
 
-    auto handleValueType = [&]<typename T>( const std::string& typeName )
+    // (idSuffix, displayType) -- `idSuffix` is the CamelCase suffix on ui.readValue*/ui.writeValue*;
+    // `displayType` matches the `type` field in listEntries output.
+    auto handleValueType = [&]<typename T>( const std::string& idSuffix, const std::string& displayType )
     {
+        const std::string readDesc = std::is_same_v<T, std::string>
+            ? "Read the string value at `path`. If the response contains `allowedValues`, `ui.writeValue" + idSuffix + "` must pass one of those strings."
+            : "Read the " + displayType + " value at `path`. Bounds `min`/`max` are inclusive for `ui.writeValue" + idSuffix + "`.";
+
+        const std::string writeDesc = std::is_same_v<T, std::string>
+            ? "Set the string value at `path`. Must match `allowedValues` (from `ui.readValue" + idSuffix + "`) when present. Fails if `status` starts with `\"disabled\"`."
+            : "Set the " + displayType + " value at `path`. Must be within the inclusive `[min, max]` from `ui.readValue" + idSuffix + "`. Fails if `status` starts with `\"disabled\"`.";
+
         server.addTool(
-            /*id*/"ui.readValue" + typeName,
-            /*name*/"Read " + typeName + " value",
-            /*desc*/"Reads the value at the given path, of type `" + typeName + "`." +
-            (
-                std::is_same_v<T, std::string>
-                ?
-                    " If the result contains an array called `allowedValues`, then when assigning a new value using `ui.writeValue" + typeName + "`, it must match one of the strings listed in `allowedValues`."
-                :
-                    " When assigning a new value using `ui.writeValue" + typeName + "`, it must be between `min` and `max` inclusive."
-            ),
+            /*id*/"ui.readValue" + idSuffix,
+            /*name*/"Read UI " + displayType + " value",
+            /*desc*/withPreamble( readDesc ),
             /*input_schema*/Mcp::Schema::Object{}.addMember( "path", Mcp::Schema::Array( Mcp::Schema::String{} ) ),
             /*output_schema*/(
                 std::is_same_v<T, std::string>
@@ -205,19 +223,19 @@ MR_ON_INIT{
         );
 
         server.addTool(
-            /*id*/"ui.writeValue" + typeName,
-            /*name*/"Write " + typeName + " value",
-            /*desc*/"Writes the value at the given path, of type `" + typeName + "`. You can call `ui.readValue" + typeName + "` before this to know what values are allowed.",
+            /*id*/"ui.writeValue" + idSuffix,
+            /*name*/"Write UI " + displayType + " value",
+            /*desc*/withPreamble( writeDesc ),
             /*input_schema*/Mcp::Schema::Object{}.addMember( "path", Mcp::Schema::Array( Mcp::Schema::String{} ) ).addMember( "value", std::is_same_v<T, std::string> ? static_cast<Mcp::Schema::Base &&>( Mcp::Schema::String{} ) : static_cast<Mcp::Schema::Base &&>( Mcp::Schema::Number{} ) ),
             /*output_schema*/Mcp::Schema::Empty{},
             /*func*/mcpToolWriteValue<T>
         );
     };
 
-    handleValueType.operator()<std::int64_t>( "Int" );
-    handleValueType.operator()<std::uint64_t>( "Uint" );
-    handleValueType.operator()<double>( "Real" );
-    handleValueType.operator()<std::string>( "String" );
+    handleValueType.operator()<std::int64_t >( "Int",    "int"    );
+    handleValueType.operator()<std::uint64_t>( "Uint",   "uint"   );
+    handleValueType.operator()<double       >( "Real",   "float"  );
+    handleValueType.operator()<std::string  >( "String", "string" );
 }; // MR_ON_INIT
 
 } // namespace MR


### PR DESCRIPTION
## Summary

Tool descriptions were long per-tool and didn't document the `##<suffix>` convention on entry names. LLMs drop `##…` and dispatch breaks.

- One shared `kPathSemantics` preamble at the top of `MRViewerMcp.cpp` holds the path / `##` / type / status vocabulary; every `ui.*` tool's `desc` gets it prepended.
- Per-tool descs shrink to the one or two sentences unique to each tool.
- Tool `name` fields go verb-first (`List UI entries (one level)`, `List UI entries (full subtree)`, `Click UI button`, `Read UI <type> value`, `Write UI <type> value`) — clearer in `tools/list`.
- Read/write lambda now takes an explicit `displayType` (`int` / `uint` / `float` / `string`) so `name` and `desc` match the `type` field in `listEntries` output.

No behaviour change.

## Test plan

- [x] Build Debug|x64 (clean compile).
- [x] `tools/list` via MCP — all 11 `ui.*` tools updated: each desc starts with the shared preamble (`##`, type set, status values) and carries a short tool-specific sentence; names are verb-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)