### PR TITLE
Support the Windows CMake build for the mimalloc redirect

### DIFF
--- a/cmake/Modules/MimallocRedirect.cmake
+++ b/cmake/Modules/MimallocRedirect.cmake
@@ -1,4 +1,4 @@
-# mr_enable_mimalloc_redirect(<target>)
+# mr_win32_enable_mimalloc_redirect(<target>)
 #
 # Enable mimalloc's transparent allocator redirect for a Windows executable:
 # link the dynamic mimalloc and force-keep the mi_version symbol so that
@@ -6,14 +6,11 @@
 # CRT allocator process-wide (covering all allocations, including those made
 # inside MRMesh and the other MeshLib DLLs).
 #
-# The redirect is an executable-only, Windows-only mechanism, so this is a no-op
-# on every other platform (Emscripten links mimalloc via -sMALLOC=mimalloc, see
-# ConfigureEmscripten.cmake). Linking the imported mimalloc target lets CMake
-# resolve the version-specific import library name for us.
-function(mr_enable_mimalloc_redirect target)
-  if(NOT WIN32)
-    return()
-  endif()
+# This is a Windows-only, executable-only mechanism; guard the call with
+# if(WIN32). Linking the imported mimalloc target lets CMake resolve the
+# version-specific import library name for us. (Emscripten links mimalloc via
+# -sMALLOC=mimalloc instead, see ConfigureEmscripten.cmake.)
+function(mr_win32_enable_mimalloc_redirect target)
   find_package(mimalloc CONFIG REQUIRED)
   target_link_libraries(${target} PRIVATE mimalloc)
   target_link_options(${target} PRIVATE "/INCLUDE:mi_version")

--- a/cmake/Modules/MimallocRedirect.cmake
+++ b/cmake/Modules/MimallocRedirect.cmake
@@ -1,0 +1,20 @@
+# mr_enable_mimalloc_redirect(<target>)
+#
+# Enable mimalloc's transparent allocator redirect for a Windows executable:
+# link the dynamic mimalloc and force-keep the mi_version symbol so that
+# mimalloc.dll is loaded early enough for mimalloc-redirect.dll to take over the
+# CRT allocator process-wide (covering all allocations, including those made
+# inside MRMesh and the other MeshLib DLLs).
+#
+# The redirect is an executable-only, Windows-only mechanism, so this is a no-op
+# on every other platform (Emscripten links mimalloc via -sMALLOC=mimalloc, see
+# ConfigureEmscripten.cmake). Linking the imported mimalloc target lets CMake
+# resolve the version-specific import library name for us.
+function(mr_enable_mimalloc_redirect target)
+  if(NOT WIN32)
+    return()
+  endif()
+  find_package(mimalloc CONFIG REQUIRED)
+  target_link_libraries(${target} PRIVATE mimalloc)
+  target_link_options(${target} PRIVATE "/INCLUDE:mi_version")
+endfunction()

--- a/source/MRTest/CMakeLists.txt
+++ b/source/MRTest/CMakeLists.txt
@@ -30,8 +30,10 @@ ELSE()
   )
 ENDIF()
 
-include(MimallocRedirect)
-mr_enable_mimalloc_redirect(${PROJECT_NAME})
+if(WIN32)
+  include(MimallocRedirect)
+  mr_win32_enable_mimalloc_redirect(${PROJECT_NAME})
+endif()
 
 add_test(
   NAME ${PROJECT_NAME}

--- a/source/MRTest/CMakeLists.txt
+++ b/source/MRTest/CMakeLists.txt
@@ -30,6 +30,9 @@ ELSE()
   )
 ENDIF()
 
+include(MimallocRedirect)
+mr_enable_mimalloc_redirect(${PROJECT_NAME})
+
 add_test(
   NAME ${PROJECT_NAME}
   COMMAND ${PROJECT_NAME}

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -199,8 +199,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- mimalloc EXE-level redirect: force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator -->
-      <AdditionalDependencies>mimalloc-debug.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!-- mimalloc EXE-level redirect: mimalloc is already auto-linked via vcpkg's lib\*.lib, so don't name its import lib (the name varies by version: 2.x mimalloc.lib, 3.x mimalloc.dll.lib). Just force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator. -->
       <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -225,8 +224,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- mimalloc EXE-level redirect: force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator -->
-      <AdditionalDependencies>mimalloc.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!-- mimalloc EXE-level redirect: mimalloc is already auto-linked via vcpkg's lib\*.lib, so don't name its import lib (the name varies by version: 2.x mimalloc.lib, 3.x mimalloc.dll.lib). Just force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator. -->
       <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -199,7 +199,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- mimalloc EXE-level redirect: mimalloc is already auto-linked via vcpkg's lib\*.lib, so don't name its import lib (the name varies by version: 2.x mimalloc.lib, 3.x mimalloc.dll.lib). Just force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator. -->
+      <!-- Force-keep mi_version so mimalloc.dll loads and mimalloc-redirect.dll redirects the allocator to mimalloc. -->
       <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -224,7 +224,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- mimalloc EXE-level redirect: mimalloc is already auto-linked via vcpkg's lib\*.lib, so don't name its import lib (the name varies by version: 2.x mimalloc.lib, 3.x mimalloc.dll.lib). Just force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator. -->
+      <!-- Force-keep mi_version so mimalloc.dll loads and mimalloc-redirect.dll redirects the allocator to mimalloc. -->
       <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>

--- a/source/MRViewerApp/CMakeLists.txt
+++ b/source/MRViewerApp/CMakeLists.txt
@@ -20,8 +20,10 @@ ELSE()
   )
 ENDIF()
 
-include(MimallocRedirect)
-mr_enable_mimalloc_redirect(${PROJECT_NAME})
+if(WIN32)
+  include(MimallocRedirect)
+  mr_win32_enable_mimalloc_redirect(${PROJECT_NAME})
+endif()
 
 install(
   TARGETS ${PROJECT_NAME}

--- a/source/MRViewerApp/CMakeLists.txt
+++ b/source/MRViewerApp/CMakeLists.txt
@@ -20,6 +20,9 @@ ELSE()
   )
 ENDIF()
 
+include(MimallocRedirect)
+mr_enable_mimalloc_redirect(${PROJECT_NAME})
+
 install(
   TARGETS ${PROJECT_NAME}
   DESTINATION "${MR_BIN_DIR}"

--- a/source/MRViewerApp/MRViewerApp.vcxproj
+++ b/source/MRViewerApp/MRViewerApp.vcxproj
@@ -93,8 +93,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- mimalloc EXE-level redirect: force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator -->
-      <AdditionalDependencies>mimalloc-debug.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!-- mimalloc EXE-level redirect: mimalloc is already auto-linked via vcpkg's lib\*.lib, so don't name its import lib (the name varies by version: 2.x mimalloc.lib, 3.x mimalloc.dll.lib). Just force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator. -->
       <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -120,8 +119,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- mimalloc EXE-level redirect: force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator -->
-      <AdditionalDependencies>mimalloc.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!-- mimalloc EXE-level redirect: mimalloc is already auto-linked via vcpkg's lib\*.lib, so don't name its import lib (the name varies by version: 2.x mimalloc.lib, 3.x mimalloc.dll.lib). Just force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator. -->
       <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>

--- a/source/MRViewerApp/MRViewerApp.vcxproj
+++ b/source/MRViewerApp/MRViewerApp.vcxproj
@@ -93,7 +93,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- mimalloc EXE-level redirect: mimalloc is already auto-linked via vcpkg's lib\*.lib, so don't name its import lib (the name varies by version: 2.x mimalloc.lib, 3.x mimalloc.dll.lib). Just force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator. -->
+      <!-- Force-keep mi_version so mimalloc.dll loads and mimalloc-redirect.dll redirects the allocator to mimalloc. -->
       <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -119,7 +119,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- mimalloc EXE-level redirect: mimalloc is already auto-linked via vcpkg's lib\*.lib, so don't name its import lib (the name varies by version: 2.x mimalloc.lib, 3.x mimalloc.dll.lib). Just force-keep mi_version so mimalloc.dll loads early enough for mimalloc-redirect.dll to take over the CRT allocator. -->
+      <!-- Force-keep mi_version so mimalloc.dll loads and mimalloc-redirect.dll redirects the allocator to mimalloc. -->
       <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
## Summary
- Add `cmake/Modules/MimallocRedirect.cmake` with `mr_enable_mimalloc_redirect(target)`: on Windows it `find_package(mimalloc)`, links the imported target, and forces `/INCLUDE:mi_version` so `mimalloc.dll` loads early enough for `mimalloc-redirect.dll` to take over the CRT allocator process-wide. No-op on other platforms (Emscripten already links mimalloc via `-sMALLOC=mimalloc`).
- Apply it to **MeshViewer** and **MRTest**, so the Windows **CMake** build gets the redirect — previously only the MSBuild/`.vcxproj` path had it.
- Drop the hardcoded mimalloc import-lib name from `MRViewerApp.vcxproj` / `MRTest.vcxproj`. The name differs across versions (2.x `mimalloc.lib`, 3.x `mimalloc.dll.lib`); vcpkg's `lib\*.lib` auto-link plus the `mi_version` anchor already pull it in, so naming it explicitly only risked `LNK1181` on toolchains resolving a different mimalloc version.

## Test plan
- [ ] Windows CMake build of MeshViewer/MRTest links and runs.
- [ ] Windows MSBuild build links (no LNK1181).
- [ ] `mi_is_redirected()` returns 1 at runtime.
- [ ] Non-Windows CMake builds unaffected (helper is a no-op).