### PR TITLE
ci: widen macos-pip-test coverage to macos-15/26 and macos-26-intel

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -694,22 +694,32 @@ jobs:
       # `runner-tier` exercises both the GitHub-hosted images that built the
       # wheels and our self-hosted fleet (different macOS versions / brew
       # prefixes), so we catch wheels that only run on a fresh hosted image.
+      # Multiple GitHub-hosted images per platform widen macOS-version
+      # coverage; collapsing the cross-product into `include` keeps each
+      # (platform, instance) pair explicit instead of relying on exclude.
       matrix:
-        platform: ["arm64", "x86"]
-        runner-tier: ["github", "self-hosted"]
         include:
-          - platform: "x86"
-            runner-tier: "github"
-            instance: macos-15-intel
-          - platform: "x86"
-            runner-tier: "self-hosted"
-            instance: macos-x64-build
           - platform: "arm64"
             runner-tier: "github"
             instance: macos-14
           - platform: "arm64"
+            runner-tier: "github"
+            instance: macos-15
+          - platform: "arm64"
+            runner-tier: "github"
+            instance: macos-26
+          - platform: "arm64"
             runner-tier: "self-hosted"
             instance: macos-arm-build-12
+          - platform: "x86"
+            runner-tier: "github"
+            instance: macos-15-intel
+          - platform: "x86"
+            runner-tier: "github"
+            instance: macos-26-intel
+          - platform: "x86"
+            runner-tier: "self-hosted"
+            instance: macos-x64-build
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Widens `macos-pip-test` in `.github/workflows/pip-build.yml` to exercise the freshly-built wheels on more macOS images:

- **arm64** — adds `macos-15` and `macos-26` alongside the existing `macos-14` (GitHub-hosted) and `macos-arm-build-12` (self-hosted).
- **x86** — adds `macos-26-intel` alongside the existing `macos-15-intel` (GitHub-hosted) and `macos-x64-build` (self-hosted).

The `platform` × `runner-tier` cross-product is collapsed into a flat `include` list, because adding more GitHub-hosted instances per platform would have made the `include` rows overwrite each other's `instance` value on the same `(platform, runner-tier)` pair.

No other jobs in the workflow are touched. Build matrices (`manylinux-pip-build`, `windows-pip-build`, `macos-pip-build`) are unchanged.

## CI scope

This PR only touches `macos-pip-test`, so non-mac platforms are disabled via labels. `full-ci` + `test-pip-build` are set so the pip-build workflow actually runs from `build-test-distribute.yml`.

## Test plan

- [x] `macos-pip-test` runs all 7 (platform, instance) combinations — confirmed in [run 26224902205](https://github.com/MeshInspector/MeshLib/actions/runs/26224902205):
  - [x] `(arm64, github, macos-14)`
  - [x] `(arm64, github, macos-15)` *(new)*
  - [x] `(arm64, github, macos-26)` *(new)*
  - [x] `(arm64, self-hosted, macos-arm-build-12)`
  - [x] `(x86, github, macos-15-intel)`
  - [x] `(x86, github, macos-26-intel)` *(new)*
  - [x] `(x86, self-hosted, macos-x64-build)`
- [x] All 7 jobs pass against Python 3.9–3.14.
