### PR TITLE
ci: fix windows test-distribution download pattern

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -263,7 +263,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - dist_pattern: "MeshLibDist_*[!-]*.zip"
+          - dist_pattern: "MeshLibDist_${{ inputs.release_tag }}.zip"
             config: Release
             app_subdir: Release
             idl: 0
@@ -278,7 +278,6 @@ jobs:
           ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Download Distributive
-        continue-on-error: true
         run: |
           echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token
           gh release download ${{ inputs.release_tag }} --pattern "${{ matrix.dist_pattern }}" --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary

The Release matrix leg of `windows-test` in `test-distribution.yml` has been silently a no-op because of two compounding bugs.

1. **Broken glob.** The pattern `MeshLibDist_*[!-]*.zip` was written in bash/POSIX dialect (meaning "any character except `-`"). `gh release download --pattern` uses Go's `filepath.Match`, where the negation marker is `^`, not `!`. With `!`, the class `[!-]` is parsed as `!-]` — an unterminated range — and `filepath.Match` returns `ErrBadPattern`. `gh` then matches no asset and the step exits 1 with `no assets match the file pattern`.
2. **Failure swallowed.** `continue-on-error: true` on the Download step let the job report success despite the exit-1. The subsequent Unpack step's `Test-Path MeshLibDist*.zip` fallback set `dist_found=false`, and every meaningful follow-up step (`Run MeshViewer`, `Show meshconv help`, `Build C++ examples`, `Build C examples`) was skipped via the `if: dist_found == 'true'` guard.

Net effect: on every run, the Release leg of `windows-test` downloaded nothing, ran nothing, and reported success. Example failed-but-green run: https://github.com/MeshInspector/MeshLib/actions/runs/25388682878/job/74467172022 — `Download Distributive` shows exit code 1 in the log, conclusion `success`.

## Fix

- Replace the negation glob with the exact filename built from the release tag: `MeshLibDist_${{ inputs.release_tag }}.zip`. Verified locally against the v1.0.0.5296 draft release: this pattern matches the asset.
- Drop `continue-on-error: true` so a real download failure now fails the job.

The Debug matrix entry's pattern (`*-IteratorDebug.zip`) is left as-is — it's a valid glob and was already working.

## Test plan

- [ ] CI's `windows-test (MeshLibDist_*, Release, ...)` matrix leg actually runs `Run MeshViewer`, `Show meshconv help`, `Build C++ examples`, `Build C examples` (instead of skipping them).
- [ ] Both matrix legs (Release + IteratorDebug) report success.
