### PR TITLE
MCP: add system.log + system.info + viewer.shutdown

### DIFF
--- a/source/MRViewer/MRSystemMcp.cpp
+++ b/source/MRViewer/MRSystemMcp.cpp
@@ -1,0 +1,103 @@
+#ifndef MESHLIB_NO_MCP
+
+#include "MRMcp/MRMcp.h"
+#include "MRMesh/MRLog.h"
+#include "MRMesh/MROnInit.h"
+#include "MRMesh/MRStringConvert.h"
+#include "MRPch/MRFmt.h"
+#include "MRViewer/MRCommandLoop.h"
+#include "MRViewer/MRGetSystemInfoJson.h"
+
+#include <json/json.h>
+
+#include <algorithm>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace MR::Mcp
+{
+
+static nlohmann::json mcpSystemLog( const nlohmann::json& args )
+{
+    size_t maxLines = args.value( "maxLines", uint64_t( 100 ) );
+    maxLines = std::min<size_t>( maxLines, 1000 );
+
+    const auto path = MR::Logger::instance().getLogFileName();
+    if ( path.empty() )
+        return nlohmann::json::object( { { "result", nlohmann::json::array() } } );
+
+    std::ifstream in( path, std::ios::binary );
+    if ( !in )
+        return nlohmann::json::object( { { "result", nlohmann::json::array() } } );
+
+    std::stringstream ss;
+    ss << in.rdbuf();
+    const std::string text = std::move( ss ).str();
+
+    // Walk backwards through the file collecting the last N non-empty lines.
+    std::vector<std::string> lines;
+    size_t end = text.size();
+    while ( end > 0 && lines.size() < maxLines )
+    {
+        size_t nl = text.rfind( '\n', end - 1 );
+        size_t start = ( nl == std::string::npos ) ? 0 : nl + 1;
+        if ( start < end )
+            lines.emplace_back( text.substr( start, end - start ) );
+        if ( nl == std::string::npos )
+            break;
+        end = nl;
+    }
+    std::reverse( lines.begin(), lines.end() );
+
+    return nlohmann::json::object( { { "result", std::move( lines ) } } );
+}
+
+static nlohmann::json mcpSystemInfo( const nlohmann::json& )
+{
+    nlohmann::json out;
+    MR::CommandLoop::runCommandFromGUIThread( [&]
+    {
+        const Json::Value sys = MR::GetSystemInfoJson();
+        Json::StreamWriterBuilder builder;
+        std::unique_ptr<Json::StreamWriter> writer{ builder.newStreamWriter() };
+        std::ostringstream oss;
+        writer->write( sys, &oss );
+        out = nlohmann::json::parse( oss.str() );
+    } );
+    return nlohmann::json::object( { { "result", std::move( out ) } } );
+}
+
+MR_ON_INIT{
+    Server& server = getDefaultServer();
+
+    server.addTool(
+        /*id*/  "system.log",
+        /*name*/"Read tail of MeshInspector log",
+        /*desc*/"Return the last `maxLines` lines (default 100, capped at 1000) from MeshInspector's spdlog file. "
+                "Each entry is a raw, pre-formatted line, e.g. `\"[27/04/26 16:18:53.767] [info] MCP server started "
+                "on port 7887\"`. To filter by level, substring-match `[error]` / `[warn]` / `[info]` / `[debug]` / "
+                "`[trace]` client-side. Returns `[]` if file logging is disabled.",
+        /*input_schema*/Schema::Object{}.addMemberOpt( "maxLines", Schema::Number{} ),
+        /*output_schema*/Schema::Array( Schema::String{} ),
+        /*func*/mcpSystemLog
+    );
+
+    server.addTool(
+        /*id*/  "system.info",
+        /*name*/"Build and host environment info",
+        /*desc*/"Snapshot of MeshInspector / host metadata used by the About dialog: `version`, `OS`, `CPU`, plus "
+                "GPU / CUDA / framebuffer / monitor info when available. The `version` string is prefixed with "
+                "`\"Debug:\"` on Debug builds. Concrete keys vary by platform/build; treat the response as a "
+                "loosely-shaped JSON object.",
+        /*input_schema*/Schema::Empty{},
+        /*output_schema*/Schema::Object{},
+        /*func*/mcpSystemInfo
+    );
+}; // MR_ON_INIT
+
+} // namespace MR::Mcp
+
+#endif

--- a/source/MRViewer/MRViewer.vcxproj
+++ b/source/MRViewer/MRViewer.vcxproj
@@ -164,6 +164,7 @@
     <ClCompile Include="MRSceneMcp.cpp" />
     <ClCompile Include="MRViewerMcp.cpp" />
     <ClCompile Include="MRToolsMcp.cpp" />
+    <ClCompile Include="MRSystemMcp.cpp" />
     <ClCompile Include="MRMcpCommon.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/source/MRViewer/MRViewer.vcxproj.filters
+++ b/source/MRViewer/MRViewer.vcxproj.filters
@@ -403,6 +403,9 @@
     <ClCompile Include="MRToolsMcp.cpp">
       <Filter>MCP</Filter>
     </ClCompile>
+    <ClCompile Include="MRSystemMcp.cpp">
+      <Filter>MCP</Filter>
+    </ClCompile>
     <ClCompile Include="MRMcpCommon.cpp">
       <Filter>MCP</Filter>
     </ClCompile>

--- a/source/MRViewer/MRViewerMcp.cpp
+++ b/source/MRViewer/MRViewerMcp.cpp
@@ -312,6 +312,15 @@ static nlohmann::json mcpViewerSendKeyboardEvent( const nlohmann::json& args )
     return nlohmann::json::object();
 }
 
+static nlohmann::json mcpViewerShutdown( const nlohmann::json& )
+{
+    MR::CommandLoop::runCommandFromGUIThread( [&]
+    {
+        MR::getViewerInstance().stopEventLoop();
+    } );
+    return nlohmann::json::object();
+}
+
 MR_ON_INIT{
     Server& server = getDefaultServer();
 
@@ -406,6 +415,17 @@ MR_ON_INIT{
             .addMemberOpt( "modifiers", Schema::Array( Schema::String{} ) ),
         /*output_schema*/Schema::Empty{},
         /*func*/mcpViewerSendKeyboardEvent
+    );
+
+    server.addTool(
+        /*id*/  "viewer.shutdown",
+        /*name*/"Close MeshInspector",
+        /*desc*/"Cleanly stop MeshInspector's event loop and exit the process. Returns immediately so the MCP "
+                "response can flush before the server socket closes; the actual shutdown happens on the next frame. "
+                "After this call the gateway's `launch` tool can bring MeshInspector back up.",
+        /*input_schema*/Schema::Empty{},
+        /*output_schema*/Schema::Empty{},
+        /*func*/mcpViewerShutdown
     );
 }; // MR_ON_INIT
 


### PR DESCRIPTION
Follow-up to the merged scene/viewer/ui/tools MCP work (#5972, #5980, #5982, #5996). Adds two `system.*` tools for host-environment observability and one `viewer.shutdown` for clean process exit.

## Tools

- **`system.log({maxLines})`** — last N pre-formatted spdlog lines (default 100, cap 1000) from the existing rotating-file sink. Opens the file fresh each call; no new sink. Returns `[]` when file logging is disabled. LLM substring-matches `[error]` / `[warn]` client-side if it wants level filtering.
- **`system.info`** — snapshot of `MR::GetSystemInfoJson()` (the same data behind the About dialog): `Version`, `OS Version`, `CPU Info`, `Graphics Info`, `Memory Info`, `Window Info`, `Process Memory`. `Version` is prefixed with `\"Debug:\"` on Debug builds.
- **`viewer.shutdown`** — calls `Viewer::stopEventLoop()` from the GUI thread; the MCP response flushes before the event loop exits next frame. The gateway's existing `launch` tool brings MI back up.

`system.runPython` is intentionally **not** in this PR — it'll land on the private MeshInspectorCode layer where access can be gated on user permission.

## Verification (live)

- `system.log` default → 100 lines including `MCP server started on port 7887`.
- `system.log {maxLines:5}` → exactly 5 lines.
- `system.info` → `{Version: \"Debug: Apr 24 2026\", OS Version: ..., CPU Info: ..., Graphics Info: ..., Memory Info: ..., Window Info: ..., Process Memory: ...}`.
- `viewer.shutdown` → `{}` response delivered, MI process exits with code 0; the gateway's `launch` brings it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)