### PR TITLE
macos: pin CMAKE_OSX_DEPLOYMENT_TARGET to 12.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,14 @@ IF(APPLE)
     set(CMAKE_USE_WIN32_THREADS_INIT 0)
     set(CMAKE_USE_PTHREADS_INIT 1)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
+
+    # Pin LC_BUILD_VERSION minos so dylibs stay loadable on older macOS
+    # releases regardless of the build host's SDK. 12.7 matches the
+    # MACOS_MIN_VER passed by scripts/mrbind/generate.mk and the
+    # macosx_12_0_* wheel filenames. Caller's -D or env wins.
+    if(NOT CMAKE_OSX_DEPLOYMENT_TARGET AND NOT DEFINED ENV{MACOSX_DEPLOYMENT_TARGET})
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "12.7" CACHE STRING "Minimum macOS version to target for deployment")
+    endif()
 ENDIF()
 
 project(MeshLib CXX)


### PR DESCRIPTION
## Summary

Pins `CMAKE_OSX_DEPLOYMENT_TARGET=12.7` in the top-level `CMakeLists.txt` (inside the existing `IF(APPLE)` block, before `project()`) so MeshLib dylibs carry `LC_BUILD_VERSION minos=12.7` regardless of which macOS version the build host happens to be running.

## Why

Without this, CMake inherits the build host's SDK as the deployment target. Concrete failure on PR #6138's run:

```
dyld[5671]: Symbol not found: __ZNSt13exception_ptr31__from_native_exception_pointerEPv
  Referenced from: .../libMRViewer.dylib (built for macOS 15.0 which is newer than running OS)
  Expected in:     /usr/lib/libc++.1.dylib
```

The arm64 .pkg was produced on the self-hosted `MACBOOK-PRO-16-2021-TBI-2` runner (matched by `[self-hosted, macos, arm64, build]` in `build-test-macos.yml`), which is on macOS 15+. The resulting dylib's `LC_BUILD_VERSION` baked in `minos=15.0`, so it refused to load against macOS 14's `libc++`.

The wheel build chain already passes `MACOS_MIN_VER=12.7` for the mrbind step at `scripts/mrbind/generate.mk:621-622`, but the C++ MeshLib build (`scripts/build_source.sh` -> CMake) has no equivalent override, so the underlying dylibs the wheel ships pick up the build host's minos. The wheel happens to work today only because its build hosts (`macos-14` for arm64, `macos-15-intel` for x86) are older than every runner in the wheel test matrix; the `macosx_12_0_*` wheel filenames have been misleading all along.

Setting `CMAKE_OSX_DEPLOYMENT_TARGET=12.7` fixes both:

- .pkg dylibs become loadable on macOS >= 12.7, including macos-14.
- Wheel dylibs gain a real 12.7 floor matching their `macosx_12_0_*` plat-name.

The set is guarded `if(NOT CMAKE_OSX_DEPLOYMENT_TARGET AND NOT DEFINED ENV{MACOSX_DEPLOYMENT_TARGET})`, so a caller passing `-DCMAKE_OSX_DEPLOYMENT_TARGET=...` or setting `MACOSX_DEPLOYMENT_TARGET=` env still wins.

## Risks

1. **New libc++ symbols.** Anything using symbols that only exist in libc++ shipped with macOS 13+ (e.g. some `std::format`, `std::expected` paths, `__from_native_exception_pointer`) now fails at compile/link instead of at runtime on old macOS. That's the intended outcome but may surface latent uses that need fixing in this PR.
2. **Thirdparty dylibs.** The .pkg bundles brew-llvm18's libc++ etc. Those bottles are built against the brew host's SDK and aren't affected by this flag. If a future bottle update bumps any bundled dylib's minos above 12.7, the same dyld failure will resurface on the bundled dependency. Worth a one-time `otool -l Frameworks/MeshLib.framework/Versions/Current/lib/*.dylib | grep -A2 LC_BUILD_VERSION` sweep on the next built artifact to confirm everything stays <= 12.7.
3. **Non-Apple platforms.** `CMAKE_OSX_DEPLOYMENT_TARGET` is a no-op outside Apple builds; the assignment is inside `IF(APPLE)`.

## CI scope

Only macOS builds are affected by this change. Linux/Windows/emscripten jobs are disabled via labels. `test-pip-build` is set so the wheel chain is exercised alongside the .pkg build — both need to compile cleanly under the new floor.

## Test plan

Verified in [run 26239552001](https://github.com/MeshInspector/MeshLib/actions/runs/26239552001):

- [x] `macos-build-test` succeeds for x64-Release, arm64-Debug, arm64-Release (no new compile errors from the lower target).
- [x] `test-pip-build / macos-pip-build` succeeds for x86 and arm64.
- [x] `test-pip-build / macos-pip-test` passes on all 7 runners introduced in #6137:
  - [x] `(arm64, github, macos-14)` ← **regression-canary for this fix** (this is the runner whose wheel/pkg dyld failure motivated the change)
  - [x] `(arm64, github, macos-15)`
  - [x] `(arm64, github, macos-26)`
  - [x] `(arm64, self-hosted, macos-arm-build-12)`
  - [x] `(x86, github, macos-15-intel)`
  - [x] `(x86, github, macos-26-intel)`
  - [x] `(x86, self-hosted, macos-x64-build)`
- [x] `test-distribution / macos-test` still passes on macos-15-intel and macos-latest (the matrix on master).
- [ ] Follow-up after merge: rebase #6138, confirm the .pkg now installs/launches on macos-14 (this PR's fix is the precondition; #6142 separately handles the self-hosted sudo issue).
