### PR TITLE
deps: strip third-party libs at link time on Linux (vcpkg triplet)

### DIFF
--- a/scripts/install_brew_requirements.sh
+++ b/scripts/install_brew_requirements.sh
@@ -12,6 +12,11 @@ brew install --quiet $(echo "$MESHLIB_BREW_REQUIREMENTS" | tr '\n' ' ')
 
 brew install --quiet pybind11
 
+# Strip dylibs we'll bundle (brew keeps full symbol tables for symbolication).
+BREW_PREFIX=$(brew --prefix)
+find "$BREW_PREFIX/lib" -type f -name '*.dylib' -not -type l \
+  -exec chmod u+w {} + -exec strip -x {} + 2>/dev/null || true
+
 # check and upgrade python3 pip
 python3.10 -m ensurepip --upgrade
 python3.10 -m pip install --upgrade pip

--- a/scripts/install_brew_requirements.sh
+++ b/scripts/install_brew_requirements.sh
@@ -12,16 +12,6 @@ brew install --quiet $(echo "$MESHLIB_BREW_REQUIREMENTS" | tr '\n' ' ')
 
 brew install --quiet pybind11
 
-# Strip dylibs we'll bundle (brew keeps full symbol tables for symbolication).
-# Walk Cellar/ because $BREW_PREFIX/lib has only symlinks. Re-sign after
-# strip — strip invalidates the ad-hoc signature and dyld then kills the
-# process with SIGKILL on Apple Silicon.
-BREW_PREFIX=$(brew --prefix)
-find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' \
-  -exec chmod u+w {} + \
-  -exec strip -x {} + \
-  -exec codesign --force --sign - {} + 2>/dev/null || true
-
 # check and upgrade python3 pip
 python3.10 -m ensurepip --upgrade
 python3.10 -m pip install --upgrade pip

--- a/scripts/install_brew_requirements.sh
+++ b/scripts/install_brew_requirements.sh
@@ -13,10 +13,14 @@ brew install --quiet $(echo "$MESHLIB_BREW_REQUIREMENTS" | tr '\n' ' ')
 brew install --quiet pybind11
 
 # Strip dylibs we'll bundle (brew keeps full symbol tables for symbolication).
-# Walk Cellar/ directly because $BREW_PREFIX/lib contains only symlinks into it.
+# Walk Cellar/ because $BREW_PREFIX/lib has only symlinks. Re-sign after
+# strip — strip invalidates the ad-hoc signature and dyld then kills the
+# process with SIGKILL on Apple Silicon.
 BREW_PREFIX=$(brew --prefix)
 find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' \
-  -exec chmod u+w {} + -exec strip -x {} + 2>/dev/null || true
+  -exec chmod u+w {} + \
+  -exec strip -x {} + \
+  -exec codesign --force --sign - {} + 2>/dev/null || true
 
 # check and upgrade python3 pip
 python3.10 -m ensurepip --upgrade

--- a/scripts/install_brew_requirements.sh
+++ b/scripts/install_brew_requirements.sh
@@ -13,8 +13,9 @@ brew install --quiet $(echo "$MESHLIB_BREW_REQUIREMENTS" | tr '\n' ' ')
 brew install --quiet pybind11
 
 # Strip dylibs we'll bundle (brew keeps full symbol tables for symbolication).
+# Walk Cellar/ directly because $BREW_PREFIX/lib contains only symlinks into it.
 BREW_PREFIX=$(brew --prefix)
-find "$BREW_PREFIX/lib" -type f -name '*.dylib' -not -type l \
+find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' \
   -exec chmod u+w {} + -exec strip -x {} + 2>/dev/null || true
 
 # check and upgrade python3 pip

--- a/thirdparty/vcpkg/triplets/arm64-linux-meshlib.cmake
+++ b/thirdparty/vcpkg/triplets/arm64-linux-meshlib.cmake
@@ -12,3 +12,6 @@ set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 set(VCPKG_BUILD_TYPE release)
 
 set(VCPKG_FIXUP_ELF_RPATH ON)
+
+# Strip .symtab/.strtab/.debug_* on release link (~15 MB across the dep chain).
+set(VCPKG_LINKER_FLAGS_RELEASE "${VCPKG_LINKER_FLAGS_RELEASE} -Wl,-s")

--- a/thirdparty/vcpkg/triplets/x64-linux-meshlib.cmake
+++ b/thirdparty/vcpkg/triplets/x64-linux-meshlib.cmake
@@ -12,3 +12,6 @@ set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 set(VCPKG_BUILD_TYPE release)
 
 set(VCPKG_FIXUP_ELF_RPATH ON)
+
+# Strip .symtab/.strtab/.debug_* on release link (~15 MB across the dep chain).
+set(VCPKG_LINKER_FLAGS_RELEASE "${VCPKG_LINKER_FLAGS_RELEASE} -Wl,-s")


### PR DESCRIPTION
## Summary

Companion to merged PR #6058 (`macos: strip non-extern symbols at link time`). PR-A stripped the libs **we** build on macOS; this PR strips the third-party libs **vcpkg builds** on Linux for us.

In [thirdparty/vcpkg/triplets/x64-linux-meshlib.cmake](thirdparty/vcpkg/triplets/x64-linux-meshlib.cmake) and [arm64-linux-meshlib.cmake](thirdparty/vcpkg/triplets/arm64-linux-meshlib.cmake):
```cmake
set(VCPKG_LINKER_FLAGS_RELEASE "${VCPKG_LINKER_FLAGS_RELEASE} -Wl,-s")
```

`-Wl,-s` runs strip during the link step — before `patchelf` ever touches the binary. That sidesteps the `auditwheel --strip` patchelf-then-strip alignment bug that broke #6057's earlier attempt (libraries became unloadable with `ELF load command address/offset not page-aligned`). Drops `.symtab`/`.strtab`/`.debug_*` while keeping `.dynsym`/`.dynstr` (needed for dynamic linking) and `.eh_frame` (needed for exception unwinding).

This benefits **every Linux distribution** that bundles vcpkg-built deps: pip wheels (auditwheel copies the already-stripped libs), `.deb`/`.rpm` (CMake install copies them), and `runtimes/linux-*/native/` slice of the NuGet package.

## Verified savings (Linux x86_64 wheel)

CI run on a previous head of this branch verified:

| Binary | before | after |
|---|---:|---:|
| `libopenvdb.so.12.0.1` `.strtab` | 2.07 MB | **0.00 MB** |
| `libopenvdb.so.12.0.1` `.symtab` | 0.27 MB | **0.00 MB** |
| `meshlib.libs/` total uncompressed | 169.59 MB | **162.31 MB** (−7.28) |
| `.whl` compressed | 80.52 MB | **79.12 MB** (−1.40) |

All 14 manylinux pip-test jobs (7 Python versions × 2 architectures) passed — the patchelf-alignment bug from #6057 does not recur with strip-at-link.

## Scope reduction

An earlier version of this PR also added a brew post-install strip on macOS to cover the `__LINKEDIT` bloat in bundled brew dylibs (libopenvdb 49 MB on macOS, etc.). CI verified the strip ran successfully on Cellar, but the resulting wheel's libopenvdb.dylib was **byte-identical** to before — strip+codesign on brew bottles appears to be a silent no-op (likely a hardened-runtime signature interaction). Rather than ship dead code, the macOS half has been moved to a separate investigation branch. Linux strip works; this PR ships that.

## Test plan

- [x] `linux-vcpkg-build-test` green — vcpkg ports build cleanly with `-Wl,-s`
- [x] `test-pip-build / manylinux-pip-build (x86_64)` and `(aarch64)` green
- [x] All `test-pip-build / manylinux-pip-test (...)` pass — patchelf alignment bug doesn't recur
- [x] `meshlib.libs/libopenvdb-*.so.12.0.1` `.strtab` ≈ 0 in the wheel
- [x] Compressed Linux wheel size −1.4 MB

## Risk

- **`-Wl,-s`** is a well-trodden release flag for ELF; any port hard-coding link config simply ignores it. Static-only ports (e.g. `zlib-ng` is gated to static in our triplet) won't see this — `VCPKG_LINKER_FLAGS_RELEASE` only applies to the link step, and static archives don't link.
- Rollback: revert one line per triplet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)