### PR TITLE
ci(macos): suppress Homebrew's spurious red-cross / yellow annotations

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -111,23 +111,42 @@ jobs:
           build_config: ${{ matrix.config }}
 
       - name: Install thirdparty libs
-        run: ./scripts/build_thirdparty.sh
         env:
           CMAKE_CXX_COMPILER: ${{ steps.setup.outputs.cxx-compiler }}
           CMAKE_C_COMPILER: ${{ steps.setup.outputs.c-compiler }}
+        run: |
+          # Suppress Homebrew's spurious GHA workflow commands
+          # (`::error::`/`::warning::` for "<pkg> is already installed" lines)
+          # emitted by the transitively-invoked install_brew_requirements.sh.
+          # Override `set -e` so the matching ::brew-quiet:: sentinel always
+          # runs and command parsing is restored even on failure.
+          set +e
+          echo "::stop-commands::brew-quiet"
+          ./scripts/build_thirdparty.sh
+          rc=$?
+          echo "::brew-quiet::"
+          exit $rc
 
       - name: Install gettext utilities
         if: ${{ inputs.upload_artifacts }}
         env:
           HOMEBREW_NO_INSTALL_UPGRADE: 1
         run: |
-          brew install gettext
+          ./scripts/brew_quiet.sh install gettext
 
       - name: Install MRBind
         if: ${{ inputs.mrbind || inputs.mrbind_c }}
         run: |
-          ./scripts/mrbind/install_deps_macos.sh
-          ./scripts/mrbind/install_mrbind_macos.sh
+          # Same rationale as "Install thirdparty libs" — install_deps_macos.sh
+          # does `brew install make grep llvm@18` internally. Wrap both
+          # MRBind install steps so we only restore command parsing once.
+          set +e
+          echo "::stop-commands::brew-quiet"
+          ./scripts/mrbind/install_deps_macos.sh && \
+            ./scripts/mrbind/install_mrbind_macos.sh
+          rc=$?
+          echo "::brew-quiet::"
+          exit $rc
 
       - name: Create virtualenv
         run: |

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -609,7 +609,7 @@ jobs:
 
       - name: Python setup
         if: ${{ !(matrix.platform == 'x86' && matrix.py-version == '3.11') }}
-        run: brew install --overwrite python@${{matrix.py-version}}
+        run: ./scripts/brew_quiet.sh install --overwrite python@${{matrix.py-version}}
 
       - name: Create virtualenv
         run: |

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Python setup
         if: ${{ matrix.py-version != '3.11' }}
-        run: brew install python@${{matrix.py-version}}
+        run: ./scripts/brew_quiet.sh install python@${{matrix.py-version}}
 
       - name: Pip setup
         run: |

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Install Pkg
         run: |
           sudo installer -pkg meshlib_*x64.pkg  -target /
-          xargs brew install < /Library/Frameworks/MeshLib.framework/Versions/Current/requirements/macos.txt
+          xargs ./scripts/brew_quiet.sh install < /Library/Frameworks/MeshLib.framework/Versions/Current/requirements/macos.txt
 
       # [error] NSGL: Failed to find a suitable pixel format
       - name: Run MeshViewer

--- a/scripts/brew_quiet.sh
+++ b/scripts/brew_quiet.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Wrapper for `brew` that suppresses the spurious GitHub Actions workflow
+# commands Homebrew emits when GITHUB_ACTIONS=true. In particular, Homebrew
+# prints `::error::` workflow commands for benign cases like
+# "<pkg> is already installed" (rendered as red-cross failure annotations
+# even though brew exits 0 because of HOMEBREW_NO_INSTALL_UPGRADE=1) and
+# `::warning::` for the sibling "<pkg> is already installed and up-to-date"
+# case (yellow-triangle warning annotations).
+#
+# We bracket the brew call with the `::stop-commands::` workflow command so
+# the GHA runner ignores any annotation directives Homebrew prints during
+# this call, then re-enable command parsing with the matching sentinel
+# afterwards. The exit status of brew is preserved.
+#
+# Outside CI this script is a transparent passthrough — no annotations would
+# be parsed anyway.
+#
+# Usage: scripts/brew_quiet.sh <subcommand> [args...]
+#        e.g. scripts/brew_quiet.sh install gettext
+
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  echo "::stop-commands::brew-quiet"
+  brew "$@"
+  rc=$?
+  echo "::brew-quiet::"
+  exit $rc
+else
+  exec brew "$@"
+fi


### PR DESCRIPTION
## Problem

`brew install` on the self-hosted macOS runners emits GitHub Actions workflow commands (`::error::` / `::warning::`) for benign cases like *"<pkg> is already installed"*, even though the step itself exits 0 (because `HOMEBREW_NO_INSTALL_UPGRADE=1` is set or the formula is fully up-to-date). The runner renders these as red-cross **failure** annotations and yellow-triangle **warning** annotations on the run summary, making good runs look broken.

A typical macOS-arm/x64 run picks up 25+ such annotations on a perfectly green job:

```
##[warning]boost 1.90.0_1 is already installed and up-to-date.
##[warning]cmake 4.3.2 is already installed and up-to-date.
##[warning]eigen 5.0.1 is already installed and up-to-date.
##[warning]llvm@18 18.1.8 is already installed and up-to-date.
##[warning]opencascade 7.9.3 is already installed and up-to-date.
##[warning]openvdb 13.0.0_1 is already installed and up-to-date.
... (28 such warnings)
```

When upstream Homebrew also has a *newer* version available, the prefix becomes `Error:` instead of `Warning:` (e.g. `gettext 0.26_1 is already installed / To upgrade to 1.0, run: brew upgrade gettext`), which the runner promotes to a red-cross **failure** annotation despite a successful step.

## Fix

Tiny wrapper `scripts/brew_quiet.sh`:

```bash
if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
  echo "::stop-commands::brew-quiet"
  brew "$@"
  rc=$?
  echo "::brew-quiet::"
  exit $rc
else
  exec brew "$@"
fi
```

`::stop-commands::brew-quiet` tells the runner to ignore any workflow-command directives until the matching `::brew-quiet::` sentinel — so Homebrew's `::error::`/`::warning::` directives disappear from the annotations panel. Brew's exit status is preserved (real install failures still fail the step). Outside CI the wrapper is a transparent passthrough.

## Sites converted

**Direct `brew install` in workflows** — routed through the wrapper:

- `.github/workflows/build-test-macos.yml` — `brew install gettext`
- `.github/workflows/pip-build.yml` — `brew install --overwrite python@<ver>`
- `.github/workflows/release-tests.yml` — `brew install python@<ver>`
- `.github/workflows/test-distribution.yml` — `xargs brew install < requirements/macos.txt` (xargs now feeds the wrapper)

**Workflow steps that transitively invoke brew via shell scripts** — wrapped inline with `::stop-commands::brew-quiet` … `::brew-quiet::`:

- `build-test-macos.yml`: `Install thirdparty libs` (calls `build_thirdparty.sh` → `install_brew_requirements.sh`)
- `build-test-macos.yml`: `Install MRBind` (calls `install_deps_macos.sh` which does `brew install make grep llvm@$CLANG_VER`)

We override `set -e` (GH Actions runs `run:` blocks under `bash -e` by default) so the matching `::brew-quiet::` sentinel always executes and command parsing is restored even if the wrapped script fails.

The shell scripts themselves (`scripts/install_brew_requirements.sh`, `scripts/mrbind/install_deps_macos.sh`, etc.) are intentionally **not** modified — they're shared with developers who run them outside CI, and the workflow-step wrap covers them transparently.

## Verified on CI

Run [`24952113086`](https://github.com/MeshInspector/MeshLib/actions/runs/24952113086) — all three macOS jobs green, zero brew annotations on any of them. `gh api … check-runs/<id>/annotations` for each job returns:

```
[
  { "annotation_level": "warning",
    "message": "Node.js 20 actions are deprecated. ..." },
  { "annotation_level": "warning",
    "message": "Unexpected input(s) 'mrbind', valid inputs are [...]" },
  { "annotation_level": "warning",
    "message": "Unexpected input(s) 'mrbind', valid inputs are [...]" }
]
```

Both residual warnings are pre-existing and unrelated to brew:
- Node.js 20 deprecation — applies to `actions/cache@v4`, `actions/upload-artifact@v4`, `Wandalen/wretry.action@v3.8.0_js_action`. Separate upgrade.
- `Unexpected input(s) 'mrbind'` — a reusable-workflow caller passes a `mrbind` input that the called workflow no longer declares. Pre-existing on master.

The previous noisy annotation cluster — 25–28 entries on every macOS job summary, including a red-cross `gettext` failure when upstream had an upgrade — is gone.

## Companion PR

Same fix in MeshInspectorCode: [#7249](https://github.com/MeshInspector/MeshInspectorCode/pull/7249).

## CI scope

Only macOS jobs run in this PR; everything else is suppressed via `disable-build-*` labels.

## Test plan

- [x] macOS-arm and macOS-x64 jobs go green (all 3 matrix legs SUCCESS).
- [x] No `failure`-level brew annotations on the run page.
- [x] No `warning`-level brew annotations either (the cluster of "X is already installed and up-to-date" lines is gone).
- [x] Step durations unchanged (the wrapper is a thin shim).
