### PR TITLE
MCP: also mark TE frameTriggered on tools.action

### DIFF
--- a/source/MRViewer/MRToolsMcp.cpp
+++ b/source/MRViewer/MRToolsMcp.cpp
@@ -9,6 +9,7 @@
 #include "MRViewer/MRRibbonSchema.h"
 #include "MRViewer/MRSceneCache.h"
 #include "MRViewer/MRStatePlugin.h"
+#include "MRViewer/MRUITestEngine.h"
 
 #include <algorithm>
 #include <string>
@@ -16,6 +17,9 @@
 
 namespace MR::Mcp
 {
+
+// Defined in MRUiMcp.cpp — drains TestEngine status messages and surfaces them as a tool error.
+void surfaceTestEngineStatusMessages();
 
 // Public type label for a ribbon item. State plugins split by `blocking()` (default: true);
 // plain RibbonMenuItem subclasses are one-shot buttons.
@@ -139,10 +143,16 @@ static nlohmann::json mcpToolsAction( const nlohmann::json& args )
             if ( !reason.empty() )
                 throw std::runtime_error( fmt::format( "tools.action {}: {}", id, reason ) );
         }
+        // Mark the frame as TE-driven so any TE-gated hook the action triggers
+        // (file-dialog bypass via stageFileDialogPaths, etc.) sees the flag set.
+        // tools.action calls item->action() directly without going through
+        // TestEngine::createButton, which is the other code path that sets it.
+        UI::TestEngine::markFrameTriggered();
         item->action();
         nowActive = item->isActive();
     } );
     skipFramesAfterInput();
+    surfaceTestEngineStatusMessages();
     return nlohmann::json::object( { { "active", nowActive } } );
 }
 

--- a/source/MRViewer/MRUITestEngine.cpp
+++ b/source/MRViewer/MRUITestEngine.cpp
@@ -292,6 +292,14 @@ bool wasFrameTriggered()
     #endif
 }
 
+void markFrameTriggered()
+{
+    #if MR_ENABLE_UI_TEST_ENGINE
+    checkForNewFrame();
+    state.frameTriggered = true;
+    #endif
+}
+
 void stageFileDialogPaths( std::vector<std::filesystem::path> paths )
 {
     #if MR_ENABLE_UI_TEST_ENGINE

--- a/source/MRViewer/MRUITestEngine.h
+++ b/source/MRViewer/MRUITestEngine.h
@@ -209,11 +209,19 @@ private:
 [[nodiscard]] MRVIEWER_API const GroupEntry& getRootEntry();
 
 // True if a TestEngine-driven action ran during the current ImGui frame:
-// either a `createButton(...)` call returned a simulated click, or a
-// `createValueLow(...)` call consumed a value override. Cleared at frame boundary.
+// either a `createButton(...)` call returned a simulated click, a
+// `createValueLow(...)` call consumed a value override, or a caller
+// explicitly invoked `markFrameTriggered()`. Cleared at frame boundary.
 // Read by code that wants to behave differently under TE control — e.g. file
 // dialogs that should bypass the OS modal.
 [[nodiscard]] MRVIEWER_API bool wasFrameTriggered();
+
+// Explicitly mark the current frame as TestEngine-driven. Use from MCP tool
+// handlers that fire plugin actions on a path that does NOT go through
+// `createButton()` (e.g. `tools.action`) but should still trigger TE-gated
+// hooks (file-dialog bypass, etc.). Call from the GUI thread before invoking
+// the action.
+MRVIEWER_API void markFrameTriggered();
 
 // Stage the path(s) that the next TE-triggered file dialog should return.
 // Replaces any previously staged value; empty vector is treated as "not staged".

--- a/source/MRViewer/MRUiMcp.cpp
+++ b/source/MRViewer/MRUiMcp.cpp
@@ -79,7 +79,8 @@ static nlohmann::json mcpToolListAllUiEntries( const nlohmann::json& args )
 
 // Drain any TestEngine status messages emitted during a just-dispatched UI action and surface
 // them as a tool error. Run on the GUI thread because TE state isn't thread-safe.
-static void surfaceTestEngineStatusMessages_()
+// Non-static so MRToolsMcp.cpp's `tools.action` handler can reuse it across TUs.
+void surfaceTestEngineStatusMessages()
 {
     std::vector<std::string> msgs;
     MR::CommandLoop::runCommandFromGUIThread( [&]
@@ -107,7 +108,7 @@ static nlohmann::json mcpToolPressButton( const nlohmann::json& args )
             throw std::runtime_error( fmt::format( "pressButton {}: {}", UI::TestEngine::Control::pathToString( path ), *ex ) );
     } );
     skipFramesAfterInput();
-    surfaceTestEngineStatusMessages_();
+    surfaceTestEngineStatusMessages();
 
     return nlohmann::json::object();
 }
@@ -167,7 +168,7 @@ static nlohmann::json mcpToolWriteValue( const nlohmann::json& args )
             throw std::runtime_error( fmt::format( "writeValue {}: {}", UI::TestEngine::Control::pathToString( path ), *ex ) );
     } );
     skipFramesAfterInput();
-    surfaceTestEngineStatusMessages_();
+    surfaceTestEngineStatusMessages();
 
     return nlohmann::json::object();
 }


### PR DESCRIPTION
## Summary
Follow-up to #6034. `tools.action` calls `item->action()` directly, bypassing `TestEngine::createButton` — so the file-dialog bypass silently did nothing when a test used `tools.action` to fire an Open/Save button.

- New `UI::TestEngine::markFrameTriggered()` exposes the flag-write as a public helper.
- `mcpToolsAction` calls it before `item->action()` and drains TE status messages after `skipFramesAfterInput()`, mirroring `ui.pressButton`'s lifecycle.
- `surfaceTestEngineStatusMessages()` is no longer `static` in `MRUiMcp.cpp` — forward-declared in `MRToolsMcp.cpp` so both TUs share it (per the "delay extraction until 2nd caller" rule, now satisfied).

Files: `source/MRViewer/MRUITestEngine.{h,cpp}`, `source/MRViewer/MRUiMcp.cpp`, `source/MRViewer/MRToolsMcp.cpp`.

## Test plan
- [x] `tools.action {id: "Open files"}` without staging → fails with the same status message as the equivalent `ui.pressButton` call.
- [x] Stage one valid `.obj` → `tools.action {id: "Open files"}` → mesh loads, no native dialog.
- [x] `ui.pressButton`-driven flows still work (regression of #6034 verification scenarios).