### PR TITLE
Move MRMeshBoolean gtests to MRTest project

### DIFF
--- a/source/MRMesh/MRMeshBoolean.cpp
+++ b/source/MRMesh/MRMeshBoolean.cpp
@@ -5,17 +5,13 @@
 #include "MRIntersectionContour.h"
 #include "MRContoursCut.h"
 #include "MRTimer.h"
-#include "MRTorus.h"
-#include "MRMatrix3.h"
 #include "MRAffineXf3.h"
 #include "MRLog.h"
-#include "MRGTest.h"
 #include "MRFillContour.h"
 #include "MRPrecisePredicates3.h"
 #include "MRRegionBoundary.h"
 #include "MRMeshComponents.h"
 #include "MRMeshCollide.h"
-#include "MRCube.h"
 #include "MRMeshBuilder.h"
 #include "MRParallelFor.h"
 #include "MRBitSetParallelFor.h"
@@ -802,86 +798,6 @@ Expected<BooleanResultPoints> getBooleanPoints( const Mesh& meshA, const Mesh& m
     }
 
     return result;
-}
-
-TEST( MRMesh, MeshBoolean )
-{
-    Mesh meshA = makeTorus( 1.1f, 0.5f, 8, 8 );
-    Mesh meshB = makeTorus( 1.0f, 0.2f, 8, 8 );
-    meshB.transform( AffineXf3f::linear( Matrix3f::rotation( Vector3f::plusZ(), Vector3f::plusY() ) ) );
-
-    const float shiftStep = 0.2f;
-    const float angleStep = PI_F;/* *1.0f / 3.0f*/;
-    const std::array<Vector3f, 3> baseAxis{Vector3f::plusX(),Vector3f::plusY(),Vector3f::plusZ()};
-    for ( int maskTrans = 0; maskTrans < 8; ++maskTrans )
-    {
-        for ( int maskRot = 0; maskRot < 8; ++maskRot )
-        {
-            for ( float shift = 0.01f; shift < 0.2f; shift += shiftStep )
-            {
-                Vector3f shiftVec;
-                for ( int i = 0; i < 3; ++i )
-                    if ( maskTrans & ( 1 << i ) )
-                        shiftVec += shift * baseAxis[i];
-                for ( float angle = PI_F * 0.01f; angle < PI_F * 7.0f / 18.0f; angle += angleStep )
-                {
-                    Matrix3f rotation;
-                    for ( int i = 0; i < 3; ++i )
-                        if ( maskRot & ( 1 << i ) )
-                            rotation = Matrix3f::rotation( baseAxis[i], angle ) * rotation;
-
-                    AffineXf3f xf;
-                    xf = AffineXf3f::translation( shiftVec ) * AffineXf3f::linear( rotation );
-
-                    EXPECT_TRUE( boolean( meshA, meshB, BooleanOperation::Union, &xf ).valid() );
-                    EXPECT_TRUE( boolean( meshB, meshA, BooleanOperation::Intersection, &xf ).valid() );
-                }
-            }
-        }
-    }
-}
-
-
-TEST( MRMesh, BooleanMultipleEdgePropogationSort )
-{
-    Mesh meshA;
-    meshA.points = std::vector<Vector3f>
-    {
-        {0.0f,0.0f,0.0f},
-        {-0.5f,1.0f,0.0f},
-        {0.5f,1.0f,0.0f},
-        {0.0f,1.5f,0.5f},
-        {-1.0f,1.5f,0.0f},
-        {1.0f,1.5f,0.0f}
-    };
-    Triangulation tA =
-    {
-        { 0_v, 2_v, 1_v },
-        { 1_v, 2_v, 3_v },
-        { 3_v, 4_v, 1_v },
-        { 2_v, 5_v, 3_v },
-        { 3_v, 5_v, 4_v }
-    };
-    meshA.topology = MeshBuilder::fromTriangles( tA );
-    {
-        Mesh meshASup = meshA;
-        meshASup.points[3_v] = { 0.0f,1.5f,-0.5f };
-
-
-        auto border = trackRightBoundaryLoop( meshA.topology, meshA.topology.findHoleRepresentiveEdges()[0] );
-
-        meshA.addMeshPart( meshASup, true, { border }, { border } );
-    }
-
-    auto meshB = makeCube( Vector3f::diagonal( 2.0f ) );
-    meshB.transform( AffineXf3f::translation( Vector3f( -1.5f, -0.2f, -0.5f ) ) );
-
-
-    for ( int i = 0; i<int( BooleanOperation::Count ); ++i )
-    {
-        EXPECT_TRUE( boolean( meshA, meshB, BooleanOperation( i ) ).valid() );
-        EXPECT_TRUE( boolean( meshB, meshA, BooleanOperation( i ) ).valid() );
-    }
 }
 
 } //namespace MR

--- a/source/MRTest/MRMeshBooleanTests.cpp
+++ b/source/MRTest/MRMeshBooleanTests.cpp
@@ -1,0 +1,141 @@
+#include <MRMesh/MRMeshBoolean.h>
+#include <MRMesh/MRBooleanOperation.h>
+#include <MRMesh/MRMesh.h>
+#include <MRMesh/MRMeshBuilder.h>
+#include <MRMesh/MRTorus.h>
+#include <MRMesh/MRCube.h>
+#include <MRMesh/MRMatrix3.h>
+#include <MRMesh/MRAffineXf3.h>
+#include <MRMesh/MRRegionBoundary.h>
+#include <MRMesh/MRGTest.h>
+
+namespace MR
+{
+
+TEST( MRMesh, MeshBoolean )
+{
+    Mesh meshA = makeTorus( 1.1f, 0.5f, 8, 8 );
+    Mesh meshB = makeTorus( 1.0f, 0.2f, 8, 8 );
+    meshB.transform( AffineXf3f::linear( Matrix3f::rotation( Vector3f::plusZ(), Vector3f::plusY() ) ) );
+
+    const float shiftStep = 0.2f;
+    const float angleStep = PI_F;/* *1.0f / 3.0f*/;
+    const std::array<Vector3f, 3> baseAxis{Vector3f::plusX(),Vector3f::plusY(),Vector3f::plusZ()};
+    for ( int maskTrans = 0; maskTrans < 8; ++maskTrans )
+    {
+        for ( int maskRot = 0; maskRot < 8; ++maskRot )
+        {
+            for ( float shift = 0.01f; shift < 0.2f; shift += shiftStep )
+            {
+                Vector3f shiftVec;
+                for ( int i = 0; i < 3; ++i )
+                    if ( maskTrans & ( 1 << i ) )
+                        shiftVec += shift * baseAxis[i];
+                for ( float angle = PI_F * 0.01f; angle < PI_F * 7.0f / 18.0f; angle += angleStep )
+                {
+                    Matrix3f rotation;
+                    for ( int i = 0; i < 3; ++i )
+                        if ( maskRot & ( 1 << i ) )
+                            rotation = Matrix3f::rotation( baseAxis[i], angle ) * rotation;
+
+                    AffineXf3f xf;
+                    xf = AffineXf3f::translation( shiftVec ) * AffineXf3f::linear( rotation );
+
+                    EXPECT_TRUE( boolean( meshA, meshB, BooleanOperation::Union, &xf ).valid() );
+                    EXPECT_TRUE( boolean( meshB, meshA, BooleanOperation::Intersection, &xf ).valid() );
+                }
+            }
+        }
+    }
+}
+
+
+TEST( MRMesh, BooleanMultipleEdgePropogationSort )
+{
+    Mesh meshA;
+    meshA.points = std::vector<Vector3f>
+    {
+        {0.0f,0.0f,0.0f},
+        {-0.5f,1.0f,0.0f},
+        {0.5f,1.0f,0.0f},
+        {0.0f,1.5f,0.5f},
+        {-1.0f,1.5f,0.0f},
+        {1.0f,1.5f,0.0f}
+    };
+    Triangulation tA =
+    {
+        { 0_v, 2_v, 1_v },
+        { 1_v, 2_v, 3_v },
+        { 3_v, 4_v, 1_v },
+        { 2_v, 5_v, 3_v },
+        { 3_v, 5_v, 4_v }
+    };
+    meshA.topology = MeshBuilder::fromTriangles( tA );
+    {
+        Mesh meshASup = meshA;
+        meshASup.points[3_v] = { 0.0f,1.5f,-0.5f };
+
+
+        auto border = trackRightBoundaryLoop( meshA.topology, meshA.topology.findHoleRepresentiveEdges()[0] );
+
+        meshA.addMeshPart( meshASup, true, { border }, { border } );
+    }
+
+    auto meshB = makeCube( Vector3f::diagonal( 2.0f ) );
+    meshB.transform( AffineXf3f::translation( Vector3f( -1.5f, -0.2f, -0.5f ) ) );
+
+
+    for ( int i = 0; i<int( BooleanOperation::Count ); ++i )
+    {
+        EXPECT_TRUE( boolean( meshA, meshB, BooleanOperation( i ) ).valid() );
+        EXPECT_TRUE( boolean( meshB, meshA, BooleanOperation( i ) ).valid() );
+    }
+}
+
+TEST( MRMesh, BooleanResultMapper )
+{
+    Mesh meshA = makeTorus( 1.1f, 0.5f, 8, 8 );
+    Mesh meshB = makeTorus( 1.0f, 0.2f, 8, 8 );
+    meshB.transform( AffineXf3f::linear( Matrix3f::rotation( Vector3f::plusZ(), Vector3f::plusY() ) ) );
+
+    BooleanResultMapper mapper;
+    BooleanParameters params;
+    params.mapper = &mapper;
+
+    const auto result = boolean( meshA, meshB, BooleanOperation::Union, params );
+    EXPECT_TRUE( result.valid() );
+
+    const auto& meshAValidVerts = meshA.topology.getValidVerts();
+    const auto& meshBValidVerts = meshB.topology.getValidVerts();
+    const auto vMapA = mapper.map( meshAValidVerts, BooleanResultMapper::MapObject::A );
+    const auto vMapB = mapper.map( meshBValidVerts, BooleanResultMapper::MapObject::B );
+    EXPECT_EQ( vMapA.size(), 60 );
+    EXPECT_EQ( vMapB.size(), 204 );
+    EXPECT_EQ( vMapA.count(), 60 );
+    EXPECT_EQ( vMapB.count(), 48 );
+
+    const auto& meshAValidFaces = meshA.topology.getValidFaces();
+    const auto& meshBValidFaces = meshB.topology.getValidFaces();
+    const auto fMapA = mapper.map( meshAValidFaces, BooleanResultMapper::MapObject::A );
+    const auto fMapB = mapper.map( meshBValidFaces, BooleanResultMapper::MapObject::B );
+    EXPECT_EQ( fMapA.size(), 224 );
+    EXPECT_EQ( fMapB.size(), 416 );
+    EXPECT_EQ( fMapA.count(), 224 );
+    EXPECT_EQ( fMapB.count(), 192 );
+
+    const auto newFaces = mapper.newFaces();
+    EXPECT_EQ( newFaces.size(), 416 );
+    EXPECT_EQ( newFaces.count(), 252 );
+
+    const auto& mapsA = mapper.getMaps( BooleanResultMapper::MapObject::A );
+    EXPECT_EQ( mapsA.old2newVerts.size(), 160 );
+    EXPECT_EQ( mapsA.cut2newFaces.size(), 348 );
+    EXPECT_EQ( mapsA.cut2origin.size(), 348 );
+
+    const auto& mapsB = mapper.getMaps( BooleanResultMapper::MapObject::B );
+    EXPECT_EQ( mapsB.old2newVerts.size(), 160 );
+    EXPECT_EQ( mapsB.cut2newFaces.size(), 384 );
+    EXPECT_EQ( mapsB.cut2origin.size(), 384 );
+}
+
+} //namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -34,6 +34,7 @@
     <ClCompile Include="MRICPTests.cpp" />
     <ClCompile Include="MRLaplacianTests.cpp" />
     <ClCompile Include="MRMarchingCubesTests.cpp" />
+    <ClCompile Include="MRMeshBooleanTests.cpp" />
     <ClCompile Include="MRMeshComponentsTests.cpp" />
     <ClCompile Include="MRMeshDecimateTests.cpp" />
     <ClCompile Include="MRMeshIntersectTests.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -187,6 +187,9 @@
     <ClCompile Include="MRZipCompressTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRMeshBooleanTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />


### PR DESCRIPTION
## Summary

- Move the two `TEST(MRMesh, ...)` cases out of `source/MRMesh/MRMeshBoolean.cpp` into a new `source/MRTest/MRMeshBooleanTests.cpp`:
  - `MRMesh, MeshBoolean`
  - `MRMesh, BooleanMultipleEdgePropogationSort`
- Compare with `source/MRTestC2/MRMeshBoolean.c`. Of the three C tests:
  - `testMeshBoolean` — duplicate of the moved C++ `MeshBoolean` (same torus sweep, only minor differences in which operations are checked)
  - `testBooleanMultipleEdgePropogationSort` — duplicate of the moved C++ `BooleanMultipleEdgePropogationSort`
  - `testBooleanMapper` — **not duplicated** in C++. Ported into the new file as `TEST(MRMesh, BooleanResultMapper)` covering `BooleanResultMapper::map`, `newFaces`, and the `getMaps` accessors with the same hardcoded expected sizes/counts.
- Drop now-unused includes from `MRMeshBoolean.cpp` (`MRGTest`, `MRTorus`, `MRCube`, `MRMatrix3`).
- Add `MRMeshBooleanTests.cpp` to `source/MRTest/MRTest.vcxproj` and `.vcxproj.filters` (CMake side picks it up via `file(GLOB SOURCES "*.cpp")` automatically).

## Test plan

- [x] `MRTest` builds on every platform (Windows MSBuild + CMake, Linux GCC/Clang x64/arm64, macOS x64/arm64, Emscripten st/mt/mt-64, vcpkg) — all build-test jobs green
- [x] All three tests run and pass — confirmed in the emscripten-singlethreaded job log:
  - `[ OK ] MRMesh.MeshBoolean (267 ms)`
  - `[ OK ] MRMesh.BooleanMultipleEdgePropogationSort (4 ms)`
  - `[ OK ] MRMesh.BooleanResultMapper (2 ms)`
- [x] `MRMesh` library still builds with the trimmed include list (`MRMesh.dll` / `libMRMesh.so` link without errors)
- [x] `MRTestC2` continues to build (no tests were removed from it by this PR)
