### PR TITLE
ci(windows): tolerate transient MSYS2 cache restore errors

### DIFF
--- a/.github/actions/install-msys2-mrbind/action.yml
+++ b/.github/actions/install-msys2-mrbind/action.yml
@@ -10,7 +10,10 @@ runs:
     - name: Cache pinned MSYS2 packages
       # Cache key tracks the lockfile; `wget -nc` makes cache-hit a no-op,
       # and `sha256sum -c` in the install script is the integrity gate.
+      # Tolerate transient cache-service failures — the install step will
+      # redownload from scratch if nothing was restored.
       uses: actions/cache@v5
+      continue-on-error: true
       with:
         path: scripts/mrbind/msys2_packages
         key: msys2-mrbind-clang22-${{ hashFiles('scripts/mrbind/msys2_package_hashes_clang22.txt') }}


### PR DESCRIPTION
## Problem

The Windows `actions/cache@v5` step inside `.github/actions/install-msys2-mrbind/action.yml` occasionally fails with a transient cache-service error, taking the whole job down before the install step can run. Example failure: https://github.com/MeshInspector/MeshLib/actions/runs/26408259717/job/77736731993

## Fix

Mark the MSYS2 cache step with `continue-on-error: true`. If the cache service errors out, the job now proceeds to the install step.

This is safe because the install step (`scripts/mrbind/msys2_download_packages.sh`) uses `wget -nc` (no-clobber) to fetch packages and `sha256sum -c` to verify them — a missing restore just means redownloading, with hash verification intact.

A cache *miss* was always non-fatal; this change only adds tolerance for cache *service* failures.
