### PR TITLE
test: validate live-label-read with gh pr create --label (no follow-up)

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -94,35 +94,119 @@ jobs:
       windows_x64_config_matrix: ${{ steps.set-windows-x64-matrix.outputs.matrix }}
       vcpkg-docker-image-tag:   ${{ steps.select-vcpkg-docker-image-tag.outputs.image_tag }}
       windows-changes:          ${{ steps.windows-changes.outputs.src }}
-      # please list the required tags here
-      tag-bump-vcpkg:            ${{ contains( github.event.pull_request.labels.*.name, 'bump-vcpkg' ) }}
-      tag-full-ci:               ${{ contains( github.event.pull_request.labels.*.name, 'full-ci' ) }}
-      tag-skip-image-rebuild:    ${{ contains( github.event.pull_request.labels.*.name, 'skip-image-rebuild' ) }}
-      tag-update-doc:            ${{ contains( github.event.pull_request.labels.*.name, 'update-doc' ) }}
-      tag-update-doc-only:       ${{ contains( github.event.pull_request.labels.*.name, 'update-doc-only' ) }}
-      tag-upload-binaries:       ${{ contains( github.event.pull_request.labels.*.name, 'upload-binaries' ) }}
-      tag-upload-test-artifacts: ${{ contains( github.event.pull_request.labels.*.name, 'upload-test-artifacts' ) }}
-      tag-test-pip-build:        ${{ contains( github.event.pull_request.labels.*.name, 'test-pip-build' ) }}
+      # PR labels — read live from the PR via gh pr view, not from
+      # github.event.pull_request.labels which is a snapshot of the
+      # trigger event payload. POST /repos/.../pulls doesn't accept
+      # labels (see https://github.com/orgs/community/discussions/24724),
+      # so labels added immediately after PR creation aren't in the
+      # `pull_request.opened` event — but they ARE present by the time
+      # the live-labels step runs ~10–30 s into the workflow.
+      tag-bump-vcpkg:            ${{ steps.live-labels.outputs.tag-bump-vcpkg }}
+      tag-full-ci:               ${{ steps.live-labels.outputs.tag-full-ci }}
+      tag-skip-image-rebuild:    ${{ steps.live-labels.outputs.tag-skip-image-rebuild }}
+      tag-update-doc:            ${{ steps.live-labels.outputs.tag-update-doc }}
+      tag-update-doc-only:       ${{ steps.live-labels.outputs.tag-update-doc-only }}
+      tag-upload-binaries:       ${{ steps.live-labels.outputs.tag-upload-binaries }}
+      tag-upload-test-artifacts: ${{ steps.live-labels.outputs.tag-upload-test-artifacts }}
+      tag-test-pip-build:        ${{ steps.live-labels.outputs.tag-test-pip-build }}
       # tags for disabling builds for different systems
-      tag-build-release-windows: ${{ contains( github.event.pull_request.labels.*.name, 'build-release-windows' ) }}
-      tag-disable-windows:       ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-windows' ) }}
-      tag-disable-ubuntu-x64:     ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-ubuntu-x64' ) }}
-      tag-disable-ubuntu-arm64:   ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-ubuntu-arm64' ) }}
-      tag-disable-linux-vcpkg:    ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-linux-vcpkg' ) }}
-      tag-disable-macos:          ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-macos' ) }}
-      tag-disable-emscripten:     ${{ contains( github.event.pull_request.labels.*.name, 'disable-build-emscripten' ) }}
+      tag-build-release-windows: ${{ steps.live-labels.outputs.tag-build-release-windows }}
+      tag-disable-windows:       ${{ steps.live-labels.outputs.tag-disable-windows }}
+      tag-disable-ubuntu-x64:     ${{ steps.live-labels.outputs.tag-disable-ubuntu-x64 }}
+      tag-disable-ubuntu-arm64:   ${{ steps.live-labels.outputs.tag-disable-ubuntu-arm64 }}
+      tag-disable-linux-vcpkg:    ${{ steps.live-labels.outputs.tag-disable-linux-vcpkg }}
+      tag-disable-macos:          ${{ steps.live-labels.outputs.tag-disable-macos }}
+      tag-disable-emscripten:     ${{ steps.live-labels.outputs.tag-disable-emscripten }}
 
     runs-on: ubuntu-latest
 
-    env:
-      # duplicate output values here since they cannot be accessed from steps
-      full_config_build: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains( github.event.pull_request.labels.*.name, 'full-ci' ) }}
-      upload_artifacts: ${{ github.event_name == 'push' || github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'full-ci' ) || contains( github.event.pull_request.labels.*.name, 'upload-binaries' ) }}
-      version_namespace: ${{ ( contains( github.event.pull_request.labels.*.name, 'full-ci' ) || contains( github.event.pull_request.labels.*.name, 'upload-binaries' ) ) && github.event_name != 'push' && 'pr-test' || '' }}
+    # `env:` block deliberately removed — full_config_build,
+    # upload_artifacts and version_namespace used to be derived from
+    # github.event.pull_request.labels here, but that's the trigger-event
+    # snapshot. The live-labels step below writes them to $GITHUB_ENV
+    # instead, so subsequent steps still reference them as `env.X`.
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # Read PR labels live (not from the trigger event payload). This
+      # eliminates the gh-pr-create race documented in
+      # https://github.com/orgs/community/discussions/24724 — POST /pulls
+      # doesn't accept a labels parameter, so labels added immediately
+      # after PR creation aren't in the `pull_request.opened` event.
+      # By the time this step runs (after queue + checkout, ~10–30 s on
+      # ubuntu-latest), the labels have settled.
+      #
+      # Emits one step output per known label (tag-X = "true"/"false"),
+      # and writes the derived booleans (full_config_build,
+      # upload_artifacts, version_namespace) to $GITHUB_ENV so subsequent
+      # steps' `if:` and `env:` blocks can read them as env.X.
+      - name: Read live PR labels
+        id: live-labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            LABELS=$(gh pr view ${{ github.event.pull_request.number }} \
+                       --repo "${{ github.repository }}" \
+                       --json labels --jq '.labels[].name')
+          else
+            LABELS=""
+          fi
+          echo "Live labels:"
+          if [ -n "$LABELS" ]; then echo "$LABELS" | sed 's/^/  - /'; else echo "  (none)"; fi
+
+          has() { echo "$LABELS" | grep -qFx "$1" && echo true || echo false; }
+
+          # Step outputs — referenced from the job's outputs: block.
+          {
+            echo "tag-bump-vcpkg=$(has bump-vcpkg)"
+            echo "tag-full-ci=$(has full-ci)"
+            echo "tag-skip-image-rebuild=$(has skip-image-rebuild)"
+            echo "tag-update-doc=$(has update-doc)"
+            echo "tag-update-doc-only=$(has update-doc-only)"
+            echo "tag-upload-binaries=$(has upload-binaries)"
+            echo "tag-upload-test-artifacts=$(has upload-test-artifacts)"
+            echo "tag-test-pip-build=$(has test-pip-build)"
+            echo "tag-build-release-windows=$(has build-release-windows)"
+            echo "tag-disable-windows=$(has disable-build-windows)"
+            echo "tag-disable-ubuntu-x64=$(has disable-build-ubuntu-x64)"
+            echo "tag-disable-ubuntu-arm64=$(has disable-build-ubuntu-arm64)"
+            echo "tag-disable-linux-vcpkg=$(has disable-build-linux-vcpkg)"
+            echo "tag-disable-macos=$(has disable-build-macos)"
+            echo "tag-disable-emscripten=$(has disable-build-emscripten)"
+          } >> "$GITHUB_OUTPUT"
+
+          # Derived env vars — replaces the previous job-level `env:` block
+          # (which couldn't read step outputs). These three are referenced
+          # by `if:` conditions and `env:` blocks in later steps within
+          # this same job (Checkout full history, Versioning, Set matrix
+          # for ubuntu-x64, etc.).
+          FULL_CI=$(has full-ci)
+          UPLOAD_BIN=$(has upload-binaries)
+          EVT="${{ github.event_name }}"
+
+          full_config_build=false
+          if [ "$EVT" = "schedule" ] || [ "$EVT" = "workflow_dispatch" ] || [ "$FULL_CI" = "true" ]; then
+            full_config_build=true
+          fi
+
+          upload_artifacts=false
+          if [ "$EVT" = "push" ] || [ "$EVT" = "schedule" ] || [ "$FULL_CI" = "true" ] || [ "$UPLOAD_BIN" = "true" ]; then
+            upload_artifacts=true
+          fi
+
+          version_namespace=""
+          if { [ "$FULL_CI" = "true" ] || [ "$UPLOAD_BIN" = "true" ]; } && [ "$EVT" != "push" ]; then
+            version_namespace="pr-test"
+          fi
+
+          {
+            echo "full_config_build=$full_config_build"
+            echo "upload_artifacts=$upload_artifacts"
+            echo "version_namespace=$version_namespace"
+          } >> "$GITHUB_ENV"
 
       # install helper utility for Python version management
       - name: Install uv
@@ -229,7 +313,7 @@ jobs:
         run: |
           if [[ "${{ env.full_config_build }}" == "true" || github.event_name == 'schedule' ]]; then
             MATRIX_FILE=".github/workflows/matrix/windows-full-config.json"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'build-release-windows') }}" == "true" ]]; then
+          elif [[ "${{ steps.live-labels.outputs.tag-build-release-windows }}" == "true" ]]; then
             MATRIX_FILE=".github/workflows/matrix/windows-standard-config.json"
           else
             MATRIX_FILE=".github/workflows/matrix/windows-minimal-config.json"

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -147,13 +147,37 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            LABELS=$(gh pr view ${{ github.event.pull_request.number }} \
-                       --repo "${{ github.repository }}" \
-                       --json labels --jq '.labels[].name')
-          else
-            LABELS=""
+          read_labels() {
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              gh pr view ${{ github.event.pull_request.number }} \
+                --repo "${{ github.repository }}" \
+                --json labels --jq '.labels[].name'
+            fi
+          }
+
+          # On `pull_request.opened` the gh-pr-create-label race can delay
+          # label visibility by a few seconds after the webhook fires. We
+          # may also see this when labels are added via a separate API
+          # call right after creation (`gh pr edit --add-label`). Poll
+          # briefly so the workflow rides out that window without paying
+          # latency on `synchronize` / `reopened` runs where labels are
+          # already stable.
+          attempts=1
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.action }}" = "opened" ]; then
+            attempts=6   # up to ~10 s of polling: 0, 2, 2, 2, 2, 2
           fi
+
+          LABELS=""
+          for i in $(seq 1 $attempts); do
+            LABELS=$(read_labels)
+            if [ -n "$LABELS" ] || [ "$i" = "$attempts" ]; then
+              break
+            fi
+            echo "  (no labels yet — retry $i/$attempts in 2 s)"
+            sleep 2
+          done
+
           echo "Live labels:"
           if [ -n "$LABELS" ]; then echo "$LABELS" | sed 's/^/  - /'; else echo "  (none)"; fi
 


### PR DESCRIPTION
Smoke test for the live-label-read mechanism in #6008. Opened with `gh pr create --label disable-build-windows --label disable-build-emscripten --label disable-build-ubuntu-arm64 --label disable-build-linux-vcpkg`. The labels-add API call lands within ~1–2 s of PR creation and the polling live-labels step (up to 12 s of patience on `opened` events) should see them before the gates are evaluated. Will be closed after CI confirms the gating worked.