### PR TITLE
ci(macos): cache thirdparty lib/include outputs across runs

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -172,7 +172,7 @@ jobs:
       # Bump the `v1-` prefix to manually invalidate.
       - name: Cache thirdparty build outputs
         id: thirdparty-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             lib

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -121,14 +121,18 @@ jobs:
           echo "cxx-compiler=$CXX_COMPILER" >> $GITHUB_OUTPUT
           echo "c-compiler=$C_COMPILER" >> $GITHUB_OUTPUT
 
-      # Inputs for the thirdparty + MRBind cache keys.
-      # - brew-hash: discriminates self-hosted ARM fleet members that share the
+      # Cache key inputs:
+      # - brew-hash: hash of the homebrew prefix, used by Build MRBind below to
+      #   discriminate self-hosted ARM fleet members that share the
       #   `[self-hosted, macos, arm64, build]` label set but have homebrew at
       #   different paths (e.g. `/Users/runner/.homebrew` vs `/opt/homebrew`);
-      #   the prefix is baked into thirdparty rpaths and into mrbind's rpath.
-      # - thirdparty-src-hash: SHAs of the source-built submodules pinned in
-      #   HEAD. `git ls-tree` reads the gitlink entries from the index, so it
-      #   works whether or not the submodules are checked out.
+      #   the prefix is baked into mrbind's rpath.
+      # - thirdparty-hash: unified hash of everything that influences the
+      #   thirdparty ./lib + ./include outputs -- brew prefix (baked into the
+      #   rpaths of the produced .dylibs), submodule SHAs pinned in HEAD (the
+      #   source we compile), and the build-relevant scripts + CMakeLists +
+      #   brew-requirements list. `git ls-tree` reads gitlink entries from the
+      #   index, so it works whether or not the submodules are checked out.
       - name: Compute cache key inputs
         id: cache-keys
         shell: bash
@@ -136,18 +140,27 @@ jobs:
           BREW_PREFIX: ${{ steps.setup.outputs.brew-prefix }}
         run: |
           echo "brew-hash=$(printf %s "$BREW_PREFIX" | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
-          echo "thirdparty-src-hash=$(git ls-tree HEAD \
-            thirdparty/googletest \
-            thirdparty/OpenCTM-git \
-            thirdparty/parallel-hashmap \
-            thirdparty/libE57Format \
-            thirdparty/glad \
-            thirdparty/mrbind-pybind11 \
-            thirdparty/tinygltf \
-            thirdparty/laz-perf \
-            thirdparty/clip \
-            thirdparty/fastmcpp \
-            | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
+          echo "thirdparty-hash=$( {
+            printf '%s\n' "$BREW_PREFIX"
+            git ls-tree HEAD \
+              thirdparty/googletest \
+              thirdparty/OpenCTM-git \
+              thirdparty/parallel-hashmap \
+              thirdparty/libE57Format \
+              thirdparty/glad \
+              thirdparty/mrbind-pybind11 \
+              thirdparty/tinygltf \
+              thirdparty/laz-perf \
+              thirdparty/clip \
+              thirdparty/fastmcpp
+            shasum -a 256 \
+              scripts/build_thirdparty.sh \
+              scripts/install_brew_requirements.sh \
+              scripts/thirdparty/clip.sh \
+              scripts/thirdparty/fastmcpp.sh \
+              thirdparty/CMakeLists.txt \
+              requirements/macos.txt
+          } | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
 
       - name: Collect runner's system stats
         if: ${{ inputs.internal_build }}
@@ -171,7 +184,7 @@ jobs:
           path: |
             lib
             include
-          key: v1-thirdparty-${{ matrix.instance }}-${{ matrix.compiler }}-${{ steps.cache-keys.outputs.brew-hash }}-${{ steps.cache-keys.outputs.thirdparty-src-hash }}-${{ hashFiles('scripts/build_thirdparty.sh', 'scripts/install_brew_requirements.sh', 'scripts/thirdparty/clip.sh', 'scripts/thirdparty/fastmcpp.sh', 'thirdparty/CMakeLists.txt', 'requirements/macos.txt') }}
+          key: v1-thirdparty-${{ matrix.instance }}-${{ matrix.compiler }}-${{ steps.cache-keys.outputs.thirdparty-hash }}
 
       # Always run: cached thirdparty .dylibs link against brew libs at runtime,
       # so brew packages must be installed on hosted runners even on cache hit.

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -121,6 +121,18 @@ jobs:
           echo "cxx-compiler=$CXX_COMPILER" >> $GITHUB_OUTPUT
           echo "c-compiler=$C_COMPILER" >> $GITHUB_OUTPUT
 
+      # Hash the homebrew prefix so two self-hosted ARM runners that share the
+      # `[self-hosted, macos, arm64, build]` label set but have homebrew at
+      # different paths (e.g. `/Users/runner/.homebrew` vs `/opt/homebrew`) get
+      # distinct cache entries -- the prefix is baked into thirdparty rpaths
+      # and into mrbind's rpath.
+      - name: Compute brew-prefix hash for cache keys
+        id: brew-hash
+        shell: bash
+        env:
+          BREW_PREFIX: ${{ steps.setup.outputs.brew-prefix }}
+        run: echo "hash=$(printf %s "$BREW_PREFIX" | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
+
       - name: Collect runner's system stats
         if: ${{ inputs.internal_build }}
         id: collect-runner-stats
@@ -132,27 +144,51 @@ jobs:
           cxx_compiler: ${{ steps.setup.outputs.cxx-compiler }}
           build_config: ${{ matrix.config }}
 
+      # Hash of the submodule SHAs pinned in HEAD for the libs that
+      # build_thirdparty.sh actually compiles into ./lib + ./include on macOS.
+      # `git ls-tree` reads the gitlink entries from the index, so it works
+      # whether or not the submodules are checked out.
+      - name: Compute thirdparty submodule SHA for cache key
+        id: thirdparty-src-hash
+        shell: bash
+        run: |
+          SHA=$(git ls-tree HEAD \
+            thirdparty/googletest \
+            thirdparty/OpenCTM-git \
+            thirdparty/parallel-hashmap \
+            thirdparty/libE57Format \
+            thirdparty/glad \
+            thirdparty/mrbind-pybind11 \
+            thirdparty/tinygltf \
+            thirdparty/laz-perf \
+            thirdparty/clip \
+            thirdparty/fastmcpp \
+            | shasum -a 256 | cut -c1-16)
+          echo "hash=$SHA" >> "$GITHUB_OUTPUT"
+
+      # Cache only the final outputs (./lib + ./include). Intermediates like
+      # ./thirdparty_build (which holds *.o, CMake metadata, etc.) are NOT
+      # cached -- they get rebuilt on a miss and discarded on a hit.
+      # Bump the `v1-` prefix to manually invalidate.
+      - name: Cache thirdparty build outputs
+        id: thirdparty-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib
+            include
+          key: v1-thirdparty-${{ matrix.instance }}-${{ matrix.compiler }}-${{ steps.brew-hash.outputs.hash }}-${{ steps.thirdparty-src-hash.outputs.hash }}-${{ hashFiles('scripts/build_thirdparty.sh', 'scripts/install_brew_requirements.sh', 'scripts/thirdparty/clip.sh', 'scripts/thirdparty/fastmcpp.sh', 'thirdparty/CMakeLists.txt', 'requirements/macos.txt') }}
+
       - name: Install thirdparty libs
         run: ./scripts/build_thirdparty.sh
         env:
           CMAKE_CXX_COMPILER: ${{ steps.setup.outputs.cxx-compiler }}
           CMAKE_C_COMPILER: ${{ steps.setup.outputs.c-compiler }}
+          MESHLIB_THIRDPARTY_SKIP_BUILD: ${{ steps.thirdparty-cache.outputs.cache-hit == 'true' && '1' || '' }}
 
       - name: Install MRBind deps
         if: ${{ inputs.mrbind || inputs.mrbind_c }}
         run: ./scripts/mrbind/install_deps_macos.sh
-
-      # Hash the homebrew prefix so two self-hosted ARM runners that share the
-      # `[self-hosted, macos, arm64, build]` label set but have homebrew at
-      # different paths (e.g. `/Users/runner/.homebrew` vs `/opt/homebrew`) get
-      # distinct cache entries -- the prefix is baked into mrbind's rpath.
-      - name: Compute brew-prefix hash for MRBind cache key
-        if: ${{ inputs.mrbind || inputs.mrbind_c }}
-        id: brew-hash
-        shell: bash
-        env:
-          BREW_PREFIX: ${{ steps.setup.outputs.brew-prefix }}
-        run: echo "hash=$(printf %s "$BREW_PREFIX" | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
 
       - name: Build MRBind
         if: ${{ inputs.mrbind || inputs.mrbind_c }}

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -121,17 +121,33 @@ jobs:
           echo "cxx-compiler=$CXX_COMPILER" >> $GITHUB_OUTPUT
           echo "c-compiler=$C_COMPILER" >> $GITHUB_OUTPUT
 
-      # Hash the homebrew prefix so two self-hosted ARM runners that share the
-      # `[self-hosted, macos, arm64, build]` label set but have homebrew at
-      # different paths (e.g. `/Users/runner/.homebrew` vs `/opt/homebrew`) get
-      # distinct cache entries -- the prefix is baked into thirdparty rpaths
-      # and into mrbind's rpath.
-      - name: Compute brew-prefix hash for cache keys
-        id: brew-hash
+      # Inputs for the thirdparty + MRBind cache keys.
+      # - brew-hash: discriminates self-hosted ARM fleet members that share the
+      #   `[self-hosted, macos, arm64, build]` label set but have homebrew at
+      #   different paths (e.g. `/Users/runner/.homebrew` vs `/opt/homebrew`);
+      #   the prefix is baked into thirdparty rpaths and into mrbind's rpath.
+      # - thirdparty-src-hash: SHAs of the source-built submodules pinned in
+      #   HEAD. `git ls-tree` reads the gitlink entries from the index, so it
+      #   works whether or not the submodules are checked out.
+      - name: Compute cache key inputs
+        id: cache-keys
         shell: bash
         env:
           BREW_PREFIX: ${{ steps.setup.outputs.brew-prefix }}
-        run: echo "hash=$(printf %s "$BREW_PREFIX" | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "brew-hash=$(printf %s "$BREW_PREFIX" | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
+          echo "thirdparty-src-hash=$(git ls-tree HEAD \
+            thirdparty/googletest \
+            thirdparty/OpenCTM-git \
+            thirdparty/parallel-hashmap \
+            thirdparty/libE57Format \
+            thirdparty/glad \
+            thirdparty/mrbind-pybind11 \
+            thirdparty/tinygltf \
+            thirdparty/laz-perf \
+            thirdparty/clip \
+            thirdparty/fastmcpp \
+            | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
 
       - name: Collect runner's system stats
         if: ${{ inputs.internal_build }}
@@ -144,28 +160,6 @@ jobs:
           cxx_compiler: ${{ steps.setup.outputs.cxx-compiler }}
           build_config: ${{ matrix.config }}
 
-      # Hash of the submodule SHAs pinned in HEAD for the libs that
-      # build_thirdparty.sh actually compiles into ./lib + ./include on macOS.
-      # `git ls-tree` reads the gitlink entries from the index, so it works
-      # whether or not the submodules are checked out.
-      - name: Compute thirdparty submodule SHA for cache key
-        id: thirdparty-src-hash
-        shell: bash
-        run: |
-          SHA=$(git ls-tree HEAD \
-            thirdparty/googletest \
-            thirdparty/OpenCTM-git \
-            thirdparty/parallel-hashmap \
-            thirdparty/libE57Format \
-            thirdparty/glad \
-            thirdparty/mrbind-pybind11 \
-            thirdparty/tinygltf \
-            thirdparty/laz-perf \
-            thirdparty/clip \
-            thirdparty/fastmcpp \
-            | shasum -a 256 | cut -c1-16)
-          echo "hash=$SHA" >> "$GITHUB_OUTPUT"
-
       # Cache only the final outputs (./lib + ./include). Intermediates like
       # ./thirdparty_build (which holds *.o, CMake metadata, etc.) are NOT
       # cached -- they get rebuilt on a miss and discarded on a hit.
@@ -177,14 +171,19 @@ jobs:
           path: |
             lib
             include
-          key: v1-thirdparty-${{ matrix.instance }}-${{ matrix.compiler }}-${{ steps.brew-hash.outputs.hash }}-${{ steps.thirdparty-src-hash.outputs.hash }}-${{ hashFiles('scripts/build_thirdparty.sh', 'scripts/install_brew_requirements.sh', 'scripts/thirdparty/clip.sh', 'scripts/thirdparty/fastmcpp.sh', 'thirdparty/CMakeLists.txt', 'requirements/macos.txt') }}
+          key: v1-thirdparty-${{ matrix.instance }}-${{ matrix.compiler }}-${{ steps.cache-keys.outputs.brew-hash }}-${{ steps.cache-keys.outputs.thirdparty-src-hash }}-${{ hashFiles('scripts/build_thirdparty.sh', 'scripts/install_brew_requirements.sh', 'scripts/thirdparty/clip.sh', 'scripts/thirdparty/fastmcpp.sh', 'thirdparty/CMakeLists.txt', 'requirements/macos.txt') }}
 
-      - name: Install thirdparty libs
+      # Always run: cached thirdparty .dylibs link against brew libs at runtime,
+      # so brew packages must be installed on hosted runners even on cache hit.
+      - name: Install brew requirements
+        run: ./scripts/install_brew_requirements.sh
+
+      - name: Build thirdparty libs
+        if: ${{ steps.thirdparty-cache.outputs.cache-hit != 'true' }}
         run: ./scripts/build_thirdparty.sh
         env:
           CMAKE_CXX_COMPILER: ${{ steps.setup.outputs.cxx-compiler }}
           CMAKE_C_COMPILER: ${{ steps.setup.outputs.c-compiler }}
-          MESHLIB_THIRDPARTY_SKIP_BUILD: ${{ steps.thirdparty-cache.outputs.cache-hit == 'true' && '1' || '' }}
 
       - name: Install MRBind deps
         if: ${{ inputs.mrbind || inputs.mrbind_c }}
@@ -199,7 +198,7 @@ jobs:
           # Shared with pip-build.yml's macOS section where the two also match.
           cache-key-prefix: ${{ matrix.instance }}-clang
           build-script: scripts/mrbind/install_mrbind_macos.sh
-          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt') }}-${{ steps.brew-hash.outputs.hash }}
+          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt') }}-${{ steps.cache-keys.outputs.brew-hash }}
 
       - name: Create virtualenv
         run: |

--- a/scripts/build_thirdparty.sh
+++ b/scripts/build_thirdparty.sh
@@ -43,6 +43,14 @@ else
   echo "Unsupported system. Installing dependencies is your responsibility."
 fi
 
+# CI: reuse cached ./lib and ./include from a previous run. Brew install above
+# still runs so dyld can resolve runtime deps.
+if [[ "${MESHLIB_THIRDPARTY_SKIP_BUILD:-}" == "1" ]]; then
+  echo "MESHLIB_THIRDPARTY_SKIP_BUILD=1; reusing existing ./lib and ./include."
+  printf "\rThirdparty build script skipped (cached outputs reused).\n\n"
+  exit 0
+fi
+
 # FIXME: make it optional
 rm -rf "${MESHLIB_THIRDPARTY_BUILD_DIR}"
 mkdir -p "${MESHLIB_THIRDPARTY_BUILD_DIR}"

--- a/scripts/build_thirdparty.sh
+++ b/scripts/build_thirdparty.sh
@@ -43,14 +43,6 @@ else
   echo "Unsupported system. Installing dependencies is your responsibility."
 fi
 
-# CI: reuse cached ./lib and ./include from a previous run. Brew install above
-# still runs so dyld can resolve runtime deps.
-if [[ "${MESHLIB_THIRDPARTY_SKIP_BUILD:-}" == "1" ]]; then
-  echo "MESHLIB_THIRDPARTY_SKIP_BUILD=1; reusing existing ./lib and ./include."
-  printf "\rThirdparty build script skipped (cached outputs reused).\n\n"
-  exit 0
-fi
-
 # FIXME: make it optional
 rm -rf "${MESHLIB_THIRDPARTY_BUILD_DIR}"
 mkdir -p "${MESHLIB_THIRDPARTY_BUILD_DIR}"


### PR DESCRIPTION
## Summary

The "Install thirdparty libs" step on macOS takes ~9 min on the x64 hosted runner: brew installs + compiling the source-built thirdparty libs (libE57Format, OpenCTM, googletest, parallel-hashmap, glad, mrbind-pybind11, tinygltf, laz-perf, clip, fastmcpp) into `./lib` + `./include`. The submodules feeding that compile rarely change between runs, so the work repeats unchanged on nearly every job. Reference cache-miss baseline: [job 76017787493](https://github.com/MeshInspector/MeshLib/actions/runs/25868701580/job/76017787493).

This PR adds `actions/cache@v5` around `./lib` + `./include` so the compile is skipped on cache hit. (v5 to match `build-mrbind`, `install-msys2-mrbind`, and `install-cuda` in this repo.)

## What changed in the workflow

`scripts/build_thirdparty.sh` is **unchanged** from master. All logic lives in `.github/workflows/build-test-macos.yml`:

1. New step `Compute cache key inputs` produces two outputs in a single bash invocation:
   - `brew-hash` — hash of `$(brew --prefix)`, consumed by `Build MRBind` below to discriminate self-hosted ARM fleet members.
   - `thirdparty-hash` — one unified hash of everything that influences the thirdparty `./lib` + `./include` outputs (brew prefix + submodule SHAs from `git ls-tree HEAD` + contents of `scripts/build_thirdparty.sh`, `scripts/install_brew_requirements.sh`, `scripts/thirdparty/{clip,fastmcpp}.sh`, `thirdparty/CMakeLists.txt`, `requirements/macos.txt`).
2. New step `Cache thirdparty build outputs` with key `v1-thirdparty-${matrix.instance}-${matrix.compiler}-${thirdparty-hash}`.
3. The old `Install thirdparty libs` step is split into two:
   - `Install brew requirements` — always runs, calls `scripts/install_brew_requirements.sh` directly. Needed on cache hit too because cached `.dylib`s link against brew libs at runtime.
   - `Build thirdparty libs` — gated `if: steps.thirdparty-cache.outputs.cache-hit != 'true'`, calls `scripts/build_thirdparty.sh`.

## Measured impact

Step "Install thirdparty libs" duration, measured on an earlier commit of this branch that still ran the steps as a single unit:

| Leg | Cache-miss | Cache-hit | Saving |
|---|---|---|---|
| x64 Release (`macos-15-intel`) | 9m 14s | 5m 27s | **3m 47s** |
| arm64 Debug (`macos-14`) | 3m 54s | 1m 53s | **2m 1s** |
| arm64 Release (self-hosted ARM) | 1m 12s | 31s | **41s** |

The savings come from skipping the cmake compile portion (now the gated `Build thirdparty libs` step). `Install brew requirements` runs on both paths. The x64 hosted leg gets the biggest win because that runner image has fewer of the required bottles pre-cached. The self-hosted ARM already has brew packages persisted across runs, so its cache-miss is short to begin with; the saving there is just the cmake compile portion.

## What gets cached

- `./lib` — final `.dylib` / `.a` from `cmake --install`
- `./include` — installed headers

What does **not** get cached:
- `./thirdparty_build/` — the CMake build dir containing `*.o`, `CMakeFiles/`, generated Makefiles, etc. Rebuilt from scratch on a miss and discarded on a hit.

Cache sizes observed: ~3.7-3.8 MiB per leg (confirming `*.o` is not included; the CMake build dir would be hundreds of MB).

## Cache key

`v1-thirdparty-${matrix.instance}-${matrix.compiler}-${thirdparty-hash}` where `thirdparty-hash` is the unified hash described above. The `v1-` prefix is hardcoded so future incompatibilities can be busted by a one-line bump.

## Test plan

- [x] First CI run: cache miss on all three matrix legs, thirdparty compile runs normally, cache gets populated (~3.7-3.8 MiB each).
- [x] Second push: cache hits on all three legs, `Build thirdparty libs` step skipped (`if: cache-hit != 'true'` false), `Install brew requirements` still runs.
- [x] Downstream `Build` / `Generate ... bindings` / `MRMesh Exported Symbols` / unit tests / pkg creation all pass on cache hit.
- [x] Cache size confirms `./thirdparty_build/*.o` is not included.
