### PR TITLE
ci(config): read PR labels live, not from trigger event payload

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -156,16 +156,16 @@ jobs:
           }
 
           # On `pull_request.opened` the gh-pr-create-label race can delay
-          # label visibility by a few seconds after the webhook fires. We
-          # may also see this when labels are added via a separate API
-          # call right after creation (`gh pr edit --add-label`). Poll
-          # briefly so the workflow rides out that window without paying
-          # latency on `synchronize` / `reopened` runs where labels are
-          # already stable.
+          # label visibility by 1–3 s after the webhook fires (the labels
+          # API call lands ~1 s after `POST /pulls`). Poll briefly so the
+          # workflow rides out that window. Capped at 3 attempts × 2 s so
+          # PRs intentionally opened without labels only pay ~4 s of
+          # latency. `synchronize` / `reopened` runs skip the polling
+          # entirely since labels are already stable by then.
           attempts=1
           if [ "${{ github.event_name }}" = "pull_request" ] && \
              [ "${{ github.event.action }}" = "opened" ]; then
-            attempts=6   # up to ~10 s of polling: 0, 2, 2, 2, 2, 2
+            attempts=3   # up to ~4 s of polling: 0, 2, 2
           fi
 
           LABELS=""

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -94,13 +94,9 @@ jobs:
       windows_x64_config_matrix: ${{ steps.set-windows-x64-matrix.outputs.matrix }}
       vcpkg-docker-image-tag:   ${{ steps.select-vcpkg-docker-image-tag.outputs.image_tag }}
       windows-changes:          ${{ steps.windows-changes.outputs.src }}
-      # PR labels — read live from the PR via gh pr view, not from
-      # github.event.pull_request.labels which is a snapshot of the
-      # trigger event payload. POST /repos/.../pulls doesn't accept
-      # labels (see https://github.com/orgs/community/discussions/24724),
-      # so labels added immediately after PR creation aren't in the
-      # `pull_request.opened` event — but they ARE present by the time
-      # the live-labels step runs ~10–30 s into the workflow.
+      # Read PR labels live; github.event.pull_request.labels is a
+      # trigger-time snapshot (POST /pulls has no labels param —
+      # see community#24724).
       tag-bump-vcpkg:            ${{ steps.live-labels.outputs.tag-bump-vcpkg }}
       tag-full-ci:               ${{ steps.live-labels.outputs.tag-full-ci }}
       tag-skip-image-rebuild:    ${{ steps.live-labels.outputs.tag-skip-image-rebuild }}
@@ -120,28 +116,17 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # `env:` block deliberately removed — full_config_build,
-    # upload_artifacts and version_namespace used to be derived from
-    # github.event.pull_request.labels here, but that's the trigger-event
-    # snapshot. The live-labels step below writes them to $GITHUB_ENV
-    # instead, so subsequent steps still reference them as `env.X`.
+    # `env:` block removed — its three label-derived booleans
+    # (full_config_build / upload_artifacts / version_namespace) are
+    # written to $GITHUB_ENV by the live-labels step below.
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      # Read PR labels live (not from the trigger event payload). This
-      # eliminates the gh-pr-create race documented in
-      # https://github.com/orgs/community/discussions/24724 — POST /pulls
-      # doesn't accept a labels parameter, so labels added immediately
-      # after PR creation aren't in the `pull_request.opened` event.
-      # By the time this step runs (after queue + checkout, ~10–30 s on
-      # ubuntu-latest), the labels have settled.
-      #
-      # Emits one step output per known label (tag-X = "true"/"false"),
-      # and writes the derived booleans (full_config_build,
-      # upload_artifacts, version_namespace) to $GITHUB_ENV so subsequent
-      # steps' `if:` and `env:` blocks can read them as env.X.
+      # Read PR labels live (trigger payload is empty right after
+      # `gh pr create --label X`). Emits one step output per label and
+      # full_config_build / upload_artifacts / version_namespace to $GITHUB_ENV.
       - name: Read live PR labels
         id: live-labels
         env:
@@ -155,13 +140,9 @@ jobs:
             fi
           }
 
-          # On `pull_request.opened` the gh-pr-create-label race can delay
-          # label visibility by 1–3 s after the webhook fires (the labels
-          # API call lands ~1 s after `POST /pulls`). Poll briefly so the
-          # workflow rides out that window. Capped at 3 attempts × 2 s so
-          # PRs intentionally opened without labels only pay ~4 s of
-          # latency. `synchronize` / `reopened` runs skip the polling
-          # entirely since labels are already stable by then.
+          # Poll briefly on `pull_request.opened` to ride out the
+          # ~1–3 s gh-pr-create-label race. 3×2 s cap, so label-less PRs
+          # only pay ~4 s; synchronize/reopened runs skip the polling.
           attempts=1
           if [ "${{ github.event_name }}" = "pull_request" ] && \
              [ "${{ github.event.action }}" = "opened" ]; then
@@ -183,23 +164,16 @@ jobs:
 
           has() { echo "$LABELS" | grep -qFx "$1" && echo true || echo false; }
 
-          # Step outputs — one per label actually present on the PR.
-          # Mapping: label name → output key. The `disable-build-X`
-          # family drops the middle `build-` segment so the key becomes
-          # `tag-disable-X` (matches the existing workflow_call outputs);
-          # everything else just gets a literal `tag-` prefix.
-          # Absent outputs evaluate to empty strings downstream, which
-          # is falsy in `== 'true'` comparisons — so we don't need to
-          # emit `=false` rows.
+          # Emit `tag-<key>=true` per label present. The `disable-build-X`
+          # family drops the middle `build-` segment to match the existing
+          # workflow_call outputs (`tag-disable-X`). Absent outputs are falsy.
           for label in $LABELS; do
             echo "tag-${label/disable-build-/disable-}=true"
           done >> "$GITHUB_OUTPUT"
 
-          # Derived env vars — replaces the previous job-level `env:` block
-          # (which couldn't read step outputs). These three are referenced
-          # by `if:` conditions and `env:` blocks in later steps within
-          # this same job (Checkout full history, Versioning, Set matrix
-          # for ubuntu-x64, etc.).
+          # Derived env vars — replaces the removed job-level `env:`
+          # block. Referenced by `if:`/`env:` in later steps (Checkout
+          # full history, Versioning, Set matrix for ubuntu-x64, etc.).
           FULL_CI=$(has full-ci)
           UPLOAD_BIN=$(has upload-binaries)
           EVT="${{ github.event_name }}"

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -94,35 +94,119 @@ jobs:
       windows_x64_config_matrix: ${{ steps.set-windows-x64-matrix.outputs.matrix }}
       vcpkg-docker-image-tag:   ${{ steps.select-vcpkg-docker-image-tag.outputs.image_tag }}
       windows-changes:          ${{ steps.windows-changes.outputs.src }}
-      # please list the required tags here
-      tag-bump-vcpkg:            ${{ contains( github.event.pull_request.labels.*.name, 'bump-vcpkg' ) }}
-      tag-full-ci:               ${{ contains( github.event.pull_request.labels.*.name, 'full-ci' ) }}
-      tag-skip-image-rebuild:    ${{ contains( github.event.pull_request.labels.*.name, 'skip-image-rebuild' ) }}
-      tag-update-doc:            ${{ contains( github.event.pull_request.labels.*.name, 'update-doc' ) }}
-      tag-update-doc-only:       ${{ contains( github.event.pull_request.labels.*.name, 'update-doc-only' ) }}
-      tag-upload-binaries:       ${{ contains( github.event.pull_request.labels.*.name, 'upload-binaries' ) }}
-      tag-upload-test-artifacts: ${{ contains( github.event.pull_request.labels.*.name, 'upload-test-artifacts' ) }}
-      tag-test-pip-build:        ${{ contains( github.event.pull_request.labels.*.name, 'test-pip-build' ) }}
+      # PR labels — read live from the PR via gh pr view, not from
+      # github.event.pull_request.labels which is a snapshot of the
+      # trigger event payload. POST /repos/.../pulls doesn't accept
+      # labels (see https://github.com/orgs/community/discussions/24724),
+      # so labels added immediately after PR creation aren't in the
+      # `pull_request.opened` event — but they ARE present by the time
+      # the live-labels step runs ~10–30 s into the workflow.
+      tag-bump-vcpkg:            ${{ steps.live-labels.outputs.tag-bump-vcpkg }}
+      tag-full-ci:               ${{ steps.live-labels.outputs.tag-full-ci }}
+      tag-skip-image-rebuild:    ${{ steps.live-labels.outputs.tag-skip-image-rebuild }}
+      tag-update-doc:            ${{ steps.live-labels.outputs.tag-update-doc }}
+      tag-update-doc-only:       ${{ steps.live-labels.outputs.tag-update-doc-only }}
+      tag-upload-binaries:       ${{ steps.live-labels.outputs.tag-upload-binaries }}
+      tag-upload-test-artifacts: ${{ steps.live-labels.outputs.tag-upload-test-artifacts }}
+      tag-test-pip-build:        ${{ steps.live-labels.outputs.tag-test-pip-build }}
       # tags for disabling builds for different systems
-      tag-build-release-windows: ${{ contains( github.event.pull_request.labels.*.name, 'build-release-windows' ) }}
-      tag-disable-windows:       ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-windows' ) }}
-      tag-disable-ubuntu-x64:     ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-ubuntu-x64' ) }}
-      tag-disable-ubuntu-arm64:   ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-ubuntu-arm64' ) }}
-      tag-disable-linux-vcpkg:    ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-linux-vcpkg' ) }}
-      tag-disable-macos:          ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-macos' ) }}
-      tag-disable-emscripten:     ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-emscripten' ) }}
+      tag-build-release-windows: ${{ steps.live-labels.outputs.tag-build-release-windows }}
+      tag-disable-windows:       ${{ steps.live-labels.outputs.tag-disable-windows }}
+      tag-disable-ubuntu-x64:     ${{ steps.live-labels.outputs.tag-disable-ubuntu-x64 }}
+      tag-disable-ubuntu-arm64:   ${{ steps.live-labels.outputs.tag-disable-ubuntu-arm64 }}
+      tag-disable-linux-vcpkg:    ${{ steps.live-labels.outputs.tag-disable-linux-vcpkg }}
+      tag-disable-macos:          ${{ steps.live-labels.outputs.tag-disable-macos }}
+      tag-disable-emscripten:     ${{ steps.live-labels.outputs.tag-disable-emscripten }}
 
     runs-on: ubuntu-latest
 
-    env:
-      # duplicate output values here since they cannot be accessed from steps
-      full_config_build: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains( github.event.pull_request.labels.*.name, 'full-ci' ) }}
-      upload_artifacts: ${{ github.event_name == 'push' || github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'full-ci' ) || contains( github.event.pull_request.labels.*.name, 'upload-binaries' ) }}
-      version_namespace: ${{ ( contains( github.event.pull_request.labels.*.name, 'full-ci' ) || contains( github.event.pull_request.labels.*.name, 'upload-binaries' ) ) && github.event_name != 'push' && 'pr-test' || '' }}
+    # `env:` block deliberately removed — full_config_build,
+    # upload_artifacts and version_namespace used to be derived from
+    # github.event.pull_request.labels here, but that's the trigger-event
+    # snapshot. The live-labels step below writes them to $GITHUB_ENV
+    # instead, so subsequent steps still reference them as `env.X`.
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # Read PR labels live (not from the trigger event payload). This
+      # eliminates the gh-pr-create race documented in
+      # https://github.com/orgs/community/discussions/24724 — POST /pulls
+      # doesn't accept a labels parameter, so labels added immediately
+      # after PR creation aren't in the `pull_request.opened` event.
+      # By the time this step runs (after queue + checkout, ~10–30 s on
+      # ubuntu-latest), the labels have settled.
+      #
+      # Emits one step output per known label (tag-X = "true"/"false"),
+      # and writes the derived booleans (full_config_build,
+      # upload_artifacts, version_namespace) to $GITHUB_ENV so subsequent
+      # steps' `if:` and `env:` blocks can read them as env.X.
+      - name: Read live PR labels
+        id: live-labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            LABELS=$(gh pr view ${{ github.event.pull_request.number }} \
+                       --repo "${{ github.repository }}" \
+                       --json labels --jq '.labels[].name')
+          else
+            LABELS=""
+          fi
+          echo "Live labels:"
+          if [ -n "$LABELS" ]; then echo "$LABELS" | sed 's/^/  - /'; else echo "  (none)"; fi
+
+          has() { echo "$LABELS" | grep -qFx "$1" && echo true || echo false; }
+
+          # Step outputs — referenced from the job's outputs: block.
+          {
+            echo "tag-bump-vcpkg=$(has bump-vcpkg)"
+            echo "tag-full-ci=$(has full-ci)"
+            echo "tag-skip-image-rebuild=$(has skip-image-rebuild)"
+            echo "tag-update-doc=$(has update-doc)"
+            echo "tag-update-doc-only=$(has update-doc-only)"
+            echo "tag-upload-binaries=$(has upload-binaries)"
+            echo "tag-upload-test-artifacts=$(has upload-test-artifacts)"
+            echo "tag-test-pip-build=$(has test-pip-build)"
+            echo "tag-build-release-windows=$(has build-release-windows)"
+            echo "tag-disable-windows=$(has disable-build-windows)"
+            echo "tag-disable-ubuntu-x64=$(has disable-build-ubuntu-x64)"
+            echo "tag-disable-ubuntu-arm64=$(has disable-build-ubuntu-arm64)"
+            echo "tag-disable-linux-vcpkg=$(has disable-build-linux-vcpkg)"
+            echo "tag-disable-macos=$(has disable-build-macos)"
+            echo "tag-disable-emscripten=$(has disable-build-emscripten)"
+          } >> "$GITHUB_OUTPUT"
+
+          # Derived env vars — replaces the previous job-level `env:` block
+          # (which couldn't read step outputs). These three are referenced
+          # by `if:` conditions and `env:` blocks in later steps within
+          # this same job (Checkout full history, Versioning, Set matrix
+          # for ubuntu-x64, etc.).
+          FULL_CI=$(has full-ci)
+          UPLOAD_BIN=$(has upload-binaries)
+          EVT="${{ github.event_name }}"
+
+          full_config_build=false
+          if [ "$EVT" = "schedule" ] || [ "$EVT" = "workflow_dispatch" ] || [ "$FULL_CI" = "true" ]; then
+            full_config_build=true
+          fi
+
+          upload_artifacts=false
+          if [ "$EVT" = "push" ] || [ "$EVT" = "schedule" ] || [ "$FULL_CI" = "true" ] || [ "$UPLOAD_BIN" = "true" ]; then
+            upload_artifacts=true
+          fi
+
+          version_namespace=""
+          if { [ "$FULL_CI" = "true" ] || [ "$UPLOAD_BIN" = "true" ]; } && [ "$EVT" != "push" ]; then
+            version_namespace="pr-test"
+          fi
+
+          {
+            echo "full_config_build=$full_config_build"
+            echo "upload_artifacts=$upload_artifacts"
+            echo "version_namespace=$version_namespace"
+          } >> "$GITHUB_ENV"
 
       # install helper utility for Python version management
       - name: Install uv
@@ -229,7 +313,7 @@ jobs:
         run: |
           if [[ "${{ env.full_config_build }}" == "true" || github.event_name == 'schedule' ]]; then
             MATRIX_FILE=".github/workflows/matrix/windows-full-config.json"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'build-release-windows') }}" == "true" ]]; then
+          elif [[ "${{ steps.live-labels.outputs.tag-build-release-windows }}" == "true" ]]; then
             MATRIX_FILE=".github/workflows/matrix/windows-standard-config.json"
           else
             MATRIX_FILE=".github/workflows/matrix/windows-minimal-config.json"

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -183,24 +183,17 @@ jobs:
 
           has() { echo "$LABELS" | grep -qFx "$1" && echo true || echo false; }
 
-          # Step outputs — referenced from the job's outputs: block.
-          {
-            echo "tag-bump-vcpkg=$(has bump-vcpkg)"
-            echo "tag-full-ci=$(has full-ci)"
-            echo "tag-skip-image-rebuild=$(has skip-image-rebuild)"
-            echo "tag-update-doc=$(has update-doc)"
-            echo "tag-update-doc-only=$(has update-doc-only)"
-            echo "tag-upload-binaries=$(has upload-binaries)"
-            echo "tag-upload-test-artifacts=$(has upload-test-artifacts)"
-            echo "tag-test-pip-build=$(has test-pip-build)"
-            echo "tag-build-release-windows=$(has build-release-windows)"
-            echo "tag-disable-windows=$(has disable-build-windows)"
-            echo "tag-disable-ubuntu-x64=$(has disable-build-ubuntu-x64)"
-            echo "tag-disable-ubuntu-arm64=$(has disable-build-ubuntu-arm64)"
-            echo "tag-disable-linux-vcpkg=$(has disable-build-linux-vcpkg)"
-            echo "tag-disable-macos=$(has disable-build-macos)"
-            echo "tag-disable-emscripten=$(has disable-build-emscripten)"
-          } >> "$GITHUB_OUTPUT"
+          # Step outputs — one per label actually present on the PR.
+          # Mapping: label name → output key. The `disable-build-X`
+          # family drops the middle `build-` segment so the key becomes
+          # `tag-disable-X` (matches the existing workflow_call outputs);
+          # everything else just gets a literal `tag-` prefix.
+          # Absent outputs evaluate to empty strings downstream, which
+          # is falsy in `== 'true'` comparisons — so we don't need to
+          # emit `=false` rows.
+          for label in $LABELS; do
+            echo "tag-${label/disable-build-/disable-}=true"
+          done >> "$GITHUB_OUTPUT"
 
           # Derived env vars — replaces the previous job-level `env:` block
           # (which couldn't read step outputs). These three are referenced

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -147,13 +147,37 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            LABELS=$(gh pr view ${{ github.event.pull_request.number }} \
-                       --repo "${{ github.repository }}" \
-                       --json labels --jq '.labels[].name')
-          else
-            LABELS=""
+          read_labels() {
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              gh pr view ${{ github.event.pull_request.number }} \
+                --repo "${{ github.repository }}" \
+                --json labels --jq '.labels[].name'
+            fi
+          }
+
+          # On `pull_request.opened` the gh-pr-create-label race can delay
+          # label visibility by a few seconds after the webhook fires. We
+          # may also see this when labels are added via a separate API
+          # call right after creation (`gh pr edit --add-label`). Poll
+          # briefly so the workflow rides out that window without paying
+          # latency on `synchronize` / `reopened` runs where labels are
+          # already stable.
+          attempts=1
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.action }}" = "opened" ]; then
+            attempts=6   # up to ~10 s of polling: 0, 2, 2, 2, 2, 2
           fi
+
+          LABELS=""
+          for i in $(seq 1 $attempts); do
+            LABELS=$(read_labels)
+            if [ -n "$LABELS" ] || [ "$i" = "$attempts" ]; then
+              break
+            fi
+            echo "  (no labels yet — retry $i/$attempts in 2 s)"
+            sleep 2
+          done
+
           echo "Live labels:"
           if [ -n "$LABELS" ]; then echo "$LABELS" | sed 's/^/  - /'; else echo "  (none)"; fi
 


### PR DESCRIPTION
## Problem

`POST /repos/{owner}/{repo}/pulls` does not accept a `labels` parameter — likewise the GraphQL `createPullRequest` mutation has no `labelIds` input. Tooling that creates a PR with labels (`gh pr create --label X`, Octokit, etc.) must do two API calls: create the PR, then `POST /issues/{n}/labels`. The `pull_request.opened` webhook fires after the first call, so its payload captures an **empty** `pull_request.labels` array — even when the user's intent was "open with these labels".

Workflows like ours that gate on `${{ contains(github.event.pull_request.labels.*.name, 'X') }}` therefore make wrong gating decisions on the *first* run and the operator has to either cancel-and-push-an-empty-commit (which `synchronize` re-fires with current labels) or accept wasted CI on Windows/Ubuntu/etc. that ought to have been skipped.

References for the underlying limitation:
- [GitHub Community Discussion #24724](https://github.com/orgs/community/discussions/24724) — confirms both REST and GraphQL.
- [REST API: Create a pull request](https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request) — body parameter list, no `labels`.

## Fix

`prepare-config` now does the label read live. A new `Read live PR labels` step runs `gh pr view <PR> --json labels` and emits per-label step outputs plus three derived env vars (`full_config_build`, `upload_artifacts`, `version_namespace`) into `$GITHUB_ENV`.

```yaml
- name: Read live PR labels
  id: live-labels
  env:
    GH_TOKEN: ${{ github.token }}
  run: |
    read_labels() {
      if [ "${{ github.event_name }}" = "pull_request" ]; then
        gh pr view ${{ github.event.pull_request.number }} \
          --repo "${{ github.repository }}" \
          --json labels --jq '.labels[].name'
      fi
    }
    # On `pull_request.opened` the gh-pr-create-label race can delay
    # label visibility by a few seconds. Poll up to 3 × 2 s on `opened`
    # only; `synchronize`/`reopened` runs see stable labels and skip
    # the polling.
    attempts=1
    if [ "${{ github.event_name }}" = "pull_request" ] && \
       [ "${{ github.event.action }}" = "opened" ]; then
      attempts=3
    fi
    LABELS=""
    for i in $(seq 1 $attempts); do
      LABELS=$(read_labels)
      [ -n "$LABELS" ] || [ "$i" = "$attempts" ] && break
      sleep 2
    done
    has() { echo "$LABELS" | grep -qFx "$1" && echo true || echo false; }
    {
      echo "tag-disable-windows=$(has disable-build-windows)"
      # …14 more tags…
    } >> "$GITHUB_OUTPUT"
```

## Refactor surface

- All `tag-X` job outputs now reference `steps.live-labels.outputs.tag-X` instead of `${{ contains(github.event.pull_request.labels.*.name, 'X') }}`.
- Job-level `env:` block deleted (it used to duplicate the label-derived booleans because step expressions can't read job outputs); the live-labels step writes the same booleans to `$GITHUB_ENV` instead, so downstream `env.full_config_build` / `env.upload_artifacts` / `env.version_namespace` references continue to work.
- One inline `contains(github.event.pull_request.labels.*.name, 'build-release-windows')` in the windows-x64-matrix step replaced with `steps.live-labels.outputs.tag-build-release-windows`.

Behaviour for non-PR triggers (`push` / `schedule` / `workflow_dispatch`) is unchanged: the live-labels step short-circuits on `github.event_name != 'pull_request'` and emits all `tag-X = false`.

## Empirical validation

### Test A — `gh pr create --label X` single-command flow

Throwaway test PR #6009 opened atomically with `--label disable-build-windows --label disable-build-emscripten --label disable-build-ubuntu-arm64 --label disable-build-linux-vcpkg`. `gh pr create` posts the labels within ~1–2 s of `POST /pulls`. The `pull_request.opened` event still fires with an empty labels array, but by the time the live-labels step ran (~10 s after PR open), the labels were visible. Run [25107344683](https://github.com/MeshInspector/MeshLib/actions/runs/25107344683):

```
Live labels:
  - disable-build-windows
  - disable-build-ubuntu-arm64
  - disable-build-emscripten
  - disable-build-linux-vcpkg
```

(No `(no labels yet — retry …)` lines in the log — labels were present on the *first* `gh pr view` call.)

Resulting gate evaluation, all green:

| Job | Result |
|---|---|
| `windows-build-test` | **skipped** ✅ |
| `ubuntu-arm64-build-test` | **skipped** ✅ |
| `emscripten-build-test` | **skipped** ✅ |
| `linux-vcpkg-build-test` | **skipped** ✅ |
| `macos-build-test` (3 legs) | running |
| `ubuntu-x64-build-test` (3 legs) | running |

**No empty-commit retrigger needed.** This is the headline result.

### Test B — labels added by separate `gh pr edit` *after* PR open

This PR (#6008) was opened *without* labels initially (`gh pr create` with no `--label` flags). The first run [25107109281](https://github.com/MeshInspector/MeshLib/actions/runs/25107109281) raced — `prepare-config` on `ubuntu-latest` was fast enough to reach the live-labels step within 8 s of PR open, before the manually-issued (i.e., Claude-roundtrip-delayed) `gh pr edit --add-label` calls landed. The `Live labels:` block showed `(none)`; all platforms ran.

This was the motivation for adding the polling refinement in commit `5f7a619`: on `opened` events with no labels yet visible, retry the read every 2 s for up to ~4 s. That's enough for any reasonable label-add API latency.

The synchronize-triggered run after that push, [25107250257](https://github.com/MeshInspector/MeshLib/actions/runs/25107250257), saw all 4 labels and skipped Windows / Ubuntu-arm / Emscripten / Linux-vcpkg as expected. This validates the mechanism in the labels-already-stable case.

## Trade-offs vs. status quo

| | Status quo (cancel + push empty commit) | Live-label read |
|---|---|---|
| CI runs per labelled PR creation | 2 (one cancelled at ~1 min) | 1 |
| Wasted compute | ~1 min × `prepare-config` | 0 |
| Workflow latency | normal | up to +4 s on `opened` events with empty initial labels (3-attempt poll) |
| Reacts to labels added later? | only after next push | only after next workflow run; doesn't auto-react |
| Reacts to labels removed later? | same | same |
| GH API dependency | none | one `gh pr view` call (~1 s) per run; default `GITHUB_TOKEN` has the read scope |
| Fragility | none | one extra step that can fail if the GH API hiccups |

The polling overhead only kicks in on `opened` events when no labels are present yet (a deliberate "wait for labels to settle" loop), so the typical PR flow (`gh pr create --label X`) pays at most one ~2 s sleep on the cold-cache miss and nothing thereafter.

## Test plan

- [x] `prepare-config` succeeds and its log shows the post-creation labels listed under "Live labels:".
- [x] Run on a fresh PR opened via `gh pr create --label X --label Y …` skips the labelled platforms on the *first* workflow run, no retrigger.
- [x] No regression on `tag-full-ci` / `upload_artifacts` / `version_namespace` evaluation paths.
- [ ] (Follow-up, separate PR) Mirror the same refactor into the sibling repo's `config.yml` once this lands.
