### PR TITLE
ci(macos): retry Download Distributive via scripts/retry.sh (auth and download separately)

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -254,23 +254,21 @@ jobs:
         # ("Bad credentials") even for a perfectly valid token -- a known
         # transient on GitHub's side. See community discussion #101661;
         # GitHub's official guidance is to retry after a short delay.
-        # Without this loop, a single 401 takes out one matrix cell and
-        # forces a manual re-run of the post-merge run.
+        # `--clobber` lets a retry overwrite a partial download from the
+        # previous attempt.
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          PKG_PATTERN: ${{ matrix.pkg_pattern }}
+          REPO: ${{ github.repository }}
         run: |
-          for attempt in 1 2 3; do
-            if echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token \
-               && gh release download ${{ inputs.release_tag }} \
-                    --pattern "${{ matrix.pkg_pattern }}" \
-                    --repo ${{ github.repository }} \
-                    --clobber; then
-              exit 0
-            fi
-            delay=$(( attempt * 10 ))
-            echo "Download Distributive: attempt ${attempt} failed; retrying in ${delay}s..."
-            sleep "${delay}"
-          done
-          echo "Download Distributive: all 3 attempts failed" >&2
-          exit 1
+          scripts/retry.sh -- bash -c '
+            echo "$GH_TOKEN" | gh auth login --with-token &&
+            gh release download "$RELEASE_TAG" \
+              --pattern "$PKG_PATTERN" \
+              --repo "$REPO" \
+              --clobber
+          '
 
       # Self-hosted runners have no passwordless sudo, so they install into
       # ~/Library via `-target CurrentUserHomeDirectory` (enabled by the

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -254,11 +254,13 @@ jobs:
         # ("Bad credentials") even for a perfectly valid token -- a known
         # transient on GitHub's side. See community discussion #101661;
         # GitHub's official guidance is to retry after a short delay.
-        # Only the auth step is retried; once it succeeds, `gh release
-        # download` runs once normally.
+        # Auth and download are wrapped in independent retry loops so a
+        # flake in one does not force the other to re-run. `--clobber`
+        # lets a download retry overwrite a partial file from a previous
+        # attempt.
         run: |
           scripts/retry.sh -- bash -c 'echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token'
-          gh release download ${{ inputs.release_tag }} --pattern "${{ matrix.pkg_pattern }}" --repo ${{ github.repository }}
+          scripts/retry.sh -- gh release download ${{ inputs.release_tag }} --pattern "${{ matrix.pkg_pattern }}" --repo ${{ github.repository }} --clobber
 
       # Self-hosted runners have no passwordless sudo, so they install into
       # ~/Library via `-target CurrentUserHomeDirectory` (enabled by the

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -256,14 +256,18 @@ jobs:
         # GitHub's official guidance is to retry after a short delay.
         # `--clobber` lets a retry overwrite a partial download from the
         # previous attempt.
+        # The token is passed via RELEASE_GH_TOKEN rather than GH_TOKEN so
+        # that `gh auth login --with-token` actually consumes it from stdin;
+        # if $GH_TOKEN is set in the environment, gh refuses --with-token
+        # and the auth step always fails.
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          RELEASE_GH_TOKEN: ${{ secrets.GH_TOKEN }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           PKG_PATTERN: ${{ matrix.pkg_pattern }}
           REPO: ${{ github.repository }}
         run: |
           scripts/retry.sh -- bash -c '
-            echo "$GH_TOKEN" | gh auth login --with-token &&
+            echo "$RELEASE_GH_TOKEN" | gh auth login --with-token &&
             gh release download "$RELEASE_TAG" \
               --pattern "$PKG_PATTERN" \
               --repo "$REPO" \

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -254,25 +254,11 @@ jobs:
         # ("Bad credentials") even for a perfectly valid token -- a known
         # transient on GitHub's side. See community discussion #101661;
         # GitHub's official guidance is to retry after a short delay.
-        # `--clobber` lets a retry overwrite a partial download from the
-        # previous attempt.
-        # The token is passed via RELEASE_GH_TOKEN rather than GH_TOKEN so
-        # that `gh auth login --with-token` actually consumes it from stdin;
-        # if $GH_TOKEN is set in the environment, gh refuses --with-token
-        # and the auth step always fails.
-        env:
-          RELEASE_GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          PKG_PATTERN: ${{ matrix.pkg_pattern }}
-          REPO: ${{ github.repository }}
+        # Only the auth step is retried; once it succeeds, `gh release
+        # download` runs once normally.
         run: |
-          scripts/retry.sh -- bash -c '
-            echo "$RELEASE_GH_TOKEN" | gh auth login --with-token &&
-            gh release download "$RELEASE_TAG" \
-              --pattern "$PKG_PATTERN" \
-              --repo "$REPO" \
-              --clobber
-          '
+          scripts/retry.sh -- bash -c 'echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token'
+          gh release download ${{ inputs.release_tag }} --pattern "${{ matrix.pkg_pattern }}" --repo ${{ github.repository }}
 
       # Self-hosted runners have no passwordless sudo, so they install into
       # ~/Library via `-target CurrentUserHomeDirectory` (enabled by the


### PR DESCRIPTION
## Summary

Replace the inline 3-attempt retry loop in `macos-test` → `Download Distributive` (added in #6155) with two independent calls to the existing helper `scripts/retry.sh` — one wrapping `gh auth login --with-token`, one wrapping `gh release download`.

## Why

`scripts/retry.sh` already encapsulates the "N attempts with cooldown" pattern for shell commands in CI. The Download Distributive step is exactly that pattern, so it makes sense to use the helper rather than carry a hand-rolled `for attempt in 1 2 3; …; sleep` block in the workflow.

Auth and download are flakey for different reasons (the auth flake is the GraphQL `viewer { login }` 401 documented in [community discussion #101661](https://github.com/orgs/community/discussions/101661); a download flake would be transport-level). Wrapping them in two independent loops means a flake in one doesn't force the other to re-run.

## What

`.github/workflows/test-distribution.yml`, `macos-test` job, `Download Distributive` step:

- `scripts/retry.sh -- bash -c 'echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token'` — retries only the auth call. `bash -c` is needed so each retry re-runs the `echo | gh` pipe.
- `scripts/retry.sh -- gh release download … --clobber` — retries only the download. No `bash -c` wrapper needed; `retry.sh` re-execs the same argv each attempt. `--clobber` lets a retry overwrite a partial file from a previous attempt.

## Behavioural notes

- **Attempts:** 3 per loop (retry.sh default) — same total as before for each phase.
- **Cooldown:** retry.sh's default flat 30s instead of the previous linear 10s/20s/30s backoff. Worst-case wait between first and last attempt is unchanged (~60s).
- The two loops are sequential, so worst-case total wall time for the step grows by the cooldowns of one extra loop (≈60s) only when both phases actually need retries — which is rare and still cheaper than a manual re-run of the matrix cell.

Scope is intentionally narrow: only the macOS step that #6155 already touched. The Linux/Windows download steps still use the original non-retrying form; converting them is a separate decision.
