### PR TITLE
C tests/examples: inline Id construction at call sites

### DIFF
--- a/examples/c-examples/MeshExtrude.dox.c
+++ b/examples/c-examples/MeshExtrude.dox.c
@@ -30,11 +30,8 @@ int main( void )
 
     // Select faces to extrude
     MR_FaceBitSet* facesToExtrude = MR_FaceBitSet_DefaultConstruct();
-    MR_FaceId face;
-    face.id_ = 1;
-    MR_FaceBitSet_autoResizeSet_2( facesToExtrude, face, NULL );
-    face.id_ = 2;
-    MR_FaceBitSet_autoResizeSet_2( facesToExtrude, face, NULL );
+    MR_FaceBitSet_autoResizeSet_2( facesToExtrude, (MR_FaceId){1}, NULL );
+    MR_FaceBitSet_autoResizeSet_2( facesToExtrude, (MR_FaceId){2}, NULL );
 
     // Create duplicated verts on region boundary
     MR_makeDegenerateBandAroundRegion( mesh, facesToExtrude, NULL );

--- a/source/MRTestC2/MRExpandShrink.c
+++ b/source/MRTestC2/MRExpandShrink.c
@@ -17,8 +17,7 @@ void testExpandShrink( void )
 
     const MR_MeshTopology* top = MR_Mesh_Get_topology( mesh );
 
-    MR_FaceId face; face.id_ = 0;
-    MR_FaceBitSet* region = MR_expand_MR_FaceId( top, face, 3 );
+    MR_FaceBitSet* region = MR_expand_MR_FaceId( top, (MR_FaceId){0}, 3 );
 
     int num = (int)MR_FaceBitSet_count( region );
     TEST_ASSERT_INT_EQUAL( num, 75 );
@@ -47,8 +46,7 @@ void testExpandShrinkVerts( void )
 
     const MR_MeshTopology* top = MR_Mesh_Get_topology( mesh );
 
-    MR_VertId vert; vert.id_ = 0;
-    MR_VertBitSet* region = MR_expand_MR_VertId( top, vert, 3 );
+    MR_VertBitSet* region = MR_expand_MR_VertId( top, (MR_VertId){0}, 3 );
 
     size_t num = MR_VertBitSet_count( region );
     TEST_ASSERT( num == 37 );

--- a/source/MRTestC2/MRMeshComponents.c
+++ b/source/MRTestC2/MRMeshComponents.c
@@ -72,11 +72,8 @@ void testLargeRegions( void )
     MR_std_pair_MR_FaceBitSet_int* regions = MR_MeshComponents_getLargeByAreaRegions( m.part, MR_std_pair_MR_Face2RegionMap_int_first( map ), *MR_std_pair_MR_Face2RegionMap_int_second( map ), 0.1f );
 
     TEST_ASSERT( *MR_std_pair_MR_FaceBitSet_int_second( regions ) == 1 );
-    MR_FaceId face;
-    face.id_ = 0;
-    TEST_ASSERT( MR_FaceBitSet_test( MR_std_pair_MR_FaceBitSet_int_first( regions ), face ) );
-    face.id_ = 12;
-    TEST_ASSERT( !MR_FaceBitSet_test( MR_std_pair_MR_FaceBitSet_int_first( regions ), face ) );
+    TEST_ASSERT( MR_FaceBitSet_test( MR_std_pair_MR_FaceBitSet_int_first( regions ), (MR_FaceId){0} ) );
+    TEST_ASSERT( !MR_FaceBitSet_test( MR_std_pair_MR_FaceBitSet_int_first( regions ), (MR_FaceId){12} ) );
 
     MR_std_pair_MR_Face2RegionMap_int_Destroy( map );
 
@@ -88,11 +85,8 @@ void testLargeComponents( void )
     CreatedMesh m = createMesh();
 
     MR_FaceBitSet* components = MR_MeshComponents_getLargeByAreaComponents_3( m.part, 0.1f, NULL );
-    MR_FaceId face;
-    face.id_ = 0;
-    TEST_ASSERT( MR_FaceBitSet_test( components, face ) );
-    face.id_ = 12;
-    TEST_ASSERT( !MR_FaceBitSet_test( components, face ) );
+    TEST_ASSERT( MR_FaceBitSet_test( components, (MR_FaceId){0} ) );
+    TEST_ASSERT( !MR_FaceBitSet_test( components, (MR_FaceId){12} ) );
 
     MR_FaceBitSet_Destroy( components );
 
@@ -105,11 +99,8 @@ void testLargestComponent( void )
 
     int smallerComponents = 0;
     MR_FaceBitSet* largestComponent = MR_MeshComponents_getLargestComponent( m.part, NULL, NULL, &(float){0.1f}, &smallerComponents );
-    MR_FaceId face;
-    face.id_ = 0;
-    TEST_ASSERT( MR_FaceBitSet_test( largestComponent, face ) );
-    face.id_ = 12;
-    TEST_ASSERT( !MR_FaceBitSet_test( largestComponent, face ) );
+    TEST_ASSERT( MR_FaceBitSet_test( largestComponent, (MR_FaceId){0} ) );
+    TEST_ASSERT( !MR_FaceBitSet_test( largestComponent, (MR_FaceId){12} ) );
     TEST_ASSERT( smallerComponents == 1 );
 
     MR_FaceBitSet_Destroy( largestComponent );
@@ -120,14 +111,11 @@ void testLargestComponent( void )
 void testGetComponent( void )
 {
     CreatedMesh m = createMesh();
-    MR_FaceId face;
-    face.id_ = 12;
 
-    MR_FaceBitSet* component = MR_MeshComponents_getComponent( m.part, face, NULL, NULL );
+    MR_FaceBitSet* component = MR_MeshComponents_getComponent( m.part, (MR_FaceId){12}, NULL, NULL );
 
-    TEST_ASSERT( MR_FaceBitSet_test( component, face ) );
-    face.id_ = 0;
-    TEST_ASSERT( !MR_FaceBitSet_test( component, face ) );
+    TEST_ASSERT( MR_FaceBitSet_test( component, (MR_FaceId){12} ) );
+    TEST_ASSERT( !MR_FaceBitSet_test( component, (MR_FaceId){0} ) );
     MR_FaceBitSet_Destroy( component );
 
     destroyMesh( m );

--- a/source/MRTestC2/MRMeshExtrude.c
+++ b/source/MRTestC2/MRMeshExtrude.c
@@ -24,11 +24,8 @@ void testDegenerateBandNonEmpty(void) {
     // Create a face bit set and select a few faces (for example, faces 0 and 1)
     MR_FaceBitSet* region = MR_FaceBitSet_DefaultConstruct();
 
-    MR_FaceId face;
-    face.id_ = 0;
-    MR_FaceBitSet_autoResizeSet_2( region, face, &(bool){true} );
-    face.id_ = 1;
-    MR_FaceBitSet_autoResizeSet_2( region, face, &(bool){true} );
+    MR_FaceBitSet_autoResizeSet_2( region, (MR_FaceId){0}, &(bool){true} );
+    MR_FaceBitSet_autoResizeSet_2( region, (MR_FaceId){1}, &(bool){true} );
 
     // Call the function to create a band of degenerate faces along the region boundary
     MR_makeDegenerateBandAroundRegion( mesh, region, NULL );

--- a/source/MRTestC2/MRVDBConversions.c
+++ b/source/MRTestC2/MRVDBConversions.c
@@ -149,9 +149,7 @@ void testAccessors( void )
     MR_VoxelBitSet* region = MR_VoxelBitSet_DefaultConstruct();
     MR_VoxelBitSet_resize( region, dims->x * dims->y * dims->z, NULL );
 
-    MR_VoxelId voxel;
-    voxel.id_ = 0;
-    MR_VoxelBitSet_set_2( region, voxel, true );
+    MR_VoxelBitSet_set_2( region, (MR_VoxelId){0}, true );
 
     MR_setValue_MR_VoxelBitSet( MR_VdbVolume_GetMutable_data( volume ), region, 1.0f );
     MR_VoxelBitSet_Destroy( region );


### PR DESCRIPTION
## Summary

In `source/MRTestC2/` and `examples/c-examples/`, replace the two-step Id construction pattern with an inline compound literal at the call site.

Before:
```c
MR_FaceId face;
face.id_ = 0;
MR_FaceBitSet_autoResizeSet_2( region, face, &(bool){true} );
face.id_ = 1;
MR_FaceBitSet_autoResizeSet_2( region, face, &(bool){true} );
```

After:
```c
MR_FaceBitSet_autoResizeSet_2( region, (MR_FaceId){0}, &(bool){true} );
MR_FaceBitSet_autoResizeSet_2( region, (MR_FaceId){1}, &(bool){true} );
```

Pure refactor — no behavior change.

## Files

- `source/MRTestC2/MRVDBConversions.c`
- `source/MRTestC2/MRMeshExtrude.c`
- `source/MRTestC2/MRMeshComponents.c`
- `source/MRTestC2/MRExpandShrink.c`
- `examples/c-examples/MeshExtrude.dox.c`
