### PR TITLE
MRFastWindingNumber: drop XML doc tags so C# bindings build cleanly

### DIFF
--- a/source/MRMesh/MRFastWindingNumber.h
+++ b/source/MRMesh/MRFastWindingNumber.h
@@ -13,37 +13,29 @@ class IFastWindingNumber
 public:
     virtual ~IFastWindingNumber() = default;
 
-    /// <summary>
     /// calculates winding numbers in the points from given vector
-    /// </summary>
-    /// <param name="res">resulting winding numbers, will be resized automatically</param>
-    /// <param name="points">incoming points</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    /// <param name="skipFace">this triangle (if it is close to `q`) will be skipped from summation</param>
+    /// \param res resulting winding numbers, will be resized automatically
+    /// \param points incoming points
+    /// \param beta determines the precision of the approximation: the more the better, recommended value 2 or more
+    /// \param skipFace this triangle (if it is close to `q`) will be skipped from summation
     virtual Expected<void> calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace = {}, const ProgressCallback& cb = {} ) = 0;
 
-    /// <summary>
     /// calculates winding numbers for all centers of mesh's triangles. if winding number is less than 0 or greater then 1, that face is marked as self-intersected
-    /// </summary>
-    /// <param name="res">resulting bit set</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
+    /// \param res resulting bit set
+    /// \param beta determines the precision of the approximation: the more the better, recommended value 2 or more
     virtual Expected<void> calcSelfIntersections( FaceBitSet& res, float beta, const ProgressCallback& cb = {} ) = 0;
 
-    /// <summary>
     /// calculates winding numbers in each point from a three-dimensional grid
-    /// </summary>
-    /// <param name="res">resulting winding numbers, will be resized automatically</param>
-    /// <param name="dims">dimensions of the grid</param>
-    /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
+    /// \param res resulting winding numbers, will be resized automatically
+    /// \param dims dimensions of the grid
+    /// \param gridToMeshXf transform from integer grid locations to voxel's centers in mesh reference frame
+    /// \param beta determines the precision of the approximation: the more the better, recommended value 2 or more
     virtual Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, const ProgressCallback& cb = {} ) = 0;
 
-    /// <summary>
     /// calculates distances with the sign obtained from generalized winding number in each point from a three-dimensional grid;
     /// if sqr(res) < minDistSq or sqr(res) >= maxDistSq, then NaN is returned for such point
-    /// </summary>
-    /// <param name="res">resulting signed distances, will be resized automatically</param>
-    /// <param name="dims">dimensions of the grid</param>
+    /// \param res resulting signed distances, will be resized automatically
+    /// \param dims dimensions of the grid
     virtual Expected<void> calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, const DistanceToMeshOptions& options, const ProgressCallback& cb ) = 0;
 };
 
@@ -85,25 +77,21 @@ public:
     /// \param zOffset - block offset in XY dimension
     using GridByPartsFunc = std::function<Expected<void> ( std::vector<float>&& data, const Vector3i& dims, int zOffset )>;
 
-    /// <summary>
     /// calculates winding numbers in each point from a three-dimensional grid
-    /// </summary>
-    /// <param name="resFunc">callback that gets a block of resulting winding numbers</param>
-    /// <param name="dims">dimensions of the grid</param>
-    /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    /// <param name="layerOverlap">overlap between two blocks of the grid, set as XY layer count</param>
+    /// \param resFunc callback that gets a block of resulting winding numbers
+    /// \param dims dimensions of the grid
+    /// \param gridToMeshXf transform from integer grid locations to voxel's centers in mesh reference frame
+    /// \param beta determines the precision of the approximation: the more the better, recommended value 2 or more
+    /// \param layerOverlap overlap between two blocks of the grid, set as XY layer count
     virtual Expected<void> calcFromGridByParts( GridByPartsFunc resFunc, const Vector3i& dims,
         const AffineXf3f& gridToMeshXf, float beta, int layerOverlap, const ProgressCallback& cb ) = 0;
 
-    /// <summary>
     /// calculates distances with the sign obtained from generalized winding number in each point from a three-dimensional grid;
     /// if sqr(res) < minDistSq or sqr(res) >= maxDistSq, then NaN is returned for such point
-    /// </summary>
-    /// <param name="resFunc">callback that gets a block of resulting winding numbers</param>
-    /// <param name="dims">dimensions of the grid</param>
-    /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
-    /// <param name="layerOverlap">overlap between two blocks of the grid, set as XY layer count</param>
+    /// \param resFunc callback that gets a block of resulting winding numbers
+    /// \param dims dimensions of the grid
+    /// \param gridToMeshXf transform from integer grid locations to voxel's centers in mesh reference frame
+    /// \param layerOverlap overlap between two blocks of the grid, set as XY layer count
     virtual Expected<void> calcFromGridWithDistancesByParts( GridByPartsFunc resFunc, const Vector3i& dims,
         const AffineXf3f& gridToMeshXf, const DistanceToMeshOptions& options, int layerOverlap, const ProgressCallback& cb ) = 0;
 };


### PR DESCRIPTION
## Summary

[`source/MRMesh/MRFastWindingNumber.h`](https://github.com/MeshInspector/MeshLib/blob/master/source/MRMesh/MRFastWindingNumber.h) used `<summary>` / `<param>` XML doc tags directly inside C++ doc comments, intending the tags to pass through verbatim to the generated C# bindings. mrbind's csharp generator detects `<summary>` and short-circuits its escape-and-wrap path, but it does not validate the XML inside. The literal `<` in `if sqr(res) < minDistSq or sqr(res) >= maxDistSq` is not a valid XML tag, so the Windows C# build emitted a long sequence of `CS1570: XML comment has badly formed XML` warnings on the generated `source/MRDotNet2/src/MRCMesh/MRFastWindingNumber.cs` (lines 107 and 543 in [the prior master run](https://github.com/MeshInspector/MeshLib/actions/runs/25161509568/job/73756960715)):

> `Whitespace is not allowed at this location.`
> `Missing equals sign between attribute and attribute value.`
> `The character(s) '(' cannot be used at this location.`
> `End tag 'summary' does not match the start tag 'minDistSq'.`
> `Expected an end tag for element 'summary'.`

…plus several `CS1573 Parameter 'cb' has no matching param tag` warnings stemming from the same blocks.

This change drops the XML doc tags and uses Doxygen `\param` style — the same convention already used elsewhere in this file (see the `GridByPartsFunc` callback docs at lines 74-77). With no `<summary>` in the source, mrbind wraps the comment in its own `<summary>` and HTML-escapes `<`/`>`/`&`, so the generated C# is well-formed XML and the warnings disappear.

## Notes

- Comment-only change to a single header. No semantic / ABI impact.
- Build platforms other than Windows are not affected — disable-build labels applied for non-Windows targets.
- The `\param` lines render as plain text inside the auto-wrapped `<summary>` (mrbind does not translate Doxygen tags into C# `<param>` tags), which is also enough to silence the CS1573 warnings since there are no longer any partial `<param>` lists.

## CI verification

PR run [25166570366](https://github.com/MeshInspector/MeshLib/actions/runs/25166570366) — all four Windows configurations succeeded; zero `CS1570`/`CS1572`/`CS1573` warnings remain on `MRFastWindingNumber.cs` (confirmed against the same `msvc-2022, Release, CMake, 2026.03.18` job that produced the original warning).

## Test plan

- [x] Windows CI completes the C# build step with no CS1570 / CS1573 warnings on `MRFastWindingNumber.cs`.
- [ ] Generated `MRFastWindingNumber.cs` shows escaped `&lt;` / `&gt;` inside the `<summary>` block on the affected methods. *(spot-check on artifact recommended; not directly verified from the CI log)*

## Follow-ups (not in this PR)

- [#6020](https://github.com/MeshInspector/MeshLib/pull/6020) promotes `CS1570` to a build error so future regressions fail the run instead of warning.
- Pre-existing `CS1572`/`CS1573` warnings on `MRProjectionMeshAttribute.cs` (a `<param name="params">` tag pointing at a parameter renamed to `params_`) are unrelated to this PR and remain in the log.
