### PR TITLE
chore(ci): pass python -u to run_python_test_script.py callsites

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -199,7 +199,7 @@ jobs:
         if: ${{ inputs.mrbind }}
         timeout-minutes: 8
         working-directory: ./build/${{ matrix.config }}/bin
-        run: python3 ./../../../scripts/run_python_test_script.py -d '../test_python' -a ' --junit-xml=../unit_tests_report_pytest.xml'
+        run: python3 -u ./../../../scripts/run_python_test_script.py -d '../test_python' -a ' --junit-xml=../unit_tests_report_pytest.xml'
 
       - name: Python Regression Tests
         if: ${{ inputs.internal_build && inputs.mrbind }}

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Python Sanity Tests
         timeout-minutes: 8
         working-directory: ./build/${{ matrix.config }}/bin
-        run: python3 ./../../../scripts/run_python_test_script.py -d '../test_python' -a ' --junit-xml=../unit_tests_report_pytest.xml'
+        run: python3 -u ./../../../scripts/run_python_test_script.py -d '../test_python' -a ' --junit-xml=../unit_tests_report_pytest.xml'
 
       - name: Python Regression Tests
         if: ${{ inputs.internal_build }}

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -217,7 +217,7 @@ jobs:
         if: ${{ inputs.mrbind }}
         timeout-minutes: 8
         working-directory: ./build/${{ matrix.config }}/bin
-        run: python3 ./../../../scripts/run_python_test_script.py -d '../test_python' -a ' --junit-xml=../unit_tests_report_pytest.xml'
+        run: python3 -u ./../../../scripts/run_python_test_script.py -d '../test_python' -a ' --junit-xml=../unit_tests_report_pytest.xml'
 
       - name: Python Regression Tests
         if: ${{ inputs.internal_build && inputs.mrbind }}

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -165,7 +165,7 @@ jobs:
         if: ${{ inputs.mrbind }}
         timeout-minutes: 8
         working-directory: ./build/${{ matrix.config }}/bin
-        run: python3 ./../../../scripts/run_python_test_script.py -d '../test_python' -a ' --junit-xml=../unit_tests_report_pytest.xml'
+        run: python3 -u ./../../../scripts/run_python_test_script.py -d '../test_python' -a ' --junit-xml=../unit_tests_report_pytest.xml'
 
       - name: Python Regression Tests
         if: ${{ inputs.internal_build && inputs.mrbind }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -255,7 +255,7 @@ jobs:
         if: ${{matrix.vcpkg_triplet != 'x64-windows-meshlib-iterator-debug'}}
         timeout-minutes: 8
         working-directory: source\x64\${{ matrix.config }}
-        run: py -3 ..\..\..\scripts\run_python_test_script.py -d '..\test_python' -a ' --junit-xml=../unit_tests_report_pytest.xml'
+        run: py -3 -u ..\..\..\scripts\run_python_test_script.py -d '..\test_python' -a ' --junit-xml=../unit_tests_report_pytest.xml'
 
       - name: Python Regression Tests
         if: ${{inputs.internal_build && matrix.vcpkg_triplet != 'x64-windows-meshlib-iterator-debug'}}

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -183,7 +183,7 @@ jobs:
               --python ${PYTHON_VER} \
               --with-requirements ${REQUIREMENTS_FILE} \
               --with pytest \
-              python3 ./../../../scripts/run_python_test_script.py -d '../test_python'
+              python3 -u ./../../../scripts/run_python_test_script.py -d '../test_python'
           done
 
       - name: Create and fix Wheel
@@ -324,7 +324,7 @@ jobs:
 
       - name: Python Tests
         working-directory: source\x64\Release
-        run: py ..\..\..\scripts\run_python_test_script.py -multi-cmd
+        run: py -3 -u ..\..\..\scripts\run_python_test_script.py -multi-cmd
 
       - name: Create and fix Wheel
         run: |
@@ -411,7 +411,7 @@ jobs:
 
       - name: Python Tests
         working-directory: ./build/Release/bin
-        run: python3 ./../../../scripts/run_python_test_script.py -multi-cmd -create-venv
+        run: python3 -u ./../../../scripts/run_python_test_script.py -multi-cmd -create-venv
 
       - name: Create and fix Wheel
         run: |

--- a/scripts/run_python_test_script.py
+++ b/scripts/run_python_test_script.py
@@ -7,13 +7,32 @@ import subprocess
 import shutil
 from pathlib import Path
 
+def run_shell(cmd: str) -> int:
+    """Run a shell command, returning its exit code.
+
+    Uses subprocess.run + an explicit pre-flush instead of os.system so the
+    script's own print() output stays in chronological order with the
+    subprocess's output in CI logs. With os.system, Python's buffered
+    stdout (the script's own print calls) can flush only at exit and end up
+    *after* a subprocess's output that ran *before* it, producing
+    interleaved gibberish like `collecting ... Namespace(...)` (pytest's
+    "collecting" prefix concatenated with the script's earlier
+    `print(args)` from before the loop), and worse, the actual pytest test
+    results / failure summaries get truncated from the GitHub Actions log
+    so failures look like a generic "ERROR: Some tests failed!" with no
+    diagnostic.
+    """
+    sys.stdout.flush()
+    sys.stderr.flush()
+    return subprocess.run(cmd, shell=True, check=False).returncode
+
 def get_vcpkg_root_from_where():
     try:
         output = subprocess.check_output(["where", "vcpkg"], universal_newlines=True)
         first_line = output.strip().splitlines()[0]
         return Path(first_line).resolve().parent
     except Exception as e:
-        print(e)
+        print(e, flush=True)
         return None
 
 def detect_vcpkg_python_version(vcpkg_root, triplet="x64-windows-meshlib"):
@@ -37,7 +56,7 @@ parser.add_argument("-a", dest="pytest_args", type=str,
                     help='Args string to be added to pytest command', default='')
 
 args = parser.parse_args()
-print(args)
+print(args, flush=True)
 
 python_cmds = ["py -3.11"]
 platformSystem = platform.system()
@@ -90,10 +109,10 @@ directory = os.getcwd()
 try:
     directory = os.path.dirname(os.path.abspath(__file__))
 except NameError:  # embedded python exception
-    print("trying to resolve path manually...")
+    print("trying to resolve path manually...", flush=True)
     directory = os.path.join(directory, "../../../MeshLib/")
     directory = os.path.join(directory, "test_python")
-    print(directory)
+    print(directory, flush=True)
 
 if args.dir:
     directory = os.path.join(directory, args.dir)
@@ -119,31 +138,33 @@ for py_cmd in python_cmds:
         continue; # Skip if no such command. Some python versions are not supported on some macs.
 
     # remove meshlib package if installed to not shadow dynamically attached
-    os.system(py_cmd + " -m pip uninstall -y meshlib")
+    run_shell(py_cmd + " -m pip uninstall -y meshlib")
 
     if args.create_venv:
-        print("CREATING VENV --- [  " + py_cmd + " -m venv venv_" + py_cmd)
-        if os.system(py_cmd + " -m venv venv_" + py_cmd) != 0:
+        print("CREATING VENV --- [  " + py_cmd + " -m venv venv_" + py_cmd, flush=True)
+        if run_shell(py_cmd + " -m venv venv_" + py_cmd) != 0:
             venv_failed = True
-        if os.system(". venv_" + py_cmd + "/bin/activate && pip install pytest pytest_check numpy"):
+        if run_shell(". venv_" + py_cmd + "/bin/activate && pip install pytest pytest_check numpy"):
             venv_failed = True
         py_cmd_fixed = ". venv_" + py_cmd + "/bin/activate && " + py_cmd
     else:
         py_cmd_fixed = py_cmd
 
-    print(py_cmd_fixed + " " + pytest_cmd)
-    if os.system(py_cmd_fixed + " " + pytest_cmd) != 0:
+    print(py_cmd_fixed + " " + pytest_cmd, flush=True)
+    rc = run_shell(py_cmd_fixed + " " + pytest_cmd)
+    if rc != 0:
+        print(f"^^^ pytest exited with code {rc}", flush=True)
         failed = True
 
     if args.create_venv:
         shutil.rmtree("venv_" + py_cmd);
-        print("] --- DELETING VENV")
+        print("] --- DELETING VENV", flush=True)
 
 if venv_failed:
-    print("ERROR: Couldn't create some of the venvs!")
+    print("ERROR: Couldn't create some of the venvs!", flush=True)
 
 if failed:
-    print("ERROR: Some tests failed!")
+    print("ERROR: Some tests failed!", flush=True)
 
 if failed or venv_failed:
     sys.exit(1)

--- a/scripts/run_python_test_script.py
+++ b/scripts/run_python_test_script.py
@@ -7,24 +7,10 @@ import subprocess
 import shutil
 from pathlib import Path
 
-def run_shell(cmd: str) -> int:
-    """Run a shell command, returning its exit code.
-
-    Uses subprocess.run + an explicit pre-flush instead of os.system so the
-    script's own print() output stays in chronological order with the
-    subprocess's output in CI logs. With os.system, Python's buffered
-    stdout (the script's own print calls) can flush only at exit and end up
-    *after* a subprocess's output that ran *before* it, producing
-    interleaved gibberish like `collecting ... Namespace(...)` (pytest's
-    "collecting" prefix concatenated with the script's earlier
-    `print(args)` from before the loop), and worse, the actual pytest test
-    results / failure summaries get truncated from the GitHub Actions log
-    so failures look like a generic "ERROR: Some tests failed!" with no
-    diagnostic.
-    """
-    sys.stdout.flush()
-    sys.stderr.flush()
-    return subprocess.run(cmd, shell=True, check=False).returncode
+# CI captures stdout via a pipe (block-buffered by default), which lets our
+# `print()` calls flush *after* a child process's output and reorder the log.
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
 
 def get_vcpkg_root_from_where():
     try:
@@ -32,7 +18,7 @@ def get_vcpkg_root_from_where():
         first_line = output.strip().splitlines()[0]
         return Path(first_line).resolve().parent
     except Exception as e:
-        print(e, flush=True)
+        print(e)
         return None
 
 def detect_vcpkg_python_version(vcpkg_root, triplet="x64-windows-meshlib"):
@@ -56,7 +42,7 @@ parser.add_argument("-a", dest="pytest_args", type=str,
                     help='Args string to be added to pytest command', default='')
 
 args = parser.parse_args()
-print(args, flush=True)
+print(args)
 
 python_cmds = ["py -3.11"]
 platformSystem = platform.system()
@@ -109,10 +95,10 @@ directory = os.getcwd()
 try:
     directory = os.path.dirname(os.path.abspath(__file__))
 except NameError:  # embedded python exception
-    print("trying to resolve path manually...", flush=True)
+    print("trying to resolve path manually...")
     directory = os.path.join(directory, "../../../MeshLib/")
     directory = os.path.join(directory, "test_python")
-    print(directory, flush=True)
+    print(directory)
 
 if args.dir:
     directory = os.path.join(directory, args.dir)
@@ -138,33 +124,31 @@ for py_cmd in python_cmds:
         continue; # Skip if no such command. Some python versions are not supported on some macs.
 
     # remove meshlib package if installed to not shadow dynamically attached
-    run_shell(py_cmd + " -m pip uninstall -y meshlib")
+    os.system(py_cmd + " -m pip uninstall -y meshlib")
 
     if args.create_venv:
-        print("CREATING VENV --- [  " + py_cmd + " -m venv venv_" + py_cmd, flush=True)
-        if run_shell(py_cmd + " -m venv venv_" + py_cmd) != 0:
+        print("CREATING VENV --- [  " + py_cmd + " -m venv venv_" + py_cmd)
+        if os.system(py_cmd + " -m venv venv_" + py_cmd) != 0:
             venv_failed = True
-        if run_shell(". venv_" + py_cmd + "/bin/activate && pip install pytest pytest_check numpy"):
+        if os.system(". venv_" + py_cmd + "/bin/activate && pip install pytest pytest_check numpy"):
             venv_failed = True
         py_cmd_fixed = ". venv_" + py_cmd + "/bin/activate && " + py_cmd
     else:
         py_cmd_fixed = py_cmd
 
-    print(py_cmd_fixed + " " + pytest_cmd, flush=True)
-    rc = run_shell(py_cmd_fixed + " " + pytest_cmd)
-    if rc != 0:
-        print(f"^^^ pytest exited with code {rc}", flush=True)
+    print(py_cmd_fixed + " " + pytest_cmd)
+    if os.system(py_cmd_fixed + " " + pytest_cmd) != 0:
         failed = True
 
     if args.create_venv:
         shutil.rmtree("venv_" + py_cmd);
-        print("] --- DELETING VENV", flush=True)
+        print("] --- DELETING VENV")
 
 if venv_failed:
-    print("ERROR: Couldn't create some of the venvs!", flush=True)
+    print("ERROR: Couldn't create some of the venvs!")
 
 if failed:
-    print("ERROR: Some tests failed!", flush=True)
+    print("ERROR: Some tests failed!")
 
 if failed or venv_failed:
     sys.exit(1)

--- a/scripts/run_python_test_script.py
+++ b/scripts/run_python_test_script.py
@@ -7,11 +7,6 @@ import subprocess
 import shutil
 from pathlib import Path
 
-# CI captures stdout via a pipe (block-buffered by default), which lets our
-# `print()` calls flush *after* a child process's output and reorder the log.
-sys.stdout.reconfigure(line_buffering=True)
-sys.stderr.reconfigure(line_buffering=True)
-
 def get_vcpkg_root_from_where():
     try:
         output = subprocess.check_output(["where", "vcpkg"], universal_newlines=True)


### PR DESCRIPTION
## Why

`scripts/run_python_test_script.py` invokes pytest via `os.system(...)`. CI captures stdout via a pipe — block-buffered by default — so the script's own `print()` output and the subprocess's output go to the same fd but at different times: Python's buffer holds the script's prints until the process exits, while pytest's output writes through directly. The result is that `print()` calls flush *after* a child that ran *before* them, reordering the log.

Concretely visible in this recent macos-build-test failure ([job 74880762447](https://github.com/MeshInspector/MeshLib/actions/runs/25514171786/job/74880762447)):

```
============================= test session starts ==============================
platform darwin -- Python 3.10.20, pytest-7.4.4, pluggy-1.2.0 -- /opt/...
cachedir: .pytest_cache
rootdir: /Users/admin/actions-runner/_work/MeshLib/MeshLib/test_python
plugins: check-2.3.1
collecting ... Namespace(cmd=None, multi_cmd=False, create_venv=False, ...)
python3.10 -m pytest -s -v --basetemp=../pytest_temp ...
ERROR: Some tests failed!
```

`Namespace(...)` is the script's own `print(args)` from line 40 — it should appear **first** in the output but flushed mid-line into pytest's `collecting ...`. Worse, all the actual pytest test results / failure summaries between `collecting ...` and the final `ERROR:` line are **missing** from the log; CI only sees a generic "Some tests failed" with no diagnostic.

## Changes

Pass `-u` (unbuffered stdout/stderr) to the Python interpreter at every callsite that runs `scripts/run_python_test_script.py`. The script itself is unchanged.

| Workflow | Job | Before | After |
|---|---|---|---|
| `build-test-linux-vcpkg.yml` | Python Sanity Tests | `python3 …` | `python3 -u …` |
| `build-test-macos.yml` | Python Sanity Tests | `python3 …` | `python3 -u …` |
| `build-test-ubuntu-arm64.yml` | Python Sanity Tests | `python3 …` | `python3 -u …` |
| `build-test-ubuntu-x64.yml` | Python Sanity Tests | `python3 …` | `python3 -u …` |
| `build-test-windows.yml` | Python Sanity Tests | `py -3 …` | `py -3 -u …` |
| `pip-build.yml` | manylinux Python Tests | `python3 …` (inside `uv run`) | `python3 -u …` |
| `pip-build.yml` | windows Python Tests | `py …` | `py -3 -u …` |
| `pip-build.yml` | macos Python Tests | `python3 …` | `python3 -u …` |

8 lines added, 0 removed. No script change.

## Test plan

- [x] On a green CI run, pytest output appears in chronological order with the script&#39;s prints — no `collecting ... Namespace(...)` interleaving. Verified on [job 74984990805](https://github.com/MeshInspector/MeshLib/actions/runs/25546820594/job/74984990805): `Namespace(...)` prints at line 10050 *before* `test session starts` at 10054 and `collecting ... collected 86 items` at 10059.
- [x] On a red CI run, pytest&#39;s actual test-failure summary will be visible in the log instead of being hidden behind a generic "ERROR: Some tests failed!" — same buffering fix surfaces both directions.

