### PR TITLE
MRMeshBoolean: drop redundant 6-arg boolean(Mesh&&, ...) overload

### DIFF
--- a/source/MRMesh/MRMeshBoolean.cpp
+++ b/source/MRMesh/MRMeshBoolean.cpp
@@ -102,7 +102,7 @@ BooleanResult boolean( const Mesh& meshA, const Mesh& meshB, BooleanOperation op
 BooleanResult boolean( Mesh&& meshA, Mesh&& meshB, BooleanOperation operation,
                        const AffineXf3f* rigidB2A /*= nullptr */, BooleanResultMapper* mapper /*= nullptr */, ProgressCallback cb )
 {
-    return boolean( meshA, meshB, operation, { .rigidB2A = rigidB2A, .mapper = mapper, .cb = cb } );
+    return boolean( std::move( meshA ), std::move( meshB ), operation, { .rigidB2A = rigidB2A, .mapper = mapper, .cb = cb } );
 }
 
 BooleanResult boolean( const Mesh& meshA, const Mesh& meshB, BooleanOperation operation, const BooleanParameters& params /*= {} */ )

--- a/source/MRMesh/MRMeshBoolean.cpp
+++ b/source/MRMesh/MRMeshBoolean.cpp
@@ -99,12 +99,6 @@ BooleanResult boolean( const Mesh& meshA, const Mesh& meshB, BooleanOperation op
     return boolean( meshA, meshB, operation, { .rigidB2A = rigidB2A, .mapper = mapper, .cb = cb } );
 }
 
-BooleanResult boolean( Mesh&& meshA, Mesh&& meshB, BooleanOperation operation,
-                       const AffineXf3f* rigidB2A /*= nullptr */, BooleanResultMapper* mapper /*= nullptr */, ProgressCallback cb )
-{
-    return boolean( std::move( meshA ), std::move( meshB ), operation, { .rigidB2A = rigidB2A, .mapper = mapper, .cb = cb } );
-}
-
 BooleanResult boolean( const Mesh& meshA, const Mesh& meshB, BooleanOperation operation, const BooleanParameters& params /*= {} */ )
 {
     bool needCutMeshA = operation != BooleanOperation::InsideB && operation != BooleanOperation::OutsideB;

--- a/source/MRMesh/MRMeshBoolean.h
+++ b/source/MRMesh/MRMeshBoolean.h
@@ -61,8 +61,7 @@ struct BooleanResult
   */
 MRMESH_API BooleanResult boolean( const Mesh& meshA, const Mesh& meshB, BooleanOperation operation,
                                   const AffineXf3f* rigidB2A, BooleanResultMapper* mapper = nullptr, ProgressCallback cb = {} );
-MRMESH_API BooleanResult boolean( Mesh&& meshA, Mesh&& meshB, BooleanOperation operation,
-                                  const AffineXf3f* rigidB2A, BooleanResultMapper* mapper = nullptr, ProgressCallback cb = {} );
+// no version of the function with rvalue-referenced meshes, because meshes' copies are currently used for sorting intersections
 
 
 struct BooleanPreCutResult


### PR DESCRIPTION
### What this changes

Removes the 6-arg `boolean( Mesh&&, Mesh&&, BooleanOperation, const AffineXf3f*, BooleanResultMapper*, ProgressCallback )` overload — both the declaration in `source/MRMesh/MRMeshBoolean.h` and the definition in `source/MRMesh/MRMeshBoolean.cpp` — and adds a header comment explaining why no rvalue version of the legacy 6-arg form exists.

### Why

The deleted overload was not broken; it simply gave callers no advantage over the `const Mesh&` overload. The implementation that ultimately runs (`boolean( const Mesh&, const Mesh&, ..., const BooleanParameters& )`) hands `booleanImpl` pointers to the original meshes (`originalMeshA = &meshA`, `originalMeshB = &meshB`), which are then used for sorting intersection contours. Any honest `Mesh&&` implementation would have to keep the originals alive for that step too, so it could not actually avoid the copies its signature seemed to promise. The overload was therefore redundant — the const-ref overload is the only useful form for this 6-arg shape.

The header now records this so the absence is intentional and discoverable:

```cpp
// no version of the function with rvalue-referenced meshes, because meshes' copies are currently used for sorting intersections
```

### Scope

- The 4-arg `boolean( Mesh&&, Mesh&&, BooleanOperation, const BooleanParameters& )` overload is unchanged. It takes a different code path (calls `booleanImpl` directly with empty `BooleanInternalParameters`) and remains available for callers that want to pass meshes by rvalue.
- No in-tree callers used the removed overload.

Original observation about the missing `std::move` came from an external reader of the source.
