### PR TITLE
ci(unity): grant contents:write so unity-nuget-test can see draft releases

### DIFF
--- a/.github/workflows/unity-nuget-test.yml
+++ b/.github/workflows/unity-nuget-test.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 concurrency:
   group: unity-test


### PR DESCRIPTION
## Summary

PR #6073 swapped `BUILD_MACHINE_TOKEN` for `github.token` across CI workflows but left `unity-nuget-test.yml` declaring `contents: read` at the workflow level. The `.nupkg` lives on a draft release, and GitHub's REST API only lists draft releases for callers with push (write) access — so the read-only `GITHUB_TOKEN` now gets `release not found` against the draft, and `gh release download` fails.

Concrete failure: [run 25607068360 / unity-nuget-test](https://github.com/MeshInspector/MeshLib/actions/runs/25607068360/job/75179586286)

```
gh release download v3.1.2.213 --pattern "*.nupkg" --repo MeshInspector/MeshLib --clobber
release not found
```

The job's `GITHUB_TOKEN Permissions` block in the log shows `Contents: read / Metadata: read`, which matches the workflow-level declaration.

This PR bumps the workflow permission to `contents: write` to match the other reusable workflows updated in #6073 (`build-test-distribute.yml`, `distro-release.yml`, `release-body-update.yml`, `versioning-release.yml`).

## Test plan

- [ ] Next scheduled `Build Test Distribute` run on master succeeds at the `windows-unity-test / unity-nuget-test` job, or
- [ ] Manual `workflow_dispatch` of `unity-nuget-test.yml` with an existing draft `release_tag` succeeds at the Download nuget package step
