### PR TITLE
ci(mrbind): make build-mrbind work without bash on PATH (Python SHA step + pwsh on Windows for Trim/Strip)

### DIFF
--- a/.github/actions/build-mrbind/action.yml
+++ b/.github/actions/build-mrbind/action.yml
@@ -53,17 +53,6 @@ inputs:
 runs:
   using: composite
   steps:
-    # actions/cache invokes `tar -z` to save the cache, which delegates
-    # compression to gzip. Git for Windows ships gzip in
-    # `C:\Program Files\Git\usr\bin`, but some self-hosted Windows runner
-    # images don't put that directory on PATH -- so cache save fails with
-    # `/bin/sh: gzip: command not found`. Prepend it here; no-op on
-    # GitHub-hosted Windows runners (gzip is already on PATH there).
-    - name: Add Git/usr/bin to PATH (Windows)
-      if: ${{ runner.os == 'Windows' }}
-      shell: pwsh
-      run: Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\Git\usr\bin'
-
     - name: Get MRBind submodule SHA
       id: mrbind-sha
       shell: python {0}

--- a/.github/actions/build-mrbind/action.yml
+++ b/.github/actions/build-mrbind/action.yml
@@ -50,35 +50,28 @@ inputs:
       elsewhere -- e.g. `C:\msys64_meshlib_mrbind` for runners pre-baked
       with the bat script's default layout.
 
-# The Windows and Unix step pairs below exist because some self-hosted
-# Windows runners (e.g. MeshInspectorCode's AMI) don't have `bash` on PATH,
-# so `shell: bash` fails to launch. `pwsh` is the safe lowest-common-
-# denominator on Windows; bash is the safe one elsewhere.
-
 runs:
   using: composite
   steps:
-    - name: Get MRBind submodule SHA (Windows)
-      if: ${{ runner.os == 'Windows' }}
-      id: mrbind-sha-win
-      shell: pwsh
+    - name: Get MRBind submodule SHA
+      id: mrbind-sha
+      shell: python {0}
+      env:
+        MRBIND_DIR: ${{ inputs.mrbind-dir }}
       run: |
-        $sha = git -C '${{ inputs.mrbind-dir }}' rev-parse HEAD
-        "sha=$sha" | Add-Content -Path $env:GITHUB_OUTPUT
-
-    - name: Get MRBind submodule SHA (Unix)
-      if: ${{ runner.os != 'Windows' }}
-      id: mrbind-sha-unix
-      shell: bash
-      run: echo "sha=$(git -C '${{ inputs.mrbind-dir }}' rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        import os, subprocess
+        sha = subprocess.check_output(
+            ['git', '-C', os.environ['MRBIND_DIR'], 'rev-parse', 'HEAD'],
+            text=True).strip()
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f'sha={sha}\n')
 
     - name: Cache MRBind build
       id: cache
       uses: actions/cache@v5
       with:
         path: ${{ inputs.mrbind-dir }}/build
-        # Exactly one of the two SHA steps ran, so concatenation yields the SHA.
-        key: mrbind-build-${{ inputs.cache-key-prefix }}-${{ steps.mrbind-sha-win.outputs.sha }}${{ steps.mrbind-sha-unix.outputs.sha }}-${{ hashFiles(inputs.build-script) }}-${{ inputs.extra-cache-key }}
+        key: mrbind-build-${{ inputs.cache-key-prefix }}-${{ steps.mrbind-sha.outputs.sha }}-${{ hashFiles(inputs.build-script) }}-${{ inputs.extra-cache-key }}
 
     - name: Build MRBind (Windows)
       # `install_mrbind_windows_msys2.bat` defaults MSYS2_DIR to
@@ -95,55 +88,49 @@ runs:
       shell: bash
       run: ${{ inputs.build-script }}
 
-    # Downstream steps only invoke the three executables (mrbind, mrbind_gen_c,
-    # mrbind_gen_csharp -- see scripts/mrbind/generate.mk:191-193). Object files,
-    # static libs, and CMake/Ninja metadata aren't consumed and would just bloat
-    # the cache (the build script wipes `build/` before rebuilding anyway, so we
-    # don't need incremental-rebuild state either).
-
-    - name: Trim MRBind build dir before cache save (Windows)
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows' }}
-      shell: pwsh
+    - name: Trim MRBind build dir before cache save
+      # Downstream steps only invoke the three executables (mrbind, mrbind_gen_c,
+      # mrbind_gen_csharp -- see scripts/mrbind/generate.mk:191-193). Object files,
+      # static libs, and CMake/Ninja metadata aren't consumed and would just bloat
+      # the cache (the build script wipes `build/` before rebuilding anyway, so we
+      # don't need incremental-rebuild state either).
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      shell: python {0}
+      env:
+        MRBIND_DIR: ${{ inputs.mrbind-dir }}
       run: |
-        $keep = @('mrbind.exe', 'mrbind_gen_c.exe', 'mrbind_gen_csharp.exe')
-        Get-ChildItem -LiteralPath '${{ inputs.mrbind-dir }}/build' |
-          Where-Object { $keep -notcontains $_.Name } |
-          Remove-Item -Recurse -Force
+        import os, shutil
+        build = os.path.join(os.environ['MRBIND_DIR'], 'build')
+        keep = {'mrbind', 'mrbind.exe',
+                'mrbind_gen_c', 'mrbind_gen_c.exe',
+                'mrbind_gen_csharp', 'mrbind_gen_csharp.exe'}
+        for entry in os.listdir(build):
+            if entry in keep:
+                continue
+            path = os.path.join(build, entry)
+            (shutil.rmtree if os.path.isdir(path) else os.remove)(path)
 
-    - name: Trim MRBind build dir before cache save (Unix)
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != 'Windows' }}
-      shell: bash
+    - name: Strip MRBind binaries
+      # Strip shrinks the cache ~5x at the cost of useful stack traces from mrbind
+      # crashes. Opt out by passing `strip-binaries: 'false'` on a debugging branch;
+      # mrbind is built with `RelWithDebInfo + -fstandalone-debug`, so a fresh local
+      # build still gives a full-info binary.
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' }}
+      shell: python {0}
+      env:
+        MRBIND_DIR: ${{ inputs.mrbind-dir }}
+        MSYS2_DIR: ${{ inputs.msys2-dir }}
       run: |
-        set -eu
-        cd '${{ inputs.mrbind-dir }}/build'
-        find . -mindepth 1 -maxdepth 1 \
-          ! -name 'mrbind'            ! -name 'mrbind.exe' \
-          ! -name 'mrbind_gen_c'      ! -name 'mrbind_gen_c.exe' \
-          ! -name 'mrbind_gen_csharp' ! -name 'mrbind_gen_csharp.exe' \
-          -exec rm -rf {} +
-
-    # Stripping shrinks the cache ~5x at the cost of useful stack traces from
-    # mrbind crashes. Opt out by passing `strip-binaries: 'false'` on a debugging
-    # branch; mrbind is built with `RelWithDebInfo + -fstandalone-debug`, so a
-    # fresh local build still gives a full-info binary.
-
-    - name: Strip MRBind binaries (macOS)
-      # -S drops debug symbols but keeps the dynamic symbol table.
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' && runner.os == 'macOS' }}
-      shell: bash
-      run: strip -S ${{ inputs.mrbind-dir }}/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp}
-
-    - name: Strip MRBind binaries (Linux)
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' && runner.os == 'Linux' }}
-      shell: bash
-      run: strip ${{ inputs.mrbind-dir }}/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp}
-
-    - name: Strip MRBind binaries (Windows)
-      # The build uses MSYS2 clang64; reach for that strip directly since neither
-      # Git Bash nor the runner's PATH typically include it.
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' && runner.os == 'Windows' }}
-      shell: pwsh
-      run: |
-        $strip = '${{ inputs.msys2-dir }}\clang64\bin\strip.exe'
-        $base  = '${{ inputs.mrbind-dir }}/build'
-        & $strip "$base/mrbind.exe" "$base/mrbind_gen_c.exe" "$base/mrbind_gen_csharp.exe"
+        import os, platform, subprocess
+        base = os.path.join(os.environ['MRBIND_DIR'], 'build')
+        names = ['mrbind', 'mrbind_gen_c', 'mrbind_gen_csharp']
+        system = platform.system()
+        if system == 'Darwin':
+            # -S drops debug symbols but keeps the dynamic symbol table.
+            cmd, ext = ['strip', '-S'], ''
+        elif system == 'Windows':
+            # MSYS2 clang64's strip; not on PATH on most runners.
+            cmd, ext = [os.path.join(os.environ['MSYS2_DIR'], 'clang64', 'bin', 'strip.exe')], '.exe'
+        else:
+            cmd, ext = ['strip'], ''
+        subprocess.check_call(cmd + [os.path.join(base, n + ext) for n in names])

--- a/.github/actions/build-mrbind/action.yml
+++ b/.github/actions/build-mrbind/action.yml
@@ -88,49 +88,52 @@ runs:
       shell: bash
       run: ${{ inputs.build-script }}
 
-    - name: Trim MRBind build dir before cache save
-      # Downstream steps only invoke the three executables (mrbind, mrbind_gen_c,
-      # mrbind_gen_csharp -- see scripts/mrbind/generate.mk:191-193). Object files,
-      # static libs, and CMake/Ninja metadata aren't consumed and would just bloat
-      # the cache (the build script wipes `build/` before rebuilding anyway, so we
-      # don't need incremental-rebuild state either).
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      shell: python {0}
-      env:
-        MRBIND_DIR: ${{ inputs.mrbind-dir }}
-      run: |
-        import os, shutil
-        build = os.path.join(os.environ['MRBIND_DIR'], 'build')
-        keep = {'mrbind', 'mrbind.exe',
-                'mrbind_gen_c', 'mrbind_gen_c.exe',
-                'mrbind_gen_csharp', 'mrbind_gen_csharp.exe'}
-        for entry in os.listdir(build):
-            if entry in keep:
-                continue
-            path = os.path.join(build, entry)
-            (shutil.rmtree if os.path.isdir(path) else os.remove)(path)
+    # Downstream steps only invoke the three executables (mrbind, mrbind_gen_c,
+    # mrbind_gen_csharp -- see scripts/mrbind/generate.mk:191-193). Object files,
+    # static libs, and CMake/Ninja metadata aren't consumed and would just bloat
+    # the cache (the build script wipes `build/` before rebuilding anyway, so we
+    # don't need incremental-rebuild state either).
 
-    - name: Strip MRBind binaries
-      # Strip shrinks the cache ~5x at the cost of useful stack traces from mrbind
-      # crashes. Opt out by passing `strip-binaries: 'false'` on a debugging branch;
-      # mrbind is built with `RelWithDebInfo + -fstandalone-debug`, so a fresh local
-      # build still gives a full-info binary.
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' }}
-      shell: python {0}
-      env:
-        MRBIND_DIR: ${{ inputs.mrbind-dir }}
-        MSYS2_DIR: ${{ inputs.msys2-dir }}
+    - name: Trim MRBind build dir before cache save (Windows)
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows' }}
+      shell: pwsh
       run: |
-        import os, platform, subprocess
-        base = os.path.join(os.environ['MRBIND_DIR'], 'build')
-        names = ['mrbind', 'mrbind_gen_c', 'mrbind_gen_csharp']
-        system = platform.system()
-        if system == 'Darwin':
-            # -S drops debug symbols but keeps the dynamic symbol table.
-            cmd, ext = ['strip', '-S'], ''
-        elif system == 'Windows':
-            # MSYS2 clang64's strip; not on PATH on most runners.
-            cmd, ext = [os.path.join(os.environ['MSYS2_DIR'], 'clang64', 'bin', 'strip.exe')], '.exe'
-        else:
-            cmd, ext = ['strip'], ''
-        subprocess.check_call(cmd + [os.path.join(base, n + ext) for n in names])
+        $keep = @('mrbind.exe', 'mrbind_gen_c.exe', 'mrbind_gen_csharp.exe')
+        Get-ChildItem -LiteralPath '${{ inputs.mrbind-dir }}/build' |
+          Where-Object { $keep -notcontains $_.Name } |
+          Remove-Item -Recurse -Force
+
+    - name: Trim MRBind build dir before cache save (Unix)
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != 'Windows' }}
+      shell: bash
+      run: |
+        set -eu
+        cd '${{ inputs.mrbind-dir }}/build'
+        find . -mindepth 1 -maxdepth 1 \
+          ! -name 'mrbind' ! -name 'mrbind_gen_c' ! -name 'mrbind_gen_csharp' \
+          -exec rm -rf {} +
+
+    # Stripping shrinks the cache ~5x at the cost of useful stack traces from
+    # mrbind crashes. Opt out by passing `strip-binaries: 'false'` on a debugging
+    # branch; mrbind is built with `RelWithDebInfo + -fstandalone-debug`, so a
+    # fresh local build still gives a full-info binary.
+
+    - name: Strip MRBind binaries (macOS)
+      # -S drops debug symbols but keeps the dynamic symbol table.
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' && runner.os == 'macOS' }}
+      shell: bash
+      run: strip -S ${{ inputs.mrbind-dir }}/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp}
+
+    - name: Strip MRBind binaries (Linux)
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' && runner.os == 'Linux' }}
+      shell: bash
+      run: strip ${{ inputs.mrbind-dir }}/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp}
+
+    - name: Strip MRBind binaries (Windows)
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' && runner.os == 'Windows' }}
+      shell: pwsh
+      run: |
+        & '${{ inputs.msys2-dir }}\clang64\bin\strip.exe' `
+          '${{ inputs.mrbind-dir }}/build/mrbind.exe' `
+          '${{ inputs.mrbind-dir }}/build/mrbind_gen_c.exe' `
+          '${{ inputs.mrbind-dir }}/build/mrbind_gen_csharp.exe'

--- a/.github/actions/build-mrbind/action.yml
+++ b/.github/actions/build-mrbind/action.yml
@@ -53,6 +53,17 @@ inputs:
 runs:
   using: composite
   steps:
+    # actions/cache invokes `tar -z` to save the cache, which delegates
+    # compression to gzip. Git for Windows ships gzip in
+    # `C:\Program Files\Git\usr\bin`, but some self-hosted Windows runner
+    # images don't put that directory on PATH -- so cache save fails with
+    # `/bin/sh: gzip: command not found`. Prepend it here; no-op on
+    # GitHub-hosted Windows runners (gzip is already on PATH there).
+    - name: Add Git/usr/bin to PATH (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      shell: pwsh
+      run: Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\Git\usr\bin'
+
     - name: Get MRBind submodule SHA
       id: mrbind-sha
       shell: python {0}

--- a/.github/actions/build-mrbind/action.yml
+++ b/.github/actions/build-mrbind/action.yml
@@ -50,11 +50,25 @@ inputs:
       elsewhere -- e.g. `C:\msys64_meshlib_mrbind` for runners pre-baked
       with the bat script's default layout.
 
+# The Windows and Unix step pairs below exist because some self-hosted
+# Windows runners (e.g. MeshInspectorCode's AMI) don't have `bash` on PATH,
+# so `shell: bash` fails to launch. `pwsh` is the safe lowest-common-
+# denominator on Windows; bash is the safe one elsewhere.
+
 runs:
   using: composite
   steps:
-    - name: Get MRBind submodule SHA
-      id: mrbind-sha
+    - name: Get MRBind submodule SHA (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      id: mrbind-sha-win
+      shell: pwsh
+      run: |
+        $sha = git -C '${{ inputs.mrbind-dir }}' rev-parse HEAD
+        "sha=$sha" | Add-Content -Path $env:GITHUB_OUTPUT
+
+    - name: Get MRBind submodule SHA (Unix)
+      if: ${{ runner.os != 'Windows' }}
+      id: mrbind-sha-unix
       shell: bash
       run: echo "sha=$(git -C '${{ inputs.mrbind-dir }}' rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
@@ -63,7 +77,8 @@ runs:
       uses: actions/cache@v5
       with:
         path: ${{ inputs.mrbind-dir }}/build
-        key: mrbind-build-${{ inputs.cache-key-prefix }}-${{ steps.mrbind-sha.outputs.sha }}-${{ hashFiles(inputs.build-script) }}-${{ inputs.extra-cache-key }}
+        # Exactly one of the two SHA steps ran, so concatenation yields the SHA.
+        key: mrbind-build-${{ inputs.cache-key-prefix }}-${{ steps.mrbind-sha-win.outputs.sha }}${{ steps.mrbind-sha-unix.outputs.sha }}-${{ hashFiles(inputs.build-script) }}-${{ inputs.extra-cache-key }}
 
     - name: Build MRBind (Windows)
       # `install_mrbind_windows_msys2.bat` defaults MSYS2_DIR to
@@ -80,13 +95,23 @@ runs:
       shell: bash
       run: ${{ inputs.build-script }}
 
-    - name: Trim MRBind build dir before cache save
-      # Downstream steps only invoke the three executables (mrbind, mrbind_gen_c,
-      # mrbind_gen_csharp -- see scripts/mrbind/generate.mk:191-193). Object files,
-      # static libs, and CMake/Ninja metadata aren't consumed and would just bloat
-      # the cache (the build script wipes `build/` before rebuilding anyway, so we
-      # don't need incremental-rebuild state either).
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+    # Downstream steps only invoke the three executables (mrbind, mrbind_gen_c,
+    # mrbind_gen_csharp -- see scripts/mrbind/generate.mk:191-193). Object files,
+    # static libs, and CMake/Ninja metadata aren't consumed and would just bloat
+    # the cache (the build script wipes `build/` before rebuilding anyway, so we
+    # don't need incremental-rebuild state either).
+
+    - name: Trim MRBind build dir before cache save (Windows)
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows' }}
+      shell: pwsh
+      run: |
+        $keep = @('mrbind.exe', 'mrbind_gen_c.exe', 'mrbind_gen_csharp.exe')
+        Get-ChildItem -LiteralPath '${{ inputs.mrbind-dir }}/build' |
+          Where-Object { $keep -notcontains $_.Name } |
+          Remove-Item -Recurse -Force
+
+    - name: Trim MRBind build dir before cache save (Unix)
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != 'Windows' }}
       shell: bash
       run: |
         set -eu
@@ -114,11 +139,11 @@ runs:
       run: strip ${{ inputs.mrbind-dir }}/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp}
 
     - name: Strip MRBind binaries (Windows)
-      # The build uses MSYS2 clang64; reach for that strip directly since Git
-      # Bash's PATH doesn't include it.
+      # The build uses MSYS2 clang64; reach for that strip directly since neither
+      # Git Bash nor the runner's PATH typically include it.
       if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' && runner.os == 'Windows' }}
-      shell: bash
-      env:
-        MSYS2_DIR: ${{ inputs.msys2-dir }}
+      shell: pwsh
       run: |
-        "$MSYS2_DIR/clang64/bin/strip.exe" ${{ inputs.mrbind-dir }}/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp}.exe
+        $strip = '${{ inputs.msys2-dir }}\clang64\bin\strip.exe'
+        $base  = '${{ inputs.mrbind-dir }}/build'
+        & $strip "$base/mrbind.exe" "$base/mrbind_gen_c.exe" "$base/mrbind_gen_csharp.exe"


### PR DESCRIPTION
## Summary

Make `.github/actions/build-mrbind` work on Windows runners where Git for Windows is installed without `bash` on PATH. Two changes:

1. **Get MRBind submodule SHA** — rewritten as a single `shell: python {0}` step (`git -C <dir> rev-parse HEAD` → append to `$GITHUB_OUTPUT`). This step used to be `shell: bash`, which is what broke on bash-less Windows.

2. **Trim / Strip steps** — split into per-platform variants using shells we know are present everywhere:
   - **Trim** — Windows `pwsh` (`Get-ChildItem | Where-Object | Remove-Item`), Unix `bash` (`find -exec rm`).
   - **Strip** — macOS `bash` (`strip -S`), Linux `bash` (`strip`), Windows `pwsh` (`MSYS2 clang64\strip.exe`).

`Build MRBind` stays split (Windows `cmd` + `call .bat`; Unix `bash` + run `.sh`) — the build scripts themselves are platform-specific.

## Why this shape

The first iteration moved all platform-shared logic to Python; the unified Python step for SHA is genuinely tighter, but for Trim and Strip the native pwsh / bash one-liners are shorter and easier to scan than the Python equivalent, so this PR keeps them platform-split.

## Inputs (unchanged)

- `cache-key-prefix`
- `build-script`
- `mrbind-dir` (default `thirdparty/mrbind`)
- `extra-cache-key`
- `strip-binaries` (default `'true'`)
- `msys2-dir` (default `C:\msys64`; consumed by the Windows Build and Strip steps)

## Test plan

- [x] MeshLib CI passes — 26/26 checks green.
- [x] Downstream consumer with a self-hosted Windows runner where bash isn't on PATH: re-ran CI against this PR's HEAD; `Build MRBind` and the new Python SHA step succeed across the four Release-config Windows matrix entries (vs-2019 + vs-2022 × MSBuild + CMake).
