### PR TITLE
Port MRFixSelfIntersections tests from MRTestC2 to MRTest

### DIFF
--- a/source/MRTest/MRFixSelfIntersectionsTests.cpp
+++ b/source/MRTest/MRFixSelfIntersectionsTests.cpp
@@ -1,0 +1,31 @@
+#include <MRMesh/MRFixSelfIntersections.h>
+#include <MRMesh/MRMesh.h>
+#include <MRMesh/MRTorus.h>
+#include <MRMesh/MRBitSet.h>
+#include <MRMesh/MRGTest.h>
+
+namespace MR
+{
+
+TEST( MRMesh, FixSelfIntersections )
+{
+    Mesh mesh = makeTorusWithSelfIntersections( 1.0f, 0.2f, 32, 16 );
+    EXPECT_EQ( mesh.topology.getValidFaces().count(), 1024 );
+
+    auto intersections = SelfIntersections::getFaces( mesh, false );
+    EXPECT_TRUE( intersections.has_value() );
+    EXPECT_EQ( intersections->count(), 128 );
+
+    SelfIntersections::Settings settings;
+    settings.method = SelfIntersections::Settings::Method::CutAndFill;
+    settings.touchIsIntersection = false;
+    EXPECT_TRUE( SelfIntersections::fix( mesh, settings ).has_value() );
+
+    EXPECT_EQ( mesh.topology.getValidFaces().count(), 1194 );
+
+    intersections = SelfIntersections::getFaces( mesh, false );
+    EXPECT_TRUE( intersections.has_value() );
+    EXPECT_EQ( intersections->count(), 0 );
+}
+
+} //namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -29,6 +29,7 @@
     <ClCompile Include="MRExtractIsolinesTests.cpp" />
     <ClCompile Include="MRFeaturesTests.cpp" />
     <ClCompile Include="MRFillHoleTests.cpp" />
+    <ClCompile Include="MRFixSelfIntersectionsTests.cpp" />
     <ClCompile Include="MRMeshCollideTests.cpp" />
     <ClCompile Include="MRGridSamplingTests.cpp" />
     <ClCompile Include="MRICPTests.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -190,6 +190,9 @@
     <ClCompile Include="MRMeshBooleanTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRFixSelfIntersectionsTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />


### PR DESCRIPTION
Convert the `testFixSelfIntersections` test case from `source/MRTestC2/MRFixSelfIntersections.c` to a regular C++ gtest in a new file `source/MRTest/MRFixSelfIntersectionsTests.cpp`, following the pattern established for `MRMeshBoolean` in #6132.

The new test (`MRMesh.FixSelfIntersections`):

- builds a torus with self-intersections via `makeTorusWithSelfIntersections`;
- verifies the initial valid face count (1024) and that 128 self-intersecting faces are reported;
- runs `SelfIntersections::fix` with `CutAndFill` and `touchIsIntersection=false`;
- checks the post-fix face count (1194) and that no intersections remain.

`MRTest.vcxproj` / `.vcxproj.filters` are updated to include the new file; the CMake build picks it up via the existing `*.cpp` glob.

The original C test is left in place for now.
