### PR TITLE
MCP: image / resource content blocks for screenshot + getObject (with /api/ mode parity)

### DIFF
--- a/source/MRMCPGateway/MRMCPGateway.cpp
+++ b/source/MRMCPGateway/MRMCPGateway.cpp
@@ -233,6 +233,10 @@ int main( int argc, char** argv )
     // joining its listener thread.
     auto transport = std::make_unique<MLClientTransport>(
         cfg.targetUrl, cfg.ssePath, cfg.messagesPath );
+    // Raw pointer retained for the proxied-`tools/call` bypass below. `templateClient`
+    // takes ownership of the unique_ptr but keeps the underlying object alive for
+    // main()'s duration, so the raw pointer remains valid.
+    MLClientTransport* transportPtr = transport.get();
     fastmcpp::client::Client templateClient( std::move( transport ) );
 
     fastmcpp::ProxyApp proxy(
@@ -252,7 +256,7 @@ int main( int argc, char** argv )
     //  2. Avoid fastmcpp's initialize handler calling `proxy.list_all_resources/templates/prompts`,
     //     which each invoke our client factory and probe the backend — making `initialize` slow
     //     enough to trip `claude mcp list`'s health-check timeout when the backend is offline.
-    auto handler = [inner]( const fastmcpp::Json& req ) -> fastmcpp::Json
+    auto handler = [inner, transportPtr]( const fastmcpp::Json& req ) -> fastmcpp::Json
     {
         const std::string method = req.is_object() ? req.value( "method", std::string{} ) : std::string{};
         if ( method == "initialize" )
@@ -267,6 +271,38 @@ int main( int argc, char** argv )
                     { "serverInfo", { { "name", "MRMCPGateway" }, { "version", "0.1" } } },
                 } },
             };
+        }
+
+        // Bypass fastmcpp's `ProxyApp` round-trip for forwarded `tools/call`
+        // requests: fastmcpp's `client::EmbeddedResourceContent` is flat (uri/blob/
+        // mimeType siblings of `type`) and its proxy re-emit echoes that flat shape,
+        // which spec-compliant MCP clients (e.g., Claude Code's Zod validator)
+        // reject. Forwarding the raw JSON-RPC through the transport preserves MI's
+        // spec-correct nested `{type: resource, resource: {...}}` shape end-to-end.
+        // Local tools (`launch`, `status`) still go through `inner` so their
+        // gateway-side handlers fire.
+        if ( method == "tools/call" && req.is_object() && req.contains( "params" )
+             && req["params"].is_object() )
+        {
+            const auto& params = req["params"];
+            const std::string toolName = params.value( "name", std::string{} );
+            static const std::set<std::string> kLocalTools = { "launch", "status" };
+            if ( !toolName.empty() && !kLocalTools.count( toolName ) )
+            {
+                const auto id = req.contains( "id" ) ? req.at( "id" ) : fastmcpp::Json();
+                try
+                {
+                    fastmcpp::Json result = transportPtr->request( "tools/call", params );
+                    return fastmcpp::Json{ { "jsonrpc", "2.0" }, { "id", id }, { "result", std::move( result ) } };
+                }
+                catch ( const std::exception& e )
+                {
+                    return fastmcpp::Json{
+                        { "jsonrpc", "2.0" }, { "id", id },
+                        { "error", { { "code", -32603 }, { "message", e.what() } } },
+                    };
+                }
+            }
         }
 
         fastmcpp::Json resp = inner( req );

--- a/source/MRMCPGateway/MRMCPGateway.cpp
+++ b/source/MRMCPGateway/MRMCPGateway.cpp
@@ -233,10 +233,7 @@ int main( int argc, char** argv )
     // joining its listener thread.
     auto transport = std::make_unique<MLClientTransport>(
         cfg.targetUrl, cfg.ssePath, cfg.messagesPath );
-    // Raw pointer retained for the proxied-`tools/call` bypass below. `templateClient`
-    // takes ownership of the unique_ptr but keeps the underlying object alive for
-    // main()'s duration, so the raw pointer remains valid.
-    MLClientTransport* transportPtr = transport.get();
+    MLClientTransport* transportPtr = transport.get(); // retained for raw `tools/call` forwarding
     fastmcpp::client::Client templateClient( std::move( transport ) );
 
     fastmcpp::ProxyApp proxy(
@@ -273,14 +270,9 @@ int main( int argc, char** argv )
             };
         }
 
-        // Bypass fastmcpp's `ProxyApp` round-trip for forwarded `tools/call`
-        // requests: fastmcpp's `client::EmbeddedResourceContent` is flat (uri/blob/
-        // mimeType siblings of `type`) and its proxy re-emit echoes that flat shape,
-        // which spec-compliant MCP clients (e.g., Claude Code's Zod validator)
-        // reject. Forwarding the raw JSON-RPC through the transport preserves MI's
-        // spec-correct nested `{type: resource, resource: {...}}` shape end-to-end.
-        // Local tools (`launch`, `status`) still go through `inner` so their
-        // gateway-side handlers fire.
+        // Forward proxied tools/call raw so MCP-spec content shapes survive
+        // (fastmcpp's ProxyApp reshapes resource blocks off-spec). Local
+        // tools stay on `inner`.
         if ( method == "tools/call" && req.is_object() && req.contains( "params" )
              && req["params"].is_object() )
         {

--- a/source/MRMcp/MRMcp.cpp
+++ b/source/MRMcp/MRMcp.cpp
@@ -12,6 +12,8 @@
 #include "MRViewer/MRViewer.h"
 
 #include <fstream>
+#include <optional>
+#include <string>
 #include <type_traits>
 
 
@@ -155,24 +157,61 @@ void writeJsonError( httplib::Response& res, int httpStatus, std::string message
     }.dump(), "application/json" );
 }
 
-// Inspect a tool's raw output for the file-output convention `{bytes, contentType}`,
-// transparently unwrapping one level of `{"result": {...}}` (the existing wrap used
-// by tools in MRViewerMcp / MRUiMcp / MRSystemMcp / MRSceneMcp).
-//
-// Returns a pointer to the inner object that has both `bytes` and `contentType`,
-// or `nullptr` if the convention isn't matched.
-const nlohmann::json* matchFileOutput( const nlohmann::json& result )
+// Extracted binary payload for the `/api/tools/call/<id>` raw-bytes response.
+// Strings are copied (not viewed) so the caller can outlive the source JSON without
+// lifetime gymnastics.
+struct BinaryOutput
 {
-    auto isFileShape = []( const nlohmann::json& j ) {
-        return j.is_object()
+    std::string data;     // base64-encoded
+    std::string mimeType;
+};
+
+// Detect a binary payload in a tool's raw output for the `/api/` HTTP path to
+// surface as a raw-bytes HTTP response instead of JSON. Recognized shapes:
+//
+//   1. Legacy `{bytes, contentType}` (and `{"result": {...}}` one-level wrap).
+//   2. MCP image content block: `{"content": [{"type": "image", "data": <b64>,
+//      "mimeType": "..."}]}` (single-block).
+//   3. MCP embedded-resource content block: `{"content": [{"type": "resource",
+//      "resource": {"blob": <b64>, "mimeType": "..."}}]}` (single-block).
+//
+// Returns the extracted payload, or `std::nullopt` when none match (the caller
+// falls back to JSON-dumping the result).
+std::optional<BinaryOutput> extractBinaryOutput( const nlohmann::json& result )
+{
+    auto matchLegacy = []( const nlohmann::json& j ) -> std::optional<BinaryOutput> {
+        if ( j.is_object()
             && j.contains( "bytes" )       && j["bytes"].is_string()
-            && j.contains( "contentType" ) && j["contentType"].is_string();
+            && j.contains( "contentType" ) && j["contentType"].is_string() )
+            return BinaryOutput{ j["bytes"].get<std::string>(), j["contentType"].get<std::string>() };
+        return std::nullopt;
     };
-    if ( isFileShape( result ) )
-        return &result;
-    if ( result.is_object() && result.contains( "result" ) && isFileShape( result["result"] ) )
-        return &result["result"];
-    return nullptr;
+    if ( auto m = matchLegacy( result ); m )
+        return m;
+    if ( result.is_object() && result.contains( "result" ) )
+        if ( auto m = matchLegacy( result["result"] ); m )
+            return m;
+
+    // Single-block image or embedded-resource content array.
+    if ( !( result.is_object() && result.contains( "content" ) && result["content"].is_array() && result["content"].size() == 1 ) )
+        return std::nullopt;
+    const auto& block = result["content"][0];
+    if ( !( block.is_object() && block.contains( "type" ) && block["type"].is_string() ) )
+        return std::nullopt;
+    const auto& type = block["type"].get_ref<const std::string&>();
+    if ( type == "image"
+        && block.contains( "data" )     && block["data"].is_string()
+        && block.contains( "mimeType" ) && block["mimeType"].is_string() )
+        return BinaryOutput{ block["data"].get<std::string>(), block["mimeType"].get<std::string>() };
+    if ( type == "resource"
+        && block.contains( "resource" ) && block["resource"].is_object() )
+    {
+        const auto& r = block["resource"];
+        if ( r.contains( "blob" )     && r["blob"].is_string()
+            && r.contains( "mimeType" ) && r["mimeType"].is_string() )
+            return BinaryOutput{ r["blob"].get<std::string>(), r["mimeType"].get<std::string>() };
+    }
+    return std::nullopt;
 }
 
 } // namespace
@@ -253,14 +292,13 @@ void Server::State::handleToolsCall( const httplib::Request& req, httplib::Respo
         return;
     }
 
-    if ( const auto* file = matchFileOutput( result ); file )
+    if ( auto bin = extractBinaryOutput( result ); bin )
     {
-        auto bytes = decode64( ( *file )["bytes"].get<std::string>() );
-        const auto& contentType = ( *file )["contentType"].get_ref<const std::string&>();
+        auto bytes = decode64( bin->data );
         res.status = 200;
         res.set_content(
             std::string( reinterpret_cast<const char*>( bytes.data() ), bytes.size() ),
-            contentType.c_str() );
+            bin->mimeType.c_str() );
         return;
     }
 

--- a/source/MRMcp/MRMcp.cpp
+++ b/source/MRMcp/MRMcp.cpp
@@ -157,29 +157,17 @@ void writeJsonError( httplib::Response& res, int httpStatus, std::string message
     }.dump(), "application/json" );
 }
 
-// Extracted binary payload for the `/api/tools/call/<id>` raw-bytes response.
-// Strings are copied (not viewed) so the caller can outlive the source JSON without
-// lifetime gymnastics.
 struct BinaryOutput
 {
-    std::string data;     // base64-encoded
+    std::string data;     // base64
     std::string mimeType;
 };
 
-// Detect a binary payload in a tool's raw output for the `/api/` HTTP path to
-// surface as a raw-bytes HTTP response instead of JSON. Recognized shapes:
-//
-//   1. Legacy `{bytes, contentType}` (and `{"result": {...}}` one-level wrap).
-//   2. MCP image content block: `{"content": [{"type": "image", "data": <b64>,
-//      "mimeType": "..."}]}` (single-block).
-//   3. MCP-spec embedded-resource content block: `{"content": [{"type":
-//      "resource", "resource": {"uri": ..., "mimeType": ..., "blob": <b64>}}]}`
-//      (single-block). The `/api/` route runs server-side on MI's own response,
-//      so we see the spec-correct nested form here (the gateway's flat-shape
-//      proxy quirk is only an issue on the gateway's outbound side).
-//
-// Returns the extracted payload, or `std::nullopt` when none match (the caller
-// falls back to JSON-dumping the result).
+// Match a binary payload in a tool result for the `/api/` raw-bytes response.
+// Accepts `{bytes, contentType}` (optionally wrapped in `{result: ...}`), a
+// single-block image content `{content: [{type:image, data, mimeType}]}`, or
+// a single-block resource content `{content: [{type:resource, resource:{blob,
+// mimeType, ...}}]}`. Returns nullopt otherwise; caller falls back to JSON.
 std::optional<BinaryOutput> extractBinaryOutput( const nlohmann::json& result )
 {
     auto matchLegacy = []( const nlohmann::json& j ) -> std::optional<BinaryOutput> {

--- a/source/MRMcp/MRMcp.cpp
+++ b/source/MRMcp/MRMcp.cpp
@@ -172,8 +172,11 @@ struct BinaryOutput
 //   1. Legacy `{bytes, contentType}` (and `{"result": {...}}` one-level wrap).
 //   2. MCP image content block: `{"content": [{"type": "image", "data": <b64>,
 //      "mimeType": "..."}]}` (single-block).
-//   3. MCP embedded-resource content block: `{"content": [{"type": "resource",
-//      "resource": {"blob": <b64>, "mimeType": "..."}}]}` (single-block).
+//   3. MCP-spec embedded-resource content block: `{"content": [{"type":
+//      "resource", "resource": {"uri": ..., "mimeType": ..., "blob": <b64>}}]}`
+//      (single-block). The `/api/` route runs server-side on MI's own response,
+//      so we see the spec-correct nested form here (the gateway's flat-shape
+//      proxy quirk is only an issue on the gateway's outbound side).
 //
 // Returns the extracted payload, or `std::nullopt` when none match (the caller
 // falls back to JSON-dumping the result).

--- a/source/MRViewer/MRSceneMcp.cpp
+++ b/source/MRViewer/MRSceneMcp.cpp
@@ -379,7 +379,8 @@ static nlohmann::json mcpSceneGetObject( const nlohmann::json& args )
                 ext.insert( ext.begin(), '.' );
 
             UniqueTemporaryFolder tmp{};
-            const std::filesystem::path path = tmp / pathFromUtf8( obj->name() + ext );
+            const std::string fileName = obj->name() + ext;
+            const std::filesystem::path path = tmp / pathFromUtf8( fileName );
             auto saved = ObjectSave::toAnySupportedFormat( *obj, path );
             if ( !saved )
                 throw std::runtime_error( saved.error() );
@@ -387,7 +388,24 @@ static nlohmann::json mcpSceneGetObject( const nlohmann::json& args )
             if ( !in )
                 throw std::runtime_error( fmt::format( "Could not read back temp file {}", utf8string( path ) ) );
             std::vector<std::uint8_t> bytes( ( std::istreambuf_iterator<char>( in ) ), std::istreambuf_iterator<char>() );
-            out["bytes"] = encode64( bytes.data(), bytes.size() );
+
+            // MCP-spec embedded-resource content block: hosts that honor `resource` content
+            // surface this as a downloadable file rather than dumping the base64 into the
+            // model's text context. The `uri` is required by the spec; we synthesize one
+            // from the in-memory file name. `application/octet-stream` is the safe default
+            // for mesh formats — most lack a registered IANA media type.
+            out = nlohmann::json{
+                { "content", nlohmann::json::array( {
+                    {
+                        { "type", "resource" },
+                        { "resource", {
+                            { "uri",      "mcp://scene_getObject/" + fileName },
+                            { "mimeType", "application/octet-stream" },
+                            { "blob",     encode64( bytes.data(), bytes.size() ) },
+                        } },
+                    },
+                } ) },
+            };
             return;
         }
         throw std::runtime_error( "scene_getObject requires either `filePath` or `extension`." );
@@ -563,18 +581,18 @@ MR_ON_INIT{
 
     server.addTool(
         /*id*/  "scene_getObject",
-        /*name*/"Serialize scene object (to file or inline bytes)",
+        /*name*/"Serialize scene object (to file or inline resource)",
         /*desc*/std::string( kSceneIdSemantics ) +
-                "Serialize an object to an STL/OBJ/PLY/etc. format. Pass either `filePath` (server-side path; "
-                "format selected by extension) — response is `{path: <written-path>}`; or `extension` (e.g. `\"stl\"`) — "
-                "response is `{bytes: <base64 payload>}`.",
+                "Serialize an object to an STL/OBJ/PLY/etc. format. Pass `filePath` (server-side path; format "
+                "selected by extension) — response is `{path: <written-path>}`. Or pass `extension` (e.g. `\"stl\"`) "
+                "to receive the bytes inline as an MCP embedded-resource content block "
+                "(`content[0].resource.blob` is the base64 payload, `mimeType` is `application/octet-stream`).",
         /*input_schema*/Schema::Object{}
             .addMember(    "id",        Schema::Number{} )
             .addMemberOpt( "filePath",  Schema::String{} )
             .addMemberOpt( "extension", Schema::String{} ),
         /*output_schema*/Schema::Object{}
-            .addMemberOpt( "path",  Schema::String{} )
-            .addMemberOpt( "bytes", Schema::String{} ),
+            .addMemberOpt( "path", Schema::String{} ),
         /*func*/mcpSceneGetObject
     );
 

--- a/source/MRViewer/MRSceneMcp.cpp
+++ b/source/MRViewer/MRSceneMcp.cpp
@@ -31,6 +31,8 @@
 #include "MRViewer/MRCommandLoop.h"
 #include "MRViewer/MRMcpCommon.h"
 
+#include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <fstream>
 #include <memory>
@@ -353,6 +355,23 @@ static nlohmann::json mcpSceneRemoveObject( const nlohmann::json& args )
     return nlohmann::json::object();
 }
 
+// Registered mesh-format media types, with `application/octet-stream` for the
+// rest. Used when emitting an embedded-resource content block for a serialized
+// scene object.
+static std::string mimeForExt( std::string_view ext )
+{
+    std::string e( ext );
+    if ( !e.empty() && e.front() == '.' )
+        e.erase( e.begin() );
+    std::transform( e.begin(), e.end(), e.begin(), []( unsigned char c ){ return char( std::tolower( c ) ); } );
+    if ( e == "stl"  ) return "model/stl";
+    if ( e == "obj"  ) return "model/obj";
+    if ( e == "ply"  ) return "model/ply";
+    if ( e == "gltf" ) return "model/gltf+json";
+    if ( e == "glb"  ) return "model/gltf-binary";
+    return "application/octet-stream";
+}
+
 static nlohmann::json mcpSceneGetObject( const nlohmann::json& args )
 {
     nlohmann::json out = nlohmann::json::object();
@@ -389,15 +408,20 @@ static nlohmann::json mcpSceneGetObject( const nlohmann::json& args )
                 throw std::runtime_error( fmt::format( "Could not read back temp file {}", utf8string( path ) ) );
             std::vector<std::uint8_t> bytes( ( std::istreambuf_iterator<char>( in ) ), std::istreambuf_iterator<char>() );
 
-            // MCP-spec embedded-resource block. application/octet-stream because mesh
-            // formats lack a registered media type.
+            // MCP-spec embedded-resource block. URN form because the resource is
+            // ephemeral (regenerated per call) — the URI is an identity label, not
+            // a fetchable location. Media type is the registered model/* for known
+            // mesh formats, `application/octet-stream` otherwise.
+            const std::string normExt = ext.front() == '.' ? ext.substr( 1 ) : ext;
+            const std::string urn = fmt::format( "urn:meshinspector:object:{}:{}",
+                args.at( "id" ).get<uint64_t>(), normExt );
             out = nlohmann::json{
                 { "content", nlohmann::json::array( {
                     {
                         { "type", "resource" },
                         { "resource", {
-                            { "uri",      "mcp://scene_getObject/" + fileName },
-                            { "mimeType", "application/octet-stream" },
+                            { "uri",      urn },
+                            { "mimeType", mimeForExt( ext ) },
                             { "blob",     encode64( bytes.data(), bytes.size() ) },
                         } },
                     },
@@ -583,7 +607,8 @@ MR_ON_INIT{
                 "Serialize an object to an STL/OBJ/PLY/etc. format. Pass `filePath` (server-side path; format "
                 "selected by extension) — response is `{path: <written-path>}`. Or pass `extension` (e.g. `\"stl\"`) "
                 "to receive the bytes inline as an MCP embedded-resource content block "
-                "(`content[0].resource.blob` is the base64 payload, `mimeType` is `application/octet-stream`).",
+                "(`content[0].resource.blob` is the base64 payload; `mimeType` is the registered model/* "
+                "media type for known mesh formats, `application/octet-stream` otherwise).",
         /*input_schema*/Schema::Object{}
             .addMember(    "id",        Schema::Number{} )
             .addMemberOpt( "filePath",  Schema::String{} )

--- a/source/MRViewer/MRSceneMcp.cpp
+++ b/source/MRViewer/MRSceneMcp.cpp
@@ -394,6 +394,10 @@ static nlohmann::json mcpSceneGetObject( const nlohmann::json& args )
             // model's text context. The `uri` is required by the spec; we synthesize one
             // from the in-memory file name. `application/octet-stream` is the safe default
             // for mesh formats — most lack a registered IANA media type.
+            //
+            // The gateway forwards this response raw (bypassing fastmcpp's `ContentBlock`
+            // parser, which uses an off-spec flat shape for `resource`), so MI emits the
+            // spec-correct nested form here and Claude Code's Zod validator accepts it.
             out = nlohmann::json{
                 { "content", nlohmann::json::array( {
                     {

--- a/source/MRViewer/MRSceneMcp.cpp
+++ b/source/MRViewer/MRSceneMcp.cpp
@@ -389,15 +389,8 @@ static nlohmann::json mcpSceneGetObject( const nlohmann::json& args )
                 throw std::runtime_error( fmt::format( "Could not read back temp file {}", utf8string( path ) ) );
             std::vector<std::uint8_t> bytes( ( std::istreambuf_iterator<char>( in ) ), std::istreambuf_iterator<char>() );
 
-            // MCP-spec embedded-resource content block: hosts that honor `resource` content
-            // surface this as a downloadable file rather than dumping the base64 into the
-            // model's text context. The `uri` is required by the spec; we synthesize one
-            // from the in-memory file name. `application/octet-stream` is the safe default
-            // for mesh formats — most lack a registered IANA media type.
-            //
-            // The gateway forwards this response raw (bypassing fastmcpp's `ContentBlock`
-            // parser, which uses an off-spec flat shape for `resource`), so MI emits the
-            // spec-correct nested form here and Claude Code's Zod validator accepts it.
+            // MCP-spec embedded-resource block. application/octet-stream because mesh
+            // formats lack a registered media type.
             out = nlohmann::json{
                 { "content", nlohmann::json::array( {
                     {

--- a/source/MRViewer/MRViewerMcp.cpp
+++ b/source/MRViewer/MRViewerMcp.cpp
@@ -219,9 +219,7 @@ static nlohmann::json mcpViewerCaptureScreenshot( const nlohmann::json& args )
         throw std::runtime_error( fmt::format( "Could not read back temp file {}", utf8string( path ) ) );
     std::vector<std::uint8_t> bytes( ( std::istreambuf_iterator<char>( in ) ), std::istreambuf_iterator<char>() );
 
-    // MCP-spec image content block: host renders it natively; the base64 payload never enters
-    // the model's text context. Keep width/height in structuredContent for callers that want the
-    // metadata.
+    // MCP image content block + structured {width, height}.
     return nlohmann::json{
         { "content", nlohmann::json::array( {
             {

--- a/source/MRViewer/MRViewerMcp.cpp
+++ b/source/MRViewer/MRViewerMcp.cpp
@@ -195,32 +195,43 @@ static nlohmann::json mcpViewerCaptureScreenshot( const nlohmann::json& args )
         } );
     }
 
-    nlohmann::json out = nlohmann::json::object();
+    nlohmann::json structured = nlohmann::json::object();
+    structured["width"]  = img.resolution.x;
+    structured["height"] = img.resolution.y;
+
     if ( args.contains( "filePath" ) )
     {
         const auto path = pathFromUtf8( args["filePath"].get<std::string>() );
         auto saved = ImageSave::toAnySupportedFormat( img, path );
         if ( !saved )
             throw std::runtime_error( saved.error() );
-        out["path"] = utf8string( path );
+        structured["path"] = utf8string( path );
+        return structured;
     }
-    else
-    {
-        UniqueTemporaryFolder tmp{};
-        const std::filesystem::path path = tmp / "screenshot.png";
-        auto saved = ImageSave::toAnySupportedFormat( img, path );
-        if ( !saved )
-            throw std::runtime_error( saved.error() );
-        std::ifstream in( path, std::ios::binary );
-        if ( !in )
-            throw std::runtime_error( fmt::format( "Could not read back temp file {}", utf8string( path ) ) );
-        std::vector<std::uint8_t> bytes( ( std::istreambuf_iterator<char>( in ) ), std::istreambuf_iterator<char>() );
-        out["bytes"] = encode64( bytes.data(), bytes.size() );
-        out["contentType"] = "image/png";
-    }
-    out["width"] = img.resolution.x;
-    out["height"] = img.resolution.y;
-    return out;
+
+    UniqueTemporaryFolder tmp{};
+    const std::filesystem::path path = tmp / "screenshot.png";
+    auto saved = ImageSave::toAnySupportedFormat( img, path );
+    if ( !saved )
+        throw std::runtime_error( saved.error() );
+    std::ifstream in( path, std::ios::binary );
+    if ( !in )
+        throw std::runtime_error( fmt::format( "Could not read back temp file {}", utf8string( path ) ) );
+    std::vector<std::uint8_t> bytes( ( std::istreambuf_iterator<char>( in ) ), std::istreambuf_iterator<char>() );
+
+    // MCP-spec image content block: host renders it natively; the base64 payload never enters
+    // the model's text context. Keep width/height in structuredContent for callers that want the
+    // metadata.
+    return nlohmann::json{
+        { "content", nlohmann::json::array( {
+            {
+                { "type", "image" },
+                { "data", encode64( bytes.data(), bytes.size() ) },
+                { "mimeType", "image/png" },
+            },
+        } ) },
+        { "structuredContent", structured },
+    };
 }
 
 static nlohmann::json mcpViewerSendMouseEvent( const nlohmann::json& args )
@@ -364,8 +375,8 @@ MR_ON_INIT{
                 "current viewport size) and `transparentBg` (default false) omits the background — these options "
                 "are ignored when `includeUi` is true (window capture always uses the current framebuffer with its "
                 "normal background). "
-                "Pass `filePath` to save server-side; response is `{path, width, height}`. Omit `filePath` to get "
-                "an inline base64 PNG; response is `{bytes, width, height}`.",
+                "Pass `filePath` to save server-side; response is `{path, width, height}`. Omit `filePath` to "
+                "receive the PNG inline as an MCP image content block; `structuredContent` carries `{width, height}`.",
         /*input_schema*/Schema::Object{}
             .addMemberOpt( "includeUi",     Schema::Bool{} )
             .addMemberOpt( "width",         Schema::Number{} )
@@ -373,11 +384,9 @@ MR_ON_INIT{
             .addMemberOpt( "transparentBg", Schema::Bool{} )
             .addMemberOpt( "filePath",      Schema::String{} ),
         /*output_schema*/Schema::Object{}
-            .addMemberOpt( "path",        Schema::String{} )
-            .addMemberOpt( "bytes",       Schema::String{} )
-            .addMemberOpt( "contentType", Schema::String{} )
-            .addMember(    "width",       Schema::Number{} )
-            .addMember(    "height",      Schema::Number{} ),
+            .addMemberOpt( "path",   Schema::String{} )
+            .addMember(    "width",  Schema::Number{} )
+            .addMember(    "height", Schema::Number{} ),
         /*func*/mcpViewerCaptureScreenshot
     );
 


### PR DESCRIPTION
## Summary

Inline-mode payloads now use MCP-spec content blocks so hosts that honor them render natively instead of relaying base64 through model text. File-mode responses unchanged.

- `viewer_captureScreenshot` inline-mode: image content block (`{type: image, data, mimeType: image/png}`) + `structuredContent: {width, height}`.
- `scene_getObject` inline-mode: nested embedded-resource content block with a URN identity URI (`urn:meshinspector:object:<id>:<ext>`) and a format-specific `model/*` media type (stl/obj/ply/gltf/glb), `application/octet-stream` otherwise.
- Drops the now-redundant `bytes` / `contentType` fields from both output schemas.
- Generalizes the `/api/tools/call/<id>` binary-response matcher to `extractBinaryOutput`: recognizes image and resource content blocks in addition to the legacy `{bytes, contentType}` shape, so the `/api/` route still serves raw bytes.
- Gateway-side bypass in `MRMCPGateway`: forwarded `tools/call` skips fastmcpp's `ProxyApp` round-trip and forwards raw JSON-RPC via `MLClientTransport`, returning MI's response verbatim. fastmcpp's proxy re-emits resource blocks in an off-spec flat shape; bypassing keeps the wire MCP-compliant end-to-end without patching fastmcpp.

## Known limitation

Claude Desktop / claude.ai chat tab silently reject the resource block — they treat blob-bearing content as images and validate against an image-MIME allowlist (`model/stl`, `application/octet-stream`, etc. all fail). Confirmed via [csharp-sdk#1261](https://github.com/modelcontextprotocol/csharp-sdk/issues/1261), [claude-agent-sdk-python#292](https://github.com/anthropics/claude-agent-sdk-python/issues/292), [claude-code#654](https://github.com/anthropics/claude-code/issues/654). Spec-compliant clients (Claude Code SDK / MCP Inspector) render the resource fine; chat users should use `filePath` mode until claude.ai's content-type allowlist expands.

## Test plan

End-to-end on local debug build (Claude Code -> McpGateway.exe stdio -> MI HTTP+SSE on 127.0.0.1:8887):

- [x] MCP tools/call viewer_captureScreenshot (no filePath): image content block; host renders inline + structured {width, height}
- [x] MCP tools/call viewer_captureScreenshot (with filePath): {path, width, height}; valid PNG written
- [x] MCP tools/call scene_getObject (no filePath): resource block (URN URI, model/stl mime); Claude Code surfaces as binary
- [x] MCP tools/call scene_getObject (with filePath): {path}; valid STL written
- [x] HTTP POST /api/tools/call/viewer_captureScreenshot (no filePath): 200, image/png, valid PNG
- [x] HTTP POST /api/tools/call/viewer_captureScreenshot (with filePath): 200, JSON {path, w, h}, PNG on disk
- [x] HTTP POST /api/tools/call/scene_getObject (no filePath): 200, application/octet-stream raw STL bytes
- [x] HTTP POST /api/tools/call/scene_getObject (with filePath): 200, JSON {path}, STL on disk
- [x] viewer_shutdown returns {} immediately; modal-close via ui_pressButton ["Don't Save"]; MI exits
- [x] status (dead): "not started"; forwarded tools/call (dead): MCP error -32603 backend not connected
- [x] launch: "started"; status (alive): "running"; auto-reconnect after backend swap
- [x] CI builds green