### PR TITLE
ci(macos,windows): drop submodules:true, use selective submodule list

### DIFF
--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -75,7 +75,13 @@ jobs:
           # related issue: https://github.com/actions/checkout/issues/1779
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
+          git submodule update --init --depth 1 \
+            thirdparty/imgui \
+            thirdparty/parallel-hashmap \
+            thirdparty/mrbind-pybind11 \
+            thirdparty/mrbind
+          # mrbind needs deps/cppdecl; recurse only there
+          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install thirdparty libs
         run: |

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -115,7 +115,15 @@ jobs:
           # related issue: https://github.com/actions/checkout/issues/1779
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/mrbind-pybind11 thirdparty/mrbind thirdparty/fastmcpp thirdparty/nlohmann-json thirdparty/cpp-httplib
+          git submodule update --init --depth 1 \
+            thirdparty/imgui \
+            thirdparty/mrbind-pybind11 \
+            thirdparty/mrbind \
+            thirdparty/fastmcpp \
+            thirdparty/nlohmann-json \
+            thirdparty/cpp-httplib
+          # mrbind needs deps/cppdecl; recurse only there
+          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install MRBind
         if: ${{ inputs.mrbind || inputs.mrbind_c }}

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -95,6 +95,7 @@ jobs:
             thirdparty/glad \
             thirdparty/tinygltf \
             thirdparty/laz-perf \
+            thirdparty/clip \
             thirdparty/fastmcpp \
             thirdparty/nlohmann-json \
             thirdparty/cpp-httplib \

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -95,6 +95,9 @@ jobs:
             thirdparty/glad \
             thirdparty/tinygltf \
             thirdparty/laz-perf \
+            thirdparty/fastmcpp \
+            thirdparty/nlohmann-json \
+            thirdparty/cpp-httplib \
             thirdparty/mrbind \
             thirdparty/mrbind-pybind11
 

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -73,13 +73,30 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Checkout third-party submodules
         run: |
-          # Download sub-submodules for certain submodules. We don't recurse above in Checkout to improve build performance. See: https://github.com/actions/checkout/issues/1779
-          git submodule update --init --recursive --depth 1 thirdparty/mrbind
+          # Selective rather than `submodules: true` on the Checkout above:
+          # the parent only inits submodules we actually use. Apple skips
+          # the heavy ones that come from Homebrew or build_thirdparty.sh
+          # (openvdb, GDCM, libzip, jsoncpp, fmt, spdlog, onetbb, c-blosc,
+          # mbedtls, mbedtls, …). The list below covers the submodules built
+          # from source via thirdparty/CMakeLists.txt's Apple branch, plus
+          # header-only ones consumed directly, plus the build-tool deps.
+          # See: https://github.com/actions/checkout/issues/1779
+          git submodule update --init --recursive --depth 1 \
+            thirdparty/imgui \
+            thirdparty/eigen \
+            thirdparty/parallel-hashmap \
+            thirdparty/expected \
+            thirdparty/googletest \
+            thirdparty/OpenCTM-git \
+            thirdparty/libE57Format \
+            thirdparty/glad \
+            thirdparty/tinygltf \
+            thirdparty/laz-perf \
+            thirdparty/mrbind \
+            thirdparty/mrbind-pybind11
 
       - name: Setup Homebrew prefix and resolve compiler paths
         id: setup

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -76,15 +76,9 @@ jobs:
 
       - name: Checkout third-party submodules
         run: |
-          # Selective rather than `submodules: true` on the Checkout above:
-          # the parent only inits submodules we actually use. Apple skips
-          # the heavy ones that come from Homebrew or build_thirdparty.sh
-          # (openvdb, GDCM, libzip, jsoncpp, fmt, spdlog, onetbb, c-blosc,
-          # mbedtls, mbedtls, …). The list below covers the submodules built
-          # from source via thirdparty/CMakeLists.txt's Apple branch, plus
-          # header-only ones consumed directly, plus the build-tool deps.
-          # See: https://github.com/actions/checkout/issues/1779
-          git submodule update --init --recursive --depth 1 \
+          # Selective init -- parent Checkout drops submodules:true.
+          # https://github.com/actions/checkout/issues/1779
+          git submodule update --init --depth 1 \
             thirdparty/imgui \
             thirdparty/eigen \
             thirdparty/parallel-hashmap \
@@ -101,6 +95,8 @@ jobs:
             thirdparty/cpp-httplib \
             thirdparty/mrbind \
             thirdparty/mrbind-pybind11
+          # mrbind needs deps/cppdecl; recurse only there
+          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Setup Homebrew prefix and resolve compiler paths
         id: setup

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -93,7 +93,14 @@ jobs:
           # related issue: https://github.com/actions/checkout/issues/1779
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory '*'
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/eigen thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
+          git submodule update --init --depth 1 \
+            thirdparty/imgui \
+            thirdparty/eigen \
+            thirdparty/parallel-hashmap \
+            thirdparty/mrbind-pybind11 \
+            thirdparty/mrbind
+          # mrbind needs deps/cppdecl; recurse only there
+          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install thirdparty libs
         run: |

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -72,7 +72,14 @@ jobs:
           # related issue: https://github.com/actions/checkout/issues/1779
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory '*'
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/eigen thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
+          git submodule update --init --depth 1 \
+            thirdparty/imgui \
+            thirdparty/eigen \
+            thirdparty/parallel-hashmap \
+            thirdparty/mrbind-pybind11 \
+            thirdparty/mrbind
+          # mrbind needs deps/cppdecl; recurse only there
+          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install thirdparty libs
         run: |

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -63,7 +63,7 @@ jobs:
           # below are header-only consumed directly by MeshLib's source,
           # plus the build-tool deps.
           # See: https://github.com/actions/checkout/issues/1779
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/eigen thirdparty/parallel-hashmap thirdparty/expected thirdparty/mrbind thirdparty/mrbind-pybind11
+          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/eigen thirdparty/parallel-hashmap thirdparty/expected thirdparty/OpenCTM-git thirdparty/laz-perf thirdparty/fastmcpp thirdparty/nlohmann-json thirdparty/cpp-httplib thirdparty/mrbind thirdparty/mrbind-pybind11
 
       - name: Get AWS instance type
         uses: ./.github/actions/get-aws-instance-type

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -54,16 +54,21 @@ jobs:
 
       - name: Checkout third-party submodules
         run: |
-          # Selective rather than `submodules: true` on the Checkout above:
-          # the parent only inits submodules we actually use. Windows gets
-          # its third-party stack from vcpkg (see thirdparty/install.bat
-          # + requirements/windows.txt), so the heavy ones (openvdb, GDCM,
-          # cpr, libzip, jsoncpp, fmt, spdlog, onetbb, c-blosc, mbedtls,
-          # libE57Format, …) are not needed in source form. The submodules
-          # below are header-only consumed directly by MeshLib's source,
-          # plus the build-tool deps.
-          # See: https://github.com/actions/checkout/issues/1779
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/eigen thirdparty/parallel-hashmap thirdparty/expected thirdparty/OpenCTM-git thirdparty/laz-perf thirdparty/fastmcpp thirdparty/nlohmann-json thirdparty/cpp-httplib thirdparty/mrbind thirdparty/mrbind-pybind11
+          # Selective init -- parent Checkout drops submodules:true.
+          # https://github.com/actions/checkout/issues/1779
+          git submodule update --init --depth 1 thirdparty/imgui
+          git submodule update --init --depth 1 thirdparty/eigen
+          git submodule update --init --depth 1 thirdparty/parallel-hashmap
+          git submodule update --init --depth 1 thirdparty/expected
+          git submodule update --init --depth 1 thirdparty/OpenCTM-git
+          git submodule update --init --depth 1 thirdparty/laz-perf
+          git submodule update --init --depth 1 thirdparty/fastmcpp
+          git submodule update --init --depth 1 thirdparty/nlohmann-json
+          git submodule update --init --depth 1 thirdparty/cpp-httplib
+          git submodule update --init --depth 1 thirdparty/mrbind
+          git submodule update --init --depth 1 thirdparty/mrbind-pybind11
+          # mrbind needs deps/cppdecl; recurse only there
+          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Get AWS instance type
         uses: ./.github/actions/get-aws-instance-type

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -51,13 +51,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Checkout third-party submodules
         run: |
-          # Download sub-submodules for certain submodules. We don't recurse above in Checkout to improve build performance. See: https://github.com/actions/checkout/issues/1779
-          git submodule update --init --recursive --depth 1 thirdparty/mrbind
+          # Selective rather than `submodules: true` on the Checkout above:
+          # the parent only inits submodules we actually use. Windows gets
+          # its third-party stack from vcpkg (see thirdparty/install.bat
+          # + requirements/windows.txt), so the heavy ones (openvdb, GDCM,
+          # cpr, libzip, jsoncpp, fmt, spdlog, onetbb, c-blosc, mbedtls,
+          # libE57Format, …) are not needed in source form. The submodules
+          # below are header-only consumed directly by MeshLib's source,
+          # plus the build-tool deps.
+          # See: https://github.com/actions/checkout/issues/1779
+          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/eigen thirdparty/parallel-hashmap thirdparty/expected thirdparty/mrbind thirdparty/mrbind-pybind11
 
       - name: Get AWS instance type
         uses: ./.github/actions/get-aws-instance-type

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -56,17 +56,18 @@ jobs:
         run: |
           # Selective init -- parent Checkout drops submodules:true.
           # https://github.com/actions/checkout/issues/1779
-          git submodule update --init --depth 1 thirdparty/imgui
-          git submodule update --init --depth 1 thirdparty/eigen
-          git submodule update --init --depth 1 thirdparty/parallel-hashmap
-          git submodule update --init --depth 1 thirdparty/expected
-          git submodule update --init --depth 1 thirdparty/OpenCTM-git
-          git submodule update --init --depth 1 thirdparty/laz-perf
-          git submodule update --init --depth 1 thirdparty/fastmcpp
-          git submodule update --init --depth 1 thirdparty/nlohmann-json
-          git submodule update --init --depth 1 thirdparty/cpp-httplib
-          git submodule update --init --depth 1 thirdparty/mrbind
-          git submodule update --init --depth 1 thirdparty/mrbind-pybind11
+          git submodule update --init --depth 1 `
+            thirdparty/imgui `
+            thirdparty/eigen `
+            thirdparty/parallel-hashmap `
+            thirdparty/expected `
+            thirdparty/OpenCTM-git `
+            thirdparty/laz-perf `
+            thirdparty/fastmcpp `
+            thirdparty/nlohmann-json `
+            thirdparty/cpp-httplib `
+            thirdparty/mrbind `
+            thirdparty/mrbind-pybind11
           # mrbind needs deps/cppdecl; recurse only there
           git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -106,7 +106,14 @@ jobs:
           git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/parallel-hashmap
           git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/mrbind-pybind11
           git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/mrbind
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/mrbind/deps/cppdecl
+          git submodule update --init --depth 1 \
+            thirdparty/imgui \
+            thirdparty/parallel-hashmap \
+            thirdparty/mrbind-pybind11 \
+            thirdparty/mrbind
+          # mrbind needs deps/cppdecl; recurse only there
+          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install mrbind
         # Also print the amount of RAM. If there's not enough RAM, building MRBind bindings can fail. Not doing it in that step, because OOM fails can erase logs from the current step.

--- a/.github/workflows/update-docs-manual.yml
+++ b/.github/workflows/update-docs-manual.yml
@@ -46,7 +46,14 @@ jobs:
           # related issue: https://github.com/actions/checkout/issues/1779
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory '*'
-          git submodule update --init --recursive --depth 1 thirdparty/imgui thirdparty/eigen thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
+          git submodule update --init --depth 1 \
+            thirdparty/imgui \
+            thirdparty/eigen \
+            thirdparty/parallel-hashmap \
+            thirdparty/mrbind-pybind11 \
+            thirdparty/mrbind
+          # mrbind needs deps/cppdecl; recurse only there
+          git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
       - name: Install thirdparty libs
         run: |


### PR DESCRIPTION
## Summary

Bring `build-test-macos.yml` and `build-test-windows.yml` in line with the **selective-list pattern** the other six workflows in this repo (`build-test-emscripten`, `build-test-linux-vcpkg`, `build-test-ubuntu-arm64`, `build-test-ubuntu-x64`, `pip-build`, `update-docs-manual`) already use, and refine the pattern in all eight to recurse only into `thirdparty/mrbind/deps/cppdecl` — the one nested submodule MeshLib's build actually consumes — instead of recursing into every entry's `.gitmodules` blindly.

After this PR, every workflow that follows the `Checkout` + `Checkout third-party submodules` two-step pattern has the same shape: parent `actions/checkout` without `submodules: true`, followed by a selective `git submodule update --init --depth 1` of just the submodules that workflow consumes, plus an explicit `git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl` for the one path that needs recursion.

## Why

Both workflows previously had:

```yaml
- name: Checkout
  uses: actions/checkout@v6
  with:
    submodules: true             # ← inits all 29 top-level submodules

- name: Checkout third-party submodules
  run: |
    git submodule update --init --recursive --depth 1 thirdparty/mrbind
```

`submodules: true` clones every entry in `.gitmodules` (29 top-level submodules — including heavyweights like openvdb, GDCM, libE57Format, mbedtls, onetbb, libzip, c-blosc) regardless of whether the build will use the source. macOS gets most of those from Homebrew or builds them via `build_thirdparty.sh`'s thirdparty CMakeLists; Windows gets them from vcpkg. Neither workflow actually consumes most of those submodules' source.

This PR drops `submodules: true` and lists exactly the submodules each platform actually consumes:

| Platform | Submodules listed | Why |
|---|---|---|
| **macOS (16)** | `imgui`, `eigen`, `parallel-hashmap`, `expected` | header-only, consumed directly |
|   | `googletest`, `OpenCTM-git`, `libE57Format`, `glad`, `tinygltf`, `laz-perf` | built via thirdparty/CMakeLists.txt's Apple branch |
|   | `clip` | built standalone via `scripts/build_thirdparty.sh` → `clip.sh` |
|   | `fastmcpp`, `nlohmann-json`, `cpp-httplib` | `add_subdirectory(${MESHLIB_THIRDPARTY_DIR}/fastmcpp)`; nlohmann-json + cpp-httplib are fastmcpp's transitive deps |
|   | `mrbind`, `mrbind-pybind11` | binding-generator build tools |
| **Windows (11)** | `imgui`, `eigen`, `parallel-hashmap`, `expected` | header-only |
|   | `OpenCTM-git`, `laz-perf` | `source/OpenCTM/CMakeLists.txt` and `source/laz-perf/CMakeLists.txt` `add_subdirectory` them |
|   | `fastmcpp`, `nlohmann-json`, `cpp-httplib` | same as macOS |
|   | `mrbind`, `mrbind-pybind11` | binding-generator build tools |

Windows lists fewer because vcpkg supplies the equivalents — except for the five that get pulled in via `add_subdirectory` from `source/<x>/CMakeLists.txt` and so need source even on the vcpkg path.

## Recursion is targeted

Of the 16 submodules on the macOS list, only **`thirdparty/mrbind`** has a nested submodule MeshLib's build actually needs (`deps/cppdecl`, the codegen library mrbind links against). Two other submodules carry nested `.gitmodules` entries but neither is consumed by MeshLib:

- `thirdparty/expected` → `cmake/tl-cmake` is unreferenced by the cantonios fork's CMakeLists at the pinned commit.
- `thirdparty/libE57Format` → `test/extern/googletest` is gated behind libE57Format's own test target, which MeshLib never builds.

The other 13 have no nested `.gitmodules` at all — `--recursive` on them was a strict no-op.

So the workflow does:

```yaml
- name: Checkout third-party submodules
  run: |
    # Selective init -- parent Checkout drops submodules:true.
    # https://github.com/actions/checkout/issues/1779
    git submodule update --init --depth 1 \
      thirdparty/imgui \
      thirdparty/eigen \
      ...
      thirdparty/mrbind \
      thirdparty/mrbind-pybind11
    # mrbind needs deps/cppdecl; recurse only there
    git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
```

Bash workflows use `\` continuation; the Windows workflow uses pwsh backtick (`` ` ``) for the same shape. (See [the Windows step](https://github.com/MeshInspector/MeshLib/blob/ci/checkout-third-party-submodules-selective/.github/workflows/build-test-windows.yml#L57).)

## Measured impact

Comparing the latest run [24994826587](https://github.com/MeshInspector/MeshLib/actions/runs/24994826587) (`764cd258`) against master baseline [24987634018](https://github.com/MeshInspector/MeshLib/actions/runs/24987634018) (`466884e1`). Times = `Checkout` + `Checkout third-party submodules` summed (seconds):

| Platform | Master | This PR | Δ |
|---|---:|---:|---:|
| macOS x64 Release (`macos-15-intel`) | 88 | 53 | **−35** |
| macOS arm64 Debug (`macos-latest`) | 112 | 47 | **−65** |
| macOS arm64 Release (self-hosted, warm) | 10 | 8 | −2 |
| Win msvc-2019 Release CMake | 96 | 31 | **−65** |
| Win msvc-2019 Debug CMake (iter-debug) | 94 | 26 | **−68** |
| Win msvc-2022 Debug MSBuild | 86 | 30 | **−56** |
| Win msvc-2022 Release CMake | 112 | 30 | **−82** |
| **Sum across 7 legs** | **598** | **225** | **−373 (−62 %)** |

Per master run that's **~6.2 minutes of cumulative runner-time saved** across these 7 GitHub-hosted/self-hosted legs, with ~50–80 s shaved off each Windows leg's critical path.

The self-hosted arm64 Release runner is essentially neutral — its `.git/modules/` cache stays warm between runs so neither pre- nor post-PR actually clones much there. The savings show up on the GitHub-hosted ephemeral-VM legs.

## Pattern uniformity

All eight workflows that follow the `Checkout` + `Checkout third-party submodules` two-step pattern now use the same shape — no `submodules: true` on the parent, selective list with explicit cppdecl recursion in the follow-up step. The remaining occurrences of `submodules: true` / `submodules: recursive` in this repo are in workflows that don't follow that pattern (`prepare-images.yml`, `update-docs.yml`, `update-win-version.yml`, the macOS- and Windows-specific jobs in `pip-build.yml`) — those genuinely need the full tree for unrelated reasons and are out of scope here.

## Iteration history

CI on this branch surfaced changes incrementally:

- `55816785` — initial drop of `submodules: true` on macOS + Windows with selective lists.
- `60fc8e3f` — added `OpenCTM-git`, `laz-perf`, `fastmcpp`, `nlohmann-json`, `cpp-httplib` after Windows configure-time errors on `source/{OpenCTM,laz-perf,fastmcpp}/CMakeLists.txt` `add_subdirectory` calls.
- `d0c12915` — added `clip` after macOS `build_thirdparty.sh` failed on the standalone `clip.sh` step.
- `0f13185b` — dropped `--recursive`, added explicit `git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl`. Windows used per-line separate commands at this stage.
- `764cd258` — switched Windows from per-line separate commands to a single batched call with pwsh backtick continuation, recouping ~7 s/leg of per-invocation overhead.

## Replaces

Closed PR #5991, which took the opposite direction (add `submodules: true` everywhere, trim the second step to just `thirdparty/mrbind`). The selective-list approach in this PR is what the repo had been using on its other six workflows; extending it to macOS and Windows is the simpler and faster end state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)