### PR TITLE
ci(pip-build): keep wheel artifacts on PR runs to survive partial reruns

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -690,7 +690,7 @@ jobs:
     if: always()
     steps:
       - name: Delete all ManyLinux
-        if: ${{ !(github.event_name == 'release' || inputs.publish) || needs.upload-to-release.outputs.uploaded == 'true' }}
+        if: ${{ ( github.event_name == 'release' || inputs.publish ) && needs.upload-to-release.outputs.uploaded == 'true' }}
         uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
         with:
           name: ManyLinux-*
@@ -719,14 +719,14 @@ jobs:
 
 
       - name: Delete all Windows
-        if: ${{ !(github.event_name == 'release' || inputs.publish) || needs.upload-to-release.outputs.uploaded == 'true' }}
+        if: ${{ ( github.event_name == 'release' || inputs.publish ) && needs.upload-to-release.outputs.uploaded == 'true' }}
         uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
         with:
           name: Windows
           failOnError: false
 
       - name: Delete all Macos
-        if: ${{ !(github.event_name == 'release' || inputs.publish) || needs.upload-to-release.outputs.uploaded == 'true' }}
+        if: ${{ ( github.event_name == 'release' || inputs.publish ) && needs.upload-to-release.outputs.uploaded == 'true' }}
         uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
         with:
           name: Macos-*


### PR DESCRIPTION
## Summary

Restrict `test-pip-build / delete-artifacts` to release/publish runs that successfully uploaded the wheels to a GitHub release. On regular PR test runs the wheel artifacts are retained for the configured `retention-days: 1` instead of being eagerly deleted.

## Why

The current condition on the `Delete all ManyLinux`, `Delete all Windows`, and `Delete all Macos` steps in [pip-build.yml:692-732](https://github.com/MeshInspector/MeshLib/blob/master/.github/workflows/pip-build.yml#L692) is:

```
if: ${{ !(github.event_name == 'release' || inputs.publish) || needs.upload-to-release.outputs.uploaded == 'true' }}
```

…which deletes the artifacts at the end of every PR test run. That breaks GitHub's "Re-run failed jobs" flow:

1. Attempt 1 runs. `manylinux-pip-build (x86_64)` succeeds and uploads `ManyLinux-x86_64`. `manylinux-pip-build (aarch64)` fails. The whole pipeline still drains to `delete-artifacts`, which deletes `ManyLinux-*`.
2. User picks "Re-run failed jobs". Attempt 2 starts. The previously-successful x86_64 build is **not** re-executed (GitHub treats it as already-passed) — so no new `ManyLinux-x86_64` upload happens.
3. The `manylinux-pip-test (x86_64, *)` matrix re-runs and fails with `Unable to download artifact(s): Artifact not found for name: ManyLinux-x86_64`.

A live example: PR #6004 run [25159519591](https://github.com/MeshInspector/MeshLib/actions/runs/25159519591), all 7 `manylinux-pip-test (x86_64, *)` jobs failed at the download-artifact step in attempt 2.

## Fix

Flip the condition to delete only when artifacts have served their purpose (a release/publish run that successfully uploaded the wheels). For PR test runs, do nothing here and let `retention-days: 1` on the upload step handle cleanup within 24h.

```diff
-        if: ${{ !(github.event_name == 'release' || inputs.publish) || needs.upload-to-release.outputs.uploaded == 'true' }}
+        if: ${{ ( github.event_name == 'release' || inputs.publish ) && needs.upload-to-release.outputs.uploaded == 'true' }}
```

Applied identically to the three steps. The `Delete Python Stubs / C bindings / Csharp bindings` steps are untouched — they already had a stricter condition gated on `update-documentation` success and publish/release.

## Test plan

- [ ] PR run leaves `ManyLinux-*`, `Windows`, `Macos-*` artifacts intact at workflow end.
- [ ] "Re-run failed jobs" on a partially-failed PR run no longer hits "Artifact not found".
- [ ] On a release/publish run, after a successful `upload-to-release`, the eager delete still runs and cleans up storage.
