### PR TITLE
mrbind generate.mk: re-tier NUM_FRAGMENTS / JOBS by cores and RAM

### DIFF
--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -387,42 +387,13 @@ CAPPED_NPROC := $(MAX_NPROC)
 override nproc_string := >=$(MAX_NPROC) cores
 endif
 
-ifneq ($(IS_MACOS),)
-# macOS GitHub-hosted runners sit at ~15 GB RAM and fall into the lowest "oof" tier,
-# which hard-codes NUM_FRAGMENTS=64 and JOBS=4 regardless of core count. Skip the
-# heuristic on macOS: scale jobs to the actual core count and halve the fragment
-# count to 32 so each translation unit batches more work (fewer redundant template
-# instantiations) while keeping per-fragment RAM well within the runner budget.
-override ram_string := $(ASSUME_RAM)G RAM (macOS override)
-NUM_FRAGMENTS := 32
-JOBS := $(CAPPED_NPROC)
-else ifneq ($(ASSUME_RAM),)
-ifeq ($(call safe_shell,echo $$(($(ASSUME_RAM) >= 64))),1)
-override ram_string := >=64G RAM
-# The default number of jobs. Override with `-jN` or `JOBS=N`, both work fine.
-JOBS := $(CAPPED_NPROC)
-# How many translation units to use for the bindings. Bigger value = less RAM usage, but usually slower build speed.
-# When changing this, update the default value for `-j` above.
-NUM_FRAGMENTS := $(CAPPED_NPROC)
-else ifeq ($(call safe_shell,echo $$(($(ASSUME_RAM) >= 32))),1)
-override ram_string := ~32G RAM
-NUM_FRAGMENTS := $(call safe_shell,echo $$(($(CAPPED_NPROC) * 2)))# = CAPPED_NPROC * 2
-JOBS := $(CAPPED_NPROC)
-else ifeq ($(call safe_shell,echo $$(($(ASSUME_RAM) >= 16))),1)
-# At this point we have so little RAM that we ignore nproc completely (or would need to clamp it to something like ~8, but who even has less cores than that?).
-override ram_string := ~16G RAM
+# Fixed defaults on every platform: split the bindings into 64 translation units
+# (small enough to keep per-fragment RAM modest) and use as many parallel jobs as
+# the machine reports cores (capped by MAX_NPROC above).
+# Override with `-jN` or `JOBS=N`; override fragment count with `NUM_FRAGMENTS=N`.
+override ram_string := $(if $(ASSUME_RAM),$(ASSUME_RAM)G RAM,unknown RAM)
 NUM_FRAGMENTS := 64
-JOBS := 8
-else
-override ram_string := ~8G RAM (oof)
-NUM_FRAGMENTS := 64
-JOBS := 4
-endif
-else
-override ram_string := unknown, assuming ~16G
-NUM_FRAGMENTS := 64
-JOBS := 8
-endif
+JOBS := $(CAPPED_NPROC)
 MAKEFLAGS += -j$(JOBS)
 ifeq ($(filter-out file,$(origin NUM_FRAGMENTS) $(origin JOBS)),)
 $(info Build machine: $(nproc_string), $(ram_string); defaulting to NUM_FRAGMENTS=$(NUM_FRAGMENTS) -j$(JOBS))

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -387,7 +387,15 @@ CAPPED_NPROC := $(MAX_NPROC)
 override nproc_string := >=$(MAX_NPROC) cores
 endif
 
-ifneq ($(ASSUME_RAM),)
+ifneq ($(IS_MACOS),)
+# macOS GitHub-hosted runners sit at ~15 GB RAM and fall into the lowest "oof" tier,
+# which hard-codes JOBS=4 regardless of core count. Skip the heuristic on macOS and
+# scale jobs to the actual core count; keep NUM_FRAGMENTS=64 so per-fragment RAM
+# stays modest.
+override ram_string := $(ASSUME_RAM)G RAM (macOS override)
+NUM_FRAGMENTS := 64
+JOBS := $(CAPPED_NPROC)
+else ifneq ($(ASSUME_RAM),)
 ifeq ($(call safe_shell,echo $$(($(ASSUME_RAM) >= 64))),1)
 override ram_string := >=64G RAM
 # The default number of jobs. Override with `-jN` or `JOBS=N`, both work fine.

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -370,11 +370,22 @@ PCH_CODEGEN_FLAGS := -fpch-debuginfo -fpch-instantiate-templates
 # Also guess the number of CPU cores.
 ifneq ($(IS_MACOS),)
 ASSUME_RAM := $(shell bash -c 'echo $$(($(shell sysctl -n hw.memsize) / 1000000000))')
-ASSUME_NPROC := $(call safe_shell,sysctl -n hw.ncpu)
+# Physical cores only -- SMT siblings hurt compile parallelism more than they
+# help (two threads on one physical core contend for execution resources).
+ASSUME_NPROC := $(call safe_shell,sysctl -n hw.physicalcpu)
 else
 # `--giga` uses 10^3 instead of 2^10, which is actually good for us, since it overreports a bit, which counters computers typically having slightly less RAM than 2^N gigs.
 ASSUME_RAM := $(shell LANG= free --giga 2>/dev/null | awk 'NR==2{print $$2}')
-ASSUME_NPROC := $(call safe_shell,nproc)
+ifneq ($(IS_WINDOWS),)
+# `nproc` (and `NUMBER_OF_PROCESSORS`) report logical CPUs on Windows. The
+# GitHub-hosted Windows runners (and effectively every Windows host we build on)
+# are x86 with SMT-2, so halving the logical count approximates the physical
+# core count without depending on `wmic`/`powershell` from the make shell.
+ASSUME_NPROC := $(shell bash -c 'echo $$(( $(shell nproc) / 2 ))')
+else
+# Linux: count unique (Core,Socket) pairs reported by lscpu == physical cores.
+ASSUME_NPROC := $(call safe_shell,lscpu -p=Core,Socket | grep -v '^\#' | sort -u | wc -l)
+endif
 endif
 
 # We clamp the nproc to this value, because when you have more cores, our heuristics fall apart (and you might run out of ram).

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -370,24 +370,14 @@ PCH_CODEGEN_FLAGS := -fpch-debuginfo -fpch-instantiate-templates
 # Also guess the number of CPU cores.
 ifneq ($(IS_MACOS),)
 ASSUME_RAM := $(shell bash -c 'echo $$(($(shell sysctl -n hw.memsize) / 1000000000))')
-# Physical cores only -- SMT siblings hurt compile parallelism more than they
-# help (two threads on one physical core contend for execution resources).
+# Physical cores only -- on macOS x86 the VM disables SMT (so logical == physical
+# already), and Apple Silicon has no SMT, so this just matches what's available.
 ASSUME_NPROC := $(call safe_shell,sysctl -n hw.physicalcpu)
 else
 # `--giga` uses 10^3 instead of 2^10, which is actually good for us, since it overreports a bit, which counters computers typically having slightly less RAM than 2^N gigs.
 ASSUME_RAM := $(shell LANG= free --giga 2>/dev/null | awk 'NR==2{print $$2}')
-ifneq ($(IS_WINDOWS),)
-# `nproc` (and `NUMBER_OF_PROCESSORS`) report logical CPUs on Windows. The
-# GitHub-hosted Windows runners (and effectively every Windows host we build on)
-# are x86 with SMT-2, so halving the logical count approximates the physical
-# core count without depending on `wmic`/`powershell` from the make shell.
-ASSUME_NPROC := $(shell bash -c 'echo $$(( $(shell nproc) / 2 ))')
-else
-# Linux: count unique (Core,Socket) pairs reported by lscpu == physical cores.
-# The literal comma in `-p=Core,Socket` has to go through $(comma), otherwise
-# $(call) splits the argument on it and only `lscpu -p=Core` reaches the shell.
-ASSUME_NPROC := $(call safe_shell,lscpu -p=Core$(comma)Socket | grep -v '^\#' | sort -u | wc -l)
-endif
+# Diagnostic only on Linux/Windows; JOBS is pinned to 4 below.
+ASSUME_NPROC := $(call safe_shell,nproc)
 endif
 
 # We clamp the nproc to this value, because when you have more cores, our heuristics fall apart (and you might run out of ram).
@@ -400,13 +390,21 @@ CAPPED_NPROC := $(MAX_NPROC)
 override nproc_string := >=$(MAX_NPROC) cores
 endif
 
-# Fixed defaults on every platform: split the bindings into 64 translation units
-# (small enough to keep per-fragment RAM modest) and use as many parallel jobs as
-# the machine reports cores (capped by MAX_NPROC above).
+# Split the bindings into 64 translation units (small enough to keep per-fragment
+# RAM modest) and pick JOBS per platform:
+#   - macOS: scale to physical cores (CAPPED_NPROC).
+#   - Linux/Windows: pin to 4. On the standard 4-vCPU GitHub-hosted runners
+#     (2-physical+HT x86 or 4-physical no-SMT ARM) this saturates the box; on
+#     x86 with HT, slight over-subscription (4 jobs on 2 physical) keeps the
+#     pipeline full when individual compile jobs stall on memory.
 # Override with `-jN` or `JOBS=N`; override fragment count with `NUM_FRAGMENTS=N`.
 override ram_string := $(if $(ASSUME_RAM),$(ASSUME_RAM)G RAM,unknown RAM)
 NUM_FRAGMENTS := 64
+ifneq ($(IS_MACOS),)
 JOBS := $(CAPPED_NPROC)
+else
+JOBS := 4
+endif
 MAKEFLAGS += -j$(JOBS)
 ifeq ($(filter-out file,$(origin NUM_FRAGMENTS) $(origin JOBS)),)
 $(info Build machine: $(nproc_string), $(ram_string); defaulting to NUM_FRAGMENTS=$(NUM_FRAGMENTS) -j$(JOBS))

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -376,7 +376,6 @@ ASSUME_NPROC := $(call safe_shell,sysctl -n hw.physicalcpu)
 else
 # `--giga` uses 10^3 instead of 2^10, which is actually good for us, since it overreports a bit, which counters computers typically having slightly less RAM than 2^N gigs.
 ASSUME_RAM := $(shell LANG= free --giga 2>/dev/null | awk 'NR==2{print $$2}')
-# Diagnostic only on Linux/Windows; JOBS is pinned to 4 below.
 ASSUME_NPROC := $(call safe_shell,nproc)
 endif
 
@@ -390,18 +389,25 @@ CAPPED_NPROC := $(MAX_NPROC)
 override nproc_string := >=$(MAX_NPROC) cores
 endif
 
-# Split the bindings into 32 translation units and pin JOBS = min(4, cores).
-# 4 matches the 4-vCPU shape of GitHub-hosted Linux/Windows runners (and is
-# enough to saturate the 4-physical macOS Intel and 10-physical self-hosted
-# ARM boxes for this workload); on the 3-core macOS ARM GitHub runners
-# (macos-14/macos-15) it drops to 3 so we don't over-subscribe a no-SMT box.
+# Pick NUM_FRAGMENTS and JOBS by machine size:
+#   < 7 cores                           -> JOBS=cores, NUM_FRAGMENTS=32 (small TUs to keep RAM in check on small boxes)
+#   >= 7 cores, RAM < 32G (or unknown)  -> JOBS=cores, NUM_FRAGMENTS=64
+#   RAM >= 64G                          -> JOBS=cores, NUM_FRAGMENTS=cores (few big fragments)
+#   32G <= RAM < 64G                    -> JOBS=cores, NUM_FRAGMENTS=cores*2
 # Override with `-jN` or `JOBS=N`; override fragment count with `NUM_FRAGMENTS=N`.
 override ram_string := $(if $(ASSUME_RAM),$(ASSUME_RAM)G RAM,unknown RAM)
+ifeq ($(call safe_shell,echo $$(( $(ASSUME_NPROC) < 7 ))),1)
 NUM_FRAGMENTS := 32
-ifeq ($(call safe_shell,echo $$(( $(CAPPED_NPROC) < 4 ))),1)
+JOBS := $(CAPPED_NPROC)
+else ifeq ($(call safe_shell,echo $$(( 0$(ASSUME_RAM) < 32 ))),1)
+NUM_FRAGMENTS := 64
+JOBS := $(CAPPED_NPROC)
+else ifeq ($(call safe_shell,echo $$(( $(ASSUME_RAM) >= 64 ))),1)
+NUM_FRAGMENTS := $(CAPPED_NPROC)
 JOBS := $(CAPPED_NPROC)
 else
-JOBS := 4
+NUM_FRAGMENTS := $(call safe_shell,echo $$(( $(CAPPED_NPROC) * 2 )))
+JOBS := $(CAPPED_NPROC)
 endif
 MAKEFLAGS += -j$(JOBS)
 ifeq ($(filter-out file,$(origin NUM_FRAGMENTS) $(origin JOBS)),)

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -389,11 +389,12 @@ endif
 
 ifneq ($(IS_MACOS),)
 # macOS GitHub-hosted runners sit at ~15 GB RAM and fall into the lowest "oof" tier,
-# which hard-codes JOBS=4 regardless of core count. Skip the heuristic on macOS and
-# scale jobs to the actual core count; keep NUM_FRAGMENTS=64 so per-fragment RAM
-# stays modest.
+# which hard-codes NUM_FRAGMENTS=64 and JOBS=4 regardless of core count. Skip the
+# heuristic on macOS: scale jobs to the actual core count and halve the fragment
+# count to 32 so each translation unit batches more work (fewer redundant template
+# instantiations) while keeping per-fragment RAM well within the runner budget.
 override ram_string := $(ASSUME_RAM)G RAM (macOS override)
-NUM_FRAGMENTS := 64
+NUM_FRAGMENTS := 32
 JOBS := $(CAPPED_NPROC)
 else ifneq ($(ASSUME_RAM),)
 ifeq ($(call safe_shell,echo $$(($(ASSUME_RAM) >= 64))),1)

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -390,17 +390,15 @@ CAPPED_NPROC := $(MAX_NPROC)
 override nproc_string := >=$(MAX_NPROC) cores
 endif
 
-# Split the bindings into 64 translation units (small enough to keep per-fragment
-# RAM modest) and pick JOBS per platform:
-#   - macOS: scale to physical cores (CAPPED_NPROC).
-#   - Linux/Windows: pin to 4. On the standard 4-vCPU GitHub-hosted runners
-#     (2-physical+HT x86 or 4-physical no-SMT ARM) this saturates the box; on
-#     x86 with HT, slight over-subscription (4 jobs on 2 physical) keeps the
-#     pipeline full when individual compile jobs stall on memory.
+# Split the bindings into 32 translation units and pin JOBS = min(4, cores).
+# 4 matches the 4-vCPU shape of GitHub-hosted Linux/Windows runners (and is
+# enough to saturate the 4-physical macOS Intel and 10-physical self-hosted
+# ARM boxes for this workload); on the 3-core macOS ARM GitHub runners
+# (macos-14/macos-15) it drops to 3 so we don't over-subscribe a no-SMT box.
 # Override with `-jN` or `JOBS=N`; override fragment count with `NUM_FRAGMENTS=N`.
 override ram_string := $(if $(ASSUME_RAM),$(ASSUME_RAM)G RAM,unknown RAM)
-NUM_FRAGMENTS := 64
-ifneq ($(IS_MACOS),)
+NUM_FRAGMENTS := 32
+ifeq ($(call safe_shell,echo $$(( $(CAPPED_NPROC) < 4 ))),1)
 JOBS := $(CAPPED_NPROC)
 else
 JOBS := 4

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -399,7 +399,7 @@ override ram_string := $(if $(ASSUME_RAM),$(ASSUME_RAM)G RAM,unknown RAM)
 ifeq ($(call safe_shell,echo $$(( $(ASSUME_NPROC) < 7 ))),1)
 NUM_FRAGMENTS := 32
 JOBS := $(CAPPED_NPROC)
-else ifeq ($(call safe_shell,echo $$(( 0$(ASSUME_RAM) < 32 ))),1)
+else ifeq ($(call safe_shell,echo $$(( $(or $(ASSUME_RAM),0) < 32 ))),1)
 NUM_FRAGMENTS := 64
 JOBS := $(CAPPED_NPROC)
 else ifeq ($(call safe_shell,echo $$(( $(ASSUME_RAM) >= 64 ))),1)

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -384,7 +384,9 @@ ifneq ($(IS_WINDOWS),)
 ASSUME_NPROC := $(shell bash -c 'echo $$(( $(shell nproc) / 2 ))')
 else
 # Linux: count unique (Core,Socket) pairs reported by lscpu == physical cores.
-ASSUME_NPROC := $(call safe_shell,lscpu -p=Core,Socket | grep -v '^\#' | sort -u | wc -l)
+# The literal comma in `-p=Core,Socket` has to go through $(comma), otherwise
+# $(call) splits the argument on it and only `lscpu -p=Core` reaches the shell.
+ASSUME_NPROC := $(call safe_shell,lscpu -p=Core$(comma)Socket | grep -v '^\#' | sort -u | wc -l)
 endif
 endif
 


### PR DESCRIPTION
## Summary

Re-tier the RAM/cores heuristic in `scripts/mrbind/generate.mk` that picks `NUM_FRAGMENTS` and `JOBS` for the bindings build.

Master's heuristic was:

| Detected RAM | `NUM_FRAGMENTS` | `JOBS` |
|---|---:|---:|
| `>= 64G` | cores | cores |
| `>= 32G` | cores × 2 | cores |
| `>= 16G` | 64 | **8** (hardcoded) |
| `< 16G` | 64 | **4** (hardcoded, "oof") |

The two lower tiers hardcoded `JOBS` independent of the actual core count, which over-subscribed the standard 4-core GitHub-hosted runners (`-j8` on a 4-vCPU box). It also fixed `NUM_FRAGMENTS=64` everywhere below 32 GB, which on the small-RAM/small-core CI machines we mostly target is denser than necessary.

Replace it with a four-tier rule driven by both cores *and* RAM:

| Detected | `NUM_FRAGMENTS` | `JOBS` |
|---|---:|---:|
| `< 7` cores | **32** | cores |
| `>= 7` cores, RAM `< 32G` (or unknown) | 64 | cores |
| `32G <= RAM < 64G` | cores × 2 | cores |
| `RAM >= 64G` | cores | cores |

Core/RAM detection (`ASSUME_NPROC` / `ASSUME_RAM`):

- macOS: `sysctl -n hw.physicalcpu` and `sysctl -n hw.memsize`. macOS x86 GitHub VMs have HT disabled and Apple Silicon has no SMT, so this is also logical-core count on every macOS host we see.
- Linux/Windows: `nproc` (logical cores) and `free --giga`.

Hyper-threading on x86: hosts like the standard 4-vCPU GitHub Linux/Windows runners are actually 2-physical + HT, and `nproc` reports 4 — using that as `JOBS` matches master's behavior on those hosts without hardcoding the value.

Resolved values on the current CI fleet:

| Runner | tier | `Build machine:` line |
|---|---|---|
| `macos-14` arm64 GH (3C / 7G) | small | `NUM_FRAGMENTS=32 -j3` |
| `macos-15-intel` (4C / 15G) | small | `NUM_FRAGMENTS=32 -j4` |
| Linux/Windows GH-hosted (4C / 16G) | small | `NUM_FRAGMENTS=32 -j4` |
| `rockylinux8` vcpkg containers on GH (4C / 16G) | small | `NUM_FRAGMENTS=32 -j4` |
| self-hosted arm64 (10C / 17G) | mid | `NUM_FRAGMENTS=64 -j10` |

The 32G+ tiers preserve master's high-RAM logic verbatim — they just don't fire on anything we run today.

## Verification — bindings step times

`build-test-distribute` builds bindings with `MODE=none`; `test-pip-build` builds with the default `MODE=release`. The two flavors take very different times and aren't directly comparable, so they're reported separately below.

### `build-test-distribute` (MODE=none) — PR run [26154522675](https://github.com/MeshInspector/MeshLib/actions/runs/26154522675) vs master run [26114829663](https://github.com/MeshInspector/MeshLib/actions/runs/26114829663)

**Faster on 28 of 31 paired jobs.** Highlights:

| Job | master | PR | Δ |
|---|---:|---:|---:|
| `macos-build-test (x64, Release)` | 25:37 | 19:39 | **−5:58** |
| `ubuntu-x64-build-test (ubuntu22, Debug, GCC-12)` | 12:10 | 7:13 | **−4:57** |
| `ubuntu-x64-build-test (ubuntu24, Release, GCC-14, OFF/OFF)` | 14:23 | 9:44 | **−4:39** |
| `ubuntu-x64-build-test (ubuntu24, Debug, Clang-18)` | 11:46 | 7:50 | **−3:56** |
| `ubuntu-x64-build-test (ubuntu24, Debug, GCC-14)` | 13:31 | 9:57 | **−3:34** |
| `linux-vcpkg-build-test (Release, x64, Clang 21)` | 14:49 | 11:26 | **−3:23** |
| `macos-build-test (arm64, Debug)` | 13:13 | 11:20 | **−1:53** |
| All 8 Windows configs | 7:32 – 9:05 | 6:50 – 8:15 | −0:14 to −1:51 |

Three configs regress by 1-2 min on small bindings steps (ubuntu22 Clang-14 Debug, ubuntu22 GCC-12 Release, ubuntu24 GCC-13 Debug) — within the shard-variance band we see across re-runs.

### `test-pip-build` (MODE=release) — PR run [26154522675](https://github.com/MeshInspector/MeshLib/actions/runs/26154522675) vs baseline run [26087331263](https://github.com/MeshInspector/MeshLib/actions/runs/26087331263)

Master push runs skip `test-pip-build` entirely, so the closest baseline is the earliest `test-pip-build`-labeled PR run, which exercised the same matrix with master's heuristic.

| Job | baseline | PR | Δ |
|---|---:|---:|---:|
| `macos-pip-build (x86)` | 36:22 | 25:22 | **−11:00** |
| `macos-pip-build (arm64)` | 16:13 | 12:49 | **−3:24** |
| `windows-pip-build` | 13:03 | 14:19 | +1:16 |
| `manylinux-pip-build (x86_64)` | — | 18:33 | (no baseline) |
| `manylinux-pip-build (aarch64)` | — | 11:26 | (no baseline) |

The `macos-pip-build (x86)` win is what originally motivated the investigation — that job's bindings step is down ~11 min, the largest single improvement in the matrix.
