### PR TITLE
mrbind/generate.mk: pass -isysroot at link time too (host-independent lld)

### DIFF
--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -618,7 +618,18 @@ COMPILER_FLAGS += -I$(HOMEBREW_DIR)/include
 # relative to the resource-dir; on llvm@22 that no longer works and the parse pass
 # fails with `'iostream' file not found`. Using Apple's SDK libc++ is also closer
 # to what the project itself compiles against.
-COMPILER_FLAGS += -isysroot $(call safe_shell,xcrun --show-sdk-path)
+#
+# Same flag also needs to go on the link line: clang's Darwin driver normally
+# auto-forwards `-syslibroot <sdk>` to the linker by sniffing `xcrun` /
+# `DEVELOPER_DIR` / `xcode-select`, but with brew `llvm@22` + LLD that
+# autodetect doesn't fire on every self-hosted runner (host-dependent --
+# /opt/homebrew + full Xcode works, /Users/runner/.homebrew + CLT-only does
+# not). Without `-syslibroot`, lld can't find `/usr/lib/libSystem.tbd`,
+# `libc++.dylib`, `libc++abi.dylib` and the link fails. Pass it explicitly
+# so the behaviour is host-independent.
+override macos_sdk_path := $(call safe_shell,xcrun --show-sdk-path)
+COMPILER_FLAGS += -isysroot $(macos_sdk_path)
+LINKER_FLAGS   += -isysroot $(macos_sdk_path)
 # Boost.stacktrace complains otherwise.
 COMPILER_FLAGS += -D_GNU_SOURCE
 


### PR DESCRIPTION
## Summary

Follow-up to #6153. That PR added `-isysroot $(xcrun --show-sdk-path)` to `COMPILER_FLAGS` in `scripts/mrbind/generate.mk` so libclang could find libc++ headers when parsing with brew `llvm@22`. The same flag also needs to go on the **link** line — without it, `mrcudapy.so` / `mrmeshpy.so` fail to link on some self-hosted ARM runners.

clang's Darwin driver normally auto-forwards `-syslibroot <sdk>` to the linker by sniffing `xcrun` / `DEVELOPER_DIR` / `xcode-select`. With brew `llvm@22` + LLD that autodetect is host-dependent — `/opt/homebrew` + full Xcode works, `/Users/runner/.homebrew` + CLT-only does not. Without `-syslibroot`, lld can't find `/usr/lib/libSystem.tbd`, `libc++.dylib`, `libc++abi.dylib`, and the link fails with:

```
ld64.lld: error: library not found for -lc++abi
ld64.lld: error: library not found for -lc++
ld64.lld: error: library not found for -lSystem
clang++: error: linker command failed with exit code 1
```

Example: [run 26452002194 / arm64 Debug](https://github.com/MeshInspector/MeshLib/actions/runs/26452002194/job/77875237769) on `MACBOOK-PRO-16-2021-TBI-2`.

The bug was always latent after #6153 — it just sat dormant on every master push that happened to land on the friendly host (`MacBook-Pro-Daniil`, `/opt/homebrew`). The `[self-hosted, macos, arm64, build]` label matches multiple machines and the scheduler rolls between them; the first roll that landed on `MACBOOK-PRO-16-2021-TBI-2` (`/Users/runner/.homebrew`) surfaced the failure.

### Fix

Hoist `xcrun --show-sdk-path` into a single `macos_sdk_path` variable and pass `-isysroot $(macos_sdk_path)` to both `COMPILER_FLAGS` *and* `LINKER_FLAGS`, so clang forwards `-syslibroot` to whatever linker is used regardless of host environment.

```diff
+override macos_sdk_path := $(call safe_shell,xcrun --show-sdk-path)
+COMPILER_FLAGS += -isysroot $(macos_sdk_path)
+LINKER_FLAGS   += -isysroot $(macos_sdk_path)
-COMPILER_FLAGS += -isysroot $(call safe_shell,xcrun --show-sdk-path)
```

Linux / Windows are inside `ifneq ($(IS_MACOS),)` — unaffected.

## Test plan

- [x] `build-test-macos.yml` `arm64 Debug` job links `mrcudapy.so` and `mrmeshpy.so` successfully on `MACBOOK-PRO-16-2021-TBI-2` (the host that previously failed).
- [x] Other macOS jobs (`arm64 Release` / `x64 Release` / `MacBook-Pro-Daniil` arm Debug) still pass — adding `-isysroot` is idempotent for them.
- [x] No regression on Linux / Windows mrbind builds (change is gated on `IS_MACOS`).
