### PR TITLE
ci: add 10-minute timeout to Unit Tests steps in all workflows

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -187,10 +187,12 @@ jobs:
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'
+        timeout-minutes: 10
         run: ./build/${{ matrix.config }}/bin/MRTest
 
       - name: C Unit Tests
         if: ${{ inputs.mrbind_c }}
+        timeout-minutes: 10
         run: ./build/${{ matrix.config }}/bin/MRTestC2
 
       - name: Python Sanity Tests

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -197,10 +197,12 @@ jobs:
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'
+        timeout-minutes: 10
         run: ./build/${{ matrix.config }}/bin/MRTest
 
       - name: C Unit Tests
         if: ${{ inputs.mrbind_c }}
+        timeout-minutes: 10
         run: ./build/${{ matrix.config }}/bin/MRTestC2
 
       - name: Python Sanity Tests

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -205,10 +205,12 @@ jobs:
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'
+        timeout-minutes: 10
         run: ./build/${{ matrix.config }}/bin/MRTest
 
       - name: C Unit Tests
         if: ${{ inputs.mrbind_c }}
+        timeout-minutes: 10
         run: ./build/${{ matrix.config }}/bin/MRTestC2
 
       - name: Python Sanity Tests

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -153,10 +153,12 @@ jobs:
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'
+        timeout-minutes: 10
         run: ./build/${{ matrix.config }}/bin/MRTest
 
       - name: C Unit Tests
         if: ${{ inputs.mrbind_c }}
+        timeout-minutes: 10
         run: ./build/${{ matrix.config }}/bin/MRTestC2
 
       - name: Python Sanity Tests

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -231,14 +231,17 @@ jobs:
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'
+        timeout-minutes: 10
         run: source\x64\${{ matrix.config }}\MRTest.exe
 
       - name: C Unit Tests
         if: ${{inputs.mrbind_c && matrix.build_system == 'CMake'}}
+        timeout-minutes: 10
         run: py -3 scripts\run_c2_unit_test_script.py ${{ matrix.config }}
 
       - name: C# Unit Tests
         if: ${{ env.BUILD_C_SHARP == 'true' }}
+        timeout-minutes: 10
         run: |
           dotnet build source\MRDotNet2Test -c ${{ matrix.config }}
           source\x64\${{ matrix.config }}\MRDotNet2Test.exe --result="_report_nunit.xml"

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -165,6 +165,7 @@ jobs:
         run: xvfb-run -a ./build/Release/bin/MeshViewer -hidden -noEventLoop -unloadPluginsAtEnd
 
       - name: Unit Tests
+        timeout-minutes: 10
         run: build/Release/bin/MRTest
 
       - name: Python Tests
@@ -318,6 +319,7 @@ jobs:
         run: .\MeshViewer.exe -tryHidden -noEventLoop
 
       - name: Unit Tests
+        timeout-minutes: 10
         run: source\x64\Release\MRTest.exe
 
       - name: Python Tests
@@ -404,6 +406,7 @@ jobs:
           make -f scripts/mrbind/generate.mk -B --trace FOR_WHEEL=1 MACOS_MIN_VER=12.7
 
       - name: Unit Tests
+        timeout-minutes: 10
         run: build/Release/bin/MRTest
 
       - name: Python Tests


### PR DESCRIPTION
## Summary

Adds `timeout-minutes: 10` to every `Unit Tests` / `C Unit Tests` / `C# Unit Tests` step in the workflow files. Without a step-level timeout, a hung native test binary keeps running until the job-level timeout (50–100 minutes) fires. Looking at recent successful runs, these steps finish in well under a minute (the slowest observed was ~1m on Debug Windows), so 10 minutes is a generous buffer over the normal range while still surfacing hangs quickly.

The same convention is already applied to `Run Start-and-Exit Tests` (3 min) and `Python Sanity Tests` (8 min) in these workflows. `build-test-emscripten.yml`'s `Unit Tests` already has `timeout-minutes: 5` and is left as-is.

Touched workflows:

- `build-test-windows.yml` — Unit Tests, C Unit Tests, C# Unit Tests
- `build-test-linux-vcpkg.yml` — Unit Tests, C Unit Tests
- `build-test-ubuntu-arm64.yml` — Unit Tests, C Unit Tests
- `build-test-ubuntu-x64.yml` — Unit Tests, C Unit Tests
- `build-test-macos.yml` — Unit Tests, C Unit Tests
- `pip-build.yml` — three `Unit Tests` occurrences (manylinux / windows / macos pip builds)

## Test plan

- [x] CI completes on all touched platforms with the new step-level timeout in place
- [x] Unit Tests step durations remain well under the 10-minute cap on each platform
