### PR TITLE
MRMcp: server-side hardening — tool validator + arg reification

### DIFF
--- a/source/MRMcp/MRMcp.cpp
+++ b/source/MRMcp/MRMcp.cpp
@@ -41,6 +41,7 @@ struct Server::State
     fastmcpp::tools::ToolManager toolManager; // This has to be persistent, or `fastmcpp::mcp::make_mcp_handler()` dangles it.
     std::unordered_map<std::string, std::string> toolDescs; // No idea why this is not a part of `toolManager`.
     std::optional<fastmcpp::server::SseServerWrapper> server;
+    Server::ToolValidator toolValidator; // Empty by default; consulted per tool call when set.
 
     void createServer( const Params& params )
     {
@@ -78,7 +79,16 @@ bool Server::addTool( std::string id, std::string name, std::string desc, Schema
         return false;
     }
 
-    state_->toolManager.register_tool( fastmcpp::tools::Tool( id, std::move( inputSchema ).asJson(), std::move( outputSchema ).asJson(), func, name, desc, {} ) );
+    auto wrapped = [statePtr = state_.get(), id, inner = std::move( func )]( const nlohmann::json& args ) -> nlohmann::json
+    {
+        if ( statePtr->toolValidator )
+        {
+            if ( auto res = statePtr->toolValidator( id ); !res )
+                throw std::runtime_error( std::move( res.error() ) );
+        }
+        return inner( args );
+    };
+    state_->toolManager.register_tool( fastmcpp::tools::Tool( id, std::move( inputSchema ).asJson(), std::move( outputSchema ).asJson(), std::move( wrapped ), name, desc, {} ) );
     return true;
 }
 
@@ -135,6 +145,13 @@ bool Server::setRunning( bool enable )
         }
         return true;
     }
+}
+
+void Server::setToolValidator( ToolValidator validator )
+{
+    if ( !state_ )
+        state_ = std::make_unique<State>();
+    state_->toolValidator = std::move( validator );
 }
 
 Server& getDefaultServer()

--- a/source/MRMcp/MRMcp.cpp
+++ b/source/MRMcp/MRMcp.cpp
@@ -36,6 +36,44 @@
 namespace MR::Mcp
 {
 
+namespace
+{
+
+// Some MCP clients serialize array/object arguments as JSON-encoded strings
+// instead of native JSON values, which makes the server's argument parsing fail.
+// Tracked at https://github.com/anthropics/claude-code/issues/18260 .
+// For each top-level argument that the input schema types as `array` or `object`,
+// reify a string-encoded value back into the proper JSON shape. Idempotent for
+// well-behaved clients that already send the right type.
+nlohmann::json reifyStringEncodedArgs( nlohmann::json args, const nlohmann::json& schema )
+{
+    if ( !args.is_object() || !schema.is_object() )
+        return args;
+    auto propsIt = schema.find( "properties" );
+    if ( propsIt == schema.end() || !propsIt->is_object() )
+        return args;
+    for ( const auto& [key, propSchema] : propsIt->items() )
+    {
+        if ( !propSchema.is_object() )
+            continue;
+        auto typeIt = propSchema.find( "type" );
+        if ( typeIt == propSchema.end() || !typeIt->is_string() )
+            continue;
+        const auto& propType = typeIt->get_ref<const std::string&>();
+        if ( propType != "array" && propType != "object" )
+            continue;
+        auto argIt = args.find( key );
+        if ( argIt == args.end() || !argIt->is_string() )
+            continue;
+        auto parsed = nlohmann::json::parse( argIt->get_ref<const std::string&>(), nullptr, /* allow_exceptions */ false );
+        if ( !parsed.is_discarded() )
+            *argIt = std::move( parsed );
+    }
+    return args;
+}
+
+} // namespace
+
 struct Server::State
 {
     fastmcpp::tools::ToolManager toolManager; // This has to be persistent, or `fastmcpp::mcp::make_mcp_handler()` dangles it.
@@ -79,16 +117,17 @@ bool Server::addTool( std::string id, std::string name, std::string desc, Schema
         return false;
     }
 
-    auto wrapped = [statePtr = state_.get(), id, inner = std::move( func )]( const nlohmann::json& args ) -> nlohmann::json
+    auto schemaJson = std::move( inputSchema ).asJson();
+    auto wrapped = [statePtr = state_.get(), id, schema = schemaJson, inner = std::move( func )]( const nlohmann::json& args ) -> nlohmann::json
     {
         if ( statePtr->toolValidator )
         {
             if ( auto res = statePtr->toolValidator( id ); !res )
                 throw std::runtime_error( std::move( res.error() ) );
         }
-        return inner( args );
+        return inner( reifyStringEncodedArgs( args, schema ) );
     };
-    state_->toolManager.register_tool( fastmcpp::tools::Tool( id, std::move( inputSchema ).asJson(), std::move( outputSchema ).asJson(), std::move( wrapped ), name, desc, {} ) );
+    state_->toolManager.register_tool( fastmcpp::tools::Tool( id, std::move( schemaJson ), std::move( outputSchema ).asJson(), std::move( wrapped ), name, desc, {} ) );
     return true;
 }
 

--- a/source/MRMcp/MRMcp.h
+++ b/source/MRMcp/MRMcp.h
@@ -2,6 +2,8 @@
 
 #include "exports.h"
 
+#include "MRMesh/MRExpected.h"
+
 #include <nlohmann/json.hpp>
 
 #include <memory>
@@ -148,6 +150,13 @@ public:
     /// Returns true on success, including if the server is already running and you're trying to start it again.
     /// Stopping always returns true.
     MRMCP_API bool setRunning( bool enable );
+
+    /// Optional predicate consulted before every tool dispatch, given the tool's id.
+    /// Return {} to allow; return `unexpected("reason")` to block — the reason surfaces
+    /// to the MCP client as the tool-call error.
+    /// Evaluated per call, so changes (e.g. user sign-in) take effect immediately.
+    using ToolValidator = std::function<Expected<void>( const std::string& toolId )>;
+    MRMCP_API void setToolValidator( ToolValidator validator );
 
 private:
     struct State;


### PR DESCRIPTION
## Summary
Two related server-side hardening additions on `MR::Mcp::Server`, layered into the existing `addTool` registration wrapper so every tool benefits without touching individual tool TUs.

### 1. `setToolValidator(fn)` — per-call gate
- New `using ToolValidator = std::function<Expected<void>(const std::string& toolId)>`.
- Optional predicate consulted before every tool dispatch. Return `{}` to allow; return `unexpected("reason")` to block — the reason surfaces to the MCP client as a JSON-RPC error.
- Empty by default; preserves existing standalone behavior.
- Lets host apps gate MCP calls on external state (sign-in, license, etc.) without forking the server. Evaluated per call, so state changes (e.g. user signing in mid-session) take effect immediately.

### 2. Reify string-encoded array/object args
Some MCP clients — notably Claude Code per [anthropics/claude-code#18260](https://github.com/anthropics/claude-code/issues/18260) — serialize array/object arguments as JSON-encoded strings instead of native JSON. The server's tool handlers can't parse them and fail with `type must be array, but is string`.

For each top-level argument that the input schema types as `array` or `object`, the server now coerces a string-encoded value back to its declared shape before dispatch. No-op for well-behaved clients that already send the right type.

## Test plan
- [x] Build clean: `MeshInspector.sln` Debug|x64, no errors.
- [x] Validator: tool call while validator returns `unexpected(...)` → JSON-RPC error with the reason string. Validator returning `{}` → tool dispatches normally.
- [x] Mid-session state change: sign-out via the same MCP server immediately re-engages the gate without restart.
- [x] Reification: `ui.pressButton {path:["Ribbon","Sign out"]}` from Claude Code (which mangles arrays to strings) now succeeds; identical raw-SSE call also succeeds (idempotent).
- [x] No-validator standalone use unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)