### PR TITLE
docker(rockylinux8-vcpkg): pin Clang to the 21.x line

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -47,22 +47,22 @@ jobs:
       matrix:
         config: [Debug, Release]
         arch: [x64, arm64]
-        compiler: [Clang 20, GCC 11]
+        compiler: [Clang 21, GCC 11]
         full_config_build:
           - ${{ fromJSON( inputs.full_config_build ) }}
         exclude:
-          # Do not run Debug Clang 20 build on every commit (but only once a day)
+          # Do not run Debug Clang 21 build on every commit (but only once a day)
           - full_config_build: false
-            compiler: Clang 20
+            compiler: Clang 21
             config: Debug
           # Do not run Release GCC 11 build on every commit (but only once a day)
           - full_config_build: false
             compiler: GCC 11
             config: Release
         include:
-          - compiler: Clang 20
-            cxx-compiler: /usr/bin/clang++-20
-            c-compiler: /usr/bin/clang-20
+          - compiler: Clang 21
+            cxx-compiler: /usr/bin/clang++-21
+            c-compiler: /usr/bin/clang-21
             cxx-standard: 23
           - compiler: GCC 11
             cxx-compiler: /opt/rh/gcc-toolset-11/root/usr/bin/g++
@@ -230,19 +230,19 @@ jobs:
           cat unit_tests_report.csv
 
       - name: Create Package
-        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 20' }}
+        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
         run: |
           ./scripts/distribution_vcpkg.sh ${{ inputs.app_version }}
           mv meshlib_linux-vcpkg.tar.xz meshlib_linux-vcpkg-${{ matrix.arch }}.tar.xz
 
       - name: Extract Package
-        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 20' }}
+        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
         run: |
           mkdir meshlib_install
           tar -xf meshlib_linux-vcpkg-${{ matrix.arch }}.tar.xz -C meshlib_install
 
       - name: Build C++ examples
-        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 20' }}
+        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
         run: |
           cmake \
             -S examples/cpp-examples \
@@ -254,7 +254,7 @@ jobs:
             --parallel $(nproc)
 
       - name: Build C examples
-        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 20'}}
+        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21'}}
         run: |
           cmake \
             -S examples/c-examples \
@@ -266,7 +266,7 @@ jobs:
             --parallel $(nproc)
 
       - name: Upload vcpkg Distribution
-        if: ${{ inputs.upload_artifacts && matrix.config == 'Release' && matrix.compiler == 'Clang 20' }}
+        if: ${{ inputs.upload_artifacts && matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
         uses: actions/upload-artifact@v7
         with:
           name: Distributives_linux-vcpkg-${{ matrix.arch }}
@@ -283,7 +283,7 @@ jobs:
           stats_file_suffix: -${{ steps.collect-runner-stats.outputs.job_id }}
 
       - name: Create and fix fake Wheel for NuGet
-        if: ${{ inputs.nuget_build_patch && matrix.compiler == 'Clang 20' && matrix.config == 'Release' }}
+        if: ${{ inputs.nuget_build_patch && matrix.compiler == 'Clang 21' && matrix.config == 'Release' }}
         shell: bash
         run: |
           python3 -m venv ./wheel_venv
@@ -292,7 +292,7 @@ jobs:
           python3 ./scripts/nuget_patch/patch_library_deps.py ./patched_content/ ./build/Release/bin/lib{MeshLibC2,MeshLibC2Cuda}.so
 
       - name: Upload NuGet files to Artifacts
-        if: ${{ inputs.nuget_build_patch && matrix.compiler == 'Clang 20' && matrix.config == 'Release' }}
+        if: ${{ inputs.nuget_build_patch && matrix.compiler == 'Clang 21' && matrix.config == 'Release' }}
         uses: actions/upload-artifact@v7
         with:
           name: DotNetPatchArchiveLinux-${{ matrix.arch }}

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -10,7 +10,7 @@ RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
     $(: network may flake ) \
     retry.sh -- dnf -y install epel-release && \
     retry.sh -- dnf -y install --enablerepo powertools \
-        git cmake gcc-toolset-11 ninja-build clang-devel \
+        git cmake gcc-toolset-11 ninja-build clang-devel-21* \
         $(: vcpkg requirements ) \
         curl zip unzip tar \
         $(: vcpkg package requirements ) \
@@ -73,13 +73,13 @@ ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
 RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
     $(: network may flake ) \
     retry.sh -- dnf -y install --enablerepo powertools \
-        git cmake gcc-toolset-11 ninja-build clang-devel \
+        git cmake gcc-toolset-11 ninja-build clang-devel-21* \
         $(: vcpkg requirements ) \
         curl zip unzip tar \
         $(: vcpkg package requirements ) \
         autoconf-archive bison dbus-libs libtool libudev-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXtst-devel mesa-libGL-devel perl-core \
         $(: mrbind requirements ) \
-        lld llvm-devel python3.12-devel which zlib-devel \
+        lld-21* llvm-devel-21* python3.12-devel which zlib-devel \
         $(: CI environment ) \
         time python3.12-pip rpm-build xorg-x11-server-Xvfb mesa-dri-drivers gettext \
         && \


### PR DESCRIPTION
## Summary

Pin Clang to the 21.x line in `docker/rockylinux8-vcpkgDockerfile`, and follow the matrix in `build-test-linux-vcpkg.yml` to match.

The Dockerfile previously installed an unpinned `clang-devel` (and `lld` / `llvm-devel` in the production stage). On Rocky Linux 8 all clang module builds (17.0.6, 18.1.8, 19.1.7, 20.1.8, 21.1.8) ship under the same default `llvm-toolset:rhel8` stream, so DNF resolves to whatever has the highest NVR at build time. That means a future Rocky update to e.g. clang 22 would silently change the toolchain the image is built with.

Pinning to `*-21*` keeps the image on the Clang 21 series while still picking up patch-level updates within that major version.

## Changes

### `docker/rockylinux8-vcpkgDockerfile`
- `clang-devel` → `clang-devel-21*` in both the `build` and `production` stages.
- `lld` → `lld-21*` and `llvm-devel` → `llvm-devel-21*` in the `production` stage (same `llvm-toolset` module — they must match the clang major version).

### `.github/workflows/build-test-linux-vcpkg.yml`
The build matrix had `Clang 20` hardcoded with versioned binary paths `/usr/bin/clang{,++}-20`, which no longer exist in the pinned image. Bumped all references:
- `compiler: [Clang 20, GCC 11]` → `[Clang 21, GCC 11]`
- `cxx-compiler: /usr/bin/clang++-20` → `/usr/bin/clang++-21`
- `c-compiler: /usr/bin/clang-20` → `/usr/bin/clang-21`
- 10 `matrix.compiler == 'Clang 20'` conditional guards → `'Clang 21'`

The `__clang_major__ >= 20` / `Clang 20 and newer` version-feature checks in `source/MRMesh/MRMacros.h` and the `mrbind` submodule are correctness gates, not CI plumbing — they keep applying under Clang 21 and are intentionally left alone.

## Test plan

- [x] `linux-vcpkg-build-test` matrix green on Clang 21 across Release/Debug × x64/arm64 — see [run 25954328648](https://github.com/MeshInspector/MeshLib/actions/runs/25954328648)
- [x] CMake inside the built image reports `-- The CXX compiler identification is Clang 21.1.8`
