### PR TITLE
ci(emscripten): run unit tests on host runner, drop firefox from image

### DIFF
--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -103,20 +103,22 @@ jobs:
             -DMR_PCH_USE_EXTRA_HEADERS=ON
         run: ./scripts/build_source.sh
 
-      - name: Unit Tests
-        timeout-minutes: 5
+      - name: Stage MRTest bundle for host-side test job
         run: |
-          echo "check the \$HOME dir permissions in case of timeout issues"
-          echo ls -al \$HOME
-          ls -al $HOME
-          echo
+          # The Unit Tests step now runs on the host runner (outside this
+          # container) so its image doesn't need firefox/xvfb/dbus. Ship
+          # MRTest* + a copy of the container's emrun.py — emrun is
+          # explicitly designed to run standalone (only stdlib imports).
+          mkdir -p mrtest-bundle
+          cp build/Release/bin/MRTest* mrtest-bundle/
+          cp /emsdk/upstream/emscripten/emrun.py mrtest-bundle/
 
-          emrun \
-            --browser=/usr/bin/firefox \
-            --browser-args="--headless" \
-            --safe-firefox-profile \
-            --kill-exit \
-            ./build/Release/bin/MRTest.html
+      - name: Upload MRTest bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: MRTest_${{ matrix.package_name }}
+          path: mrtest-bundle
+          retention-days: 1
 
       - name: Create Package
         run: |
@@ -151,3 +153,40 @@ jobs:
           artifact_path: ${{ github.workspace }}
           artifact_glob: meshlib_${{ matrix.package_name }}.zip
           stats_file_suffix: -${{ steps.collect-runner-stats.outputs.job_id }}
+
+  emscripten-test:
+    needs: emscripten-build
+    timeout-minutes: 10
+    # Runs directly on the host (no `container:`) so we can use the runner
+    # image's pre-installed firefox instead of carrying one in the docker
+    # image. ubuntu-24.04-arm ships firefox + geckodriver out of the box.
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [Singlethreaded, Multithreaded, Multithreaded-64Bit]
+        include:
+          - config: Singlethreaded
+            package_name: emscripten-singlethreaded
+          - config: Multithreaded
+            package_name: emscripten-multithreaded
+          - config: Multithreaded-64Bit
+            package_name: emscripten-multithreaded-64bit
+
+    steps:
+      - name: Download MRTest bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: MRTest_${{ matrix.package_name }}
+          path: mrtest-bundle
+
+      - name: Unit Tests
+        timeout-minutes: 5
+        working-directory: mrtest-bundle
+        run: |
+          python3 emrun.py \
+            --browser=/usr/bin/firefox \
+            --browser-args="--headless" \
+            --safe-firefox-profile \
+            --kill-exit \
+            ./MRTest.html

--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -103,15 +103,10 @@ jobs:
             -DMR_PCH_USE_EXTRA_HEADERS=ON
         run: ./scripts/build_source.sh
 
-      - name: Stage MRTest bundle for host-side test job
+      - name: Stage MRTest bundle
         run: |
-          # The Unit Tests step now runs on the host runner (outside this
-          # container) so its image doesn't need firefox/xvfb/dbus. Ship
-          # MRTest* + a copy of the container's emrun.py — emrun is
-          # explicitly designed to run standalone (only stdlib imports).
-          mkdir -p mrtest-bundle
-          cp build/Release/bin/MRTest* mrtest-bundle/
-          cp /emsdk/upstream/emscripten/emrun.py mrtest-bundle/
+          mkdir mrtest-bundle
+          cp build/Release/bin/MRTest* /emsdk/upstream/emscripten/emrun.py mrtest-bundle/
 
       - name: Upload MRTest bundle
         uses: actions/upload-artifact@v7
@@ -157,21 +152,14 @@ jobs:
   emscripten-test:
     needs: emscripten-build
     timeout-minutes: 10
-    # Runs directly on the host (no `container:`) so we can use the runner
-    # image's pre-installed firefox instead of carrying one in the docker
-    # image. ubuntu-24.04-arm ships firefox + geckodriver out of the box.
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
-        config: [Singlethreaded, Multithreaded, Multithreaded-64Bit]
-        include:
-          - config: Singlethreaded
-            package_name: emscripten-singlethreaded
-          - config: Multithreaded
-            package_name: emscripten-multithreaded
-          - config: Multithreaded-64Bit
-            package_name: emscripten-multithreaded-64bit
+        package_name:
+          - emscripten-singlethreaded
+          - emscripten-multithreaded
+          - emscripten-multithreaded-64bit
 
     steps:
       - name: Download MRTest bundle

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -59,10 +59,6 @@ RUN ./scripts/build_thirdparty.sh && \
 ## ============================================================================
 FROM emscripten/emsdk:4.0.10-arm64
 
-# Runtime apt set. Firefox/xvfb/dbus-x11/yaru-theme-icon and the
-# mozillateam PPA dance (needed to dodge Ubuntu's snap-only firefox) are
-# gone — MRTest now runs on the host runner where firefox is already
-# pre-installed. This image is build-only.
 RUN export DEBIAN_FRONTEND=noninteractive; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections; \

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -59,25 +59,18 @@ RUN ./scripts/build_thirdparty.sh && \
 ## ============================================================================
 FROM emscripten/emsdk:4.0.10-arm64
 
-# Full runtime apt set. Same as pre-multi-stage master, except the x86_64
-# AWS CLI install was already dropped upstream.
-# yaru-theme-icon fixes `Icon 'dialog-warning' not present in theme Yaru:
-# 'glib warning'` during testing.
+# Runtime apt set. Firefox/xvfb/dbus-x11/yaru-theme-icon and the
+# mozillateam PPA dance (needed to dodge Ubuntu's snap-only firefox) are
+# gone — MRTest now runs on the host runner where firefox is already
+# pre-installed. This image is build-only.
 RUN export DEBIAN_FRONTEND=noninteractive; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections; \
     echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections; \
     sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list; \
     apt-get update -qqy \
- && apt-get install -qqy --no-install-recommends gpg-agent software-properties-common \
- && echo '\
-Package: *\n\
-Pin: release o=LP-PPA-mozillateam\n\
-Pin-Priority: 1001\
-' | tee /etc/apt/preferences.d/mozilla-firefox \
- && add-apt-repository -y ppa:mozillateam/ppa \
  && apt-get install -qqy --no-install-recommends \
-        tzdata git firefox pkg-config xvfb yaru-theme-icon ninja-build dbus-x11 gettext \
+        tzdata git pkg-config ninja-build gettext \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

- Split `build-test-emscripten.yml` into two jobs: `emscripten-build` (in the docker container, builds + packages as before) and `emscripten-test` (on the host runner, runs MRTest against the pre-installed firefox).
- Drop `firefox`, `xvfb`, `dbus-x11`, `yaru-theme-icon` and the whole `mozillateam` PPA dance (`gpg-agent`, `software-properties-common`, the `Pin-Priority: 1001` file, `add-apt-repository`) from the final stage of `emscriptenDockerfile`. The PPA only existed to dodge Ubuntu's snap-only firefox; with no firefox in the image it's not needed.

## Why

`ubuntu-24.04-arm` runner images ship firefox + geckodriver pre-installed (per [actions/partner-runner-images](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md)), so carrying a separate firefox install inside our docker image is duplicate work. The build steps don't need a browser, so the image becomes build-only.

## How emrun reaches the host

`emrun.py` is explicitly designed to run standalone — its source comment reads `N.B. Do not introduce external dependencies to this file. It is often used standalone outside Emscripten directory tree.` and it imports stdlib only. So the build job copies `/emsdk/upstream/emscripten/emrun.py` from the container into the test artifact alongside `MRTest*`, and the test job runs `python3 emrun.py ... MRTest.html` against `/usr/bin/firefox` on the host. No `setup-emsdk` action needed (avoids a third-party dependency and a hundreds-of-MB toolchain pull).

## Measured impact (vs. master)

Numbers from PR run [25367811203](https://github.com/MeshInspector/MeshLib/actions/runs/25367811203) (two attempts) vs. recent master runs. Two PR attempts shown so runner variance is visible — attempt 1 happened to draw a slow image-build runner, attempt 2 a fast one.

### Image size — `meshlib/meshlib-emscripten-arm64` (compressed manifest from Docker Hub)

| Layer | master (`latest`) | PR (`cicd-emscripten-test-on-host`) |
|---|---:|---:|
| 0–4 (emsdk base + env) | identical | identical |
| **final-stage `apt install`** | **220.5 MiB** | **9.2 MiB** |
| 6–9 (thirdparty trees + non-root user setup) | identical | identical |
| **TOTAL (compressed)** | **1044.8 MiB** | **833.5 MiB** |

**−211 MiB (−20%) compressed.** All concentrated in the final apt layer (firefox + xvfb + dbus-x11 + yaru-theme-icon + PPA tooling were the bulk). On-disk impact ~2× that.

### `prepare-image / linux-image-build-upload (emscripten, arm64)`

| Step | master | PR att1 | PR att2 |
|---|---:|---:|---:|
| Build Linux image | 25:35 | 27:05 | **24:38** |
| Push Linux image | 22s | 11s | 13s |
| Job total | 27:04 | 28:25 | **26:18** |

Build time is dominated by `build_thirdparty.sh` (3 emsdk variants) which is unchanged — its variance dwarfs the apt savings. Att2 happens to come in 57s under master; the slim image is at worst neutral, often slightly faster.

### `emscripten-build` (per matrix entry)

| | master | PR att1 | PR att2 |
|---|---:|---:|---:|
| Singlethreaded total | 7:32 | 6:52 | **6:44** |
| Multithreaded total | 7:18 | 7:05 | **7:09** |
| Multithreaded-64Bit total | 8:19 | 8:08 | **7:46** |
| `Initialize containers` (avg of 3) | ~57s | ~50s | **~47s** |

`Unit Tests (in container)` (~13–14s) is dropped; replaced by `Stage MRTest bundle` + `Upload MRTest bundle` (~1–4s combined). Container init is consistently faster on the slimmer image (~−10s on att2).

### `emscripten-test` (host runner, new — no `container:` so no `Initialize containers`)

| Config | Set up | Download MRTest | Unit Tests | Job total |
|---|---:|---:|---:|---:|
| Singlethreaded | 1–2s | 1–3s | 18s | 22s |
| Multithreaded | 2s | 2–3s | 17–28s | 24–33s |
| Multithreaded-64Bit | 1s | 1–3s | 20–31s | 22–38s |

Unit-test wall is comparable to in-container (was 13–14s, host runs 17–31s — extra cost is firefox cold-start variance on the runner). Skipping container init on this side is what keeps the new job from costing ~1 min.

### End-to-end matrix wall time

| | master | PR att1 | PR att2 |
|---|---:|---:|---:|
| max(build) | 8:19 | 8:08 | **7:46** |
| build → test gap | — | ~5s | ~4s |
| max(test) | — | 38s | 33s |
| **End-to-end** | **8:19** | **8:51 (+32s)** | **~8:24 (+5s)** |

## Net trade

- End-to-end wall time: **essentially neutral** (+5s on att2; +32s on att1 due to one slow test cell — within run-to-run variance).
- Image build job: **−46s on att2** (−1:21 was att1's variance, not a structural cost).
- Image size: **−211 MiB compressed (−20%)** — structural, not run-to-run.
- `Initialize containers`: **~−10s per parallel build, every build, forever after.**
- Image is build-only; no PPA setup or snap-firefox workarounds to maintain.

## Test plan

- [x] `prepare-image` rebuilds the emscripten image without firefox/xvfb/PPA (both attempts).
- [x] `emscripten-build` succeeds for all three configs (Singlethreaded, Multithreaded, Multithreaded-64Bit) and uploads `MRTest_*` artifacts.
- [x] `emscripten-test` on `ubuntu-24.04-arm` downloads each bundle and runs `python3 emrun.py ... MRTest.html` to completion against the host's firefox.
- [x] Package + C++ examples + `Distributives_*` upload still pass.
