### PR TITLE
ci: widen test-distribution macos-test Intel coverage; bump fastmcpp

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -224,6 +224,12 @@ jobs:
           - arch: x64
             runner: macos-15-intel
             pkg_pattern: '*x64.pkg'
+          - arch: x64
+            runner: macos-26-intel
+            pkg_pattern: '*x64.pkg'
+          - arch: x64
+            runner: macos-x64-build
+            pkg_pattern: '*x64.pkg'
           - arch: arm64
             runner: macos-latest  # github-hosted Apple Silicon
             pkg_pattern: '*arm.pkg'


### PR DESCRIPTION
## Summary

Carves out the Intel-only subset of #6138 so it can land independently:

- **`test-distribution / macos-test`** gains two x64 rows alongside the existing `macos-15-intel`:
  - `macos-26-intel` (GitHub-hosted, newer macOS)
  - `macos-x64-build` (self-hosted Mac Pro 2013 on Monterey 12)

  The arm64 row stays at the single `macos-latest` runner — exactly as in master. No arm64 build host or test runner is touched.

- **`thirdparty/fastmcpp`** bumped to `c5271bc` (MeshInspector/fastmcpp#2, already merged into main). That PR widens fastmcpp's `_LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION 0` workaround so it also fires under AppleClang, both in `clang.hpp`'s `#if` and at the `CMAKE_CXX_COMPILER_ID` gate in CMakeLists.txt.

  Without this bump, `libMRMcp.dylib` (built with AppleClang for the x64 .pkg) references `__from_native_exception_pointer` — a libc++ helper absent from `/usr/lib/libc++.1.dylib` on macOS 12. MeshViewer then aborts at load time on Mac Pro 2013 / Monterey:

  ```
  dyld: Symbol not found: __ZNSt13exception_ptr31__from_native_exception_pointerEPv
    Referenced from: .../libMRMcp.dylib
    Expected in:     /usr/lib/libc++.1.dylib
  ```

  The submodule bump is what makes the new `macos-x64-build` matrix row actually pass.

## Why not also include the arm64 changes from #6138

The arm64 side of #6138 expanded the matrix to `macos-14` / `macos-15` / `macos-26` / `macos-arm-build-12`, and to make `macos-14` pass it also had to rebuild Homebrew's `cpr` formula from source on the arm64 build host (the prebuilt `arm64_sequoia` cpr bottle ships with `LC_BUILD_VERSION minos=15` and references the same `__from_native_exception_pointer` symbol).

That arm64 rebuild trick only works because our self-hosted arm64 build hosts happen to carry an older Xcode whose libc++ properly suppresses the symbol at the `MACOSX_DEPLOYMENT_TARGET=12.7` we pass; on a GitHub-hosted `macos-15` arm64 runner (latest Xcode) the same rebuild would *re*introduce the symbol. The arm64 path is therefore an undocumented invariant on the build hosts' Xcode version, and worth landing separately once we have a host-independent fix (likely building cpr in MeshLib's own source tree rather than via brew).

This PR sidesteps that whole question — it keeps the arm64 test on `macos-latest` (a current macOS, where the brew cpr bottle's libc++ symbol does resolve), so no rebuild is needed.

## CI scope

Only macOS distribution testing is affected. Non-mac jobs are disabled via labels. `full-ci` is set so `upload_artifacts` is true and `test-distribution` actually runs from `build-test-distribute.yml`.

## Test plan

Verified in [run 26288059992](https://github.com/MeshInspector/MeshLib/actions/runs/26288059992):

- [x] All `test-distribution / macos-test` rows pass:
  - [x] `(x64, macos-15-intel)`
  - [x] `(x64, macos-26-intel)` *(new)*
  - [x] `(x64, macos-x64-build)` *(new — canary for the fastmcpp fix on Monterey)*
  - [x] `(arm64, macos-latest)` *(unchanged from master)*
- [x] No arm64 build or test configuration has changed vs master.
- [x] All 3 `macos-build-test` variants succeed; `upload-distributions` succeeds.

## Related

- Subset of #6138.
- Depends on the already-merged MeshInspector/fastmcpp#2.
- Builds on the runner-environment branching in `Install Pkg` from #6142 (already in master).
