### PR TITLE
ci(docker): retry dnf install on transient mirror failures

### DIFF
--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -4,9 +4,12 @@ ARG VCPKG_TRIPLET=x64-linux-meshlib
 
 FROM rockylinux:8 AS build
 
+COPY scripts/retry.sh /usr/local/bin/retry.sh
+
 RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
-    dnf -y install epel-release && \
-    dnf -y install --enablerepo powertools \
+    $(: network may flake ) \
+    retry.sh -- dnf -y install epel-release && \
+    retry.sh -- dnf -y install --enablerepo powertools \
         git cmake gcc-toolset-11 ninja-build clang-devel \
         $(: vcpkg requirements ) \
         curl zip unzip tar \
@@ -43,7 +46,6 @@ RUN sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.o
 COPY requirements/vcpkg-linux.txt MeshLib/requirements.txt
 COPY thirdparty/vcpkg/ports MeshLib/ports
 COPY thirdparty/vcpkg/triplets MeshLib/triplets
-COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
@@ -58,6 +60,7 @@ RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/tr
 FROM nvidia/cuda:12.0.1-devel-rockylinux8 AS production
 
 COPY --from=build /opt/vcpkg /opt/vcpkg
+COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 ENV MR_STATE=DOCKER_BUILD
 ENV MESHLIB_USE_VCPKG=ON
@@ -67,7 +70,8 @@ ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
 
 RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
-    dnf -y install --enablerepo powertools \
+    $(: network may flake ) \
+    retry.sh -- dnf -y install --enablerepo powertools \
         git cmake gcc-toolset-11 ninja-build clang-devel \
         $(: vcpkg requirements ) \
         curl zip unzip tar \
@@ -81,9 +85,9 @@ RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
     dnf clean all
 
 # install github-cli
-RUN dnf -y install 'dnf-command(config-manager)' && \
-    dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
-    dnf -y install gh && \
+RUN retry.sh -- dnf -y install 'dnf-command(config-manager)' && \
+    retry.sh -- dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
+    retry.sh -- dnf -y install gh && \
     dnf clean all
 
 # install aws cli

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -4,8 +4,11 @@ ARG VCPKG_TRIPLET=x64-linux-meshlib
 
 FROM rockylinux:9 AS build
 
+COPY scripts/retry.sh /usr/local/bin/retry.sh
+
 RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
-    dnf -y install --enablerepo crb \
+    $(: network may flake ) \
+    retry.sh -- dnf -y install --enablerepo crb \
         git cmake ninja-build clang-devel \
         $(: vcpkg requirements ) \
         curl-minimal zip unzip tar \
@@ -32,7 +35,6 @@ RUN sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.o
 COPY requirements/vcpkg-linux.txt MeshLib/requirements.txt
 COPY thirdparty/vcpkg/ports MeshLib/ports
 COPY thirdparty/vcpkg/triplets MeshLib/triplets
-COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
@@ -45,6 +47,7 @@ RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=MeshLib/tr
 FROM nvidia/cuda:12.0.1-devel-rockylinux9 AS production
 
 COPY --from=build /opt/vcpkg /opt/vcpkg
+COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 ENV MR_STATE=DOCKER_BUILD
 ENV MESHLIB_USE_VCPKG=ON
@@ -54,7 +57,8 @@ ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
 
 RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
-    dnf -y install --enablerepo crb \
+    $(: network may flake ) \
+    retry.sh -- dnf -y install --enablerepo crb \
         git cmake ninja-build clang-devel \
         $(: vcpkg requirements ) \
         curl-minimal zip unzip tar \
@@ -68,9 +72,9 @@ RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
     dnf clean all
 
 # install github-cli
-RUN dnf -y install 'dnf-command(config-manager)' && \
-    dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
-    dnf -y install gh && \
+RUN retry.sh -- dnf -y install 'dnf-command(config-manager)' && \
+    retry.sh -- dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
+    retry.sh -- dnf -y install gh && \
     dnf clean all
 
 # install aws cli


### PR DESCRIPTION
## Summary

Wrap every `dnf -y install` (and the `dnf config-manager --add-repo` for the gh-cli repo) in both `docker/rockylinux8-vcpkgDockerfile` and `docker/rockylinux9-vcpkgDockerfile` with the existing `scripts/retry.sh` helper (3 attempts, 30s backoff). Move `COPY scripts/retry.sh /usr/local/bin/retry.sh` to the top of each build/production stage so it is available before the first `dnf install` runs.

## Motivation

Run [25045542370](https://github.com/MeshInspector/MeshLib/actions/runs/25045542370) job [73359583376](https://github.com/MeshInspector/MeshLib/actions/runs/25045542370/job/73359583376) on PR #5998 failed in the **production stage** at `rockylinux8-vcpkgDockerfile:69` with:

```
Error: Failed to download metadata for repo 'baseos': Yum repo downloading error:
  repodata/...-primary.xml.gz    - Cannot download, all mirrors were already tried without success
  repodata/...-filelists.xml.gz  - Cannot download, all mirrors were already tried without success
  repodata/...-updateinfo.xml.gz - Cannot download, all mirrors were already tried without success
```

Every Rocky Linux 8.10 aarch64 `baseos` mirror returned **404** for those specific repodata files (Bahnhof, FAU, Intermax, hostico, ctrliq GCP, ftp.sh.cvut.cz, vhosting-it, melbourne, uv.es, ...). It is the classic Rocky Linux "stale repomd" sync gap — `repomd.xml` advertises checksums that mirrors have not yet picked up, and clears after a few minutes once mirrors re-sync.

#5985 already wraps `./vcpkg install` with retry, but #5985 does not cover `dnf install` — so this failure mode runs once and exits 1 with no retry. The same Dockerfiles also do a `dnf-command(config-manager)` + `dnf -y install gh` block in the production stage that hits cli.github.com, which is wrapped here for symmetry with the same kind of one-shot CDN flake.

## Implementation

- `docker/rockylinux8-vcpkgDockerfile`
  - Move `COPY scripts/retry.sh /usr/local/bin/retry.sh` to the top of the `build` stage (before the first `dnf install`).
  - Add `COPY scripts/retry.sh /usr/local/bin/retry.sh` to the `production` stage (it was previously not present in that stage at all).
  - Wrap each `dnf -y install ...` with `retry.sh --`. `dnf clean all` is local and stays unwrapped.

- `docker/rockylinux9-vcpkgDockerfile`
  - Same restructuring.

The retry helper itself (`scripts/retry.sh`, added in #5985) is unchanged.
