### PR TITLE
ci(windows): make 'Diagnostic — bin DLL inventory' step robust to missing build dir

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -224,8 +224,24 @@ jobs:
         if: ${{ always() }}
         shell: pwsh
         continue-on-error: true
-        working-directory: source\x64\${{ matrix.config }}
-        run: ${{ github.workspace }}\scripts\diagnostics\windows-bin-imports.ps1 -VcPath "${{ matrix.vc-path }}"
+        # Don't pin working-directory to source\x64\${{ matrix.config }} — when
+        # an upstream step fails before MSBuild runs, that directory does not
+        # exist and the runner cannot start pwsh, which makes the failure
+        # cascade look like the previous step is the failing one.
+        # Instead enter the directory inside the script and bail out cleanly
+        # if it doesn't exist.
+        run: |
+          $buildDir = Join-Path $Env:GITHUB_WORKSPACE 'source\x64\${{ matrix.config }}'
+          if (-not (Test-Path $buildDir)) {
+            Write-Host "Build output directory '$buildDir' does not exist — skipping diagnostic."
+            exit 0
+          }
+          Push-Location $buildDir
+          try {
+            & "$Env:GITHUB_WORKSPACE\scripts\diagnostics\windows-bin-imports.ps1" -VcPath "${{ matrix.vc-path }}"
+          } finally {
+            Pop-Location
+          }
 
       - name: Run Start-and-Exit Tests
         timeout-minutes: 3


### PR DESCRIPTION
## Summary

Make the `Diagnostic — output bin DLL inventory + MRMesh imports` step in `build-test-windows.yml` robust to the case where the MSBuild output directory doesn't yet exist (because an upstream step failed and `Build` was skipped).

## What was breaking

The step has `if: always()` and `continue-on-error: true`, intentionally so it produces diagnostic output even when build/test steps fail. But it also has:

```yaml
working-directory: source\x64\${{ matrix.config }}
```

When an upstream step (e.g. `Restore CUDA Cache`) is classified as `failure`, all default-`if: success()` steps in between — including `Build` — are skipped. That means `source\x64\Release` is never created. The runner then tries to start `pwsh.EXE` with `working-directory: source\x64\Release` for the diagnostic step, hits *"The directory name is invalid."*, and **stamps the failure on the previous step** (the boundary where it couldn't transition cleanly), not on the diagnostic itself.

This is why the failed step report on [run 24934965772 / job 73018847201](https://github.com/MeshInspector/MeshLib/actions/runs/24934965772/job/73018847201) said `[failure] Restore CUDA Cache` even though the cache restore had logged a clean `Cache hit for: cuda-toolkit-12.0.1.52833-v2` immediately before — and even though `continue-on-error: true` should have prevented the diagnostic step from failing the job.

## What this PR does

```diff
       - name: Diagnostic — output bin DLL inventory + MRMesh imports
         if: ${{ always() }}
         shell: pwsh
         continue-on-error: true
-        working-directory: source\x64\${{ matrix.config }}
-        run: ${{ github.workspace }}\scripts\diagnostics\windows-bin-imports.ps1 -VcPath "${{ matrix.vc-path }}"
+        run: |
+          $buildDir = Join-Path $Env:GITHUB_WORKSPACE 'source\x64\${{ matrix.config }}'
+          if (-not (Test-Path $buildDir)) {
+            Write-Host "Build output directory '$buildDir' does not exist — skipping diagnostic."
+            exit 0
+          }
+          Push-Location $buildDir
+          try {
+            & "$Env:GITHUB_WORKSPACE\scripts\diagnostics\windows-bin-imports.ps1" -VcPath "${{ matrix.vc-path }}"
+          } finally {
+            Pop-Location
+          }
```

Now the step:
- Always starts cleanly (default working dir = `$GITHUB_WORKSPACE`, which always exists).
- Logs an informational message and exits 0 if there's no build output to inspect.
- On the normal happy path, pushes into the same directory the previous version used and runs the existing `windows-bin-imports.ps1` script unchanged.

## Effect on the original symptom

| | Before | After |
|---|---|---|
| Build step succeeded → `source\x64\Release` exists | Diagnostic ran in build dir | Same — diagnostic runs in build dir |
| Build step skipped (upstream failure) → directory missing | runner can't start pwsh; previous step gets a misleading `failure` status; build steps cascade to `skipped` | Diagnostic logs "skipping" and exits 0; previous step's real conclusion is reported correctly |

This won't fix the *root* cause of any genuine upstream failure, but it stops a small step-transition race from masking it as something else.

## Labels

- `full-ci` — exercises the full Windows matrix (`msvc-2022, Release, MSBuild, ...`) where the original failure was observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)