### PR TITLE
macos: drop unused llvm@14 from requirements

### DIFF
--- a/requirements/macos.txt
+++ b/requirements/macos.txt
@@ -13,7 +13,6 @@ libharu
 libpng
 libtiff
 libzip
-llvm@14
 ninja
 nlohmann-json
 opencascade


### PR DESCRIPTION
## Summary

Removes `llvm@14` from `requirements/macos.txt`. Nothing in the repo references it — it appears to be vestigial from before the mrbind-driven `llvm@18` install was wired up.

## Why this is safe

- The only reference to `llvm@14` in the entire repo is the line being removed. No script, CMake file, or workflow uses it.
- On macOS the compiler is either AppleClang (`/usr/bin/clang++`) for the hosted runners or brew `llvm@18` for the self-hosted ARM runner. `llvm@18` is installed by `scripts/mrbind/install_deps_macos.sh` (driven by `scripts/mrbind/clang_version.txt`), not via `requirements/macos.txt`.
- `thirdparty/CMakeLists.txt` skips the openvdb-from-source build on `APPLE`, so macOS uses brew's `openvdb` binary and does not invoke `find_package(LLVM)`.
- The `-I.../opt/llvm/include` / `-L.../opt/llvm/lib` lines in `cmake/Modules/ConfigureHomebrew.cmake` set local CMake variables (`CPPFLAGS` / `LDFLAGS`) that are never propagated to `CMAKE_*_FLAGS`, and they reference the unversioned `opt/llvm` path (which doesn't exist when only `llvm@14` is installed) — so they couldn't have been doing anything even if they were wired up.
- Git history shows the line being bumped (`llvm@13` → `llvm@14` in #3938) but never re-justified or referenced from build code.

## CI savings

Measured on `macos-build-test (arm64, Debug)` (same hosted image and runner pool, so directly comparable):

| | `install_brew_requirements.sh` duration |
|---|---|
| master (with `llvm@14`) | 119.4 s |
| this PR (no `llvm@14`) | 97.7 s |
| **delta** | **−21.7 s (~18% faster)** |

`install_brew_requirements.sh` is invoked unconditionally by the `install-macos-thirdparty` action — even on a thirdparty-cache hit — so this applies to every macOS job on every run (three `macos-build-test` + two `macos-pip-build` rows ≈ 5 jobs/run, ~100 s of CI time per Build-Test-Distribute run). Also drops ~1 GB of brew install footprint.

## Test plan

- [x] macOS Intel (hosted) build + MRTest + pkg green
- [x] macOS ARM (hosted, `macos-14`) build + MRTest green
- [x] macOS self-hosted ARM (`brew-llvm18`) build + MRTest + pkg green
