### PR TITLE
ci: make MRBind build cache non-fatal

### DIFF
--- a/.github/actions/build-mrbind/action.yml
+++ b/.github/actions/build-mrbind/action.yml
@@ -70,6 +70,10 @@ runs:
     - name: Cache MRBind build
       id: cache
       uses: actions/cache@v5
+      # Cache-service errors (silent restore crashes, save upload failures) must
+      # not abort the build -- on miss we rebuild from scratch anyway, and the
+      # build script wipes `build/` first, so falling through is always safe.
+      continue-on-error: true
       with:
         path: ${{ inputs.mrbind-dir }}/build
         # Exactly one of the two SHA steps ran, so concatenation yields the SHA.


### PR DESCRIPTION
## Summary

Make `actions/cache@v5` non-fatal inside the `build-mrbind` composite action — a silent cache-service crash should not abort the whole job.

## Motivation

On PR #6121, the `windows-build-test (msvc-2019, Release, CMake, x64-windows-vs2019-meshlib)` job in [run 26152206642](https://github.com/MeshInspector/MeshLib/actions/runs/26152206642/job/76922322315) failed at the `Build MRBind` composite step in ~2 seconds with zero log output. Tracing the timeline:

- `Get MRBind submodule SHA` succeeded
- `actions/cache@v5` started at `09:00:14.67Z`, the next workflow step's group started at `09:00:15.25Z` — a 0.57 s gap with **no output at all**, while the two earlier `actions/cache@v5` invocations in the same job (CUDA cache, MSYS2 cache) both printed `Cache restored successfully` as expected
- the composite was marked `failure`, so `Generate C bindings`, `Build`, tests, archive, upload — all skipped

Looks like a transient cache-service blip causing the action to crash before its logger flushes anything. Even with debug logging enabled we'd still pay a full job failure for what should be a recoverable event.

## Fix

One-line `continue-on-error: true` on the cache step. On a cache-service error:

- the composite continues
- `steps.cache.outputs.cache-hit` is empty → the existing `if: steps.cache.outputs.cache-hit != 'true'` guards on the platform-specific `Build MRBind` sub-steps fire → MRBind rebuilds from scratch
- `install_mrbind_windows_msys2.bat` (and the Unix equivalent) wipes `build/` before rebuilding, so a partially restored cache dir is safe
- the post-action save still runs and repopulates the cache, so the next run is back to cache-hit speed

Worst-case cost on a transient failure: one rebuild (~10 min on Windows, less elsewhere) instead of a hard job failure that takes the entire matrix entry down.

## Test plan

- [x] CI green across all platforms that use `build-mrbind` ([run 26155116273](https://github.com/MeshInspector/MeshLib/actions/runs/26155116273)): 28 success, 11 skipped, **0 failures** across Windows (msvc-2019 + msvc-2022, Debug + Release), Linux vcpkg (x64 + arm64, Debug + Release, GCC 11 + Clang 21), Ubuntu (22.04 + 24.04, arm64 + x64, GCC 12 / 13 / 14), macOS (arm64 Debug + Release, x64 Release), and emscripten (singlethreaded + multithreaded + multithreaded-64bit, build + test).
- [x] Cache-hit path still short-circuits the build. On the exact matrix entry that failed silently on #6121 (`windows-build-test (msvc-2019, Release, CMake, x64-windows-vs2019-meshlib)`, [job 76932415924](https://github.com/MeshInspector/MeshLib/actions/runs/26155116273/job/76932415924)): the MRBind cache key was unchanged by this PR (only `action.yml` was touched, not the cache-key inputs), so the step hit cache (`Cache hit for: mrbind-build-windows-clang18-d5ca6d...`), the conditional `Build MRBind (Windows)` sub-step was skipped, and the next workflow step (`Generate C bindings`) immediately invoked the cached `mrbind` / `mrbind_gen_c` binaries. Post-action correctly logged `Cache hit occurred on the primary key ..., not saving cache.`
