### PR TITLE
Prevent HoleFillPlanner re-entry under nested ParallelFor

### DIFF
--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -616,8 +616,6 @@ public:
     HoleFillPlan run( const Mesh& mesh, EdgeId e, const FillHoleParams& params = {} );
     HoleFillPlan runPlanar( const Mesh& mesh, EdgeId e );
 
-    bool parallelProcessing = true;
-
 private:
     std::vector<EdgeId> edgeMap_;
     std::vector<std::vector<WeightedConn>> newEdgesMap_;
@@ -696,20 +694,10 @@ HoleFillPlan HoleFillPlanner::run( const Mesh& mesh, EdgeId a0, const FillHolePa
             getOptimalSteps( optimalSteps, ( i + 1 ) % loopEdgesCounter, steps, loopEdgesCounter, params.maxPolygonSubdivisions );
             getTriangulationWeights( mesh.topology, newEdgesMap_, edgeMap_, metrics, params.smoothBd, optimalSteps, current ); // find better among steps
         };
-        if ( parallelProcessing )
+        ParallelFor( unsigned( 0 ), loopEdgesCounter, optimalStepsCache_, [&]( unsigned i, std::vector<unsigned>& optimalSteps )
         {
-            ParallelFor( unsigned( 0 ), loopEdgesCounter, optimalStepsCache_, [&]( unsigned i, std::vector<unsigned>& optimalSteps )
-            {
-                work( i, optimalSteps );
-            } );
-        }
-        else
-        {
-            auto & optimalSteps = optimalStepsCache_.local();
-            for ( unsigned i = 0; i < loopEdgesCounter; ++i )
-                work( i, optimalSteps );
-        }
-
+            work( i, optimalSteps );
+        } );
     }
     // find minimum triangulation
     savedMapPatch_.clear();
@@ -827,8 +815,11 @@ std::vector<HoleFillPlan> getHoleFillPlans( const Mesh& mesh, const std::vector<
     tbb::enumerable_thread_specific<HoleFillPlanner> threadData_;
     ParallelFor( holeRepresentativeEdges, threadData_, [&]( size_t i, HoleFillPlanner& planner )
     {
-        planner.parallelProcessing = false; // to prevent run() from calling this lambda for a different i-index
-        fillPlans[i] = planner.run( mesh, holeRepresentativeEdges[i], params );
+        // isolate keeps run()'s nested ParallelFor from stealing this thread onto another i-index
+        tbb::this_task_arena::isolate( [&]
+        {
+            fillPlans[i] = planner.run( mesh, holeRepresentativeEdges[i], params );
+        } );
     } );
     return fillPlans;
 }
@@ -845,8 +836,11 @@ std::vector<HoleFillPlan> getPlanarHoleFillPlans( const Mesh& mesh, const std::v
     tbb::enumerable_thread_specific<HoleFillPlanner> threadData_;
     ParallelFor( holeRepresentativeEdges, threadData_, [&]( size_t i, HoleFillPlanner& planner )
     {
-        planner.parallelProcessing = false; // to prevent run() from calling this lambda for a different i-index
-        fillPlans[i] = planner.runPlanar( mesh, holeRepresentativeEdges[i] );
+        // isolate keeps run()'s nested ParallelFor from stealing this thread onto another i-index
+        tbb::this_task_arena::isolate( [&]
+        {
+            fillPlans[i] = planner.runPlanar( mesh, holeRepresentativeEdges[i] );
+        } );
     } );
     return fillPlans;
 }


### PR DESCRIPTION
## Summary

`getHoleFillPlans` and `getPlanarHoleFillPlans` run an outer `ParallelFor` over holes, with each thread reusing a per-thread `HoleFillPlanner` via `tbb::enumerable_thread_specific`. `HoleFillPlanner::run()` launches its own nested `ParallelFor`. While a thread is blocked on that inner loop, TBB's work-stealer can hand the same thread another *outer* iteration; `enumerable_thread_specific::local()` is keyed by TBB thread id, so the recursion lands on the **same** planner instance and clobbers its mutable buffers (`edgeMap_`, `newEdgesMap_`, `savedMapPatch_`, `cachedMapPatch_`, `newEdgesQueue_`).

This wraps each iteration body in `tbb::this_task_arena::isolate(...)`, so the calling thread cannot steal sibling outer tasks while inside `run()` / `runPlanar()`, while other threads can still join the inner `ParallelFor`. Nested parallelism is preserved; re-entry is blocked.

The legacy `HoleFillPlanner::parallelProcessing` flag (a disable-inner-parallelism workaround used only by `getHoleFillPlans`) is no longer needed and is removed; the `if (parallelProcessing) { ... } else { ... }` branch in `run()` collapses to a single parallel call.

`<tbb/task_arena.h>` is already pulled in via `MRPch/MRTBB.h`, so no new includes are needed.

## Test plan

- [x] Debug x64 build passes (verified locally)
- [x] Release x64 build passes
- [ ] Hole-fill operations on multi-hole meshes produce deterministic results across repeated runs (re-entry corruption typically manifested as nondeterminism)
- [ ] Spot-check `extrudeFaces` and `triangulateContourPlans` flows that call `getPlanarHoleFillPlans`
- [ ] Stress with varied thread counts via `tbb::global_control`

🤖 Generated with [Claude Code](https://claude.com/claude-code)