### PR TITLE
mrbind(linux): pad PHT against patchelf overrun via -z separate-loadable-segments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,15 +38,19 @@ add_compile_definitions(MR_PROJECT_NAME=\"${MESHLIB_PROJECT_NAME}\")
 #
 # `-z separate-loadable-segments` is an lld extension — `ld.bfd` warns and
 # ignores it. Clang's default linker on RHEL/Rocky is `ld.bfd` from
-# gcc-toolset, so we also force `-fuse-ld=lld` for Clang builds. (The MR
-# bindings makefile already does this; this just brings the CMake-driven
-# targets in line.)
+# gcc-toolset, so we also force `-fuse-ld=lld`. Apply only on Clang builds
+# where lld is actually installed; some of our Linux images (e.g. the older
+# ubuntu22 Clang 14 image) don't ship it, so we probe first and skip if it
+# isn't available — those builds aren't AppImage-packaged anyway, so they
+# don't need this fix.
 # Applies to executables and shared libraries; static libraries are unaffected.
-IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN)
-  IF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  include(CheckLinkerFlag)
+  check_linker_flag(CXX "-fuse-ld=lld" MESHLIB_HAVE_LLD)
+  IF(MESHLIB_HAVE_LLD)
     add_link_options("-fuse-ld=lld")
+    add_link_options("LINKER:-z,separate-loadable-segments")
   ENDIF()
-  add_link_options("LINKER:-z,separate-loadable-segments")
 ENDIF()
 
 include(CompilerOptions)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,17 @@ add_compile_definitions(MR_PROJECT_NAME=\"${MESHLIB_PROJECT_NAME}\")
 # SIGSEGV-on-dlopen of `libpybind11nonlimitedapi_meshlib_3.12.so` on x86_64
 # Clang 21 inside AppImages produced by `linuxdeploy`. The flag gives the PHT
 # headroom so patchelf can grow it without trampling executable code.
+#
+# `-z separate-loadable-segments` is an lld extension — `ld.bfd` warns and
+# ignores it. Clang's default linker on RHEL/Rocky is `ld.bfd` from
+# gcc-toolset, so we also force `-fuse-ld=lld` for Clang builds. (The MR
+# bindings makefile already does this; this just brings the CMake-driven
+# targets in line.)
 # Applies to executables and shared libraries; static libraries are unaffected.
 IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN)
+  IF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    add_link_options("-fuse-ld=lld")
+  ENDIF()
   add_link_options("LINKER:-z,separate-loadable-segments")
 ENDIF()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,21 @@ project(MeshLib CXX)
 set(MESHLIB_PROJECT_NAME "MeshLib" CACHE STRING "Project name")
 add_compile_definitions(MR_PROJECT_NAME=\"${MESHLIB_PROJECT_NAME}\")
 
+# Make each PT_LOAD segment occupy its own file block / memory page on Linux.
+# Without this, lld packs the program-header table tight against
+# `.note.gnu.build-id` and `.init` in the first PT_LOAD; when a downstream
+# packager (e.g. `patchelf` inside `linuxdeploy`) later extends the PHT to add
+# an entry (e.g. for a new `$ORIGIN` in RUNPATH), the new entry overwrites
+# `.init`, but `DT_INIT` is left pointing at the now-clobbered `_init`
+# address, so `_dl_init` jumps into garbage at module-load time. Observed as
+# SIGSEGV-on-dlopen of `libpybind11nonlimitedapi_meshlib_3.12.so` on x86_64
+# Clang 21 inside AppImages produced by `linuxdeploy`. The flag gives the PHT
+# headroom so patchelf can grow it without trampling executable code.
+# Applies to executables and shared libraries; static libraries are unaffected.
+IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN)
+  add_link_options("LINKER:-z,separate-loadable-segments")
+ENDIF()
+
 include(CompilerOptions)
 IF(EMSCRIPTEN)
   include(ConfigureEmscripten)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,30 +25,21 @@ project(MeshLib CXX)
 set(MESHLIB_PROJECT_NAME "MeshLib" CACHE STRING "Project name")
 add_compile_definitions(MR_PROJECT_NAME=\"${MESHLIB_PROJECT_NAME}\")
 
-# Make each PT_LOAD segment occupy its own file block / memory page on Linux.
-# Without this, lld packs the program-header table tight against
-# `.note.gnu.build-id` and `.init` in the first PT_LOAD; when a downstream
-# packager (e.g. `patchelf` inside `linuxdeploy`) later extends the PHT to add
-# an entry (e.g. for a new `$ORIGIN` in RUNPATH), the new entry overwrites
-# `.init`, but `DT_INIT` is left pointing at the now-clobbered `_init`
-# address, so `_dl_init` jumps into garbage at module-load time. Observed as
-# SIGSEGV-on-dlopen of `libpybind11nonlimitedapi_meshlib_3.12.so` on x86_64
-# Clang 21 inside AppImages produced by `linuxdeploy`. The flag gives the PHT
-# headroom so patchelf can grow it without trampling executable code.
-#
-# `-z separate-loadable-segments` is an lld extension — `ld.bfd` warns and
-# ignores it. Clang's default linker on RHEL/Rocky is `ld.bfd` from
-# gcc-toolset, so we also force `-fuse-ld=lld`. Apply only on Clang builds
-# where lld is actually installed; some of our Linux images (e.g. the older
-# ubuntu22 Clang 14 image) don't ship it, so we probe first and skip if it
-# isn't available — those builds aren't AppImage-packaged anyway, so they
-# don't need this fix.
-# Applies to executables and shared libraries; static libraries are unaffected.
+# Work around patchelf bug: https://github.com/NixOS/patchelf/issues/639
+# Force lld + give it room to grow PHT so patchelf doesn't trample `.init`.
+# Skip on images without lld (older ubuntu22 Clang 14 etc., which aren't
+# AppImage-packaged anyway).
 IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   include(CheckLinkerFlag)
   check_linker_flag(CXX "-fuse-ld=lld" MESHLIB_HAVE_LLD)
   IF(MESHLIB_HAVE_LLD)
-    add_link_options("-fuse-ld=lld")
+    # Prefer CMAKE_LINKER_TYPE (CMake >= 3.29); fall back to -fuse-ld= on
+    # older CMakes (our minimum is 3.18).
+    IF(NOT CMAKE_VERSION VERSION_LESS "3.29")
+      set(CMAKE_LINKER_TYPE LLD)
+    ELSE()
+      add_link_options("-fuse-ld=lld")
+    ENDIF()
     add_link_options("LINKER:-z,separate-loadable-segments")
   ENDIF()
 ENDIF()

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -610,6 +610,17 @@ endif # Windows
 # Linux.
 ifneq ($(IS_LINUX),)
 COMPILER_FLAGS += -I/usr/include/jsoncpp -isystem/usr/include/freetype2 -isystem/usr/include/gdcm-3.0
+# Make each PT_LOAD segment occupy its own file block / memory page. Without
+# this, lld packs the program-header table tight against `.note.gnu.build-id`
+# and `.init` in the first PT_LOAD; when a downstream packager (e.g. patchelf
+# inside linuxdeploy) later extends the PHT to add an entry (e.g. for a new
+# `$ORIGIN` in RUNPATH), the new entry overwrites `.init`, but `DT_INIT` is
+# left pointing at the now-clobbered `_init` address, so `_dl_init` jumps into
+# garbage at module-load time. Observed as SIGSEGV-on-dlopen of the bindings
+# shim on x86_64 Clang 21 inside AppImages produced by linuxdeploy.
+# `-z separate-loadable-segments` gives patchelf room to grow the PHT without
+# trampling executable code.
+LINKER_FLAGS += -Wl,-z,separate-loadable-segments
 endif
 
 # MacOS.

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -610,16 +610,7 @@ endif # Windows
 # Linux.
 ifneq ($(IS_LINUX),)
 COMPILER_FLAGS += -I/usr/include/jsoncpp -isystem/usr/include/freetype2 -isystem/usr/include/gdcm-3.0
-# Make each PT_LOAD segment occupy its own file block / memory page. Without
-# this, lld packs the program-header table tight against `.note.gnu.build-id`
-# and `.init` in the first PT_LOAD; when a downstream packager (e.g. patchelf
-# inside linuxdeploy) later extends the PHT to add an entry (e.g. for a new
-# `$ORIGIN` in RUNPATH), the new entry overwrites `.init`, but `DT_INIT` is
-# left pointing at the now-clobbered `_init` address, so `_dl_init` jumps into
-# garbage at module-load time. Observed as SIGSEGV-on-dlopen of the bindings
-# shim on x86_64 Clang 21 inside AppImages produced by linuxdeploy.
-# `-z separate-loadable-segments` gives patchelf room to grow the PHT without
-# trampling executable code.
+# Work around patchelf bug: https://github.com/NixOS/patchelf/issues/639
 LINKER_FLAGS += -Wl,-z,separate-loadable-segments
 endif
 


### PR DESCRIPTION
## Summary

Work around an upstream patchelf bug ([NixOS/patchelf#639](https://github.com/NixOS/patchelf/issues/639) — filed during this PR's investigation) that silently corrupts `libpybind11nonlimitedapi_meshlib_<py>.so` (and the other Linux mrbind shims, and several MeshLib `.so`s in general) when a downstream packager runs `patchelf --set-rpath` over them. Symptom in the wild: SIGSEGV on `dlopen` of the bindings shim on x86_64 Clang 21 builds after AppImage packaging.

## Background

For full mechanism + readelf evidence + reproducer + version matrix, see [NixOS/patchelf#639](https://github.com/NixOS/patchelf/issues/639). In short:

- lld 21 on x86_64 lays out the first PT_LOAD as `ELF header + PHT + .note.gnu.build-id + .init + .plt + .text + .fini`, packed tight — PHT ends at file offset `0x200`, `.init` starts at `0x224`.
- patchelf (any version 0.15.0–0.18.0 we tested — confirmed) handles a RUNPATH change by appending a new PT_LOAD program-header entry. That new Phdr is written at offset `0x40 + 8*56 = 0x200` — directly on top of `.note.gnu.build-id` and the first 20 bytes of `.init`.
- patchelf relocates `.init` to a high address, but **never updates `DT_INIT`**. It still points at `0x224`, now in the middle of the new Phdr.
- `_dl_init` calls `<base>+0x224`. The CPU executes Phdr bytes as instructions → SIGSEGV.

The bug fires only when: linker is lld (recent lld's tight first-PT_LOAD layout), the `.so` is run through `patchelf --set-rpath`, and the new RUNPATH needs a fresh PT_LOAD. GCC + `ld.bfd` builds escape because `ld.bfd` leaves more headroom in the first PT_LOAD. arm64 escapes for the same reason (different layout). MeshLib's own CI doesn't trigger it because nothing post-processes the `.so`.

## Fix

Two coordinated changes, both Linux-only:

### `CMakeLists.txt`
Force lld for Clang builds (so `-z separate-loadable-segments` is honoured — `ld.bfd` ignores it) and pad PT_LOAD layout so `.init` sits well clear of the PHT. Probe with `check_linker_flag` first so images that don't ship lld (e.g. our ubuntu22 Clang 14) silently skip — they don't go through AppImage anyway.

```cmake
IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
  include(CheckLinkerFlag)
  check_linker_flag(CXX "-fuse-ld=lld" MESHLIB_HAVE_LLD)
  IF(MESHLIB_HAVE_LLD)
    # Prefer CMAKE_LINKER_TYPE (CMake >= 3.29); fall back to -fuse-ld= on
    # older CMakes (our minimum is 3.18).
    IF(NOT CMAKE_VERSION VERSION_LESS "3.29")
      set(CMAKE_LINKER_TYPE LLD)
    ELSE()
      add_link_options("-fuse-ld=lld")
    ENDIF()
    add_link_options("LINKER:-z,separate-loadable-segments")
  ENDIF()
ENDIF()
```

### `scripts/mrbind/generate.mk`
Belt-and-braces for the mrbind-driven shims (mrmeshpy.so / mrcudapy.so / etc.) which use their own Makefile-driven link, separate from the CMake path:

```make
ifneq ($(IS_LINUX),)
COMPILER_FLAGS += -I/usr/include/jsoncpp -isystem/usr/include/freetype2 -isystem/usr/include/gdcm-3.0
# Work around patchelf bug: https://github.com/NixOS/patchelf/issues/639
LINKER_FLAGS += -Wl,-z,separate-loadable-segments
endif
```

Cost: a few KB of file padding per shared library. No runtime overhead, no behavior change. The flag is `lld`-specific and Linux-only; macOS/Windows links are untouched.

## Why a workaround in MeshLib instead of upgrading patchelf

We tried. patchelf 0.15.0 (bundled in linuxdeploy's `continuous` AppImage), 0.16.1 (community-recommended in [#446](https://github.com/NixOS/patchelf/issues/446)), 0.17.2, and 0.18.0 (latest) all reproduce the same `DT_INIT`-stale crash. 0.18.0 additionally introduces a libquadmath alignment regression ([#492](https://github.com/NixOS/patchelf/issues/492)). The missing `DT_INIT` update on section relocation is a long-standing design gap, not version-specific. Until upstream lands a fix (proposed direction outlined in #639), this MeshLib-side flag is the cleanest mitigation.

## Test plan

- [x] All Linux CI jobs build cleanly with the new flag — verified on PR CI.
- [x] x86_64 Clang 21 AppImage smoke test (downstream consumer) no longer SIGSEGVs on `dlopen` of the bindings shim — verified end-to-end on a downstream branch (8/8 cells green).
- [x] `DT_INIT` in the produced shim now points to a high virtual address (e.g. `0x2ef08`), far clear of any patchelf-PHT-overrun zone — confirmed via `readelf -d` on the built `.so`.

## Related links

- Upstream patchelf bug: [NixOS/patchelf#639](https://github.com/NixOS/patchelf/issues/639) (clean reproducer + readelf evidence + proposed fix direction, filed during this investigation).
- Related-but-not-duplicate patchelf issues: [#446](https://github.com/NixOS/patchelf/issues/446) (AppImage `$ORIGIN` SIGSEGV, since Nov 2022), [#492](https://github.com/NixOS/patchelf/issues/492) (0.18.0 alignment regression).
