### PR TITLE
macOS: use Homebrew googletest instead of submodule build

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -85,7 +85,6 @@ jobs:
             thirdparty/eigen \
             thirdparty/parallel-hashmap \
             thirdparty/expected \
-            thirdparty/googletest \
             thirdparty/OpenCTM-git \
             thirdparty/libE57Format \
             thirdparty/glad \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,12 +144,6 @@ IF(APPLE)
   # TODO: revise
   set(CMAKE_INSTALL_RPATH "@loader_path;@loader_path/..;@loader_path/../lib;@loader_path/../lib/lib;@loader_path/meshlib;${MESHLIB_THIRDPARTY_ROOT_DIR}/lib;${CMAKE_BINARY_DIR}/bin")
   set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-
-  IF(BUILD_TESTING)
-    set(GTest_DIR ${HOMEBREW_PREFIX}/lib/cmake/GTest)
-    find_package(GTest REQUIRED CONFIG)
-    include_directories(${GTEST_INCLUDE_DIRS})
-  ENDIF()
 ENDIF()
 
 include(DetectPlatform)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ IF(APPLE)
   set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 
   IF(BUILD_TESTING)
-    set(GTest_DIR ${MESHLIB_THIRDPARTY_ROOT_DIR}/lib/cmake/GTest)
+    set(GTest_DIR ${HOMEBREW_PREFIX}/lib/cmake/GTest)
     find_package(GTest REQUIRED CONFIG)
     include_directories(${GTEST_INCLUDE_DIRS})
   ENDIF()

--- a/requirements/macos.txt
+++ b/requirements/macos.txt
@@ -6,6 +6,7 @@ eigen
 fmt
 gdcm
 glfw
+googletest
 hidapi
 jpeg-turbo
 jsoncpp

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -38,16 +38,20 @@ IF(MR_EMSCRIPTEN)
   ENDIF()
 ENDIF()
 
-set(INSTALL_GTEST ON)
-IF(EMSCRIPTEN)
-  add_compile_definitions(GTEST_HAS_CXXABI_H_=0)
-  add_subdirectory(./googletest ./googletest)
-ELSE()
-  # https://stackoverflow.com/a/42643260/7325599
-  set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
-  set(BUILD_SHARED_LIBS ON CACHE BOOL "" FORCED)
-  add_subdirectory(./googletest ./googletest)
-  set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD} CACHE BOOL "" FORCED)
+# On Apple GTest comes from Homebrew (see requirements/macos.txt); build it
+# from the submodule everywhere else.
+IF(NOT APPLE)
+  set(INSTALL_GTEST ON)
+  IF(EMSCRIPTEN)
+    add_compile_definitions(GTEST_HAS_CXXABI_H_=0)
+    add_subdirectory(./googletest ./googletest)
+  ELSE()
+    # https://stackoverflow.com/a/42643260/7325599
+    set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
+    set(BUILD_SHARED_LIBS ON CACHE BOOL "" FORCED)
+    add_subdirectory(./googletest ./googletest)
+    set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD} CACHE BOOL "" FORCED)
+  ENDIF()
 ENDIF()
 
 IF(NOT APPLE AND NOT MR_EMSCRIPTEN)


### PR DESCRIPTION
## Summary

On macOS, get GoogleTest from Homebrew instead of building it from the `thirdparty/googletest` submodule.

- `requirements/macos.txt`: add the `googletest` brew formula.
- `thirdparty/CMakeLists.txt`: wrap the googletest submodule build in `IF(NOT APPLE)` so it is no longer compiled from source on macOS (Emscripten and other platforms unchanged).
- `CMakeLists.txt`: point `GTest_DIR` at the Homebrew prefix (`${HOMEBREW_PREFIX}/lib/cmake/GTest`) so `find_package(GTest CONFIG)` resolves the brew package. This is required on Apple Silicon, whose `/opt/homebrew` prefix is not on CMake's default search path.
- `.github/workflows/build-test-macos.yml`: drop `thirdparty/googletest` from the selective submodule init.

## Notes

- The thirdparty cache key already hashes `requirements/macos.txt` and `thirdparty/CMakeLists.txt`, so the macOS thirdparty cache invalidates on first run.
- Non-Apple platforms are untouched: the submodule build path is preserved behind `IF(NOT APPLE)`, and the `GTest_DIR` change lives inside the existing `IF(APPLE)` block. Unaffected platforms are disabled via labels.
