### PR TITLE
wheel: strip non-extern symbols on macOS and Linux

### DIFF
--- a/scripts/wheel/build_wheel.py
+++ b/scripts/wheel/build_wheel.py
@@ -158,6 +158,20 @@ def build_wheel():
         subprocess.check_call(
             ["delocate-path", "meshlib"]
         )
+
+        # Strip non-extern symbols from every native binary in the wheel staging tree.
+        # macOS Mach-O retains all local symbols by default; without this step
+        # __LINKEDIT accounts for ~67% of mrmeshpy.so. `-x` keeps externs that dyld
+        # binds (PyInit_*, library entrypoints), so dynamic loading is unaffected.
+        # delocate-wheel below re-validates and re-signs after we touch the binaries.
+        binaries_to_strip = [
+            *WHEEL_SRC_DIR.glob("*.so"),
+            *WHEEL_SRC_DIR.glob("libpybind11nonlimitedapi_*.dylib"),
+            *(WHEEL_SRC_DIR / ".dylibs").glob("*.dylib"),
+        ]
+        for b in binaries_to_strip:
+            subprocess.check_call(["strip", "-x", str(b)])
+
         os.chdir(SOURCE_DIR)
         subprocess.check_call(
             ["delocate-wheel", "-w", ".", "-v", wheel_file]

--- a/scripts/wheel/build_wheel.py
+++ b/scripts/wheel/build_wheel.py
@@ -170,6 +170,8 @@ def build_wheel():
             *(WHEEL_SRC_DIR / ".dylibs").glob("*.dylib"),
         ]
         for b in binaries_to_strip:
+            # Brew-sourced dylibs delocate copies in are often 0444; strip needs +w.
+            b.chmod(b.stat().st_mode | 0o200)
             subprocess.check_call(["strip", "-x", str(b)])
 
         os.chdir(SOURCE_DIR)

--- a/scripts/wheel/build_wheel.py
+++ b/scripts/wheel/build_wheel.py
@@ -123,6 +123,11 @@ def build_wheel():
                 sys.executable, "-m", "auditwheel",
                 "repair",
                 "--plat", f"manylinux_{manylinux_version}_{platform.machine()}",
+                # Strip .symtab/.strtab/.debug_* from every bundled .so. ~15 MB
+                # uncompressed across the dep chain (libopenvdb, libxerces, OCCT,
+                # libMR*, etc.); compresses down well so net .whl saving is modest
+                # (~3-5 MB) but free.
+                "--strip",
                 wheel_file
             ]
         )


### PR DESCRIPTION
## Summary

The macOS pip wheel ships every Mach-O binary with its `__LINKEDIT` segment intact. On `mrmeshpy.so` (124.6 MB) `__LINKEDIT` is **82.8 MB — 67% of the file**; `libopenvdb.dylib` shows the same: 49 MB of 68.8 MB. The macOS build has no `strip` step; the Linux build has `auditwheel repair` but doesn't pass `--strip`, so the 99 bundled libs in `meshlib.libs/` retain ~15 MB of `.symtab`/`.strtab`/`.debug_*` they don't need at runtime.

This PR adds the missing strip step on both platforms:

- **macOS** — `strip -x` between `delocate-path` and `delocate-wheel` in `scripts/wheel/build_wheel.py`. `-x` removes only local symbols; externs that dyld binds (`PyInit_*`, library entrypoints) stay intact, so dynamic loading is unaffected. `chmod +w` first because delocate copies brew dylibs preserving their `0444` mode. `delocate-wheel` runs after the strip and re-validates / re-signs.
- **Linux** — `--strip` flag on `auditwheel repair`. auditwheel runs `strip` on each bundled library during the repair step.
- **Windows** — no change. PE files don't carry the equivalent symbol payload; PDBs are external and not bundled by `delvewheel`.

Expected savings from analysis of v3.1.2.192 wheels:
- macOS `.whl` (compressed): roughly **−30 MB** per wheel × 2 architectures
  - `mrmeshpy.so` 124.6 → ~50 MB uncompressed
  - `libopenvdb.dylib` 68.8 → ~25 MB uncompressed
- Linux `.whl` (compressed): roughly **−3-5 MB** per wheel × 2 architectures
  - 15 MB of strippable bytes across 99 bundled `.so` files (mostly `.strtab` which compresses well, hence the modest net savings)

## Test plan

CI under the `test-pip-build` label produces all 4 wheel artifacts; size delta is visible in the workflow summary.

- [ ] CI builds all 5 pip-build matrices green (macos x86, macos arm64, manylinux x86_64, manylinux aarch64, win amd64)
- [ ] Compare each platform's artifact size to baseline (current master) — confirm ~30 MB drop on macOS, ~3-5 MB on Linux, ~0 on Windows
- [ ] `pip install` the macOS arm64 wheel in a fresh venv, run `import meshlib.mrmeshpy; meshlib.mrmeshpy.makeCube()` — should succeed (catches any extern accidentally trimmed)
- [ ] Same for Linux x86_64 wheel
- [ ] Spot-check `lief.parse(...).segments` on a stripped Mach-O: `__LINKEDIT` should drop from ~80 MB to ~20-30 MB on `mrmeshpy.so`
- [ ] Spot-check `lief.parse(...).sections` on a stripped Linux bundled lib (e.g. `libopenvdb.so`): `.symtab`/`.strtab` should be near zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)