### PR TITLE
MRDotNet2: fail build on CS1570 "XML comment has badly formed XML"

### DIFF
--- a/source/MRDotNet2/MRDotNet2.csproj
+++ b/source/MRDotNet2/MRDotNet2.csproj
@@ -16,6 +16,12 @@
         1591 - Missing comments
     -->
     <NoWarn>CS0659;CS0661;1591</NoWarn>
+
+    <!-- Promoted to errors:
+        CS1570 - "XML comment has badly formed XML". Generated bindings should always emit well-formed XML doc comments;
+                 if this fires, the bug is in the C++ source comment or in mrbind's csharp generator and must be fixed.
+    -->
+    <WarningsAsErrors>CS1570</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/source/MRMesh/MRFastWindingNumber.h
+++ b/source/MRMesh/MRFastWindingNumber.h
@@ -13,37 +13,29 @@ class IFastWindingNumber
 public:
     virtual ~IFastWindingNumber() = default;
 
-    /// <summary>
     /// calculates winding numbers in the points from given vector
-    /// </summary>
-    /// <param name="res">resulting winding numbers, will be resized automatically</param>
-    /// <param name="points">incoming points</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    /// <param name="skipFace">this triangle (if it is close to `q`) will be skipped from summation</param>
+    /// \param res resulting winding numbers, will be resized automatically
+    /// \param points incoming points
+    /// \param beta determines the precision of the approximation: the more the better, recommended value 2 or more
+    /// \param skipFace this triangle (if it is close to `q`) will be skipped from summation
     virtual Expected<void> calcFromVector( std::vector<float>& res, const std::vector<Vector3f>& points, float beta, FaceId skipFace = {}, const ProgressCallback& cb = {} ) = 0;
 
-    /// <summary>
     /// calculates winding numbers for all centers of mesh's triangles. if winding number is less than 0 or greater then 1, that face is marked as self-intersected
-    /// </summary>
-    /// <param name="res">resulting bit set</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
+    /// \param res resulting bit set
+    /// \param beta determines the precision of the approximation: the more the better, recommended value 2 or more
     virtual Expected<void> calcSelfIntersections( FaceBitSet& res, float beta, const ProgressCallback& cb = {} ) = 0;
 
-    /// <summary>
     /// calculates winding numbers in each point from a three-dimensional grid
-    /// </summary>
-    /// <param name="res">resulting winding numbers, will be resized automatically</param>
-    /// <param name="dims">dimensions of the grid</param>
-    /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
+    /// \param res resulting winding numbers, will be resized automatically
+    /// \param dims dimensions of the grid
+    /// \param gridToMeshXf transform from integer grid locations to voxel's centers in mesh reference frame
+    /// \param beta determines the precision of the approximation: the more the better, recommended value 2 or more
     virtual Expected<void> calcFromGrid( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, float beta, const ProgressCallback& cb = {} ) = 0;
 
-    /// <summary>
     /// calculates distances with the sign obtained from generalized winding number in each point from a three-dimensional grid;
     /// if sqr(res) < minDistSq or sqr(res) >= maxDistSq, then NaN is returned for such point
-    /// </summary>
-    /// <param name="res">resulting signed distances, will be resized automatically</param>
-    /// <param name="dims">dimensions of the grid</param>
+    /// \param res resulting signed distances, will be resized automatically
+    /// \param dims dimensions of the grid
     virtual Expected<void> calcFromGridWithDistances( std::vector<float>& res, const Vector3i& dims, const AffineXf3f& gridToMeshXf, const DistanceToMeshOptions& options, const ProgressCallback& cb ) = 0;
 };
 
@@ -85,25 +77,21 @@ public:
     /// \param zOffset - block offset in XY dimension
     using GridByPartsFunc = std::function<Expected<void> ( std::vector<float>&& data, const Vector3i& dims, int zOffset )>;
 
-    /// <summary>
     /// calculates winding numbers in each point from a three-dimensional grid
-    /// </summary>
-    /// <param name="resFunc">callback that gets a block of resulting winding numbers</param>
-    /// <param name="dims">dimensions of the grid</param>
-    /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
-    /// <param name="beta">determines the precision of the approximation: the more the better, recommended value 2 or more</param>
-    /// <param name="layerOverlap">overlap between two blocks of the grid, set as XY layer count</param>
+    /// \param resFunc callback that gets a block of resulting winding numbers
+    /// \param dims dimensions of the grid
+    /// \param gridToMeshXf transform from integer grid locations to voxel's centers in mesh reference frame
+    /// \param beta determines the precision of the approximation: the more the better, recommended value 2 or more
+    /// \param layerOverlap overlap between two blocks of the grid, set as XY layer count
     virtual Expected<void> calcFromGridByParts( GridByPartsFunc resFunc, const Vector3i& dims,
         const AffineXf3f& gridToMeshXf, float beta, int layerOverlap, const ProgressCallback& cb ) = 0;
 
-    /// <summary>
     /// calculates distances with the sign obtained from generalized winding number in each point from a three-dimensional grid;
     /// if sqr(res) < minDistSq or sqr(res) >= maxDistSq, then NaN is returned for such point
-    /// </summary>
-    /// <param name="resFunc">callback that gets a block of resulting winding numbers</param>
-    /// <param name="dims">dimensions of the grid</param>
-    /// <param name="gridToMeshXf">transform from integer grid locations to voxel's centers in mesh reference frame</param>
-    /// <param name="layerOverlap">overlap between two blocks of the grid, set as XY layer count</param>
+    /// \param resFunc callback that gets a block of resulting winding numbers
+    /// \param dims dimensions of the grid
+    /// \param gridToMeshXf transform from integer grid locations to voxel's centers in mesh reference frame
+    /// \param layerOverlap overlap between two blocks of the grid, set as XY layer count
     virtual Expected<void> calcFromGridWithDistancesByParts( GridByPartsFunc resFunc, const Vector3i& dims,
         const AffineXf3f& gridToMeshXf, const DistanceToMeshOptions& options, int layerOverlap, const ProgressCallback& cb ) = 0;
 };


### PR DESCRIPTION
## Summary

Adds `<WarningsAsErrors>CS1570</WarningsAsErrors>` to `source/MRDotNet2/MRDotNet2.csproj` so any "XML comment has badly formed XML" warning in the generated C# bindings fails the Windows build instead of being buried in the warning list.

CS1570 surfaces real bugs — either the C++ source comment contains characters mrbind cannot pass through safely (the case fixed in #6019), or mrbind's csharp generator is emitting invalid XML. Either way it's something that should be fixed at the source, not tolerated as a warning.

## Scope

The other XML-doc warnings (`CS1572` "param tag for nonexistent parameter" and `CS1573` "parameter has no matching param tag") are intentionally **not** promoted by this PR. Today they fire on `MRProjectionMeshAttribute.cs` because mrbind renames C++ parameters that collide with C# keywords (e.g. `params` → `params_`) but does not rewrite the `<param name="…">` tags in the passed-through XML doc to match. That's a separate fix in mrbind itself; once it lands, `CS1572`/`CS1573` can be added here in a follow-up.

## CI verification

PR run [25168161937](https://github.com/MeshInspector/MeshLib/actions/runs/25168161937) — all four Windows configurations succeeded with `CS1570` promoted. Built on top of #6019, so the previously-warning `MRFastWindingNumber.cs` no longer trips the new error.

## Test plan

- [x] Windows C# build completes with `WarningsAsErrors=CS1570` and no errors (relies on #6019, now merged).
- [ ] Locally introduce a stray `<` in a C++ doc comment and confirm the build now fails with `error CS1570` rather than `warning CS1570`.
