### PR TITLE
ci(macos): retry Download Distributive on transient gh-api 401

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -249,9 +249,28 @@ jobs:
           ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Download Distributive
+        # `gh auth login --with-token` validates the token by calling the
+        # GraphQL `viewer` query, which intermittently returns HTTP 401
+        # ("Bad credentials") even for a perfectly valid token -- a known
+        # transient on GitHub's side. See community discussion #101661;
+        # GitHub's official guidance is to retry after a short delay.
+        # Without this loop, a single 401 takes out one matrix cell and
+        # forces a manual re-run of the post-merge run.
         run: |
-          echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token
-          gh release download ${{ inputs.release_tag }} --pattern "${{ matrix.pkg_pattern }}" --repo ${{ github.repository }}
+          for attempt in 1 2 3; do
+            if echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token \
+               && gh release download ${{ inputs.release_tag }} \
+                    --pattern "${{ matrix.pkg_pattern }}" \
+                    --repo ${{ github.repository }} \
+                    --clobber; then
+              exit 0
+            fi
+            delay=$(( attempt * 10 ))
+            echo "Download Distributive: attempt ${attempt} failed; retrying in ${delay}s..."
+            sleep "${delay}"
+          done
+          echo "Download Distributive: all 3 attempts failed" >&2
+          exit 1
 
       # Self-hosted runners have no passwordless sudo, so they install into
       # ~/Library via `-target CurrentUserHomeDirectory` (enabled by the


### PR DESCRIPTION
## Summary

Wrap the `Download Distributive` step in `macos-test` with a 3-attempt retry loop (10s/20s/30s backoff) so a transient `gh auth login --with-token` failure no longer takes out a matrix cell.

## Why

Post-merge run [26329782283](https://github.com/MeshInspector/MeshLib/actions/runs/26329782283) lost exactly one matrix cell — `macos-test (arm64, macos-26, *arm64.pkg)` — at the auth step:

```
echo *** | gh auth login --with-token
...
error retrieving current user: HTTP 401: Bad credentials (https://api.github.com/graphql)
```

The same secret succeeded on every other parallel `macos-test` cell in the same run on the same SHA. This is the intermittent 401 documented in [community discussion #101661](https://github.com/orgs/community/discussions/101661): a valid token, sufficient rate limit, and an occasional 401 from the `viewer { login }` whoami probe that `gh auth login --with-token` runs to validate the token. GitHub's official guidance there is "retry the request at least once after a 401, with a slight delay."

## What

`.github/workflows/test-distribution.yml`, `macos-test` job, `Download Distributive` step:

- Wrap `gh auth login --with-token` + `gh release download` in a `for attempt in 1 2 3` loop with `sleep $((attempt * 10))` backoff.
- Add `--clobber` to `gh release download` so a retry after a partial download doesn't fail on the existing file.
- In-line comment explains the 401-retry rationale.

Scope is intentionally narrow: this PR only touches the macOS step that actually flaked. The same `gh auth login --with-token` pattern exists in the Linux x64, Linux arm64, and Windows download steps; we haven't observed the flake there yet, so leaving them alone for now. Easy follow-up if the same 401 ever shows up on those.
