### PR TITLE
test: make MRMesh.ZlibCompressStats engine-agnostic

### DIFF
--- a/source/MRTest/MRZlibTests.cpp
+++ b/source/MRTest/MRZlibTests.cpp
@@ -138,12 +138,12 @@ TEST( MRMesh, ZlibCompressStats )
     const std::string inputStr( reinterpret_cast<const char*>( cInput ), sizeof( cInput ) );
     const uint32_t expectedCrc = crc32Ref( cInput, sizeof( cInput ) );
 
-    struct Case { bool rawDeflate; int level; size_t expectedCompSize; };
+    struct Case { bool rawDeflate; int level; };
     const Case cases[] = {
-        { true,  1, sizeof( cRawLevel1 ) },
-        { true,  9, sizeof( cRawLevel9 ) },
-        { false, 1, sizeof( cWrappedLevel1 ) },
-        { false, 9, sizeof( cWrappedLevel9 ) },
+        { true,  1 },
+        { true,  9 },
+        { false, 1 },
+        { false, 9 },
     };
 
     for ( const auto& c : cases )
@@ -155,10 +155,19 @@ TEST( MRMesh, ZlibCompressStats )
             MR::ZlibCompressParams{ { .rawDeflate = c.rawDeflate }, c.level, &stats } );
         EXPECT_TRUE( res.has_value() );
 
+        // Engine-agnostic assertions: CRC and uncompressed size are defined by
+        // the input; stats.compressedSize must equal out.str().size() (API
+        // consistency); compressed output must be non-empty and smaller than
+        // the input. We deliberately do NOT pin stats.compressedSize to the
+        // size of cRawLevel*/cWrappedLevel* -- those reference blobs were
+        // captured from stock zlib, and the exact compressed byte count drifts
+        // from one deflate implementation to another (stock zlib vs zlib-ng
+        // compat vs zlib-ng native vs libdeflate, all lossless).
         EXPECT_EQ( stats.crc32, expectedCrc );
         EXPECT_EQ( stats.uncompressedSize, sizeof( cInput ) );
-        EXPECT_EQ( stats.compressedSize, c.expectedCompSize );
-        EXPECT_EQ( out.str().size(), c.expectedCompSize );
+        EXPECT_EQ( stats.compressedSize, out.str().size() );
+        EXPECT_GT( stats.compressedSize, 0u );
+        EXPECT_LT( stats.compressedSize, sizeof( cInput ) );
     }
 }
 


### PR DESCRIPTION
## Summary

Relax `MRMesh.ZlibCompressStats` so it stops comparing `stats.compressedSize` against the byte-exact size of the `cRawLevel*` / `cWrappedLevel*` reference blobs. Those blobs were captured from stock zlib, and the exact compressed byte count drifts from one deflate implementation to another — stock zlib, zlib-ng (native and compat), libdeflate, etc. all produce different (still-valid-DEFLATE) bytestreams for the same input and level, per RFC 1951's encoder latitude. The moment any part of the compress path is swapped to a non-zlib engine, this assertion fires for reasons that have nothing to do with correctness.

## What the new assertions actually check

- `stats.crc32 == expectedCrc` — defined by the input, engine-independent.
- `stats.uncompressedSize == sizeof( cInput )` — guards stats wiring.
- `stats.compressedSize == out.str().size()` — API consistency: the stats block's claim matches the actual stream length, whichever engine produced it.
- `0 < stats.compressedSize < sizeof( cInput )` — sanity floor + ceiling: we produced a non-empty payload, and it's strictly smaller than the input.

This preserves every property the test was *actually* trying to verify (CRC correctness, stats plumbing, that compression happened) while dropping the one that pinned correctness to one specific encoder's byte-level output.

## Why a standalone PR

Split out of #5959 (route `MRZlib` through zlib-ng). The zlib-ng PR needs this relaxation to pass, but the relaxation itself is orthogonal — anyone benchmarking libdeflate, zlib-ng-compat, etc. wants the same change. Landing it first keeps #5959 focused on the compressor routing and avoids a test-assertion change bundled into an ABI / CI PR.

## Scope

One file: `source/MRTest/MRZlibTests.cpp`. No source/build/CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)