### PR TITLE
i18n: Tune msgmerge arguments for less file changes

### DIFF
--- a/scripts/gettext/merge_po_from_pot.py
+++ b/scripts/gettext/merge_po_from_pot.py
@@ -47,6 +47,8 @@ if __name__ == "__main__":
             subprocess.run([
                 msgmerge,
                 "--update",
+                "--backup=none",
+                "--no-fuzzy-matching",
                 po_file,
                 pot_file,
             ], check=True)


### PR DESCRIPTION
By default `msgmerge` creates backup files (while we have a version control system called Git) and tries to auto-translate new records (unsuccessfully). This change disables both behaviors which leads to less mess during .po file updates.