### PR TITLE
ci(windows): do not copy release zlib1.dll in debug

### DIFF
--- a/source/MRIOExtras/MRIOExtras.vcxproj
+++ b/source/MRIOExtras/MRIOExtras.vcxproj
@@ -107,9 +107,6 @@
       <DelayLoadDLLs>
       </DelayLoadDLLs>
     </Link>
-    <PostBuildEvent>
-      <Command>copy $(VcpkgCurrentInstalledDir)\bin\zlib1.dll $(TargetDir)zlib1.dll</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>

--- a/source/MRPython/CMakeLists.txt
+++ b/source/MRPython/CMakeLists.txt
@@ -43,10 +43,6 @@ IF(MSVC AND DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
   # By default only the `python311[_d].dll` gets copied, but we also need `python3.dll` and the non-debug `python311.dll` in Debug mode as said above.
   file(COPY ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/python${Python_VERSION_MAJOR}.dll DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
   file(COPY ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}.dll DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-
-  # Need a Release build of Zlib too. In Release mode it usually gets copied with something else, but in Debug we must copy manually.
-  # Might as well copy unconditionally here.
-  file(COPY ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/zlib1.dll DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 ENDIF()
 
 IF(WIN32)


### PR DESCRIPTION
This was necessary, when we used Release `laz-perf` library in Debug Windows builds.