### PR TITLE
docker(ubuntu24): trim CUDA via NVIDIA sbsa repo (3.8 GB -> 1.2 GB on arm64)

### DIFF
--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -29,21 +29,13 @@ ENV MR_STATE=DOCKER_BUILD
 RUN ./scripts/build_thirdparty.sh
 
 
-# no CUDA packages for Ubuntu 24.04 ARM64 for some reason, have to copy them from a Docker image
-FROM nvidia/cuda:12.6.0-devel-ubuntu24.04 AS cuda
-COPY scripts/ubuntu_cuda_libs.txt /tmp/ubuntu_cuda_libs.txt
-# remove excess libraries; arch-specific lib dir (x86_64-linux on x86_64, sbsa-linux on arm64)
-RUN ARCH_LIB_DIR=$(ls -d /usr/local/cuda-12.6/targets/*-linux/lib | head -1) && \
-    cd "${ARCH_LIB_DIR}" && \
-    find -type f,l ! -path "./cmake/*" $(printf "! -path ./%s " $(cat /tmp/ubuntu_cuda_libs.txt)) -delete
-
-
 FROM ubuntu:24.04 AS production
 
 RUN mkdir /usr/local/lib/meshlib-thirdparty-lib/
 WORKDIR "/usr/local/lib/meshlib-thirdparty-lib/"
 
 COPY scripts/install_apt_requirements.sh scripts/install_apt_requirements.sh
+COPY scripts/install_apt_cuda.sh scripts/install_apt_cuda.sh
 COPY scripts/mrbind/install_deps_ubuntu.sh scripts/mrbind/install_deps_ubuntu.sh
 COPY scripts/mrbind/clang_version.txt scripts/mrbind/clang_version.txt
 COPY scripts/install_thirdparty.sh scripts/install_thirdparty.sh
@@ -54,7 +46,6 @@ COPY scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh scripts/
 COPY --from=build /home/MeshLib/lib /usr/local/lib/meshlib-thirdparty-lib/lib
 COPY --from=build /home/MeshLib/include /usr/local/lib/meshlib-thirdparty-lib/include
 COPY --from=build /home/MeshLib/share /usr/local/lib/meshlib-thirdparty-lib/share
-COPY --from=cuda /usr/local/cuda-12.6 /usr/local/cuda-12.6
 
 ENV MR_STATE=DOCKER_BUILD
 
@@ -68,6 +59,7 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
  && apt-get install -qqy --no-install-recommends \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext \
  && ./scripts/install_apt_requirements.sh \
+ && ./scripts/install_apt_cuda.sh \
  && ./scripts/mrbind/install_deps_ubuntu.sh \
  && ./scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh \
  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -31,10 +31,11 @@ RUN ./scripts/build_thirdparty.sh
 
 # no CUDA packages for Ubuntu 24.04 ARM64 for some reason, have to copy them from a Docker image
 FROM nvidia/cuda:12.6.0-devel-ubuntu24.04 AS cuda
-WORKDIR /usr/local/cuda-12.6/targets/x86_64-linux/lib
-COPY scripts/ubuntu_cuda_libs.txt ubuntu_cuda_libs.txt
-# remove excess libraries
-RUN find -type f,l ! -path "./cmake/*" $(printf "! -path ./%s " $(cat ubuntu_cuda_libs.txt)) -delete
+COPY scripts/ubuntu_cuda_libs.txt /tmp/ubuntu_cuda_libs.txt
+# remove excess libraries; arch-specific lib dir (x86_64-linux on x86_64, sbsa-linux on arm64)
+RUN ARCH_LIB_DIR=$(ls -d /usr/local/cuda-12.6/targets/*-linux/lib | head -1) && \
+    cd "${ARCH_LIB_DIR}" && \
+    find -type f,l ! -path "./cmake/*" $(printf "! -path ./%s " $(cat /tmp/ubuntu_cuda_libs.txt)) -delete
 
 
 FROM ubuntu:24.04 AS production

--- a/scripts/install_apt_cuda.sh
+++ b/scripts/install_apt_cuda.sh
@@ -14,10 +14,6 @@ case "$(uname -m)" in
     "x86_64")
         ARCH="x86_64" ;;
     "aarch64")
-        # NVIDIA splits aarch64 packages between two repo paths:
-        #   arm64 — Tegra/Jetson (embedded GPU systems)
-        #   sbsa  — Server Base System Architecture (AWS Graviton, etc.)
-        # ubuntu2404 ships cuda-minimal-build-12-6 only under sbsa.
         ARCH="sbsa" ;;
     *)
         echo "Unsupported arch: $(uname -m)"

--- a/scripts/install_apt_cuda.sh
+++ b/scripts/install_apt_cuda.sh
@@ -14,7 +14,11 @@ case "$(uname -m)" in
     "x86_64")
         ARCH="x86_64" ;;
     "aarch64")
-        ARCH="arm64" ;;
+        # NVIDIA splits aarch64 packages between two repo paths:
+        #   arm64 — Tegra/Jetson (embedded GPU systems)
+        #   sbsa  — Server Base System Architecture (AWS Graviton, etc.)
+        # ubuntu2404 ships cuda-minimal-build-12-6 only under sbsa.
+        ARCH="sbsa" ;;
     *)
         echo "Unsupported arch: $(uname -m)"
         exit 1 ;;


### PR DESCRIPTION
## Summary

Fix `meshlib-ubuntu24-arm64` shipping 3.8 GB of unused CUDA content (vs 1.5 GB for the x86_64 counterpart). The fix routes aarch64 to NVIDIA's `sbsa` (Server Base System Architecture) repo path instead of `arm64`, which lets `ubuntu24Dockerfile` drop its multi-stage workaround and use the same `install_apt_cuda.sh` install path as `ubuntu22Dockerfile`.

## Why

`docker/ubuntu24Dockerfile` previously had an intermediate `nvidia/cuda:12.6.0-devel-ubuntu24.04 AS cuda` stage that pulled the whole devel image and pruned libs to an allow-list before COPYing into the production stage. The reason was that NVIDIA's apt repo at `ubuntu2404/arm64` doesn't ship `cuda-minimal-build-12-6`, so the simpler apt install path (used by `ubuntu22Dockerfile`) didn't work on arm64.

NVIDIA actually splits aarch64 packages between two repo paths:

| repo path | purpose | `cuda-minimal-build-12-6` |
|---|---|---:|
| `ubuntu2404/arm64` | Tegra / Jetson (embedded GPUs) | **0** |
| `ubuntu2404/sbsa` | Server Base System Architecture (AWS Graviton etc.) | **4** |
| `ubuntu2204/arm64` | Tegra / Jetson | 4 |
| `ubuntu2204/sbsa` | Server class | 4 |

`sbsa` is also the correct path for the CI's actual hardware (AWS Graviton runners). The previous mapping (`aarch64 -> arm64`) happened to work for ubuntu2204 because NVIDIA mirrors most packages there, but it doesn't cover ubuntu2404.

## Fix

Two-file change implementing the reviewer's suggestion:

1. **`scripts/install_apt_cuda.sh`**: map `aarch64 -> sbsa` (was `arm64`). Comment in the script records the Tegra-vs-Server reasoning.
2. **`docker/ubuntu24Dockerfile`**: drop the intermediate `cuda` stage and the `COPY --from=cuda /usr/local/cuda-12.6 …`; instead call `./scripts/install_apt_cuda.sh` from the production-stage install chain, mirroring `ubuntu22Dockerfile`.

Net: +7 / −11 lines across both files. The "no CUDA packages for Ubuntu 24.04 ARM64 for some reason" comment is no longer accurate and is removed along with the workaround.

## Measured results

### Image size on Docker Hub

| Image | master | this PR | Δ |
|---|---:|---:|---:|
| **`meshlib-ubuntu24-arm64`** | **3814.5 MB** | **1220.5 MB** | **−2594 MB (−68%)** |
| `meshlib-ubuntu24` (x64) | 1488.3 MB | **1334.4 MB** | **−154 MB (−10%)** |
| `meshlib-ubuntu22` (x64) | 1379.2 MB | 1385.4 MB | +6 MB (upstream-package noise) |
| `meshlib-ubuntu22-arm64` | 1322.7 MB | 1325.3 MB | +3 MB (sbsa vs arm64 deb size diff) |

ubuntu24-arm64 now matches the x86_64 size, as expected.

ubuntu24 x86_64 also got 154 MB smaller, even though the bug was only visible on arm64. The intermediate-stage approach `COPY`-ed the entire `/usr/local/cuda-12.6` tree (bin, include, doc, share, …) minus the `lib/` files matched by the deny list; `cuda-minimal-build-12-6` is a tighter selection of just what nvcc + cudart actually depend on.

ubuntu22 images are unchanged in observable behaviour. The script now uses `sbsa` packages for arm64 instead of `arm64` (Tegra) packages — same versions, slightly different binaries (NVIDIA SHA256s differ), comparable size.

### "Initialize containers" step

| Matrix | master | this PR | Δ |
|---|---:|---:|---:|
| ubuntu24 · arm64 · Release | 137 s | **70 s** | **−67 s (−49%)** |
| ubuntu24 · x64 · Release GCC g++13 | 80 s | 70 s | −10 s |
| ubuntu22 · arm64 · Release | 73 s | 75 s | +2 s (noise) |

arm64-ubuntu24 init drop is proportional to bytes saved (image 68% smaller → init 49% faster; the remaining time is GHA's fixed container-init overhead).

### Build step — no regression

| Matrix | master | this PR |
|---|---:|---:|
| ubuntu24 · arm64 Build | 1086 s | 998 s |
| ubuntu24 · x64 Build | 1007 s | 1316 s |
| ubuntu22 · arm64 Build | 672 s | 661 s |

arm64 cells are within noise. The ubuntu24 x64 wobble is runner variance plus a one-off "Install MRBind" step the master baseline skipped — unrelated to this PR. All four ubuntu cells passed across multiple compiler/config combinations, including ubuntu22 arm64 (which now consumes `sbsa` packages), confirming the script change is transparent on the existing arches as well.

## Net result

- arm64 `meshlib-ubuntu24` drops to parity with x86_64 (~1.2 GB), saving ~2.6 GB on every Docker Hub pull and every runner's disk.
- arm64-ubuntu24 CI saves ~67 s per "Initialize containers".
- A bonus ~154 MB trim on the ubuntu24 x86_64 image because apt is more selective than the file-allow-list approach.
- `ubuntu24Dockerfile` is structurally simpler: no second FROM, no allow-list dance, no intermediate `nvidia/cuda:devel` pull during image build.

`scripts/ubuntu_cuda_libs.txt` is no longer referenced from any Dockerfile in this repo but left in place for now (still used elsewhere via the submodule); it can be removed in a follow-up.
