### PR TITLE
ci(windows): add diagnostics around Restore Vcpkg Cache

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -105,10 +105,25 @@ jobs:
       - name: Restore Vcpkg Cache
         uses: actions/cache@v5
         id: vcpkg-cache
+        env:
+          RUNNER_DEBUG: 1
         with:
           key: vcpkg-cache-${{ matrix.vcpkg-version }}-${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
           path: |
             C:\vcpkg\*
+
+      - name: Diagnostic — Restore Vcpkg Cache result
+        if: always()
+        shell: pwsh
+        run: |
+          Write-Host "outcome:    ${{ steps.vcpkg-cache.outcome }}"
+          Write-Host "conclusion: ${{ steps.vcpkg-cache.conclusion }}"
+          Write-Host "cache-hit:  ${{ steps.vcpkg-cache.outputs.cache-hit }}"
+          Write-Host "key:        vcpkg-cache-${{ matrix.vcpkg-version }}-${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}"
+          Write-Host "C:\vcpkg exists: $(Test-Path C:\vcpkg)"
+          if (Test-Path C:\vcpkg) {
+            Get-ChildItem C:\vcpkg | Select-Object Name, Mode | Format-Table | Out-String | Write-Host
+          }
 
       - name: Configure AWS Credentials
         if: ${{ inputs.internal_build }}


### PR DESCRIPTION
## Summary

Add diagnostics around the Windows `Restore Vcpkg Cache` step so the next time it fails we have something to look at.

Motivation: in run [25110225370 / job 73582043050](https://github.com/MeshInspector/MeshLib/actions/runs/25110225370/job/73582043050) (PR [#6011](https://github.com/MeshInspector/MeshLib/pull/6011)), the cache step was marked `failure` after ~1 second with **zero log output** — no "Cache restored", no "Cache not found", no error annotation. Every downstream step then cascade-skipped on the implicit `success()` condition. Same matrix cell on master succeeded normally a couple hours earlier, so it looked like a transient cache-service hiccup, but the step's silence made it impossible to confirm.

Two small additions on the Windows workflow:

- `RUNNER_DEBUG: 1` as step-level env on `actions/cache@v5` — turns on its internal `core.debug()` output (request URLs, response codes, archive size). Adds noise on every run, but makes a future silent failure self-explanatory.
- A new `Diagnostic — Restore Vcpkg Cache result` step with `if: always()` that prints `steps.vcpkg-cache.outcome / .conclusion / .outputs.cache-hit`, the resolved key, and the state of `C:\vcpkg`. Runs even when the cache step fails, so we get *something* in the log next time.

No behavior change for the cached build itself.

## Test plan

- [x] Confirm the workflow still parses (CI green on this PR — [run 25111553955](https://github.com/MeshInspector/MeshLib/actions/runs/25111553955), all required checks SUCCESS).
- [x] On a successful run: diagnostic step shows `outcome: success`, `cache-hit: true|false`, and the cache action prints its debug-level lines. Confirmed on [job 73586767099](https://github.com/MeshInspector/MeshLib/actions/runs/25111553955/job/73586767099): `Cache restored from key: vcpkg-cache-2026.03.18-x64-windows-meshlib` followed by `outcome: success / conclusion: success / cache-hit: true`.
- [ ] (Cannot reproduce on demand) On a future flaky cache failure: diagnostic step still runs, gives us `outcome` + `conclusion` + cache-hit value, and `actions/cache@v5` debug logs are present in the step output above it.
