### PR TITLE
ci(macos): surface pytest crash cause + capture runner state on failure

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -326,6 +326,43 @@ jobs:
           sys.path.insert(0, '.')
           import meshlib.mrmeshnumpy
           " 2>&1 | tail -120
+
+          # Test: is the kernel page-hash refusal sticky to the file currently on disk
+          # (so `pip install --force-reinstall` rewrites it and unsticks the kill),
+          # or is it a kernel-cache fault that survives a file rewrite?
+          # Unset VIRTUAL_ENV so pip writes to brew's python@3.10 site-packages
+          # (the 3.14 venv was activated earlier in the job and is irrelevant here).
+          unset VIRTUAL_ENV
+          PY310=/opt/homebrew/bin/python3.10
+          PY310_SITE=$("$PY310" -c "import site,sys; sys.stdout.write(site.getsitepackages()[0])" 2>/dev/null)
+          echo "==== python3.10 site-packages: $PY310_SITE ===="
+          echo "==== before: codesign -dvv + ls -la on numpy native modules ===="
+          for f in $(find "$PY310_SITE/numpy" -name '*.cpython-310-darwin.so' 2>/dev/null); do
+            echo "---- $f ----"
+            ls -la "$f"
+            codesign -dvv "$f" 2>&1 | head -15
+            codesign --verify --verbose=2 "$f" 2>&1
+          done
+          REQS="$GITHUB_WORKSPACE/requirements/python.txt"
+          echo "==== requirements/python.txt contents ===="
+          cat "$REQS"
+          echo "==== pip install --force-reinstall -r requirements/python.txt (python3.10) ===="
+          "$PY310" -m pip install --force-reinstall --no-deps -r "$REQS" 2>&1 | tail -60
+          echo "==== after: codesign -dvv + ls -la on numpy native modules ===="
+          for f in $(find "$PY310_SITE/numpy" -name '*.cpython-310-darwin.so' 2>/dev/null); do
+            echo "---- $f ----"
+            ls -la "$f"
+            codesign -dvv "$f" 2>&1 | head -15
+            codesign --verify --verbose=2 "$f" 2>&1
+          done
+          echo "==== retry mrmeshnumpy import (post-reinstall) ===="
+          PYTHONFAULTHANDLER=1 "$PY310" -X faulthandler -c "
+          import sys
+          sys.path.insert(0, '.')
+          import meshlib.mrmeshnumpy as n
+          print('mrmeshnumpy OK after reinstall:', n.__file__)
+          " 2>&1 || echo "still failing after reinstall"
+
           echo "==== diagnostic smoke import via venv python3 ===="
           PYTHONFAULTHANDLER=1 python3 -X faulthandler -c "
           import sys, importlib

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -205,10 +205,70 @@ jobs:
         timeout-minutes: 10
         run: ./build/${{ matrix.config }}/bin/MRTestC2
 
+      - name: Python smoke import
+        if: ${{ inputs.mrbind }}
+        timeout-minutes: 1
+        working-directory: ./build/${{ matrix.config }}/bin
+        env:
+          PYTHONFAULTHANDLER: '1'
+          PYTHONUNBUFFERED: '1'
+        # Fast canary: if the freshly built bindings can't be imported, bail before
+        # pytest collection swallows the failure inside its subprocess.
+        run: |
+          python3 -X faulthandler -c "
+          import sys
+          sys.path.insert(0, '.')
+          import meshlib.mrmeshpy as m
+          import meshlib.mrmeshnumpy as n
+          print('mrmeshpy:', m.__file__)
+          print('mrmeshnumpy:', n.__file__)
+          "
+
       - name: Python Sanity Tests
         timeout-minutes: 8
         working-directory: ./build/${{ matrix.config }}/bin
         run: python3 ./../../../scripts/run_python_test_script.py -d '../test_python' -a ' --junit-xml=../unit_tests_report_pytest.xml'
+
+      - name: Runner diagnostics on Python test failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          set +e
+          echo "==== runner identity ===="
+          echo "RUNNER_NAME=${RUNNER_NAME:-unknown}"
+          echo "==== sw_vers / uptime ===="
+          sw_vers
+          uptime
+          echo "==== disk / memory ===="
+          df -h .
+          vm_stat
+          echo "==== relevant brew packages ===="
+          brew list --versions python@3.10 llvm@18 libomp openvdb tbb cmake ninja make 2>/dev/null
+          echo "==== which python3 ===="
+          which -a python3 python3.10
+          python3 --version
+          echo "==== recent DiagnosticReports (top 20) ===="
+          ls -lt ~/Library/Logs/DiagnosticReports/ 2>/dev/null | head -21
+          echo "==== latest python/pytest crash reports (max 3, last 80 lines each) ===="
+          for f in $(ls -t ~/Library/Logs/DiagnosticReports/python*.ips ~/Library/Logs/DiagnosticReports/pytest*.ips 2>/dev/null | head -3); do
+            echo "---- $f ----"
+            tail -80 "$f"
+          done
+          echo "==== orphan python/pytest processes ===="
+          ps -ax -o pid,pcpu,rss,etime,command | grep -E 'python|pytest' | grep -v grep
+          echo "==== diagnostic smoke import (force-resolve paths) ===="
+          cd ./build/${{ matrix.config }}/bin
+          PYTHONFAULTHANDLER=1 python3 -X faulthandler -c "
+          import sys, importlib
+          sys.path.insert(0, '.')
+          for name in ['meshlib.mrmeshpy', 'meshlib.mrmeshnumpy']:
+              try:
+                  m = importlib.import_module(name)
+                  print(name, 'OK', m.__file__)
+              except BaseException as e:
+                  print(name, 'FAIL', type(e).__name__, e)
+          "
+          true
 
       - name: Python Regression Tests
         if: ${{ inputs.internal_build }}

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -212,10 +212,11 @@ jobs:
         env:
           PYTHONFAULTHANDLER: '1'
           PYTHONUNBUFFERED: '1'
-        # Fast canary: if the freshly built bindings can't be imported, bail before
-        # pytest collection swallows the failure inside its subprocess.
+        # Use python3.10 to match the build target (PYTHON_PKGCONF_NAME=python-3.10-embed)
+        # and what `Python Sanity Tests` invokes — `python3` would pick the venv's
+        # python (3.14 today on these runners), which is a separate latent issue.
         run: |
-          python3 -X faulthandler -c "
+          python3.10 -X faulthandler -c "
           import sys
           sys.path.insert(0, '.')
           import meshlib.mrmeshpy as m

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -247,6 +247,28 @@ jobs:
           echo "==== which python3 ===="
           which -a python3 python3.10
           python3 --version
+          echo "==== .venv state (mtime / pyvenv.cfg / python symlink) ===="
+          ls -lad .venv 2>/dev/null
+          ls -lad .venv/bin/python* 2>/dev/null
+          echo "---- .venv/pyvenv.cfg ----"
+          cat .venv/pyvenv.cfg 2>/dev/null
+          echo "==== candidate python3 binaries (existence / symlink target / version) ===="
+          for p in \
+              /Users/admin/anaconda3/bin/python3 \
+              /Users/admin/anaconda3/bin/python3.10 \
+              /Users/admin/anaconda3/bin/python3.14 \
+              /opt/homebrew/bin/python3 \
+              /opt/homebrew/bin/python3.10 \
+              /opt/homebrew/bin/python3.14 \
+              /usr/bin/python3; do
+            if [ -e "$p" ]; then
+              tgt=$(readlink "$p" 2>/dev/null)
+              ver=$("$p" --version 2>&1)
+              echo "$p -> ${tgt:-(not a symlink)} : $ver"
+            else
+              echo "$p : MISSING"
+            fi
+          done
           echo "==== recent DiagnosticReports (top 20) ===="
           ls -lt ~/Library/Logs/DiagnosticReports/ 2>/dev/null | head -21
           echo "==== latest python/pytest crash reports (max 3, last 80 lines each) ===="

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -205,23 +205,35 @@ jobs:
         timeout-minutes: 10
         run: ./build/${{ matrix.config }}/bin/MRTestC2
 
-      - name: Python smoke import
+      - name: Python smoke import (mrmeshpy only)
         if: ${{ inputs.mrbind }}
         timeout-minutes: 1
         working-directory: ./build/${{ matrix.config }}/bin
         env:
           PYTHONFAULTHANDLER: '1'
           PYTHONUNBUFFERED: '1'
-        # Use python3.10 to match the build target (PYTHON_PKGCONF_NAME=python-3.10-embed)
-        # and what `Python Sanity Tests` invokes — `python3` would pick the venv's
-        # python (3.14 today on these runners), which is a separate latent issue.
+        # Split mrmeshpy and mrmeshnumpy so the failing one is identified.
+        # Crash report from the prior unsplit step pointed inside PyInit_mrmeshnumpy.
         run: |
           python3.10 -X faulthandler -c "
           import sys
           sys.path.insert(0, '.')
           import meshlib.mrmeshpy as m
-          import meshlib.mrmeshnumpy as n
           print('mrmeshpy:', m.__file__)
+          "
+
+      - name: Python smoke import (mrmeshnumpy only)
+        if: ${{ inputs.mrbind }}
+        timeout-minutes: 1
+        working-directory: ./build/${{ matrix.config }}/bin
+        env:
+          PYTHONFAULTHANDLER: '1'
+          PYTHONUNBUFFERED: '1'
+        run: |
+          python3.10 -X faulthandler -c "
+          import sys
+          sys.path.insert(0, '.')
+          import meshlib.mrmeshnumpy as n
           print('mrmeshnumpy:', n.__file__)
           "
 
@@ -303,16 +315,17 @@ jobs:
           echo "==== signature on python3.10 itself ===="
           codesign -dvv /opt/homebrew/bin/python3.10 2>&1 | head -10
           codesign --verify --verbose=2 /opt/homebrew/bin/python3.10 2>&1
-          echo "==== dyld trace of failing import (dyld_info / DYLD_PRINT_LIBRARIES) ===="
-          # Try to capture which dylib triggered SIGKILL via dyld's verbose load logging.
-          # Apple Silicon SIGKILLs on signature failure tend to leave a crash report
-          # naming the offender — but the live load trace pinpoints the same file faster.
+          echo "==== otool -L on mrmeshnumpy.so (dep chain) ===="
+          otool -L meshlib/mrmeshnumpy.so 2>&1 || true
+          echo "==== dyld trace of failing mrmeshnumpy import (DYLD_PRINT_LIBRARIES) ===="
+          # The SIGKILL is inside PyInit_mrmeshnumpy per the crash report; trace the
+          # dylib load order so the LAST line before kill names the offending file.
           DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_LIBRARY_PATH=1 \
               python3.10 -X faulthandler -c "
           import sys
           sys.path.insert(0, '.')
-          import meshlib.mrmeshpy
-          " 2>&1 | tail -80
+          import meshlib.mrmeshnumpy
+          " 2>&1 | tail -120
           echo "==== diagnostic smoke import via venv python3 ===="
           PYTHONFAULTHANDLER=1 python3 -X faulthandler -c "
           import sys, importlib

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -272,15 +272,48 @@ jobs:
           done
           echo "==== recent DiagnosticReports (top 20) ===="
           ls -lt ~/Library/Logs/DiagnosticReports/ 2>/dev/null | head -21
-          echo "==== latest python/pytest crash reports (max 3, last 80 lines each) ===="
-          for f in $(ls -t ~/Library/Logs/DiagnosticReports/python*.ips ~/Library/Logs/DiagnosticReports/pytest*.ips 2>/dev/null | head -3); do
+          echo "==== latest Python/pytest crash reports from today (max 3, full content) ===="
+          today=$(date +%Y-%m-%d)
+          shopt -s nocaseglob
+          for f in $(ls -t ~/Library/Logs/DiagnosticReports/Python*${today}*.ips ~/Library/Logs/DiagnosticReports/pytest*${today}*.ips 2>/dev/null | head -3); do
             echo "---- $f ----"
-            tail -80 "$f"
+            cat "$f"
+            echo "---- end $f ----"
           done
-          echo "==== orphan python/pytest processes ===="
-          ps -ax -o pid,pcpu,rss,etime,command | grep -E 'python|pytest' | grep -v grep
-          echo "==== diagnostic smoke import (force-resolve paths) ===="
+          shopt -u nocaseglob
+          echo "==== codesign on suspect dylibs in build/${{ matrix.config }}/bin ===="
           cd ./build/${{ matrix.config }}/bin
+          for d in meshlib/mrmeshpy.so \
+                   meshlib/mrmeshnumpy.so \
+                   meshlib/libpybind11nonlimitedapi_meshlib_3.10.dylib \
+                   meshlib/libpybind11nonlimitedapi_meshlib_3.14.dylib \
+                   libpybind11nonlimitedapi_stubs.dylib \
+                   libMRMesh.dylib \
+                   libMRPython.dylib \
+                   libMRViewer.dylib \
+                   libMRVoxels.dylib; do
+            if [ -e "$d" ]; then
+              echo "---- $d ----"
+              codesign -dvv "$d" 2>&1 | head -15
+              codesign --verify --verbose=2 "$d" 2>&1
+            else
+              echo "$d : MISSING"
+            fi
+          done
+          echo "==== signature on python3.10 itself ===="
+          codesign -dvv /opt/homebrew/bin/python3.10 2>&1 | head -10
+          codesign --verify --verbose=2 /opt/homebrew/bin/python3.10 2>&1
+          echo "==== dyld trace of failing import (dyld_info / DYLD_PRINT_LIBRARIES) ===="
+          # Try to capture which dylib triggered SIGKILL via dyld's verbose load logging.
+          # Apple Silicon SIGKILLs on signature failure tend to leave a crash report
+          # naming the offender — but the live load trace pinpoints the same file faster.
+          DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_LIBRARY_PATH=1 \
+              python3.10 -X faulthandler -c "
+          import sys
+          sys.path.insert(0, '.')
+          import meshlib.mrmeshpy
+          " 2>&1 | tail -80
+          echo "==== diagnostic smoke import via venv python3 ===="
           PYTHONFAULTHANDLER=1 python3 -X faulthandler -c "
           import sys, importlib
           sys.path.insert(0, '.')

--- a/scripts/run_python_test_script.py
+++ b/scripts/run_python_test_script.py
@@ -1,11 +1,39 @@
 import argparse
 import os
 import re
+import signal
 import sys
 import platform
 import subprocess
 import shutil
 from pathlib import Path
+
+
+def run_pytest(cmd):
+    # os.system swallows signal info into a packed wait status, and Python parent-process
+    # buffering reorders prints past pytest's output — both made a recent CI crash
+    # appear as a silent "Some tests failed!" with no cause. Use subprocess + flush + faulthandler.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    env = os.environ.copy()
+    env.setdefault("PYTHONFAULTHANDLER", "1")
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    rc = subprocess.run(cmd, shell=True, env=env).returncode
+    if rc < 0:  # POSIX: killed by signal
+        try:
+            signame = signal.Signals(-rc).name
+        except (ValueError, AttributeError):
+            signame = f"signal {-rc}"
+        print(f"!!! pytest terminated by {signame} (returncode {rc})", flush=True)
+    elif 128 <= rc < 256:  # POSIX shell convention: 128 + signum
+        try:
+            signame = signal.Signals(rc - 128).name
+            print(f"!!! pytest terminated by {signame} (shell exit {rc})", flush=True)
+        except (ValueError, AttributeError):
+            print(f"!!! pytest exited with code {rc}", flush=True)
+    elif rc != 0:
+        print(f"!!! pytest exited with code {rc}", flush=True)
+    return rc
 
 def get_vcpkg_root_from_where():
     try:
@@ -132,7 +160,7 @@ for py_cmd in python_cmds:
         py_cmd_fixed = py_cmd
 
     print(py_cmd_fixed + " " + pytest_cmd)
-    if os.system(py_cmd_fixed + " " + pytest_cmd) != 0:
+    if run_pytest(py_cmd_fixed + " " + pytest_cmd) != 0:
         failed = True
 
     if args.create_venv:


### PR DESCRIPTION
## Why

Today's self-hosted-runner outage on `MacBook-Pro-Daniil` showed up in CI logs as just:

```
============================= test session starts ==============================
platform darwin -- Python 3.10.20, pytest-7.4.4 ...
plugins: check-2.3.1
collecting ...
ERROR: Some tests failed!
##[error]Process completed with exit code 1.
```

No traceback, no signal, no crash report. That made me chase a wrong PR ([#6067](https://github.com/MeshInspector/MeshLib/pull/6067), now closed) before realizing the actual problem was just one runner being broken — the same code on `MACBOOK-PRO-16-2021-TBI-2` ran fine on rerun ([attempt 2](https://github.com/MeshInspector/MeshLib/actions/runs/25494990063?attempt=2)).

The CI silence had two compounding causes that this PR fixes:

1. `scripts/run_python_test_script.py` invokes pytest via `os.system`, which encodes signal exits into a packed wait status and prints a generic \"Some tests failed!\". And the parent script's `print()`s buffered behind pytest's stdout, then flushed out of order after pytest died, so even the few lines we did see didn't make sense.
2. No pre-pytest sanity check: if `import meshlib.mrmeshpy` is what's breaking, you only learn that during pytest collection — and only when collection prints something. If pytest is killed mid-collection, you get nothing.

## What this PR adds

- **`run_python_test_script.py`**: replace the pytest `os.system` with `subprocess.run`, flush parent stdout first, and decode the exit status. POSIX signal kills (returncode `< 0` or shell `128 + signum`) now print e.g. `!!! pytest terminated by SIGSEGV (returncode -11)`. Subprocess inherits `PYTHONFAULTHANDLER=1` and `PYTHONUNBUFFERED=1` so a segfault during pytest collection dumps a Python traceback instead of disappearing.
- **`build-test-macos.yml` — `Python smoke import` step**: 1-minute canary right before `Python Sanity Tests` that just `import meshlib.mrmeshpy; import meshlib.mrmeshnumpy`. If the freshly built bindings can't load, this fails fast with the actual import error, before pytest gets to swallow it.
- **`build-test-macos.yml` — `Runner diagnostics on Python test failure` step** (`if: failure()`): macOS version, uptime, disk, memory, brew versions of the relevant deps, recent `~/Library/Logs/DiagnosticReports/` listing, the last 80 lines of up to 3 latest `python*.ips` / `pytest*.ips` crash reports, orphan python/pytest processes, and a faulthandler-enabled re-import attempt for triangulation.

Strictly observability — no behavior change on the green path. Marked draft because I want to verify the new step layout actually fires sensibly in a real failure before merging; happy to demote/remove either of the workflow steps if reviewers think they're too noisy.

## Test plan

- [ ] CI green on the green path (smoke import succeeds → pytest succeeds → diagnostic step skipped via `if: failure()`).
- [ ] Diagnostic step fires when `Python Sanity Tests` fails — most easily confirmed if `MacBook-Pro-Daniil` reproduces today's failure on this branch.
- [ ] Smoke import emits an `ImportError` line with traceback when bindings are broken (negative test — only verifiable if a binding regression lands; not pre-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)