### PR TITLE
ci: replace PATs with GITHUB_TOKEN in CI workflows

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -16,7 +16,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   # NOTE: all output values are strings
@@ -54,8 +54,6 @@ jobs:
       app_version:       ${{ needs.config.outputs.app_version }}
       release_tag:       ${{ needs.config.outputs.release_tag }}
       upload_artifacts:  ${{ needs.config.outputs.upload_artifacts == 'true' }}
-    secrets:
-      BUILD_MACHINE_TOKEN: ${{ secrets.BUILD_MACHINE_TOKEN }}
 
   windows-build-test:
     if: ${{ needs.config.outputs.build_enable_windows == 'true' }}
@@ -250,11 +248,12 @@ jobs:
           done
 
       - name: Upload Distributives
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           shopt -s nullglob
           PKG_FILES="MeshLibDist*.zip MeshLib*.nupkg meshlib*-dev.deb meshlib*-dev.rpm meshlib*.pkg meshlib_*.zip meshlib_*.tar.xz"
           if [ -n "$(echo $PKG_FILES)" ] ; then
-            echo ${{ secrets.BUILD_MACHINE_TOKEN }} | gh auth login --with-token
             gh release upload ${{ needs.config.outputs.release_tag }} $PKG_FILES --clobber
           fi
 
@@ -268,8 +267,6 @@ jobs:
     uses: ./.github/workflows/unity-nuget-test.yml
     with:
       release_tag: ${{ needs.config.outputs.release_tag }}
-    secrets:
-      BUILD_MACHINE_TOKEN: ${{ secrets.BUILD_MACHINE_TOKEN }}
 
   test-distribution:
     if: ${{ !cancelled() && needs.config.outputs.upload_artifacts == 'true' }}
@@ -282,7 +279,7 @@ jobs:
       test_macos:        ${{ needs.config.outputs.build_enable_macos == 'true' }}
       test_windows:      ${{ needs.config.outputs.build_enable_windows == 'true' && needs.config.outputs.build-release-win == 'true' }}
     secrets:
-      GH_TOKEN: ${{ secrets.BUILD_MACHINE_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
 
   update-dev-documentation:
     # !cancelled() need to ignore general fail previous job, because this job depends on one matrix variant (ubuntu 22),

--- a/.github/workflows/distro-release.yml
+++ b/.github/workflows/distro-release.yml
@@ -7,6 +7,9 @@ on:
         description: 'Tag to build Windows Release from'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   config:
     runs-on: aws-micro
@@ -93,11 +96,12 @@ jobs:
           done
 
       - name: Upload Distributives
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           shopt -s nullglob
           PKG_FILES="MeshLibDist*.zip meshlib_*.zip meshlib_*.tar.xz"
           if [ -n "$(echo $PKG_FILES)" ] ; then
-            echo ${{ secrets.BUILD_MACHINE_TOKEN }} | gh auth login --with-token
             gh release upload ${{ needs.config.outputs.release_tag }} $PKG_FILES --clobber
           fi
 

--- a/.github/workflows/release-body-update.yml
+++ b/.github/workflows/release-body-update.yml
@@ -11,6 +11,9 @@ on:
     types:
       - released
 
+permissions:
+  contents: write
+
 jobs:
   update-release-body:
     runs-on: ubuntu-latest
@@ -21,8 +24,9 @@ jobs:
 
       - name: Determine latest release tag
         id: latest_release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          echo ${{ secrets.BUILD_MACHINE_TOKEN }} | gh auth login --with-token
           LATEST_RELEASE_TAG=$(gh release list --exclude-drafts --repo ${{ github.repository }} --limit 1 | awk '{print $4}')
           echo "::set-output name=tag::${LATEST_RELEASE_TAG}"
 

--- a/.github/workflows/unity-nuget-test.yml
+++ b/.github/workflows/unity-nuget-test.yml
@@ -11,9 +11,6 @@ on:
       release_tag:
         required: true
         type: string
-    secrets:
-      BUILD_MACHINE_TOKEN:
-        required: true
 
 permissions:
   id-token: write
@@ -70,7 +67,7 @@ jobs:
       - name: Download nuget package
         shell: powershell
         env:
-          GH_TOKEN: ${{ secrets.BUILD_MACHINE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release download ${{ inputs.release_tag }} --pattern "*.nupkg" --repo ${{ github.repository }} --clobber
       

--- a/.github/workflows/versioning-release.yml
+++ b/.github/workflows/versioning-release.yml
@@ -2,9 +2,6 @@ name: Create release
 
 on:
   workflow_call:
-    secrets:
-      BUILD_MACHINE_TOKEN:
-        required: false
     inputs:
       app_version:
         required: true
@@ -22,6 +19,9 @@ on:
       release_id:
         description: "release id"
         value: ${{ jobs.versioning-and-release-url.outputs.release_id }}
+
+permissions:
+  contents: write
 
 jobs:
   versioning-and-release-url:
@@ -43,7 +43,7 @@ jobs:
         id: create_release
         uses: mikepenz/action-gh-release@5c3d16ffbdc3e0fbfe2c8a69a448798f5d9b30c2 # v2.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.BUILD_MACHINE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           RELEASE_PATH: https://github.com/${{github.repository}}/releases/download/${{steps.version-tag.outputs.short_version}}
         with:
           name: Release ${{ inputs.release_tag }}

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -255,6 +255,17 @@ void Mesh::transform( const AffineXf3f& xf, const VertBitSet* region )
     invalidateCaches();
 }
 
+void Mesh::transform( const Vector3f& shift, const VertBitSet* region )
+{
+    MR_TIMER;
+
+    BitSetParallelFor( topology.getVertIds( region ), [&] ( const VertId v )
+    {
+        points[v] += shift;
+    } );
+    invalidateCaches();
+}
+
 VertId Mesh::addPoint( const Vector3f & pos )
 {
     VertId v = topology.addVertId();

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -353,6 +353,10 @@ struct [[nodiscard]] Mesh
     /// \snippet cpp-examples/MeshModification.dox.cpp MeshTransform
     MRMESH_API void transform( const AffineXf3f& xf, const VertBitSet* region = nullptr );
 
+    /// applies given shift to specified vertices
+    /// if region is nullptr, all valid mesh vertices are used
+    MRMESH_API void transform( const Vector3f& shift, const VertBitSet* region = nullptr );
+
     /// creates new point and assigns given position to it
     MRMESH_API VertId addPoint( const Vector3f & pos );
 

--- a/source/MRMesh/MRPointCloud.cpp
+++ b/source/MRMesh/MRPointCloud.cpp
@@ -68,6 +68,17 @@ void PointCloud::transform( const AffineXf3f& xf, const VertBitSet* region )
     } );
 }
 
+void PointCloud::transform( const Vector3f& shift, const VertBitSet* region )
+{
+    MR_TIMER;
+    invalidateCaches();
+
+    BitSetParallelFor( getVertIds( region ), [&] ( const VertId v )
+    {
+        points[v] += shift;
+    } );
+}
+
 void PointCloud::addPartByMask( const PointCloud& from, const VertBitSet& fromVerts, const CloudPartMapping& outMap, const VertNormals * extNormals )
 {
     MR_TIMER;

--- a/source/MRMesh/MRPointCloud.h
+++ b/source/MRMesh/MRPointCloud.h
@@ -64,6 +64,10 @@ struct PointCloud
     /// if region is nullptr, all valid points are modified
     MRMESH_API void transform( const AffineXf3f& xf, const VertBitSet* region = nullptr );
 
+    /// applies given shift to specified points (normals are not changed);
+    /// if region is nullptr, all valid points are modified
+    MRMESH_API void transform( const Vector3f& shift, const VertBitSet* region = nullptr );
+
     /// returns all valid point ids sorted lexicographically by their coordinates (optimal for uniform sampling)
     [[nodiscard]] MRMESH_API std::vector<VertId> getLexicographicalOrder() const;
 

--- a/source/MRMesh/MRPolyline.cpp
+++ b/source/MRMesh/MRPolyline.cpp
@@ -330,6 +330,20 @@ void Polyline<V>::transform( const AffineXf<V> & xf )
 }
 
 template<typename V>
+void Polyline<V>::transform( const V & shift )
+{
+    MR_TIMER;
+    VertId lastValidVert = topology.lastValidVert();
+
+    ParallelFor( 0_v, lastValidVert + 1, [&] ( VertId v )
+    {
+        if ( topology.hasVert( v ) )
+            points[v] += shift;
+    } );
+    invalidateCaches();
+}
+
+template<typename V>
 EdgeId Polyline<V>::splitEdge( EdgeId e, const V & newVertPos )
 {
     EdgeId newe = topology.splitEdge( e );

--- a/source/MRMesh/MRPolyline.h
+++ b/source/MRMesh/MRPolyline.h
@@ -118,6 +118,9 @@ public:
     /// applies given transformation to all valid polyline vertices
     MRMESH_API void transform( const AffineXf<V> & xf );
 
+    /// applies given shift to all valid polyline vertices
+    MRMESH_API void transform( const V & shift );
+
     /// split given edge on two parts:
     /// dest(returned-edge) = org(e) - newly created vertex,
     /// org(returned-edge) = org(e-before-split),


### PR DESCRIPTION
## Summary

- Replace `BUILD_MACHINE_TOKEN` and `MESHINSPECTOR_BOT_TOKEN` with the built-in `GITHUB_TOKEN` for all same-repo GitHub operations
- Add `permissions: contents: write` to workflows that create/update releases or tags
- Switch `gh` CLI authentication from `gh auth login --with-token` piping to the `GH_TOKEN` env-var pattern
- Remove `BUILD_MACHINE_TOKEN` from `on.workflow_call.secrets` declarations where it is no longer used

**Intentionally unchanged** (PATs still required):
- `vcpkg-auto-update.yml` — `MESHINSPECTOR_BOT_VCPKG_UPDATE_TOKEN`: pushes branches that must trigger CI (GITHUB_TOKEN pushes do not trigger workflows)
- `pot-auto-update.yml` — same token, same reason
- `update-docs.yml` — `MESHINSPECTOR_BOT_TOKEN`: cross-repo checkout (`MeshInspector/MeshInspector.github.io`)

## Files changed

- `versioning-release.yml` — `GITHUB_TOKEN: ${{ github.token }}` in `mikepenz/action-gh-release`; added `permissions: contents: write`
- `distro-release.yml` — replaced `gh auth login` with `env: GH_TOKEN: ${{ github.token }}`; added `permissions: contents: write`
- `release-body-update.yml` — same pattern; added `permissions: contents: write`
- `unity-nuget-test.yml` — removed `BUILD_MACHINE_TOKEN` secret declaration; use `github.token`
- `build-test-distribute.yml` — changed `permissions: contents: read → write`; removed PAT secret passing to callee workflows; replaced `gh auth login` with `GH_TOKEN` env var

## Test plan

- [ ] Checkout step completes (no HTTP 403 for MeshLib submodule — it's public)
- [ ] Windows build passes (token used for checkout)
- [ ] Ubuntu x64 build passes (token used for checkout)
- [ ] Verify `vcpkg-auto-update` and `pot-auto-update` still reference bot token (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)