### PR TITLE
ci: gate Collect artifact stats to match the upload step

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -285,7 +285,11 @@ jobs:
             overwrite: true
 
       - name: Collect artifact stats
-        if: ${{ inputs.internal_build && inputs.upload_artifacts }}
+        # Mirror `Upload Macos Distribution`'s gate -- otherwise Debug jobs
+        # invoke this step with no matching .pkg and the action fails (with
+        # `continue-on-error: true` the job still succeeds, but a confusing
+        # `failure`-level annotation is surfaced on the run summary).
+        if: ${{ inputs.internal_build && inputs.upload_artifacts && matrix.config == 'Release' }}
         continue-on-error: true
         uses: ./.github/actions/collect-artifact-stats
         with:

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -253,7 +253,13 @@ jobs:
           retention-days: 1
 
       - name: Collect artifact stats
-        if: ${{ inputs.internal_build && inputs.upload_artifacts }}
+        # Mirror `Upload Ubuntu Developer Distribution`'s gate -- otherwise
+        # matrix entries that don't produce a .deb (Debug, Clang, or
+        # `upload_release == 'OFF'`) invoke this step with no matching file
+        # and the action fails (with `continue-on-error: true` the job still
+        # succeeds, but a confusing `failure`-level annotation is surfaced
+        # on the run summary).
+        if: ${{ inputs.internal_build && inputs.upload_artifacts && matrix.upload_release == 'ON' && matrix.compiler == 'GCC' && matrix.config == 'Release' }}
         continue-on-error: true
         uses: ./.github/actions/collect-artifact-stats
         with:


### PR DESCRIPTION
## Summary

On `build-test-macos.yml` and `build-test-ubuntu-x64.yml`, the `Collect artifact stats` step ran on every matrix entry where `internal_build && upload_artifacts` was true — including entries that **never produced the artifact** in the first place (e.g. Debug builds, which skip `Create Pkg` / the `.deb` packaging path). `collect-artifact-stats` then exits `1` because its `ARTIFACT_GLOB` expands to nothing.

`continue-on-error: true` keeps those jobs green, but each occurrence surfaces a `failure`-level annotation on the workflow-run summary, which makes real failures harder to spot. Example: [run 26330086183](https://github.com/MeshInspector/MeshLib/actions/runs/26330086183) shows six such annotations (one macOS arm64 Debug + five ubuntu-x64 entries) — none of them real failures.

The fix mirrors each `Collect artifact stats` `if:` against the gating already present on the matching `Upload …` step in the same workflow:

- `build-test-macos.yml`: add `matrix.config == 'Release'`.
- `build-test-ubuntu-x64.yml`: add `matrix.upload_release == 'ON' && matrix.compiler == 'GCC' && matrix.config == 'Release'`.

The other workflows (`build-test-ubuntu-arm64.yml`, `build-test-emscripten.yml`, `build-test-linux-vcpkg.yml`, `build-test-windows.yml`) already had matching gates and are untouched.

## Test plan

Verified on PR CI [run 26331128758](https://github.com/MeshInspector/MeshLib/actions/runs/26331128758) (`pull_request`, `upload_artifacts=false`):

- [x] No `failure`-level annotations anywhere on the run (baseline had 6 from this exact step).
- [x] `macos-build-test (arm64, Debug)` — `Collect artifact stats` is now `skipped` (previously: ran and failed).
- [x] Every `ubuntu-x64-build-test` matrix entry — `Collect artifact stats` is now `skipped` (previously: ran and failed on 5 of them).

Verified on PR CI [run 26332264883](https://github.com/MeshInspector/MeshLib/actions/runs/26332264883) (`pull_request` + `upload-binaries` label → `upload_artifacts=true`):

- [x] `macos-build-test (*, Release)` runs `Collect artifact stats` and uploads `ArtifactStats-<job_id>.json` with the `meshlib_<arch>.pkg` size (77 143 785 B / 81 698 492 B).
- [x] `ubuntu-x64-build-test (*, Release, GCC, upload_release == 'ON')` runs `Collect artifact stats` and uploads `ArtifactStats-<job_id>.json` with the `meshlib_<os>-dev.deb` size (ubuntu22: 103 780 100 B, ubuntu24: 102 788 424 B).
- [x] `macos-build-test (arm64, Debug)` and `ubuntu-x64 (… upload_release == 'OFF')` still correctly `skipped`.
- [x] Still no `failure`-level annotations from `collect-artifact-stats`.

The change only *adds* conjunctive conditions to each `if:`; it can't cause a step that previously ran to be skipped on the post-merge run unless the corresponding upload step would also be skipped there.
