### PR TITLE
ci: install pkg to user home on runners without passwordless sudo

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -238,17 +238,30 @@ jobs:
           echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token
           gh release download ${{ inputs.release_tag }} --pattern "${{ matrix.pkg_pattern }}" --repo ${{ github.repository }}
 
+      # Self-hosted runners have no passwordless sudo, so they install into
+      # ~/Library via `-target CurrentUserHomeDirectory` (enabled by the
+      # `<domains enable_currentUserHome="true">` in macos/Distribution.xml).
+      # GitHub-hosted runners keep the production sudo-into-/Library path so
+      # the end-user install scenario is still exercised.
       - name: Install Pkg
         run: |
-          sudo installer -pkg meshlib_*.pkg -target /
-          xargs brew install --quiet < /Library/Frameworks/MeshLib.framework/Versions/Current/requirements/macos.txt
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            sudo installer -pkg meshlib_*.pkg -target /
+            MESHLIB_FW=/Library/Frameworks/MeshLib.framework/Versions/Current
+          else
+            installer -pkg meshlib_*.pkg -target CurrentUserHomeDirectory
+            MESHLIB_FW="${HOME}/Library/Frameworks/MeshLib.framework/Versions/Current"
+          fi
+          xargs brew install --quiet < "${MESHLIB_FW}/requirements/macos.txt"
+          echo "MESHLIB_FW=${MESHLIB_FW}" >> "${GITHUB_ENV}"
+          echo "${MESHLIB_FW}/bin" >> "${GITHUB_PATH}"
 
       # [error] NSGL: Failed to find a suitable pixel format
       - name: Run MeshViewer
-        run: /Library/Frameworks/MeshLib.framework/Versions/Current/bin/MeshViewer -tryHidden -noEventLoop -unloadPluginsAtEnd
+        run: MeshViewer -tryHidden -noEventLoop -unloadPluginsAtEnd
 
       - name: Show meshconv help
-        run: /Library/Frameworks/MeshLib.framework/Versions/Current/bin/meshconv --help
+        run: meshconv --help
 
       - name: Build C++ examples
         working-directory: examples/cpp-examples

--- a/macos/Distribution.xml
+++ b/macos/Distribution.xml
@@ -7,6 +7,9 @@
     <conclusion file="Conclusion.rtf" mime-type="text/richtext"/>
     <pkg-ref id="com.MeshInspector.MeshLib"/>
     <options customize="never" require-scripts="false" hostArchitectures="x86_64,arm64"/>
+    <!-- Allow `installer -target CurrentUserHomeDirectory` (no sudo) in
+         addition to the default system-wide /Library install. -->
+    <domains enable_currentUserHome="true" enable_localSystem="true"/>
     <choices-outline>
         <line choice="default">
             <line choice="com.MeshInspector.MeshLib"/>


### PR DESCRIPTION
## Summary

Lets `test-distribution / macos-test` run on runners without passwordless sudo (e.g. our self-hosted macOS fleet) by installing the .pkg into `~/Library` via `installer -target CurrentUserHomeDirectory` instead of `sudo installer -target /`.

Two coordinated changes:

- **`macos/Distribution.xml`** — adds `<domains enable_currentUserHome="true" enable_localSystem="true"/>`. macOS rejects `-target CurrentUserHomeDirectory` by default unless the pkg explicitly opts into the currentUserHome domain. `enable_localSystem="true"` keeps the existing default system-wide install path, so end users are unaffected and the GUI installer still defaults to /Library.

- **`.github/workflows/test-distribution.yml`** — `macos-test` Install Pkg step branches on `runner.environment`:
  - **github-hosted** → keeps `sudo installer -pkg ... -target /` into `/Library/Frameworks/...` (production install path stays exercised end-to-end).
  - **self-hosted** → `installer -pkg ... -target CurrentUserHomeDirectory` into `~/Library/Frameworks/...` (no sudo).
  - The downstream steps (`Run MeshViewer`, `Show meshconv help`, `brew install -< macos.txt`, C/C++ example builds) are made install-location-agnostic by capturing `MESHLIB_FW` once and putting `$MESHLIB_FW/bin` on `$GITHUB_PATH`. CMake's `find_package(MeshLib CONFIG REQUIRED)` in the examples auto-discovers the framework via `CMAKE_SYSTEM_FRAMEWORK_PATH` (`~/Library/Frameworks` is in the macOS default), so no `-DCMAKE_PREFIX_PATH=` is needed.

## Why this came up

PR #6138 expanded the `macos-test` matrix to include the self-hosted runners `macos-arm-build-12` and `macos-x64-build`, and both failed at "Install Pkg" with `sudo: a password is required` — the runner service on those hosts runs as a non-admin user, so `sudo installer` never succeeds. This PR is one of the two follow-ups discussed in #6138's thread (the other is #6141, which pinned `CMAKE_OSX_DEPLOYMENT_TARGET=12.7` and is now in master). With both in master, #6138 can be rebased and the full 7-runner matrix should go green.

## CI scope

Only macOS distribution testing is affected. Non-mac jobs are disabled via labels. `full-ci` is set so `upload_artifacts` is true and `test-distribution` actually runs from `build-test-distribute.yml`.

## Limitations of this PR's own CI run

Master's current `macos-test` matrix has only the two GitHub-hosted runners (`macos-15-intel`, `macos-latest`). Both take the github-hosted branch of the new `if [ "${{ runner.environment }}" = "github-hosted" ]`, so the new self-hosted branch is **not exercised** by this PR's own CI. What this PR's run did verify:

- the new branching, env-var capture, and `$GITHUB_PATH` plumbing don't break the existing github-hosted path,
- the `<domains>` addition to `Distribution.xml` doesn't break .pkg generation or system-wide installs.

The self-hosted branch is verified once #6138 rebases on top and its matrix expansion lands.

## Test plan

Verified in [run 26240775524](https://github.com/MeshInspector/MeshLib/actions/runs/26240775524):

- [x] `test-distribution / macos-test (x64, macos-15-intel, *x64.pkg)` still passes — .pkg installs to /Library via sudo (the github-hosted code path).
- [x] `test-distribution / macos-test (arm64, macos-latest, *arm.pkg)` still passes — same code path.
- [x] No downstream step regresses on the env-var captured paths (`Run MeshViewer`, `Show meshconv help`, examples builds).
- [x] `upload-distributions` succeeds — the `<domains>` addition to `Distribution.xml` doesn't break `productbuild`.
- [x] All 3 `macos-build-test` variants compile cleanly (x64-Release, arm64-Debug, arm64-Release).
- [ ] Follow-up after merge: rebase #6138, confirm the self-hosted rows (`macos-arm-build-12`, `macos-x64-build`) reach "Install Pkg" without sudo and proceed through MeshViewer / meshconv / examples.
