### PR TITLE
Locale: emit TelemetrySignal on language change

### DIFF
--- a/source/MRViewer/MRLocale.cpp
+++ b/source/MRViewer/MRLocale.cpp
@@ -7,6 +7,7 @@
 #include "MRMesh/MRString.h"
 #include "MRMesh/MRStringConvert.h"
 #include "MRMesh/MRSystemPath.h"
+#include "MRMesh/MRTelemetry.h"
 #include "MRPch/MRWasm.h"
 
 #pragma warning( push )
@@ -69,6 +70,7 @@ const std::locale& Locale::set( const std::string& localeName )
     gLocaleName = localeName;
     MR_FINALLY {
         gLocaleNameChanged( gLocaleName );
+        TelemetrySignal( "Set Language " + gLocaleName );
     };
 
     gLocaleCanonicalName = localeName;


### PR DESCRIPTION
## Summary
- Adds a `"Set Language <code>"` event to `MR::TelemetrySignal` from inside `Locale::set`, alongside the existing `gLocaleNameChanged` signal, so we can see which UI locales are actually used and how often users switch.
- Single-site placement covers all language-change paths uniformly (settings dialog combo, ribbon-menu picker, startup restore from saved config). Backend interprets per-session startup events as "language used in this session".
- Payload uses the canonical locale code (e.g. `"ru"`, `"de_DE"`), not the localized display name, so analytics don't fragment across UI languages.

## Test plan
- [ ] Build Debug|x64; confirm `MRLocale.cpp` recompiles with the new `MRMesh/MRTelemetry.h` include.
- [ ] Launch with a saved non-default locale; confirm one `"Set Language <code>"` event is emitted at startup.
- [ ] Change language via Settings → Application → Language combo; confirm one event with the chosen code.
- [ ] Change language via the ribbon-menu language picker; confirm one event with the chosen code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)