### PR TITLE
CI(macos): silence example-build ld deployment-target warnings in test-distribution

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -287,15 +287,9 @@ jobs:
       - name: Show meshconv help
         run: meshconv --help
 
-      # On macOS-12 hosts (where the SDK still defaults min-macOS to 12.0)
-      # bump the examples' deployment target to 12.7 to match the value
-      # baked into the framework dylibs by CMAKE_OSX_DEPLOYMENT_TARGET in
-      # top-level CMakeLists.txt; otherwise ld warns "dylib was built for
-      # newer macOS version (12.7) than being linked (12.0)" against every
-      # MeshLib dylib. Do *not* set it on macOS-13+ hosts: there the SDK
-      # default already covers MeshLib's 12.7, and forcing 12.7 makes ld
-      # complain in the other direction about brew bottles built at the
-      # host's macOS version.
+      # Match the framework dylibs' 12.7 target on the macOS-12 SDK (which
+      # otherwise defaults to 12.0); skip on 13+ where forcing 12.7 would
+      # instead warn against brew bottles built for the host's macOS.
       - name: Build C++ examples
         working-directory: examples/cpp-examples
         run: |

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -287,17 +287,21 @@ jobs:
       - name: Show meshconv help
         run: meshconv --help
 
-      # MACOSX_DEPLOYMENT_TARGET below matches the value baked into the
-      # framework dylibs (see CMAKE_OSX_DEPLOYMENT_TARGET in top-level
-      # CMakeLists.txt). Without it, the macos-12 SDK on the self-hosted
-      # macos-12-intel runner defaults the examples to min-macOS 12.0,
-      # producing "dylib was built for newer macOS version (12.7) than
-      # being linked (12.0)" warnings against every MeshLib dylib.
+      # On macOS-12 hosts (where the SDK still defaults min-macOS to 12.0)
+      # bump the examples' deployment target to 12.7 to match the value
+      # baked into the framework dylibs by CMAKE_OSX_DEPLOYMENT_TARGET in
+      # top-level CMakeLists.txt; otherwise ld warns "dylib was built for
+      # newer macOS version (12.7) than being linked (12.0)" against every
+      # MeshLib dylib. Do *not* set it on macOS-13+ hosts: there the SDK
+      # default already covers MeshLib's 12.7, and forcing 12.7 makes ld
+      # complain in the other direction about brew bottles built at the
+      # host's macOS version.
       - name: Build C++ examples
         working-directory: examples/cpp-examples
-        env:
-          MACOSX_DEPLOYMENT_TARGET: "12.7"
         run: |
+          if [ "$(sw_vers -productVersion | cut -d. -f1)" -lt 13 ]; then
+            export MACOSX_DEPLOYMENT_TARGET=12.7
+          fi
           mkdir build && \
           cd build && \
           cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/clang++ && \
@@ -306,9 +310,10 @@ jobs:
 
       - name: Build C examples
         working-directory: examples/c-examples
-        env:
-          MACOSX_DEPLOYMENT_TARGET: "12.7"
         run: |
+          if [ "$(sw_vers -productVersion | cut -d. -f1)" -lt 13 ]; then
+            export MACOSX_DEPLOYMENT_TARGET=12.7
+          fi
           cmake -S . -B build -DCMAKE_C_COMPILER=/usr/bin/clang && \
           cmake --build build
 

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -287,8 +287,16 @@ jobs:
       - name: Show meshconv help
         run: meshconv --help
 
+      # MACOSX_DEPLOYMENT_TARGET below matches the value baked into the
+      # framework dylibs (see CMAKE_OSX_DEPLOYMENT_TARGET in top-level
+      # CMakeLists.txt). Without it, the macos-12 SDK on the self-hosted
+      # macos-12-intel runner defaults the examples to min-macOS 12.0,
+      # producing "dylib was built for newer macOS version (12.7) than
+      # being linked (12.0)" warnings against every MeshLib dylib.
       - name: Build C++ examples
         working-directory: examples/cpp-examples
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "12.7"
         run: |
           mkdir build && \
           cd build && \
@@ -298,6 +306,8 @@ jobs:
 
       - name: Build C examples
         working-directory: examples/c-examples
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "12.7"
         run: |
           cmake -S . -B build -DCMAKE_C_COMPILER=/usr/bin/clang && \
           cmake --build build


### PR DESCRIPTION
## What

Bump the deployment target of the C/C++ example builds in `macos-test` (`.github/workflows/test-distribution.yml`) to `12.7` **only on macOS-12 hosts**, leaving the SDK default in place everywhere else:

```bash
if [ "$(sw_vers -productVersion | cut -d. -f1)" -lt 13 ]; then
  export MACOSX_DEPLOYMENT_TARGET=12.7
fi
```

## Why

The `test-distribution / macos-test (x64, macos-12-intel, *x64.pkg)` job was producing a wall of linker warnings against every dylib in the installed framework, e.g.:

```
ld: warning: dylib (.../MeshLib.framework/.../libMeshLibC2.dylib) was built for newer macOS version (12.7) than being linked (12.0)
```

(See run https://github.com/MeshInspector/MeshLib/actions/runs/26396912525/job/77711295815.)

The mismatch has two ends:

- **The framework dylibs are stamped at min-macOS 12.7.** MeshLib's top-level `CMakeLists.txt` (lines 26-28) defaults `CMAKE_OSX_DEPLOYMENT_TARGET` to `12.7` on macOS, and that value is baked into every `libMR*.dylib` / `libMeshLibC2.dylib` shipped in the `.pkg`.
- **The example binaries were stamped at min-macOS 12.0.** The `cmake ..` invocations for `examples/cpp-examples` and `examples/c-examples` don't set a deployment target, so AppleClang on the self-hosted `macos-12-intel` runner falls back to the macOS-12 SDK's default min-macOS of `12.0`.

`ld` then sees a 12.0-target binary linking against 12.7-target dylibs and warns for every example. Only the `macos-12-intel` cell showed this — on macOS-13+ cells the SDK default min-macOS is already >= 12.7.

## Why the fix is conditional

The obvious fix — exporting `MACOSX_DEPLOYMENT_TARGET=12.7` unconditionally — fixes `macos-12-intel` but introduces the *symmetric* warning on newer cells, because the brew bottles there are built at the host's macOS version:

```
# macos-13 arm64
ld: warning: dylib (/opt/homebrew/lib/libfmt.12.1.0.dylib) was built for newer macOS version (13.0) than being linked (12.7)
# macos-26 / macos-26-intel
ld: warning: building for macOS-12.7, but linking with dylib '.../libjsoncpp.27.dylib' which was built for newer version 26.0
```

The warning fires whenever any linked dylib's min-macOS exceeds the binary's link target. Forcing 12.7 everywhere drops the target below the brew bottles on every macOS-13+ host. So the target is bumped to 12.7 **only** when the host SDK would otherwise default below it (macOS-12); on macOS-13+ the SDK default already covers both MeshLib's 12.7 and the brew bottles.

## Scope

CI workflow only. No source, no CMake files, no example logic touched. The `12.7` literal matches the constant in the top-level `CMakeLists.txt`; if that moves, both should move together.

## Test plan / results

Verified on run https://github.com/MeshInspector/MeshLib/actions/runs/26468388117 — all 7 `macos-test` cells pass with **zero `ld` warnings**:

| Cell | Original master | Unconditional 12.7 | This PR (conditional) |
|---|---|---|---|
| `x64, macos-12-intel` | 65 | 0 | **0** |
| `x64, macos-15-intel` | 0 | 0 | **0** |
| `x64, macos-26-intel` | 0 | 133 | **0** |
| `arm64, macos-13` | 0 | 124 | **0** |
| `arm64, macos-14` | 0 | 0 | **0** |
| `arm64, macos-15` | 0 | 0 | **0** |
| `arm64, macos-26` | 0 | 133 | **0** |

- [x] `macos-12-intel` cell: original 65 warnings gone.
- [x] All other cells: still warning-free (no regression from the conditional).
- [x] `MeshModification` example still runs at the end of "Build C++ examples".

Note: `test-distribution.yml` is invoked via `workflow_call` from the release pipeline; on this PR it was exercised by applying the `upload-binaries` label.
