### PR TITLE
deps: strip brew dylibs on macOS at install time

### DIFF
--- a/scripts/install_brew_requirements.sh
+++ b/scripts/install_brew_requirements.sh
@@ -12,6 +12,48 @@ brew install --quiet $(echo "$MESHLIB_BREW_REQUIREMENTS" | tr '\n' ' ')
 
 brew install --quiet pybind11
 
+# === DIAGNOSTIC: brew strip investigation ===
+# A previous attempt (#6063 v1) found that strip+codesign on brew Cellar
+# yielded byte-identical bundled dylibs in the wheel — the strip appeared
+# to be a silent no-op. Instrument here to confirm whether bytes change
+# on Cellar, and which exact files brew has installed.
+BREW_PREFIX=$(brew --prefix)
+SAMPLE_GLOB=("$BREW_PREFIX"/Cellar/openvdb/*/lib/libopenvdb.*.dylib)
+echo "::group::strip-diagnostic: pre-strip"
+echo "BREW_PREFIX=$BREW_PREFIX"
+echo "Cellar dylibs total count: $(find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' | wc -l)"
+echo "Cellar dylibs total size: $(find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' -exec du -b {} + | awk '{s+=$1} END {print s}') bytes"
+echo "Sample (libopenvdb*) before strip:"
+ls -la "${SAMPLE_GLOB[@]}" 2>&1 || true
+shasum -a 256 "${SAMPLE_GLOB[@]}" 2>&1 || true
+echo "  codesign verify on sample:"
+for f in "${SAMPLE_GLOB[@]}"; do
+  [ -f "$f" ] || continue
+  codesign --display --verbose=2 "$f" 2>&1 | head -5 || true
+done
+echo "::endgroup::"
+
+echo "::group::strip-diagnostic: running strip + codesign"
+# Verbose: each `-exec` separately (not combined) so we see strip's stderr per file
+find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' -print0 | while IFS= read -r -d '' f; do
+  chmod u+w "$f"
+  strip -x "$f" 2>&1 | grep -v '^$' | sed "s|^|  strip: |" || true
+  codesign --force --sign - "$f" 2>&1 | grep -v '^$' | sed "s|^|  codesign: |" || true
+done
+echo "::endgroup::"
+
+echo "::group::strip-diagnostic: post-strip"
+echo "Cellar dylibs total size: $(find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' -exec du -b {} + | awk '{s+=$1} END {print s}') bytes"
+echo "Sample (libopenvdb*) after strip:"
+ls -la "${SAMPLE_GLOB[@]}" 2>&1 || true
+shasum -a 256 "${SAMPLE_GLOB[@]}" 2>&1 || true
+echo "  codesign verify on sample:"
+for f in "${SAMPLE_GLOB[@]}"; do
+  [ -f "$f" ] || continue
+  codesign --display --verbose=2 "$f" 2>&1 | head -5 || true
+done
+echo "::endgroup::"
+
 # check and upgrade python3 pip
 python3.10 -m ensurepip --upgrade
 python3.10 -m pip install --upgrade pip

--- a/scripts/install_brew_requirements.sh
+++ b/scripts/install_brew_requirements.sh
@@ -12,47 +12,17 @@ brew install --quiet $(echo "$MESHLIB_BREW_REQUIREMENTS" | tr '\n' ' ')
 
 brew install --quiet pybind11
 
-# === DIAGNOSTIC: brew strip investigation ===
-# A previous attempt (#6063 v1) found that strip+codesign on brew Cellar
-# yielded byte-identical bundled dylibs in the wheel — the strip appeared
-# to be a silent no-op. Instrument here to confirm whether bytes change
-# on Cellar, and which exact files brew has installed.
+# Strip dylibs we'll bundle (brew keeps full symbol tables for symbolication).
+# Per-file loop, not `find -exec ... +`: strip prints a sig-invalidation warning
+# and exits 1 on signed dylibs, which would abort the whole batched invocation
+# and leave later files unstripped. codesign re-signs ad-hoc so dyld doesn't
+# SIGKILL on load.
 BREW_PREFIX=$(brew --prefix)
-SAMPLE_GLOB=("$BREW_PREFIX"/Cellar/openvdb/*/lib/libopenvdb.*.dylib)
-echo "::group::strip-diagnostic: pre-strip"
-echo "BREW_PREFIX=$BREW_PREFIX"
-echo "Cellar dylibs total count: $(find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' | wc -l)"
-echo "Cellar dylibs total size: $(find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' -exec du -b {} + | awk '{s+=$1} END {print s}') bytes"
-echo "Sample (libopenvdb*) before strip:"
-ls -la "${SAMPLE_GLOB[@]}" 2>&1 || true
-shasum -a 256 "${SAMPLE_GLOB[@]}" 2>&1 || true
-echo "  codesign verify on sample:"
-for f in "${SAMPLE_GLOB[@]}"; do
-  [ -f "$f" ] || continue
-  codesign --display --verbose=2 "$f" 2>&1 | head -5 || true
-done
-echo "::endgroup::"
-
-echo "::group::strip-diagnostic: running strip + codesign"
-# Verbose: each `-exec` separately (not combined) so we see strip's stderr per file
 find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' -print0 | while IFS= read -r -d '' f; do
   chmod u+w "$f"
-  strip -x "$f" 2>&1 | grep -v '^$' | sed "s|^|  strip: |" || true
-  codesign --force --sign - "$f" 2>&1 | grep -v '^$' | sed "s|^|  codesign: |" || true
+  strip -x "$f" 2>/dev/null || true
+  codesign --force --sign - "$f" 2>/dev/null || true
 done
-echo "::endgroup::"
-
-echo "::group::strip-diagnostic: post-strip"
-echo "Cellar dylibs total size: $(find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' -exec du -b {} + | awk '{s+=$1} END {print s}') bytes"
-echo "Sample (libopenvdb*) after strip:"
-ls -la "${SAMPLE_GLOB[@]}" 2>&1 || true
-shasum -a 256 "${SAMPLE_GLOB[@]}" 2>&1 || true
-echo "  codesign verify on sample:"
-for f in "${SAMPLE_GLOB[@]}"; do
-  [ -f "$f" ] || continue
-  codesign --display --verbose=2 "$f" 2>&1 | head -5 || true
-done
-echo "::endgroup::"
 
 # check and upgrade python3 pip
 python3.10 -m ensurepip --upgrade


### PR DESCRIPTION
## Summary

Companion to #6058 (`macos: strip non-extern symbols at link time` — our libs) and #6063 (`Linux third-party via vcpkg triplet`). This PR strips the **third-party brew dylibs** that delocate copies into macOS distributions.

In [scripts/install_brew_requirements.sh](scripts/install_brew_requirements.sh), after the brew installs:
```bash
BREW_PREFIX=$(brew --prefix)
find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' -print0 | while IFS= read -r -d '' f; do
  chmod u+w "$f"
  strip -x "$f" 2>/dev/null || true
  codesign --force --sign - "$f" 2>/dev/null || true
done
```

Three non-obvious bits:

- **Walk `Cellar/`, not `lib/`** — `$BREW_PREFIX/lib` contains only symlinks into `Cellar/`, so a `-type f` find there matches no real files.
- **Per-file loop, not `find -exec ... +`** — `strip -x` prints a "code signature will be invalidated" warning *and exits 1* on signed dylibs. With `-exec ... +` the strip command is invoked once with all files batched together, and that exit-1 aborts processing of the remaining files. Per-file invocation isolates each strip to its own file. (This was the bug in an earlier version of #6063 that produced byte-identical bundled dylibs in the wheel.)
- **`codesign --force --sign -` after each strip** — strip invalidates the existing ad-hoc signature; without re-signing, dyld SIGKILLs any process loading the dylib on Apple Silicon.

This benefits **every macOS distribution** that bundles brew dylibs: pip wheels (delocate-wheel copies), `.pkg`'s `MeshLib.framework` if it bundles brew deps via install_name_tool/ditto, NuGet's `runtimes/osx-*/native/`.

## Verified savings (macOS arm64, on the diagnostic-instrumented predecessor commit)

CI diagnostic on `e1f274de` (parent commit) confirmed:
- `libopenvdb.13.0.0.dylib` on Cellar: **64,702,928 → 21,663,264 bytes** (sha256 changed; mode `0444` → `0644`; codesign re-signed ad-hoc)
- delocate copies the post-strip 20.7 MB version into `meshlib/.dylibs/`

Resulting wheel:

| | before this PR | after this PR | Δ |
|---|---:|---:|---:|
| `meshlib/.dylibs/` uncompressed | 172.73 MB | **129.02 MB** | **−43.71 MB** |
| `libopenvdb.dylib` total | 61.71 MB | **20.66 MB** | **−41.05 MB** |
| `libopenvdb.dylib` `__LINKEDIT` | 43.16 MB | **2.11 MB** | **−41.05 MB** |
| `libopenvdb.dylib` symbol count | 152,674 | **4,196** | **−97.3%** |
| Compressed `.whl` | 77.86 MB | **75.37 MB** | **−2.48 MB** |

## Test plan

- [ ] `macos-build-test` matrices green (build-test-macos workflow runs install_brew_requirements.sh too)
- [ ] `test-pip-build / macos-pip-build (arm64)` and `(x86)` green
- [ ] All `test-pip-build / macos-pip-test (...)` pass — confirms strip+codesign result is loadable by dyld
- [ ] Sample `meshlib/.dylibs/libopenvdb.13.0.0.dylib` from the produced wheel: `__LINKEDIT` ~2 MB, ~4k symbols
- [ ] Compare compressed wheel vs current master mac wheel — expect ~−2.5 MB

## Risk

Low. `chmod u+w` is needed because brew installs at 0444. The `|| true` swallows transient failures so a single weird brew dylib doesn't tank the whole CI. codesign+strip on brew dylibs is identical to what shipping macOS wheel projects do (delocate-wheel internally re-signs after rpath rewrites). All `macos-pip-test` jobs on the diagnostic predecessor commit passed — `import meshlib.mrmeshpy` works after the strip. Rollback: revert this single edit in `install_brew_requirements.sh`.

## Related

- #6058 (merged): macos link-time strip on our libs
- #6063 (open): Linux third-party strip via vcpkg triplet `-Wl,-s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)