### PR TITLE
ci: rename Checkout third-party submodules step -> Checkout mrbind submodules

### DIFF
--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: true
 
       - name: Get AWS instance type
         uses: ./.github/actions/get-aws-instance-type
@@ -69,13 +71,16 @@ jobs:
           build_config: Release
           aws_instance_type: ${{ env.AWS_INSTANCE_TYPE }}
 
-      - name: Checkout third-party submodules
+      - name: Checkout mrbind submodules
         run: |
-          # have to checkout selective submodules by our own
-          # related issue: https://github.com/actions/checkout/issues/1779
+          # The earlier `actions/checkout@... submodules: true` already
+          # initialised every top-level submodule, but non-recursively. Of
+          # the entire thirdparty/ tree, only thirdparty/mrbind has nested
+          # sub-submodules (deps/cppdecl), so a targeted recursive update
+          # here is enough.
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
+          git submodule update --init --recursive --depth 1 thirdparty/mrbind
 
       - name: Install thirdparty libs
         run: |

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: true
 
       - name: Get AWS instance type
         uses: ./.github/actions/get-aws-instance-type
@@ -109,13 +111,16 @@ jobs:
           build_config: ${{ matrix.config }}
           aws_instance_type: ${{ env.AWS_INSTANCE_TYPE }}
 
-      - name: Checkout third-party submodules
+      - name: Checkout mrbind submodules
         run: |
-          # have to checkout selective submodules by our own
-          # related issue: https://github.com/actions/checkout/issues/1779
+          # The earlier `actions/checkout@... submodules: true` already
+          # initialised every top-level submodule, but non-recursively. Of
+          # the entire thirdparty/ tree, only thirdparty/mrbind has nested
+          # sub-submodules (deps/cppdecl), so a targeted recursive update
+          # here is enough.
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/mrbind-pybind11 thirdparty/mrbind thirdparty/fastmcpp thirdparty/nlohmann-json thirdparty/cpp-httplib
+          git submodule update --init --recursive --depth 1 thirdparty/mrbind
 
       - name: Install MRBind
         if: ${{ inputs.mrbind || inputs.mrbind_c }}

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -76,9 +76,15 @@ jobs:
         with:
           submodules: true
 
-      - name: Checkout third-party submodules
+      - name: Checkout mrbind submodules
         run: |
-          # Download sub-submodules for certain submodules. We don't recurse above in Checkout to improve build performance. See: https://github.com/actions/checkout/issues/1779
+          # The earlier `actions/checkout@... submodules: true` already
+          # initialised every top-level submodule, but non-recursively. Of
+          # the entire thirdparty/ tree, only thirdparty/mrbind has nested
+          # sub-submodules (deps/cppdecl), so a targeted recursive update
+          # here is enough. Avoiding `submodules: recursive` on the parent
+          # checkout improves build performance.
+          # See: https://github.com/actions/checkout/issues/1779
           git submodule update --init --recursive --depth 1 thirdparty/mrbind
 
       - name: Setup Homebrew prefix and resolve compiler paths

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: true
 
       - name: Get AWS instance type
         uses: ./.github/actions/get-aws-instance-type
@@ -87,13 +89,16 @@ jobs:
           build_config: ${{ matrix.config }}
           aws_instance_type: ${{ env.AWS_INSTANCE_TYPE }}
 
-      - name: Checkout third-party submodules
+      - name: Checkout mrbind submodules
         run: |
-          # have to checkout selective submodules by our own
-          # related issue: https://github.com/actions/checkout/issues/1779
+          # The earlier `actions/checkout@... submodules: true` already
+          # initialised every top-level submodule, but non-recursively. Of
+          # the entire thirdparty/ tree, only thirdparty/mrbind has nested
+          # sub-submodules (deps/cppdecl), so a targeted recursive update
+          # here is enough.
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory '*'
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/eigen thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
+          git submodule update --init --recursive --depth 1 thirdparty/mrbind
 
       - name: Install thirdparty libs
         run: |

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: true
 
       - name: Collect runner's system stats
         if: ${{ inputs.internal_build }}
@@ -66,13 +68,16 @@ jobs:
           cxx_compiler: ${{ matrix.cxx-compiler }}
           build_config: ${{ matrix.config }}
 
-      - name: Checkout third-party submodules
+      - name: Checkout mrbind submodules
         run: |
-          # have to checkout selective submodules by our own
-          # related issue: https://github.com/actions/checkout/issues/1779
+          # The earlier `actions/checkout@... submodules: true` already
+          # initialised every top-level submodule, but non-recursively. Of
+          # the entire thirdparty/ tree, only thirdparty/mrbind has nested
+          # sub-submodules (deps/cppdecl), so a targeted recursive update
+          # here is enough.
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory '*'
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/eigen thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
+          git submodule update --init --recursive --depth 1 thirdparty/mrbind
 
       - name: Install thirdparty libs
         run: |

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -54,9 +54,15 @@ jobs:
         with:
           submodules: true
 
-      - name: Checkout third-party submodules
+      - name: Checkout mrbind submodules
         run: |
-          # Download sub-submodules for certain submodules. We don't recurse above in Checkout to improve build performance. See: https://github.com/actions/checkout/issues/1779
+          # The earlier `actions/checkout@... submodules: true` already
+          # initialised every top-level submodule, but non-recursively. Of
+          # the entire thirdparty/ tree, only thirdparty/mrbind has nested
+          # sub-submodules (deps/cppdecl), so a targeted recursive update
+          # here is enough. Avoiding `submodules: recursive` on the parent
+          # checkout improves build performance.
+          # See: https://github.com/actions/checkout/issues/1779
           git submodule update --init --recursive --depth 1 thirdparty/mrbind
 
       - name: Get AWS instance type

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -93,20 +93,20 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{needs.setup.outputs.version_tag}}
+          submodules: true
 
-      - name: Checkout third-party submodules
-        # Some of those safe.directory rules could be redudant.
+      - name: Checkout mrbind submodules
         run: |
-          # have to checkout selective submodules by our own
-          # related issue: https://github.com/actions/checkout/issues/1779
+          # The earlier `actions/checkout@... submodules: true` already
+          # initialised every top-level submodule, but non-recursively. Of
+          # the entire thirdparty/ tree, only thirdparty/mrbind has nested
+          # sub-submodules (deps/cppdecl), so a targeted recursive update
+          # here is enough.
           export HOME=${RUNNER_TEMP}
           echo ${GITHUB_WORKSPACE}
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/imgui
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/parallel-hashmap
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/mrbind-pybind11
           git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/mrbind
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
+          git submodule update --init --recursive --depth 1 thirdparty/mrbind
 
       - name: Install mrbind
         # Also print the amount of RAM. If there's not enough RAM, building MRBind bindings can fail. Not doing it in that step, because OOM fails can erase logs from the current step.

--- a/.github/workflows/update-docs-manual.yml
+++ b/.github/workflows/update-docs-manual.yml
@@ -39,14 +39,19 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: true
 
-      - name: Checkout third-party submodules
+      - name: Checkout mrbind submodules
         run: |
-          # have to checkout selective submodules by our own
-          # related issue: https://github.com/actions/checkout/issues/1779
+          # The earlier `actions/checkout@... submodules: true` already
+          # initialised every top-level submodule, but non-recursively. Of
+          # the entire thirdparty/ tree, only thirdparty/mrbind has nested
+          # sub-submodules (deps/cppdecl), so a targeted recursive update
+          # here is enough.
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory '*'
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/eigen thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
+          git submodule update --init --recursive --depth 1 thirdparty/mrbind
 
       - name: Install thirdparty libs
         run: |


### PR DESCRIPTION
## Summary

Make every workflow that runs the `Checkout … submodules` two-step pattern look the same:

1. parent `Checkout` does `submodules: true` (shallow-cloning all 29 top-level submodules at the parent's `fetch-depth: 1`),
2. a single follow-up step recursively fetches only `thirdparty/mrbind`'s nested sub-submodule (`deps/cppdecl`) — the only path under `thirdparty/` that has its own `.gitmodules`.

## Why

Of the 29 top-level submodules in MeshLib, **only `thirdparty/mrbind` has nested sub-submodules**. So the second step is genuinely only about mrbind on every workflow — but the previous step name ("Checkout third-party submodules") suggested a broader scope, and most workflows had a long selective list of submodules in the `git submodule update` line that hid the actual intent and caused drift between workflows.

```
$ for sm in thirdparty/mrbind thirdparty/imgui thirdparty/eigen \
            thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 \
            thirdparty/fastmcpp thirdparty/nlohmann-json thirdparty/cpp-httplib ; do
    echo "=== $sm ==="
    [ -f $sm/.gitmodules ] && cat $sm/.gitmodules || echo "(no .gitmodules)"
done
=== thirdparty/mrbind ===
[submodule "deps/cppdecl"]
        path = deps/cppdecl
        url = https://github.com/MeshInspector/cppdecl
=== thirdparty/imgui ===          (no .gitmodules)
=== thirdparty/eigen ===          (no .gitmodules)
=== thirdparty/parallel-hashmap ===   (no .gitmodules)
=== thirdparty/mrbind-pybind11 ===    (no .gitmodules)
=== thirdparty/fastmcpp ===       (no .gitmodules)
=== thirdparty/nlohmann-json ===  (no .gitmodules)
=== thirdparty/cpp-httplib ===    (no .gitmodules)
```

## Files changed (8 workflows)

| Workflow | Change |
|---|---|
| `build-test-macos.yml` | step renamed + comment expanded (parent already had `submodules: true`; submodule list already only `thirdparty/mrbind`) |
| `build-test-windows.yml` | same as macos |
| `build-test-emscripten.yml` | + `submodules: true` on parent; submodule list trimmed to just `thirdparty/mrbind`; step renamed |
| `build-test-linux-vcpkg.yml` | same |
| `build-test-ubuntu-arm64.yml` | same |
| `build-test-ubuntu-x64.yml` | same |
| `pip-build.yml` | same; also drops the per-submodule `safe.directory` lines that only existed for the previous selective-list approach |
| `update-docs-manual.yml` | same |

## Trade-off

Six of the eight workflows previously fetched only a 4-6 submodule selective list (no `submodules: true` on parent). Adding `submodules: true` makes the parent shallow-clone all 29 top-level submodules at depth 1 — the heavy ones (openvdb, GDCM, libE57Format, mbedtls, onetbb, opencascade-related) are now fetched even though the docker image already provides them pre-built. With depth 1 over GitHub's fast remote this adds an estimated **20–50 s per matrix leg**, and is paid in parallel with other parts of the checkout — small relative to multi-minute build times.

In exchange, the workflow code becomes much easier to reason about: every "Checkout / Checkout mrbind submodules" pair across the repo now does the same thing.

## Net diff

+69 / −32 across 8 files, two commits:

- `b7e8069c` — macos + windows rename only
- `161b3cfa` — extend pattern to the other six workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)