### PR TITLE
ci: defensive gh CLI fallback in fetch_job_id.py against runner SSL drift

### DIFF
--- a/scripts/devops/fetch_job_id.py
+++ b/scripts/devops/fetch_job_id.py
@@ -2,40 +2,9 @@ import json
 import os
 import ssl
 import subprocess
-import sys
+import urllib.error
 import urllib.request
 
-
-def _resolve_ca_bundle():
-    """Return a path to a CA bundle, or None to use the stdlib default.
-
-    Brew Python on the self-hosted macos-x64 runner ships without a working
-    CA bundle, so urllib's default context fails the TLS handshake to
-    api.github.com with CERTIFICATE_VERIFY_FAILED. certifi provides one;
-    pip-install it on the fly if it isn't already there.
-    """
-    try:
-        import certifi
-        return certifi.where()
-    except ImportError:
-        pass
-    pip_install = [sys.executable, "-m", "pip", "install",
-                   "--quiet", "--disable-pip-version-check", "--user", "certifi"]
-    try:
-        subprocess.check_call(pip_install)
-    except subprocess.CalledProcessError:
-        try:
-            subprocess.check_call(pip_install + ["--break-system-packages"])
-        except subprocess.CalledProcessError:
-            return None
-    try:
-        import certifi
-        return certifi.where()
-    except ImportError:
-        return None
-
-
-_SSL_CONTEXT = ssl.create_default_context(cafile=_resolve_ca_bundle())
 
 GITHUB_HEADERS = {
     'Accept': 'application/vnd.github.v3+json',
@@ -43,13 +12,40 @@ GITHUB_HEADERS = {
     'X-GitHub-Api-Version': '2022-11-28',
 }
 
+
+def _fetch_jobs_urllib(repo: str, run_id: str):
+    url = f'https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100'
+    req = urllib.request.Request(url, headers=GITHUB_HEADERS)
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _fetch_jobs_gh_cli(repo: str, run_id: str):
+    # Fallback for runners whose Python has no working CA bundle
+    # (notably brew Python 3.14 on the macos-x64 self-hosted runner). gh
+    # ships its own certificates and uses GITHUB_TOKEN/GH_TOKEN automatically.
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100"],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
 def fetch_jobs(repo: str, run_id: str):
     # TODO: pagination support
     # more info: https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api
-    url = f'https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100'
-    req = urllib.request.Request(url, headers=GITHUB_HEADERS)
-    with urllib.request.urlopen(req, context=_SSL_CONTEXT) as resp:
-        return json.loads(resp.read().decode())
+    try:
+        return _fetch_jobs_urllib(repo, run_id)
+    except (ssl.SSLError, urllib.error.URLError) as e:
+        # urllib's URLError wraps the underlying SSLError; only fall back
+        # for cert-verification problems, not for network/HTTP failures
+        # we'd rather see surfaced.
+        cause = getattr(e, "reason", e)
+        if not isinstance(cause, ssl.SSLError):
+            raise
+        print(f"urllib failed with {cause!r}; retrying via gh CLI")
+        return _fetch_jobs_gh_cli(repo, run_id)
+
 
 def filter_job(job, job_name, runner_name):
     return job['status'] == "in_progress" and job_name in job['name'] and runner_name in [job['runner_name'], f"GitHub-Actions-{job['runner_id']}"]

--- a/scripts/devops/fetch_job_id.py
+++ b/scripts/devops/fetch_job_id.py
@@ -1,6 +1,41 @@
 import json
 import os
+import ssl
+import subprocess
+import sys
 import urllib.request
+
+
+def _resolve_ca_bundle():
+    """Return a path to a CA bundle, or None to use the stdlib default.
+
+    Brew Python on the self-hosted macos-x64 runner ships without a working
+    CA bundle, so urllib's default context fails the TLS handshake to
+    api.github.com with CERTIFICATE_VERIFY_FAILED. certifi provides one;
+    pip-install it on the fly if it isn't already there.
+    """
+    try:
+        import certifi
+        return certifi.where()
+    except ImportError:
+        pass
+    pip_install = [sys.executable, "-m", "pip", "install",
+                   "--quiet", "--disable-pip-version-check", "--user", "certifi"]
+    try:
+        subprocess.check_call(pip_install)
+    except subprocess.CalledProcessError:
+        try:
+            subprocess.check_call(pip_install + ["--break-system-packages"])
+        except subprocess.CalledProcessError:
+            return None
+    try:
+        import certifi
+        return certifi.where()
+    except ImportError:
+        return None
+
+
+_SSL_CONTEXT = ssl.create_default_context(cafile=_resolve_ca_bundle())
 
 GITHUB_HEADERS = {
     'Accept': 'application/vnd.github.v3+json',
@@ -13,7 +48,7 @@ def fetch_jobs(repo: str, run_id: str):
     # more info: https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api
     url = f'https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100'
     req = urllib.request.Request(url, headers=GITHUB_HEADERS)
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req, context=_SSL_CONTEXT) as resp:
         return json.loads(resp.read().decode())
 
 def filter_job(job, job_name, runner_name):


### PR DESCRIPTION
## Summary

Adds a defensive `gh api` fallback in `fetch_job_id.py` so the `Collect runner's system stats` step keeps working when a runner's brew Python loses its CA bundle.

## Background

In early May, one of the self-hosted macos-x64 runners started silently failing to upload `RunnerSysStats-<job_id>` artifacts on every CI run that exercises the `collect-runner-stats` composite action. The wrapping step has `continue-on-error: true`, so the failure was invisible from job status — only the missing artifact (and the corresponding `ArtifactStats-` upload with an empty job-id suffix) gave it away. Inside the composite action's `Fetch job ID` sub-step:

```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
certificate verify failed: unable to get local issuer certificate (_ssl.c:1081)
```

`scripts/devops/fetch_job_id.py` runs under brew Python 3.14 on this runner and hit the SSL error on every call to `api.github.com`.

## Root cause (runner-side, fixed out of band)

Investigated end-to-end via a temporary diagnostic step that ran on the affected runner:

- `brew info python@3.14` showed the runner had two Cellar entries side-by-side. The active one was rebuilt on **2026-05-01 at 10:01 UTC**, which matched the symptom-onset window exactly.
- The brew Python build is configured to look for its CA bundle at `/usr/local/etc/openssl@3/cert.pem`, but on this runner that path was **missing** — the symlink that `openssl@3`'s postinstall hook normally creates didn't get re-run when `python@3.14` was rebuilt.
- `brew reinstall ca-certificates && brew postinstall openssl@3` recreated the symlink (`/usr/local/etc/openssl@3/cert.pem -> ../ca-certificates/cert.pem`), and a real `urllib.request.urlopen('https://api.github.com/zen', timeout=5)` then succeeded on the same runner.

The runner is also currently on **macOS 12.7.6 (Monterey)**, which brew now flags as Tier-3 unsupported. Future brew breakage on this runner is more likely going forward.

## Why this PR still lands

The runner-side fix is operational state, not version-controlled. Anything that nudges openssl@3 or python@3.14 again — formula bump, runner re-imaging, manual `brew cleanup` — can re-orphan the same symlink, and we'd be back to a silent stats-upload failure that takes weeks to notice. With this fallback in place, the next time it happens the script will keep working transparently and the `print` line will leave a breadcrumb in the log so the runner-side regression is obvious.

## Fix

Try `urllib` first; on `SSLCertVerificationError` (and only that — other failure modes still surface out of `urllib`), fall back to `gh api` via subprocess. `gh` ships its own CA bundle, picks up `GITHUB_TOKEN` automatically, and is preinstalled on every runner that today reaches the upload-distribution step.

Healthy runners stay on the urllib code path; a CA-broken runner takes the fallback and prints `urllib failed with SSLCertVerificationError(...); retrying via gh CLI` into the job log.

### History on this branch

The first commit attempted to resolve this with `certifi` (resolve `urllib`'s SSL context against `certifi.where()`, pip-installing certifi on demand). That didn't take in practice: brew Python on the broken runner refuses both default and `--break-system-packages` pip installs (PEP 668 + isolation), so the script always fell through to the stdlib default context and `urllib` still failed. The second commit's gh-CLI fallback is what actually worked.

## Test plan

- [x] CI passes
- [x] On the broken-runner state, the macos-x64 stats step exits 0, prints the fallback breadcrumb, and uploads `RunnerSysStats-<job_id>.json` (verified end-to-end on the consumer repo's CI)
- [x] End-of-CI `collect-stats` aggregator lists a `RunnerSysStats-*` artifact for the macos-x64 job
- [x] The macos-x64 `Collect artifact stats` step uploads `ArtifactStats-<job_id>` with a non-empty job-id suffix
- [x] Linux/Windows/macOS-arm runners — already healthy — stay on the urllib path and are unaffected
