### PR TITLE
docker(rockylinux8-vcpkg): trim image 4.4 GB -> 1.1 GB (drop nvidia/cuda devel base)

### DIFF
--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -58,7 +58,7 @@ RUN source /opt/rh/gcc-toolset-11/enable && \
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
 
 
-FROM nvidia/cuda:12.0.1-devel-rockylinux8 AS production
+FROM rockylinux:8 AS production
 
 COPY --from=build /opt/vcpkg /opt/vcpkg
 COPY scripts/retry.sh /usr/local/bin/retry.sh
@@ -85,9 +85,22 @@ RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
         && \
     dnf clean all
 
-# install github-cli
+# install minimal CUDA toolkit (nvcc + cudart) from NVIDIA's RHEL8 repo
+# replaces nvidia/cuda:devel base image, dropping ~3.5 GB of unused CUDA libs / nsight / devel tooling
 RUN retry.sh -- dnf -y install 'dnf-command(config-manager)' && \
-    retry.sh -- dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
+    retry.sh -- dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && \
+    retry.sh -- dnf -y install \
+        cuda-nvcc-12-0 \
+        cuda-cudart-12-0 \
+        cuda-cudart-devel-12-0 \
+        cuda-driver-devel-12-0 \
+        cuda-cuxxfilt-12-0 \
+        && \
+    dnf clean all
+ENV PATH=/usr/local/cuda/bin:$PATH
+
+# install github-cli
+RUN retry.sh -- dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
     retry.sh -- dnf -y install gh && \
     dnf clean all
 

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -87,8 +87,14 @@ RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
 
 # install minimal CUDA toolkit (nvcc + cudart) from NVIDIA's RHEL8 repo
 # replaces nvidia/cuda:devel base image, dropping ~3.5 GB of unused CUDA libs / nsight / devel tooling
+# NVIDIA uses different repo paths per arch: x86_64 -> x86_64, aarch64 -> sbsa
 RUN retry.sh -- dnf -y install 'dnf-command(config-manager)' && \
-    retry.sh -- dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && \
+    case "$(uname -m)" in \
+        x86_64)  CUDA_REPO_ARCH=x86_64 ;; \
+        aarch64) CUDA_REPO_ARCH=sbsa ;; \
+        *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;; \
+    esac && \
+    retry.sh -- dnf config-manager --add-repo "https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${CUDA_REPO_ARCH}/cuda-rhel8.repo" && \
     retry.sh -- dnf -y install \
         cuda-nvcc-12-0 \
         cuda-cudart-12-0 \

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -85,9 +85,7 @@ RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
         && \
     dnf clean all
 
-# install minimal CUDA toolkit (nvcc + cudart) from NVIDIA's RHEL8 repo
-# replaces nvidia/cuda:devel base image, dropping ~3.5 GB of unused CUDA libs / nsight / devel tooling
-# NVIDIA uses different repo paths per arch: x86_64 -> x86_64, aarch64 -> sbsa
+# install minimal CUDA 12.0 toolkit (nvcc + cudart)
 RUN retry.sh -- dnf -y install 'dnf-command(config-manager)' && \
     case "$(uname -m)" in \
         x86_64)  CUDA_REPO_ARCH=x86_64 ;; \


### PR DESCRIPTION
## Summary

Switch the rockylinux8-vcpkg production stage from `nvidia/cuda:12.0.1-devel-rockylinux8` to plain `rockylinux:8`, and install only the CUDA packages MeshLib actually uses for compilation: `nvcc` + `cudart`. This mirrors the Windows job's selection (`["nvcc", "cudart", "visual_studio_integration"]`).

## Why

The `nvidia/cuda:12.0.1-devel-rockylinux8` base shipped ~3.5 GB of CUDA content that MeshLib does not link against:

| CUDA layer | Size | Content | Kept? |
|---|---:|---|---|
| `cuda-cudart` + compat | 113 MB | runtime headers/lib needed by nvcc | yes |
| `cuda-libraries` (cuBLAS, cuFFT, cuSPARSE, NPP, NCCL, …) | 1314 MB | unused by MeshLib | dropped |
| `cuda-libraries-devel` + `cuda-command-line-tools` + `nsight-compute` | 2154 MB | unused by MeshLib | dropped |

The replacement set (`cuda-nvcc-12-0`, `cuda-cudart-12-0`, `cuda-cudart-devel-12-0`, `cuda-driver-devel-12-0`, `cuda-cuxxfilt-12-0`) totals ~60 MB compressed RPM.

NVIDIA publishes the RPMs at different repo paths per architecture (x86_64 → `repos/rhel8/x86_64/`, aarch64 → `repos/rhel8/sbsa/`); the Dockerfile picks the right one at build time from `uname -m`.

## Measured results

### Image size on Docker Hub

| Image | master | this PR | Δ |
|---|---:|---:|---:|
| `meshlib-rockylinux8-vcpkg-x64` | 4396.9 MB | **1096.5 MB** | **−3300 MB (−75%)** |
| `meshlib-rockylinux8-vcpkg-arm64` | 3831.7 MB | **1043.5 MB** | **−2788 MB (−73%)** |

Layer count also drops 15 → 7, which improves pull parallelism (the old 2.15 GB devel-CUDA layer was a serial-extraction bottleneck).

### "Initialize containers" step (linux-vcpkg-build-test matrix)

| Matrix leg | master | this PR | Δ |
|---|---:|---:|---:|
| Release · x64 · Clang 21 | 90 s | **55 s** | −35 s (−39%) |
| Release · arm64 · Clang 21 | 123 s | **54 s** | −69 s (−56%) |
| Debug · x64 · GCC 11 | 89 s | **57 s** | −36 s (−40%) |
| Debug · arm64 · GCC 11 | 113 s | **55 s** | −58 s (−51%) |

About 3.3 minutes shaved off every `linux-vcpkg-build-test` sweep. The remaining ~55 s is GitHub Actions' container-init overhead (auth, container start, "Waiting for all services to be ready"), not docker pull. arm64 benefits more in absolute terms — master arm64 had slower effective registry throughput; after the trim both arches converge to the same ~55 s.

All four matrix legs passed; build time and downstream steps are unchanged, confirming `nvcc` + `cudart` is sufficient for MeshLib's CUDA compilation on Linux.

## Notes

- Same CUDA version family (12.0) — only the package selection changes.
- `PATH` is updated to include `/usr/local/cuda/bin` (previously set by the nvidia/cuda base image).
- The `LD_LIBRARY_PATH` / `LIBRARY_PATH` / `nvidia_entrypoint.sh` that the nvidia/cuda base set are dropped. They targeted GPU runtime, not compilation-only CI.
