### PR TITLE
ci(macos): link mrbind against libclang-cpp + libLLVM dylibs

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -142,6 +142,26 @@ jobs:
         if: ${{ inputs.mrbind || inputs.mrbind_c }}
         run: ./scripts/mrbind/install_deps_macos.sh
 
+      # Diagnostic: dump Homebrew llvm@N's lib directory so we can see which
+      # clang/LLVM archives vs dylibs are present on each runner -- relevant
+      # because mrbind links against libclang-cpp.dylib + libLLVM.dylib here.
+      - name: List installed clang/LLVM libraries
+        if: ${{ inputs.mrbind || inputs.mrbind_c }}
+        shell: bash
+        env:
+          BREW_PREFIX: ${{ steps.setup.outputs.brew-prefix }}
+        run: |
+          CLANG_VER="$(cat scripts/mrbind/clang_version.txt | xargs)"
+          LLVM_LIB_DIR="$BREW_PREFIX/opt/llvm@$CLANG_VER/lib"
+          echo "=== llvm@$CLANG_VER lib dir: $LLVM_LIB_DIR ==="
+          ls -lh "$LLVM_LIB_DIR" || true
+          echo
+          echo "=== Static archives (libclang*.a, libLLVM*.a) ==="
+          find "$LLVM_LIB_DIR" -maxdepth 2 \( -name 'libclang*.a' -o -name 'libLLVM*.a' \) -exec ls -lh {} + 2>/dev/null || true
+          echo
+          echo "=== Dynamic libs (libclang*.dylib, libLLVM*.dylib) ==="
+          find "$LLVM_LIB_DIR" -maxdepth 2 \( -name 'libclang*.dylib' -o -name 'libLLVM*.dylib' \) -exec ls -lh {} + 2>/dev/null || true
+
       # Hash the homebrew prefix so two self-hosted ARM runners that share the
       # `[self-hosted, macos, arm64, build]` label set but have homebrew at
       # different paths (e.g. `/Users/runner/.homebrew` vs `/opt/homebrew`) get

--- a/scripts/mrbind/install_mrbind_macos.sh
+++ b/scripts/mrbind/install_mrbind_macos.sh
@@ -28,5 +28,9 @@ export PATH="$HOMEBREW_DIR/opt/llvm@$CLANG_VER/bin:$PATH"
 # Guess the number of build threads.
 [[ ${JOBS:=} ]] || JOBS=$(sysctl -n hw.ncpu)
 
-CC=clang CXX=clang++ cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_LINKER_TYPE=LLD
+# Homebrew's llvm@N is built with LLVM_LINK_LLVM_DYLIB=ON, so we can safely
+# link mrbind against libclang-cpp.dylib + libLLVM.dylib instead of pulling
+# clangTooling in statically. Shrinks the resulting mrbind binary ~6x, which
+# also shrinks the CI cache footprint by the same factor.
+CC=clang CXX=clang++ cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_LINKER_TYPE=LLD -DMRBIND_LINK_CLANG_CPP_DYLIB=ON
 cmake --build build -j$JOBS

--- a/scripts/mrbind/install_mrbind_macos.sh
+++ b/scripts/mrbind/install_mrbind_macos.sh
@@ -28,9 +28,5 @@ export PATH="$HOMEBREW_DIR/opt/llvm@$CLANG_VER/bin:$PATH"
 # Guess the number of build threads.
 [[ ${JOBS:=} ]] || JOBS=$(sysctl -n hw.ncpu)
 
-# Homebrew's llvm@N is built with LLVM_LINK_LLVM_DYLIB=ON, so we can safely
-# link mrbind against libclang-cpp.dylib + libLLVM.dylib instead of pulling
-# clangTooling in statically. Shrinks the resulting mrbind binary ~6x, which
-# also shrinks the CI cache footprint by the same factor.
-CC=clang CXX=clang++ cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_LINKER_TYPE=LLD -DMRBIND_LINK_CLANG_CPP_DYLIB=ON
+CC=clang CXX=clang++ cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_LINKER_TYPE=LLD
 cmake --build build -j$JOBS


### PR DESCRIPTION
## Summary

Pass `-DMRBIND_LINK_CLANG_CPP_DYLIB=ON` to mrbind's cmake configure in [`scripts/mrbind/install_mrbind_macos.sh`](scripts/mrbind/install_mrbind_macos.sh). Bumps the `thirdparty/mrbind` submodule to a commit that exposes the new flag (MeshInspector/mrbind#35).

## Why

`mrbind`'s parser currently statically pulls in `clangTooling` on macOS (and Ubuntu, Windows-MSYS2). The resulting binary is ~30 MiB stripped. On Rocky Linux the toolchain happens to take the alternative dynamic-link branch (`clang-cpp + LLVM` shared libs), giving a ~5 MiB stripped binary.

Homebrew's `llvm@N` is built with `LLVM_LINK_LLVM_DYLIB=ON`, which means we can safely take the dynamic path on macOS without the `LLVM ERROR: inconsistency in registered CommandLine options` runtime crash that apt-clang/Ubuntu hits. MeshInspector/mrbind#35 adds an opt-in flag (`MRBIND_LINK_CLANG_CPP_DYLIB`) for exactly this case; this PR turns it on for macOS.

The mrbind PR ended up needing two iterations: the naive `target_link_libraries(... clang-cpp ...)` propagated Homebrew's `INTERFACE_INCLUDE_DIRECTORIES` (`/opt/homebrew/opt/llvm@N/include`) into mrbind's compile commands and broke libc++'s `<cstddef>` include chain. Final shape uses `find_library` to resolve to absolute lib paths, which CMake links without any usage-requirement propagation.

## Files changed

- `scripts/mrbind/install_mrbind_macos.sh` — appends `-DMRBIND_LINK_CLANG_CPP_DYLIB=ON` to the cmake configure.
- `thirdparty/mrbind` — pinned to MeshInspector/mrbind#35's HEAD.

Linux and Windows are not affected — they continue to take the static `clangTooling` path because the option defaults to `OFF`.

## Submodule pin

`thirdparty/mrbind` advances from `b895ca0d…` to MeshInspector/mrbind#35's HEAD. Will move to a master commit once that PR merges.

## Test plan

- [x] **macOS CI passes** — verified on [run 25877837374](https://github.com/MeshInspector/MeshLib/actions/runs/25877837374). All three macOS jobs (`x64 Release`, `arm64 Release`, `arm64 Debug`) green; `Build MRBind`, `Generate C bindings`, and `Generate and build Python bindings` all succeed. No `LLVM ERROR: inconsistency in registered CommandLine options` and no libc++ `<cstddef>` failures.
- [x] **Cache footprint drops** — all three macOS runners (two GitHub-hosted, one self-hosted) repopulated at the new size:

  | Runner | Cache key | Before | After |
  |---|---|---:|---:|
  | GitHub-hosted x64 (`macos-15-intel`) | `mrbind-build-macos-15-intel-clang` | 13.0 MiB | **2.0 MiB** |
  | GitHub-hosted arm64 (`macos-14`) | `mrbind-build-macos-14-clang` | 12.4 MiB | **2.1 MiB** |
  | Self-hosted arm64 | `mrbind-build-self-hosted-arm-clang` | 12.4 MiB | **2.1 MiB** |
  | **Total macOS footprint** | | **~38 MiB** | **~6 MiB** |

  Matches Rocky's footprint, as predicted.
