### PR TITLE
ci(windows): install only required CUDA sub-packages

### DIFF
--- a/.github/actions/install-cuda/action.yml
+++ b/.github/actions/install-cuda/action.yml
@@ -1,0 +1,36 @@
+name: 'Install CUDA Toolkit (subset)'
+description: 'Restore the cached CUDA toolkit (or install the nvcc/cudart/visual_studio_integration sub-packages on miss) at the standard NVIDIA install path.'
+inputs:
+  cuda-version:
+    description: 'Full chocolatey-style CUDA version (e.g. 12.0.1.52833). The trailing build number is stripped before being passed to Jimver/cuda-toolkit.'
+    required: true
+  cuda-major:
+    description: 'CUDA major version (e.g. 12).'
+    required: true
+  cuda-minor:
+    description: 'CUDA minor version (e.g. 0).'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve CUDA semver
+      id: cuda-semver
+      shell: pwsh
+      run: |
+        $semver = (("${{ inputs.cuda-version }}" -split '\.')[0..2]) -join '.'
+        "version=$semver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+    - name: Restore CUDA Cache
+      uses: actions/cache@v5
+      id: cuda-cache
+      with:
+        key: cuda-toolkit-subset-${{ inputs.cuda-version }}-v1
+        path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ inputs.cuda-major }}.${{ inputs.cuda-minor }}
+
+    - name: Install CUDA
+      if: steps.cuda-cache.outputs.cache-hit != 'true'
+      uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
+      with:
+        cuda: ${{ steps.cuda-semver.outputs.version }}
+        method: network
+        sub-packages: '["nvcc", "cudart", "visual_studio_integration"]'

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -139,7 +139,15 @@ jobs:
           $semver = (("${{ matrix.CUDA-VERSION }}" -split '\.')[0..2]) -join '.'
           "version=$semver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
+      - name: Restore CUDA Cache
+        uses: actions/cache@v5
+        id: cuda-cache
+        with:
+          key: cuda-toolkit-subset-${{ matrix.CUDA-VERSION }}-v1
+          path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ matrix.CUDA-MAJOR }}.${{ matrix.CUDA-MINOR }}
+
       - name: Install CUDA
+        if: steps.cuda-cache.outputs.cache-hit != 'true'
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
         with:
           cuda: ${{ steps.cuda-semver.outputs.version }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -132,27 +132,12 @@ jobs:
         continue-on-error: true
         run: ./scripts/diagnostics/windows-vcpkg-tree.ps1 -Triplet "${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}"
 
-      - name: Resolve CUDA semver
-        id: cuda-semver
-        shell: pwsh
-        run: |
-          $semver = (("${{ matrix.CUDA-VERSION }}" -split '\.')[0..2]) -join '.'
-          "version=$semver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-      - name: Restore CUDA Cache
-        uses: actions/cache@v5
-        id: cuda-cache
-        with:
-          key: cuda-toolkit-subset-${{ matrix.CUDA-VERSION }}-v1
-          path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ matrix.CUDA-MAJOR }}.${{ matrix.CUDA-MINOR }}
-
       - name: Install CUDA
-        if: steps.cuda-cache.outputs.cache-hit != 'true'
-        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
+        uses: ./.github/actions/install-cuda
         with:
-          cuda: ${{ steps.cuda-semver.outputs.version }}
-          method: network
-          sub-packages: '["nvcc", "cudart", "visual_studio_integration"]'
+          cuda-version: ${{ matrix.CUDA-VERSION }}
+          cuda-major: ${{ matrix.CUDA-MAJOR }}
+          cuda-minor: ${{ matrix.CUDA-MINOR }}
 
       - name: Setup CUDA
         shell: cmd

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -132,16 +132,12 @@ jobs:
         continue-on-error: true
         run: ./scripts/diagnostics/windows-vcpkg-tree.ps1 -Triplet "${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}"
 
-      - name: Restore CUDA Cache
-        uses: actions/cache@v5
-        id: cuda-cache
-        with:
-          key: cuda-toolkit-${{ matrix.CUDA-VERSION }}-v2
-          path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ matrix.CUDA-MAJOR }}.${{ matrix.CUDA-MINOR }}
-
       - name: Install CUDA
-        if: ${{ steps.cuda-cache.outputs.cache-hit != 'true' }}
-        run: choco install cuda --version=${{matrix.CUDA-VERSION}} --confirm
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
+        with:
+          cuda: ${{ matrix.CUDA-VERSION }}
+          method: network
+          sub-packages: '["nvcc", "cudart", "thrust", "visual_studio_integration"]'
 
       - name: Setup CUDA
         shell: cmd

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -132,12 +132,19 @@ jobs:
         continue-on-error: true
         run: ./scripts/diagnostics/windows-vcpkg-tree.ps1 -Triplet "${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}"
 
+      - name: Resolve CUDA semver
+        id: cuda-semver
+        shell: pwsh
+        run: |
+          $semver = (("${{ matrix.CUDA-VERSION }}" -split '\.')[0..2]) -join '.'
+          "version=$semver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       - name: Install CUDA
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
         with:
-          cuda: ${{ matrix.CUDA-VERSION }}
+          cuda: ${{ steps.cuda-semver.outputs.version }}
           method: network
-          sub-packages: '["nvcc", "cudart", "thrust", "visual_studio_integration"]'
+          sub-packages: '["nvcc", "cudart", "visual_studio_integration"]'
 
       - name: Setup CUDA
         shell: cmd

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -303,27 +303,12 @@ jobs:
       - name: Install all Python versions
         run: scripts/mrbind-pybind11/install_all_python_versions_windows.bat
 
-      - name: Resolve CUDA semver
-        id: cuda-semver
-        shell: pwsh
-        run: |
-          $semver = (("${{ env.CUDA-VERSION }}" -split '\.')[0..2]) -join '.'
-          "version=$semver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-      - name: Restore CUDA Cache
-        uses: actions/cache@v5
-        id: cuda-cache
-        with:
-          key: cuda-toolkit-subset-${{ env.CUDA-VERSION }}-v1
-          path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ env.CUDA-MAJOR }}.${{ env.CUDA-MINOR }}
-
       - name: Install CUDA
-        if: steps.cuda-cache.outputs.cache-hit != 'true'
-        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
+        uses: ./.github/actions/install-cuda
         with:
-          cuda: ${{ steps.cuda-semver.outputs.version }}
-          method: network
-          sub-packages: '["nvcc", "cudart", "visual_studio_integration"]'
+          cuda-version: ${{ env.CUDA-VERSION }}
+          cuda-major: ${{ env.CUDA-MAJOR }}
+          cuda-minor: ${{ env.CUDA-MINOR }}
 
       - name: Setup CUDA
         run: |

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -303,12 +303,19 @@ jobs:
       - name: Install all Python versions
         run: scripts/mrbind-pybind11/install_all_python_versions_windows.bat
 
+      - name: Resolve CUDA semver
+        id: cuda-semver
+        shell: pwsh
+        run: |
+          $semver = (("${{ env.CUDA-VERSION }}" -split '\.')[0..2]) -join '.'
+          "version=$semver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       - name: Install CUDA
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
         with:
-          cuda: ${{ env.CUDA-VERSION }}
+          cuda: ${{ steps.cuda-semver.outputs.version }}
           method: network
-          sub-packages: '["nvcc", "cudart", "thrust", "visual_studio_integration"]'
+          sub-packages: '["nvcc", "cudart", "visual_studio_integration"]'
 
       - name: Setup CUDA
         run: |

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -310,7 +310,15 @@ jobs:
           $semver = (("${{ env.CUDA-VERSION }}" -split '\.')[0..2]) -join '.'
           "version=$semver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
+      - name: Restore CUDA Cache
+        uses: actions/cache@v5
+        id: cuda-cache
+        with:
+          key: cuda-toolkit-subset-${{ env.CUDA-VERSION }}-v1
+          path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ env.CUDA-MAJOR }}.${{ env.CUDA-MINOR }}
+
       - name: Install CUDA
+        if: steps.cuda-cache.outputs.cache-hit != 'true'
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
         with:
           cuda: ${{ steps.cuda-semver.outputs.version }}

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -303,16 +303,12 @@ jobs:
       - name: Install all Python versions
         run: scripts/mrbind-pybind11/install_all_python_versions_windows.bat
 
-      - name: Restore CUDA Cache
-        uses: actions/cache@v5
-        id: cuda-cache
-        with:
-          key: cuda-toolkit-${{ env.CUDA-VERSION }}-v2
-          path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ env.CUDA-MAJOR }}.${{ env.CUDA-MINOR }}
-
       - name: Install CUDA
-        if: steps.cuda-cache.outputs.cache-hit != 'true'
-        run: choco install cuda --version=${{env.CUDA-VERSION}} --confirm
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
+        with:
+          cuda: ${{ env.CUDA-VERSION }}
+          method: network
+          sub-packages: '["nvcc", "cudart", "thrust", "visual_studio_integration"]'
 
       - name: Setup CUDA
         run: |


### PR DESCRIPTION
## Summary

Replace the full `choco install cuda` on Windows CI with the [Jimver/cuda-toolkit](https://github.com/Jimver/cuda-toolkit) action installing only the sub-packages MeshLib actually links against, wrapped with `actions/cache` so a warmed cache is reused across jobs. The whole sequence is packaged as a reusable composite action so both Windows workflows share one source of truth.

MRCuda only links `CUDA::cudart_static` (see [cmake/Modules/ConfigureCuda.cmake](https://github.com/MeshInspector/MeshLib/blob/master/cmake/Modules/ConfigureCuda.cmake)), so cuBLAS, cuFFT, cuSPARSE, cuSOLVER, NPP, nvJPEG, Nsight, samples, and documentation are dead weight.

Sub-packages installed: `nvcc`, `cudart`, `visual_studio_integration`.

## Changes

- New composite action `.github/actions/install-cuda/action.yml` with inputs `cuda-version` (full chocolatey 4-component, e.g. `12.0.1.52833`), `cuda-major`, `cuda-minor`. It does:
  1. Strip the build suffix into a 3-component semver (Jimver requires `12.0.1`, not `12.0.1.52833`).
  2. `actions/cache@v5` keyed on the full version (so a version bump invalidates), path = `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v<MAJOR>.<MINOR>`.
  3. Run Jimver only on cache miss; the cache step stores the small installed tree.
- `.github/workflows/build-test-windows.yml` and `.github/workflows/pip-build.yml` collapsed from three CUDA steps to a single `uses: ./.github/actions/install-cuda`.
- Cache key bumped to `cuda-toolkit-subset-…-v1` so it doesn't collide with the old `cuda-toolkit-…-v2` entries that hold the full ~1.15 GB toolkit. The old entries can be deleted from the repo Actions cache once this lands.

The pre-existing "Setup CUDA" and "Install Visual Studio Integration" steps stay inline — they reference matrix-specific values (`vc-path`) and workflow-specific shells, and they have to run on both cache hit and miss because `BuildCustomizations` and `CUDA_PATH_VX_Y` aren't covered by the cache.

## Measured impact (warm-cache rerun [25073851213](https://github.com/MeshInspector/MeshLib/actions/runs/25073851213))

### Cache size

| CUDA version | master (full toolkit) | PR (subset) | ratio |
|---|---|---|---|
| 12.0.1 | 1149 MB | **57 MB** | ~5% of old |
| 11.4.2 | (similar) | **45 MB** | ~5% |

### CUDA-setup wall-clock per job (msvc-2022 / Release / CMake / 12.0)

| step | master (cache hit, full toolkit) | PR cache miss (first run) | PR cache hit |
|---|---|---|---|
| Restore CUDA Cache | 54.2 s | — (miss) | **1.6 s** |
| Install CUDA (Jimver) | — | 3 m 50 s – 11 m 41 s | skipped |
| Setup CUDA + VS Integration | ~1.2 s | ~1.2 s | **0.7 s** |
| **CUDA total** | **~55 s** | **4–12 min (one-off per version bump)** | **~2.3 s** |

`msvc-2019 / 11.4.2` cache-hit total is comparable (~6 s).

Net: ~95% smaller cache and ~25× faster steady-state setup; the only regression is a slightly slower one-off install when CUDA-VERSION changes (offset by no longer having to download/install Nsight, cuBLAS, etc.).

## Test plan

- [x] `build-test-windows.yml` succeeds across the full Windows matrix (Debug + Release, msvc-2019 + msvc-2022, MSBuild + CMake) — see latest run [25101757244](https://github.com/MeshInspector/MeshLib/actions/runs/25101757244)
- [x] CUDA cache populates on first run and hits on subsequent runs
- [x] `Install Visual Studio Integration` step still finds `visual_studio_integration\MSBuildExtensions\*` under restored `CUDA_PATH`
- [ ] `pip-build.yml` Windows job (only triggered on release / `workflow_dispatch`, not on PRs) — verify on next release that it still produces `MeshLibC2Cuda.dll` as before
