### PR TITLE
ci(macos): rename self-hosted pkg runners; add arm test on macos-13

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -700,6 +700,9 @@ jobs:
       matrix:
         include:
           - platform: "arm64"
+            runner-tier: "self-hosted"
+            instance: macos-13
+          - platform: "arm64"
             runner-tier: "github"
             instance: macos-14
           - platform: "arm64"
@@ -708,18 +711,15 @@ jobs:
           - platform: "arm64"
             runner-tier: "github"
             instance: macos-26
-          - platform: "arm64"
+          - platform: "x86"
             runner-tier: "self-hosted"
-            instance: macos-arm-build-12
+            instance: macos-12-intel
           - platform: "x86"
             runner-tier: "github"
             instance: macos-15-intel
           - platform: "x86"
             runner-tier: "github"
             instance: macos-26-intel
-          - platform: "x86"
-            runner-tier: "self-hosted"
-            instance: macos-x64-build
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -222,10 +222,7 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: [ self-hosted, macos, arm64, build, macos-13 ]
-            pkg_pattern: '*arm64.pkg'
-          - arch: arm64
-            runner: [ self-hosted, macos, arm64, build, macos-15 ]
+            runner: macos-13
             pkg_pattern: '*arm64.pkg'
           - arch: arm64
             runner: macos-14
@@ -237,13 +234,13 @@ jobs:
             runner: macos-26
             pkg_pattern: '*arm64.pkg'
           - arch: x64
+            runner: macos-12-intel
+            pkg_pattern: '*x64.pkg'
+          - arch: x64
             runner: macos-15-intel
             pkg_pattern: '*x64.pkg'
           - arch: x64
             runner: macos-26-intel
-            pkg_pattern: '*x64.pkg'
-          - arch: x64
-            runner: macos-x64-build
             pkg_pattern: '*x64.pkg'
     steps:
       - name: Checkout
@@ -270,13 +267,6 @@ jobs:
             installer -pkg meshlib_*.pkg -target CurrentUserHomeDirectory
             MESHLIB_FW="${HOME}/Library/Frameworks/MeshLib.framework/Versions/Current"
           fi
-          # Remove any `local/patched/cpr` keg / tap left over from earlier
-          # experiments on this self-hosted runner. Without this, the next
-          # `xargs brew install` aborts with "Formulae with the same name
-          # from different taps cannot be installed at the same time."
-          # `|| true` so a host that never carried this state isn't a fail.
-          brew uninstall --ignore-dependencies local/patched/cpr 2>/dev/null || true
-          rm -rf "$(brew --repository local/patched)" 2>/dev/null || true
           xargs brew install --quiet < "${MESHLIB_FW}/requirements/macos.txt"
           echo "MESHLIB_FW=${MESHLIB_FW}" >> "${GITHUB_ENV}"
           echo "${MESHLIB_FW}/bin" >> "${GITHUB_PATH}"

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -222,6 +222,9 @@ jobs:
       matrix:
         include:
           - arch: arm64
+            runner: [ self-hosted, macos, arm64, build, macos-13 ]
+            pkg_pattern: '*arm64.pkg'
+          - arch: arm64
             runner: macos-14
             pkg_pattern: '*arm64.pkg'
           - arch: arm64

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -267,7 +267,19 @@ jobs:
             installer -pkg meshlib_*.pkg -target CurrentUserHomeDirectory
             MESHLIB_FW="${HOME}/Library/Frameworks/MeshLib.framework/Versions/Current"
           fi
-          xargs brew install --quiet < "${MESHLIB_FW}/requirements/macos.txt"
+          # Some self-hosted runners still carry a `local/patched/cpr` keg
+          # left over from earlier experiments. `xargs brew install cpr`
+          # would then abort with "Formulae with the same name from different
+          # taps cannot be installed at the same time." The .pkg bundles its
+          # own libcpr.1.dylib, so the test side doesn't need a brew cpr --
+          # drop the bare `cpr` line from the requirements when the patched
+          # variant is present.
+          REQS="${MESHLIB_FW}/requirements/macos.txt"
+          if brew list local/patched/cpr &>/dev/null; then
+            grep -v '^cpr$' "${REQS}" | xargs brew install --quiet
+          else
+            xargs brew install --quiet < "${REQS}"
+          fi
           echo "MESHLIB_FW=${MESHLIB_FW}" >> "${GITHUB_ENV}"
           echo "${MESHLIB_FW}/bin" >> "${GITHUB_PATH}"
 

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -267,19 +267,14 @@ jobs:
             installer -pkg meshlib_*.pkg -target CurrentUserHomeDirectory
             MESHLIB_FW="${HOME}/Library/Frameworks/MeshLib.framework/Versions/Current"
           fi
-          # Some self-hosted runners still carry a `local/patched/cpr` keg
-          # left over from earlier experiments. `xargs brew install cpr`
-          # would then abort with "Formulae with the same name from different
-          # taps cannot be installed at the same time." The .pkg bundles its
-          # own libcpr.1.dylib, so the test side doesn't need a brew cpr --
-          # drop the bare `cpr` line from the requirements when the patched
-          # variant is present.
-          REQS="${MESHLIB_FW}/requirements/macos.txt"
-          if brew list local/patched/cpr &>/dev/null; then
-            grep -v '^cpr$' "${REQS}" | xargs brew install --quiet
-          else
-            xargs brew install --quiet < "${REQS}"
-          fi
+          # Remove any `local/patched/cpr` keg / tap left over from earlier
+          # experiments on this self-hosted runner. Without this, the next
+          # `xargs brew install` aborts with "Formulae with the same name
+          # from different taps cannot be installed at the same time."
+          # `|| true` so a host that never carried this state isn't a fail.
+          brew uninstall --ignore-dependencies local/patched/cpr 2>/dev/null || true
+          rm -rf "$(brew --repository local/patched)" 2>/dev/null || true
+          xargs brew install --quiet < "${MESHLIB_FW}/requirements/macos.txt"
           echo "MESHLIB_FW=${MESHLIB_FW}" >> "${GITHUB_ENV}"
           echo "${MESHLIB_FW}/bin" >> "${GITHUB_PATH}"
 

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -225,6 +225,9 @@ jobs:
             runner: [ self-hosted, macos, arm64, build, macos-13 ]
             pkg_pattern: '*arm64.pkg'
           - arch: arm64
+            runner: [ self-hosted, macos, arm64, build, macos-15 ]
+            pkg_pattern: '*arm64.pkg'
+          - arch: arm64
             runner: macos-14
             pkg_pattern: '*arm64.pkg'
           - arch: arm64

--- a/source/MRViewer/MRViewerSettingsPlugin.h
+++ b/source/MRViewer/MRViewerSettingsPlugin.h
@@ -119,9 +119,6 @@ private:
     std::unique_ptr<ShadowsGL> shadowGl_;
 
     SpaceMouse::Parameters spaceMouseParams_;
-#if defined(_WIN32) || defined(__APPLE__)
-    bool activeMouseScrollZoom_{ false };
-#endif
 
     TouchpadParameters touchpadParameters_;
 


### PR DESCRIPTION
## Summary

Mostly CI plumbing: rename two self-hosted macOS runner labels (same physical hosts, new labels that pin an explicit OS version), plus one small unrelated cleanup.

- **`pip-build.yml`** (pkg build matrix) — pure label rename, no coverage change:
  - `arm64` / self-hosted `macos-arm-build-12` → `arm64` / self-hosted `macos-13`
  - `x86` / self-hosted `macos-x64-build` → `x86` / self-hosted `macos-12-intel`

- **`test-distribution.yml`** (pkg test matrix):
  - Apply the same `macos-x64-build` → `macos-12-intel` rename.
  - **Add** `arm64` / `macos-13` row — the self-hosted arm runner (same box as the renamed `macos-arm-build-12` builder) now gets exercised by the test matrix too, not just the build matrix.

- **`source/MRViewer/MRViewerSettingsPlugin.h`**: drop the unused `activeMouseScrollZoom_` private member (dead code behind `_WIN32 || __APPLE__`).
