### PR TITLE
ubuntu-x64 CI: pass CMAKE_C_COMPILER to the Build step

### DIFF
--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -121,6 +121,7 @@ jobs:
         env:
           MESHLIB_BUILD_RELEASE: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Release'] }}
           MESHLIB_BUILD_DEBUG: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Debug'] }}
+          CMAKE_C_COMPILER: ${{ matrix.c-compiler }}
           CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
           MR_VERSION: ${{ inputs.app_version }}
           # options to be passed to cmake


### PR DESCRIPTION
## Summary

- The ubuntu-x64 build job's `Build` step only passed `CMAKE_CXX_COMPILER` to cmake. The matrix already supplies a matching `c-compiler` (e.g. `/usr/bin/clang-18` for ubuntu24 Clang), but it was never wired through, so cmake auto-detected the container default — `/usr/bin/cc` (gcc) on ubuntu24.
- This regressed after #6109 added `add_link_options("-fuse-ld=lld")` / `LINKER:-z,separate-loadable-segments` at the top level (gated on `CMAKE_CXX_COMPILER_ID = Clang`). C-language link commands still ran through gcc, which honours `-fuse-ld=lld` via `collect2`; on the ubuntu24 image `collect2` can't find an `ld` and the link dies.
- Failing link in [run 26050137010 / job 76584478137](https://github.com/MeshInspector/MeshLib/actions/runs/26050137010/job/76584478137):
  ```
  [535/822] Linking C executable bin/MRTestC2
  FAILED: bin/MRTestC2
  /usr/bin/cc ... -fuse-ld=lld -Wl,-z,separate-loadable-segments ... -o bin/MRTestC2
  collect2: fatal error: cannot find 'ld'
  ```
- Fix: export `CMAKE_C_COMPILER: ${{ matrix.c-compiler }}` alongside `CMAKE_CXX_COMPILER` in the `Build` step env. `scripts/build_source.sh` already forwards `CMAKE_C_COMPILER` to cmake when set.

The same env-only-sets-CXX pattern exists in `build-test-ubuntu-arm64.yml` and `build-test-linux-vcpkg.yml`. They are not failing today (arm64 Clang 14 has no lld so the gate in CMakeLists.txt skips the `-fuse-ld=lld` path; linux-vcpkg's Clang 21 image evidently has a working `ld` on `cc`'s path) — leaving those alone for now to keep the PR minimal and re-evaluate if they break.

## Test plan

Verified on [run 26057557229](https://github.com/MeshInspector/MeshLib/actions/runs/26057557229) (full-ci, all other platforms disabled):

- [x] All 9 ubuntu-x64 matrix entries pass, including the previously-failing configs:
  - `ubuntu24, Release, Clang, clang++-18, clang-18, 23, ON` — pass (32m10s)
  - `ubuntu24, Debug, Clang, clang++-18, clang-18, 23, ON` — pass (31m20s)
- [x] cmake configure log on the ubuntu24-Clang job confirms the toolchain swap:
  - `CMAKE_C_COMPILER: /usr/bin/clang-18`
  - `-- The C compiler identification is Clang 18.1.3`
  - `-- Performing Test MESHLIB_HAVE_LLD - Success` (the `-fuse-ld=lld` path is still exercised; the C link works because clang resolves lld directly, bypassing the gcc/`collect2` lookup that was failing before).
