### PR TITLE
ci(linux): key mrbind cache on Dockerfile hash, not docker_image_tag

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -127,10 +127,12 @@ jobs:
         if: ${{ inputs.mrbind || inputs.mrbind_c }}
         uses: ./.github/actions/build-mrbind
         with:
-          # Key matches the Docker image identifier exactly so this cache is shared
-          # with pip-build.yml's rocky section, which uses the same image and script.
-          cache-key-prefix: rockylinux8-vcpkg-${{ matrix.arch }}-${{ inputs.docker_image_tag }}
+          # Prefix is shared with pip-build.yml's rocky section, which uses the same
+          # image and script. The Dockerfile hash in extra-cache-key busts the cache
+          # whenever the toolchain inside the image changes (e.g. clang upgrade).
+          cache-key-prefix: rockylinux8-vcpkg-${{ matrix.arch }}
           build-script: scripts/mrbind/install_mrbind_rockylinux.sh
+          extra-cache-key: ${{ hashFiles('docker/rockylinux8-vcpkgDockerfile') }}
 
       - name: Create virtualenv
         run: |

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -113,9 +113,11 @@ jobs:
         if: ${{ inputs.mrbind || inputs.mrbind_c }}
         uses: ./.github/actions/build-mrbind
         with:
-          cache-key-prefix: ubuntu-arm64-${{ matrix.os }}-${{ inputs.docker_image_tag }}
+          cache-key-prefix: ubuntu-arm64-${{ matrix.os }}
           build-script: scripts/mrbind/install_mrbind_ubuntu.sh
-          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt') }}
+          # Dockerfile hash busts the cache when the toolchain in the image changes
+          # (e.g. glibc, clang upgrade).
+          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt', format('docker/{0}Dockerfile', matrix.os)) }}
 
       - name: Create virtualenv
         run: |

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -92,10 +92,11 @@ jobs:
         if: ${{ inputs.mrbind || inputs.mrbind_c }}
         uses: ./.github/actions/build-mrbind
         with:
-          # Include the Docker image tag (e.g. glibc, clang install) and clang version file in the cache key.
-          cache-key-prefix: ubuntu-x64-${{ matrix.os }}-${{ inputs.docker_image_tag }}
+          # The Dockerfile hash in extra-cache-key busts the cache whenever the
+          # toolchain inside the image changes (e.g. glibc, clang upgrade).
+          cache-key-prefix: ubuntu-x64-${{ matrix.os }}
           build-script: scripts/mrbind/install_mrbind_ubuntu.sh
-          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt') }}
+          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt', format('docker/{0}Dockerfile', matrix.os)) }}
 
       - name: Create virtualenv
         run: |

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -204,10 +204,12 @@ jobs:
       - name: Install mrbind
         uses: ./.github/actions/build-mrbind
         with:
-          # Key matches the Docker image identifier exactly so this cache is shared
-          # with build-test-linux-vcpkg.yml, which uses the same image and script.
-          cache-key-prefix: ${{ matrix.os }}-${{ inputs.vcpkg_docker_image_tag || 'latest' }}
+          # Prefix is shared with build-test-linux-vcpkg.yml, which uses the same
+          # image and script. The Dockerfile hash in extra-cache-key busts the cache
+          # whenever the toolchain inside the image changes (e.g. clang upgrade).
+          cache-key-prefix: ${{ matrix.os }}
           build-script: scripts/mrbind/install_mrbind_rockylinux.sh
+          extra-cache-key: ${{ hashFiles('docker/rockylinux8-vcpkgDockerfile') }}
 
       - name: Print RAM
         # If there's not enough RAM, building MRBind bindings can fail. Not running this in the mrbind step itself, because OOM fails can erase logs from the current step.


### PR DESCRIPTION
## Summary

Make the Linux `Install MRBind` cache key track the **Dockerfile contents**, not the Docker image tag string. This is the structural fix for the cache-poisoning failure observed on master after #6106.

## What was broken

`build-mrbind` is wrapped in `actions/cache`. The cache key on all Linux workflows was of the form:

```
mrbind-build-<platform>-<arch>-<docker_image_tag>-<mrbind-sha>-<hashFiles(build-script)>-<extra>
```

`docker_image_tag` is computed in `config.yml` and resolves to `latest` for most branches — it only changes when paths-filter detects a Dockerfile (or related requirement) change in a non-push/non-schedule event. So a routine master CI run that picks up a Dockerfile change still uses tag `latest`, and the mrbind cache key doesn't move.

The symptom on master right after #6106 merged ([run](https://github.com/MeshInspector/MeshLib/actions/runs/25956775984/job/76313508703)):

```
thirdparty/mrbind/build/mrbind: error while loading shared libraries:
libclang-cpp.so.20.1: cannot open shared object file: No such file or directory
```

The cache restored the previous Clang-20-linked mrbind binary verbatim into the freshly-built Clang-21 image, where the matching libclang.so no longer exists.

## What this PR does

For each Linux workflow that invokes `./.github/actions/build-mrbind`:

1. **Drop `docker_image_tag` from `cache-key-prefix`.** It was contributing nothing useful — the cache key didn't actually observe the image content.
2. **Hash the corresponding Dockerfile into `extra-cache-key`.** Any toolchain change inside the image (clang upgrade, glibc, lld, etc.) now moves the cache key automatically.

### Per-workflow mapping

| Workflow | Job | Dockerfile hashed |
|---|---|---|
| `build-test-linux-vcpkg.yml` | `linux-vcpkg-build-test` | `docker/rockylinux8-vcpkgDockerfile` |
| `build-test-ubuntu-x64.yml` | `ubuntu-x64-build-test` | `docker/${matrix.os}Dockerfile` (`ubuntu22` / `ubuntu24`) |
| `build-test-ubuntu-arm64.yml` | `ubuntu-arm64-build-test` | `docker/${matrix.os}Dockerfile` (`ubuntu22` / `ubuntu24`) |
| `pip-build.yml` | `manylinux-pip-build` | `docker/rockylinux8-vcpkgDockerfile` |

For the two ubuntu workflows, the existing `hashFiles('scripts/mrbind/clang_version.txt')` is preserved and concatenated with the Dockerfile hash.

### Cache sharing

`build-test-linux-vcpkg.yml` and `pip-build.yml`'s manylinux section were sharing the cache under the old key. They still do — both use `cache-key-prefix: rockylinux8-vcpkg-<arch>` (in pip-build, `matrix.os` resolves to that exact string) and the same Dockerfile hash, so the composed key remains identical between the two workflows.

## Out of scope

- macOS (`build-test-macos.yml`) — no `docker_image_tag` in the cache key; already correctly fingerprinted via `clang_version.txt` + brew-prefix hash.
- Windows (`build-test-windows.yml`, `pip-build.yml`'s windows section) — no `docker_image_tag`; uses `msys2_package_hashes_clang18.txt`.
- `update-docs-manual.yml` — has a static prefix without `docker_image_tag`.

## Test plan

Verified against [run 25960399740](https://github.com/MeshInspector/MeshLib/actions/runs/25960399740):

- [x] **New cache key shape is what's actually used.** Sample keys observed in the run:
  - `linux-vcpkg x64`:   `mrbind-build-rockylinux8-vcpkg-x64-<mrbind-sha>-<build-sh>-0131dddf…` with `extra-cache-key: 0131dddf…` (= `hashFiles('docker/rockylinux8-vcpkgDockerfile')`)
  - `linux-vcpkg arm64`: same shape; same Dockerfile hash `0131dddf…`
  - `ubuntu-x64 (ubuntu22)`:   `mrbind-build-ubuntu-x64-ubuntu22-<…>-dd5d86ab…` with `extra-cache-key: dd5d86ab…` (= `hashFiles('clang_version.txt', 'docker/ubuntu22Dockerfile')`)
  - `ubuntu-arm64 (ubuntu22)`: same `dd5d86ab…` hash (workflows hash the same inputs, as intended)
  - `docker_image_tag` is gone from every observed key.
- [x] **Cache miss → rebuild → save under new key.** All four sampled jobs reported `Cache not found for input keys: …`, ran the build script, then `Cache saved with key: …`.
- [x] **No `libclang-cpp.so.*: cannot open shared object file` regression** anywhere in the logs.
- [x] **No regressions on the workflows this PR touches:** 4/4 `linux-vcpkg-build-test` cells + 3/3 `ubuntu-x64-build-test` cells + 2/2 `ubuntu-arm64-build-test` cells all green.

### Caveat

`test-pip-build` was skipped on this CI run, so the `pip-build.yml` manylinux section I edited didn't actually execute the new cache step. The workflow parsed cleanly (otherwise `config / prepare-config` would have failed), and the edit is structurally identical to the three sibling files that did run successfully — low risk but technically unexercised by this run. Anyone wanting belt-and-braces validation can trigger a `workflow_dispatch` of `test-pip-build` against this branch before merge.
