### PR TITLE
Link mimalloc with EXE-level redirect on Windows (MeshViewer, MRTest)

### DIFF
--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -24,6 +24,7 @@ laz-perf
 libe57format
 libharu
 libzip
+mimalloc[override]
 opencascade
 openctm
 openvdb

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -156,6 +156,9 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <!-- mimalloc EXE-level redirect: force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator -->
+      <AdditionalDependencies>mimalloc-debug.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -179,6 +182,9 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <!-- mimalloc EXE-level redirect: force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator -->
+      <AdditionalDependencies>mimalloc.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/source/MRViewerApp/MRViewerApp.vcxproj
+++ b/source/MRViewerApp/MRViewerApp.vcxproj
@@ -93,6 +93,9 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <!-- mimalloc EXE-level redirect: force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator -->
+      <AdditionalDependencies>mimalloc-debug.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -117,6 +120,9 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <!-- mimalloc EXE-level redirect: force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator -->
+      <AdditionalDependencies>mimalloc.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
## Summary
- Declare `mimalloc[override]` in `requirements/windows.txt`.
- Link mimalloc into the Windows executables **MeshViewer** and **MRTest**, forcing an `mi_version` reference (`/INCLUDE:mi_version` via `ForceSymbolReferences`) so `mimalloc-redirect.dll` loads early and transparently routes *all* process allocations — including those inside MRMesh/MRVoxels/MRIOExtras/etc. — through mimalloc.
- Per-config import libs: Debug links `mimalloc-debug.dll.lib`, Release links `mimalloc.dll.lib`. `mimalloc-redirect.dll` is imported by `mimalloc.dll`, so vcpkg app-local deploy carries it automatically — no copy step needed.

Windows-only change (`*.vcxproj` + `requirements/windows.txt`); other platforms don't read these files, so their CI builds are disabled on this PR.

## Test plan
- [ ] Windows Debug + Release build of MeshViewer and MRTest links and runs.
- [ ] `mi_is_redirected()` returns 1 at runtime (redirect engaged).
- [ ] MRTest suite passes under mimalloc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)