### PR TITLE
MRTest(CPR): add SSL/CA diagnostic test (backends, paths, env, versions)

### DIFF
--- a/source/MRTest/MRCPRTests.cpp
+++ b/source/MRTest/MRCPRTests.cpp
@@ -1,11 +1,32 @@
 #include "MRMesh/MRMeshFwd.h"
 #if !defined( __EMSCRIPTEN__)
 #include <cpr/cpr.h>
+#include <curl/curl.h>
 #include "MRPch/MRSpdlog.h"
 #include "MRMesh/MRGTest.h"
 
 constexpr int MAX_RETRIES = 10;
 constexpr std::chrono::seconds COOLDOWN_PERIOD { 10 };
+
+TEST( MRViewer, CPRSslBackends )
+{
+    const curl_version_info_data * info = curl_version_info( CURLVERSION_NOW );
+    ASSERT_NE( info, nullptr );
+    spdlog::info( "libcurl default SSL backend: {}", info->ssl_version ? info->ssl_version : "<none>" );
+
+    const curl_ssl_backend ** avail = nullptr;
+    // Documented query idiom: CURLSSLBACKEND_NONE returns CURLSSLSET_UNKNOWN_BACKEND and fills `avail`.
+    curl_global_sslset( CURLSSLBACKEND_NONE, nullptr, &avail );
+    if ( avail )
+    {
+        for ( int i = 0; avail[i]; ++i )
+            spdlog::info( "libcurl SSL backend [{}]: {} (id={})", i, avail[i]->name, (int)avail[i]->id );
+    }
+    else
+    {
+        spdlog::info( "libcurl reports a single SSL backend (no list available)" );
+    }
+}
 
 TEST( MRViewer, CPRTestGet )
 {

--- a/source/MRTest/MRCPRTests.cpp
+++ b/source/MRTest/MRCPRTests.cpp
@@ -1,6 +1,7 @@
 #include "MRMesh/MRMeshFwd.h"
 #if !defined( __EMSCRIPTEN__)
 #include <cpr/cpr.h>
+#include <cpr/cprver.h>
 #include <curl/curl.h>
 #include "MRPch/MRSpdlog.h"
 #include "MRMesh/MRGTest.h"
@@ -10,9 +11,17 @@ constexpr std::chrono::seconds COOLDOWN_PERIOD { 10 };
 
 TEST( MRViewer, CPRSslBackends )
 {
+    spdlog::info( "cpr version: {}", CPR_VERSION );
+    spdlog::info( "libcurl version: {}", curl_version() );
+
     const curl_version_info_data * info = curl_version_info( CURLVERSION_NOW );
     ASSERT_NE( info, nullptr );
     spdlog::info( "libcurl default SSL backend: {}", info->ssl_version ? info->ssl_version : "<none>" );
+
+#if LIBCURL_VERSION_NUM >= 0x075400 // 7.84.0: cainfo/capath fields added (CURLVERSION_TENTH)
+    spdlog::info( "libcurl compiled-in CAINFO: {}", info->cainfo ? info->cainfo : "<none>" );
+    spdlog::info( "libcurl compiled-in CAPATH: {}", info->capath ? info->capath : "<none>" );
+#endif
 
     const curl_ssl_backend ** avail = nullptr;
     // Documented query idiom: CURLSSLBACKEND_NONE returns CURLSSLSET_UNKNOWN_BACKEND and fills `avail`.

--- a/source/MRTest/MRCPRTests.cpp
+++ b/source/MRTest/MRCPRTests.cpp
@@ -23,6 +23,15 @@ TEST( MRViewer, CPRSslBackends )
     spdlog::info( "libcurl compiled-in CAPATH: {}", info->capath ? info->capath : "<none>" );
 #endif
 
+    if ( const char * v = std::getenv( "CURL_CA_BUNDLE" ) )
+        spdlog::info( "env CURL_CA_BUNDLE: {}", v );
+    else
+        spdlog::info( "env CURL_CA_BUNDLE: <unset>" );
+    if ( const char * v = std::getenv( "SSL_CERT_FILE" ) )
+        spdlog::info( "env SSL_CERT_FILE: {}", v );
+    else
+        spdlog::info( "env SSL_CERT_FILE: <unset>" );
+
     const curl_ssl_backend ** avail = nullptr;
     // Documented query idiom: CURLSSLBACKEND_NONE returns CURLSSLSET_UNKNOWN_BACKEND and fills `avail`.
     curl_global_sslset( CURLSSLBACKEND_NONE, nullptr, &avail );


### PR DESCRIPTION
## Summary

Adds `MRViewer.CPRSslBackends` to `MRTest`. The test logs (via `spdlog::info`) the SSL/HTTP toolchain that `MRTest` is actually linked against, plus the runtime environment that influences cert resolution:

- **cpr version** (`CPR_VERSION` from `<cpr/cprver.h>`)
- **libcurl version** (`curl_version()`)
- **libcurl default SSL backend** (`curl_version_info()->ssl_version`)
- **libcurl compiled-in CAINFO** (`curl_version_info()->cainfo`, libcurl ≥ 7.84.0)
- **libcurl compiled-in CAPATH** (`curl_version_info()->capath`, libcurl ≥ 7.84.0)
- **`CURL_CA_BUNDLE`** env var (libcurl override)
- **`SSL_CERT_FILE`** env var (OpenSSL fallback)
- **All compiled-in SSL backends**, queried via the documented `curl_global_sslset(CURLSSLBACKEND_NONE, nullptr, &avail)` idiom — order in the list is meaningful: index 0 is the runtime default in a multi-SSL build.

## Motivation

`CPRTestGet` / `CPRTestPost` can fail locally with `unable to get local issuer certificate` when libcurl is built multi-SSL (OpenSSL + Schannel) but defaults to OpenSSL at runtime — vcpkg builds curl with `CURL_CA_BUNDLE=none`/`CURL_CA_PATH=none`, so OpenSSL has no trust store to fall back on, and a typical Windows dev box doesn't have one at the path it would otherwise look for. The same vcpkg recipe links Schannel as the default on the GitHub Actions runner, so CI passes.

Today there's no easy way to tell, from a built binary, which backend a given libcurl actually uses, whether any compiled-in CA path was kept, or whether a runtime override was supplied. This test surfaces all of that in the test log on every platform.

Example local output (Windows, OpenSSL-default multi-SSL build):
```
[info] cpr version: 1.14.2
[info] libcurl version: libcurl/8.x.y (Schannel) OpenSSL/3.6.1 zlib/...
[info] libcurl default SSL backend: OpenSSL/3.6.1 (Schannel)
[info] libcurl compiled-in CAINFO: <none>
[info] libcurl compiled-in CAPATH: <none>
[info] env CURL_CA_BUNDLE: <unset>
[info] env SSL_CERT_FILE: <unset>
[info] libcurl SSL backend [0]: openssl (id=1)
[info] libcurl SSL backend [1]: schannel (id=8)
```

## Test plan

- [x] CI green on all platforms (Windows MSVC 2019/2022 Debug+Release, Linux x64/arm64 GCC/Clang, macOS x64/arm64, Emscripten, Ubuntu 22/24)
- [x] Local Windows MSBuild run prints all expected fields (cpr/curl versions, default backend, compiled-in CA paths, env-var overrides, backend list)
