### PR TITLE
ci(windows): tolerate transient CUDA cache restore errors

### DIFF
--- a/.github/actions/install-cuda/action.yml
+++ b/.github/actions/install-cuda/action.yml
@@ -23,6 +23,7 @@ runs:
     - name: Restore CUDA Cache
       uses: actions/cache@v5
       id: cuda-cache
+      continue-on-error: true
       with:
         key: cuda-toolkit-subset-${{ inputs.cuda-version }}-v1
         path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ inputs.cuda-major }}.${{ inputs.cuda-minor }}


### PR DESCRIPTION
## Problem

The Windows `actions/cache@v5` step inside `.github/actions/install-cuda/action.yml` occasionally fails with a transient cache-service error, taking the whole job down before the Jimver/cuda-toolkit install step can run. Example failure: https://github.com/MeshInspector/MeshLib/actions/runs/26445200137/job/77853966876

## Fix

Mark the CUDA cache step with `continue-on-error: true`. If the cache service errors out, `steps.cuda-cache.outputs.cache-hit` is not `'true'`, so the existing gated install step runs and installs the toolkit from the NVIDIA network installer.

This mirrors the fix landed in #6164 for the MSYS2 cache. A cache *miss* was always non-fatal; this change only adds tolerance for cache *service* failures.
