### PR TITLE
ci(emscripten): fail build when firefox apt-resolves to the snap stub

### DIFF
--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -64,18 +64,23 @@ FROM emscripten/emsdk:4.0.10-arm64
 # yaru-theme-icon fixes `Icon 'dialog-warning' not present in theme Yaru:
 # 'glib warning'` during testing.
 #
-# The post-install dpkg-query check guards against a silent regression: when
+# The two post-PPA checks guard against a silent regression: when
 # ppa.launchpadcontent.net is briefly unreachable, add-apt-repository /
 # apt-get update skip the PPA, Ubuntu's transitional `firefox` package (the
 # `snap install firefox` stub) becomes the only candidate, the build still
-# succeeds, and emrun later hangs at test time on /usr/bin/firefox. Real
-# mozillateam PPA versions end in `~mt1`; if it's missing, fail the build
-# loudly so CI retries instead of pushing a broken image to `:latest`.
+# succeeds, and emrun later hangs at test time on /usr/bin/firefox.
+#  1. `Acquire::Retries "5"` lets apt itself retry transient fetch failures.
+#  2. `apt-cache policy firefox | grep mozillateam` fails fast if the PPA's
+#     package list didn't actually load into apt's cache.
+#  3. The trailing dpkg-query confirms the *installed* firefox carries the
+#     mozillateam `~mt1` version suffix; if it doesn't, fail the build so
+#     CI retries instead of pushing a broken image to `:latest`.
 RUN export DEBIAN_FRONTEND=noninteractive; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections; \
     echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections; \
     sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list; \
+    echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries; \
     apt-get update -qqy \
  && apt-get install -qqy --no-install-recommends gpg-agent software-properties-common \
  && echo '\
@@ -84,6 +89,10 @@ Pin: release o=LP-PPA-mozillateam\n\
 Pin-Priority: 1001\
 ' | tee /etc/apt/preferences.d/mozilla-firefox \
  && add-apt-repository -y ppa:mozillateam/ppa \
+ && { apt-cache policy firefox | grep -q mozillateam \
+      || { echo 'ERROR: mozillateam PPA did not load into apt cache (launchpad unreachable?); retry the build.' >&2 ; \
+           apt-cache policy firefox >&2 ; \
+           exit 1 ; } ; } \
  && apt-get install -qqy --no-install-recommends \
         tzdata git firefox pkg-config xvfb yaru-theme-icon ninja-build dbus-x11 gettext \
  && { dpkg-query -W -f='${Version}\n' firefox | grep -qE '~mt1$' \

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -63,6 +63,14 @@ FROM emscripten/emsdk:4.0.10-arm64
 # AWS CLI install was already dropped upstream.
 # yaru-theme-icon fixes `Icon 'dialog-warning' not present in theme Yaru:
 # 'glib warning'` during testing.
+#
+# The post-install dpkg-query check guards against a silent regression: when
+# ppa.launchpadcontent.net is briefly unreachable, add-apt-repository /
+# apt-get update skip the PPA, Ubuntu's transitional `firefox` package (the
+# `snap install firefox` stub) becomes the only candidate, the build still
+# succeeds, and emrun later hangs at test time on /usr/bin/firefox. Real
+# mozillateam PPA versions end in `~mt1`; if it's missing, fail the build
+# loudly so CI retries instead of pushing a broken image to `:latest`.
 RUN export DEBIAN_FRONTEND=noninteractive; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections; \
@@ -78,6 +86,11 @@ Pin-Priority: 1001\
  && add-apt-repository -y ppa:mozillateam/ppa \
  && apt-get install -qqy --no-install-recommends \
         tzdata git firefox pkg-config xvfb yaru-theme-icon ninja-build dbus-x11 gettext \
+ && { dpkg-query -W -f='${Version}\n' firefox | grep -qE '~mt1$' \
+      || { dpkg-query -W -f='installed firefox version: ${Version}\n' firefox >&2 ; \
+           echo 'ERROR: firefox is the Ubuntu snap-install stub, not the mozillateam PPA build.' >&2 ; \
+           echo '       launchpad was likely unreachable during apt-get update; retry the build.' >&2 ; \
+           exit 1 ; } ; } \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Fail the docker image build when `firefox` resolves to Ubuntu's transitional snap-install stub instead of the real mozillateam PPA build, so we never silently push a broken `:latest`.

## Why

`docker/emscriptenDockerfile` installs `firefox` from the [`ppa:mozillateam/ppa`](https://launchpad.net/~mozillateam/+archive/ubuntu/ppa) (with `Pin-Priority: 1001`) so that `emrun --browser=/usr/bin/firefox …` works in [build-test-emscripten.yml](.github/workflows/build-test-emscripten.yml). When `ppa.launchpadcontent.net` is briefly unreachable during the build:

- `add-apt-repository -y ppa:mozillateam/ppa` / the subsequent `apt-get update` silently skip the PPA;
- Ubuntu's transitional `firefox` package (the `snap install firefox` stub) becomes the only candidate apt knows about;
- `apt-get install firefox` quietly installs the stub;
- the build succeeds;
- `/usr/bin/firefox` in the resulting image just prints `Command '/usr/bin/firefox' requires the firefox snap to be installed.`;
- the `emscripten-build / Unit Tests` step times out after 5 minutes, on every PR's CI, until someone notices and re-pushes a good `:latest`.

This is the failure mode behind the broken `:latest` push at 2026-05-04 16:56 UTC (which broke [run 25333416710](https://github.com/MeshInspector/MeshLib/actions/runs/25333416710)) and was reproduced again at ~22:27 UTC: attempt 1 of [run 25330431096](https://github.com/MeshInspector/MeshLib/actions/runs/25330431096)'s `prepare-image / linux-image-build-upload (emscripten, arm64)` job failed loudly on a launchpad fetch timeout, but attempt 6 succeeded with the snap stub installed (`firefox_1:1snap1-0ubuntu2_arm64.deb` instead of `firefox_150.0.1+build1-0ubuntu0.22.04.1~mt1_arm64.deb`).

## What

Verify post-install that the installed `firefox` carries the mozillateam PPA's `~mt1` version suffix. If not, dump the installed version and `exit 1`, so docker build fails, image push doesn't happen, and CI retries — instead of producing a broken image.

## Test plan

- [ ] Image build on this PR succeeds and the new check passes (real PPA firefox installed).
- [ ] Emscripten unit tests pass on the rebuilt image (proves `/usr/bin/firefox` actually works under emrun).

