### PR TITLE
ci(linux-vcpkg): only collect artifact stats when an artifact exists

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -274,7 +274,7 @@ jobs:
           retention-days: 1
 
       - name: Collect artifact stats
-        if: ${{ inputs.internal_build && inputs.upload_artifacts }}
+        if: ${{ inputs.internal_build && inputs.upload_artifacts && matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
         continue-on-error: true
         uses: ./.github/actions/collect-artifact-stats
         with:


### PR DESCRIPTION
## Summary

Stop emitting a noisy "failure" annotation on every Debug / GCC 11 linux-vcpkg build.

### Diagnosis

Every otherwise-green internal `linux-vcpkg-build-test` job currently carries an annotation:

```
##[error] Process completed with exit code 1.
```

It originates from the `Collect artifact stats` step, which runs whenever `inputs.internal_build && inputs.upload_artifacts`. The step shells out to `scripts/devops/collect_artifact_stats.py`, which calls `sys.exit(1)` when its glob matches no files.

The glob is `meshlib_linux-vcpkg-${{ matrix.arch }}.tar.xz`, and that artifact is produced by the earlier `Create Package` / `Upload vcpkg Distribution` steps — both gated on `matrix.config == 'Release' && matrix.compiler == 'Clang 21'`. So on Debug builds and on GCC 11 builds, the package simply doesn't exist, the glob misses, and the script exits 1.

The step is wrapped in `continue-on-error: true`, so the job stays green, but GitHub still surfaces a `failure`-level annotation in the run summary. Six out of nine internal `linux-vcpkg-build-test` jobs were flagging this on every PR.

### Fix

Tighten the `if:` on `Collect artifact stats` to match the conditions that actually produce the artifact, so the step is skipped (not failed) on Debug / GCC builds.

```diff
       - name: Collect artifact stats
-        if: ${{ inputs.internal_build && inputs.upload_artifacts }}
+        if: ${{ inputs.internal_build && inputs.upload_artifacts && matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
         continue-on-error: true
         uses: ./.github/actions/collect-artifact-stats
```

The Python script itself is left alone — its `sys.exit(1)` is the right behavior for a "should have produced an artifact but didn't" failure mode, we just shouldn't be invoking it when no artifact was expected in the first place.

## Test plan

> Note on context: PR-event runs have `inputs.upload_artifacts: false`, which already short-circuits `Collect artifact stats` to `skipped` regardless of this fix. So the noisy annotation only manifests on `push`-event master/internal runs, and the same is true for verification of this PR. The PR's own run confirms no regression; pre/post-fix comparison against master `push` runs is what shows the behavior change.

### Pre-fix master push evidence (head 9228d3e1, run 25961874734 — most recent master before this fix)

| Job | `Collect artifact stats` step | failure annotation |
|---|---|---|
| Debug, x64, GCC 11 (76318493099) | success (under `continue-on-error`) | **`Process completed with exit code 1.`** |
| Debug, arm64, GCC 11 (76318493102) | success (under `continue-on-error`) | **`Process completed with exit code 1.`** |
| Release, x64, Clang 21 (76318493096) | success | — |
| Release, arm64, Clang 21 (76318493093) | success | — |

Same pattern on the prior master push (run 25927388388): Debug jobs carry the failure annotation, Release jobs don't.

### This PR's run (run 25961884363)

PR-event run, so `upload_artifacts: false`. On all four `linux-vcpkg-build-test` jobs (Debug x64/arm64 GCC 11, Release x64/arm64 Clang 21), `Collect artifact stats` is `skipped` and there is no `Process completed with exit code 1.` annotation. Only the standard Node.js-20-deprecation and missing-`time_log/` warnings remain. No regression.

### Status

- [x] **Debug and GCC 11 `linux-vcpkg-build-test` jobs no longer fail with `Process completed with exit code 1.`** — pre-fix master push runs reproducibly carry this annotation on the two Debug jobs; the new `if:` matches the same matrix gate as `Create Package` / `Upload vcpkg Distribution`, so on master `push` Debug/GCC builds the step will skip instead of running-and-failing. On this PR's own run the annotation is absent (though the step was already skipped via `upload_artifacts: false`, so this run alone isn't a conclusive demonstration — the pre-fix master push contrast is).
- [ ] **Release + Clang 21 jobs still run `Collect artifact stats` and upload `ArtifactStats-*` as before.** Logically guaranteed (the new clause matches exactly those rows of the matrix; on the pre-fix master push run, both Release/Clang 21 jobs ran the step to `success` with no annotation). **Cannot be directly verified on this PR's run** because PR context has `upload_artifacts: false` — confirm on the next master `push` after merge.
