### PR TITLE
CMake: silence CMP0167 from MRViewer Boost::locale lookup

### DIFF
--- a/source/MRViewer/CMakeLists.txt
+++ b/source/MRViewer/CMakeLists.txt
@@ -107,7 +107,15 @@ IF(NOT MRVIEWER_NO_VOXELS)
 ENDIF()
 
 IF(NOT MRVIEWER_NO_LOCALE)
-  find_package(Boost COMPONENTS locale REQUIRED)
+  # Emscripten's Boost package doesn't contain CMake config files
+  IF(EMSCRIPTEN)
+    IF(POLICY CMP0167)
+      cmake_policy(SET CMP0167 OLD)
+    ENDIF()
+    find_package(Boost COMPONENTS locale REQUIRED)
+  ELSE()
+    find_package(Boost CONFIG COMPONENTS locale REQUIRED)
+  ENDIF()
   target_link_libraries(${PROJECT_NAME} PRIVATE Boost::locale)
 ENDIF()
 


### PR DESCRIPTION
## Summary

Switch the `find_package(Boost ... locale)` call in `source/MRViewer/CMakeLists.txt` to `CONFIG` mode on non-Emscripten builds, mirroring the pattern already used in `MRMesh/CMakeLists.txt` and `MRPch/CMakeLists.txt`.

This silences the `CMP0167` deprecation warning ("The FindBoost module is removed") emitted by CMake 3.30+ when the legacy `FindBoost` module is invoked indirectly via vcpkg's Boost wrapper.

## Why

CMake 3.30 removed the bundled `FindBoost` module in favor of Boost's own `BoostConfig.cmake`. Calling `find_package(Boost ...)` without `CONFIG` falls into the legacy module path, triggering:

```
CMake Warning (dev) at C:/vcpkg/installed/.../share/boost/vcpkg-cmake-wrapper.cmake:3 (_find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.
Call Stack (most recent call first):
  C:/vcpkg/scripts/buildsystems/vcpkg.cmake:813 (include)
  source/MRViewer/CMakeLists.txt:110 (find_package)
```

vcpkg already ships `BoostConfig.cmake` (its wrapper just forwards to it), so switching to `CONFIG` mode is a no-op functionally — the same Boost is found, only the legacy code path is avoided.

The Emscripten branch keeps module mode because vcpkg's Emscripten Boost port doesn't install CMake config files; that branch additionally sets `CMP0167 OLD` so the warning stays suppressed there too.

## Test plan

- [x] `CMP0167` warning gone from the `windows-vs2019-meshlib` configure log (the job that originated the warning).
- [x] Windows MSVC 2019 / MSVC 2022 build & test jobs pass.
- [x] Linux x64 (GCC 12/13/14, Clang 20) and arm64 (GCC 11, Clang 20, ubuntu22/24) build & test jobs pass.
- [x] macOS arm64 Debug + Release build & test jobs pass.
- [x] Emscripten Singlethreaded / Multithreaded / Multithreaded-64Bit configure, build & runtime tests pass — `Boost::locale` linkage unchanged on WASM.
