### PR TITLE
ci(windows): cache MSYS2 mrbind tree via actions/cache

### DIFF
--- a/.github/actions/install-msys2-mrbind/action.yml
+++ b/.github/actions/install-msys2-mrbind/action.yml
@@ -1,9 +1,19 @@
 name: 'Install MSYS2 for MRBind'
-description: 'Download the MeshLib MSYS2 archive from S3 with retry on transient failures and extract to C:\'
+description: 'Restore the MeshLib MSYS2 tree from GitHub Actions Cache, falling back to the S3 archive on cache miss.'
 runs:
   using: 'composite'
   steps:
-    - name: Install MSYS2 for MRBind
+    - name: Restore MSYS2 cache
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: C:\msys64_meshlib_mrbind
+        # Bump the version suffix manually if the upstream zip is re-uploaded
+        # under the same URL (otherwise stale caches will keep being served).
+        key: msys64-meshlib-mrbind-v1-${{ hashFiles('.github/actions/install-msys2-mrbind/action.yml') }}
+
+    - name: Download MSYS2 archive from S3
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: pwsh
       run: |
         # Retry the S3 fetch -- transient 404 / connection blips have been


### PR DESCRIPTION
> **Closing without merging.** Empirical measurements after the run showed this PR does not accelerate Windows CI and would permanently occupy ~1.5 GB of the 10 GB per-repo Actions cache. Superseded by [#6021](https://github.com/MeshInspector/MeshLib/pull/6021) (use the runner's preinstalled MSYS2 + pacman). See the *Verdict* section at the bottom.

## Summary

- Wrap the MSYS2 fetch in `.github/actions/install-msys2-mrbind/action.yml` with `actions/cache@v4` so the extracted `C:\msys64_meshlib_mrbind` tree is restored from the GitHub Actions cache on subsequent Windows jobs.
- Keep the existing S3 download + retry logic as the cold-cache fallback (it now runs only on a cache miss).
- Cache key is `msys64-meshlib-mrbind-v1-${{ hashFiles('.github/actions/install-msys2-mrbind/action.yml') }}` — edits to the action invalidate naturally; if the upstream zip is ever re-uploaded under the same URL, bump the `v1` suffix to force a refresh.

## Motivation

In [run 25158874431](https://github.com/MeshInspector/MeshLib/actions/runs/25158874431/job/73747809376) the `Install MSYS2 for MRBind` step failed with five consecutive `404 Not Found` responses from `vcpkg-export.s3.us-east-1.amazonaws.com/msys64_meshlib_mrbind.zip`, hard-failing the windows-build-test job. Retries cannot recover when the object is genuinely missing. Caching the extracted tree via the GitHub Actions cache decouples the vast majority of runs from S3 availability.

## Tradeoffs

- The extracted msys64 tree is ~1–2 GB, which consumes a meaningful slice of the 10 GB per-repo cache cap. LRU eviction may push out other caches (vcpkg, etc.).
- A cold cache combined with an S3 outage still fails — same as today, just much rarer.
- `hashFiles('.github/actions/install-msys2-mrbind/action.yml')` is resolved relative to the workflow's repo root; it works because the action lives in this repo. If the action is ever extracted to its own repo, the cache key needs to be reworked.

## Verdict — closing without merging

Measured `Install MSYS2 for MRBind` step duration across the four Windows variants ([master baseline run 25154718847](https://github.com/MeshInspector/MeshLib/actions/runs/25154718847) vs this branch's [run 25161145309](https://github.com/MeshInspector/MeshLib/actions/runs/25161145309)):

| Variant | Master Install | PR cold Install | PR cold Post (cache save) | **PR warm Install** | PR warm Post |
|---|---|---|---|---|---|
| msvc-2019 Rel CMake | 68s | 59s | 110s | **63s** | 0s |
| msvc-2022 Rel CMake | 65s | 129s | 293s | **46s** | 0s |
| msvc-2022 Dbg MSBuild | 67s | 169s | 468s | **61s** | 1s |
| msvc-2019 Dbg CMake | 51s | 63s | 60s | **57s** | 0s |

Conclusions:
- **No steady-state speedup.** The warm-cache restore (`actions/cache` download + tar -x) takes about the same wall-clock time as the original S3 download + extract.
- **Cold runs are net slower.** Whenever the cache key is invalidated, the post-job save adds 1–8 minutes per job, and parallel jobs collide on the save (only one wins).
- **Permanent cache footprint.** ~1.5 GB resident in the 10 GB per-repo Actions cache, evicting other caches via LRU.
- **Original 404 reliability win is moot** if [#6021](https://github.com/MeshInspector/MeshLib/pull/6021) lands: that PR removes the S3 dependency entirely by installing MRBind's clang toolchain into the runner's preinstalled MSYS2 via `pacman`.

Tagged at HEAD as `wip/cache-msys2-mrbind-pr-6017` for future reference.
