### PR TITLE
Revert "macos: strip non-extern symbols at link time" (#6058)

### DIFF
--- a/cmake/Modules/CompilerOptions.cmake
+++ b/cmake/Modules/CompilerOptions.cmake
@@ -27,8 +27,6 @@ ELSE() # if APPLE
   IF( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 17 ) # ethier AppleClang or Clang
     set(MESHLIB_COMMON_C_CXX_FLAGS "${MESHLIB_COMMON_C_CXX_FLAGS} -fno-assume-unique-vtables")
   ENDIF()
-  # Drop local Mach-O symbols in non-Debug builds (most of __LINKEDIT).
-  add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,-x>)
 ENDIF()
 
 # Warnings and misc compiler settings.

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -240,7 +240,7 @@ EXTRA_LDLAGS :=
 MODE := release
 ifeq ($(MODE),release)
 override EXTRA_CFLAGS += -Oz -flto=thin -DNDEBUG
-override EXTRA_LDFLAGS += -Oz -flto=thin $(if $(IS_MACOS),-Wl$(comma)-x,-s)# Apple's ld rejects `-s`; `-Wl,-x` drops local Mach-O symbols (most of __LINKEDIT) instead.
+override EXTRA_LDFLAGS += -Oz -flto=thin $(if $(IS_MACOS),,-s)# No `-s` on macos. It seems to have no effect, and the linker warns about it.
 else ifeq ($(MODE),debug)
 override EXTRA_CFLAGS += -g
 override EXTRA_LDFLAGS += -g


### PR DESCRIPTION
## Why

Master `macos-build-test (arm64, Release) / Python Sanity Tests` has been red since `d06d744e` ([run 25494990063](https://github.com/MeshInspector/MeshLib/actions/runs/25494990063/job/74812356579)). The C++ unit tests on the same job pass, but `import meshlib.mrmeshpy` fails with `ImportError: initialization failed` — visible directly in MRTest's embedded-python sub-test on a GitHub-hosted runner: [job 74838233324, line 7841](https://github.com/MeshInspector/MeshLib/actions/runs/25502267459/job/74838233324).

```
[error] ImportError: initialization failed
At:
  <string>(2): <module>
[error] Embedded python run failed
```

Root cause is #6058: `-Wl,-x` + `-flto=thin` + `-fvisibility=hidden` on `mrmeshpy.so` produces a binary whose pybind11 module-init returns NULL when loaded by Python. ThinLTO's parallel codegen makes this build-to-build non-deterministic — pre-merge CI of #6062 happened to land on a working LTO partition; the post-merge link did not. #6062 didn't introduce the bug, only forced the re-link that exposed it. Same failure family as the `wheel/strip-thirdparty` branch's [4db5cf8c](https://github.com/MeshInspector/MeshLib/commit/4db5cf8c) ("strip invalidates the existing ad-hoc signature, and dyld then SIGKILLs any process trying to load the dylib").

Reverting both files restores the pre-#6058 link line. Unblocks PR #6064 and any other PR currently red on this job without further code changes.

## Follow-up (separate)

Re-attempt the wheel-size optimization with safer mechanics:
- Post-link `strip -x` + `codesign --force --sign -` instead of linker `-Wl,-x` (the shape `wheel/strip-thirdparty` is converging on for brew dylibs).
- Or restrict strip to our hand-written libs (`libMRMesh` etc., proven safe by the still-passing C++ unit tests) and exclude mrbind-generated `*.so`.
- Add `python3 -c "import meshlib.mrmeshpy"` as a smoke step right after link so this regression class is caught in seconds, not buried in pytest collection silence.

## Test plan

- [ ] CI green on `macos-build-test (arm64, Release) / Python Sanity Tests`
- [ ] All other macOS jobs still green (Debug, x64 Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)