### PR TITLE
MRTestC2: less voxels in testThickenMesh for faster execution

### DIFF
--- a/source/MRTestC2/MRMeshOffset.c
+++ b/source/MRTestC2/MRMeshOffset.c
@@ -106,7 +106,7 @@ void testThickenMesh(void)
     MR_Mesh* mesh = MR_makeCube(&size, &base);
     MR_MeshPart* inputMeshPart = MR_MeshPart_Construct(mesh, NULL);
     MR_GeneralOffsetParameters* params = MR_GeneralOffsetParameters_DefaultConstruct();
-    MR_BaseShellParameters_Set_voxelSize(MR_GeneralOffsetParameters_MutableUpcastTo_MR_BaseShellParameters(params), MR_suggestVoxelSize(inputMeshPart, 10000000.f));
+    MR_BaseShellParameters_Set_voxelSize(MR_GeneralOffsetParameters_MutableUpcastTo_MR_BaseShellParameters(params), MR_suggestVoxelSize(inputMeshPart, 10000.f));
     MR_GeneralOffsetParameters_Set_mode(params, MR_OffsetMode_Standard);
     float offset = 0.1f;
     MR_PartMapping* map = MR_PartMapping_DefaultConstruct();


### PR DESCRIPTION
Reduce the voxel count in `testThickenMesh` so it stops dominating the C Unit Tests step in Debug CMake CI jobs.

### Measured impact

`testThickenMesh` self-reported time:

| | master | this PR |
|---|---|---|
| `testThickenMesh` | 36.009 s | 0.247 s |

"C Unit Tests" step total (Debug, CMake):

| Matrix entry | master | this PR |
|---|---|---|
| msvc-2019, Debug, CMake (iterator-debug) | 58 s | 8 s |
| msvc-2022, Debug, CMake | 42 s | — |

On master, `testThickenMesh` alone accounted for ~86% of the step time; the remaining tests sum to ~5 s.
