### PR TITLE
pip-build CI: consolidate per-py-version Windows/macOS test jobs

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -321,6 +321,7 @@ jobs:
       disable_ubuntu_x64:   ${{ needs.config.outputs.build_enable_ubuntu_x64 != 'true' }}
       disable_ubuntu_arm64: ${{ needs.config.outputs.build_enable_ubuntu_arm64 != 'true' }}
       disable_macos:        ${{ needs.config.outputs.build_enable_macos != 'true' }}
+      disable_windows:      ${{ needs.config.outputs.build_enable_windows != 'true' }}
 
   collect-stats:
     timeout-minutes: 5

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -43,6 +43,10 @@ on:
         default: false
         required: false
         type: boolean
+      disable_windows:
+        default: false
+        required: false
+        type: boolean
 
 env:
   VCPKG-VERSION: '2026.04.27'
@@ -350,6 +354,7 @@ jobs:
 
   windows-pip-build:
     needs: setup
+    if: ${{ inputs.disable_windows != true }}
     timeout-minutes: 90
     runs-on:  [windows-2022]
     strategy:
@@ -621,6 +626,7 @@ jobs:
 
   windows-pip-test:
     needs: [windows-pip-build]
+    if: ${{ inputs.disable_windows != true }}
     timeout-minutes: 90
     runs-on: windows-latest
     steps:

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -621,12 +621,8 @@ jobs:
 
   windows-pip-test:
     needs: [windows-pip-build]
-    timeout-minutes: 20
+    timeout-minutes: 90
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -642,78 +638,59 @@ jobs:
       - name: Python setup
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.py-version }}
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+            3.14
 
-      - name: Setup pip
-        run: |
-          py -${{matrix.py-version}} -m pip install --upgrade pip
-          py -${{matrix.py-version}} -m pip uninstall -y meshlib
-          py -${{matrix.py-version}} -m pip install --upgrade -r ./requirements/python.txt
-          py -${{matrix.py-version}} -m pip install pytest
-
-      - name: Install Meshlib wheel
+      - name: Test wheel against all Python versions
         shell: pwsh
-        run: $wheel_file=Get-ChildItem -Filter meshlib*win*.whl; py -${{matrix.py-version}} -m pip install $wheel_file
-
-      - name: Run Python tests
-        working-directory: test_python
-        run: py -${{matrix.py-version}} -m pytest -s -v
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $versions = '3.8','3.9','3.10','3.11','3.12','3.13','3.14'
+          $wheel_file = Get-ChildItem -Filter meshlib*win*.whl
+          foreach ($v in $versions) {
+            Write-Host "===== Python $v ====="
+            py -$v -m pip install --upgrade pip
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            py -$v -m pip uninstall -y meshlib
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            py -$v -m pip install --upgrade -r ./requirements/python.txt
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            py -$v -m pip install pytest
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            py -$v -m pip install $wheel_file
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            Push-Location test_python
+            py -$v -m pytest -s -v
+            $rc = $LASTEXITCODE
+            Pop-Location
+            if ($rc -ne 0) { exit $rc }
+          }
 
   macos-pip-test:
     needs: [macos-pip-build]
     if: ${{ inputs.disable_macos != true }}
-    timeout-minutes: 40
+    timeout-minutes: 120
     runs-on: ${{ matrix.instance }}
     strategy:
       fail-fast: false
       matrix:
         platform: ["arm64", "x86"]
-        py-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"] # python 3.8 disabled on macOS since 2024-10-14
         include:
           - platform: "x86"
-            plat-name: macosx_12_0_x86_64
             instance: macos-15-intel
           - platform: "arm64"
-            plat-name: macosx_12_0_arm64
             instance: macos-14
-          - py-version: "3.9"
-            py-cmd: "python3.9"
-          - py-version: "3.10"
-            py-cmd: "python3.10"
-          - py-version: "3.11"
-            py-cmd: "python3.11"
-          - py-version: "3.12"
-            py-cmd: "python3.12"
-          - py-version: "3.13"
-            py-cmd: "python3.13"
-          - py-version: "3.14"
-            py-cmd: "python3.14"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{needs.setup.outputs.version_tag}}
-
-      - name: Python setup
-        if: ${{ !(matrix.platform == 'x86' && matrix.py-version == '3.11') }}
-        run: brew install --overwrite --quiet python@${{matrix.py-version}}
-
-      - name: Create virtualenv
-        run: |
-          # Remove from PATH anything with the word `anaconda` in it.
-          # Even if Anaconda's Python works, it's probably a good idea to avoid it for consistency (because without this line only one specific Python version gets taken from Anaconda.)
-          export PATH="$(echo "$PATH" | perl -pe 's/[^:]*anaconda[^:]*//g;s/::|^:|:$//g')"
-          ${{ matrix.py-cmd }} -m venv .venv
-          . .venv/bin/activate
-          echo PATH=$PATH >> $GITHUB_ENV
-          pip install pytest
-
-      - name: Pip setup
-        run: |
-          ${{ matrix.py-cmd }} -m pip install --upgrade pip
-          ${{ matrix.py-cmd }} -m pip uninstall -y meshlib
-          ${{ matrix.py-cmd }} -m pip install --upgrade -r ./requirements/python.txt
-          ${{ matrix.py-cmd }} -m pip install pytest
 
       - name: Download Meshlib wheel from Artifact
         uses: actions/download-artifact@v8
@@ -721,12 +698,31 @@ jobs:
           name: Macos-${{matrix.platform}}
           merge-multiple: true
 
-      - name: Meshlib wheel install
-        run: ${{ matrix.py-cmd }} -m pip install ${{ matrix.pip-options }} ./meshlib-*${{matrix.platform}}*.whl
-
-      - name: Run Python tests
-        working-directory: test_python
-        run: ${{ matrix.py-cmd }} -m pytest -s -v
+      - name: Test wheel against all Python versions
+        # python 3.8 disabled on macOS since 2024-10-14
+        run: |
+          # Remove from PATH anything with the word `anaconda` in it.
+          # Even if Anaconda's Python works, it's probably a good idea to avoid it for consistency (because without this line only one specific Python version gets taken from Anaconda.)
+          export PATH="$(echo "$PATH" | perl -pe 's/[^:]*anaconda[^:]*//g;s/::|^:|:$//g')"
+          WHEEL=$(ls ./meshlib-*${{matrix.platform}}*.whl | head -n 1)
+          for PY_VER in 3.9 3.10 3.11 3.12 3.13 3.14 ; do
+            echo "===== Python ${PY_VER} ====="
+            # python 3.11 is pre-installed on macos-15-intel; brew install fails there
+            if [ "${{matrix.platform}}" != "x86" ] || [ "${PY_VER}" != "3.11" ]; then
+              brew install --overwrite --quiet python@${PY_VER}
+            fi
+            PY_CMD="python${PY_VER}"
+            VENV=".venv-${PY_VER}"
+            rm -rf "${VENV}"
+            ${PY_CMD} -m venv "${VENV}"
+            . "${VENV}/bin/activate"
+            python -m pip install --upgrade pip
+            python -m pip install --upgrade -r ./requirements/python.txt
+            python -m pip install pytest
+            python -m pip install "${WHEEL}"
+            ( cd test_python && python -m pytest -s -v )
+            deactivate
+          done
 
   upload-to-release:
     if: ${{ github.event_name == 'release' || inputs.publish }}

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -653,30 +653,36 @@ jobs:
             3.13
             3.14
 
-      - name: Test wheel against all Python versions
+      # One step per Python ABI so the GitHub Actions UI shows per-version
+      # status / timing / logs. Each step is a thin wrapper around the
+      # shared `test_wheel_windows.ps1` script.
+      - name: Test wheel against Python 3.8
         shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $versions = '3.8','3.9','3.10','3.11','3.12','3.13','3.14'
-          $wheel_file = Get-ChildItem -Filter meshlib*win*.whl
-          foreach ($v in $versions) {
-            Write-Host "===== Python $v ====="
-            py -$v -m pip install --upgrade pip
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-            py -$v -m pip uninstall -y meshlib
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-            py -$v -m pip install --upgrade -r ./requirements/python.txt
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-            py -$v -m pip install pytest
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-            py -$v -m pip install $wheel_file
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-            Push-Location test_python
-            py -$v -m pytest -s -v
-            $rc = $LASTEXITCODE
-            Pop-Location
-            if ($rc -ne 0) { exit $rc }
-          }
+        run: ./scripts/wheel/test_wheel_windows.ps1 -Version 3.8
+
+      - name: Test wheel against Python 3.9
+        shell: pwsh
+        run: ./scripts/wheel/test_wheel_windows.ps1 -Version 3.9
+
+      - name: Test wheel against Python 3.10
+        shell: pwsh
+        run: ./scripts/wheel/test_wheel_windows.ps1 -Version 3.10
+
+      - name: Test wheel against Python 3.11
+        shell: pwsh
+        run: ./scripts/wheel/test_wheel_windows.ps1 -Version 3.11
+
+      - name: Test wheel against Python 3.12
+        shell: pwsh
+        run: ./scripts/wheel/test_wheel_windows.ps1 -Version 3.12
+
+      - name: Test wheel against Python 3.13
+        shell: pwsh
+        run: ./scripts/wheel/test_wheel_windows.ps1 -Version 3.13
+
+      - name: Test wheel against Python 3.14
+        shell: pwsh
+        run: ./scripts/wheel/test_wheel_windows.ps1 -Version 3.14
 
   macos-pip-test:
     needs: [macos-pip-build]
@@ -704,31 +710,27 @@ jobs:
           name: Macos-${{matrix.platform}}
           merge-multiple: true
 
-      - name: Test wheel against all Python versions
-        # python 3.8 disabled on macOS since 2024-10-14
-        run: |
-          # Remove from PATH anything with the word `anaconda` in it.
-          # Even if Anaconda's Python works, it's probably a good idea to avoid it for consistency (because without this line only one specific Python version gets taken from Anaconda.)
-          export PATH="$(echo "$PATH" | perl -pe 's/[^:]*anaconda[^:]*//g;s/::|^:|:$//g')"
-          WHEEL=$(ls ./meshlib-*${{matrix.platform}}*.whl | head -n 1)
-          for PY_VER in 3.9 3.10 3.11 3.12 3.13 3.14 ; do
-            echo "===== Python ${PY_VER} ====="
-            # python 3.11 is pre-installed on macos-15-intel; brew install fails there
-            if [ "${{matrix.platform}}" != "x86" ] || [ "${PY_VER}" != "3.11" ]; then
-              brew install --overwrite --quiet python@${PY_VER}
-            fi
-            PY_CMD="python${PY_VER}"
-            VENV=".venv-${PY_VER}"
-            rm -rf "${VENV}"
-            ${PY_CMD} -m venv "${VENV}"
-            . "${VENV}/bin/activate"
-            python -m pip install --upgrade pip
-            python -m pip install --upgrade -r ./requirements/python.txt
-            python -m pip install pytest
-            python -m pip install "${WHEEL}"
-            ( cd test_python && python -m pytest -s -v )
-            deactivate
-          done
+      # One step per Python ABI so the GitHub Actions UI shows per-version
+      # status / timing / logs. Each step is a thin wrapper around the
+      # shared `test_wheel_macos.sh` script.
+      # python 3.8 disabled on macOS since 2024-10-14
+      - name: Test wheel against Python 3.9
+        run: scripts/wheel/test_wheel_macos.sh 3.9 ${{ matrix.platform }}
+
+      - name: Test wheel against Python 3.10
+        run: scripts/wheel/test_wheel_macos.sh 3.10 ${{ matrix.platform }}
+
+      - name: Test wheel against Python 3.11
+        run: scripts/wheel/test_wheel_macos.sh 3.11 ${{ matrix.platform }}
+
+      - name: Test wheel against Python 3.12
+        run: scripts/wheel/test_wheel_macos.sh 3.12 ${{ matrix.platform }}
+
+      - name: Test wheel against Python 3.13
+        run: scripts/wheel/test_wheel_macos.sh 3.13 ${{ matrix.platform }}
+
+      - name: Test wheel against Python 3.14
+        run: scripts/wheel/test_wheel_macos.sh 3.14 ${{ matrix.platform }}
 
   upload-to-release:
     if: ${{ github.event_name == 'release' || inputs.publish }}

--- a/scripts/wheel/test_wheel_macos.sh
+++ b/scripts/wheel/test_wheel_macos.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install the freshly-built meshlib wheel into the requested Python
+# interpreter and run the wheel's pytest suite. Run from the repo root;
+# the wheel artifact must already be unpacked in the working directory.
+
+PY_VER="${1:?usage: test_wheel_macos.sh <py-version> <platform: arm64|x86>}"
+PLATFORM="${2:?usage: test_wheel_macos.sh <py-version> <platform: arm64|x86>}"
+
+# Remove from PATH anything with the word `anaconda` in it.
+# Even if Anaconda's Python works, it's probably a good idea to avoid it
+# for consistency (without this, only one specific Python version may be
+# picked up from Anaconda).
+export PATH="$(echo "$PATH" | perl -pe 's/[^:]*anaconda[^:]*//g;s/::|^:|:$//g')"
+
+WHEEL=$(ls ./meshlib-*"${PLATFORM}"*.whl | head -n 1)
+
+# Python 3.11 ships pre-installed on macos-15-intel; brew install fails there.
+if [ "${PLATFORM}" != "x86" ] || [ "${PY_VER}" != "3.11" ]; then
+  brew install --overwrite --quiet "python@${PY_VER}"
+fi
+
+PY_CMD="python${PY_VER}"
+VENV=".venv-${PY_VER}"
+rm -rf "${VENV}"
+"${PY_CMD}" -m venv "${VENV}"
+# shellcheck disable=SC1091
+. "${VENV}/bin/activate"
+
+python -m pip install --upgrade pip
+python -m pip install --upgrade -r ./requirements/python.txt
+python -m pip install pytest
+python -m pip install "${WHEEL}"
+
+( cd test_python && python -m pytest -s -v )

--- a/scripts/wheel/test_wheel_windows.ps1
+++ b/scripts/wheel/test_wheel_windows.ps1
@@ -1,0 +1,26 @@
+param([Parameter(Mandatory)][string]$Version)
+
+# Install the freshly-built meshlib wheel into the requested Python
+# interpreter (via the `py` launcher) and run the wheel's pytest suite.
+# Run from the repo root; the wheel artifact must already be unpacked in
+# the working directory.
+
+$ErrorActionPreference = 'Stop'
+
+$wheel = Get-ChildItem -Filter meshlib*win*.whl
+if ($null -eq $wheel) { throw "No meshlib*win*.whl wheel found in $(Get-Location)" }
+
+py -$Version -m pip install --upgrade pip
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+py -$Version -m pip uninstall -y meshlib
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+py -$Version -m pip install --upgrade -r ./requirements/python.txt
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+py -$Version -m pip install pytest
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+py -$Version -m pip install $wheel
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Set-Location test_python
+py -$Version -m pytest -s -v
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
## Summary

The Windows and macOS wheel-test phases in `pip-build.yml` previously fanned out into one matrix job per Python ABI. Each fanned-out job re-checked out the repo, re-downloaded the wheel artifact, and re-installed Python + requirements + pytest. This PR collapses the py-version dimension into a single job per platform/arch, with one named step per Python version so per-version status / timing / logs still surface individually in the GitHub Actions UI.

| job | before | after (this PR) |
|---|---|---|
| `windows-pip-test` | 7 matrix jobs (one per py-version) | **1 job**, 7 steps `Test wheel against Python 3.8` … `3.14` |
| `macos-pip-test`   | 12 matrix jobs (2 archs × 6 py-versions) | **2 jobs** (one per arch), each with 6 steps `Test wheel against Python 3.9` … `3.14` |

`manylinux-pip-test` is intentionally left alone: each py-version is paired with a different distro container (`rockylinux:8` → 3.8, `debian:11-slim` → 3.9, `ubuntu:22.04` → 3.10, `fedora:37/39/42` → 3.11/3.12/3.13, `ubuntu:25.10` → 3.14) to exercise wheel portability. Collapsing that dimension would lose coverage.

## Changes

### Per-version test logic extracted into shared scripts
- New [`scripts/wheel/test_wheel_windows.ps1`](scripts/wheel/test_wheel_windows.ps1): takes `-Version X.Y`, installs the freshly-built wheel into that interpreter via the `py` launcher (`pip install` + requirements + pytest + wheel), runs `pytest test_python -s -v`. Explicit `$LASTEXITCODE` checks after every native call.
- New [`scripts/wheel/test_wheel_macos.sh`](scripts/wheel/test_wheel_macos.sh): takes `<py-version> <platform>`, `brew install python@<ver>` (skipping `3.11` on `macos-15-intel`, which ships it pre-installed — the existing carve-out), fresh `.venv-<ver>` per call, install requirements + pytest + wheel, run `pytest test_python -s -v`. The anaconda-stripping `PATH` workaround is preserved. `set -euo pipefail`, marked executable via `git update-index --chmod=+x`, LF line endings.

### Workflow shape
- **`windows-pip-test`** — drops the py-version matrix. `actions/setup-python@v6` is fed a newline list `3.8` through `3.14` once; then one named step per version invokes the shared `.ps1` with the version literal (e.g. `./scripts/wheel/test_wheel_windows.ps1 -Version 3.8`).
- **`macos-pip-test`** — keeps only the architecture dimension (`arm64` / `x86`). Per-arch matrix entry includes only `instance` (`macos-15-intel` / `macos-14`). Then 6 named steps invoke the shared `.sh` with `<ver> ${{ matrix.platform }}`.
- **Timeouts bumped to absorb sequential per-version runs**: `windows-pip-test` 20 → 90 min, `macos-pip-test` 40 → 120 min.

### `disable-build-windows` label now suppresses pip Windows build + test
The `disable-build-macos` label already gated both `macos-pip-build` and `macos-pip-test` via `inputs.disable_macos`. The Windows side had no equivalent. Symmetry restored:

- `pip-build.yml` gains a `disable_windows` `workflow_call` input (default `false`, so `workflow_dispatch` and release events are unchanged).
- `windows-pip-build` and `windows-pip-test` get `if: ${{ inputs.disable_windows != true }}` guards, mirroring the macOS pattern.
- `build-test-distribute.yml` now passes `disable_windows: ${{ ... build_enable_windows != 'true' }}` when invoking `pip-build.yml`, so the existing `disable-build-windows` label suppresses both the Windows pip build and test together — matching what `disable-build-macos` already does.

## Verification — [run 26087331263](https://github.com/MeshInspector/MeshLib/actions/runs/26087331263)

All targeted jobs green; manylinux skipped via `disable-build-ubuntu-x64` / `disable-build-ubuntu-arm64` labels as expected.

| job | result | duration |
|---|---|---|
| `test-pip-build / windows-pip-build` | ✅ pass | 49m40s |
| `test-pip-build / windows-pip-test` (3.8..3.14, 7 steps) | ✅ pass | **4m21s** |
| `test-pip-build / macos-pip-build (arm64)` | ✅ pass | 39m04s |
| `test-pip-build / macos-pip-build (x86)`   | ✅ pass | 1h30m34s |
| `test-pip-build / macos-pip-test (arm64)` (3.9..3.14, 6 steps) | ✅ pass | **2m41s** |
| `test-pip-build / macos-pip-test (x86)`   (3.9..3.14, 6 steps) | ✅ pass | **4m19s** |
| `test-pip-build / manylinux-pip-*` | ⏭ skipped (labels) | — |

Per-step breakdown on `windows-pip-test`:

| step | duration |
|---|---|
| Test wheel against Python 3.8 | 20s |
| Test wheel against Python 3.9 | 21s |
| Test wheel against Python 3.10 | 23s |
| Test wheel against Python 3.11 | 25s |
| Test wheel against Python 3.12 | 24s |
| Test wheel against Python 3.13 | 25s |
| Test wheel against Python 3.14 | 26s |

Sequential cost is minor: a single Windows test job covering 7 interpreters takes ~4 min, compared to 7 parallel matrix entries before. macOS is similarly bounded.
