### PR TITLE
ci(windows): drop wretry.action from upload-artifact steps

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -329,16 +329,12 @@ jobs:
 
       - name: Upload Windows Binaries Archive
         if: ${{ env.job_upload_artifact == 'true' }}
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/upload-artifact@v7
         with:
-          action: actions/upload-artifact@v7
-          attempt_limit: 3
-          attempt_delay: 30000 # milliseconds
-          with: |
-            name: WindowsArchive_${{ matrix.upload_name || matrix.config }}
-            path: MREDist_${{ matrix.upload_name || matrix.config }}.zip
-            retention-days: 1
-            overwrite: true
+          name: WindowsArchive_${{ matrix.upload_name || matrix.config }}
+          path: MREDist_${{ matrix.upload_name || matrix.config }}.zip
+          retention-days: 1
+          overwrite: true
 
       - name: Collect artifact stats
         if: ${{ inputs.internal_build && env.job_upload_artifact == 'true' }}
@@ -351,16 +347,12 @@ jobs:
 
       - name: Upload MeshLibC2 headers archive
         if: ${{ env.job_upload_artifact == 'true' && matrix.config == 'Release' && inputs.mrbind_c }}
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/upload-artifact@v7
         with:
-          action: actions/upload-artifact@v7
-          attempt_limit: 3
-          attempt_delay: 30000 # milliseconds
-          with: |
-            name: WindowsArchive_MeshLibC2Headers
-            path: MeshLibC2Headers.zip
-            retention-days: 1
-            overwrite: true
+          name: WindowsArchive_MeshLibC2Headers
+          path: MeshLibC2Headers.zip
+          retention-days: 1
+          overwrite: true
 
       - name: Create and fix fake Wheel for NuGet
         if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
@@ -372,28 +364,20 @@ jobs:
 
       - name: Upload NuGet files to Artifacts
         if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/upload-artifact@v7
         with:
-          action: actions/upload-artifact@v7
-          attempt_limit: 3
-          attempt_delay: 30000 # milliseconds
-          with: |
-            name: DotNetPatchArchiveWindows-x64
-            path: ./patched_content/*
-            retention-days: 1
-            overwrite: true
+          name: DotNetPatchArchiveWindows-x64
+          path: ./patched_content/*
+          retention-days: 1
+          overwrite: true
 
       - name: Upload NuGet library DLL and XML to Artifacts
         if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/upload-artifact@v7
         with:
-          action: actions/upload-artifact@v7
-          attempt_limit: 3
-          attempt_delay: 30000 # milliseconds
-          with: |
-            name: DotNetDllXml
-            path: |
-              ./source/x64/Release/MRDotNet2.dll
-              ./source/x64/Release/MRDotNet2.xml
-            retention-days: 1
-            overwrite: true
+          name: DotNetDllXml
+          path: |
+            ./source/x64/Release/MRDotNet2.dll
+            ./source/x64/Release/MRDotNet2.xml
+          retention-days: 1
+          overwrite: true


### PR DESCRIPTION
## Summary

Removes the `Wandalen/wretry.action` wrapper from the four `actions/upload-artifact@v7` steps in `.github/workflows/build-test-windows.yml`. The wrapper was added in #5975 to retry artifact uploads on transient self-hosted-runner network flakes (typically `ENOTFOUND` on `CreateArtifact`).

## Why drop it for Windows

1. **Most of our Windows CI runs on GitHub-hosted runners**, where the DNS / connect blips that motivated #5975 are not a real concern. (The macOS workflow keeps the wrapper since those runners are self-hosted.)
2. **The wrapper is noisy on Windows.** Every wretry-wrapped step emits:

    ```
    Warning: Environment variable 'INPUT_GITHUB_CONTEXT' exceeds the maximum supported length. Environment variable length: 39289 , Maximum supported length: 32766
    ```

    `wretry.action` forwards `toJson(github)` to its inner action via the `INPUT_GITHUB_CONTEXT` env var, and the serialized context (~39 KB on `pull_request` runs in this repo) exceeds Windows' 32767-char `CreateProcessW` env-block limit. The runner truncates the value and logs the warning. Tracking issue upstream: https://github.com/Wandalen/wretry.action/issues/192.

The truncation itself is harmless (`actions/upload-artifact` doesn't read `INPUT_GITHUB_CONTEXT`), but with 4 wretry steps × every Windows matrix leg the warning floods the logs.

## Test plan

- [x] Windows build-test legs pass with plain `actions/upload-artifact@v7` — all 4 matrix legs green on this PR.
- [x] No more `INPUT_GITHUB_CONTEXT exceeds the maximum supported length` warnings in the Windows job logs — verified zero occurrences in run [25182993114](https://github.com/MeshInspector/MeshLib/actions/runs/25182993114).
