### PR TITLE
ci: delete consumed artifacts on success, not in workflow-end cleanup

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -258,6 +258,16 @@ jobs:
             gh release upload ${{ needs.config.outputs.release_tag }} $PKG_FILES --clobber
           fi
 
+      # Delete the source artifacts only after they have been successfully
+      # uploaded to the GitHub release. Default `if: success()` keeps them
+      # intact on failure so "Re-run failed jobs" can pick them up without
+      # rebuilding from scratch.
+      - name: Delete consumed Distribution artifacts
+        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
+        with:
+          name: Distributives*
+          failOnError: false
+
   windows-unity-test:
     if: ${{ needs.config.outputs.run_unity_nuget_test == 'true' }}
     needs:
@@ -360,12 +370,8 @@ jobs:
         with:
           name: DotNetPatchArchive*
           failOnError: false
-      # Distributives
-      - name: Delete Distribution
-        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
-        with:
-          name: Distributives*
-          failOnError: false
+      # `Distributives*` artifacts are deleted at the tail of upload-distributions
+      # once they have been successfully pushed to the GitHub release.
 
       - name: Delete Wheelhouse
         uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0

--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -212,14 +212,12 @@ jobs:
          path: MeshLib.nupkg
          retention-days: 1
 
-     # Delete the per-platform .NET patch archives only after the .nupkg has
-     # been successfully built and uploaded as the DistributivesNuGet artifact.
-     # Default `if: success()` keeps them intact on failure so "Re-run failed
-     # jobs" can pick them up without rebuilding the whole platform matrix.
-     - name: Delete consumed NuGet Patches artifacts
+     - name: Delete consumed NuGet input artifacts
        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
        with:
-         name: DotNetPatchArchive*
+         name: |
+           DotNetPatchArchive*
+           DotNetDllXml
          failOnError: false
 
   upload-distributions:
@@ -268,10 +266,6 @@ jobs:
             gh release upload ${{ needs.config.outputs.release_tag }} $PKG_FILES --clobber
           fi
 
-      # Delete the source artifacts only after they have been successfully
-      # uploaded to the GitHub release. Default `if: success()` keeps them
-      # intact on failure so "Re-run failed jobs" can pick them up without
-      # rebuilding from scratch.
       - name: Delete consumed Distribution artifacts
         uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
         with:
@@ -369,18 +363,6 @@ jobs:
     if: always()
     continue-on-error: true
     steps:
-      # .NET
-      - name: Delete .NET Binaries Archive artifact
-        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
-        with:
-          name: DotNetDllXml
-          failOnError: false
-      # `DotNetPatchArchive*` artifacts are deleted at the tail of
-      # create-nuget-package once they have been successfully consumed by
-      # nuget.exe pack and the resulting .nupkg uploaded.
-      # `Distributives*` artifacts are deleted at the tail of upload-distributions
-      # once they have been successfully pushed to the GitHub release.
-
       - name: Delete Wheelhouse
         uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
         with:

--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -212,6 +212,16 @@ jobs:
          path: MeshLib.nupkg
          retention-days: 1
 
+     # Delete the per-platform .NET patch archives only after the .nupkg has
+     # been successfully built and uploaded as the DistributivesNuGet artifact.
+     # Default `if: success()` keeps them intact on failure so "Re-run failed
+     # jobs" can pick them up without rebuilding the whole platform matrix.
+     - name: Delete consumed NuGet Patches artifacts
+       uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
+       with:
+         name: DotNetPatchArchive*
+         failOnError: false
+
   upload-distributions:
     if: ${{ !cancelled() && needs.config.outputs.upload_artifacts == 'true' }}
     timeout-minutes: 10
@@ -365,11 +375,9 @@ jobs:
         with:
           name: DotNetDllXml
           failOnError: false
-      - name: Delete NuGet Patches artifact
-        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
-        with:
-          name: DotNetPatchArchive*
-          failOnError: false
+      # `DotNetPatchArchive*` artifacts are deleted at the tail of
+      # create-nuget-package once they have been successfully consumed by
+      # nuget.exe pack and the resulting .nupkg uploaded.
       # `Distributives*` artifacts are deleted at the tail of upload-distributions
       # once they have been successfully pushed to the GitHub release.
 


### PR DESCRIPTION
## Summary

Move artifact deletions from the workflow-end `update-artifacts` job (which runs with `if: always()`) into the tail of the consumer job, gated implicitly on the default `if: success()`. Two artifact families covered:

| Artifact pattern(s) | Producer job(s) | Consumer job (now also deletes) |
|---|---|---|
| `DotNetPatchArchive*`, `DotNetDllXml` | per-platform build jobs | `create-nuget-package` |
| `Distributives*` (incl. `DistributivesNuGet` = the .nupkg) | `create-nuget-package` and per-platform build jobs | `upload-distributions` |

## Why

Today's flow:

1. Producer jobs upload artifact.
2. Consumer job downloads → uses → produces something else (a .nupkg, or release uploads).
3. `update-artifacts` (`if: always()`) → unconditionally deletes the artifacts.

If step 2 hits a transient failure, step 3 still runs and wipes the source artifacts. When an engineer clicks **"Re-run failed jobs"**, the rerun finds nothing to consume and either silently produces an empty result or fails differently. The only safe rerun option in that situation is **"Re-run all jobs"**, which re-executes the full Windows + Linux + macOS build matrix — much more expensive.

This was prompted by a recent "missing or corrupt .nupkg" symptom in `windows-unity-test`.

## What changes

### `create-nuget-package` — delete `DotNetPatchArchive*` + `DotNetDllXml` after successful nupkg upload

```yaml
- name: Delete consumed NuGet input artifacts
  uses: geekyeggo/delete-artifact@... # v6.0.0
  with:
    name: |
      DotNetPatchArchive*
      DotNetDllXml
    failOnError: false
```

### `upload-distributions` — delete `Distributives*` after successful release upload

```yaml
- name: Delete consumed Distribution artifacts
  uses: geekyeggo/delete-artifact@... # v6.0.0
  with:
    name: Distributives*
    failOnError: false
```

### `update-artifacts` — corresponding deletes removed

The `Delete .NET Binaries Archive artifact` (`DotNetDllXml`), `Delete NuGet Patches artifact` (`DotNetPatchArchive*`), and `Delete Distribution` (`Distributives*`) steps are removed from the end-of-workflow `update-artifacts` job.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| All jobs succeed | Artifacts kept until end-of-workflow, then deleted | Artifacts deleted seconds after consumer job's success — same end state, slightly earlier |
| `create-nuget-package` fails | `DotNetPatchArchive*` + `DotNetDllXml` wiped → "Re-run failed jobs" finds nothing → rerun fails differently | **Patch archives + DllXml retained** → "Re-run failed jobs" of `create-nuget-package` re-uses them |
| `upload-distributions` fails | `Distributives*` wiped → release ends up missing the .nupkg / distros after rerun | **Distributives retained** → rerun re-attempts the upload with the correct file set |
| `windows-unity-test` fails | unchanged (unity-test reads from release, not artifact) | unchanged |

## Storage impact

Negligible. On a successful run the artifacts are deleted within seconds of when `update-artifacts` would have deleted them anyway. The `retention-days: 1` set at upload time remains as a safety net.

## Review

- @Grantim asked to fold `DotNetDllXml` into the same inline delete as `DotNetPatchArchive*` (same lifecycle — only consumed by `create-nuget-package`). Done in `1f896f0`; both patterns now live in a single multi-pattern `name: |` block.
- @Grantim noted the explanatory block comments were excessive given the descriptive step names ("Delete **consumed** …"). Comments dropped from all three sites.

## Labels

- `full-ci` — activates the full CI path so `create-nuget-package`, `upload-distributions`, and `windows-unity-test` all run, exercising both changes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)