### PR TITLE
ci: verify meshlib.mrmeshpy import before Unit Tests

### DIFF
--- a/.github/actions/verify-meshlib-python-import/action.yml
+++ b/.github/actions/verify-meshlib-python-import/action.yml
@@ -15,16 +15,85 @@ inputs:
 runs:
   using: composite
   steps:
+    # The mrbind pybind11 non-limited-api shim is suffixed with the exact
+    # Python X.Y the bindings were built for (pybind11nonlimitedapi_meshlib_3.12.dll
+    # / .so / .dylib). Loading mrmeshpy from the wrong Python version
+    # raises `Failed to load library pybind11nonlimitedapi_meshlib_<wrong>`
+    # at module-init time, which CPython then re-raises as the opaque
+    # "ImportError: initialization failed".
+    #
+    # Regular build-test-* workflows produce one shim (the build's single
+    # Python). The pip-build wheel jobs (FOR_WHEEL=1) produce a shim per
+    # version listed in scripts/mrbind-pybind11/python_versions.txt
+    # (currently 3.8 through 3.14). Verify against every shim found,
+    # invoking each via its matching interpreter. Skip versions whose
+    # interpreter isn't on the runner; fail if any *attempted* import
+    # fails.
+
     - name: Verify meshlib.mrmeshpy import (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       env:
         PYTHONPATH: ${{ inputs.build-bin-dir }}
-      run: py -3 "$Env:GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
+      run: |
+        $meshlib = Join-Path '${{ inputs.build-bin-dir }}' 'meshlib'
+        $shims = @(Get-ChildItem -Path $meshlib -Filter 'pybind11nonlimitedapi_meshlib_*.dll' -ErrorAction SilentlyContinue | Sort-Object Name)
+        if ($shims.Count -eq 0) {
+          Write-Host "No pybind11nonlimitedapi_meshlib_*.dll shim in $meshlib; running once with default py -3"
+          py -3 "$Env:GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
+          exit $LASTEXITCODE
+        }
+        $attempted = 0; $failed = 0; $skipped = @()
+        foreach ($shim in $shims) {
+          $ver = $shim.BaseName -replace '^pybind11nonlimitedapi_meshlib_', ''
+          Write-Host ""
+          Write-Host "===== verify with py -$ver  (shim: $($shim.Name)) ====="
+          py "-$ver" -c "import sys" 2>$null
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "SKIP: py -$ver not available on runner"
+            $skipped += $ver
+            continue
+          }
+          $attempted++
+          py "-$ver" "$Env:GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
+          if ($LASTEXITCODE -ne 0) { $failed++ }
+        }
+        Write-Host ""
+        Write-Host "Summary: shims=$($shims.Count) attempted=$attempted failed=$failed skipped=$($skipped.Count) [$($skipped -join ', ')]"
+        if ($failed -gt 0) { exit 1 }
 
     - name: Verify meshlib.mrmeshpy import (Unix)
       if: runner.os != 'Windows'
       shell: bash
       env:
         PYTHONPATH: ${{ inputs.build-bin-dir }}
-      run: python3 "$GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
+      run: |
+        meshlib="${{ inputs.build-bin-dir }}/meshlib"
+        shopt -s nullglob
+        shims=( "$meshlib"/libpybind11nonlimitedapi_meshlib_*.so "$meshlib"/libpybind11nonlimitedapi_meshlib_*.dylib )
+        shopt -u nullglob
+        if [ "${#shims[@]}" -eq 0 ]; then
+          echo "No libpybind11nonlimitedapi_meshlib_*.{so,dylib} shim in $meshlib; running once with default python3"
+          exec python3 "$GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
+        fi
+        attempted=0
+        failed=0
+        skipped=()
+        for shim in "${shims[@]}"; do
+          ver=$(basename "$shim" | sed -E 's/^libpybind11nonlimitedapi_meshlib_([0-9]+\.[0-9]+)\.(so|dylib)$/\1/')
+          py_cmd="python${ver}"
+          echo
+          echo "===== verify with $py_cmd  (shim: $(basename "$shim")) ====="
+          if ! command -v "$py_cmd" >/dev/null 2>&1; then
+            echo "SKIP: $py_cmd not on PATH"
+            skipped+=( "$ver" )
+            continue
+          fi
+          attempted=$((attempted + 1))
+          if ! "$py_cmd" "$GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"; then
+            failed=$((failed + 1))
+          fi
+        done
+        echo
+        echo "Summary: shims=${#shims[@]} attempted=${attempted} failed=${failed} skipped=${#skipped[@]} [${skipped[*]}]"
+        [ "$failed" -eq 0 ]

--- a/.github/actions/verify-meshlib-python-import/action.yml
+++ b/.github/actions/verify-meshlib-python-import/action.yml
@@ -1,11 +1,7 @@
 name: 'Verify meshlib.mrmeshpy import'
 description: |
-  Run scripts/ci/verify_meshlib_import.py with PYTHONPATH pointing at the
-  given build directory so that `import meshlib.mrmeshpy` is exercised
-  before MRTest's embedded-python smoke test does. Fails the job with a
-  real Python traceback if the import doesn't work — clearer than
-  CPython's wrapped "ImportError: initialization failed" that MRTest
-  would otherwise emit.
+  Run scripts/ci/verify_meshlib_import.py against every Python shim in
+  the build dir, to surface import failures with a real traceback.
 
 inputs:
   build-bin-dir:
@@ -15,20 +11,10 @@ inputs:
 runs:
   using: composite
   steps:
-    # The mrbind pybind11 non-limited-api shim is suffixed with the exact
-    # Python X.Y the bindings were built for (pybind11nonlimitedapi_meshlib_3.12.dll
-    # / .so / .dylib). Loading mrmeshpy from the wrong Python version
-    # raises `Failed to load library pybind11nonlimitedapi_meshlib_<wrong>`
-    # at module-init time, which CPython then re-raises as the opaque
-    # "ImportError: initialization failed".
-    #
-    # Regular build-test-* workflows produce one shim (the build's single
-    # Python). The pip-build wheel jobs (FOR_WHEEL=1) produce a shim per
-    # version listed in scripts/mrbind-pybind11/python_versions.txt
-    # (currently 3.8 through 3.14). Verify against every shim found,
-    # invoking each via its matching interpreter. Skip versions whose
-    # interpreter isn't on the runner; fail if any *attempted* import
-    # fails.
+    # The pybind11 shim filename (pybind11nonlimitedapi_meshlib_X.Y.{dll,so,dylib})
+    # encodes the Python version the bindings target; pip-build jobs produce
+    # one shim per version. Run verify against each shim using the matching
+    # interpreter; skip versions whose interpreter isn't on the runner.
 
     - name: Verify meshlib.mrmeshpy import (Windows)
       if: runner.os == 'Windows'

--- a/.github/actions/verify-meshlib-python-import/action.yml
+++ b/.github/actions/verify-meshlib-python-import/action.yml
@@ -1,0 +1,30 @@
+name: 'Verify meshlib.mrmeshpy import'
+description: |
+  Run scripts/ci/verify_meshlib_import.py with PYTHONPATH pointing at the
+  given build directory so that `import meshlib.mrmeshpy` is exercised
+  before MRTest's embedded-python smoke test does. Fails the job with a
+  real Python traceback if the import doesn't work — clearer than
+  CPython's wrapped "ImportError: initialization failed" that MRTest
+  would otherwise emit.
+
+inputs:
+  build-bin-dir:
+    description: 'Directory containing the meshlib/ package (e.g. build/Release/bin on Linux/macOS, source\x64\Release on Windows)'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Verify meshlib.mrmeshpy import (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        PYTHONPATH: ${{ inputs.build-bin-dir }}
+      run: py -3 "$Env:GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
+
+    - name: Verify meshlib.mrmeshpy import (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        PYTHONPATH: ${{ inputs.build-bin-dir }}
+      run: python3 "$GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"

--- a/.github/actions/verify-meshlib-python-import/action.yml
+++ b/.github/actions/verify-meshlib-python-import/action.yml
@@ -40,7 +40,7 @@ runs:
         $shims = @(Get-ChildItem -Path $meshlib -Filter 'pybind11nonlimitedapi_meshlib_*.dll' -ErrorAction SilentlyContinue | Sort-Object Name)
         if ($shims.Count -eq 0) {
           Write-Host "No pybind11nonlimitedapi_meshlib_*.dll shim in $meshlib; running once with default py -3"
-          py -3 "$Env:GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
+          py -3 -u "$Env:GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
           exit $LASTEXITCODE
         }
         $attempted = 0; $failed = 0; $skipped = @()
@@ -55,7 +55,7 @@ runs:
             continue
           }
           $attempted++
-          py "-$ver" "$Env:GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
+          py "-$ver" -u "$Env:GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
           if ($LASTEXITCODE -ne 0) { $failed++ }
         }
         Write-Host ""
@@ -74,7 +74,7 @@ runs:
         shopt -u nullglob
         if [ "${#shims[@]}" -eq 0 ]; then
           echo "No libpybind11nonlimitedapi_meshlib_*.{so,dylib} shim in $meshlib; running once with default python3"
-          exec python3 "$GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
+          exec python3 -u "$GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"
         fi
         attempted=0
         failed=0
@@ -90,7 +90,7 @@ runs:
             continue
           fi
           attempted=$((attempted + 1))
-          if ! "$py_cmd" "$GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"; then
+          if ! "$py_cmd" -u "$GITHUB_WORKSPACE/scripts/ci/verify_meshlib_import.py"; then
             failed=$((failed + 1))
           fi
         done

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -184,6 +184,12 @@ jobs:
         timeout-minutes: 3
         run: xvfb-run -a ./build/${{ matrix.config }}/bin/MeshViewer -hidden -noEventLoop -unloadPluginsAtEnd
 
+      - name: Verify meshlib.mrmeshpy import
+        if: ${{ inputs.mrbind }}
+        uses: ./.github/actions/verify-meshlib-python-import
+        with:
+          build-bin-dir: ./build/${{ matrix.config }}/bin
+
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -186,6 +186,7 @@ jobs:
 
       - name: Verify meshlib.mrmeshpy import
         if: ${{ inputs.mrbind }}
+        timeout-minutes: 3
         uses: ./.github/actions/verify-meshlib-python-import
         with:
           build-bin-dir: ./build/${{ matrix.config }}/bin

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -194,6 +194,12 @@ jobs:
         timeout-minutes: 3
         run: ./build/${{ matrix.config }}/bin/MeshViewer -tryHidden -noEventLoop -unloadPluginsAtEnd
 
+      - name: Verify meshlib.mrmeshpy import
+        if: ${{ inputs.mrbind }}
+        uses: ./.github/actions/verify-meshlib-python-import
+        with:
+          build-bin-dir: ./build/${{ matrix.config }}/bin
+
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -196,6 +196,7 @@ jobs:
 
       - name: Verify meshlib.mrmeshpy import
         if: ${{ inputs.mrbind }}
+        timeout-minutes: 3
         uses: ./.github/actions/verify-meshlib-python-import
         with:
           build-bin-dir: ./build/${{ matrix.config }}/bin

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -204,6 +204,7 @@ jobs:
 
       - name: Verify meshlib.mrmeshpy import
         if: ${{ inputs.mrbind }}
+        timeout-minutes: 3
         uses: ./.github/actions/verify-meshlib-python-import
         with:
           build-bin-dir: ./build/${{ matrix.config }}/bin

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -202,6 +202,12 @@ jobs:
         timeout-minutes: 3
         run: xvfb-run -a ./build/${{ matrix.config }}/bin/MeshViewer -hidden -noEventLoop -unloadPluginsAtEnd
 
+      - name: Verify meshlib.mrmeshpy import
+        if: ${{ inputs.mrbind }}
+        uses: ./.github/actions/verify-meshlib-python-import
+        with:
+          build-bin-dir: ./build/${{ matrix.config }}/bin
+
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -152,6 +152,7 @@ jobs:
 
       - name: Verify meshlib.mrmeshpy import
         if: ${{ inputs.mrbind }}
+        timeout-minutes: 3
         uses: ./.github/actions/verify-meshlib-python-import
         with:
           build-bin-dir: ./build/${{ matrix.config }}/bin

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -150,6 +150,12 @@ jobs:
         timeout-minutes: 3
         run: xvfb-run -a ./build/${{ matrix.config }}/bin/MeshViewer -hidden -noEventLoop -unloadPluginsAtEnd
 
+      - name: Verify meshlib.mrmeshpy import
+        if: ${{ inputs.mrbind }}
+        uses: ./.github/actions/verify-meshlib-python-import
+        with:
+          build-bin-dir: ./build/${{ matrix.config }}/bin
+
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -230,6 +230,7 @@ jobs:
 
       - name: Verify meshlib.mrmeshpy import
         if: ${{ inputs.mrbind && matrix.vcpkg_triplet != 'x64-windows-meshlib-iterator-debug' }}
+        timeout-minutes: 3
         uses: ./.github/actions/verify-meshlib-python-import
         with:
           build-bin-dir: source\x64\${{ matrix.config }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -228,6 +228,12 @@ jobs:
         run: .\MeshViewer.exe -tryHidden -noEventLoop -unloadPluginsAtEnd
         shell: cmd
 
+      - name: Verify meshlib.mrmeshpy import
+        if: ${{ inputs.mrbind && matrix.vcpkg_triplet != 'x64-windows-meshlib-iterator-debug' }}
+        uses: ./.github/actions/verify-meshlib-python-import
+        with:
+          build-bin-dir: source\x64\${{ matrix.config }}
+
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -164,6 +164,11 @@ jobs:
       - name: Run Tests
         run: xvfb-run -a ./build/Release/bin/MeshViewer -hidden -noEventLoop -unloadPluginsAtEnd
 
+      - name: Verify meshlib.mrmeshpy import
+        uses: ./.github/actions/verify-meshlib-python-import
+        with:
+          build-bin-dir: ./build/Release/bin
+
       - name: Unit Tests
         timeout-minutes: 10
         run: build/Release/bin/MRTest
@@ -318,6 +323,11 @@ jobs:
         working-directory: source\x64\Release
         run: .\MeshViewer.exe -tryHidden -noEventLoop
 
+      - name: Verify meshlib.mrmeshpy import
+        uses: ./.github/actions/verify-meshlib-python-import
+        with:
+          build-bin-dir: source\x64\Release
+
       - name: Unit Tests
         timeout-minutes: 10
         run: source\x64\Release\MRTest.exe
@@ -404,6 +414,11 @@ jobs:
         run: |
           make --version
           make -f scripts/mrbind/generate.mk -B --trace FOR_WHEEL=1 MACOS_MIN_VER=12.7
+
+      - name: Verify meshlib.mrmeshpy import
+        uses: ./.github/actions/verify-meshlib-python-import
+        with:
+          build-bin-dir: ./build/Release/bin
 
       - name: Unit Tests
         timeout-minutes: 10

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -165,6 +165,7 @@ jobs:
         run: xvfb-run -a ./build/Release/bin/MeshViewer -hidden -noEventLoop -unloadPluginsAtEnd
 
       - name: Verify meshlib.mrmeshpy import
+        timeout-minutes: 3
         uses: ./.github/actions/verify-meshlib-python-import
         with:
           build-bin-dir: ./build/Release/bin
@@ -324,6 +325,7 @@ jobs:
         run: .\MeshViewer.exe -tryHidden -noEventLoop
 
       - name: Verify meshlib.mrmeshpy import
+        timeout-minutes: 3
         uses: ./.github/actions/verify-meshlib-python-import
         with:
           build-bin-dir: source\x64\Release
@@ -416,6 +418,7 @@ jobs:
           make -f scripts/mrbind/generate.mk -B --trace FOR_WHEEL=1 MACOS_MIN_VER=12.7
 
       - name: Verify meshlib.mrmeshpy import
+        timeout-minutes: 3
         uses: ./.github/actions/verify-meshlib-python-import
         with:
           build-bin-dir: ./build/Release/bin

--- a/scripts/ci/verify_meshlib_import.py
+++ b/scripts/ci/verify_meshlib_import.py
@@ -1,21 +1,7 @@
 """
-Sanity-check that the freshly-built meshlib Python bindings load cleanly.
-
-Run with PYTHONPATH pointing at the build's bin directory. Exits non-zero
-with a real Python traceback if `import meshlib` or
-`import meshlib.mrmeshpy` fails — catches missing PyInit_*, wrong
-libc++/libpython ABI, and binding-generation regressions before pytest's
-collection (or MRTest's embedded-python smoke test) buries them under
-CPython's opaque "ImportError: initialization failed".
-
-Only `mrmeshpy` is checked here: it's the one whose load failure has
-been the silent failure mode we hit. Other submodules pull in external
-runtime deps (`mrmeshnumpy` requires `numpy`, which isn't installed in
-some CI envs like manylinux's bare system Python) or trigger
-pre-existing shutdown bugs (`mrviewerpy`'s CommandLoop destructor
-asserts on a non-empty queue), and exercising them here produces false
-positives. Their actual load is still covered downstream by pytest's
-test collection (which runs in an env with proper deps).
+Sanity-check that `import meshlib.mrmeshpy` works, with a real traceback
+on failure instead of CPython's opaque "ImportError: initialization failed".
+Run with PYTHONPATH pointing at the build's bin directory.
 """
 
 import os

--- a/scripts/ci/verify_meshlib_import.py
+++ b/scripts/ci/verify_meshlib_import.py
@@ -3,15 +3,47 @@ Sanity-check that the freshly-built meshlib Python bindings load cleanly.
 
 Run this with PYTHONPATH pointing at the build's bin directory (so that the
 `meshlib/` package directory is discoverable). Exits non-zero with a real
-Python traceback if `import meshlib` or `import meshlib.mrmeshpy` fails —
-catches problems like missing PyInit_*, wrong libc++/libpython ABI,
-binding-generation regressions, etc. before MRTest's embedded-python smoke
-test buries them under CPython's opaque "ImportError: initialization failed".
+Python traceback if any submodule import fails — catches problems like
+missing PyInit_*, wrong libc++/libpython ABI, binding-generation
+regressions, etc. before MRTest's embedded-python smoke test or pytest
+collection bury them under CPython's opaque "ImportError: initialization
+failed".
+
+Iterates over every submodule shipped in the `meshlib/` package
+directory (`mrmeshpy`, `mrmeshnumpy`, `mrviewerpy`, `mrcudapy`, …) so a
+crash in any one of them is surfaced with its real traceback. This
+mirrors what `test_python/helper/__init__.py` does at pytest
+collection-time (it imports `meshlib.mrmeshpy` *and*
+`meshlib.mrmeshnumpy`), so a successful run here means pytest's
+collection-time imports won't trip either.
 """
 
+import importlib
 import os
 import sys
 import traceback
+
+
+def discover_submodules(pkg) -> list[str]:
+    """Find native-extension submodules in the meshlib package dir.
+
+    Returns submodule names like 'mrmeshpy', 'mrmeshnumpy' — extracted
+    from filenames matching `{name}.{so,dylib,pyd}`.
+    """
+    pkg_dir = os.path.dirname(pkg.__file__)
+    extensions = ('.so', '.dylib', '.pyd')
+    out = []
+    for entry in sorted(os.listdir(pkg_dir)):
+        for ext in extensions:
+            if entry.endswith(ext):
+                stem = entry[: -len(ext)]
+                # Strip ABI tags like "mrmeshpy.cpython-310-darwin.so" → "mrmeshpy".
+                if '.' in stem:
+                    stem = stem.split('.', 1)[0]
+                if stem and stem not in out and not stem.startswith('libpybind11nonlimitedapi'):
+                    out.append(stem)
+                break
+    return out
 
 
 def main() -> int:
@@ -29,14 +61,29 @@ def main() -> int:
         return 2
     print('OK: meshlib at', meshlib.__file__, flush=True)
 
-    try:
-        import meshlib.mrmeshpy as _mrmeshpy
-    except BaseException:
-        print('FAIL: import meshlib.mrmeshpy', flush=True)
-        traceback.print_exc()
-        return 3
-    print('OK: meshlib.mrmeshpy at', _mrmeshpy.__file__, flush=True)
+    submodules = discover_submodules(meshlib)
+    if not submodules:
+        print('FAIL: no native submodules discovered alongside meshlib/__init__.py', flush=True)
+        return 4
+    print('Submodules to import:', submodules, flush=True)
 
+    failed: list[str] = []
+    for name in submodules:
+        full = f'meshlib.{name}'
+        try:
+            mod = importlib.import_module(full)
+        except BaseException:
+            print(f'FAIL: import {full}', flush=True)
+            traceback.print_exc()
+            failed.append(name)
+            continue
+        loc = getattr(mod, '__file__', '<built-in>')
+        print(f'OK:   {full} at {loc}', flush=True)
+
+    if failed:
+        print(f'\nSummary: {len(failed)}/{len(submodules)} submodule imports failed: {failed}', flush=True)
+        return 3
+    print(f'\nSummary: {len(submodules)}/{len(submodules)} submodules imported OK', flush=True)
     return 0
 
 

--- a/scripts/ci/verify_meshlib_import.py
+++ b/scripts/ci/verify_meshlib_import.py
@@ -1,0 +1,44 @@
+"""
+Sanity-check that the freshly-built meshlib Python bindings load cleanly.
+
+Run this with PYTHONPATH pointing at the build's bin directory (so that the
+`meshlib/` package directory is discoverable). Exits non-zero with a real
+Python traceback if `import meshlib` or `import meshlib.mrmeshpy` fails —
+catches problems like missing PyInit_*, wrong libc++/libpython ABI,
+binding-generation regressions, etc. before MRTest's embedded-python smoke
+test buries them under CPython's opaque "ImportError: initialization failed".
+"""
+
+import os
+import sys
+import traceback
+
+
+def main() -> int:
+    print('python:    ', sys.version)
+    print('exe:       ', sys.executable)
+    print('prefix:    ', sys.prefix)
+    print('PYTHONPATH:', os.environ.get('PYTHONPATH', '<unset>'))
+    print('---', flush=True)
+
+    try:
+        import meshlib  # noqa: F401
+    except BaseException:
+        print('FAIL: import meshlib', flush=True)
+        traceback.print_exc()
+        return 2
+    print('OK: meshlib at', meshlib.__file__, flush=True)
+
+    try:
+        import meshlib.mrmeshpy as _mrmeshpy
+    except BaseException:
+        print('FAIL: import meshlib.mrmeshpy', flush=True)
+        traceback.print_exc()
+        return 3
+    print('OK: meshlib.mrmeshpy at', _mrmeshpy.__file__, flush=True)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/ci/verify_meshlib_import.py
+++ b/scripts/ci/verify_meshlib_import.py
@@ -28,23 +28,23 @@ def main() -> int:
     print('exe:       ', sys.executable)
     print('prefix:    ', sys.prefix)
     print('PYTHONPATH:', os.environ.get('PYTHONPATH', '<unset>'))
-    print('---', flush=True)
+    print('---')
 
     try:
         import meshlib  # noqa: F401
     except BaseException:
-        print('FAIL: import meshlib', flush=True)
+        print('FAIL: import meshlib')
         traceback.print_exc()
         return 2
-    print('OK: meshlib at', meshlib.__file__, flush=True)
+    print('OK: meshlib at', meshlib.__file__)
 
     try:
         import meshlib.mrmeshpy as _mrmeshpy
     except BaseException:
-        print('FAIL: import meshlib.mrmeshpy', flush=True)
+        print('FAIL: import meshlib.mrmeshpy')
         traceback.print_exc()
         return 3
-    print('OK: meshlib.mrmeshpy at', _mrmeshpy.__file__, flush=True)
+    print('OK: meshlib.mrmeshpy at', _mrmeshpy.__file__)
     return 0
 
 

--- a/scripts/ci/verify_meshlib_import.py
+++ b/scripts/ci/verify_meshlib_import.py
@@ -1,33 +1,26 @@
 """
 Sanity-check that the freshly-built meshlib Python bindings load cleanly.
 
-Run this with PYTHONPATH pointing at the build's bin directory (so that the
-`meshlib/` package directory is discoverable). Exits non-zero with a real
-Python traceback if any of the targeted submodule imports fails — catches
-problems like missing PyInit_*, wrong libc++/libpython ABI,
-binding-generation regressions, etc. before pytest's collection (or
-MRTest's embedded-python smoke test) buries them under CPython's opaque
-"ImportError: initialization failed".
+Run with PYTHONPATH pointing at the build's bin directory. Exits non-zero
+with a real Python traceback if `import meshlib` or
+`import meshlib.mrmeshpy` fails — catches missing PyInit_*, wrong
+libc++/libpython ABI, and binding-generation regressions before pytest's
+collection (or MRTest's embedded-python smoke test) buries them under
+CPython's opaque "ImportError: initialization failed".
 
-The targeted submodule list mirrors what `test_python/helper/__init__.py`
-imports at module load — that helper module is pulled in by every test
-file, so its imports run during pytest collection, and a crash in any of
-those imports kills the collector before pytest can report it. Other
-submodules in the `meshlib/` package (e.g. `mrviewerpy`) are intentionally
-NOT exercised here: importing `mrviewerpy` and letting Python shut down
-trips a separate pre-existing assertion (CommandLoop destructor expecting
-a drained command queue), which is unrelated to the
-binding-load problem this script is meant to gate. If the helper file ever
-imports more submodules, mirror them here.
+Only `mrmeshpy` is checked here: it's the one whose load failure has
+been the silent failure mode we hit. Other submodules pull in external
+runtime deps (`mrmeshnumpy` requires `numpy`, which isn't installed in
+some CI envs like manylinux's bare system Python) or trigger
+pre-existing shutdown bugs (`mrviewerpy`'s CommandLoop destructor
+asserts on a non-empty queue), and exercising them here produces false
+positives. Their actual load is still covered downstream by pytest's
+test collection (which runs in an env with proper deps).
 """
 
-import importlib
 import os
 import sys
 import traceback
-
-# Keep in sync with test_python/helper/__init__.py.
-HELPER_SUBMODULES = ('mrmeshpy', 'mrmeshnumpy')
 
 
 def main() -> int:
@@ -45,25 +38,13 @@ def main() -> int:
         return 2
     print('OK: meshlib at', meshlib.__file__, flush=True)
 
-    print('Submodules to import:', list(HELPER_SUBMODULES), flush=True)
-
-    failed: list[str] = []
-    for name in HELPER_SUBMODULES:
-        full = f'meshlib.{name}'
-        try:
-            mod = importlib.import_module(full)
-        except BaseException:
-            print(f'FAIL: import {full}', flush=True)
-            traceback.print_exc()
-            failed.append(name)
-            continue
-        loc = getattr(mod, '__file__', '<built-in>')
-        print(f'OK:   {full} at {loc}', flush=True)
-
-    if failed:
-        print(f'\nSummary: {len(failed)}/{len(HELPER_SUBMODULES)} submodule imports failed: {failed}', flush=True)
+    try:
+        import meshlib.mrmeshpy as _mrmeshpy
+    except BaseException:
+        print('FAIL: import meshlib.mrmeshpy', flush=True)
+        traceback.print_exc()
         return 3
-    print(f'\nSummary: {len(HELPER_SUBMODULES)}/{len(HELPER_SUBMODULES)} submodules imported OK', flush=True)
+    print('OK: meshlib.mrmeshpy at', _mrmeshpy.__file__, flush=True)
     return 0
 
 

--- a/scripts/ci/verify_meshlib_import.py
+++ b/scripts/ci/verify_meshlib_import.py
@@ -3,19 +3,22 @@ Sanity-check that the freshly-built meshlib Python bindings load cleanly.
 
 Run this with PYTHONPATH pointing at the build's bin directory (so that the
 `meshlib/` package directory is discoverable). Exits non-zero with a real
-Python traceback if any submodule import fails — catches problems like
-missing PyInit_*, wrong libc++/libpython ABI, binding-generation
-regressions, etc. before MRTest's embedded-python smoke test or pytest
-collection bury them under CPython's opaque "ImportError: initialization
-failed".
+Python traceback if any of the targeted submodule imports fails — catches
+problems like missing PyInit_*, wrong libc++/libpython ABI,
+binding-generation regressions, etc. before pytest's collection (or
+MRTest's embedded-python smoke test) buries them under CPython's opaque
+"ImportError: initialization failed".
 
-Iterates over every submodule shipped in the `meshlib/` package
-directory (`mrmeshpy`, `mrmeshnumpy`, `mrviewerpy`, `mrcudapy`, …) so a
-crash in any one of them is surfaced with its real traceback. This
-mirrors what `test_python/helper/__init__.py` does at pytest
-collection-time (it imports `meshlib.mrmeshpy` *and*
-`meshlib.mrmeshnumpy`), so a successful run here means pytest's
-collection-time imports won't trip either.
+The targeted submodule list mirrors what `test_python/helper/__init__.py`
+imports at module load — that helper module is pulled in by every test
+file, so its imports run during pytest collection, and a crash in any of
+those imports kills the collector before pytest can report it. Other
+submodules in the `meshlib/` package (e.g. `mrviewerpy`) are intentionally
+NOT exercised here: importing `mrviewerpy` and letting Python shut down
+trips a separate pre-existing assertion (CommandLoop destructor expecting
+a drained command queue), which is unrelated to the
+binding-load problem this script is meant to gate. If the helper file ever
+imports more submodules, mirror them here.
 """
 
 import importlib
@@ -23,27 +26,8 @@ import os
 import sys
 import traceback
 
-
-def discover_submodules(pkg) -> list[str]:
-    """Find native-extension submodules in the meshlib package dir.
-
-    Returns submodule names like 'mrmeshpy', 'mrmeshnumpy' — extracted
-    from filenames matching `{name}.{so,dylib,pyd}`.
-    """
-    pkg_dir = os.path.dirname(pkg.__file__)
-    extensions = ('.so', '.dylib', '.pyd')
-    out = []
-    for entry in sorted(os.listdir(pkg_dir)):
-        for ext in extensions:
-            if entry.endswith(ext):
-                stem = entry[: -len(ext)]
-                # Strip ABI tags like "mrmeshpy.cpython-310-darwin.so" → "mrmeshpy".
-                if '.' in stem:
-                    stem = stem.split('.', 1)[0]
-                if stem and stem not in out and not stem.startswith('libpybind11nonlimitedapi'):
-                    out.append(stem)
-                break
-    return out
+# Keep in sync with test_python/helper/__init__.py.
+HELPER_SUBMODULES = ('mrmeshpy', 'mrmeshnumpy')
 
 
 def main() -> int:
@@ -61,14 +45,10 @@ def main() -> int:
         return 2
     print('OK: meshlib at', meshlib.__file__, flush=True)
 
-    submodules = discover_submodules(meshlib)
-    if not submodules:
-        print('FAIL: no native submodules discovered alongside meshlib/__init__.py', flush=True)
-        return 4
-    print('Submodules to import:', submodules, flush=True)
+    print('Submodules to import:', list(HELPER_SUBMODULES), flush=True)
 
     failed: list[str] = []
-    for name in submodules:
+    for name in HELPER_SUBMODULES:
         full = f'meshlib.{name}'
         try:
             mod = importlib.import_module(full)
@@ -81,9 +61,9 @@ def main() -> int:
         print(f'OK:   {full} at {loc}', flush=True)
 
     if failed:
-        print(f'\nSummary: {len(failed)}/{len(submodules)} submodule imports failed: {failed}', flush=True)
+        print(f'\nSummary: {len(failed)}/{len(HELPER_SUBMODULES)} submodule imports failed: {failed}', flush=True)
         return 3
-    print(f'\nSummary: {len(submodules)}/{len(submodules)} submodules imported OK', flush=True)
+    print(f'\nSummary: {len(HELPER_SUBMODULES)}/{len(HELPER_SUBMODULES)} submodules imported OK', flush=True)
     return 0
 
 


### PR DESCRIPTION
## Why

When the Python bindings build but `mrmeshpy.pyd` / `.so` can't be loaded — DLL load failure, missing `PyInit_*`, libpython ABI mismatch, binding-generation regression that drops a referenced class — MRTest's embedded-python smoke test surfaces it as just:

```
[error] ImportError: initialization failed
At:
  <string>(N): <module>
```

…with no traceback. Diagnosing requires reproducing the import out-of-process.

[#6021](https://github.com/MeshInspector/MeshLib/pull/6021) added a one-off post-Unit-Tests diagnostic step that did exactly that (a standalone `py -3.12 -c "import meshlib.mrmeshpy"`) and turned an opaque failure into a real `AttributeError: module 'meshlib.mrmeshpy' has no attribute 'std_vector_const_Mesh'`. This PR promotes that "standalone import attempt" into a proper pre-flight check that runs before Unit Tests in every workflow that builds bindings.

## Changes

- **New script `scripts/ci/verify_meshlib_import.py`** — runs `import meshlib` then `import meshlib.mrmeshpy` with PYTHONPATH set, exits non-zero with a `traceback.print_exc()` on failure, prints the resolved Python interpreter / sys.prefix / PYTHONPATH for context.

- **New composite action `.github/actions/verify-meshlib-python-import`** — takes one input (`build-bin-dir`), then:
  1. Scans `<build-bin-dir>/meshlib/` for the pybind11 non-limited-api shim files (`pybind11nonlimitedapi_meshlib_<X.Y>.{dll,so,dylib}`) — those filenames encode the exact Python the bindings were built for.
  2. For each shim, invokes the matching interpreter (`py -X.Y` on Windows, `pythonX.Y` on Unix) on the verify script. Skips with a clear `SKIP: pythonX.Y not on PATH` message if the interpreter isn't installed.
  3. Aggregates results, prints a summary line `shims=N attempted=N failed=N skipped=N [list]`, exits non-zero if any *attempted* import failed.

  This handles both the regular `build-test-*` workflows (one shim per build) and the `pip-build.yml` wheel jobs (a shim per Python in `python_versions.txt`, currently 7 of them).

- **Wired into all eight Unit Tests sites** in the existing workflows, immediately before the `MRTest`/`MRTest.exe` invocation:

  | Workflow | Job | `build-bin-dir` |
  |---|---|---|
  | `build-test-windows.yml` | `windows-build-test` matrix | `source\x64\${{ matrix.config }}` |
  | `build-test-linux-vcpkg.yml` | `linux-vcpkg-build-test` matrix | `./build/${{ matrix.config }}/bin` |
  | `build-test-macos.yml` | `macos-build-test` matrix | same |
  | `build-test-ubuntu-x64.yml` | matrix | same |
  | `build-test-ubuntu-arm64.yml` | matrix | same |
  | `pip-build.yml` | `manylinux-pip-build` | `./build/Release/bin` |
  | `pip-build.yml` | `windows-pip-build` | `source\x64\Release` |
  | `pip-build.yml` | `macos-pip-build` | `./build/Release/bin` |

  Each invocation re-uses the workflow's existing gate that decides whether bindings were built (`inputs.mrbind` for the build-test matrices, the iterator-debug-triplet exclusion on Windows, unconditional for the pip-wheel jobs which always build bindings).

## Why only `mrmeshpy` and not every submodule

The script imports only `meshlib.mrmeshpy`. Earlier iterations of this PR widened the check to every native submodule in `meshlib/`, but that surfaced unrelated false positives:

- **`mrmeshnumpy` requires `numpy` at module init** — fails in the manylinux pip-build container's bare system Python (where numpy is only installed inside `uv run --with-requirements`).
- **`mrviewerpy` aborts at Python shutdown** — its `MR::CommandLoop::~CommandLoop()` debug assertion fires on a non-empty queue (`MRViewer/MRCommandLoop.cpp:13`), killing the process despite a successful import.

Both are real but pre-existing issues unrelated to the binding-load failure mode this gate is meant to catch. Their actual load failures still surface downstream in pytest collection (in environments that have the right deps).

## What this catches

- **DLL load failures** in `mrmeshpy.pyd` / `.so` — surface here with `LoadLibrary error 126` etc. instead of opaque "initialization failed" later.
- **Binding-generation regressions** like the [#6021](https://github.com/MeshInspector/MeshLib/pull/6021) `std_vector_const_Mesh` case — surface here with `AttributeError: module ... has no attribute ...`.
- **Python ABI mismatch** (e.g. wheel built against 3.12 loaded by 3.14) — surface here with `Failed to load library pybind11nonlimitedapi_meshlib_<X.Y>` and the matching-Python lookup picks the right version.

## Test plan

- [x] All affected workflows pass on this branch — see latest CI run on the PR (100 successful checks, 7 skipped, 0 failed).
- [x] Verify step runs before Unit Tests on every wired-in job and reports `OK: meshlib.mrmeshpy at …`.
- [x] When import succeeds, no behavior change downstream.
- [x] When import fails, the step exits with a real Python traceback in the log before Unit Tests / pytest's collection mask the cause.
