### PR TITLE
MCP: rename tool ids from dot- to underscore-namespacing

### DIFF
--- a/source/MRViewer/MRFileDialog.cpp
+++ b/source/MRViewer/MRFileDialog.cpp
@@ -440,7 +440,7 @@ std::vector<std::filesystem::path> runDialog( const MR::FileDialog::Parameters& 
         {
             MR::UI::TestEngine::appendStatusMessage( fmt::format(
                 "TestEngine-triggered file dialog: {}. "
-                "Call ui.stageFileDialogPaths(...) with the right path(s) before pressing the button.",
+                "Call ui_stageFileDialogPaths(...) with the right path(s) before pressing the button.",
                 ex.error() ) );
             return {};
         }

--- a/source/MRViewer/MRMcpCommon.cpp
+++ b/source/MRViewer/MRMcpCommon.cpp
@@ -26,7 +26,7 @@ Expected<std::shared_ptr<Object>> resolveId( uint64_t id )
         if ( obj.get() == asPtr )
             return obj;
     }
-    return unexpected( fmt::format( "No object with id {}. Call scene.listObjectTree to enumerate.", id ) );
+    return unexpected( fmt::format( "No object with id {}. Call scene_listObjectTree to enumerate.", id ) );
 }
 
 } // namespace MR::Mcp

--- a/source/MRViewer/MRMcpCommon.h
+++ b/source/MRViewer/MRMcpCommon.h
@@ -17,7 +17,7 @@ namespace Mcp
 // Pointer -> id (as a JSON number). Matches the `##<id>` suffix in ImGui labels for the same object.
 uint64_t idOf( const Object* obj );
 
-// Resolve a raw-pointer id (as returned by scene.listObjectTree) to a shared_ptr<Object>, verifying
+// Resolve a raw-pointer id (as returned by scene_listObjectTree) to a shared_ptr<Object>, verifying
 // the object is still reachable from SceneRoot. Defends against stale ids into freed memory.
 Expected<std::shared_ptr<Object>> resolveId( uint64_t id );
 

--- a/source/MRViewer/MRSceneMcp.cpp
+++ b/source/MRViewer/MRSceneMcp.cpp
@@ -50,7 +50,7 @@ static Expected<Object*> pickRoot( const nlohmann::json& args )
     return resolved->get();
 }
 
-// Same translation/rotation/scale shape that `scene.setObjectState` accepts. Rotation is XYZ-Euler
+// Same translation/rotation/scale shape that `scene_setObjectState` accepts. Rotation is XYZ-Euler
 // in degrees. Agents can read-modify-write without matrix math.
 struct DecomposedXf { Vector3f translation, rotationDeg, scale; };
 
@@ -74,7 +74,7 @@ static AffineXf3f composeXf( const DecomposedXf& d )
     return xf;
 }
 
-// Parse the `transform` subobject accepted by scene.setObjectState. Every field is optional;
+// Parse the `transform` subobject accepted by scene_setObjectState. Every field is optional;
 // omitted components fall back to identity (translation=0, rotation=0, scale=1). `scale` may be
 // a scalar (applies uniformly) or a 3-element array.
 static DecomposedXf parseTransform( const nlohmann::json& t )
@@ -390,7 +390,7 @@ static nlohmann::json mcpSceneGetObject( const nlohmann::json& args )
             out["bytes"] = encode64( bytes.data(), bytes.size() );
             return;
         }
-        throw std::runtime_error( "scene.getObject requires either `filePath` or `extension`." );
+        throw std::runtime_error( "scene_getObject requires either `filePath` or `extension`." );
     } );
     return out;
 }
@@ -436,7 +436,7 @@ static nlohmann::json mcpSceneAddObject( const nlohmann::json& args )
         }
         else
         {
-            throw std::runtime_error( "scene.addObject requires either `filePath` or `bytes`+`extension`+`name`." );
+            throw std::runtime_error( "scene_addObject requires either `filePath` or `bytes`+`extension`+`name`." );
         }
 
         auto loaded = loadObjectFromFile( path );
@@ -458,8 +458,8 @@ static nlohmann::json mcpSceneAddObject( const nlohmann::json& args )
 }
 
 static constexpr std::string_view kSceneIdSemantics =
-    "`id`: opaque uint64 from `scene.listObjectTree` / `scene.getObjectInfo`. Same integer appears as the `##<id>` "
-    "suffix in ImGui labels for the object, so it's usable across `scene.*` and `ui.*`. "
+    "`id`: opaque uint64 from `scene_listObjectTree` / `scene_getObjectInfo`. Same integer appears as the `##<id>` "
+    "suffix in ImGui labels for the object, so it's usable across `scene_*` and `ui_*`. "
     "Invalidated when the object is removed; subsequent calls with a stale id return a typed error.\n\n";
 
 MR_ON_INIT{
@@ -485,13 +485,13 @@ MR_ON_INIT{
     };
 
     server.addTool(
-        /*id*/  "scene.listObjectTree",
+        /*id*/  "scene_listObjectTree",
         /*name*/"List scene objects (subtree)",
         /*desc*/std::string( kSceneIdSemantics ) +
                 "Flat depth-first list of every descendant of `rootId` (root itself excluded; pass `rootId = 0` or "
                 "omit to walk from the scene root). Each row carries its own `parentId`, so the tree structure is "
                 "recoverable. `transform` decomposes the object's xf into `{translation:[x,y,z], rotation:[rx,ry,rz], "
-                "scale:[sx,sy,sz]}` (rotation is XYZ-Euler in degrees) — same shape `scene.setObjectState` accepts. "
+                "scale:[sx,sy,sz]}` (rotation is XYZ-Euler in degrees) — same shape `scene_setObjectState` accepts. "
                 "`type` values include `\"Mesh\"`, `\"Point Cloud\"`, `\"Polyline\"`, `\"Voxel Volume\"`.",
         /*input_schema*/Schema::Object{}.addMemberOpt( "rootId", Schema::Number{} ),
         /*output_schema*/Schema::Array( entrySchema() ),
@@ -499,13 +499,13 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/  "scene.getObjectInfo",
+        /*id*/  "scene_getObjectInfo",
         /*name*/"Get scene object info",
         /*desc*/std::string( kSceneIdSemantics ) +
-                "Return a single object's row (same shape as `scene.listObjectTree` entries) plus `childIds` (direct "
+                "Return a single object's row (same shape as `scene_listObjectTree` entries) plus `childIds` (direct "
                 "children), `worldBox` (axis-aligned world-space bounding box), `info` (human-readable property "
                 "lines - e.g. vertex/face counts, area - from the UI's info panel), and `visualization` (current "
-                "render-time properties — colors, alpha, size, flags; see `scene.setObjectState` for field semantics; "
+                "render-time properties — colors, alpha, size, flags; see `scene_setObjectState` for field semantics; "
                 "fields that don't apply to this object's type are omitted).",
         /*input_schema*/Schema::Object{}.addMember( "id", Schema::Number{} ),
         /*output_schema*/entrySchema()
@@ -519,7 +519,7 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/  "scene.setObjectState",
+        /*id*/  "scene_setObjectState",
         /*name*/"Set scene object state",
         /*desc*/std::string( kSceneIdSemantics ) +
                 "Mutate an existing object. Every field other than `id` is optional; absent fields leave state alone. "
@@ -552,7 +552,7 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/  "scene.removeObject",
+        /*id*/  "scene_removeObject",
         /*name*/"Remove scene object",
         /*desc*/std::string( kSceneIdSemantics ) +
                 "Detach the object from its parent (recursive — removing a group removes its subtree). Undoable.",
@@ -562,7 +562,7 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/  "scene.getObject",
+        /*id*/  "scene_getObject",
         /*name*/"Serialize scene object (to file or inline bytes)",
         /*desc*/std::string( kSceneIdSemantics ) +
                 "Serialize an object to an STL/OBJ/PLY/etc. format. Pass either `filePath` (server-side path; "
@@ -579,7 +579,7 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/  "scene.addObject",
+        /*id*/  "scene_addObject",
         /*name*/"Add scene object from file or bytes",
         /*desc*/std::string( kSceneIdSemantics ) +
                 "Load one or more objects into the scene. Pass either `filePath` (server-side path to an STL/OBJ/PLY/etc. "

--- a/source/MRViewer/MRSystemMcp.cpp
+++ b/source/MRViewer/MRSystemMcp.cpp
@@ -74,7 +74,7 @@ MR_ON_INIT{
     Server& server = getDefaultServer();
 
     server.addTool(
-        /*id*/  "system.log",
+        /*id*/  "system_log",
         /*name*/"Read tail of MeshInspector log",
         /*desc*/"Return the last `maxLines` lines (default 100, capped at 1000) from MeshInspector's spdlog file. "
                 "Each entry is a raw, pre-formatted line, e.g. `\"[27/04/26 16:18:53.767] [info] MCP server started "
@@ -86,7 +86,7 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/  "system.info",
+        /*id*/  "system_info",
         /*name*/"Build and host environment info",
         /*desc*/"Snapshot of MeshInspector / host metadata used by the About dialog: `version`, `OS`, `CPU`, plus "
                 "GPU / CUDA / framebuffer / monitor info when available. The `version` string is prefixed with "

--- a/source/MRViewer/MRToolsMcp.cpp
+++ b/source/MRViewer/MRToolsMcp.cpp
@@ -141,11 +141,11 @@ static nlohmann::json mcpToolsAction( const nlohmann::json& args )
             const auto& selected = SceneCache::getAllObjects<const Object, ObjectSelectivityType::Selected>();
             auto reason = item->isAvailable( selected );
             if ( !reason.empty() )
-                throw std::runtime_error( fmt::format( "tools.action {}: {}", id, reason ) );
+                throw std::runtime_error( fmt::format( "tools_action {}: {}", id, reason ) );
         }
         // Mark the frame as TE-driven so any TE-gated hook the action triggers
         // (file-dialog bypass via stageFileDialogPaths, etc.) sees the flag set.
-        // tools.action calls item->action() directly without going through
+        // tools_action calls item->action() directly without going through
         // TestEngine::createButton, which is the other code path that sets it.
         UI::TestEngine::markFrameTriggered();
         item->action();
@@ -160,30 +160,30 @@ MR_ON_INIT{
     Server& server = getDefaultServer();
 
     server.addTool(
-        /*id*/"tools.listAll",
+        /*id*/"tools_listAll",
         /*name*/"List all tool ids",
         /*desc*/"Sorted array of every registered tool/plugin id, regardless of which ribbon tab is currently rendered. "
-                "Pass interesting ids to `tools.getInfo` for caption / tab / type / status / tooltip, or to "
-                "`tools.action` to open or fire the tool. Same id space as the ribbon `ui.pressButton` entries.",
+                "Pass interesting ids to `tools_getInfo` for caption / tab / type / status / tooltip, or to "
+                "`tools_action` to open or fire the tool. Same id space as the ribbon `ui_pressButton` entries.",
         /*input_schema*/Schema::Object{},
         /*output_schema*/Schema::Array( Schema::String{} ),
         /*func*/mcpToolsListAll
     );
 
     server.addTool(
-        /*id*/"tools.listActive",
+        /*id*/"tools_listActive",
         /*name*/"List active tool ids",
         /*desc*/"Sorted array of currently-active tool ids — state plugins whose dialog is open. Empty when no tool is "
-                "open. Subset of `tools.listAll`.",
+                "open. Subset of `tools_listAll`.",
         /*input_schema*/Schema::Object{},
         /*output_schema*/Schema::Array( Schema::String{} ),
         /*func*/mcpToolsListActive
     );
 
     server.addTool(
-        /*id*/"tools.getInfo",
+        /*id*/"tools_getInfo",
         /*name*/"Get tool metadata (batch)",
-        /*desc*/"Look up metadata for one or more tool ids (from `tools.listAll`). "
+        /*desc*/"Look up metadata for one or more tool ids (from `tools_listAll`). "
                 "`type`: `\"button\"` (one-shot) | `\"stateBlocking\"` (modal-style dialog) | `\"stateNonBlocking\"`. "
                 "`status`: `\"available\"` | `\"disabled: <reason>\"` (active state plugins are always reported "
                 "available so they can be toggled off). `tab` is the ribbon tab name or `\"\"` for non-tabbed items "
@@ -207,11 +207,11 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/"tools.action",
+        /*id*/"tools_action",
         /*name*/"Toggle/fire tool by id",
         /*desc*/"Equivalent to clicking the tool's ribbon button. State plugins toggle open/closed; one-shot buttons "
-                "run their action. Errors if the id isn't in `tools.listAll`, or if the tool is currently disabled "
-                "(message has the same shape as `ui.pressButton` disabled errors). Returns `{active}` — the tool's "
+                "run their action. Errors if the id isn't in `tools_listAll`, or if the tool is currently disabled "
+                "(message has the same shape as `ui_pressButton` disabled errors). Returns `{active}` — the tool's "
                 "post-call active state (always `false` for one-shot buttons).",
         /*input_schema*/Schema::Object{}.addMember( "id", Schema::String{} ),
         /*output_schema*/Schema::Object{}.addMember( "active", Schema::Bool{} ),

--- a/source/MRViewer/MRUITestEngine.h
+++ b/source/MRViewer/MRUITestEngine.h
@@ -218,7 +218,7 @@ private:
 
 // Explicitly mark the current frame as TestEngine-driven. Use from MCP tool
 // handlers that fire plugin actions on a path that does NOT go through
-// `createButton()` (e.g. `tools.action`) but should still trigger TE-gated
+// `createButton()` (e.g. `tools_action`) but should still trigger TE-gated
 // hooks (file-dialog bypass, etc.). Call from the GUI thread before invoking
 // the action.
 MRVIEWER_API void markFrameTriggered();

--- a/source/MRViewer/MRUiMcp.cpp
+++ b/source/MRViewer/MRUiMcp.cpp
@@ -79,7 +79,7 @@ static nlohmann::json mcpToolListAllUiEntries( const nlohmann::json& args )
 
 // Drain any TestEngine status messages emitted during a just-dispatched UI action and surface
 // them as a tool error. Run on the GUI thread because TE state isn't thread-safe.
-// Non-static so MRToolsMcp.cpp's `tools.action` handler can reuse it across TUs.
+// Non-static so MRToolsMcp.cpp's `tools_action` handler can reuse it across TUs.
 void surfaceTestEngineStatusMessages()
 {
     std::vector<std::string> msgs;
@@ -178,7 +178,7 @@ static nlohmann::json mcpToolWriteValue( const nlohmann::json& args )
 static constexpr std::string_view kPathSemantics =
     "`path`: array of entry names from the root (empty = root). Whitespace-sensitive. "
     "Names may contain `##<suffix>` — a hidden ImGui uniqueness marker; pass the name VERBATIM "
-    "as returned by `ui.listEntries` / `ui.listAllEntries`, do not strip `##<suffix>`.\n"
+    "as returned by `ui_listEntries` / `ui_listAllEntries`, do not strip `##<suffix>`.\n"
     "`type`: `button` | `group` | `int` | `uint` | `float` | `string`.\n"
     "`status`: `\"available\"` | `\"disabled: <reason>\"` (widget greyed out) | "
     "`\"disabled: blocked by modal '<name>'\"` (dismiss the modal first).\n\n";
@@ -207,9 +207,9 @@ MR_ON_INIT{
     Server& server = getDefaultServer();
 
     server.addTool(
-        /*id*/"ui.listEntries",
+        /*id*/"ui_listEntries",
         /*name*/"List UI entries (one level)",
-        /*desc*/withPreamble( "List the direct children of `path`. Use `ui.listAllEntries` to get the entire subtree in one call." ),
+        /*desc*/withPreamble( "List the direct children of `path`. Use `ui_listAllEntries` to get the entire subtree in one call." ),
         /*input_schema*/Schema::Object{}.addMember( "path", Schema::Array( Schema::String{} ) ),
         /*output_schema*/Schema::Array(
             Schema::Object{}
@@ -221,9 +221,9 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/"ui.listAllEntries",
+        /*id*/"ui_listAllEntries",
         /*name*/"List UI entries (full subtree)",
-        /*desc*/withPreamble( "Flat depth-first dump of every entry in the subtree at `path` (omit or empty = whole tree). Each row carries its own `path`, so tree structure is recoverable. Prefer this for first-contact exploration; use `ui.listEntries` for a single level after a state change." ),
+        /*desc*/withPreamble( "Flat depth-first dump of every entry in the subtree at `path` (omit or empty = whole tree). Each row carries its own `path`, so tree structure is recoverable. Prefer this for first-contact exploration; use `ui_listEntries` for a single level after a state change." ),
         /*input_schema*/Schema::Object{}.addMemberOpt( "path", Schema::Array( Schema::String{} ) ),
         /*output_schema*/Schema::Array(
             Schema::Object{}
@@ -236,7 +236,7 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/"ui.pressButton",
+        /*id*/"ui_pressButton",
         /*name*/"Click UI button",
         /*desc*/withPreamble( "Click the button at `path` (must end in a `type == \"button\"` entry). Fails if `status` starts with `\"disabled\"`." ),
         /*input_schema*/Schema::Object{}.addMember( "path", Schema::Array( Schema::String{} ) ),
@@ -245,39 +245,39 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/"ui.stageFileDialogPaths",
+        /*id*/"ui_stageFileDialogPaths",
         /*name*/"Stage paths for next TestEngine-triggered file dialog",
         /*desc*/
             "Pre-load the path(s) that the next OS file/folder dialog opened by a "
-            "ui.pressButton-driven click will return. The dialog is skipped — no native "
+            "ui_pressButton-driven click will return. The dialog is skipped — no native "
             "modal appears — and the caller (Open / Save / Browse...) receives the staged "
             "paths. Single-shot: consumed by the next dialog. Use absolute paths in UTF-8. "
-            "Stage before calling ui.pressButton on a button that opens a file dialog; if no "
-            "paths are staged when such a button is pressed, ui.pressButton fails with a "
+            "Stage before calling ui_pressButton on a button that opens a file dialog; if no "
+            "paths are staged when such a button is pressed, ui_pressButton fails with a "
             "status message asking you to stage first. Validation: number of paths must "
             "match the dialog's multiselect mode; for open dialogs each path must exist with "
             "the right type (file vs directory); for save dialogs existence is not required "
             "but the path must not already exist as a directory. Real human clicks (not from "
-            "ui.pressButton) always show the native dialog and ignore staged paths.",
+            "ui_pressButton) always show the native dialog and ignore staged paths.",
         /*input_schema*/Schema::Object{}.addMember( "paths", Schema::Array( Schema::String{} ) ),
         /*output_schema*/Schema::Object{},
         /*func*/mcpToolStageFileDialogPaths
     );
 
-    // (idSuffix, displayType) -- `idSuffix` is the CamelCase suffix on ui.readValue*/ui.writeValue*;
+    // (idSuffix, displayType) -- `idSuffix` is the CamelCase suffix on ui_readValue*/ui_writeValue*;
     // `displayType` matches the `type` field in listEntries output.
     auto handleValueType = [&]<typename T>( const std::string& idSuffix, const std::string& displayType )
     {
         const std::string readDesc = std::is_same_v<T, std::string>
-            ? "Read the string value at `path`. If the response contains `allowedValues`, `ui.writeValue" + idSuffix + "` must pass one of those strings."
-            : "Read the " + displayType + " value at `path`. Bounds `min`/`max` are inclusive for `ui.writeValue" + idSuffix + "`.";
+            ? "Read the string value at `path`. If the response contains `allowedValues`, `ui_writeValue" + idSuffix + "` must pass one of those strings."
+            : "Read the " + displayType + " value at `path`. Bounds `min`/`max` are inclusive for `ui_writeValue" + idSuffix + "`.";
 
         const std::string writeDesc = std::is_same_v<T, std::string>
-            ? "Set the string value at `path`. Must match `allowedValues` (from `ui.readValue" + idSuffix + "`) when present. Fails if `status` starts with `\"disabled\"`."
-            : "Set the " + displayType + " value at `path`. Must be within the inclusive `[min, max]` from `ui.readValue" + idSuffix + "`. Fails if `status` starts with `\"disabled\"`.";
+            ? "Set the string value at `path`. Must match `allowedValues` (from `ui_readValue" + idSuffix + "`) when present. Fails if `status` starts with `\"disabled\"`."
+            : "Set the " + displayType + " value at `path`. Must be within the inclusive `[min, max]` from `ui_readValue" + idSuffix + "`. Fails if `status` starts with `\"disabled\"`.";
 
         server.addTool(
-            /*id*/"ui.readValue" + idSuffix,
+            /*id*/"ui_readValue" + idSuffix,
             /*name*/"Read UI " + displayType + " value",
             /*desc*/withPreamble( readDesc ),
             /*input_schema*/Schema::Object{}.addMember( "path", Schema::Array( Schema::String{} ) ),
@@ -296,7 +296,7 @@ MR_ON_INIT{
         );
 
         server.addTool(
-            /*id*/"ui.writeValue" + idSuffix,
+            /*id*/"ui_writeValue" + idSuffix,
             /*name*/"Write UI " + displayType + " value",
             /*desc*/withPreamble( writeDesc ),
             /*input_schema*/Schema::Object{}.addMember( "path", Schema::Array( Schema::String{} ) ).addMember( "value", std::is_same_v<T, std::string> ? static_cast<Schema::Base &&>( Schema::String{} ) : static_cast<Schema::Base &&>( Schema::Number{} ) ),
@@ -311,12 +311,12 @@ MR_ON_INIT{
     handleValueType.operator()<std::string  >( "String", "string" );
 
     server.addTool(
-        /*id*/"ui.progressStatus",
+        /*id*/"ui_progressStatus",
         /*name*/"Read progress bar state",
         /*desc*/"Snapshot of the global progress bar. Returns `{active: false}` if no long-running operation is in "
                 "flight, else `{active: true, title: string, percent: number}`. `title` is the operation name passed "
                 "to the underlying `ProgressBar::order(...)` (e.g. \"Boolean\", \"Loading\"). `percent` is 0-100. "
-                "Poll this while `ui.*` dispatch is blocked by a `'Progress'` modal — once `active: false` comes "
+                "Poll this while `ui_*` dispatch is blocked by a `'Progress'` modal — once `active: false` comes "
                 "back, the UI is responsive again.",
         /*input_schema*/Schema::Object{},
         /*output_schema*/Schema::Object{}

--- a/source/MRViewer/MRViewerMcp.cpp
+++ b/source/MRViewer/MRViewerMcp.cpp
@@ -134,7 +134,7 @@ static nlohmann::json mcpViewerFit( const nlohmann::json& args )
         for ( const Vector3f& pt : points )
             box.include( pt );
         if ( !box.valid() )
-            throw std::runtime_error( "viewer.fit: the given objects and points contribute no bounding volume." );
+            throw std::runtime_error( "viewer_fit: the given objects and points contribute no bounding volume." );
         vp.preciseFitBoxToScreenBorder( { box, factor } );
     } );
     skipFramesAfterInput();
@@ -326,10 +326,10 @@ MR_ON_INIT{
     Server& server = getDefaultServer();
 
     server.addTool(
-        /*id*/  "viewer.fit",
+        /*id*/  "viewer_fit",
         /*name*/"Fit camera to scene or a subset",
         /*desc*/"Frame a set of objects and/or world-space points in the active viewport. Pass `objectIds` (scene-object "
-                "ids from `scene.listObjectTree`) and/or `points` (3-element `[x,y,z]` arrays). If both are present, "
+                "ids from `scene_listObjectTree`) and/or `points` (3-element `[x,y,z]` arrays). If both are present, "
                 "their bounding volumes are unioned. If neither is given, fits the whole scene (same as the UI's "
                 "\"Fit\" action). `factor` (default 1.0) controls framing margin — higher means more screen coverage. "
                 "The camera angle is preserved (no canonical-view snapping).",
@@ -342,7 +342,7 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/  "viewer.setupCamera",
+        /*id*/  "viewer_setupCamera",
         /*name*/"Set camera forward and up directions",
         /*desc*/"Point the camera along `forwardDir` (a world-space direction vector pointing from the camera toward "
                 "the subject). `upDir` sets the screen-up direction; it is automatically orthogonalized against "
@@ -356,7 +356,7 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/  "viewer.captureScreenshot",
+        /*id*/  "viewer_captureScreenshot",
         /*name*/"Capture viewport screenshot",
         /*desc*/"Render the viewer to a PNG. Default (`includeUi: true`) captures the whole window including panels, ribbon, and dialogs; set "
                 "`includeUi: false` to capture only the 3D viewport. "
@@ -382,7 +382,7 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/  "viewer.sendMouseEvent",
+        /*id*/  "viewer_sendMouseEvent",
         /*name*/"Inject a mouse event",
         /*desc*/"Queue a mouse event on the viewer's event loop. `type` is one of `down`, `up`, `click`, `move`, `scroll`. "
                 "`button` is `left`/`right`/`middle` (required for `down`/`up`/`click`). `x`/`y` are window pixels, "
@@ -402,7 +402,7 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/  "viewer.sendKeyboardEvent",
+        /*id*/  "viewer_sendKeyboardEvent",
         /*name*/"Inject a keyboard event",
         /*desc*/"Queue a keyboard event on the viewer's event loop. `type` is one of `down`, `up`, `press`, `repeat`. "
                 "`key` is either a single printable character (e.g. `\"a\"`, `\"A\"`, `\"5\"`) or a named key "
@@ -420,13 +420,13 @@ MR_ON_INIT{
     );
 
     server.addTool(
-        /*id*/  "viewer.shutdown",
+        /*id*/  "viewer_shutdown",
         /*name*/"Close MeshInspector",
         /*desc*/"Cleanly stop MeshInspector's event loop and exit the process. Returns immediately so the MCP "
                 "response can flush before the server socket closes; the actual shutdown happens on the next frame. "
                 "After this call the gateway's `launch` tool can bring MeshInspector back up. "
                 "If the scene has unsaved changes, an `Application Close` modal is raised instead of exiting; "
-                "check `ui.listEntries` for the modal and dismiss it with the `Cancel` / `Don't Save` / `Save` buttons.",
+                "check `ui_listEntries` for the modal and dismiss it with the `Cancel` / `Don't Save` / `Save` buttons.",
         /*input_schema*/Schema::Object{},
         /*output_schema*/Schema::Object{},
         /*func*/mcpViewerShutdown


### PR DESCRIPTION
## Summary

- Claude Desktop validates frontend MCP tool names against `^[a-zA-Z0-9_-]{1,64}$` and rejects ids like `ui.pressButton`. Claude Code clients aren't affected (they internally translate `.` -> `_` before display), but anything talking to the MCP server directly is.
- Rename all 32 tool ids dot- -> underscore-namespacing (`ui.listEntries` -> `ui_listEntries`, `scene.removeObject` -> `scene_removeObject`, etc.); update every desc/error/comment reference accordingly. No schema or behavior change.
- Pure mechanical string-rename. No new files, no `.vcxproj` edits.

## Test plan

- [x] CI builds green on every platform
- [x] After merge: regenerate the gateway tools cache; tools/list returns underscore names; tool calls dispatch correctly