### PR TITLE
Docs: update ThirdpartyList — OpenVDB Apache-2.0, hidapi link fix

### DIFF
--- a/doxygen/general_pages/ThirdpartyList.dox
+++ b/doxygen/general_pages/ThirdpartyList.dox
@@ -82,7 +82,8 @@ Below is a summary of all modules and their dependencies, so you can see what ea
 
 |Name                                                                                      |Description                                                                  |License             |
 |------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|--------------------|
-|<a rel="nofollow" href="https://github.com/AcademySoftwareFoundation/openvdb">OpenVDB</a> |efficient manipulation of sparse, time-varying, volumetric data discretized  |MPL2                |
+|<a rel="nofollow" href="https://github.com/AcademySoftwareFoundation/openvdb">OpenVDB</a> |efficient manipulation of sparse, time-varying, volumetric data discretized  |Apache-2.0          |
+|<a rel="nofollow" href="https://github.com/Blosc/c-blosc">c-blosc</a>                              |a blocking, shuffling and lossless compression library (transitive dep of OpenVDB) |BSD-3-Clause  |
 |<a rel="nofollow" href="https://sourceforge.net/projects/gdcm/">gdcm</a>                             |C++ library dedicated to reading/parsing and writing DICOM medical files     |BSD                 |
 
 ### MRCuda
@@ -105,7 +106,7 @@ Below is a summary of all modules and their dependencies, so you can see what ea
 |<a rel="nofollow" href="https://github.com/ocornut/imgui">Dear ImGui</a>               |a bloat-free graphical user interface library for C++                                               |MIT                          |
 |<a rel="nofollow" href="https://github.com/libcpr/cpr">Curl for People</a>             |Curl for People - a simple wrapper around libcurl                                                   |MIT                          |
 |<a rel="nofollow" href="https://github.com/dacap/clip">clip</a>                        |cross-platform C++ library to copy/paste clipboard content                                          |MIT                          |
-|<a rel="nofollow" href="https://github.com/signal11/hidapi">hidapi</a>                 |is a Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac, and Windows |HIDAPI, BSD-3-Clause, GPL-3.0|
+|<a rel="nofollow" href="https://github.com/libusb/hidapi">hidapi</a>                  |is a Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac, and Windows |HIDAPI, BSD-3-Clause, GPL-3.0|
 |<a rel="nofollow" href="https://fontawesome.com">Fontawesome</a>                       |is the Internet's icon library and toolkit, used by millions of designers, developers, and content creators |<a rel="nofollow" href="https://fontawesome.com/license/free">Fontawesome License</a>|
 |<a rel="nofollow" href="https://fonts.google.com/noto/specimen/Noto+Sans">NotoSans</a> |is a global font collection for writing in all modern and ancient languages                         |OPEN FONT|
 

--- a/doxygen/general_pages/ThirdpartyList.dox
+++ b/doxygen/general_pages/ThirdpartyList.dox
@@ -83,7 +83,6 @@ Below is a summary of all modules and their dependencies, so you can see what ea
 |Name                                                                                      |Description                                                                  |License             |
 |------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|--------------------|
 |<a rel="nofollow" href="https://github.com/AcademySoftwareFoundation/openvdb">OpenVDB</a> |efficient manipulation of sparse, time-varying, volumetric data discretized  |Apache-2.0          |
-|<a rel="nofollow" href="https://github.com/Blosc/c-blosc">c-blosc</a>                              |a blocking, shuffling and lossless compression library (transitive dep of OpenVDB) |BSD-3-Clause  |
 |<a rel="nofollow" href="https://sourceforge.net/projects/gdcm/">gdcm</a>                             |C++ library dedicated to reading/parsing and writing DICOM medical files     |BSD                 |
 
 ### MRCuda


### PR DESCRIPTION
## Summary

Three accuracy fixes to `doxygen/general_pages/ThirdpartyList.dox` (which renders to https://meshlib.io/documentation/ThirdParty.html), found during a compliance audit triggered by a paying customer (CIMsystem / Pyramis) asking for a third-party license file.

- **Add c-blosc** to the MRVoxels section. It is linked into MRVoxels (`source/MRVoxels/CMakeLists.txt:36` — `target_link_libraries(\${PROJECT_NAME} PRIVATE blosc)`) as a transitive dependency of OpenVDB, but is missing from the published list. License: BSD-3-Clause.
- **Update OpenVDB license: MPL2 → Apache-2.0.** OpenVDB was re-licensed when it joined the Academy Software Foundation in 2020 (see [RE-LICENSE_NOTE.txt](https://github.com/AcademySoftwareFoundation/openvdb/blob/master/RE-LICENSE_NOTE.txt) upstream). Current `LICENSE` file in upstream is Apache-2.0.
- **Update hidapi link: signal11/hidapi → libusb/hidapi.** The `signal11` repo has been archived and unmaintained for years; the live, MeshInspector-used fork is `libusb/hidapi`. MeshInspector's About/Credits dialog already uses the new URL ([MRAbout.h:47](https://github.com/MeshInspector/MeshInspectorCode/blob/master/source/MRPlugins/Others/MRAbout.h)) — this just aligns the public doc.

## Context

This is the lightest of three related compliance changes. Two larger ones are tracked separately:

- MeshInspector/MeshInspectorCode#7332 — Ship `third_party_licenses/` folder with the SDK distribution (the SDK currently does not include upstream LICENSE texts).
- MeshInspectorCode #7331 — About / Credits dialog should bundle LICENSE texts as resources instead of opening project home pages.

## Test plan

- [ ] Verify Doxygen renders the updated table without alignment issues.
- [ ] Confirm new c-blosc row appears under MRVoxels at https://meshlib.io/documentation/ThirdParty.html after next docs build.