### PR TITLE
Fix findSignedDistance crash when upDistLimitSq sentinel is returned

### DIFF
--- a/source/MRMesh/MRMeshMeshDistance.cpp
+++ b/source/MRMesh/MRMeshMeshDistance.cpp
@@ -213,11 +213,9 @@ InternalZoneWithProjections findSignedDistanceOneWay( const MeshPart & a, const 
 MeshMeshSignedDistanceResult findSignedDistance( const MeshPart & a, const MeshPart & b, const AffineXf3f* rigidB2A, float upDistLimitSq )
 {
     MR_TIMER;
-    // If meshes has no collision no need to find signed distance
     auto res = findDistance( a, b, rigidB2A, upDistLimitSq );
-    if ( res.distSq == upDistLimitSq )
-        // findDistance returns the limit sentinel when nothing closer was found; skip collision checks on the bogus result
-        return { res.a, res.b, MeshMeshCollisionStatus::BothOutside, std::sqrt( res.distSq ) };
+    if ( res.distSq == upDistLimitSq ) // findDistance returns the limit sentinel when nothing closer was found
+        return { res.a, res.b, MeshMeshCollisionStatus::NotColliding, std::sqrt( res.distSq ) };
     std::vector<FaceFace> collisions;
     auto status = findCollisionStatus( a, b, res, rigidB2A, &collisions );
     if ( status == MeshMeshCollisionStatus::Touching )

--- a/source/MRMesh/MRMeshMeshDistance.cpp
+++ b/source/MRMesh/MRMeshMeshDistance.cpp
@@ -214,8 +214,12 @@ MeshMeshSignedDistanceResult findSignedDistance( const MeshPart & a, const MeshP
 {
     MR_TIMER;
     auto res = findDistance( a, b, rigidB2A, upDistLimitSq );
-    if ( res.distSq == upDistLimitSq ) // findDistance returns the limit sentinel when nothing closer was found
+    if ( !res.a || !res.b )
+    {   // findDistance returns the limit sentinel when nothing closer was found
+        assert( res.distSq == upDistLimitSq );
         return { res.a, res.b, MeshMeshCollisionStatus::NotColliding, std::sqrt( res.distSq ) };
+    }
+    assert( res.distSq < upDistLimitSq );
     std::vector<FaceFace> collisions;
     auto status = findCollisionStatus( a, b, res, rigidB2A, &collisions );
     if ( status == MeshMeshCollisionStatus::Touching )

--- a/source/MRMesh/MRMeshMeshDistance.cpp
+++ b/source/MRMesh/MRMeshMeshDistance.cpp
@@ -215,6 +215,9 @@ MeshMeshSignedDistanceResult findSignedDistance( const MeshPart & a, const MeshP
     MR_TIMER;
     // If meshes has no collision no need to find signed distance
     auto res = findDistance( a, b, rigidB2A, upDistLimitSq );
+    if ( res.distSq == upDistLimitSq )
+        // findDistance returns the limit sentinel when nothing closer was found; skip collision checks on the bogus result
+        return { res.a, res.b, MeshMeshCollisionStatus::BothOutside, std::sqrt( res.distSq ) };
     std::vector<FaceFace> collisions;
     auto status = findCollisionStatus( a, b, res, rigidB2A, &collisions );
     if ( status == MeshMeshCollisionStatus::Touching )

--- a/source/MRMesh/MRMeshMeshDistance.h
+++ b/source/MRMesh/MRMeshMeshDistance.h
@@ -28,7 +28,8 @@ enum class MeshMeshCollisionStatus
     AInside,
     BInside,
     Colliding,
-    Touching
+    Touching,
+    NotColliding ///< the meshes do not touch or collide one another, but inside/outside relation cannot be determined
 };
 
 struct MeshMeshSignedDistanceResult
@@ -54,7 +55,7 @@ MRMESH_API MeshMeshDistanceResult findDistance( const MeshPart & a, const MeshPa
 /**
  * \brief computes minimal distance between two meshes
  * \param rigidB2A rigid transformation from B-mesh space to A mesh space, nullptr considered as identity transformation
- * \param upDistLimitSq upper limit on the positive distance in question, if the real distance is larger then the function exists returning upDistLimitSq and no valid points
+ * \param upDistLimitSq upper limit on the squared distance in question, if the real distance is larger then the function exists returning +sqrt(upDistLimitSq) and no valid points
  * \note if one mesh is fully inside the other one - closest points are returned
  */
 MRMESH_API MeshMeshSignedDistanceResult findSignedDistance( const MeshPart & a, const MeshPart & b,

--- a/source/MRTest/MRMeshMeshDistanceTest.cpp
+++ b/source/MRTest/MRMeshMeshDistanceTest.cpp
@@ -43,7 +43,7 @@ TEST( MRMesh, findSignedDistanceTest )
     // with signedDist == sqrt(upDistLimitSq), not run collision checks on the sentinel result
     const float upDistLimitSq = 0.001f; // xf.b.z = 1.6f gives real distSq = 0.01
     dist = findSignedDistance( a, b, &xf, upDistLimitSq );
-    EXPECT_TRUE( dist.status == MeshMeshCollisionStatus::BothOutside );
+    EXPECT_TRUE( dist.status == MeshMeshCollisionStatus::NotColliding );
     EXPECT_NEAR( dist.signedDist, std::sqrt( upDistLimitSq ), 1e-6f );
 }
 

--- a/source/MRTest/MRMeshMeshDistanceTest.cpp
+++ b/source/MRTest/MRMeshMeshDistanceTest.cpp
@@ -38,6 +38,13 @@ TEST( MRMesh, findSignedDistanceTest )
     dist = findSignedDistance( a, b, &xf );
     EXPECT_TRUE( dist.signedDist > 0.0f );
     EXPECT_TRUE( dist.status == MeshMeshCollisionStatus::BothOutside );
+
+    // upDistLimitSq smaller than the real distSq: must short-circuit to BothOutside
+    // with signedDist == sqrt(upDistLimitSq), not run collision checks on the sentinel result
+    const float upDistLimitSq = 0.001f; // xf.b.z = 1.6f gives real distSq = 0.01
+    dist = findSignedDistance( a, b, &xf, upDistLimitSq );
+    EXPECT_TRUE( dist.status == MeshMeshCollisionStatus::BothOutside );
+    EXPECT_NEAR( dist.signedDist, std::sqrt( upDistLimitSq ), 1e-6f );
 }
 
 } //namespace MR

--- a/source/MRTest/MRMeshMeshDistanceTest.cpp
+++ b/source/MRTest/MRMeshMeshDistanceTest.cpp
@@ -44,6 +44,8 @@ TEST( MRMesh, findSignedDistanceTest )
     const float upDistLimitSq = 0.001f; // xf.b.z = 1.6f gives real distSq = 0.01
     dist = findSignedDistance( a, b, &xf, upDistLimitSq );
     EXPECT_TRUE( dist.status == MeshMeshCollisionStatus::NotColliding );
+    EXPECT_FALSE( dist.a );
+    EXPECT_FALSE( dist.b );
     EXPECT_NEAR( dist.signedDist, std::sqrt( upDistLimitSq ), 1e-6f );
 }
 


### PR DESCRIPTION
## Summary

`findDistance()` returns a `MeshMeshDistanceResult` with invalid feature points (`!res.a || !res.b`) and `res.distSq == upDistLimitSq` when no pair is found closer than the limit — its documented contract. `findSignedDistance()` previously handed that sentinel straight to `findCollisionStatus()`, which could crash.

This PR short-circuits on the invalid-points case. A new `MeshMeshCollisionStatus::NotColliding` value is added: the meshes do not touch or collide, but the inside/outside relation cannot be determined because the search was bounded by `upDistLimitSq`. `signedDist` is set to `+sqrt(upDistLimitSq)`, matching the unsquared-distance contract of `MeshMeshSignedDistanceResult`. Two `assert`s tie the no-valid-points condition to `res.distSq == upDistLimitSq` so the two views of the sentinel stay in sync. The `findSignedDistance` docstring is updated to spell out the squared-distance unit and the sentinel return value.

A regression test in `findSignedDistanceTest` calls `findSignedDistance` with `upDistLimitSq` smaller than the real squared distance and asserts:
- `status == NotColliding`
- `!dist.a && !dist.b`
- `signedDist ≈ sqrt(upDistLimitSq)`

## Test plan

- [x] `MRTest` passes across the CI build matrix
