### PR TITLE
ci: cover both x64 and arm64 macOS .pkg in test-distribution

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -213,7 +213,7 @@ jobs:
         working-directory: test_python
         run: python3 -m pytest -s -v
 
-  macos-test:
+  macos-x64-test:
     if: ${{ inputs.test_macos }}
     runs-on: macos-15-intel
     timeout-minutes: 30
@@ -254,7 +254,50 @@ jobs:
         run: |
           cmake -S . -B build -DCMAKE_C_COMPILER=/usr/bin/clang && \
           cmake --build build
-  
+
+  macos-arm64-test:
+    if: ${{ inputs.test_macos }}
+    runs-on: macos-latest  # github-hosted Apple Silicon
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{needs.setup.outputs.version_tag}}
+
+      - name: Download Distributive
+        run: |
+          echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token
+          gh release download ${{ inputs.release_tag }} --pattern "*arm.pkg" --repo ${{ github.repository }}
+
+      - name: Install Pkg
+        run: |
+          sudo installer -pkg meshlib_*arm.pkg  -target /
+          xargs brew install --quiet < /Library/Frameworks/MeshLib.framework/Versions/Current/requirements/macos.txt
+
+      # [error] NSGL: Failed to find a suitable pixel format
+      - name: Run MeshViewer
+        run: /Library/Frameworks/MeshLib.framework/Versions/Current/bin/MeshViewer -tryHidden -noEventLoop -unloadPluginsAtEnd
+
+      - name: Show meshconv help
+        run: /Library/Frameworks/MeshLib.framework/Versions/Current/bin/meshconv --help
+
+      - name: Build C++ examples
+        working-directory: examples/cpp-examples
+        run: |
+          mkdir build && \
+          cd build && \
+          cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/clang++ && \
+          cmake --build . && \
+          ./MeshModification
+
+      - name: Build C examples
+        working-directory: examples/c-examples
+        run: |
+          cmake -S . -B build -DCMAKE_C_COMPILER=/usr/bin/clang && \
+          cmake --build build
+
+
   windows-test:
     if: ${{ inputs.test_windows }}
     runs-on: windows-2022


### PR DESCRIPTION
## Problem

`test-distribution` validates only the x64 macOS `.pkg` ([test-distribution.yml#L216-256](https://github.com/MeshInspector/MeshLib/blob/master/.github/workflows/test-distribution.yml#L216-L256)). The arm64 `.pkg` is built and uploaded to every release but never installed and launched in CI, so regressions specific to Apple Silicon packaging (linker paths, install-name rewrites, code-signing) ship without warning. Linux has had this covered for a long time via the separate `linux-x64-test` / `linux-arm64-test` jobs.

## Change

Split the single `macos-test` job into two parallel jobs that mirror the Linux pattern:

- **`macos-x64-test`** — `macos-15-intel`, downloads `*x64.pkg` (unchanged behavior, just renamed)
- **`macos-arm64-test`** — `macos-latest` (github-hosted Apple Silicon), downloads `*arm.pkg`

Steps are otherwise identical: install via `sudo installer`, install runtime deps from the bundled `requirements/macos.txt`, launch `MeshViewer` and `meshconv`, build the C and C++ examples against the installed framework.

## Test plan

- [ ] After this merges, the next master release's `test-distribution` chain shows both `macos-x64-test` and `macos-arm64-test` running
- [ ] Both pass against a clean macos-15 (Intel and Apple Silicon) host

Non-macOS CI is disabled via labels — this PR only touches the macOS portion of `test-distribution.yml`.
