### PR TITLE
add mesh parts over given vacant elements

### DIFF
--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -183,16 +183,6 @@ float Mesh::signedDistance( const Vector3f & pt, const MeshProjectionResult & pr
         return -std::sqrt( proj.distSq );
 }
 
-float Mesh::signedDistance( const Vector3f & pt, const MeshTriPoint & proj, const FaceBitSet * region ) const
-{
-    const auto projPt = triPoint( proj );
-    const float d = ( pt - projPt ).length();
-    if ( dot( projPt - pt, pseudonormal( proj, region ) ) <= 0 )
-        return d;
-    else
-        return -d;
-}
-
 float Mesh::signedDistance( const Vector3f & pt ) const
 {
     auto res = signedDistance( pt, FLT_MAX );
@@ -374,15 +364,15 @@ void Mesh::addMesh( const Mesh & from, PartMapping map, bool rearrangeTriangles 
     map.src2tgtVerts->forEach( [&]( VertId fromVert, VertId thisVert ) { points[thisVert] = from.points[fromVert]; } );
 }
 
-void Mesh::addMeshPart( const MeshPart & from, const PartMapping & map )
+void Mesh::addMeshPart( const MeshPart & from, const PartMapping & map, VacantElements * vacant )
 {
-    addMeshPart( from, false, {}, {}, map );
+    addMeshPart( from, false, {}, {}, map, vacant );
 }
 
 void Mesh::addMeshPart( const MeshPart & from, bool flipOrientation,
     const std::vector<EdgePath> & thisContours,
     const std::vector<EdgePath> & fromContours,
-    PartMapping map )
+    PartMapping map, VacantElements * vacant )
 {
     MR_TIMER;
     invalidateCaches();
@@ -390,7 +380,7 @@ void Mesh::addMeshPart( const MeshPart & from, bool flipOrientation,
     auto localVmap = VertMapOrHashMap::createHashMap();
     if ( !map.src2tgtVerts )
         map.src2tgtVerts = &localVmap;
-    topology.addPartByMask( from.mesh.topology, from.region, flipOrientation, thisContours, fromContours, map );
+    topology.addPartByMask( from.mesh.topology, from.region, flipOrientation, thisContours, fromContours, map, vacant );
     VertId lastPointId = topology.lastValidVert();
     if ( points.size() < lastPointId + 1 )
         points.resize( lastPointId + 1 );

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -496,12 +496,11 @@ Expected<PackMapping> Mesh::packOptimally( bool preserveAABBTree, ProgressCallba
     return map;
 }
 
-void Mesh::deleteFaces( const FaceBitSet & fs, const UndirectedEdgeBitSet * keepEdges )
+VacantElements Mesh::deleteFaces( const FaceBitSet & fs, const UndirectedEdgeBitSet * keepEdges )
 {
-    if ( fs.none() )
-        return;
-    topology.deleteFaces( fs, keepEdges );
-    invalidateCaches(); // some points can be deleted as well
+    if ( fs.any() )
+        invalidateCaches(); // some points can be deleted as well
+    return topology.deleteFaces( fs, keepEdges );
 }
 
 bool Mesh::projectPoint( const Vector3f& point, PointOnFace& res, float maxDistSq, const FaceBitSet * region, const AffineXf3f * xf ) const

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -237,7 +237,6 @@ struct [[nodiscard]] Mesh
     /// \return signed distance from pt to mesh: positive value - outside mesh, negative - inside mesh;
     /// this method can return wrong sign if the closest point is located on self-intersecting part of the mesh
     [[nodiscard]] MRMESH_API float signedDistance( const Vector3f & pt, const MeshProjectionResult & proj, const FaceBitSet * region = nullptr ) const;
-    [[deprecated]] MRMESH_API MR_BIND_IGNORE float signedDistance( const Vector3f & pt, const MeshTriPoint & proj, const FaceBitSet * region = nullptr ) const;
 
     /// given a point (pt) in 3D, computes the closest point on mesh, and
     /// \return signed distance from pt to mesh: positive value - outside mesh, negative - inside mesh;
@@ -394,12 +393,9 @@ struct [[nodiscard]] Mesh
     MRMESH_API void addMesh( const Mesh & from,
         // optionally returns mappings: from.id -> this.id
         FaceMap * outFmap, VertMap * outVmap = nullptr, WholeEdgeMap * outEmap = nullptr, bool rearrangeTriangles = false );
-    [[deprecated]] MR_BIND_IGNORE void addPart( const Mesh & from, FaceMap * outFmap = nullptr, VertMap * outVmap = nullptr, WholeEdgeMap * outEmap = nullptr, bool rearrangeTriangles = false )
-        { addMesh( from, outFmap, outVmap, outEmap, rearrangeTriangles ); }
 
     /// appends whole or part of another mesh as separate connected component(s) to this
-    MRMESH_API void addMeshPart( const MeshPart & from, const PartMapping & map );
-    [[deprecated]] MR_BIND_IGNORE void addPartByMask( const Mesh & from, const FaceBitSet & fromFaces, const PartMapping & map ) { addMeshPart( { from, &fromFaces }, map ); }
+    MRMESH_API void addMeshPart( const MeshPart & from, const PartMapping & map, VacantElements * vacant = {} );
 
     /// appends whole or part of another mesh to this joining added faces with existed ones along given contours
     /// \param flipOrientation true means that every (from) triangle is inverted before adding
@@ -407,10 +403,7 @@ struct [[nodiscard]] Mesh
         const std::vector<EdgePath> & thisContours = {}, // contours on this mesh that have to be stitched with
         const std::vector<EdgePath> & fromContours = {}, // contours on from mesh during addition
         // optionally returns mappings: from.id -> this.id
-        PartMapping map = {} );
-    [[deprecated]] MR_BIND_IGNORE void addPartByMask( const Mesh & from, const FaceBitSet & fromFaces, bool flipOrientation = false,
-        const std::vector<EdgePath> & thisContours = {}, const std::vector<EdgePath> & fromContours = {}, const PartMapping & map = {} )
-        { addMeshPart( { from, &fromFaces }, flipOrientation, thisContours, fromContours, map ); }
+        PartMapping map = {}, VacantElements * vacant = {} );
 
     /// creates new mesh from given triangles of this mesh
     MRMESH_API Mesh cloneRegion( const FaceBitSet & region, bool flipOrientation = false, const PartMapping & map = {} ) const;

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -395,10 +395,12 @@ struct [[nodiscard]] Mesh
         FaceMap * outFmap, VertMap * outVmap = nullptr, WholeEdgeMap * outEmap = nullptr, bool rearrangeTriangles = false );
 
     /// appends whole or part of another mesh as separate connected component(s) to this
+    /// optional \param vacant can be passed to copy elements not at the end, but over given ones, which the user guaranties to be free/lone
     MRMESH_API void addMeshPart( const MeshPart & from, const PartMapping & map, VacantElements * vacant = {} );
 
     /// appends whole or part of another mesh to this joining added faces with existed ones along given contours
     /// \param flipOrientation true means that every (from) triangle is inverted before adding
+    /// optional \param vacant can be passed to copy elements not at the end, but over given ones, which the user guaranties to be free/lone
     MRMESH_API void addMeshPart( const MeshPart & from, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, // contours on this mesh that have to be stitched with
         const std::vector<EdgePath> & fromContours = {}, // contours on from mesh during addition
@@ -423,6 +425,7 @@ struct [[nodiscard]] Mesh
     MRMESH_API Expected<PackMapping> packOptimally( bool preserveAABBTree, ProgressCallback cb );
 
     /// deletes multiple given faces, also deletes adjacent edges and vertices if they were not shared by remaining faces and not in \param keepEdges
+    /// return bit sets of all vacant elements in this mesh after deletion
     MRMESH_API VacantElements deleteFaces( const FaceBitSet & fs, const UndirectedEdgeBitSet * keepEdges = nullptr );
 
     /// finds the closest mesh point on this mesh (or its region) to given point;

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -423,7 +423,7 @@ struct [[nodiscard]] Mesh
     MRMESH_API Expected<PackMapping> packOptimally( bool preserveAABBTree, ProgressCallback cb );
 
     /// deletes multiple given faces, also deletes adjacent edges and vertices if they were not shared by remaining faces and not in \param keepEdges
-    MRMESH_API void deleteFaces( const FaceBitSet & fs, const UndirectedEdgeBitSet * keepEdges = nullptr );
+    MRMESH_API VacantElements deleteFaces( const FaceBitSet & fs, const UndirectedEdgeBitSet * keepEdges = nullptr );
 
     /// finds the closest mesh point on this mesh (or its region) to given point;
     /// \param point source location to look the closest to

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1936,7 +1936,7 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
     }
 
     auto * vacantEdges = vacant ? &vacant->edges : nullptr;
-    EdgeId lastNewEdge = vacant ? EdgeId{} : edges_.endId() - 2;
+    UndirectedEdgeId lastNewEdge = vacant ? UndirectedEdgeId{} : UndirectedEdgeId( edges_.endId() ) - 1;
     auto copyEdge = [&]( UndirectedEdgeId fromUe )
     {
         assert( !getAt( emap, fromUe ) );
@@ -1952,8 +1952,8 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
             }
         }
         else
-            lastNewEdge += 2;
-        setAt( emap, fromUe, lastNewEdge );
+            ++lastNewEdge;
+        setAt( emap, fromUe, EdgeId( lastNewEdge ) );
         if ( map.tgt2srcEdges )
             map.tgt2srcEdges->pushBack( UndirectedEdgeId{ lastNewEdge }, EdgeId{ fromUe } );
     };
@@ -1967,7 +1967,11 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
         {
             lastNewVert = vacantVerts->find_next( lastNewVert );
             if ( lastNewVert )
+            {
                 vacantVerts->reset( lastNewVert );
+                if ( updateValids_ )
+                    validVerts_.set( lastNewVert );
+            }
             else
             {
                 vacantVerts = nullptr;
@@ -1991,7 +1995,11 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
         {
             lastNewFace = vacantFaces->find_next( lastNewFace );
             if ( lastNewFace )
+            {
                 vacantFaces->reset( lastNewFace );
+                if ( updateValids_ )
+                    validFaces_.set( lastNewFace );
+            }
             else
             {
                 vacantFaces = nullptr;
@@ -2114,8 +2122,8 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
     }
 
     // translate edge records
-    if ( edges_.size() < lastNewEdge + 2 )
-        edges_.resizeNoInit( lastNewEdge + 2 );
+    if ( edges_.size() < 2 * ( lastNewEdge + 1 ) )
+        edges_.resizeNoInit( 2 * ( lastNewEdge + 1 ) );
     BitSetParallelFor( fromCopiedEdges, [&]( UndirectedEdgeId fromUe )
     {
         auto e0 = from.edges_[EdgeId{ fromUe }];

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1852,15 +1852,17 @@ void MeshTopology::computeAllFromEdges_()
     }
 }
 
-void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces, const PartMapping & map )
+void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces, const PartMapping & map, VacantElements * vacant )
 {
-    addPartByMask( from, fromFaces, false, {}, {}, map );
+    addPartByMask( from, fromFaces, false, {}, {}, map, vacant );
 }
 
 void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces0, bool flipOrientation,
     const std::vector<EdgePath> & thisContours,
     const std::vector<EdgePath> & fromContours,
-    const PartMapping & map )
+    const PartMapping & map,
+    VacantElements * vacant
+    )
 {
     MR_TIMER;
     const auto szContours = thisContours.size();
@@ -1933,15 +1935,27 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
         }
     }
 
-    const EdgeId firstNewEdge = edges_.endId();
-    EdgeId nextNewEdge = firstNewEdge;
+    auto * vacantEdges = vacant ? &vacant->edges : nullptr;
+    EdgeId lastNewEdge = vacant ? EdgeId{} : edges_.endId() - 2;
     auto copyEdge = [&]( UndirectedEdgeId fromUe )
     {
         assert( !getAt( emap, fromUe ) );
-        setAt( emap, fromUe, nextNewEdge );
+        if ( vacantEdges )
+        {
+            lastNewEdge = vacantEdges->find_next( lastNewEdge );
+            if ( lastNewEdge )
+                vacantEdges->reset( lastNewEdge );
+            else
+            {
+                vacantEdges = nullptr;
+                lastNewEdge = edges_.endId();
+            }
+        }
+        else
+            lastNewEdge += 2;
+        setAt( emap, fromUe, lastNewEdge );
         if ( map.tgt2srcEdges )
-            map.tgt2srcEdges->pushBack( UndirectedEdgeId{ nextNewEdge }, EdgeId{ fromUe } );
-        nextNewEdge += 2;
+            map.tgt2srcEdges->pushBack( UndirectedEdgeId{ lastNewEdge }, EdgeId{ fromUe } );
     };
 
     const VertId firstNewVert = edgePerVertex_.endId();
@@ -2072,7 +2086,8 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
     }
 
     // translate edge records
-    edges_.resizeNoInit( nextNewEdge );
+    if ( edges_.size() < lastNewEdge + 2 )
+        edges_.resizeNoInit( lastNewEdge + 2 );
     BitSetParallelFor( fromCopiedEdges, [&]( UndirectedEdgeId fromUe )
     {
         auto e0 = from.edges_[EdgeId{ fromUe }];

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1958,15 +1958,29 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
             map.tgt2srcEdges->pushBack( UndirectedEdgeId{ lastNewEdge }, EdgeId{ fromUe } );
     };
 
-    const VertId firstNewVert = edgePerVertex_.endId();
-    VertId nextNewVert = firstNewVert;
+    auto * vacantVerts = vacant ? &vacant->verts : nullptr;
+    VertId lastNewVert = vacant ? VertId{} : edgePerVertex_.endId() - 1;
     auto copyVert = [&]( VertId fromV )
     {
-        auto nv = nextNewVert++;
         assert( !getAt( vmap, fromV ) );
-        setAt( vmap, fromV, nv );
+        if ( vacantVerts )
+        {
+            lastNewVert = vacantVerts->find_next( lastNewVert );
+            if ( lastNewVert )
+                vacantVerts->reset( lastNewVert );
+            else
+            {
+                vacantVerts = nullptr;
+                lastNewVert = edgePerVertex_.endId();
+            }
+        }
+        else
+            ++lastNewVert;
+        setAt( vmap, fromV, lastNewVert );
         if ( map.tgt2srcVerts )
-            map.tgt2srcVerts->pushBack( nv, fromV );
+            map.tgt2srcVerts->pushBack( lastNewVert, fromV );
+        if ( updateValids_ )
+            ++numValidVerts_;
     };
 
     const FaceId firstNewFace = edgePerFace_.endId();
@@ -2101,12 +2115,12 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
     } );
 
     // translate vertex records
-    if ( updateValids_ )
+    if ( edgePerVertex_.size() < lastNewVert + 1 )
     {
-        validVerts_.autoResizeSet( firstNewVert, nextNewVert - firstNewVert, true );
-        numValidVerts_ += nextNewVert - firstNewVert;
+        if ( updateValids_ )
+            validVerts_.autoResizeSet( edgePerVertex_.endId(), lastNewVert + 1 - edgePerVertex_.size(), true );
+        edgePerVertex_.resizeNoInit( lastNewVert + 1 );
     }
-    edgePerVertex_.resizeNoInit( nextNewVert );
     BitSetParallelFor( fromCopiedVerts, [&]( VertId v )
     {
         for ( auto fromE : orgRing( from, v ) )

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1944,7 +1944,10 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
         {
             lastNewEdge = vacantEdges->find_next( lastNewEdge );
             if ( lastNewEdge )
+            {
+                assert( isLoneEdge( lastNewEdge ) );
                 vacantEdges->reset( lastNewEdge );
+            }
             else
             {
                 vacantEdges = nullptr;
@@ -1969,8 +1972,12 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
             if ( lastNewVert )
             {
                 vacantVerts->reset( lastNewVert );
+                assert( lastNewVert < edgePerVertex_.size() );
                 if ( updateValids_ )
+                {
+                    assert( !validVerts_.test( lastNewVert ) );
                     validVerts_.set( lastNewVert );
+                }
             }
             else
             {
@@ -1997,8 +2004,12 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
             if ( lastNewFace )
             {
                 vacantFaces->reset( lastNewFace );
+                assert( lastNewFace < edgePerFace_.size() );
                 if ( updateValids_ )
+                {
+                    assert( !validFaces_.test( lastNewFace ) );
                     validFaces_.set( lastNewFace );
+                }
             }
             else
             {

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1983,14 +1983,28 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
             ++numValidVerts_;
     };
 
-    const FaceId firstNewFace = edgePerFace_.endId();
-    FaceId nextNewFace = firstNewFace;
+    auto * vacantFaces = vacant ? &vacant->faces : nullptr;
+    FaceId lastNewFace = vacant ? FaceId{} : edgePerFace_.endId() - 1;
     auto copyFace = [&]( FaceId fromF )
     {
-        auto nf = nextNewFace++;
+        if ( vacantFaces )
+        {
+            lastNewFace = vacantFaces->find_next( lastNewFace );
+            if ( lastNewFace )
+                vacantFaces->reset( lastNewFace );
+            else
+            {
+                vacantFaces = nullptr;
+                lastNewFace = edgePerFace_.endId();
+            }
+        }
+        else
+            ++lastNewFace;
         if ( map.tgt2srcFaces )
-            map.tgt2srcFaces ->pushBack( nf, fromF );
-        setAt( fmap, fromF, nf );
+            map.tgt2srcFaces ->pushBack( lastNewFace, fromF );
+        setAt( fmap, fromF, lastNewFace );
+        if ( updateValids_ )
+            ++numValidFaces_;
     };
 
     // fill all maps
@@ -2133,12 +2147,12 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
     } );
 
     // translate face records
-    if ( updateValids_ )
+    if ( edgePerFace_.size() < lastNewFace + 1 )
     {
-        validFaces_.autoResizeSet( firstNewFace, nextNewFace - firstNewFace, true );
-        numValidFaces_ += nextNewFace - firstNewFace;
+        if ( updateValids_ )
+            validFaces_.autoResizeSet( edgePerFace_.endId(), lastNewFace + 1 - edgePerFace_.size(), true );
+        edgePerFace_.resizeNoInit( lastNewFace + 1 );
     }
-    edgePerFace_.resizeNoInit( nextNewFace );
     BitSetParallelFor( fromFaces, [&]( FaceId f )
     {
         for ( auto fromE : leftRing( from, f ) )

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -472,8 +472,10 @@ public:
         FaceMap * outFmap = nullptr, VertMap * outVmap = nullptr, WholeEdgeMap * outEmap = nullptr, ///< returns mappings: from.id -> this.id
         bool rearrangeTriangles = false );
 
-    /// the same but copies only portion of (from) specified by fromFaces,
+    /// appends the portion of (from) specified by fromFaces in addition to the current topology: creates new edges, faces, verts;
+    /// optional \param vacant can be passed to copy elements not at the end, but over given ones, which the user guaranties to be free/lone
     MRMESH_API void addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces, const PartMapping & map = {}, VacantElements * vacant = {} );
+
     /// This is skipped in the bindings because it conflicts with the overload taking a pointer in C#. Since that overload is strictly more useful, we're keeping that one.
     MR_BIND_IGNORE void addPartByMask( const MeshTopology & from, const FaceBitSet & fromFaces, const PartMapping & map = {}, VacantElements * vacant = {} )
         { addPartByMask( from, &fromFaces, map, vacant ); }
@@ -482,6 +484,7 @@ public:
     /// \param flipOrientation if true then every from triangle is inverted before adding
     /// \param thisContours contours on this mesh (no left face) that have to be stitched with
     /// \param fromContours contours on from mesh during addition (no left face if flipOrientation otherwise no right face)
+    /// optional \param vacant can be passed to copy elements not at the end, but over given ones, which the user guaranties to be free/lone
     MRMESH_API void addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, const std::vector<EdgePath> & fromContours = {},
         const PartMapping & map = {}, VacantElements * vacant = {} );
@@ -489,7 +492,7 @@ public:
     /// This is skipped in the bindings because it conflicts with the overload taking a pointer in C#. Since that overload is strictly more useful, we're keeping that one.
     MR_BIND_IGNORE void addPartByMask( const MeshTopology & from, const FaceBitSet & fromFaces, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, const std::vector<EdgePath> & fromContours = {},
-        const PartMapping & map = {} ) { addPartByMask( from, &fromFaces, flipOrientation, thisContours, fromContours, map ); }
+        const PartMapping & map = {}, VacantElements * vacant = {} ) { addPartByMask( from, &fromFaces, flipOrientation, thisContours, fromContours, map, vacant ); }
 
     /// for each triangle selects edgeWithLeft with minimal origin vertex
     MRMESH_API void rotateTriangles();

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -473,10 +473,10 @@ public:
         bool rearrangeTriangles = false );
 
     /// the same but copies only portion of (from) specified by fromFaces,
-    MRMESH_API void addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces, const PartMapping & map = {} );
+    MRMESH_API void addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces, const PartMapping & map = {}, VacantElements * vacant = {} );
     /// This is skipped in the bindings because it conflicts with the overload taking a pointer in C#. Since that overload is strictly more useful, we're keeping that one.
-    MR_BIND_IGNORE void addPartByMask( const MeshTopology & from, const FaceBitSet & fromFaces, const PartMapping & map = {} )
-        { addPartByMask( from, &fromFaces, map ); }
+    MR_BIND_IGNORE void addPartByMask( const MeshTopology & from, const FaceBitSet & fromFaces, const PartMapping & map = {}, VacantElements * vacant = {} )
+        { addPartByMask( from, &fromFaces, map, vacant ); }
 
     /// this version has more parameters
     /// \param flipOrientation if true then every from triangle is inverted before adding
@@ -484,7 +484,7 @@ public:
     /// \param fromContours contours on from mesh during addition (no left face if flipOrientation otherwise no right face)
     MRMESH_API void addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, const std::vector<EdgePath> & fromContours = {},
-        const PartMapping & map = {} );
+        const PartMapping & map = {}, VacantElements * vacant = {} );
 
     /// This is skipped in the bindings because it conflicts with the overload taking a pointer in C#. Since that overload is strictly more useful, we're keeping that one.
     MR_BIND_IGNORE void addPartByMask( const MeshTopology & from, const FaceBitSet & fromFaces, bool flipOrientation = false,

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -14,6 +14,13 @@
 namespace MR
 {
 
+struct VacantElements
+{
+    UndirectedEdgeBitSet edges;
+    VertBitSet verts;
+    FaceBitSet faces;
+};
+
 /// Mesh Topology
 /// \ingroup MeshGroup
 class MeshTopology
@@ -261,13 +268,6 @@ public:
 
     /// deletes the face, also deletes its edges and vertices if they were not shared by other faces and not in \param keepFaces
     MRMESH_API void deleteFace( FaceId f, const UndirectedEdgeBitSet * keepEdges = nullptr );
-
-    struct VacantElements
-    {
-        UndirectedEdgeBitSet edges;
-        VertBitSet verts;
-        FaceBitSet faces;
-    };
 
     /// deletes from this topology:
     /// 1) all the gives faces,

--- a/source/MRTest/MRMeshTests.cpp
+++ b/source/MRTest/MRMeshTests.cpp
@@ -155,11 +155,13 @@ TEST(MRMesh, AddPartByMaskOnVacantElements)
 {
     auto cube = makeCube();
 
+    // mesh1 has two cube components
     Mesh mesh1;
     mesh1.addMesh( cube );
     FaceBitSet fs = mesh1.topology.getValidFaces();
     mesh1.addMesh( cube );
 
+    // mesh2 has the first cube component deleted
     Mesh mesh2 = mesh1;
     EXPECT_EQ( mesh1, mesh2 );
     auto vacant = mesh2.deleteFaces( fs );
@@ -167,17 +169,20 @@ TEST(MRMesh, AddPartByMaskOnVacantElements)
     EXPECT_EQ( vacant.edges.count(), cube.topology.computeNotLoneUndirectedEdges() );
     EXPECT_EQ( vacant.verts.count(), cube.topology.numValidVerts() );
 
+    // mesh3 = mesh2 + first cube from mesh1
     Mesh mesh3 = mesh2;
     EXPECT_EQ( mesh3, mesh2 );
     mesh3.addMeshPart( { mesh1, &fs } );
-    EXPECT_NE( mesh3, mesh1 );
     EXPECT_EQ( mesh3.topology.numValidFaces(), mesh1.topology.numValidFaces() );
+    EXPECT_NE( mesh1.topology.getValidFaces(), mesh2.topology.getValidFaces() );
+    EXPECT_NE( mesh1.topology.getValidVerts(), mesh2.topology.getValidVerts() );
 
+    // put first cube from mesh1 in vacant space of mesh2
     mesh2.addMeshPart( { mesh1, &fs }, {}, &vacant );
-    EXPECT_EQ( mesh2, mesh1 );
     EXPECT_EQ( vacant.edges.count(), 0 );
     EXPECT_EQ( vacant.verts.count(), 0 );
     EXPECT_EQ( vacant.faces.count(), 0 );
+    EXPECT_EQ( mesh2, mesh1 );
 }
 
 TEST(MRMesh, AddPartByMaskAndStitch) 

--- a/source/MRTest/MRMeshTests.cpp
+++ b/source/MRTest/MRMeshTests.cpp
@@ -166,6 +166,18 @@ TEST(MRMesh, AddPartByMaskOnVacantElements)
     EXPECT_EQ( vacant.faces, fs );
     EXPECT_EQ( vacant.edges.count(), cube.topology.computeNotLoneUndirectedEdges() );
     EXPECT_EQ( vacant.verts.count(), cube.topology.numValidVerts() );
+
+    Mesh mesh3 = mesh2;
+    EXPECT_EQ( mesh3, mesh2 );
+    mesh3.addMeshPart( { mesh1, &fs } );
+    EXPECT_NE( mesh3, mesh1 );
+    EXPECT_EQ( mesh3.topology.numValidFaces(), mesh1.topology.numValidFaces() );
+
+    mesh2.addMeshPart( { mesh1, &fs }, {}, &vacant );
+    EXPECT_EQ( mesh2, mesh1 );
+    EXPECT_EQ( vacant.edges.count(), 0 );
+    EXPECT_EQ( vacant.verts.count(), 0 );
+    EXPECT_EQ( vacant.faces.count(), 0 );
 }
 
 TEST(MRMesh, AddPartByMaskAndStitch) 

--- a/source/MRTest/MRMeshTests.cpp
+++ b/source/MRTest/MRMeshTests.cpp
@@ -151,6 +151,23 @@ TEST(MRMesh, AddPartByMask)
     EXPECT_EQ( mesh.topology.lastNotLoneEdge(), 21_e ); // 11*2 = 22 half-edges in total
 }
 
+TEST(MRMesh, AddPartByMaskOnVacantElements)
+{
+    auto cube = makeCube();
+
+    Mesh mesh1;
+    mesh1.addMesh( cube );
+    FaceBitSet fs = mesh1.topology.getValidFaces();
+    mesh1.addMesh( cube );
+
+    Mesh mesh2 = mesh1;
+    EXPECT_EQ( mesh1, mesh2 );
+    auto vacant = mesh2.deleteFaces( fs );
+    EXPECT_EQ( vacant.faces, fs );
+    EXPECT_EQ( vacant.edges.count(), cube.topology.computeNotLoneUndirectedEdges() );
+    EXPECT_EQ( vacant.verts.count(), cube.topology.numValidVerts() );
+}
+
 TEST(MRMesh, AddPartByMaskAndStitch) 
 {
     Triangulation t{ { 0_v, 1_v, 2_v } };

--- a/source/MRTestC2/MRMeshBoolean.c
+++ b/source/MRTestC2/MRMeshBoolean.c
@@ -139,7 +139,7 @@ void testBooleanMultipleEdgePropogationSort( void )
         const MR_FaceBitSet* meshASupFaces = MR_MeshTopology_getValidFaces( MR_Mesh_Get_topology( meshASup ) );
 
         MR_MeshPart *mp = MR_MeshPart_Construct( meshASup, meshASupFaces );
-        MR_Mesh_addMeshPart_5( meshA, mp, &(bool){true}, borderVec, borderVec, NULL );
+        MR_Mesh_addMeshPart_6( meshA, mp, &(bool){true}, borderVec, borderVec, NULL, NULL );
         MR_MeshPart_Destroy( mp );
 
         MR_std_vector_std_vector_MR_EdgeId_Destroy( borderVec );


### PR DESCRIPTION
`Mesh::addMeshPart` and `MeshTopology::addPartByMask` functions take optional `VacantElements` argument, and put copied elements there first of all.

Test added.