### PR TITLE
UI::TestEngine: expose modal X-button as "Close"

### DIFF
--- a/source/MRViewer/ImGuiHelpers.cpp
+++ b/source/MRViewer/ImGuiHelpers.cpp
@@ -1625,7 +1625,11 @@ bool ModalExitButton()
     const auto pos = ImGui::GetCursorScreenPos();
     const float buttonSize = MR::StyleConsts::Modal::exitBtnSize * UI::scale();
 
-    if ( ImGui::Button( "##ExitButton", ImVec2( buttonSize, buttonSize ) ) || ImGui::IsKeyPressed( ImGuiKey_Escape ) )
+    // Use UI::buttonEx so the X is exposed to UI::TestEngine under name "Close".
+    UI::ButtonCustomizationParams params;
+    params.forceImGuiBackground = true;
+    params.testEngineName = "Close";
+    if ( UI::buttonEx( "##ExitButton", MR::Vector2f( buttonSize, buttonSize ), params ) || ImGui::IsKeyPressed( ImGuiKey_Escape ) )
     {
         ImGui::CloseCurrentPopup();
         ImGui::PopStyleColor( 4 );


### PR DESCRIPTION
## Summary

`ModalExitButton` (the X in the top-right of every `ModalBigTitle` popup) used a raw `ImGui::Button` so it didn't show up in UI::TestEngine listings. Switched to `UI::buttonEx` with `testEngineName = "Close"` and `forceImGuiBackground = true` (preserves the existing transparent/hover-grey rendering driven by the pushed style colors).

## Why

So MCP's `ui.pressButton` can dismiss modal popups (Hotkeys, Settings, etc.) via the test-engine entry instead of synthetic Escape key events — the latter close the popup at the ImGui level but leave MI's internal "open" flags alone, so dialogs like F1 Hotkeys re-open the next frame. Pressing the actual Close button goes through `ImGui::CloseCurrentPopup()` which the close-handlers expect.

## Test plan

- [x] Build clean.
- [x] Visual: open F1 Hotkeys modal, screenshot — close-X still rendered correctly (no regression).
- [x] MCP: F1 to open modal → `ui.listAllEntries` returns `{path:["Close"], name:"Close", type:"button", status:"available"}` → `ui.pressButton({path:["Close"]})` closes the modal (0 blocked entries after, dialog gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)