### PR TITLE
ci(update-docs): serialize concurrent runs that publish to MeshInspector.github.io

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -10,6 +10,14 @@ on:
 
 jobs:
   update-documentation:
+    # Serialize concurrent runs that publish to MeshInspector.github.io.
+    # Without this, two CI runs that finish near-simultaneously race on
+    # `git push` and the loser fails with "[rejected] master -> master
+    # (fetch first)". cancel-in-progress: false queues runs so every
+    # commit's docs eventually publish.
+    concurrency:
+      group: meshinspector-github-io-publish
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - name: Install Doxygen


### PR DESCRIPTION
## Summary

Add a job-level `concurrency:` block to the `update-documentation` job in `.github/workflows/update-docs.yml`. GitHub will now serialize all runs that publish to the `MeshInspector.github.io` repo through a shared group, eliminating the `git push` race that produces:

```
! [rejected]          master -> master (fetch first)
error: failed to push some refs to 'https://github.com/MeshInspector/MeshInspector.github.io'
```

## Why

When two CI runs (e.g. two PRs merged within minutes of each other, or a `push` and a `schedule` overlapping) finish near-simultaneously, the `update-docs.yml` job in each:

1. Checks out `MeshInspector.github.io@master` at slightly different points in time.
2. Regenerates docs locally.
3. Commits "Auto update docs".
4. Tries `git push`.

The first push wins; the second sees the ref has moved and is rejected, failing the entire `update-dev-documentation` job. Observed today in [run 24936234953](https://github.com/MeshInspector/MeshLib/actions/runs/24936234953) (job `update-documentation`, scheduled run on master).

## Change

```diff
 jobs:
   update-documentation:
+    concurrency:
+      group: meshinspector-github-io-publish
+      cancel-in-progress: false
     runs-on: ubuntu-latest
```

`group: meshinspector-github-io-publish` — any string; same string = same concurrency group = serialized.

`cancel-in-progress: false` — queue, don't cancel. Every commit's docs eventually publish; the second run waits for the first one's `git push` to land, then runs against the already-updated remote `master` and pushes its own commit on top. Trade-off vs. `cancel-in-progress: true`:

| Setting | Behavior on overlapping runs | Throughput |
|---|---|---|
| `false` (this PR) | run B waits for run A, then publishes its own docs | every commit's docs make it eventually |
| `true` | run B cancels run A in flight; only B's docs publish | wastes A's Doxygen + artifact-download work |

For a docs-publishing pipeline where each commit's docs are individually meaningful, `false` is the right default. We can flip to `true` later if we decide we only ever care about the latest doc snapshot.

## Coverage

The concurrency block lives in the **called** workflow (`update-docs.yml`), so it protects both callers:

- `build-test-distribute.yml` → `update-dev-documentation` job → calls `update-docs.yml` (the one that hit the race today)
- `update-docs-manual.yml` → calls `update-docs.yml` (manual `workflow_dispatch`)

A scheduled run, a push-to-master run, and a manual run all serialize through the same group.

## What this does *not* fix

Concurrency serializes CI-driven publishes only. If a human directly pushes to `MeshInspector.github.io@master` while a CI publish is in flight, the CI publish can still race against the human push. If that ever becomes a concern, a follow-up PR can wrap the push step in a `pull --rebase` + retry loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)