### PR TITLE
[SANDBOX/DO-NOT-MERGE] verify prepare-images disable-build-* skipping for #6029

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -45,6 +45,11 @@ jobs:
       vcpkg_docker_image_tag:     ${{ needs.config.outputs.vcpkg_docker_image_tag }}
       vs19_vcpkg_version:         ${{ needs.config.outputs.vs19_vcpkg_version }}
       vs22_vcpkg_version:         ${{ needs.config.outputs.vs22_vcpkg_version }}
+      disable_ubuntu_x64:         ${{ needs.config.outputs.build_enable_ubuntu_x64 != 'true' }}
+      disable_ubuntu_arm64:       ${{ needs.config.outputs.build_enable_ubuntu_arm64 != 'true' }}
+      disable_emscripten:         ${{ needs.config.outputs.build_enable_emscripten != 'true' }}
+      disable_linux_vcpkg:        ${{ needs.config.outputs.build_enable_linux_vcpkg != 'true' }}
+      disable_windows:            ${{ needs.config.outputs.build_enable_windows != 'true' }}
     secrets: inherit
 
   versioning-and-release-url:

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -24,6 +24,24 @@ on:
       vs22_vcpkg_version:
         required: true
         type: string
+      # `disable-build-<platform>` PR labels (resolved upstream in
+      # config.yml) — skip the matching image build cells / jobs so we
+      # don't burn runner time producing images no consumer will use.
+      disable_ubuntu_x64:
+        type: boolean
+        default: false
+      disable_ubuntu_arm64:
+        type: boolean
+        default: false
+      disable_emscripten:
+        type: boolean
+        default: false
+      disable_linux_vcpkg:
+        type: boolean
+        default: false
+      disable_windows:
+        type: boolean
+        default: false
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -36,7 +54,13 @@ jobs:
         run: echo
 
   linux-image-build-upload:
-    if: ${{ inputs.need_linux_image_rebuild }}
+    # Skip per-cell when the disable-build-<platform> label for this
+    # (distro, arch) is set — see workflow_call inputs above.
+    if: >-
+      ${{ inputs.need_linux_image_rebuild
+          && !(matrix.distro == 'emscripten' && inputs.disable_emscripten)
+          && !(startsWith(matrix.distro, 'ubuntu') && matrix.arch == 'x64' && inputs.disable_ubuntu_x64)
+          && !(startsWith(matrix.distro, 'ubuntu') && matrix.arch == 'arm64' && inputs.disable_ubuntu_arm64) }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
@@ -102,7 +126,7 @@ jobs:
         run: docker system prune --force --all --volumes
 
   linux-vcpkg-build-upload:
-    if: ${{ inputs.need_linux_vcpkg_rebuild }}
+    if: ${{ inputs.need_linux_vcpkg_rebuild && !inputs.disable_linux_vcpkg }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
@@ -141,7 +165,7 @@ jobs:
         run: docker system prune --force --all --volumes
 
   windows-vcpkg-build-upload:
-    if: ${{ inputs.need_windows_vcpkg_rebuild }}
+    if: ${{ inputs.need_windows_vcpkg_rebuild && !inputs.disable_windows }}
     timeout-minutes: 240
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -70,16 +70,19 @@ jobs:
           DISABLE_UBUNTU_ARM64: ${{ inputs.disable_ubuntu_arm64 }}
           DISABLE_EMSCRIPTEN:   ${{ inputs.disable_emscripten }}
         run: |
+          # Only `distro` and `arch` are encoded here so the auto-generated
+          # cell name stays "(<distro>, <arch>)"; the runner OS and image
+          # suffix are derived from `matrix.arch` inline below.
           MATRIX=$(jq -nc \
             --argjson dx64   "$DISABLE_UBUNTU_X64" \
             --argjson darm64 "$DISABLE_UBUNTU_ARM64" \
             --argjson demscr "$DISABLE_EMSCRIPTEN" \
             '[
-              {distro:"ubuntu22",   arch:"x64",   "image-suffix":"",       os:"ubuntu-latest"},
-              {distro:"ubuntu24",   arch:"x64",   "image-suffix":"",       os:"ubuntu-latest"},
-              {distro:"ubuntu22",   arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"},
-              {distro:"ubuntu24",   arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"},
-              {distro:"emscripten", arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"}
+              {distro:"ubuntu22",   arch:"x64"  },
+              {distro:"ubuntu24",   arch:"x64"  },
+              {distro:"ubuntu22",   arch:"arm64"},
+              {distro:"ubuntu24",   arch:"arm64"},
+              {distro:"emscripten", arch:"arm64"}
              ] | map(select(
               (((.distro|startswith("ubuntu")) and (.arch=="x64"  ) and $dx64  ) | not)
               and (((.distro|startswith("ubuntu")) and (.arch=="arm64") and $darm64) | not)
@@ -101,10 +104,10 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.compute-linux-image-matrix.outputs.matrix) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     env:
       dockerfile: ${{ matrix.distro }}Dockerfile
-      image: meshlib/meshlib-${{ matrix.distro }}${{ matrix.image-suffix }}:${{ inputs.docker_image_tag }}
+      image: meshlib/meshlib-${{ matrix.distro }}${{ matrix.arch == 'arm64' && '-arm64' || '' }}:${{ inputs.docker_image_tag }}
     steps:
       - name: Work-around possible permission issues
         shell: bash

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -53,30 +53,54 @@ jobs:
       - name: Do nothing
         run: echo
 
+  # Build the linux-image matrix dynamically so we can drop cells the
+  # PR has opted out of via `disable-build-<platform>` labels. The
+  # `matrix` context is not available in job-level `if:` for reusable
+  # workflow inputs, so per-cell skipping must happen here.
+  compute-linux-image-matrix:
+    if: ${{ inputs.need_linux_image_rebuild }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+      empty:  ${{ steps.compute.outputs.empty }}
+    steps:
+      - id: compute
+        env:
+          DISABLE_UBUNTU_X64:   ${{ inputs.disable_ubuntu_x64 }}
+          DISABLE_UBUNTU_ARM64: ${{ inputs.disable_ubuntu_arm64 }}
+          DISABLE_EMSCRIPTEN:   ${{ inputs.disable_emscripten }}
+        run: |
+          MATRIX=$(jq -nc \
+            --argjson dx64   "$DISABLE_UBUNTU_X64" \
+            --argjson darm64 "$DISABLE_UBUNTU_ARM64" \
+            --argjson demscr "$DISABLE_EMSCRIPTEN" \
+            '[
+              {distro:"ubuntu22",   arch:"x64",   "image-suffix":"",       os:"ubuntu-latest"},
+              {distro:"ubuntu24",   arch:"x64",   "image-suffix":"",       os:"ubuntu-latest"},
+              {distro:"ubuntu22",   arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"},
+              {distro:"ubuntu24",   arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"},
+              {distro:"emscripten", arch:"arm64", "image-suffix":"-arm64", os:"ubuntu-24.04-arm"}
+             ] | map(select(
+              (((.distro|startswith("ubuntu")) and (.arch=="x64"  ) and $dx64  ) | not)
+              and (((.distro|startswith("ubuntu")) and (.arch=="arm64") and $darm64) | not)
+              and (((.distro=="emscripten")                              and $demscr) | not)
+             ))')
+          echo "matrix=${MATRIX}"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+          if [[ "${MATRIX}" == "[]" ]]; then
+            echo "empty=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "empty=false" >> "$GITHUB_OUTPUT"
+          fi
+
   linux-image-build-upload:
-    # Skip per-cell when the disable-build-<platform> label for this
-    # (distro, arch) is set — see workflow_call inputs above.
-    if: >-
-      ${{ inputs.need_linux_image_rebuild
-          && !(matrix.distro == 'emscripten' && inputs.disable_emscripten)
-          && !(startsWith(matrix.distro, 'ubuntu') && matrix.arch == 'x64' && inputs.disable_ubuntu_x64)
-          && !(startsWith(matrix.distro, 'ubuntu') && matrix.arch == 'arm64' && inputs.disable_ubuntu_arm64) }}
+    needs: compute-linux-image-matrix
+    if: ${{ needs.compute-linux-image-matrix.outputs.empty == 'false' }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
-        distro: [ ubuntu22, ubuntu24, emscripten ]
-        arch: [ x64, arm64 ]
-        exclude:
-          - distro: emscripten
-            arch: x64
-        include:
-          - arch: x64
-            image-suffix: ''
-            os: ubuntu-latest
-          - arch: arm64
-            image-suffix: '-arm64'
-            os: ubuntu-24.04-arm
+        include: ${{ fromJSON(needs.compute-linux-image-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     env:
       dockerfile: ${{ matrix.distro }}Dockerfile

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:22.04 AS build
 
+# sandbox CI verification touch — exercises prepare-images.yml disable-build-* labels in PR #6029
 # update and install req
 RUN export DEBIAN_FRONTEND=noninteractive; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \

--- a/thirdparty/vcpkg/triplets/x64-linux-meshlib.cmake
+++ b/thirdparty/vcpkg/triplets/x64-linux-meshlib.cmake
@@ -1,3 +1,4 @@
+# sandbox CI verification touch — exercises prepare-images.yml disable-build-* labels in PR #6029
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)


### PR DESCRIPTION
## Sandbox / DRAFT — do not merge

Throwaway PR to exercise the per-cell / per-job `disable-build-*` label skipping introduced in #6029. Branched off `ci-prepare-images-respect-disable-labels` (so PR #6029's logic is in effect) plus a tiny touch to two trigger paths so all three `need_*_rebuild` flags fire:

- `docker/ubuntu22Dockerfile` (comment line) → `need_linux_image_rebuild=true`
- `thirdparty/vcpkg/triplets/x64-linux-meshlib.cmake` (comment line) → `need_linux_vcpkg_rebuild=true` and `need_windows_vcpkg_rebuild=true`

### Labels applied

- `disable-build-ubuntu-x64` — should drop `ubuntu22/x64` + `ubuntu24/x64` cells from `linux-image-build-upload`
- `disable-build-windows` — should skip `windows-vcpkg-build-upload` (despite `need_windows_vcpkg_rebuild=true`)
- `disable-build-linux-vcpkg` — should skip `linux-vcpkg-build-upload` (despite `need_linux_vcpkg_rebuild=true`)
- `disable-build-macos` — keeps macos out of CI burn

### Expected results

`prepare-image` jobs:

| Job | Expected | Verifies |
|---|---|---|
| `compute-linux-image-matrix` | runs, outputs 3-cell include | per-cell drop logic |
| `linux-image-build-upload` | runs `ubuntu22-arm64`, `ubuntu24-arm64`, `emscripten-arm64`; **no** `*/x64` cells | item 2 |
| `linux-vcpkg-build-upload` | **skipped** | item 1 (vcpkg variant) |
| `windows-vcpkg-build-upload` | **skipped** | item 1 |

Downstream `*-build-test` jobs are not the focus here — the user can cancel them once `prepare-image` reports complete to limit CI burn.

### After verification

Close without merging.
