### PR TITLE
ci(prepare-images): respect disable-build-* PR labels

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -45,6 +45,11 @@ jobs:
       vcpkg_docker_image_tag:     ${{ needs.config.outputs.vcpkg_docker_image_tag }}
       vs19_vcpkg_version:         ${{ needs.config.outputs.vs19_vcpkg_version }}
       vs22_vcpkg_version:         ${{ needs.config.outputs.vs22_vcpkg_version }}
+      disable_ubuntu_x64:         ${{ needs.config.outputs.build_enable_ubuntu_x64 != 'true' }}
+      disable_ubuntu_arm64:       ${{ needs.config.outputs.build_enable_ubuntu_arm64 != 'true' }}
+      disable_emscripten:         ${{ needs.config.outputs.build_enable_emscripten != 'true' }}
+      disable_linux_vcpkg:        ${{ needs.config.outputs.build_enable_linux_vcpkg != 'true' }}
+      disable_windows:            ${{ needs.config.outputs.build_enable_windows != 'true' }}
     secrets: inherit
 
   versioning-and-release-url:

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -24,6 +24,24 @@ on:
       vs22_vcpkg_version:
         required: true
         type: string
+      # `disable-build-<platform>` PR labels (resolved upstream in
+      # config.yml) — skip the matching image build cells / jobs so we
+      # don't burn runner time producing images no consumer will use.
+      disable_ubuntu_x64:
+        type: boolean
+        default: false
+      disable_ubuntu_arm64:
+        type: boolean
+        default: false
+      disable_emscripten:
+        type: boolean
+        default: false
+      disable_linux_vcpkg:
+        type: boolean
+        default: false
+      disable_windows:
+        type: boolean
+        default: false
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -36,7 +54,13 @@ jobs:
         run: echo
 
   linux-image-build-upload:
-    if: ${{ inputs.need_linux_image_rebuild }}
+    # Skip per-cell when the disable-build-<platform> label for this
+    # (distro, arch) is set — see workflow_call inputs above.
+    if: >-
+      ${{ inputs.need_linux_image_rebuild
+          && !(matrix.distro == 'emscripten' && inputs.disable_emscripten)
+          && !(startsWith(matrix.distro, 'ubuntu') && matrix.arch == 'x64' && inputs.disable_ubuntu_x64)
+          && !(startsWith(matrix.distro, 'ubuntu') && matrix.arch == 'arm64' && inputs.disable_ubuntu_arm64) }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
@@ -102,7 +126,7 @@ jobs:
         run: docker system prune --force --all --volumes
 
   linux-vcpkg-build-upload:
-    if: ${{ inputs.need_linux_vcpkg_rebuild }}
+    if: ${{ inputs.need_linux_vcpkg_rebuild && !inputs.disable_linux_vcpkg }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
@@ -141,7 +165,7 @@ jobs:
         run: docker system prune --force --all --volumes
 
   windows-vcpkg-build-upload:
-    if: ${{ inputs.need_windows_vcpkg_rebuild }}
+    if: ${{ inputs.need_windows_vcpkg_rebuild && !inputs.disable_windows }}
     timeout-minutes: 240
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -70,16 +70,19 @@ jobs:
           DISABLE_UBUNTU_ARM64: ${{ inputs.disable_ubuntu_arm64 }}
           DISABLE_EMSCRIPTEN:   ${{ inputs.disable_emscripten }}
         run: |
+          # Only `distro` and `arch` are encoded here so the auto-generated
+          # cell name stays "(<distro>, <arch>)"; the runner OS and image
+          # suffix are derived from `matrix.arch` inline below.
           MATRIX=$(jq -nc \
             --argjson dx64   "$DISABLE_UBUNTU_X64" \
             --argjson darm64 "$DISABLE_UBUNTU_ARM64" \
             --argjson demscr "$DISABLE_EMSCRIPTEN" \
             '[
-              {distro:"ubuntu22",   arch:"x64",   "image-suffix":"",       os:"ubuntu-latest"},
-              {distro:"ubuntu24",   arch:"x64",   "image-suffix":"",       os:"ubuntu-latest"},
-              {distro:"ubuntu22",   arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"},
-              {distro:"ubuntu24",   arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"},
-              {distro:"emscripten", arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"}
+              {distro:"ubuntu22",   arch:"x64"  },
+              {distro:"ubuntu24",   arch:"x64"  },
+              {distro:"ubuntu22",   arch:"arm64"},
+              {distro:"ubuntu24",   arch:"arm64"},
+              {distro:"emscripten", arch:"arm64"}
              ] | map(select(
               (((.distro|startswith("ubuntu")) and (.arch=="x64"  ) and $dx64  ) | not)
               and (((.distro|startswith("ubuntu")) and (.arch=="arm64") and $darm64) | not)
@@ -101,10 +104,10 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.compute-linux-image-matrix.outputs.matrix) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     env:
       dockerfile: ${{ matrix.distro }}Dockerfile
-      image: meshlib/meshlib-${{ matrix.distro }}${{ matrix.image-suffix }}:${{ inputs.docker_image_tag }}
+      image: meshlib/meshlib-${{ matrix.distro }}${{ matrix.arch == 'arm64' && '-arm64' || '' }}:${{ inputs.docker_image_tag }}
     steps:
       - name: Work-around possible permission issues
         shell: bash

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -53,30 +53,54 @@ jobs:
       - name: Do nothing
         run: echo
 
+  # Build the linux-image matrix dynamically so we can drop cells the
+  # PR has opted out of via `disable-build-<platform>` labels. The
+  # `matrix` context is not available in job-level `if:` for reusable
+  # workflow inputs, so per-cell skipping must happen here.
+  compute-linux-image-matrix:
+    if: ${{ inputs.need_linux_image_rebuild }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+      empty:  ${{ steps.compute.outputs.empty }}
+    steps:
+      - id: compute
+        env:
+          DISABLE_UBUNTU_X64:   ${{ inputs.disable_ubuntu_x64 }}
+          DISABLE_UBUNTU_ARM64: ${{ inputs.disable_ubuntu_arm64 }}
+          DISABLE_EMSCRIPTEN:   ${{ inputs.disable_emscripten }}
+        run: |
+          MATRIX=$(jq -nc \
+            --argjson dx64   "$DISABLE_UBUNTU_X64" \
+            --argjson darm64 "$DISABLE_UBUNTU_ARM64" \
+            --argjson demscr "$DISABLE_EMSCRIPTEN" \
+            '[
+              {distro:"ubuntu22",   arch:"x64",   "image-suffix":"",       os:"ubuntu-latest"},
+              {distro:"ubuntu24",   arch:"x64",   "image-suffix":"",       os:"ubuntu-latest"},
+              {distro:"ubuntu22",   arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"},
+              {distro:"ubuntu24",   arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"},
+              {distro:"emscripten", arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"}
+             ] | map(select(
+              (((.distro|startswith("ubuntu")) and (.arch=="x64"  ) and $dx64  ) | not)
+              and (((.distro|startswith("ubuntu")) and (.arch=="arm64") and $darm64) | not)
+              and (((.distro=="emscripten")                              and $demscr) | not)
+             ))')
+          echo "matrix=${MATRIX}"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+          if [[ "${MATRIX}" == "[]" ]]; then
+            echo "empty=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "empty=false" >> "$GITHUB_OUTPUT"
+          fi
+
   linux-image-build-upload:
-    # Skip per-cell when the disable-build-<platform> label for this
-    # (distro, arch) is set — see workflow_call inputs above.
-    if: >-
-      ${{ inputs.need_linux_image_rebuild
-          && !(matrix.distro == 'emscripten' && inputs.disable_emscripten)
-          && !(startsWith(matrix.distro, 'ubuntu') && matrix.arch == 'x64' && inputs.disable_ubuntu_x64)
-          && !(startsWith(matrix.distro, 'ubuntu') && matrix.arch == 'arm64' && inputs.disable_ubuntu_arm64) }}
+    needs: compute-linux-image-matrix
+    if: ${{ needs.compute-linux-image-matrix.outputs.empty == 'false' }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
-        distro: [ ubuntu22, ubuntu24, emscripten ]
-        arch: [ x64, arm64 ]
-        exclude:
-          - distro: emscripten
-            arch: x64
-        include:
-          - arch: x64
-            image-suffix: ''
-            os: ubuntu-latest
-          - arch: arm64
-            image-suffix: '-arm64'
-            os: ubuntu-24.04-arm
+        include: ${{ fromJSON(needs.compute-linux-image-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     env:
       dockerfile: ${{ matrix.distro }}Dockerfile


### PR DESCRIPTION
## Summary

The `prepare-images` workflow rebuilt every Docker image whenever the relevant Dockerfile / requirements / `vcpkg/**` paths changed, ignoring any `disable-build-<platform>` PR labels. So a PR that legitimately disabled a platform still paid for that platform's image build (the slowest of which — the Windows vcpkg cache — is a 4-hour budget job).

This PR plumbs the existing `build_enable_<platform>` config outputs through to `prepare-images` and skips the matching cells / jobs. Live-label semantics from #6008 are inherited transparently — `build_enable_*` is already derived from `gh pr view`-fetched labels at job time, so adding/removing a `disable-build-*` label and re-running CI takes effect on the next run.

Label → skipped image build:

| Label | Skipped cells |
|---|---|
| `disable-build-ubuntu-x64` | `ubuntu22/x64`, `ubuntu24/x64` |
| `disable-build-ubuntu-arm64` | `ubuntu22/arm64`, `ubuntu24/arm64` |
| `disable-build-emscripten` | `emscripten/arm64` |
| `disable-build-linux-vcpkg` | `rockylinux8-vcpkg/{x64,arm64}` |
| `disable-build-windows` | vs2019 + vs2022 vcpkg cache builds |

Implementation:

- `prepare-images.yml` — five new boolean `workflow_call` inputs (`disable_ubuntu_x64`, `disable_ubuntu_arm64`, `disable_emscripten`, `disable_linux_vcpkg`, `disable_windows`), all defaulting to `false` so `workflow_dispatch` keeps building everything.
  - The two single-platform jobs (`linux-vcpkg-build-upload`, `windows-vcpkg-build-upload`) just AND `!inputs.disable_<platform>` into the existing rebuild-needed `if:`.
  - The `linux-image-build-upload` job needs per-cell skipping (drop `ubuntu*/x64` cells while keeping `ubuntu*/arm64` and `emscripten/arm64`). `matrix` context isn't available in job-level `if:` for reusable workflow inputs, so a small upstream `compute-linux-image-matrix` job emits a `jq`-filtered include list and the build job consumes it via `matrix.include: ${{ fromJSON(...) }}`. Matrix entries carry only `{distro, arch}` so the auto-generated cell name stays `(<distro>, <arch>)`; `runs-on` and the image suffix are derived from `matrix.arch` inline.
- `build-test-distribute.yml` — wires the existing `needs.config.outputs.build_enable_<platform>` flags (negated, so `enable=false` → `disable=true`) into the new inputs. No new config outputs needed since `build_enable_*` already collapses `tag-disable-<platform>` and `tag-update-doc-only`.

Skipped matrix cells / jobs show as "Skipped" in the UI, and the called workflow remains a `success()` for downstream `needs:` consumers (the existing `always-success` job guarantees at least one cell).

## Test plan

Verified end-to-end in sandbox PR #6030 (closed; HEAD preserved as tag `wip/sandbox-test-disable-labels-pr-6030`), which touched `docker/ubuntu22Dockerfile` + `thirdparty/vcpkg/triplets/x64-linux-meshlib.cmake` to force all three `need_*_rebuild=true`, with labels `disable-build-{ubuntu-x64,windows,linux-vcpkg,macos}` applied. Run [25277872552](https://github.com/MeshInspector/MeshLib/actions/runs/25277872552):

- [x] `disable-build-windows` skips `windows-vcpkg-build-upload` (and `disable-build-linux-vcpkg` skips `linux-vcpkg-build-upload`) **even when** their `need_*_rebuild` is `true` — both observed `skipped`.
- [x] `disable-build-ubuntu-x64` drops `ubuntu*/x64` cells while keeping `ubuntu*/arm64` and `emscripten/arm64` — `compute-linux-image-matrix` emitted exactly 3 cells (`(ubuntu22, arm64)`, `(ubuntu24, arm64)`, `(emscripten, arm64)`), no `*/x64` cells spawned. `(emscripten, arm64)` built green; the two ubuntu arm64 cells failed inside the Dockerfile on a transient Launchpad PPA timeout (`add-apt-repository` → `api.launchpad.net`), unrelated to this PR.
- [x] No `disable-build-*` labels behaves identically to today — verified by inspection: all `disable_*` default to `false`, the `jq` filter then keeps all 5 cells, and the two single-platform jobs reduce to the master-baseline `if:` expression.
- [x] `workflow_dispatch` keeps building everything — verified by inspection: every new input has `default: false`; no preexisting `need_*_rebuild` semantics change.
