### PR TITLE
ci(test-distribution): drop if: always() from post-install steps

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -94,15 +94,12 @@ jobs:
           apt-get -y install ${{ matrix.compiler }}
 
       - name: Run MeshViewer
-        if: always()
         run: xvfb-run -a MeshViewer -hidden -noEventLoop -unloadPluginsAtEnd
 
       - name: Show meshconv help
-        if: always()
         run: meshconv --help
 
       - name: Build C++ examples
-        if: always()
         working-directory: examples/cpp-examples
         run: |
           mkdir build && \
@@ -112,14 +109,12 @@ jobs:
           ./MeshModification
 
       - name: Build C examples
-        if: always()
         working-directory: examples/c-examples
         run: |
           cmake -S . -B build -DCMAKE_C_COMPILER=${{matrix.c-compiler}} && \
           cmake --build build
 
       - name: Ubuntu python test
-        if: ${{ always() }}
         env:
           PYTHONPATH: /usr/local/lib/MeshLib/
         working-directory: test_python
@@ -192,15 +187,12 @@ jobs:
         run: apt-get -y install ${{ matrix.compiler }}
 
       - name: Run MeshViewer
-        if: always()
         run: xvfb-run -a MeshViewer -hidden -noEventLoop -unloadPluginsAtEnd
 
       - name: Show meshconv help
-        if: always()
         run: meshconv --help
 
       - name: Build C++ examples
-        if: always()
         working-directory: examples/cpp-examples
         run: |
           mkdir build && \
@@ -210,14 +202,12 @@ jobs:
           ./MeshModification
 
       - name: Build C examples
-        if: always()
         working-directory: examples/c-examples
         run: |
           cmake -S . -B build -DCMAKE_C_COMPILER=${{matrix.c-compiler}} && \
           cmake --build build
 
       - name: Ubuntu python test
-        if: always()
         env:
           PYTHONPATH: /usr/local/lib/MeshLib/
         working-directory: test_python
@@ -245,15 +235,12 @@ jobs:
 
       # [error] NSGL: Failed to find a suitable pixel format
       - name: Run MeshViewer
-        if: always()
         run: /Library/Frameworks/MeshLib.framework/Versions/Current/bin/MeshViewer -tryHidden -noEventLoop -unloadPluginsAtEnd
 
       - name: Show meshconv help
-        if: always()
         run: /Library/Frameworks/MeshLib.framework/Versions/Current/bin/meshconv --help
 
       - name: Build C++ examples
-        if: always()
         working-directory: examples/cpp-examples
         run: |
           mkdir build && \
@@ -263,7 +250,6 @@ jobs:
           ./MeshModification
 
       - name: Build C examples
-        if: always()
         working-directory: examples/c-examples
         run: |
           cmake -S . -B build -DCMAKE_C_COMPILER=/usr/bin/clang && \
@@ -309,15 +295,15 @@ jobs:
           }
 
       - name: Run MeshViewer
-        if: ${{ always() && steps.unpack-dist.outputs.dist_found == 'true' }}
+        if: ${{ steps.unpack-dist.outputs.dist_found == 'true' }}
         run: MeshViewer.exe -tryHidden -noEventLoop -unloadPluginsAtEnd
 
       - name: Show meshconv help
-        if: ${{ always() && steps.unpack-dist.outputs.dist_found == 'true' }}
+        if: ${{ steps.unpack-dist.outputs.dist_found == 'true' }}
         run: meshconv.exe --help
 
       - name: Build C++ examples
-        if: ${{ always() && steps.unpack-dist.outputs.dist_found == 'true' }}
+        if: ${{ steps.unpack-dist.outputs.dist_found == 'true' }}
         working-directory: examples/cpp-examples
         env:
           DIST_DIR: C:\meshlib-built
@@ -330,7 +316,7 @@ jobs:
           .\build\${{ matrix.config }}\MeshModification.exe
 
       - name: Build C examples
-        if: ${{ always() && steps.unpack-dist.outputs.dist_found == 'true' }}
+        if: ${{ steps.unpack-dist.outputs.dist_found == 'true' }}
         working-directory: examples/c-examples
         env:
           DIST_DIR: C:\meshlib-built


### PR DESCRIPTION
## Summary

When the install step in `test-distribution.yml` fails (e.g. flaky apt mirror, see [run 25330382467](https://github.com/MeshInspector/MeshLib/actions/runs/25330382467/job/74272302033)), the steps that follow — `Run MeshViewer`, `Show meshconv help`, the C/C++ example builds, `Ubuntu python test` — cannot succeed because the binaries and headers are missing. They were marked `if: always()`, so they ran anyway and produced a cascade of `exit code 127` errors that buried the real cause.

Drop `if: always()` from the post-install steps in the `linux-x64-test`, `linux-arm64-test`, and `macos-test` jobs. The default `success()` then short-circuits the rest of the job after a failed install, so the log surfaces the actual failure cleanly. The Windows job already gates on `steps.unpack-dist.outputs.dist_found == 'true'`; the redundant `always()` is dropped there too.

The intent of `if: always()` was to keep one failing test from masking the others. That still works between sibling test steps via `success()` semantics — what changes is only the behavior when the *install* itself fails, where running the rest is pure noise.

## Test plan

- [ ] No platform builds are affected by this PR (workflow-file-only change). All platform builds disabled via labels.
- [ ] Re-run a release distribution test after merge and confirm a successful run looks identical to before.
- [ ] Manually verify a forced install failure now stops the job at the install step instead of cascading 127s.
