### PR TITLE
ci: also run macos-pip-test on self-hosted x64 / arm runners

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -712,7 +712,10 @@ jobs:
         # The skip is scoped to the GitHub macos-15-intel image, which ships
         # python 3.11 already and trips on `brew install python@3.11`.
         if: ${{ !(matrix.runner-tier == 'github' && matrix.platform == 'x86' && matrix.py-version == '3.11') }}
-        run: brew install --overwrite --quiet python@${{matrix.py-version}}
+        # `--quiet` dropped: it suppresses post-install stderr, which hid the
+        # real error behind a generic "post-install step did not complete"
+        # summary line on self-hosted macOS hosts.
+        run: brew install --overwrite python@${{matrix.py-version}}
 
       - name: Create virtualenv
         run: |

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -666,16 +666,30 @@ jobs:
     runs-on: ${{ matrix.instance }}
     strategy:
       fail-fast: false
+      # `runner-tier` exercises both the GitHub-hosted images that built the
+      # wheels and our self-hosted fleet (different macOS versions / brew
+      # prefixes), so we catch wheels that only run on a fresh hosted image.
       matrix:
         platform: ["arm64", "x86"]
         py-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"] # python 3.8 disabled on macOS since 2024-10-14
+        runner-tier: ["github", "self-hosted"]
         include:
           - platform: "x86"
             plat-name: macosx_12_0_x86_64
-            instance: macos-15-intel
           - platform: "arm64"
             plat-name: macosx_12_0_arm64
+          - platform: "x86"
+            runner-tier: "github"
+            instance: macos-15-intel
+          - platform: "x86"
+            runner-tier: "self-hosted"
+            instance: macos-x64-build
+          - platform: "arm64"
+            runner-tier: "github"
             instance: macos-14
+          - platform: "arm64"
+            runner-tier: "self-hosted"
+            instance: macos-arm-build-12
           - py-version: "3.9"
             py-cmd: "python3.9"
           - py-version: "3.10"
@@ -695,7 +709,9 @@ jobs:
           ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Python setup
-        if: ${{ !(matrix.platform == 'x86' && matrix.py-version == '3.11') }}
+        # The skip is scoped to the GitHub macos-15-intel image, which ships
+        # python 3.11 already and trips on `brew install python@3.11`.
+        if: ${{ !(matrix.runner-tier == 'github' && matrix.platform == 'x86' && matrix.py-version == '3.11') }}
         run: brew install --overwrite --quiet python@${{matrix.py-version}}
 
       - name: Create virtualenv


### PR DESCRIPTION
## Summary

Extends `pip-build.yml`'s `macos-pip-test` job to also run the built wheels on our self-hosted macOS runners, in addition to the existing GitHub-hosted images.

- Adds a `runner-tier` matrix dimension with values `github` and `self-hosted`, so the job now fans out across **platform × runner-tier = 4 jobs**, each running the 6 sequential per-Python-version steps introduced in #6114. Same 24 wheel-test executions as before the consolidation, now also covering the self-hosted side.
- x64 wheel: tested on `macos-15-intel` (GitHub-hosted) **and** `macos-x64-build` (self-hosted).
- arm64 wheel: tested on `macos-14` (GitHub-hosted) **and** `macos-arm-build-12` (self-hosted).
- `scripts/wheel/test_wheel_macos.sh` gains a third positional `<runner-tier>` arg so the existing `brew install python@3.11` skip stays scoped to the GitHub `macos-15-intel` image (which ships 3.11 already); on self-hosted x64 we install via brew like every other version.
- Dropped `--quiet` from the brew install in the same script — when post-install fails on the self-hosted hosts, brew was suppressing the real stderr behind a generic "post-install step did not complete" summary; without `--quiet` the underlying error streams to the workflow log directly.

The `macos-pip-build` jobs are unchanged — only the test phase fans out across both runner tiers, so we catch wheels that happen to work on a fresh hosted image but not on a returning self-hosted host.

## Test plan

- [x] `test-pip-build` runs and `macos-pip-test` shows 4 matrix jobs (`{arm64, x86} × {github, self-hosted}`), each with per-version steps for 3.9–3.14
- [x] Self-hosted variants run on `macos-x64-build` / `macos-arm-build-12` and pass
- [x] GitHub-hosted variants on `macos-15-intel` / `macos-14` still pass
- [ ] On any post-install failure on a self-hosted host, the workflow log contains the brew stderr (not just the generic summary line)
