### PR TITLE
ci(windows): generate_win.bat — fail loudly when MSYS2 isn't installed

### DIFF
--- a/scripts/mrbind/generate_win.bat
+++ b/scripts/mrbind/generate_win.bat
@@ -15,7 +15,8 @@ set args=%*
 
 if not exist %MSYS2_DIR% (
     echo MSYS2 was NOT found at `%MSYS2_DIR%`. Run `install_deps_windows_msys2.bat` to build it.
-) else (
-    echo Found MSYS2 at `%MSYS2_DIR%`.
-    call %MSYS2_DIR%\msys2_shell.cmd -no-start -defterm -full-path -here -clang64 -c "time make -f '%~dp0generate.mk' %args:"=""% "
+    exit /b 1
 )
+
+echo Found MSYS2 at `%MSYS2_DIR%`.
+call %MSYS2_DIR%\msys2_shell.cmd -no-start -defterm -full-path -here -clang64 -c "time make -f '%~dp0generate.mk' %args:"=""% "


### PR DESCRIPTION
## Summary

`scripts/mrbind/generate_win.bat` exits 0 when `%MSYS2_DIR%` doesn't exist — it prints an error to stdout but the implicit return code is success, so callers (CI workflows, local devs) think binding generation completed with no output and move on. The bug only surfaces when something goes wrong with MSYS2 setup; in normal operation the directory exists and the script proceeds correctly.

Fix: explicitly `exit /b 1` after the error message, and de-nest the success path so the normal flow is the script's straight-line body rather than the `else` branch of the missing-MSYS2 check.

## Test plan

- [x] When `MSYS2_DIR` is set to a missing directory, the script prints the error and exits with code 1 (verified locally).
- [x] When `MSYS2_DIR` exists, the script runs `msys2_shell.cmd … make …` exactly as before — no behavior change in the happy path.
- [ ] CI: Windows binding-generation matrix passes (no behavior change in normal builds).

## Notes

Extracted from PR #6060.
