### PR TITLE
ci(macos): brew install --quiet, drop dead gettext step

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -116,13 +116,6 @@ jobs:
           CMAKE_CXX_COMPILER: ${{ steps.setup.outputs.cxx-compiler }}
           CMAKE_C_COMPILER: ${{ steps.setup.outputs.c-compiler }}
 
-      - name: Install gettext utilities
-        if: ${{ inputs.upload_artifacts }}
-        env:
-          HOMEBREW_NO_INSTALL_UPGRADE: 1
-        run: |
-          brew install gettext
-
       - name: Install MRBind
         if: ${{ inputs.mrbind || inputs.mrbind_c }}
         run: |

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -609,7 +609,7 @@ jobs:
 
       - name: Python setup
         if: ${{ !(matrix.platform == 'x86' && matrix.py-version == '3.11') }}
-        run: brew install --overwrite python@${{matrix.py-version}}
+        run: brew install --overwrite --quiet python@${{matrix.py-version}}
 
       - name: Create virtualenv
         run: |

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Python setup
         if: ${{ matrix.py-version != '3.11' }}
-        run: brew install python@${{matrix.py-version}}
+        run: brew install --quiet python@${{matrix.py-version}}
 
       - name: Pip setup
         run: |

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Install Pkg
         run: |
           sudo installer -pkg meshlib_*x64.pkg  -target /
-          xargs brew install < /Library/Frameworks/MeshLib.framework/Versions/Current/requirements/macos.txt
+          xargs brew install --quiet < /Library/Frameworks/MeshLib.framework/Versions/Current/requirements/macos.txt
 
       # [error] NSGL: Failed to find a suitable pixel format
       - name: Run MeshViewer

--- a/scripts/install_brew_requirements.sh
+++ b/scripts/install_brew_requirements.sh
@@ -8,9 +8,9 @@ if [ -n "$MESHLIB_EXTRA_BREW_REQUIREMENTS" ] ; then
   MESHLIB_BREW_REQUIREMENTS=$MESHLIB_BREW_REQUIREMENTS$'\n'$MESHLIB_EXTRA_BREW_REQUIREMENTS
 fi
 
-brew install $(echo "$MESHLIB_BREW_REQUIREMENTS" | tr '\n' ' ')
+brew install --quiet $(echo "$MESHLIB_BREW_REQUIREMENTS" | tr '\n' ' ')
 
-brew install pybind11
+brew install --quiet pybind11
 
 # check and upgrade python3 pip
 python3.10 -m ensurepip --upgrade

--- a/scripts/mrbind/install_deps_macos.sh
+++ b/scripts/mrbind/install_deps_macos.sh
@@ -11,4 +11,4 @@ CLANG_VER="$(cat $SCRIPT_DIR/clang_version.txt | xargs)"
 [[ $CLANG_VER ]] || (echo "Not sure what version of Clang to use." && false)
 
 brew update
-brew install make grep llvm@$CLANG_VER
+brew install --quiet make grep llvm@$CLANG_VER


### PR DESCRIPTION
## Problem

Same as #5990 / #5993: macOS runners pick up 25+ yellow-triangle annotations per green job from Homebrew's "<pkg> is already installed and up-to-date" warnings, which the runner promotes from `opoo` → `::warning::` workflow command → annotation panel.

## Fix #1: `--quiet` on every `brew install` call

Reading `Library/Homebrew/install.rb` lines 148-154:

```ruby
elsif !quiet
  opoo <<~EOS
    #{formula.full_name} #{formula.pkg_version} is already installed and up-to-date.
    To reinstall #{formula.pkg_version}, run:
      brew reinstall #{formula.name}
  EOS
end
```

The `opoo` is guarded by `!quiet`, so `brew install --quiet <pkg>` short-circuits the warning at its source — no workflow command emitted, no annotation rendered. Five touch points:

| File | Change |
|---|---|
| `scripts/install_brew_requirements.sh` | `brew install --quiet $(...)` for the bulk `macos.txt` install + `--quiet` for the pybind11 follow-up. |
| `scripts/mrbind/install_deps_macos.sh` | `brew install --quiet make grep llvm@$CLANG_VER`. |
| `.github/workflows/pip-build.yml` | `brew install --overwrite --quiet python@${{matrix.py-version}}`. |
| `.github/workflows/release-tests.yml` | `brew install --quiet python@${{matrix.py-version}}`. |
| `.github/workflows/test-distribution.yml` | `xargs brew install --quiet < .../requirements/macos.txt`. |

## Fix #2: drop the "Install gettext utilities" step entirely

It was dead code paying ~6 s of CI per run for nothing useful:

- `cmake/Modules/I18nHelpers.cmake`'s `mr_add_translations()` only invokes `msgfmt` when it finds `.po` files via the `${LOCALE_DIR}/*/<DOMAIN>.po` glob.
- The repo has zero `.po` files. Only `.pot` templates exist (`locale/MeshLib.pot`, `locale/MRRibbonCommonMenuStructure.pot`).
- So `msgfmt` is never actually invoked at build time, and the brew-installed `gettext` binaries are never used.

`gettext` was also pre-installed on every macOS runner (it's part of the GitHub-hosted macOS image baseline), so the step was a no-op anyway — it just printed the "already installed" warning and exited in 1–3 s per leg.

Removing the step also eliminates the only place in the macOS workflow that still set `HOMEBREW_NO_INSTALL_UPGRADE=1`. That env var was what specifically triggered the *red-cross* `::error::` annotations PR #5990 called out for gettext (when upstream had a newer version and brew refused to upgrade, it fired `onoe`, which `--quiet` doesn't suppress). With the step gone and `HOMEBREW_NO_INSTALL_UPGRADE=1` not set on the remaining calls, the `onoe` branch isn't reachable — the remaining calls let brew silently auto-upgrade if needed.

## Diff

**6 files changed, +6 / −13.** No new files, no wrapper, no Brewfile, no script restructuring.

## CI verification

Run [24990900644](https://github.com/MeshInspector/MeshLib/actions/runs/24990900644) on commit `79aafaed`. Counting actual `is already installed and up-to-date` log lines on the macOS legs:

| macOS leg | Master baseline | This PR |
|---|---:|---:|
| x64 Release (`macos-15-intel`) | **11** | **0** |
| arm64 Debug (`macos-latest`) | **10** | **0** |

That's the actual goal — yellow-triangle `::warning::` annotations gone entirely from the macOS matrix.

Wallclock variance on GitHub-hosted macOS runners (~30–40 % run-to-run swings on `Install thirdparty libs` / `Install MRBind` due to ephemeral VM CPU/network conditions) dominates any deterministic effect of the PR. The deterministic gain is just the ~6 s/run from the dropped `gettext` step. `--quiet` only suppresses stderr text — it doesn't change what `brew install` actually does.

## Comparison vs #5990 and #5993

| Approach | New files | Total diff | Suppresses warnings | Suppresses red-cross errors | Avoids auto-upgrade |
|---|---|---|---|---|---|
| #5990 (`::stop-commands::` wrapper) | 1 (`brew_quiet.sh`) | +56 / −7 | Yes (via runner-side filter) | Yes | Yes (keeps `HOMEBREW_NO_INSTALL_UPGRADE=1`) |
| #5993 (`brew bundle`) | 0 | +38 / −16 | Yes | Yes | Yes |
| **This PR (`--quiet` + drop gettext)** | 0 | **+6 / −13** | Yes | Yes (the only step that triggered them is removed) | No — auto-upgrade is allowed for the remaining steps |

The trade-off this PR accepts: brew is allowed to silently auto-upgrade tooling formulae on macOS when newer versions appear upstream. For build-time tools (`make`, `grep`, `llvm@N`, `python@N`) this is generally fine — versions float forward, builds keep working. If a strict pin is needed in future, `HOMEBREW_NO_INSTALL_UPGRADE=1` can be re-added per-step, but at the cost of re-introducing the `onoe` annotation path.

Pick whichever PR you prefer; the other two can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)