### PR TITLE
ci(docker): retry vcpkg install on transient download failures

### DIFF
--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -43,26 +43,15 @@ RUN sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.o
 COPY requirements/vcpkg-linux.txt MeshLib/requirements.txt
 COPY thirdparty/vcpkg/ports MeshLib/ports
 COPY thirdparty/vcpkg/triplets MeshLib/triplets
+COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
-# Retry on transient download failures (HTTP 502 / network blips from
-# github.com archive endpoint, etc.). vcpkg's per-port build cache means
-# that on retry, only the failed-to-download port is re-fetched; ports
-# already built earlier in the install sequence are reused from cache.
 RUN source /opt/rh/gcc-toolset-11/enable && \
     source /opt/autoconf27/enable && \
     source /root/venv/bin/activate && \
-    for attempt in 1 2 3 ; do \
-        if ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --overlay-ports=MeshLib/ports $(cat MeshLib/requirements.txt | tr '\n' ' ') ; then \
-            break ; \
-        fi ; \
-        if [ "$attempt" = "3" ] ; then \
-            echo "vcpkg install failed after 3 attempts" >&2 ; exit 1 ; \
-        fi ; \
-        echo "vcpkg install failed (attempt $attempt/3); retrying in 30s..." >&2 ; \
-        sleep 30 ; \
-    done
+    $(: network may flake ) \
+    retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --overlay-ports=MeshLib/ports $(cat MeshLib/requirements.txt | tr '\n' ' ')
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
 
 

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -46,10 +46,23 @@ COPY thirdparty/vcpkg/triplets MeshLib/triplets
 
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
+# Retry on transient download failures (HTTP 502 / network blips from
+# github.com archive endpoint, etc.). vcpkg's per-port build cache means
+# that on retry, only the failed-to-download port is re-fetched; ports
+# already built earlier in the install sequence are reused from cache.
 RUN source /opt/rh/gcc-toolset-11/enable && \
     source /opt/autoconf27/enable && \
     source /root/venv/bin/activate && \
-    ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --overlay-ports=MeshLib/ports $(cat MeshLib/requirements.txt | tr '\n' ' ')
+    for attempt in 1 2 3 ; do \
+        if ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --overlay-ports=MeshLib/ports $(cat MeshLib/requirements.txt | tr '\n' ' ') ; then \
+            break ; \
+        fi ; \
+        if [ "$attempt" = "3" ] ; then \
+            echo "vcpkg install failed after 3 attempts" >&2 ; exit 1 ; \
+        fi ; \
+        echo "vcpkg install failed (attempt $attempt/3); retrying in 30s..." >&2 ; \
+        sleep 30 ; \
+    done
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
 
 

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -32,24 +32,13 @@ RUN sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.o
 COPY requirements/vcpkg-linux.txt MeshLib/requirements.txt
 COPY thirdparty/vcpkg/ports MeshLib/ports
 COPY thirdparty/vcpkg/triplets MeshLib/triplets
+COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
-# Retry on transient download failures (HTTP 502 / network blips from
-# github.com archive endpoint, etc.). vcpkg's per-port build cache means
-# that on retry, only the failed-to-download port is re-fetched; ports
-# already built earlier in the install sequence are reused from cache.
 RUN source /opt/rh/autoconf271/enable && \
-    for attempt in 1 2 3 ; do \
-        if ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --overlay-ports=MeshLib/ports $(cat MeshLib/requirements.txt | tr '\n' ' ') ; then \
-            break ; \
-        fi ; \
-        if [ "$attempt" = "3" ] ; then \
-            echo "vcpkg install failed after 3 attempts" >&2 ; exit 1 ; \
-        fi ; \
-        echo "vcpkg install failed (attempt $attempt/3); retrying in 30s..." >&2 ; \
-        sleep 30 ; \
-    done
+    $(: network may flake ) \
+    retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --overlay-ports=MeshLib/ports $(cat MeshLib/requirements.txt | tr '\n' ' ')
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
 
 

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -35,8 +35,21 @@ COPY thirdparty/vcpkg/triplets MeshLib/triplets
 
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
+# Retry on transient download failures (HTTP 502 / network blips from
+# github.com archive endpoint, etc.). vcpkg's per-port build cache means
+# that on retry, only the failed-to-download port is re-fetched; ports
+# already built earlier in the install sequence are reused from cache.
 RUN source /opt/rh/autoconf271/enable && \
-    ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --overlay-ports=MeshLib/ports $(cat MeshLib/requirements.txt | tr '\n' ' ')
+    for attempt in 1 2 3 ; do \
+        if ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --overlay-ports=MeshLib/ports $(cat MeshLib/requirements.txt | tr '\n' ' ') ; then \
+            break ; \
+        fi ; \
+        if [ "$attempt" = "3" ] ; then \
+            echo "vcpkg install failed after 3 attempts" >&2 ; exit 1 ; \
+        fi ; \
+        echo "vcpkg install failed (attempt $attempt/3); retrying in 30s..." >&2 ; \
+        sleep 30 ; \
+    done
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
 
 

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -eu
+
+times=3
+cooldown=30
+
+usage() {
+    echo "Usage: $0 [--times N] [--cooldown S] -- COMMAND [ARGS...]" >&2
+    exit 2
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --times)    times="${2:?--times requires a value}"; shift 2 ;;
+        --cooldown) cooldown="${2:?--cooldown requires a value}"; shift 2 ;;
+        --)         shift; break ;;
+        *)          echo "Unknown argument: $1" >&2; usage ;;
+    esac
+done
+
+[[ "$times"    =~ ^[1-9][0-9]*$ ]] || { echo "--times must be a positive integer"         >&2; exit 2; }
+[[ "$cooldown" =~ ^[0-9]+$       ]] || { echo "--cooldown must be a non-negative integer" >&2; exit 2; }
+[ $# -ge 1 ] || { echo "Missing command after --" >&2; usage; }
+
+rc=0
+for attempt in $(seq 1 "$times"); do
+    rc=0
+    # `|| rc=$?` captures the exit code without tripping `set -e`.
+    "$@" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        exit 0
+    fi
+    if [ "$attempt" -lt "$times" ]; then
+        echo "$(basename "$0"): attempt $attempt/$times failed (exit $rc); retrying in ${cooldown}s..." >&2
+        sleep "$cooldown"
+    fi
+done
+echo "$(basename "$0"): command failed after $times attempts (exit $rc): $*" >&2
+exit "$rc"


### PR DESCRIPTION
## Summary

Wrap `./vcpkg install` in both `docker/rockylinux8-vcpkgDockerfile` and `docker/rockylinux9-vcpkgDockerfile` with a 3-attempt retry (30 s backoff). Catches transient HTTP 502s and other one-shot network blips from github.com's source-archive endpoint when vcpkg downloads port tarballs at image-build time.

## Motivation

Run [24927294301](https://github.com/MeshInspector/MeshLib/actions/runs/24927294301) job [72999298143](https://github.com/MeshInspector/MeshLib/actions/runs/24927294301/job/72999298143) on PR #5959 failed with:

```
error: curl operation failed with response code 502.
error: curl operation failed with response code 502.
error: Reached maximum number of attempts, won't retry download from
   https://github.com/malaterre/GDCM/archive/v3.2.2.tar.gz.
CMake Error at scripts/cmake/vcpkg_download_distfile.cmake:136 (message):
  Download failed, halting portfile.
error: building gdcm:x64-linux-meshlib failed with: BUILD_FAILED
```

A transient response from GitHub's auto-generated `/archive/<ref>.tar.gz` endpoint — github.com served two 502s in a row, vcpkg's hardcoded internal retry limit of 3 attempts was reached, and the entire image build failed. Same kind of one-shot CDN flake that #5966's `wretry.action` wrapper for `gha-setup-ninja` solved on the Windows side.

## Why a workflow-level retry rather than vcpkg-level

vcpkg's `vcpkg_download_distfile` retry count is **hardcoded at 3 inside the compiled vcpkg binary** — there's no env var, no CLI flag, no cmake variable that exposes it. (Long-standing GitHub issue, no fix planned.)

A retry around the full `./vcpkg install` invocation is the simplest and most effective workaround:

- **Cheap on retry.** vcpkg's per-port build cache means that on a retry, only the failed-to-download port is actually re-fetched. Every port that succeeded in the previous attempt is reused from `/root/vcpkg/installed/...` immediately. We pay roughly one download attempt per retry, not a full clean rebuild.
- **No new infrastructure.** No mirror buckets to provision, no overlay ports to maintain, no asset-cache plumbing to wire up. (Asset-cache via `X_VCPKG_ASSET_SOURCES` is a more strategic fix but requires bucket setup and is a much larger change. This retry is the targeted fix.)
- **Symmetric with what we already do elsewhere.** PR #5966 wraps `seanmiddleditch/gha-setup-ninja` in `Wandalen/wretry.action` for the same reason — a download endpoint that's mostly fine but occasionally serves a 5xx.

## Implementation

Three files. The retry primitive is factored into a reusable `scripts/retry.sh` utility (per @oitel's refactor on this branch) so other flaky-network sites in the project can use it later if needed.

**`scripts/retry.sh`** — generic retry wrapper, `--times N` / `--cooldown S` flags with `--` delimiter before the command:

```bash
#!/bin/bash
set -eu

times=3
cooldown=30

# ... arg parsing ...

for attempt in $(seq 1 "$times"); do
    rc=0
    "$@" || rc=$?
    if [ "$rc" -eq 0 ]; then exit 0; fi
    if [ "$attempt" -lt "$times" ]; then
        echo "$(basename "$0"): attempt $attempt/$times failed (exit $rc); retrying in ${cooldown}s..." >&2
        sleep "$cooldown"
    fi
done
exit "$rc"
```

`set -eu` for strict error handling; `|| rc=$?` captures the exit code without tripping `set -e`; final attempt's exit code propagates so genuine failures still fail loudly after exhausting retries.

**`docker/rockylinux8-vcpkgDockerfile`** + **`docker/rockylinux9-vcpkgDockerfile`** — copy the script into the image and wrap `./vcpkg install`:

```dockerfile
COPY scripts/retry.sh /usr/local/bin/retry.sh
...
RUN source /opt/rh/gcc-toolset-11/enable && \
    source /opt/autoconf27/enable && \
    source /root/venv/bin/activate && \
    $(: network may flake ) \
    retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} ...
```

(`$(: network may flake )` is a bash idiom for an inline comment inside a backslash-continued `RUN` chain — `:` is the null command, `$()` captures empty stdout, so it expands to nothing while leaving the human-readable note in place. A bare `#` would consume the rest of the joined command.)

## Diff

3 files, **+45 / −2**. New `scripts/retry.sh` (39 lines, executable), 3-line edits in each Dockerfile (one `COPY` plus the inline retry-loop replacement). No source code changes; no behavioural change on the happy path; new behaviour visible only when `vcpkg install` exits non-zero in one of the first two attempts.

## Future work

The same `retry.sh` should be plumbed into MeshInspectorCode's `docker/rockylinux{8,9}-vcpkgDockerfile`, which have the same exposure. Out of scope here so this PR can land focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)