### PR TITLE
ci: retry upload-artifact via Wandalen/wretry.action

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -255,7 +255,6 @@ jobs:
             --build c-examples-build \
             --parallel $(sysctl -n hw.physicalcpu)
 
-      # Retry the upload on self-hosted-runner network blips.
       - name: Upload Macos Distribution
         if: ${{ inputs.upload_artifacts && matrix.config == 'Release' }}
         env:

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -255,15 +255,21 @@ jobs:
             --build c-examples-build \
             --parallel $(sysctl -n hw.physicalcpu)
 
+      # Retry the upload on self-hosted-runner network blips.
       - name: Upload Macos Distribution
         if: ${{ inputs.upload_artifacts && matrix.config == 'Release' }}
-        uses: actions/upload-artifact@v7
         env:
           ACTIONS_ARTIFACT_UPLOAD_TIMEOUT_MS: 1800000
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          name: Distributives_macos-${{matrix.os}}
-          path: meshlib_${{matrix.os}}.pkg
-          retention-days: 1
+          action: actions/upload-artifact@v7
+          attempt_limit: 3
+          attempt_delay: 30000 # milliseconds
+          with: |
+            name: Distributives_macos-${{matrix.os}}
+            path: meshlib_${{matrix.os}}.pkg
+            retention-days: 1
+            overwrite: true
 
       - name: Collect artifact stats
         if: ${{ inputs.internal_build && inputs.upload_artifacts }}
@@ -286,8 +292,13 @@ jobs:
 
       - name: Upload NuGet files to Artifacts
         if: ${{ inputs.nuget_build_patch && matrix.config == 'Release' }}
-        uses: actions/upload-artifact@v7
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          name: DotNetPatchArchiveMacOs-${{ matrix.arch }}
-          path: ./patched_content/*
-          retention-days: 1
+          action: actions/upload-artifact@v7
+          attempt_limit: 3
+          attempt_delay: 30000 # milliseconds
+          with: |
+            name: DotNetPatchArchiveMacOs-${{ matrix.arch }}
+            path: ./patched_content/*
+            retention-days: 1
+            overwrite: true

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -333,13 +333,19 @@ jobs:
         if: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' && matrix.config == 'Release' && inputs.mrbind_c }}
         run: tar -a -c -f MeshLibC2Headers.zip ./source/MeshLibC2/include
 
+      # Retry the upload on self-hosted-runner network blips.
       - name: Upload Windows Binaries Archive
         if: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
-        uses: actions/upload-artifact@v7
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          name: WindowsArchive_${{ matrix.upload_name || matrix.config }}
-          path: MREDist_${{ matrix.upload_name || matrix.config }}.zip
-          retention-days: 1
+          action: actions/upload-artifact@v7
+          attempt_limit: 3
+          attempt_delay: 30000 # milliseconds
+          with: |
+            name: WindowsArchive_${{ matrix.upload_name || matrix.config }}
+            path: MREDist_${{ matrix.upload_name || matrix.config }}.zip
+            retention-days: 1
+            overwrite: true
 
       - name: Collect artifact stats
         if: ${{ inputs.internal_build && inputs.upload_artifacts }}
@@ -352,11 +358,16 @@ jobs:
 
       - name: Upload MeshLibC2 headers archive
         if: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' && matrix.config == 'Release' && inputs.mrbind_c }}
-        uses: actions/upload-artifact@v7
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          name: WindowsArchive_MeshLibC2Headers
-          path: MeshLibC2Headers.zip
-          retention-days: 1
+          action: actions/upload-artifact@v7
+          attempt_limit: 3
+          attempt_delay: 30000 # milliseconds
+          with: |
+            name: WindowsArchive_MeshLibC2Headers
+            path: MeshLibC2Headers.zip
+            retention-days: 1
+            overwrite: true
 
       - name: Create and fix fake Wheel for NuGet
         if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
@@ -368,18 +379,28 @@ jobs:
 
       - name: Upload NuGet files to Artifacts
         if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          name: DotNetPatchArchiveWindows-x64
-          path: ./patched_content/*
-          retention-days: 1
+          action: actions/upload-artifact@v7
+          attempt_limit: 3
+          attempt_delay: 30000 # milliseconds
+          with: |
+            name: DotNetPatchArchiveWindows-x64
+            path: ./patched_content/*
+            retention-days: 1
+            overwrite: true
 
       - name: Upload NuGet library DLL and XML to Artifacts
         if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          name: DotNetDllXml
-          path: |
-            ./source/x64/Release/MRDotNet2.dll
-            ./source/x64/Release/MRDotNet2.xml
-          retention-days: 1
+          action: actions/upload-artifact@v7
+          attempt_limit: 3
+          attempt_delay: 30000 # milliseconds
+          with: |
+            name: DotNetDllXml
+            path: |
+              ./source/x64/Release/MRDotNet2.dll
+              ./source/x64/Release/MRDotNet2.xml
+            retention-days: 1
+            overwrite: true

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -333,7 +333,6 @@ jobs:
         if: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' && matrix.config == 'Release' && inputs.mrbind_c }}
         run: tar -a -c -f MeshLibC2Headers.zip ./source/MeshLibC2/include
 
-      # Retry the upload on self-hosted-runner network blips.
       - name: Upload Windows Binaries Archive
         if: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0


### PR DESCRIPTION
## Summary

Wraps each `actions/upload-artifact@v7` step in the Windows and macOS workflows with `Wandalen/wretry.action` so transient self-hosted-runner network flakes during artifact upload (typically `ENOTFOUND` on `CreateArtifact`) no longer fail the whole build.

`actions/upload-artifact@v7` retries transient twirp `Request timeout`s internally but treats `ENOTFOUND` / DNS errors as fatal — a ~45-minute build is lost to a one-second DNS blip. Our self-hosted runners have exhibited this failure mode intermittently.

## Change

6 `actions/upload-artifact@v7` steps wrapped:

- `.github/workflows/build-test-macos.yml` — `Upload Macos Distribution` + `Upload NuGet files to Artifacts`
- `.github/workflows/build-test-windows.yml` — `Upload Windows Binaries Archive` + `Upload MeshLibC2 headers archive` + `Upload NuGet files to Artifacts` + `Upload NuGet library DLL and XML to Artifacts`

Each wrap:

```yaml
- name: Upload …
  uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
  with:
    action: actions/upload-artifact@v7
    attempt_limit: 3
    attempt_delay: 30000 # milliseconds
    with: |
      name: …
      path: …
      retention-days: 1
      overwrite: true
```

3 attempts × 30 s delay covers a typical 1-minute github.com blip. `overwrite: true` lets a retry replace a partial artifact atomically (upload-artifact@v4+ finalises atomically, so this is safe).

## Scope

Only the self-hosted-runner workflows (Windows + macOS arm64/Release matrix leg). The other upload-artifact sites run on GitHub-hosted runners and haven't exhibited this failure mode; `disable-build-*` labels suppress non-Windows / non-macOS CI in this PR.

Note: this PR intentionally does **not** wrap `actions/checkout` — a separate attempt to do so ([#5969](https://github.com/MeshInspector/MeshLib/pull/5969)) hit a `startup_failure` when wretry's composite layer tried to dispatch around `actions/checkout@v6`. That PR now uses an in-workflow git-submodule retry loop instead. `actions/upload-artifact@v7` doesn't trigger the same parse-time refusal.

## Test plan

- [ ] Windows and macOS CI on this PR complete normally (first-attempt upload succeeds; delays skipped).
- [ ] A future build where `CreateArtifact` hits a transient 5xx / `ENOTFOUND`: retry kicks in, job still succeeds.
