### PR TITLE
MRDotNet2: fail build on CS1572/CS1573 ("XML param tag mismatch")

### DIFF
--- a/source/MRDotNet2/MRDotNet2.csproj
+++ b/source/MRDotNet2/MRDotNet2.csproj
@@ -20,8 +20,14 @@
     <!-- Promoted to errors:
         CS1570 - "XML comment has badly formed XML". Generated bindings should always emit well-formed XML doc comments;
                  if this fires, the bug is in the C++ source comment or in mrbind's csharp generator and must be fixed.
+        CS1572 - "XML comment has a param tag for 'X', but there is no parameter by that name". Usually means a C++
+                 source comment carries a `<param name="X">` tag whose name no longer matches the generated C# parameter
+                 (e.g. mrbind renames `params` -> `params_` to dodge the C# keyword). Fix the source comment, or drop
+                 the XML tags so mrbind wraps the comment in its own `<summary>` instead.
+        CS1573 - "Parameter 'X' has no matching param tag in the XML comment ... (but other parameters do)". Same root
+                 cause as CS1572 — partial / misnamed `<param>` lists in a passed-through C++ comment.
     -->
-    <WarningsAsErrors>CS1570</WarningsAsErrors>
+    <WarningsAsErrors>CS1570;CS1572;CS1573</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/source/MRMesh/MRProjectionMeshAttribute.h
+++ b/source/MRMesh/MRProjectionMeshAttribute.h
@@ -28,15 +28,13 @@ bool projectVertAttribute( const MeshVertPart& mp, const Mesh& oldMesh, F&& func
 template<typename F>
 bool projectFaceAttribute( const MeshPart& mp, const Mesh& oldMesh, F&& func, const ProjectAttributeParams& params = {} );
 
-/// <summary>
 /// finds attributes of new mesh by projecting faces/vertices on old mesh
 /// \note for now clears edges attributes
-/// </summary>
-/// <param name="oldMeshData">old mesh along with input attributes</param>
-/// <param name="newMeshData">new mesh along with outpuyt attributes</param>
-/// <param name="region">optional input region for projecting (usefull if newMesh is changed part of old mesh)</param>
-/// <param name="params">parameters of prohecting</param>
-[[nodiscard]] MRMESH_API Expected<void> projectObjectMeshData( 
+/// \param oldMeshData old mesh along with input attributes
+/// \param newMeshData new mesh along with outpuyt attributes
+/// \param region optional input region for projecting (usefull if newMesh is changed part of old mesh)
+/// \param params parameters of prohecting
+[[nodiscard]] MRMESH_API Expected<void> projectObjectMeshData(
     const ObjectMeshData& oldMeshData, ObjectMeshData& newMeshData, const FaceBitSet* region = nullptr,
     const ProjectAttributeParams& params = {} );
 

--- a/source/MRMesh/MRProjectionMeshAttribute.h
+++ b/source/MRMesh/MRProjectionMeshAttribute.h
@@ -33,7 +33,7 @@ bool projectFaceAttribute( const MeshPart& mp, const Mesh& oldMesh, F&& func, co
 /// \param oldMeshData old mesh along with input attributes
 /// \param newMeshData new mesh along with outpuyt attributes
 /// \param region optional input region for projecting (usefull if newMesh is changed part of old mesh)
-/// \param params parameters of prohecting
+/// \param params parameters of projecting
 [[nodiscard]] MRMESH_API Expected<void> projectObjectMeshData(
     const ObjectMeshData& oldMeshData, ObjectMeshData& newMeshData, const FaceBitSet* region = nullptr,
     const ProjectAttributeParams& params = {} );

--- a/source/MRMesh/MRProjectionMeshAttribute.h
+++ b/source/MRMesh/MRProjectionMeshAttribute.h
@@ -31,8 +31,8 @@ bool projectFaceAttribute( const MeshPart& mp, const Mesh& oldMesh, F&& func, co
 /// finds attributes of new mesh by projecting faces/vertices on old mesh
 /// \note for now clears edges attributes
 /// \param oldMeshData old mesh along with input attributes
-/// \param newMeshData new mesh along with outpuyt attributes
-/// \param region optional input region for projecting (usefull if newMesh is changed part of old mesh)
+/// \param newMeshData new mesh along with output attributes
+/// \param region optional input region for projecting (useful if newMesh is changed part of old mesh)
 /// \param params parameters of projecting
 [[nodiscard]] MRMESH_API Expected<void> projectObjectMeshData(
     const ObjectMeshData& oldMeshData, ObjectMeshData& newMeshData, const FaceBitSet* region = nullptr,


### PR DESCRIPTION
## Summary

Follow-up to [#6019](https://github.com/MeshInspector/MeshLib/pull/6019) and [#6020](https://github.com/MeshInspector/MeshLib/pull/6020). Clears the last remaining XML-doc warnings on the Windows C# build and promotes the related warning codes to errors so future regressions fail CI instead of accumulating.

## What's fixed

The `msvc-2022, Release, CMake, 2026.03.18` Windows job has been emitting these on every run:

```
warning CS1572: XML comment has a param tag for 'params', but there is no parameter by that name
  -> source/MRDotNet2/src/MRCMesh/MRProjectionMeshAttribute.cs(271,22)
warning CS1573: Parameter 'params_' has no matching param tag in the XML comment for 'MR.projectObjectMeshData(...)'
  -> source/MRDotNet2/src/MRCMesh/MRProjectionMeshAttribute.cs(274,190)
```

Root cause: in [`source/MRMesh/MRProjectionMeshAttribute.h`](https://github.com/MeshInspector/MeshLib/blob/master/source/MRMesh/MRProjectionMeshAttribute.h), the doc comment for `projectObjectMeshData` includes `<param name="params">`. The C++ parameter is named `params`, which is a reserved keyword in C# — mrbind renames it to `params_` in the generated binding, but the passed-through `<param name="params">` survives unchanged, leaving a tag for a parameter that doesn't exist (CS1572) and a parameter with no matching tag (CS1573).

Drop the `<summary>` / `<param>` XML tags from that comment block and use Doxygen `\param` style — same approach used for `MRFastWindingNumber.h` in #6019. mrbind then wraps the comment in its own `<summary>` and the name mismatch goes away. Also corrects three typos in the same comment block while it's being rewritten (`prohecting` → `projecting`, `outpuyt` → `output`, `usefull` → `useful`).

## Promoted to errors

Adds `CS1572;CS1573` to `<WarningsAsErrors>` in `source/MRDotNet2/MRDotNet2.csproj`, joining `CS1570` from #6020. Any future C++ binding whose `<param name="…">` doesn't match the generated C# parameter (or that drops a tag for one parameter while keeping tags for others) will now fail the Windows build at the source.

## CI verification

PR run [25171962194](https://github.com/MeshInspector/MeshLib/actions/runs/25171962194) — all four Windows configurations succeeded with `WarningsAsErrors=CS1570;CS1572;CS1573` and zero CS1572/CS1573 errors on `MRProjectionMeshAttribute.cs`.

## Notes

- A more durable fix lives in mrbind itself: when it renames a parameter (e.g. for keyword collisions), it should also rewrite `<param name="…">` tags in passed-through doc comments to use the new name. That's a separate, cross-repo change. The source-side fix here is enough to clear master and turn the warnings into errors today.
- Comment-only changes; no semantic / ABI impact.
- Windows-only change in practice (the warnings only surface in the C# build) — disable-build labels applied for the other platforms.

## Test plan

- [x] Windows CI completes with `WarningsAsErrors=CS1570;CS1572;CS1573` and zero CS1572/CS1573 errors on `MRProjectionMeshAttribute.cs`.
- [ ] Locally introduce a `<param name="bogus">` in a C++ doc comment for an existing function and confirm the build now fails with `error CS1572` rather than `warning`.
