### PR TITLE
MCP: route gateway and -mcpDumpFile paths through UTF-8

### DIFF
--- a/source/MRMCPGateway/CMakeLists.txt
+++ b/source/MRMCPGateway/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(${PROJECT_NAME}
   MRMCPGatewayCache.cpp
   MRMCPGatewayMlTransport.cpp
   MRMCPGatewaySpawn.cpp
+  MRMCPGatewayUtf8.cpp
 )
 
 # Same fastmcpp acquisition strategy as MRMcp/CMakeLists.txt — bundled subdirectory

--- a/source/MRMCPGateway/MRMCPGateway.cpp
+++ b/source/MRMCPGateway/MRMCPGateway.cpp
@@ -6,6 +6,7 @@
 #include "MRMCPGatewayCache.h"
 #include "MRMCPGatewayConfig.h"
 #include "MRMCPGatewayMlTransport.h"
+#include "MRMCPGatewayUtf8.h"
 
 #include <nlohmann/json.hpp>
 
@@ -98,11 +99,12 @@ void printUsage()
         "  --help, -h               Show this message.\n";
 }
 
-bool parseArgs( int argc, char** argv, Config& cfg )
+bool parseArgs( const std::vector<std::string>& args, Config& cfg )
 {
+    const int argc = static_cast<int>( args.size() );
     for ( int i = 1; i < argc; ++i )
     {
-        const std::string a = argv[i];
+        const std::string& a = args[i];
         const auto needNext = [&]( const char* what ) -> bool
         {
             if ( i + 1 >= argc )
@@ -116,37 +118,40 @@ bool parseArgs( int argc, char** argv, Config& cfg )
         if ( a == "--target-url" )
         {
             if ( !needNext( "--target-url" ) ) return false;
-            cfg.targetUrl = argv[++i];
+            cfg.targetUrl = args[++i];
         }
         else if ( a == "--sse-path" )
         {
             if ( !needNext( "--sse-path" ) ) return false;
-            cfg.ssePath = argv[++i];
+            cfg.ssePath = args[++i];
         }
         else if ( a == "--messages-path" )
         {
             if ( !needNext( "--messages-path" ) ) return false;
-            cfg.messagesPath = argv[++i];
+            cfg.messagesPath = args[++i];
         }
         else if ( a == "--launch-cmd" )
         {
             if ( !needNext( "--launch-cmd" ) ) return false;
-            cfg.launchCommand = argv[++i];
+            // pathFromUtf8 instead of implicit string->path: argv is UTF-8
+            // (via getUtf8Argv on Windows), and a plain construction would
+            // re-narrow through the system codepage.
+            cfg.launchCommand = pathFromUtf8( args[++i] );
         }
         else if ( a == "--launch-arg" )
         {
             if ( !needNext( "--launch-arg" ) ) return false;
-            cfg.launchArgs.emplace_back( argv[++i] );
+            cfg.launchArgs.emplace_back( args[++i] );
         }
         else if ( a == "--launch-timeout" )
         {
             if ( !needNext( "--launch-timeout" ) ) return false;
-            cfg.launchTimeout = std::chrono::seconds( std::atoi( argv[++i] ) );
+            cfg.launchTimeout = std::chrono::seconds( std::atoi( args[++i].c_str() ) );
         }
         else if ( a == "--tools-cache-namespace" )
         {
             if ( !needNext( "--tools-cache-namespace" ) ) return false;
-            cfg.toolsCacheNamespace = argv[++i];
+            cfg.toolsCacheNamespace = args[++i];
         }
         else if ( a == "--help" || a == "-h" )
         {
@@ -178,8 +183,18 @@ int main( int argc, char** argv )
 {
     using namespace MR::McpGateway;
 
+    // On Windows, the CRT-supplied argv is system-codepage and silently drops any
+    // character not representable in the locale (e.g. CJK on a US-Windows install).
+    // Re-decode from `GetCommandLineW` so paths in --launch-cmd / --tools-cache-namespace
+    // round-trip cleanly through to the spawned backend.
+#ifdef _WIN32
+    const auto args = getUtf8Argv();
+#else
+    std::vector<std::string> args( argv, argv + argc );
+#endif
+
     Config cfg;
-    if ( !parseArgs( argc, argv, cfg ) )
+    if ( !parseArgs( args, cfg ) )
         return 1;
     cfg.launchCommand = resolveLaunchCommand( cfg.launchCommand );
 

--- a/source/MRMCPGateway/MRMCPGateway.cpp
+++ b/source/MRMCPGateway/MRMCPGateway.cpp
@@ -207,6 +207,8 @@ int main( int argc, char** argv )
     // Re-decode from `GetCommandLineW` so paths in --launch-cmd / --tools-cache-namespace
     // round-trip cleanly through to the spawned backend.
 #ifdef _WIN32
+    (void)argc;
+    (void)argv;
     const auto args = getUtf8Argv();
 #else
     std::vector<std::string> args( argv, argv + argc );

--- a/source/MRMCPGateway/MRMCPGateway.vcxproj
+++ b/source/MRMCPGateway/MRMCPGateway.vcxproj
@@ -16,6 +16,7 @@
     <ClInclude Include="MRMCPGatewayConfig.h" />
     <ClInclude Include="MRMCPGatewayMlTransport.h" />
     <ClInclude Include="MRMCPGatewaySpawn.h" />
+    <ClInclude Include="MRMCPGatewayUtf8.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRMCPGateway.cpp" />
@@ -23,6 +24,7 @@
     <ClCompile Include="MRMCPGatewayCache.cpp" />
     <ClCompile Include="MRMCPGatewayMlTransport.cpp" />
     <ClCompile Include="MRMCPGatewaySpawn.cpp" />
+    <ClCompile Include="MRMCPGatewayUtf8.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\fastmcpp\fastmcpp.vcxproj">

--- a/source/MRMCPGateway/MRMCPGateway.vcxproj.filters
+++ b/source/MRMCPGateway/MRMCPGateway.vcxproj.filters
@@ -26,6 +26,9 @@
     <ClCompile Include="MRMCPGatewaySpawn.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRMCPGatewayUtf8.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MRMCPGatewayBackend.h">
@@ -41,6 +44,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="MRMCPGatewaySpawn.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MRMCPGatewayUtf8.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/source/MRMCPGateway/MRMCPGatewayCache.cpp
+++ b/source/MRMCPGateway/MRMCPGatewayCache.cpp
@@ -2,6 +2,7 @@
 #include "MRMCPGatewayBackend.h"
 #include "MRMCPGatewayConfig.h"
 #include "MRMCPGatewaySpawn.h"
+#include "MRMCPGatewayUtf8.h"
 
 #include <cstdlib>
 #include <fstream>
@@ -52,7 +53,7 @@ std::filesystem::path gatewayUserConfigDir()
     {
         std::filesystem::create_directories( filepath, ec );
         if ( ec )
-            std::cerr << "MRMCPGateway: cannot create " << filepath.string()
+            std::cerr << "MRMCPGateway: cannot create " << pathToUtf8( filepath )
                       << ": " << ec.message() << "\n";
     }
     return filepath;
@@ -62,7 +63,7 @@ std::filesystem::path cacheDir( const Config& cfg )
 {
     auto d = gatewayUserConfigDir();
     if ( !cfg.toolsCacheNamespace.empty() )
-        d /= cfg.toolsCacheNamespace;
+        d /= pathFromUtf8( cfg.toolsCacheNamespace );
     return d;
 }
 
@@ -144,7 +145,10 @@ void ensureFreshCache( const Config& cfg )
     for ( const char* flag : { "-hidden", "-noEventLoop", "-noTelemetry", "-noSplash" } )
         primeArgs.emplace_back( flag );
     primeArgs.emplace_back( "-mcpDumpFile" );
-    primeArgs.emplace_back( cache.string() );
+    // pathToUtf8 instead of cache.string(): Spawn pipes args through utf8ToWide,
+    // and `path::string()` on Windows narrows via the system codepage, so
+    // non-ASCII path components were getting mangled before reaching the backend.
+    primeArgs.emplace_back( pathToUtf8( cache ) );
 
     // Synchronous spawn: blocks until the backend exits (or times out). Avoids
     // the polling-sees-stale-cache race that file-existence polling has when an

--- a/source/MRMCPGateway/MRMCPGatewayUtf8.cpp
+++ b/source/MRMCPGateway/MRMCPGatewayUtf8.cpp
@@ -1,0 +1,71 @@
+#include "MRMCPGatewayUtf8.h"
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <shellapi.h>
+#endif
+
+namespace MR::McpGateway
+{
+
+#ifdef _WIN32
+
+namespace
+{
+
+// Wide UTF-16 -> narrow UTF-8. Used by both `pathToUtf8` (path -> wstring source)
+// and `getUtf8Argv` (CommandLineToArgvW source).
+std::string utf16ToUtf8( const wchar_t* w, int len )
+{
+    if ( len <= 0 )
+        return {};
+    int n = WideCharToMultiByte( CP_UTF8, 0, w, len, nullptr, 0, nullptr, nullptr );
+    std::string out( static_cast<size_t>( n ), '\0' );
+    WideCharToMultiByte( CP_UTF8, 0, w, len, out.data(), n, nullptr, nullptr );
+    return out;
+}
+
+} // anonymous namespace
+
+#endif // _WIN32
+
+std::filesystem::path pathFromUtf8( const std::string& s )
+{
+    // On Windows, `path( std::string )` interprets the bytes as the active locale.
+    // Constructing through `std::u8string` keeps the bytes labeled as UTF-8 so
+    // libstdc++/MSVC routes them through the UTF-8 codec instead.
+    return std::filesystem::path( std::u8string( s.begin(), s.end() ) );
+}
+
+std::string pathToUtf8( const std::filesystem::path& p )
+{
+#ifdef _WIN32
+    // `path::string()` on Windows narrows via the active locale (CP_ACP), which
+    // corrupts non-ASCII paths. Go through the UTF-16 internal representation and
+    // encode as UTF-8 explicitly.
+    const auto w = p.wstring();
+    return utf16ToUtf8( w.data(), static_cast<int>( w.size() ) );
+#else
+    // POSIX paths are byte sequences; the convention is UTF-8.
+    return p.string();
+#endif
+}
+
+#ifdef _WIN32
+std::vector<std::string> getUtf8Argv()
+{
+    int wargc = 0;
+    wchar_t** wargv = CommandLineToArgvW( GetCommandLineW(), &wargc );
+    std::vector<std::string> out;
+    if ( !wargv )
+        return out;
+    out.reserve( wargc );
+    for ( int i = 0; i < wargc; ++i )
+        out.push_back( utf16ToUtf8( wargv[i], static_cast<int>( wcslen( wargv[i] ) ) ) );
+    LocalFree( wargv );
+    return out;
+}
+#endif
+
+} // namespace MR::McpGateway

--- a/source/MRMCPGateway/MRMCPGatewayUtf8.h
+++ b/source/MRMCPGateway/MRMCPGatewayUtf8.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace MR::McpGateway
+{
+
+// UTF-8 std::string -> std::filesystem::path. On Windows this is non-trivial:
+// `path( std::string )` interprets the bytes as the system code page, which silently
+// loses any character not representable in the current locale (e.g. CJK on US-Windows).
+// On POSIX, paths are UTF-8 by convention so this is essentially a passthrough.
+std::filesystem::path pathFromUtf8( const std::string& s );
+
+// std::filesystem::path -> UTF-8 std::string. Mirror of pathFromUtf8 — on Windows,
+// `path::string()` narrows via the system code page, which corrupts non-ASCII chars
+// before we hand the string off to spawn args / log output / cerr.
+std::string pathToUtf8( const std::filesystem::path& p );
+
+#ifdef _WIN32
+// Re-decodes argv from `GetCommandLineW` so that non-ASCII paths and arguments
+// survive a launch from the command line. The CRT-supplied `argv` in `main(int,char**)`
+// is system-codepage on Windows, so any character outside the locale (e.g. Cyrillic
+// on a US-Windows install) becomes `?` before we even parse the flags.
+std::vector<std::string> getUtf8Argv();
+#endif
+
+} // namespace MR::McpGateway

--- a/source/MRMcp/MRMcp.cpp
+++ b/source/MRMcp/MRMcp.cpp
@@ -257,7 +257,10 @@ void Server::processCmdArgs( const std::vector<std::string>& commandArgs ) const
     {
         if ( commandArgs[i] == "-mcpDumpFile" )
         {
-            const std::filesystem::path target = commandArgs[i + 1];
+            // pathFromUtf8 instead of implicit string->path: commandArgs are UTF-8
+            // (see MR::ConvertArgv on Windows), and a plain construction would
+            // narrow through the system codepage and mangle non-ASCII paths.
+            const auto target = pathFromUtf8( commandArgs[i + 1] );
             if ( auto res = saveToolsCache( target ); !res )
                 spdlog::error( "MRMcp: {}", res.error() );
             return;


### PR DESCRIPTION
## Summary
On Windows, two points along the gateway → MI path mangled non-ASCII characters:

- **`MRMCPGateway::main`** — CRT's `argv` is system-codepage; any character outside the active locale becomes `?`. Now re-decoded from `GetCommandLineW` via a small `MRMCPGatewayUtf8` helper (mirrors `MR::ConvertArgv` in `MRConsoleWindows.cpp`).
- **`path::string()` / implicit `string→path`** — also narrow via the active codepage. Use `pathFromUtf8` / `pathToUtf8` at the ingest (`--launch-cmd`, `--tools-cache-namespace`) and emit (`-mcpDumpFile` arg, error logs) boundaries.

Matching one-line fix in `Server::processCmdArgs`: construct the dump-file path via `pathFromUtf8` so MI also stops re-narrowing the (now-correct) UTF-8 string it receives.

## Test plan
- [x] `--tools-cache-namespace тест_juni日本` (Cyrillic + CJK) round-trips intact: MI's log shows `argv[7]: ...\тест_juni日本\mcp_tools_cache.json` and the cache file lands at the correctly-decoded path.
- [x] Plain ASCII namespace (`ascii_smoke`): no regression — gateway exits 0, cache file at expected location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)