### PR TITLE
macOS CI: extract thirdparty install into reusable composite action (share cache with pip-build)

### DIFF
--- a/.github/actions/install-macos-thirdparty/action.yml
+++ b/.github/actions/install-macos-thirdparty/action.yml
@@ -1,0 +1,152 @@
+name: Install macOS thirdparty libs
+description: >
+  Resolve the Homebrew prefix and compiler paths, cache the thirdparty
+  build outputs (./lib and ./include), install brew requirements, and
+  build the thirdparty libs on a cache miss. Shared between
+  build-test-macos.yml and pip-build.yml so both reuse the same cache.
+
+inputs:
+  cache-instance:
+    required: true
+    description: >
+      Runner-image identifier baked into the cache key (e.g. `macos-15-intel`,
+      `macos-14`, `self-hosted-arm`). Must match across workflows for the cache
+      to be shared.
+  cache-compiler:
+    required: true
+    description: >
+      Compiler identifier baked into the cache key (e.g. `AppleClang`,
+      `brew-llvm18`). Different compilers produce incompatible thirdparty
+      .dylibs, so this discriminates their caches.
+  cxx-compiler-template:
+    required: false
+    default: /usr/bin/clang++
+    description: >
+      C++ compiler path template; literal `BREW_PREFIX` is replaced with
+      the resolved homebrew prefix.
+  c-compiler-template:
+    required: false
+    default: /usr/bin/clang
+    description: >
+      C compiler path template; literal `BREW_PREFIX` is replaced with
+      the resolved homebrew prefix.
+  cache-prefix:
+    required: false
+    default: v1-thirdparty
+    description: >
+      Cache key prefix. Bump to manually invalidate the cache.
+
+outputs:
+  brew-prefix:
+    description: Output of `brew --prefix`.
+    value: ${{ steps.setup.outputs.brew-prefix }}
+  cxx-compiler:
+    description: Resolved C++ compiler path (with BREW_PREFIX substituted).
+    value: ${{ steps.setup.outputs.cxx-compiler }}
+  c-compiler:
+    description: Resolved C compiler path (with BREW_PREFIX substituted).
+    value: ${{ steps.setup.outputs.c-compiler }}
+  brew-hash:
+    description: >
+      16-char hash of the brew prefix. Use as part of the build-mrbind
+      cache key to discriminate self-hosted ARM fleet members that share
+      the same label set but have homebrew at different paths.
+    value: ${{ steps.cache-keys.outputs.brew-hash }}
+  thirdparty-hash:
+    description: 16-char hash of all inputs influencing the thirdparty build.
+    value: ${{ steps.cache-keys.outputs.thirdparty-hash }}
+  cache-hit:
+    description: >
+      `'true'` if the thirdparty cache was restored, `'false'` if the libs
+      were rebuilt from source.
+    value: ${{ steps.thirdparty-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Homebrew prefix and resolve compiler paths
+      id: setup
+      shell: bash
+      run: |
+        BREW_PREFIX=$(brew --prefix)
+        echo "Brew prefix: $BREW_PREFIX"
+        echo "brew-prefix=$BREW_PREFIX" >> $GITHUB_OUTPUT
+        echo "BREW_PREFIX=$BREW_PREFIX" >> $GITHUB_ENV
+
+        # Substitute BREW_PREFIX in templates and set actual compiler paths
+        CXX_COMPILER=$(echo "${{ inputs.cxx-compiler-template }}" | sed "s|BREW_PREFIX|$BREW_PREFIX|g")
+        C_COMPILER=$(echo "${{ inputs.c-compiler-template }}" | sed "s|BREW_PREFIX|$BREW_PREFIX|g")
+
+        echo "CXX compiler: $CXX_COMPILER"
+        echo "C compiler: $C_COMPILER"
+
+        echo "cxx-compiler=$CXX_COMPILER" >> $GITHUB_OUTPUT
+        echo "c-compiler=$C_COMPILER" >> $GITHUB_OUTPUT
+
+    # Cache key inputs:
+    # - brew-hash: hash of the homebrew prefix, used by Build MRBind in the
+    #   caller to discriminate self-hosted ARM fleet members that share the
+    #   `[self-hosted, macos, arm64, build]` label set but have homebrew at
+    #   different paths (e.g. `/Users/runner/.homebrew` vs `/opt/homebrew`);
+    #   the prefix is baked into mrbind's rpath.
+    # - thirdparty-hash: unified hash of everything that influences the
+    #   thirdparty ./lib + ./include outputs -- brew prefix (baked into the
+    #   rpaths of the produced .dylibs), submodule SHAs pinned in HEAD (the
+    #   source we compile), and the build-relevant scripts + CMakeLists +
+    #   brew-requirements list. `git ls-tree` reads gitlink entries from the
+    #   index, so it works whether or not the submodules are checked out.
+    - name: Compute cache key inputs
+      id: cache-keys
+      shell: bash
+      env:
+        BREW_PREFIX: ${{ steps.setup.outputs.brew-prefix }}
+      run: |
+        echo "brew-hash=$(printf %s "$BREW_PREFIX" | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
+        echo "thirdparty-hash=$( {
+          printf '%s\n' "$BREW_PREFIX"
+          git ls-tree HEAD \
+            thirdparty/googletest \
+            thirdparty/OpenCTM-git \
+            thirdparty/parallel-hashmap \
+            thirdparty/libE57Format \
+            thirdparty/glad \
+            thirdparty/mrbind-pybind11 \
+            thirdparty/tinygltf \
+            thirdparty/laz-perf \
+            thirdparty/clip \
+            thirdparty/fastmcpp
+          shasum -a 256 \
+            scripts/build_thirdparty.sh \
+            scripts/install_brew_requirements.sh \
+            scripts/thirdparty/clip.sh \
+            scripts/thirdparty/fastmcpp.sh \
+            thirdparty/CMakeLists.txt \
+            requirements/macos.txt
+        } | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
+
+    # Cache only the final outputs (./lib + ./include). Intermediates like
+    # ./thirdparty_build (which holds *.o, CMake metadata, etc.) are NOT
+    # cached -- they get rebuilt on a miss and discarded on a hit.
+    # Bump the `cache-prefix` input to manually invalidate.
+    - name: Cache thirdparty build outputs
+      id: thirdparty-cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          lib
+          include
+        key: ${{ inputs.cache-prefix }}-${{ inputs.cache-instance }}-${{ inputs.cache-compiler }}-${{ steps.cache-keys.outputs.thirdparty-hash }}
+
+    # Always run: cached thirdparty .dylibs link against brew libs at runtime,
+    # so brew packages must be installed on hosted runners even on cache hit.
+    - name: Install brew requirements
+      shell: bash
+      run: ./scripts/install_brew_requirements.sh
+
+    - name: Build thirdparty libs
+      if: ${{ steps.thirdparty-cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      env:
+        CMAKE_CXX_COMPILER: ${{ steps.setup.outputs.cxx-compiler }}
+        CMAKE_C_COMPILER: ${{ steps.setup.outputs.c-compiler }}
+      run: ./scripts/build_thirdparty.sh

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -103,64 +103,14 @@ jobs:
           # mrbind needs deps/cppdecl; recurse only there
           bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
-      - name: Setup Homebrew prefix and resolve compiler paths
-        id: setup
-        run: |
-          BREW_PREFIX=$(brew --prefix)
-          echo "Brew prefix: $BREW_PREFIX"
-          echo "brew-prefix=$BREW_PREFIX" >> $GITHUB_OUTPUT
-          echo "BREW_PREFIX=$BREW_PREFIX" >> $GITHUB_ENV
-
-          # Substitute BREW_PREFIX in templates and set actual compiler paths
-          CXX_COMPILER=$(echo "${{ matrix.cxx-compiler-template }}" | sed "s|BREW_PREFIX|$BREW_PREFIX|g")
-          C_COMPILER=$(echo "${{ matrix.c-compiler-template }}" | sed "s|BREW_PREFIX|$BREW_PREFIX|g")
-
-          echo "CXX compiler: $CXX_COMPILER"
-          echo "C compiler: $C_COMPILER"
-
-          echo "cxx-compiler=$CXX_COMPILER" >> $GITHUB_OUTPUT
-          echo "c-compiler=$C_COMPILER" >> $GITHUB_OUTPUT
-
-      # Cache key inputs:
-      # - brew-hash: hash of the homebrew prefix, used by Build MRBind below to
-      #   discriminate self-hosted ARM fleet members that share the
-      #   `[self-hosted, macos, arm64, build]` label set but have homebrew at
-      #   different paths (e.g. `/Users/runner/.homebrew` vs `/opt/homebrew`);
-      #   the prefix is baked into mrbind's rpath.
-      # - thirdparty-hash: unified hash of everything that influences the
-      #   thirdparty ./lib + ./include outputs -- brew prefix (baked into the
-      #   rpaths of the produced .dylibs), submodule SHAs pinned in HEAD (the
-      #   source we compile), and the build-relevant scripts + CMakeLists +
-      #   brew-requirements list. `git ls-tree` reads gitlink entries from the
-      #   index, so it works whether or not the submodules are checked out.
-      - name: Compute cache key inputs
-        id: cache-keys
-        shell: bash
-        env:
-          BREW_PREFIX: ${{ steps.setup.outputs.brew-prefix }}
-        run: |
-          echo "brew-hash=$(printf %s "$BREW_PREFIX" | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
-          echo "thirdparty-hash=$( {
-            printf '%s\n' "$BREW_PREFIX"
-            git ls-tree HEAD \
-              thirdparty/googletest \
-              thirdparty/OpenCTM-git \
-              thirdparty/parallel-hashmap \
-              thirdparty/libE57Format \
-              thirdparty/glad \
-              thirdparty/mrbind-pybind11 \
-              thirdparty/tinygltf \
-              thirdparty/laz-perf \
-              thirdparty/clip \
-              thirdparty/fastmcpp
-            shasum -a 256 \
-              scripts/build_thirdparty.sh \
-              scripts/install_brew_requirements.sh \
-              scripts/thirdparty/clip.sh \
-              scripts/thirdparty/fastmcpp.sh \
-              thirdparty/CMakeLists.txt \
-              requirements/macos.txt
-          } | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
+      - name: Install thirdparty libs
+        id: thirdparty
+        uses: ./.github/actions/install-macos-thirdparty
+        with:
+          cache-instance: ${{ matrix.instance }}
+          cache-compiler: ${{ matrix.compiler }}
+          cxx-compiler-template: ${{ matrix.cxx-compiler-template }}
+          c-compiler-template: ${{ matrix.c-compiler-template }}
 
       - name: Collect runner's system stats
         if: ${{ inputs.internal_build }}
@@ -170,33 +120,8 @@ jobs:
         with:
           target_os: macos
           target_arch: ${{ matrix.arch }}
-          cxx_compiler: ${{ steps.setup.outputs.cxx-compiler }}
+          cxx_compiler: ${{ steps.thirdparty.outputs.cxx-compiler }}
           build_config: ${{ matrix.config }}
-
-      # Cache only the final outputs (./lib + ./include). Intermediates like
-      # ./thirdparty_build (which holds *.o, CMake metadata, etc.) are NOT
-      # cached -- they get rebuilt on a miss and discarded on a hit.
-      # Bump the `v1-` prefix to manually invalidate.
-      - name: Cache thirdparty build outputs
-        id: thirdparty-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            lib
-            include
-          key: v1-thirdparty-${{ matrix.instance }}-${{ matrix.compiler }}-${{ steps.cache-keys.outputs.thirdparty-hash }}
-
-      # Always run: cached thirdparty .dylibs link against brew libs at runtime,
-      # so brew packages must be installed on hosted runners even on cache hit.
-      - name: Install brew requirements
-        run: ./scripts/install_brew_requirements.sh
-
-      - name: Build thirdparty libs
-        if: ${{ steps.thirdparty-cache.outputs.cache-hit != 'true' }}
-        run: ./scripts/build_thirdparty.sh
-        env:
-          CMAKE_CXX_COMPILER: ${{ steps.setup.outputs.cxx-compiler }}
-          CMAKE_C_COMPILER: ${{ steps.setup.outputs.c-compiler }}
 
       - name: Install MRBind deps
         if: ${{ inputs.mrbind || inputs.mrbind_c }}
@@ -211,7 +136,7 @@ jobs:
           # Shared with pip-build.yml's macOS section where the two also match.
           cache-key-prefix: ${{ matrix.instance }}-clang
           build-script: scripts/mrbind/install_mrbind_macos.sh
-          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt') }}-${{ steps.cache-keys.outputs.brew-hash }}
+          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt') }}-${{ steps.thirdparty.outputs.brew-hash }}
 
       - name: Create virtualenv
         run: |
@@ -228,8 +153,8 @@ jobs:
       - name: Generate C bindings
         if: ${{ inputs.mrbind_c }}
         env:
-          PATH: ${{ steps.setup.outputs.brew-prefix }}/opt/make/libexec/gnubin:${{ steps.setup.outputs.brew-prefix }}/opt/grep/libexec/gnubin:${{env.PATH}}
-          CXX: ${{ steps.setup.outputs.cxx-compiler }}
+          PATH: ${{ steps.thirdparty.outputs.brew-prefix }}/opt/make/libexec/gnubin:${{ steps.thirdparty.outputs.brew-prefix }}/opt/grep/libexec/gnubin:${{env.PATH}}
+          CXX: ${{ steps.thirdparty.outputs.cxx-compiler }}
         run: |
           make --version
           make -f scripts/mrbind/generate.mk -B --trace TARGET=c
@@ -239,7 +164,7 @@ jobs:
         env:
           MESHLIB_BUILD_RELEASE: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Release'] }}
           MESHLIB_BUILD_DEBUG: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Debug'] }}
-          CMAKE_CXX_COMPILER: ${{ steps.setup.outputs.cxx-compiler }}
+          CMAKE_CXX_COMPILER: ${{ steps.thirdparty.outputs.cxx-compiler }}
           MR_VERSION: ${{ inputs.app_version }}
           MR_CMAKE_OPTIONS: >
             -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
@@ -254,8 +179,8 @@ jobs:
       - name: Generate and build Python bindings
         if: ${{ inputs.mrbind }}
         env:
-          PATH: ${{ steps.setup.outputs.brew-prefix }}/opt/make/libexec/gnubin:${{ steps.setup.outputs.brew-prefix }}/opt/grep/libexec/gnubin:${{env.PATH}}
-          CXX: ${{ steps.setup.outputs.cxx-compiler }}
+          PATH: ${{ steps.thirdparty.outputs.brew-prefix }}/opt/make/libexec/gnubin:${{ steps.thirdparty.outputs.brew-prefix }}/opt/grep/libexec/gnubin:${{env.PATH}}
+          CXX: ${{ steps.thirdparty.outputs.cxx-compiler }}
         run: |
           make --version
           make -f scripts/mrbind/generate.mk \
@@ -324,7 +249,7 @@ jobs:
       - name: Build C++ examples
         if: ${{ matrix.config == 'Release' }}
         env:
-          CXX: ${{ steps.setup.outputs.cxx-compiler }}
+          CXX: ${{ steps.thirdparty.outputs.cxx-compiler }}
         run: |
           cmake \
             -S examples/cpp-examples \
@@ -337,7 +262,7 @@ jobs:
       - name: Build C examples
         if: ${{ matrix.config == 'Release' }}
         env:
-          CC: ${{ steps.setup.outputs.c-compiler }}
+          CC: ${{ steps.thirdparty.outputs.c-compiler }}
         run: |
           cmake \
             -S examples/c-examples \

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -491,18 +491,18 @@ jobs:
           echo PATH=$PATH >> $GITHUB_ENV
 
       - name: Install thirdparty libs
-        run: |
-          ./scripts/build_thirdparty.sh
-          ./scripts/mrbind/install_deps_macos.sh
+        id: thirdparty
+        uses: ./.github/actions/install-macos-thirdparty
+        with:
+          # `cache-instance` and `cache-compiler` must match the values used by
+          # build-test-macos.yml on the same runner image (`AppleClang` here matches
+          # build-test-macos.yml's x64-Release and arm64-Debug matrix entries), so
+          # the thirdparty ./lib + ./include cache is shared across the two workflows.
+          cache-instance: ${{ matrix.instance }}
+          cache-compiler: AppleClang
 
-      # See comment in build-test-macos.yml -- the brew-prefix hash discriminates
-      # runners with the same instance label but different homebrew install paths.
-      - name: Compute brew-prefix hash for MRBind cache key
-        id: brew-hash
-        shell: bash
-        env:
-          BREW_PREFIX: ${{ matrix.brewpath }}
-        run: echo "hash=$(printf %s "$BREW_PREFIX" | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
+      - name: Install MRBind deps
+        run: ./scripts/mrbind/install_deps_macos.sh
 
       - name: Build MRBind
         uses: ./.github/actions/build-mrbind
@@ -511,7 +511,7 @@ jobs:
           # build-test-macos.yml when its matrix.instance matches.
           cache-key-prefix: ${{ matrix.instance }}-clang
           build-script: scripts/mrbind/install_mrbind_macos.sh
-          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt') }}-${{ steps.brew-hash.outputs.hash }}
+          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt') }}-${{ steps.thirdparty.outputs.brew-hash }}
 
       - name: Build
         run: ./scripts/build_source.sh


### PR DESCRIPTION
## Summary

Extract the macOS thirdparty install logic from `build-test-macos.yml` into a new reusable composite action `install-macos-thirdparty`, and reuse it from the macOS portion of `pip-build.yml` so the thirdparty `./lib + ./include` cache is shared across both workflows.

## What changed

- **New action** `.github/actions/install-macos-thirdparty/action.yml` bundles five previously-inline steps:
  - Setup Homebrew prefix and resolve compiler paths
  - Compute cache key inputs (`brew-hash`, `thirdparty-hash`)
  - Cache thirdparty build outputs (`./lib` + `./include`)
  - Install brew requirements (always runs — cached `.dylibs` link against brew libs at runtime)
  - Build thirdparty libs (only on cache miss)

  Exposes outputs downstream steps need: `brew-prefix`, `cxx-compiler`, `c-compiler`, `brew-hash`, `thirdparty-hash`, `cache-hit`.

- **`build-test-macos.yml`** replaces the five inline steps with a single `uses:` of the new action; references to `steps.setup.outputs.*` and `steps.cache-keys.outputs.*` are repointed to `steps.thirdparty.outputs.*`. `Collect runner's system stats` now runs after the bundled action instead of between its sub-steps — it's `continue-on-error` and only records sys info, so the order change is benign.

- **`pip-build.yml`** macOS portion now calls the new action for `Install thirdparty libs` with `cache-instance: ${{ matrix.instance }}` and `cache-compiler: AppleClang`. The removed `Compute brew-prefix hash` step is replaced by the action's `brew-hash` output. `./scripts/mrbind/install_deps_macos.sh` was previously inlined into `Install thirdparty libs`; it now lives in its own `Install MRBind deps` step.

## Cache sharing

Cache key shape unchanged: `v1-thirdparty-<instance>-<compiler>-<thirdparty-hash>`. With `cache-compiler: AppleClang`, pip-build's two macOS variants now share with the matching build-test-macos matrix entries:

| pip-build variant | shares cache with build-test-macos entry |
| --- | --- |
| `macos-15-intel` / x86 / AppleClang | `macos-15-intel` / x64-Release / AppleClang |
| `macos-14` / arm64 / AppleClang | `macos-14` / arm64-Debug / AppleClang |

The `brew-llvm18` arm64-Release entry in build-test-macos keeps its own cache (different compiler → different rpaths → different .dylibs).

## CI verification (run 26090196890)

All five macOS jobs got a thirdparty cache hit; pip-build's keys match the keys produced by build-test-macos on the same runner image, confirming the cache is now shared:

| Job | Thirdparty cache key | Hit |
| --- | --- | --- |
| `build-test-macos` x64 Release | `v1-thirdparty-macos-15-intel-AppleClang-909319fe2869d58f` | yes |
| `build-test-macos` arm64 Debug | `v1-thirdparty-macos-14-AppleClang-805f740b1b8fa463` | yes |
| `build-test-macos` arm64 Release | `v1-thirdparty-self-hosted-arm-brew-llvm18-805f740b1b8fa463` | yes |
| `macos-pip-build` x86 | `v1-thirdparty-macos-15-intel-AppleClang-909319fe2869d58f` (= x64 above) | yes |
| `macos-pip-build` arm64 | `v1-thirdparty-macos-14-AppleClang-805f740b1b8fa463` (= arm64-Debug above) | yes |

MRBind caches also hit in all five jobs. All `test-pip-build` macOS test variants (12 × py-version × arch) passed.
