### PR TITLE
MCP: bypass file dialogs under TestEngine with staged paths

### DIFF
--- a/source/MRViewer/MRFileDialog.cpp
+++ b/source/MRViewer/MRFileDialog.cpp
@@ -3,11 +3,14 @@
 #include "MRViewerFwd.h"
 #include "MRColorTheme.h"
 #include "MRCommandLoop.h"
+#include "MRUITestEngine.h"
 #include "MRViewer.h"
 #include "MRMesh/MRConfig.h"
+#include "MRMesh/MRExpected.h"
 #include "MRMesh/MRFinally.h"
 #include "MRMesh/MRStringConvert.h"
 #include "MRMesh/MRSystem.h"
+#include "MRPch/MRFmt.h"
 #include "MRPch/MRSpdlog.h"
 #include "MRPch/MRWasm.h"
 
@@ -384,8 +387,66 @@ std::string webAccumFilter( const MR::IOFilters& filters )
 }
 #endif
 
+// Validate paths staged by `MR::UI::TestEngine::stageFileDialogPaths` against the
+// dialog's `Parameters`. Empty error means OK. Rules:
+//   - paths must be non-empty.
+//   - if !multiselect: exactly one path.
+//   - saveDialog: target is always a file (no save-folder API). Skip existence check
+//     (file may be brand-new), but reject paths that already exist as a directory.
+//   - else folderDialog: each path must be an existing directory.
+//   - else (open file): each path must be an existing regular file.
+MR::Expected<void> sValidateStagedFileDialogPaths(
+    const std::vector<std::filesystem::path>& paths,
+    const MR::FileDialog::Parameters& parameters )
+{
+    if ( paths.empty() )
+        return MR::unexpected( std::string( "no paths were staged" ) );
+
+    if ( !parameters.multiselect && paths.size() > 1 )
+        return MR::unexpected( fmt::format( "dialog expects a single path but {} were staged", paths.size() ) );
+
+    if ( parameters.saveDialog )
+    {
+        std::error_code ec;
+        if ( std::filesystem::is_directory( paths[0], ec ) )
+            return MR::unexpected( fmt::format(
+                "save target '{}' exists and is a directory, expected a file path",
+                MR::utf8string( paths[0] ) ) );
+        return {};
+    }
+
+    for ( const auto& p : paths )
+    {
+        std::error_code ec;
+        const bool ok = parameters.folderDialog
+            ? std::filesystem::is_directory( p, ec )
+            : std::filesystem::is_regular_file( p, ec );
+        if ( !ok )
+        {
+            return MR::unexpected( fmt::format( "staged path '{}' is not an existing {}",
+                MR::utf8string( p ),
+                parameters.folderDialog ? "directory" : "file" ) );
+        }
+    }
+    return {};
+}
+
 std::vector<std::filesystem::path> runDialog( const MR::FileDialog::Parameters& parameters )
 {
+    if ( MR::UI::TestEngine::wasFrameTriggered() )
+    {
+        auto staged = MR::UI::TestEngine::consumeStagedFileDialogPaths();
+        if ( auto ex = sValidateStagedFileDialogPaths( staged, parameters ); !ex )
+        {
+            MR::UI::TestEngine::appendStatusMessage( fmt::format(
+                "TestEngine-triggered file dialog: {}. "
+                "Call ui.stageFileDialogPaths(...) with the right path(s) before pressing the button.",
+                ex.error() ) );
+            return {};
+        }
+        return staged;
+    }
+
 #if defined( __EMSCRIPTEN__ )
     (void)parameters;
     return {};

--- a/source/MRViewer/MRUITestEngine.cpp
+++ b/source/MRViewer/MRUITestEngine.cpp
@@ -25,6 +25,16 @@ struct State
 
     // The stack for `pushTree()`, `popTree()`. Always has at least one element.
     std::vector<GroupEntry*> stack = { &root };
+
+    // True if a TE-driven action (simulated click or value override) ran this frame.
+    // Cleared at frame boundary in `checkForNewFrame()`.
+    bool frameTriggered = false;
+
+    // Paths staged for the next TE-triggered file dialog to return. Single-shot.
+    std::vector<std::filesystem::path> stagedFileDialogPaths;
+
+    // Status messages emitted during TE-driven actions; drained by MCP after each dispatch.
+    std::vector<std::string> statusMessages;
 };
 // Our global state. Stores the current tree of buttons and button groups.
 State state;
@@ -75,6 +85,7 @@ void checkForNewFrame()
     if ( ImGui::GetFrameCount() != state.curFrame )
     {
         state.curFrame = ImGui::GetFrameCount();
+        state.frameTriggered = false;
 
         // Make sure the tree stack is fine.
         assert(state.stack.size() == 1 && "Missing `UI::TestEngine::popTree()`.");
@@ -145,6 +156,8 @@ std::optional<T> detail::createValueLow( std::string_view name, std::optional<Bo
         {
             ret = val->simulatedValue;
         }
+        if ( ret )
+            state.frameTriggered = true;
     }
     else
     {
@@ -210,7 +223,10 @@ bool createButton( std::string_view name, const EntryAttributes& attrs )
     // if ( button->simulateClick )
     //    spdlog::info( "Button {} click simulation", name );
 
-    return std::exchange( button->simulateClick, false );
+    const bool clicked = std::exchange( button->simulateClick, false );
+    if ( clicked )
+        state.frameTriggered = true;
+    return clicked;
     #else
     (void)attrs;
     return false;
@@ -265,6 +281,51 @@ std::string_view Entry::getKindName() const
 const GroupEntry& getRootEntry()
 {
     return state.root;
+}
+
+bool wasFrameTriggered()
+{
+    #if MR_ENABLE_UI_TEST_ENGINE
+    return state.frameTriggered;
+    #else
+    return false;
+    #endif
+}
+
+void stageFileDialogPaths( std::vector<std::filesystem::path> paths )
+{
+    #if MR_ENABLE_UI_TEST_ENGINE
+    state.stagedFileDialogPaths = std::move( paths );
+    #else
+    (void)paths;
+    #endif
+}
+
+std::vector<std::filesystem::path> consumeStagedFileDialogPaths()
+{
+    #if MR_ENABLE_UI_TEST_ENGINE
+    return std::exchange( state.stagedFileDialogPaths, {} );
+    #else
+    return {};
+    #endif
+}
+
+void appendStatusMessage( std::string msg )
+{
+    #if MR_ENABLE_UI_TEST_ENGINE
+    state.statusMessages.push_back( std::move( msg ) );
+    #else
+    (void)msg;
+    #endif
+}
+
+std::vector<std::string> consumeStatusMessages()
+{
+    #if MR_ENABLE_UI_TEST_ENGINE
+    return std::exchange( state.statusMessages, {} );
+    #else
+    return {};
+    #endif
 }
 
 [[nodiscard]] MRVIEWER_API Unexpected<std::string> Entry::unexpected_( std::string_view selfName, std::string_view tKindName )

--- a/source/MRViewer/MRUITestEngine.h
+++ b/source/MRViewer/MRUITestEngine.h
@@ -4,6 +4,7 @@
 #include "MRViewer/exports.h"
 
 #include <cstdint>
+#include <filesystem>
 #include <limits>
 #include <map>
 #include <optional>
@@ -206,5 +207,29 @@ private:
 
 // Returns the current entry tree.
 [[nodiscard]] MRVIEWER_API const GroupEntry& getRootEntry();
+
+// True if a TestEngine-driven action ran during the current ImGui frame:
+// either a `createButton(...)` call returned a simulated click, or a
+// `createValueLow(...)` call consumed a value override. Cleared at frame boundary.
+// Read by code that wants to behave differently under TE control — e.g. file
+// dialogs that should bypass the OS modal.
+[[nodiscard]] MRVIEWER_API bool wasFrameTriggered();
+
+// Stage the path(s) that the next TE-triggered file dialog should return.
+// Replaces any previously staged value; empty vector is treated as "not staged".
+// Single-shot: consumed by the next file dialog opened during a TE-triggered frame.
+MRVIEWER_API void stageFileDialogPaths( std::vector<std::filesystem::path> paths );
+
+// Consume the staged paths. Returns empty if nothing is staged.
+// File-dialog code calls this; not normally called by user code.
+[[nodiscard]] MRVIEWER_API std::vector<std::filesystem::path> consumeStagedFileDialogPaths();
+
+// Append a status message describing a problem during a TE-driven action
+// (e.g. "file dialog triggered but no paths staged"). MCP tool handlers
+// drain these after dispatching input and surface them to the LLM.
+MRVIEWER_API void appendStatusMessage( std::string msg );
+
+// Drain and return all status messages accumulated since the last drain.
+[[nodiscard]] MRVIEWER_API std::vector<std::string> consumeStatusMessages();
 
 }

--- a/source/MRViewer/MRUiMcp.cpp
+++ b/source/MRViewer/MRUiMcp.cpp
@@ -2,9 +2,11 @@
 
 #include "MRMcp/MRMcp.h"
 #include "MRMesh/MROnInit.h"
+#include "MRMesh/MRStringConvert.h"
 #include "MRPch/MRFmt.h"
 #include "MRViewer/MRCommandLoop.h"
 #include "MRViewer/MRProgressBar.h"
+#include "MRViewer/MRUITestEngine.h"
 #include "MRViewer/MRUITestEngineControl.h"
 
 namespace MR::Mcp
@@ -75,6 +77,23 @@ static nlohmann::json mcpToolListAllUiEntries( const nlohmann::json& args )
     return nlohmann::json::object( { { "result", ret } } );
 }
 
+// Drain any TestEngine status messages emitted during a just-dispatched UI action and surface
+// them as a tool error. Run on the GUI thread because TE state isn't thread-safe.
+static void surfaceTestEngineStatusMessages_()
+{
+    std::vector<std::string> msgs;
+    MR::CommandLoop::runCommandFromGUIThread( [&]
+    {
+        msgs = UI::TestEngine::consumeStatusMessages();
+    } );
+    if ( msgs.empty() )
+        return;
+    std::string joined = msgs.front();
+    for ( size_t i = 1; i < msgs.size(); ++i )
+        joined += '\n' + msgs[i];
+    throw std::runtime_error( std::move( joined ) );
+}
+
 static nlohmann::json mcpToolPressButton( const nlohmann::json& args )
 {
     const auto path = args.at( "path" ).get<std::vector<std::string>>();
@@ -88,7 +107,21 @@ static nlohmann::json mcpToolPressButton( const nlohmann::json& args )
             throw std::runtime_error( fmt::format( "pressButton {}: {}", UI::TestEngine::Control::pathToString( path ), *ex ) );
     } );
     skipFramesAfterInput();
+    surfaceTestEngineStatusMessages_();
 
+    return nlohmann::json::object();
+}
+
+static nlohmann::json mcpToolStageFileDialogPaths( const nlohmann::json& args )
+{
+    std::vector<std::filesystem::path> paths;
+    for ( const auto& p : args.at( "paths" ) )
+        paths.push_back( pathFromUtf8( p.get<std::string>() ) );
+
+    MR::CommandLoop::runCommandFromGUIThread( [&]
+    {
+        UI::TestEngine::stageFileDialogPaths( std::move( paths ) );
+    } );
     return nlohmann::json::object();
 }
 
@@ -134,6 +167,7 @@ static nlohmann::json mcpToolWriteValue( const nlohmann::json& args )
             throw std::runtime_error( fmt::format( "writeValue {}: {}", UI::TestEngine::Control::pathToString( path ), *ex ) );
     } );
     skipFramesAfterInput();
+    surfaceTestEngineStatusMessages_();
 
     return nlohmann::json::object();
 }
@@ -207,6 +241,26 @@ MR_ON_INIT{
         /*input_schema*/Schema::Object{}.addMember( "path", Schema::Array( Schema::String{} ) ),
         /*output_schema*/Schema::Object{},
         /*func*/mcpToolPressButton
+    );
+
+    server.addTool(
+        /*id*/"ui.stageFileDialogPaths",
+        /*name*/"Stage paths for next TestEngine-triggered file dialog",
+        /*desc*/
+            "Pre-load the path(s) that the next OS file/folder dialog opened by a "
+            "ui.pressButton-driven click will return. The dialog is skipped — no native "
+            "modal appears — and the caller (Open / Save / Browse...) receives the staged "
+            "paths. Single-shot: consumed by the next dialog. Use absolute paths in UTF-8. "
+            "Stage before calling ui.pressButton on a button that opens a file dialog; if no "
+            "paths are staged when such a button is pressed, ui.pressButton fails with a "
+            "status message asking you to stage first. Validation: number of paths must "
+            "match the dialog's multiselect mode; for open dialogs each path must exist with "
+            "the right type (file vs directory); for save dialogs existence is not required "
+            "but the path must not already exist as a directory. Real human clicks (not from "
+            "ui.pressButton) always show the native dialog and ignore staged paths.",
+        /*input_schema*/Schema::Object{}.addMember( "paths", Schema::Array( Schema::String{} ) ),
+        /*output_schema*/Schema::Object{},
+        /*func*/mcpToolStageFileDialogPaths
     );
 
     // (idSuffix, displayType) -- `idSuffix` is the CamelCase suffix on ui.readValue*/ui.writeValue*;


### PR DESCRIPTION
## Summary
- New `ui.stageFileDialogPaths` MCP tool stages path(s) the next TestEngine-driven file/folder dialog should return.
- `runDialog` short-circuits the OS modal when `UI::TestEngine::wasFrameTriggered()` is set (a TE-driven `createButton`/`createValueLow` ran this frame); real human clicks still see the native dialog.
- Validates count + type before consuming: rejects empty stage, multi-paths-into-single-select, missing files for open dialogs, files-passed-as-folders, and directories-passed-as-save-targets. Errors surface back to the caller via the existing `ui.pressButton` / `ui.writeValue*` error path.

Files: `source/MRViewer/MRUITestEngine.{h,cpp}`, `source/MRViewer/MRFileDialog.cpp`, `source/MRViewer/MRUiMcp.cpp`. No new TUs / `.vcxproj` updates.

## Test plan
- [x] `ui.pressButton` on `Open files` without staging → fails: "no paths were staged".
- [x] Stage one valid `.obj` → press → mesh loads, no native dialog.
- [x] Stage consumed single-shot — second press without re-stage fails as above.
- [x] Stage a directory for an open-file dialog → "not an existing file".
- [x] Stage a missing path → "not an existing file".
- [x] Stage 2 paths for `Open directory` (single-select) → "expects a single path but 2 were staged".
- [x] Stage a regular file for a folder dialog → "not an existing directory".
- [x] Stage a brand-new save path → STL written; existence not required for save.
- [x] Stage an existing directory for save → "exists and is a directory, expected a file path".
- [x] Stage 2 valid files for `Open files` (multi) → both load.
- [x] Real human click of an Open/Save button (no MCP) — native dialog appears (architecture: TE flag isn't set on real clicks).
- [ ] Release build with `MR_ENABLE_UI_TEST_ENGINE=0` — TE surface compiles out, intercept short-circuits to `false`.