### PR TITLE
optimize MeshTopology::deleteFaces

### DIFF
--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -987,11 +987,24 @@ void MeshTopology::deleteFace( FaceId f, const UndirectedEdgeBitSet * keepEdges 
     }
 }
 
-void MeshTopology::deleteFaces( const FaceBitSet & fs, const UndirectedEdgeBitSet * keepEdges )
+auto MeshTopology::deleteFaces( FaceBitSet && fs, const UndirectedEdgeBitSet * keepEdges ) -> VacantElements
 {
     MR_TIMER;
+    auto res = deleteFaces( fs, keepEdges );
+    assert( res.faces.empty() );
+    res.faces = std::move( fs );
+    return res;
+}
+
+auto MeshTopology::deleteFaces( const FaceBitSet & fs, const UndirectedEdgeBitSet * keepEdges ) -> VacantElements
+{
+    MR_TIMER;
+    VacantElements res;
+
     for ( auto f : fs )
         deleteFace( f, keepEdges );
+
+    return res;
 }
 
 template<typename FM, typename VM, typename WEM>

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -987,24 +987,92 @@ void MeshTopology::deleteFace( FaceId f, const UndirectedEdgeBitSet * keepEdges 
     }
 }
 
-auto MeshTopology::deleteFaces( FaceBitSet && fs, const UndirectedEdgeBitSet * keepEdges ) -> VacantElements
-{
-    MR_TIMER;
-    auto res = deleteFaces( fs, keepEdges );
-    assert( res.faces.empty() );
-    res.faces = std::move( fs );
-    return res;
-}
-
 auto MeshTopology::deleteFaces( const FaceBitSet & fs, const UndirectedEdgeBitSet * keepEdges ) -> VacantElements
 {
     MR_TIMER;
-    VacantElements res;
+    VacantElements vacant;
 
-    for ( auto f : fs )
-        deleteFace( f, keepEdges );
+    UndirectedEdgeBitSet oldLoneEdge( undirectedEdgeSize() );
+    vacant.edges.resize( undirectedEdgeSize() );
+    BitSetParallelForAll( vacant.edges, [&]( UndirectedEdgeId ue )
+    {
+        if ( isLoneEdge( ue ) )
+        {
+            oldLoneEdge.set( ue );
+            vacant.edges.set( ue );
+            return;
+        }
+        if ( keepEdges && keepEdges->test( ue ) )
+            return;
+        if ( auto l = left( ue ); l && !fs.test( l ) )
+            return; // left face exists and will not be deleted
+        if ( auto r = right( ue ); r && !fs.test( r ) )
+            return; // right face exists and will not be deleted
+        vacant.edges.set( ue );
+    } );
 
-    return res;
+    assert( updateValids_ );
+
+    vacant.verts.resize( vertSize(), true );
+    vacant.verts -= validVerts_;
+    BitSetParallelFor( validVerts_, [&]( VertId v )
+    {
+        for ( auto e : orgRing( *this, v ) )
+            if ( !vacant.edges.test( e ) )
+            {
+                // at least one edge incident to this vertex is not deleted
+                if ( vacant.edges.test( edgePerVertex_[v] ) )
+                    edgePerVertex_[v] = e;
+                return;
+            }
+        validVerts_.reset( v );
+        vacant.verts.set( v );
+        edgePerVertex_[v] = EdgeId();
+    } );
+    numValidVerts_ = (int)validVerts_.count();
+
+    const auto fsValid = fs & validFaces_;
+    BitSetParallelFor( fsValid, [&]( FaceId f )
+    {
+        edgePerFace_[f] = EdgeId();
+    } );
+    validFaces_ -= fsValid;
+    numValidFaces_ = (int)validFaces_.count();
+    vacant.faces.resize( faceSize(), true );
+    vacant.faces -= validFaces_;
+
+    // pass 1: update edges that will remain
+    ParallelFor( edges_, [&]( EdgeId e )
+    {
+        if ( vacant.edges.test( e ) )
+            return;
+        assert( !oldLoneEdge.test( e ) );
+
+        HalfEdgeRecord he = edges_[e];
+        while ( vacant.edges.test( he.next ) )
+            he.next = next( he.next );
+        while ( vacant.edges.test( he.prev ) )
+            he.prev = prev( he.prev );
+        assert( !vacant.verts.test( he.org ) ); // all edges around deleted vertices must be made lone
+        if ( vacant.faces.test( he.left ) )
+            he.left = FaceId{};
+        edges_[e] = he;
+    } );
+
+    // pass 2: make new lone edges
+    ParallelFor( edges_, [&]( EdgeId e )
+    {
+        if ( !vacant.edges.test( e ) )
+            return;
+        if ( oldLoneEdge.test( e ) )
+            return; // quick path for the edges that were already lone before
+
+        HalfEdgeRecord he;
+        he.next = he.prev = e;
+        edges_[e] = he;
+    } );
+
+    return vacant;
 }
 
 template<typename FM, typename VM, typename WEM>

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -273,14 +273,7 @@ public:
     /// 1) all the gives faces,
     /// 2) all the vertices, which had incident only deleted faces and no edges from \param keepEdges,
     /// 3) make lone all the edges, which had to the left/right only deleted faces except for the edges from \param keepEdges;
-    /// return bit sets of deleted elements
-    MRMESH_API VacantElements deleteFaces( FaceBitSet && fs, const UndirectedEdgeBitSet * keepEdges = nullptr );
-
-    /// deletes from this topology:
-    /// 1) all the gives faces,
-    /// 2) all the vertices, which had incident only deleted faces and no edges from \param keepEdges,
-    /// 3) make lone all the edges, which had to the left/right only deleted faces except for the edges from \param keepEdges;
-    /// return bit sets of deleted elements, except for VacantElements::faces, which is returned empty
+    /// return bit sets of all vacant elements in this topology after deletion
     MRMESH_API VacantElements deleteFaces( const FaceBitSet & fs, const UndirectedEdgeBitSet * keepEdges = nullptr );
 
     /// explicitly increases the size of faces vector

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -262,8 +262,26 @@ public:
     /// deletes the face, also deletes its edges and vertices if they were not shared by other faces and not in \param keepFaces
     MRMESH_API void deleteFace( FaceId f, const UndirectedEdgeBitSet * keepEdges = nullptr );
 
-    /// deletes multiple given faces by calling \ref deleteFace for each
-    MRMESH_API void deleteFaces( const FaceBitSet & fs, const UndirectedEdgeBitSet * keepEdges = nullptr );
+    struct VacantElements
+    {
+        UndirectedEdgeBitSet edges;
+        VertBitSet verts;
+        FaceBitSet faces;
+    };
+
+    /// deletes from this topology:
+    /// 1) all the gives faces,
+    /// 2) all the vertices, which had incident only deleted faces and no edges from \param keepEdges,
+    /// 3) make lone all the edges, which had to the left/right only deleted faces except for the edges from \param keepEdges;
+    /// return bit sets of deleted elements
+    MRMESH_API VacantElements deleteFaces( FaceBitSet && fs, const UndirectedEdgeBitSet * keepEdges = nullptr );
+
+    /// deletes from this topology:
+    /// 1) all the gives faces,
+    /// 2) all the vertices, which had incident only deleted faces and no edges from \param keepEdges,
+    /// 3) make lone all the edges, which had to the left/right only deleted faces except for the edges from \param keepEdges;
+    /// return bit sets of deleted elements, except for VacantElements::faces, which is returned empty
+    MRMESH_API VacantElements deleteFaces( const FaceBitSet & fs, const UndirectedEdgeBitSet * keepEdges = nullptr );
 
     /// explicitly increases the size of faces vector
     MRMESH_API void faceResize( size_t newSize );


### PR DESCRIPTION
`MeshTopology::deleteFaces` is implemented with parallel processing inside, and returns all vacant mesh elements after deletion.