### PR TITLE
macos: strip non-extern symbols at link time (CMake + mrbind)

### DIFF
--- a/cmake/Modules/CompilerOptions.cmake
+++ b/cmake/Modules/CompilerOptions.cmake
@@ -27,6 +27,8 @@ ELSE() # if APPLE
   IF( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 17 ) # ethier AppleClang or Clang
     set(MESHLIB_COMMON_C_CXX_FLAGS "${MESHLIB_COMMON_C_CXX_FLAGS} -fno-assume-unique-vtables")
   ENDIF()
+  # Drop local Mach-O symbols in non-Debug builds (most of __LINKEDIT).
+  add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,-x>)
 ENDIF()
 
 # Warnings and misc compiler settings.

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -240,7 +240,7 @@ EXTRA_LDLAGS :=
 MODE := release
 ifeq ($(MODE),release)
 override EXTRA_CFLAGS += -Oz -flto=thin -DNDEBUG
-override EXTRA_LDFLAGS += -Oz -flto=thin $(if $(IS_MACOS),,-s)# No `-s` on macos. It seems to have no effect, and the linker warns about it.
+override EXTRA_LDFLAGS += -Oz -flto=thin $(if $(IS_MACOS),-Wl$(comma)-x,-s)# Apple's ld rejects `-s`; `-Wl,-x` drops local Mach-O symbols (most of __LINKEDIT) instead.
 else ifeq ($(MODE),debug)
 override EXTRA_CFLAGS += -g
 override EXTRA_LDFLAGS += -g


### PR DESCRIPTION
## Summary

The wheel-size investigation found that on macOS our shipped Mach-O binaries carry their full local symbol table in `__LINKEDIT`. On `mrmeshpy.so` that's **86 MB out of 119 MB (72% of the file)**, with similar ratios on `libMRMesh`/`libMRViewer`/`libMRVoxels`/`libMRMcp`/`libMRIOExtras`/etc. Linux strips by default; only macOS doesn't.

This PR adds `-Wl,-x` (the linker analog of `strip -x` — drops local symbols, keeps externs that dyld binds) on the macOS link line for non-Debug configs, in two places:

1. **`cmake/Modules/CompilerOptions.cmake`** — `add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,-x>)` in the existing Apple branch. Covers every CMake target (our libs, `libMeshLibC2`, in-tree thirdparty wrapped via `add_subdirectory`).
2. **`scripts/mrbind/generate.mk:243`** — replaces `$(if $(IS_MACOS),,-s)` (which skipped strip on macOS because Apple's `ld` rejects `-s`) with `$(if $(IS_MACOS),-Wl$(comma)-x,-s)`. Covers `mrmeshpy.so` and the other mrbind-generated Python bindings, which are linked outside the CMake tree.

This benefits **every macOS distribution** — wheels, the `.pkg` installer's `MeshLib.framework`, the `runtimes/osx-*/native/` slice of NuGet, the zip distribution. Replaces #6057 (a wheel-only attempt where the strip placement was ineffective).

## Verified savings — mac wheels (both archs)

| | arm64 | x86_64 |
|---|---:|---:|
| baseline `.whl` | 87.87 MB | 91.25 MB |
| this PR `.whl` | **77.86 MB** | **82.85 MB** |
| compressed Δ | **−10.01 MB (−11.4%)** | **−8.40 MB (−9.2%)** |

`mrmeshpy.so` (the dominant binary) before/after:

| | arm64 baseline | arm64 PR | x86_64 baseline | x86_64 PR |
|---|---:|---:|---:|---:|
| File size | 119.52 MB | **34.88** | 124.59 MB | **47.29** |
| `__TEXT` | 31.70 | 31.70 | 40.09 | 40.09 |
| `__LINKEDIT` | 86.08 | **1.44** | 82.80 | **5.49** |
| Symbol count | 528,811 | **2,958** | 394,251 | **23,858** |

`__TEXT` is byte-identical on both archs (sanity check: strip removed no code). Most of `__LINKEDIT` is mangled symbol names — DEFLATE crushes them ~10×, so the ~80 MB uncompressed save lands as ~9 MB compressed on the wheel.

Per-binary `__LINKEDIT` (arm64; x86_64 deltas are within ±10% of these):

| Binary | before MB | after MB | Δ MB |
|---|---:|---:|---:|
| **`mrmeshpy.so`** | **86.08** | **1.44** | **−84.64** |
| `libMRViewer.dylib` | 3.31 | 0.63 | −2.68 |
| `libMRMesh.dylib` | 3.04 | 0.60 | −2.44 |
| `libMRVoxels.dylib` | 2.76 | 0.24 | −2.53 |
| `libMRMcp.dylib` | 1.01 | 0.16 | −0.85 |
| `mrviewerpy.so` | 0.50 | 0.06 | −0.44 |
| `libMRIOExtras.dylib` | 0.37 | 0.10 | −0.28 |
| Others (mrcuda/mrmeshnumpy/MRPython/MRSymbolMesh) | 0.42 | 0.16 | −0.26 |

Equivalent verification on the `.pkg` from `macos-build-test`: every bundled dylib in `MeshLib.framework` is also stripped (e.g., `libMRMesh.dylib` `__LINKEDIT` 3.04 → 0.58 MB). `mrmeshpy.so` isn't in the `.pkg` (only the framework C++ libs + companion Python modules are), but the same lever benefits anyone consuming the framework or NuGet.

## Test plan

CI under `full-ci` + `test-pip-build` produces all relevant artifacts:

- [x] `macos-build-test (arm64, Release)` green
- [x] `macos-build-test (x64, Release)` green
- [x] `macos-build-test (arm64, Debug)` green (Debug skips strip — confirmed via generator expression)
- [x] `test-pip-build / macos-pip-build (arm64)` green
- [x] `test-pip-build / macos-pip-build (x86)` green
- [x] all `test-pip-build / macos-pip-test (arm64, ...)` green (6 Python versions)
- [x] all `test-pip-build / macos-pip-test (x86, ...)` green (6 Python versions)
- [x] `mrmeshpy.so` `__LINKEDIT` shrinks ~98% on both archs
- [x] `__TEXT` byte-identical on every binary
- [x] `Distributives_macos-arm` `.pkg` framework dylibs also stripped

## Risk

Low. `-Wl,-x` is the standard release-build linker option used by Apple's own SDK and most C++ projects shipping macOS dylibs. Doesn't affect dyld linkage, exception unwinding (CFI tables live in `__TEXT`'s `__unwind_info`/`__eh_frame`), `__cxa_*` lookups (in `__DATA_CONST`), or pybind11 entry points (`PyInit_*` is extern). All 12 macos-pip-test jobs (2 archs × 6 Python versions) pass — `import meshlib.mrmeshpy` and friends all work after dyld linkage. Rollback is a one-line revert per file.

## Follow-up

PR-B (separate) will strip third-party deps that we consume (vcpkg-installed libs on Linux+Windows via triplet linker flag, brew-installed dylibs on macOS via CI post-install strip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)