### PR TITLE
ci(mrbind): re-apply bashless-Windows fix via pwsh/bash split (no Python)

### DIFF
--- a/.github/actions/build-mrbind/action.yml
+++ b/.github/actions/build-mrbind/action.yml
@@ -53,8 +53,17 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get MRBind submodule SHA
-      id: mrbind-sha
+    - name: Get MRBind submodule SHA (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      id: mrbind-sha-win
+      shell: pwsh
+      run: |
+        $sha = git -C '${{ inputs.mrbind-dir }}' rev-parse HEAD
+        "sha=$sha" | Add-Content -Path $env:GITHUB_OUTPUT
+
+    - name: Get MRBind submodule SHA (Unix)
+      if: ${{ runner.os != 'Windows' }}
+      id: mrbind-sha-unix
       shell: bash
       run: echo "sha=$(git -C '${{ inputs.mrbind-dir }}' rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
@@ -63,7 +72,8 @@ runs:
       uses: actions/cache@v5
       with:
         path: ${{ inputs.mrbind-dir }}/build
-        key: mrbind-build-${{ inputs.cache-key-prefix }}-${{ steps.mrbind-sha.outputs.sha }}-${{ hashFiles(inputs.build-script) }}-${{ inputs.extra-cache-key }}
+        # Exactly one of the two SHA steps ran, so concatenation yields the SHA.
+        key: mrbind-build-${{ inputs.cache-key-prefix }}-${{ steps.mrbind-sha-win.outputs.sha }}${{ steps.mrbind-sha-unix.outputs.sha }}-${{ hashFiles(inputs.build-script) }}-${{ inputs.extra-cache-key }}
 
     - name: Build MRBind (Windows)
       # `install_mrbind_windows_msys2.bat` defaults MSYS2_DIR to
@@ -80,21 +90,29 @@ runs:
       shell: bash
       run: ${{ inputs.build-script }}
 
-    - name: Trim MRBind build dir before cache save
-      # Downstream steps only invoke the three executables (mrbind, mrbind_gen_c,
-      # mrbind_gen_csharp -- see scripts/mrbind/generate.mk:191-193). Object files,
-      # static libs, and CMake/Ninja metadata aren't consumed and would just bloat
-      # the cache (the build script wipes `build/` before rebuilding anyway, so we
-      # don't need incremental-rebuild state either).
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+    # Downstream steps only invoke the three executables (mrbind, mrbind_gen_c,
+    # mrbind_gen_csharp -- see scripts/mrbind/generate.mk:191-193). Object files,
+    # static libs, and CMake/Ninja metadata aren't consumed and would just bloat
+    # the cache (the build script wipes `build/` before rebuilding anyway, so we
+    # don't need incremental-rebuild state either).
+
+    - name: Trim MRBind build dir before cache save (Windows)
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows' }}
+      shell: pwsh
+      run: |
+        $keep = @('mrbind.exe', 'mrbind_gen_c.exe', 'mrbind_gen_csharp.exe')
+        Get-ChildItem -LiteralPath '${{ inputs.mrbind-dir }}/build' |
+          Where-Object { $keep -notcontains $_.Name } |
+          Remove-Item -Recurse -Force
+
+    - name: Trim MRBind build dir before cache save (Unix)
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != 'Windows' }}
       shell: bash
       run: |
         set -eu
         cd '${{ inputs.mrbind-dir }}/build'
         find . -mindepth 1 -maxdepth 1 \
-          ! -name 'mrbind'            ! -name 'mrbind.exe' \
-          ! -name 'mrbind_gen_c'      ! -name 'mrbind_gen_c.exe' \
-          ! -name 'mrbind_gen_csharp' ! -name 'mrbind_gen_csharp.exe' \
+          ! -name 'mrbind' ! -name 'mrbind_gen_c' ! -name 'mrbind_gen_csharp' \
           -exec rm -rf {} +
 
     # Stripping shrinks the cache ~5x at the cost of useful stack traces from
@@ -114,11 +132,10 @@ runs:
       run: strip ${{ inputs.mrbind-dir }}/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp}
 
     - name: Strip MRBind binaries (Windows)
-      # The build uses MSYS2 clang64; reach for that strip directly since Git
-      # Bash's PATH doesn't include it.
       if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' && runner.os == 'Windows' }}
-      shell: bash
-      env:
-        MSYS2_DIR: ${{ inputs.msys2-dir }}
+      shell: pwsh
       run: |
-        "$MSYS2_DIR/clang64/bin/strip.exe" ${{ inputs.mrbind-dir }}/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp}.exe
+        & '${{ inputs.msys2-dir }}\clang64\bin\strip.exe' `
+          '${{ inputs.mrbind-dir }}/build/mrbind.exe' `
+          '${{ inputs.mrbind-dir }}/build/mrbind_gen_c.exe' `
+          '${{ inputs.mrbind-dir }}/build/mrbind_gen_csharp.exe'


### PR DESCRIPTION
## Why

[#6093](https://github.com/MeshInspector/MeshLib/pull/6093) was reverted in [15091a932](https://github.com/MeshInspector/MeshLib/commit/15091a932) because its `Get MRBind submodule SHA` step used `shell: python {0}`, which works on Windows but fails on ubuntu Docker containers that ship `python3` only:

```
OCI runtime exec failed: exec failed: unable to start container process:
exec: "python": executable file not found in $PATH
```

The revert restored bash-everywhere — including for the `Trim` step and the Windows `Strip` step — which re-introduces the original `bash: command not found` failure on self-hosted Windows runners that don't have bash on PATH (the issue [#6093](https://github.com/MeshInspector/MeshLib/pull/6093) set out to fix in the first place).

## What

Re-apply the bash-on-Windows fix without the Python detour. Use pwsh on Windows + bash on Unix for the three operations that previously used bash unconditionally:

- **Get MRBind submodule SHA**: split into Windows (`pwsh`) + Unix (`bash`); cache key concatenates `mrbind-sha-win.outputs.sha` and `mrbind-sha-unix.outputs.sha` (exactly one is set per run).
- **Trim MRBind build dir**: split into Windows (`pwsh` with `Get-ChildItem | Where-Object | Remove-Item`) + Unix (`bash` with `find -exec rm`). The Unix `find` invocation drops the now-irrelevant `*.exe` clauses.
- **Strip MRBind binaries (Windows)**: change from `bash` (which invoked MSYS2's `strip.exe` via Git Bash heredoc-with-brace-expansion) to `pwsh` calling the same binary with explicit args.

`Build MRBind` and the macOS/Linux `Strip` steps are unchanged — they already use the right shells for their platforms.

## Note for #6093 reviewers

This PR is functionally identical to commit [6738d78e8](https://github.com/MeshInspector/MeshLib/commit/6738d78e8) on the #6093 branch (the "restore pwsh/bash split" iteration, which had a green CI run). The only later changes on #6093 that landed in the squashed-merge were the Python unification (broke ubuntu) and the PR title text. Going forward without the Python unification.

## Test plan

- [x] MeshLib CI passes — verified on [run 25864506191](https://github.com/MeshInspector/MeshLib/actions/runs/25864506191). Both regression platforms green:
  - `ubuntu-arm64-build-test (ubuntu22 / ubuntu24, Release)` — the container that broke at `exec: "python"` on the merged #6093 — now hits cache (`Cache hit for: mrbind-build-ubuntu-arm64-ubuntu22-latest-…`).
  - All `windows-build-test` matrix entries — including `(msvc-2019, Release, CMake, …)` — also hit cache (`Cache hit for: mrbind-build-windows-clang18-…`), Build MRBind step skipped.
- [x] Downstream consumers with bash-less Windows runners can re-run and get past `bash: command not found`. Already confirmed against an earlier iteration of this code (commit [6738d78e8](https://github.com/MeshInspector/MeshLib/commit/6738d78e8), functionally identical to this PR's HEAD).
