### PR TITLE
ci: enable step debug logging for nuget upload-artifact

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -207,6 +207,8 @@ jobs:
 
      - name: Upload NuGet Package
        uses: actions/upload-artifact@v7
+       env:
+         ACTIONS_STEP_DEBUG: true
        with:
          name: DistributivesNuGet
          path: MeshLib.nupkg


### PR DESCRIPTION
## Summary

`actions/upload-artifact@v7` silently failed in the `create-nuget-package` job of [run 25167087676](https://github.com/MeshInspector/MeshLib/actions/runs/25167087676/job/73784202589):

```
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
```

…and then the step jumped straight to "Post job cleanup" with no error message and no `DistributivesNuGet` artifact produced.

This PR sets `ACTIONS_STEP_DEBUG: true` on just that one step so `core.debug()` output from the action is captured next time it fails. Scoped to the single step to avoid noise in the rest of the workflow logs.

## Test plan

- [ ] CI runs through the `create-nuget-package` job successfully (and logs are noisier, as expected).
- [ ] If/when the upload step fails again, debug output is visible in the step log.
