### PR TITLE
ci(windows): use Ninja for cpp/c-examples, align with main Build step

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -309,6 +309,13 @@ jobs:
           VCPKG_ROOT: C:\vcpkg
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
         run: |
+          # The Ninja generator searches PATH for cl.exe; earlier steps put MSYS2 clang
+          # on PATH, so we must activate the MSVC dev environment in this step.
+          $installationPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -arch=amd64 -no_logo && set" | foreach-object {
+            $name, $value = $_ -split '=', 2
+            set-content env:\"$name" $value
+          }
           & $env:CMAKE_EXE `
             -S examples/cpp-examples `
             -B cpp-examples-build `

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -312,6 +312,7 @@ jobs:
           & $env:CMAKE_EXE `
             -S examples/cpp-examples `
             -B cpp-examples-build `
+            -G "Ninja Multi-Config" `
             -D MESHLIB_INCLUDE_DIRS="$pwd/source;$pwd/thirdparty/parallel-hashmap;$env:VCPKG_ROOT/installed/$env:VCPKG_TARGET_TRIPLET/include;$env:VCPKG_ROOT/installed/$env:VCPKG_TARGET_TRIPLET/include/eigen3" `
             -D MESHLIB_LIB_DIRS="$pwd/source/x64/${{ matrix.config }};$env:VCPKG_ROOT/installed/$env:VCPKG_TARGET_TRIPLET/lib"
           & $env:CMAKE_EXE `

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -311,11 +311,17 @@ jobs:
         run: |
           # The Ninja generator searches PATH for cl.exe; earlier steps put MSYS2 clang
           # on PATH, so we must activate the MSVC dev environment in this step.
+          # VsDevCmd.bat also sets VCPKG_ROOT to the VS-bundled vcpkg; preserve the
+          # values from the step's env: block so MESHLIB_INCLUDE_DIRS stays correct.
+          $savedVcpkgRoot = $env:VCPKG_ROOT
+          $savedVcpkgTriplet = $env:VCPKG_TARGET_TRIPLET
           $installationPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
           & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -arch=amd64 -no_logo && set" | foreach-object {
             $name, $value = $_ -split '=', 2
             set-content env:\"$name" $value
           }
+          $env:VCPKG_ROOT = $savedVcpkgRoot
+          $env:VCPKG_TARGET_TRIPLET = $savedVcpkgTriplet
           & $env:CMAKE_EXE `
             -S examples/cpp-examples `
             -B cpp-examples-build `

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -290,26 +290,12 @@ jobs:
           if exist source\x64\Debug\pybind11nonlimitedapi_meshlib_3*.dll del /Q source\x64\Debug\pybind11nonlimitedapi_meshlib_3*.dll
           if exist source\x64\Release\pybind11nonlimitedapi_meshlib_3*.dll del /Q source\x64\Release\pybind11nonlimitedapi_meshlib_3*.dll
 
-      - name: Find CMake
-        run: |
-          # https://github.com/microsoft/vswhere/wiki/Start-Developer-Command-Prompt#using-powershell
-          $installationPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -no_logo && set" | foreach-object {
-            $name, $value = $_ -split '=', 2
-            set-content env:\"$name" $value
-          }
-          $env:CMAKE_EXE = (Get-Command cmake.exe).Path
-          & $env:CMAKE_EXE --version
-          # https://github.com/actions/runner-images/issues/5251#issuecomment-1071030822
-          echo "CMAKE_EXE=$env:CMAKE_EXE" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
       - name: Build C++ examples
         if: ${{ matrix.config == 'Release' }}  # debug builds not supported due to missing file 'tbb12_debug.lib'
         shell: cmd
         env:
           VCPKG_ROOT: C:\vcpkg
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
-        # `|| exit /b 1` matches the main Build step's error-propagation pattern.
         run: |
           rem VsDevCmd.bat overrides VCPKG_ROOT with the VS-bundled vcpkg; preserve the
           rem step env: value so MESHLIB_INCLUDE_DIRS resolves to the project vcpkg.
@@ -322,16 +308,12 @@ jobs:
 
       - name: Build C examples
         if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
+        shell: cmd
         run: |
-          & $env:CMAKE_EXE `
-            -S examples/c-examples `
-            -B c-examples-build `
-            -D MESHLIB_INCLUDE_DIRS="$pwd/source/MeshLibC2/include" `
-            -D MESHLIB_LIB_DIRS="$pwd/source/x64/${{ matrix.config }}"
-          & $env:CMAKE_EXE `
-            --build c-examples-build `
-            --config ${{ matrix.config }} `
-            --parallel $env:NUMBER_OF_PROCESSORS
+          call "${{matrix.vc-path}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
+          cmake --version || exit /b 1
+          cmake -S examples/c-examples -B c-examples-build -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DMESHLIB_INCLUDE_DIRS="%CD%/source/MeshLibC2/include" -DMESHLIB_LIB_DIRS="%CD%/source/x64/${{matrix.config}}" || exit /b 1
+          cmake --build c-examples-build -j || exit /b 1
 
         # https://github.com/actions/download-artifact#maintaining-file-permissions-and-case-sensitive-files
       - name: Archive files

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -305,33 +305,20 @@ jobs:
 
       - name: Build C++ examples
         if: ${{ matrix.config == 'Release' }}  # debug builds not supported due to missing file 'tbb12_debug.lib'
+        shell: cmd
         env:
           VCPKG_ROOT: C:\vcpkg
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
+        # `|| exit /b 1` matches the main Build step's error-propagation pattern.
         run: |
-          # The Ninja generator searches PATH for cl.exe; earlier steps put MSYS2 clang
-          # on PATH, so we must activate the MSVC dev environment in this step.
-          # VsDevCmd.bat also sets VCPKG_ROOT to the VS-bundled vcpkg; preserve the
-          # values from the step's env: block so MESHLIB_INCLUDE_DIRS stays correct.
-          $savedVcpkgRoot = $env:VCPKG_ROOT
-          $savedVcpkgTriplet = $env:VCPKG_TARGET_TRIPLET
-          $installationPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -arch=amd64 -no_logo && set" | foreach-object {
-            $name, $value = $_ -split '=', 2
-            set-content env:\"$name" $value
-          }
-          $env:VCPKG_ROOT = $savedVcpkgRoot
-          $env:VCPKG_TARGET_TRIPLET = $savedVcpkgTriplet
-          & $env:CMAKE_EXE `
-            -S examples/cpp-examples `
-            -B cpp-examples-build `
-            -G "Ninja Multi-Config" `
-            -D MESHLIB_INCLUDE_DIRS="$pwd/source;$pwd/thirdparty/parallel-hashmap;$env:VCPKG_ROOT/installed/$env:VCPKG_TARGET_TRIPLET/include;$env:VCPKG_ROOT/installed/$env:VCPKG_TARGET_TRIPLET/include/eigen3" `
-            -D MESHLIB_LIB_DIRS="$pwd/source/x64/${{ matrix.config }};$env:VCPKG_ROOT/installed/$env:VCPKG_TARGET_TRIPLET/lib"
-          & $env:CMAKE_EXE `
-            --build cpp-examples-build `
-            --config ${{ matrix.config }} `
-            --parallel $env:NUMBER_OF_PROCESSORS
+          rem VsDevCmd.bat overrides VCPKG_ROOT with the VS-bundled vcpkg; preserve the
+          rem step env: value so MESHLIB_INCLUDE_DIRS resolves to the project vcpkg.
+          set "PROJ_VCPKG_ROOT=%VCPKG_ROOT%"
+          call "${{matrix.vc-path}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
+          set "VCPKG_ROOT=%PROJ_VCPKG_ROOT%"
+          cmake --version || exit /b 1
+          cmake -S examples/cpp-examples -B cpp-examples-build -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DMESHLIB_INCLUDE_DIRS="%CD%/source;%CD%/thirdparty/parallel-hashmap;%VCPKG_ROOT%/installed/%VCPKG_TARGET_TRIPLET%/include;%VCPKG_ROOT%/installed/%VCPKG_TARGET_TRIPLET%/include/eigen3" -DMESHLIB_LIB_DIRS="%CD%/source/x64/${{matrix.config}};%VCPKG_ROOT%/installed/%VCPKG_TARGET_TRIPLET%/lib" || exit /b 1
+          cmake --build cpp-examples-build -j || exit /b 1
 
       - name: Build C examples
         if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -303,7 +303,13 @@ jobs:
           call "${{matrix.vc-path}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
           set "VCPKG_ROOT=%PROJ_VCPKG_ROOT%"
           cmake --version || exit /b 1
-          cmake -S examples/cpp-examples -B cpp-examples-build -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DMESHLIB_INCLUDE_DIRS="%CD%/source;%CD%/thirdparty/parallel-hashmap;%VCPKG_ROOT%/installed/%VCPKG_TARGET_TRIPLET%/include;%VCPKG_ROOT%/installed/%VCPKG_TARGET_TRIPLET%/include/eigen3" -DMESHLIB_LIB_DIRS="%CD%/source/x64/${{matrix.config}};%VCPKG_ROOT%/installed/%VCPKG_TARGET_TRIPLET%/lib" || exit /b 1
+          cmake ^
+            -S examples/cpp-examples ^
+            -B cpp-examples-build ^
+            -GNinja ^
+            -DCMAKE_BUILD_TYPE=${{matrix.config}} ^
+            -DMESHLIB_INCLUDE_DIRS="%CD%/source;%CD%/thirdparty/parallel-hashmap;%VCPKG_ROOT%/installed/%VCPKG_TARGET_TRIPLET%/include;%VCPKG_ROOT%/installed/%VCPKG_TARGET_TRIPLET%/include/eigen3" ^
+            -DMESHLIB_LIB_DIRS="%CD%/source/x64/${{matrix.config}};%VCPKG_ROOT%/installed/%VCPKG_TARGET_TRIPLET%/lib" || exit /b 1
           cmake --build cpp-examples-build -j || exit /b 1
 
       - name: Build C examples
@@ -312,7 +318,13 @@ jobs:
         run: |
           call "${{matrix.vc-path}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
           cmake --version || exit /b 1
-          cmake -S examples/c-examples -B c-examples-build -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DMESHLIB_INCLUDE_DIRS="%CD%/source/MeshLibC2/include" -DMESHLIB_LIB_DIRS="%CD%/source/x64/${{matrix.config}}" || exit /b 1
+          cmake ^
+            -S examples/c-examples ^
+            -B c-examples-build ^
+            -GNinja ^
+            -DCMAKE_BUILD_TYPE=${{matrix.config}} ^
+            -DMESHLIB_INCLUDE_DIRS="%CD%/source/MeshLibC2/include" ^
+            -DMESHLIB_LIB_DIRS="%CD%/source/x64/${{matrix.config}}" || exit /b 1
           cmake --build c-examples-build -j || exit /b 1
 
         # https://github.com/actions/download-artifact#maintaining-file-permissions-and-case-sensitive-files


### PR DESCRIPTION
## Summary

Reshape the Windows example-build steps to match the main `Build` step and pick up its Ninja generator. Three related changes to `build-test-windows.yml`:

1. **`Build C++ examples`** — switch from the implicit Visual Studio 17 generator to single-config `-GNinja` (mirroring the main `Build` step). The VS generator emitted 30 `.vcxproj` files with per-target MSBuild startup, and its configure spent ~7 s on the MSVC compiler-id `try_compile`. Step rewritten in `shell: cmd`, sources `${{matrix.vc-path}}\Common7\Tools\VsDevCmd.bat` with the same `-arch=amd64` / `-vcvars_ver=14.2` conditional as `Build`, and propagates errors with `|| exit /b 1`. One deviation from `Build`: `VCPKG_ROOT` is saved/restored around `VsDevCmd.bat` because VsDevCmd overrides it with the VS-bundled vcpkg, and this step interpolates `%VCPKG_ROOT%` into `MESHLIB_INCLUDE_DIRS` (the main `Build` step doesn't read `%VCPKG_ROOT%` post-VsDevCmd).
2. **`Build C examples`** — same shape (cmd shell, VsDevCmd, single-config `-GNinja`, `|| exit /b 1`); no `VCPKG_ROOT` save/restore since this step doesn't reference it.
3. **`Find CMake` step removed** — it existed to source VsDevCmd in pwsh and stash the resulting `cmake.exe` into `$env:CMAKE_EXE` for the example steps. Both example steps now source VsDevCmd themselves and call `cmake` from PATH directly, so the step is dead weight.

## Measured impact

`Build C++ examples` step, apples-to-apples (`Release` × `CMake` matrix entries):

| matrix entry | baseline (VS gen) | this PR (`-GNinja`) | Δ |
|---|---|---|---|
| msvc-2022 / x64-windows-meshlib | 51 s | 29 s | −22 s (−43%) |
| msvc-2019 / x64-windows-vs2019-meshlib | 49 s | 33 s | −16 s (−33%) |

`Build C examples` was already cheap (one small `.c`); switching it is structural, not a perf change (3–6 s either way).

## Test plan
- [x] CI green for `windows-build-test` matrix entries that exercise the C++ examples step (CMake, Release; Debug is gated off by the existing `if:`)
- [x] CI green for `Build C examples` across the Debug and Release CMake entries that exercise it
- [x] `Build C++ examples` step runtime drops vs. baseline
