### PR TITLE
MCP: shut server down before plugin DLLs unload

### DIFF
--- a/source/MRMcp/MRMcp.cpp
+++ b/source/MRMcp/MRMcp.cpp
@@ -170,6 +170,15 @@ bool Server::setRunning( bool enable )
     }
 }
 
+void Server::shutdown()
+{
+    // ~State destroys members in reverse declaration order: server first (joins asio
+    // worker threads, releases the make_mcp_handler reference), then toolDescs, then
+    // toolManager last — so by the time tool callbacks destruct, no in-flight handler
+    // can be running, and we're still in MRMcp.dll's frame with all plugin DLLs loaded.
+    state_.reset();
+}
+
 nlohmann::json Server::dumpToolsAsJson() const
 {
     auto out = nlohmann::json::array();

--- a/source/MRMcp/MRMcp.cpp
+++ b/source/MRMcp/MRMcp.cpp
@@ -172,10 +172,6 @@ bool Server::setRunning( bool enable )
 
 void Server::shutdown()
 {
-    // ~State destroys members in reverse declaration order: server first (joins asio
-    // worker threads, releases the make_mcp_handler reference), then toolDescs, then
-    // toolManager last — so by the time tool callbacks destruct, no in-flight handler
-    // can be running, and we're still in MRMcp.dll's frame with all plugin DLLs loaded.
     state_.reset();
 }
 

--- a/source/MRMcp/MRMcp.h
+++ b/source/MRMcp/MRMcp.h
@@ -164,6 +164,12 @@ public:
     /// Stopping always returns true.
     MRMCP_API bool setRunning( bool enable );
 
+    /// Tears down the running asio server (if any) and clears all registered tools.
+    /// Use before unloading DLLs whose translation units called `addTool` — their captured
+    /// std::function deleters dangle once those DLLs are unmapped, so a later `~Server`
+    /// would segfault. Idempotent. Safe to call when nothing was registered.
+    MRMCP_API void shutdown();
+
     /// Returns the list of currently-registered tools as a JSON array of MCP `tool` entries
     /// (`name`, optional `title`/`description`, `inputSchema`, `outputSchema`).
     /// Suitable for splicing into a `tools/list` response or persisting to a cache file.

--- a/source/MRViewer/MRSetupViewer.cpp
+++ b/source/MRViewer/MRSetupViewer.cpp
@@ -207,4 +207,14 @@ bool ViewerSetup::setupMcp() const
     #endif
 }
 
+bool ViewerSetup::shutdownMcp() const
+{
+    #ifndef MESHLIB_NO_MCP
+    Mcp::getDefaultServer().shutdown();
+    return true;
+    #else
+    return false;
+    #endif
+}
+
 } //namespace MR

--- a/source/MRViewer/MRSetupViewer.h
+++ b/source/MRViewer/MRSetupViewer.h
@@ -47,6 +47,12 @@ public:
     /// Returns false if the MCP support is not compiled in.
     MRVIEWER_API virtual bool setupMcp() const;
 
+    /// Stop the MCP server and clear tool registrations. Called from `MRViewer.cpp` after
+    /// `viewer.launch()` returns, before `unloadExtendedLibraries()` — captured tool
+    /// callbacks live in plugin DLLs and dangle once those DLLs are unloaded.
+    /// Returns false if the MCP support is not compiled in.
+    MRVIEWER_API virtual bool shutdownMcp() const;
+
     // functor to setup custom log sink, i.e. sending logs to web
     std::function<void()> setupCustomLogSink;
 

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -412,6 +412,7 @@ int launchDefaultViewer( const Viewer::LaunchParams& params, const ViewerSetup& 
         res = 1;
     }
 #endif
+    setup.shutdownMcp();
     if ( params.unloadPluginsAtEnd )
         setup.unloadExtendedLibraries();
     if ( setup.shutdownCustomLogSink )


### PR DESCRIPTION
## Problem

When a plugin DLL registers an MCP tool via `MR_ON_INIT { server.addTool(...); }`, the captured `std::function`'s deleter lives in that DLL's code section. Running MI with `-unloadPluginsAtEnd` `FreeLibrary`'s plugin DLLs after `viewer.launch()` returns; later, the static `Server` destructor at process exit walks `toolManager` and calls each `std::function`'s deleter — which now points into unmapped memory. **SIGSEGV.**

The crash is silent on Windows (different DllMain detach order) but reproducible on Linux / macOS — surfaced by MeshInspectorCode#7255's `python.run` registration in `MRPlugins.dll`.

## Fix

Shut the MCP server down **inside `viewer.launch`'s scope, before `unloadExtendedLibraries()` ever runs**, so all captured `std::function`s destruct while their DLLs are still loaded.

- `Server::shutdown()` — `state_.reset()`. State member-destruction order already does the right thing internally: `server` first (joining its asio worker threads), `toolManager` last.
- `ViewerSetup::shutdownMcp()` — paired with the existing `setupMcp()`, same shape (`bool` return, `MESHLIB_NO_MCP` gate, virtual).
- One call site: `setup.shutdownMcp()` in `MRViewer.cpp` right after `viewer.launch()` returns, before the conditional `unloadExtendedLibraries()`. Always-run, mirroring the always-run `setupMcp()` during launch.

5 files, +32 lines.

## Verification

- Locally on Windows: `MeshInspector.exe -hidden -noEventLoop -unloadPluginsAtEnd` exits with code 0 (and no `Crash signal:` in the log) when MRPlugins.dll has registered an MCP tool. (Pre-fix Windows didn't crash either — different DLL-detach order — but the fix is still correct, just unobservable here.)
- CI Linux/macOS smoke test (`-hidden -noEventLoop -unloadPluginsAtEnd`) — same shape currently green on master without plugin-DLL tools, must stay green with the new shutdown call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)