### PR TITLE
Ubuntu: use apt googletest instead of submodule build

### DIFF
--- a/requirements/ubuntu.txt
+++ b/requirements/ubuntu.txt
@@ -9,6 +9,7 @@ libfmt-dev
 libfreetype-dev
 libgdcm-dev
 libglfw3-dev
+libgtest-dev
 libgtk-3-dev
 libhidapi-dev
 libhpdf-dev

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -38,8 +38,6 @@ IF(MR_EMSCRIPTEN)
   ENDIF()
 ENDIF()
 
-# GTest comes from Homebrew on Apple and from apt on Linux; build it from
-# the submodule only for Emscripten.
 IF(EMSCRIPTEN)
   set(INSTALL_GTEST ON)
   add_compile_definitions(GTEST_HAS_CXXABI_H_=0)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -38,9 +38,10 @@ IF(MR_EMSCRIPTEN)
   ENDIF()
 ENDIF()
 
-# On Apple GTest comes from Homebrew (see requirements/macos.txt); build it
-# from the submodule everywhere else.
-IF(NOT APPLE)
+# GTest is provided by Homebrew on Apple (see requirements/macos.txt) and by
+# apt on Linux (see requirements/ubuntu.txt -- libgtest-dev); build it from
+# the submodule everywhere else.
+IF(NOT APPLE AND NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux"))
   set(INSTALL_GTEST ON)
   IF(EMSCRIPTEN)
     add_compile_definitions(GTEST_HAS_CXXABI_H_=0)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -38,21 +38,12 @@ IF(MR_EMSCRIPTEN)
   ENDIF()
 ENDIF()
 
-# GTest is provided by Homebrew on Apple (see requirements/macos.txt) and by
-# apt on Linux (see requirements/ubuntu.txt -- libgtest-dev); build it from
-# the submodule everywhere else.
-IF(NOT APPLE AND NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux"))
+# GTest comes from Homebrew on Apple and from apt on Linux; build it from
+# the submodule only for Emscripten.
+IF(EMSCRIPTEN)
   set(INSTALL_GTEST ON)
-  IF(EMSCRIPTEN)
-    add_compile_definitions(GTEST_HAS_CXXABI_H_=0)
-    add_subdirectory(./googletest ./googletest)
-  ELSE()
-    # https://stackoverflow.com/a/42643260/7325599
-    set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
-    set(BUILD_SHARED_LIBS ON CACHE BOOL "" FORCED)
-    add_subdirectory(./googletest ./googletest)
-    set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD} CACHE BOOL "" FORCED)
-  ENDIF()
+  add_compile_definitions(GTEST_HAS_CXXABI_H_=0)
+  add_subdirectory(./googletest ./googletest)
 ENDIF()
 
 IF(NOT APPLE AND NOT MR_EMSCRIPTEN)


### PR DESCRIPTION
## Summary

Mirror of #6174 for the Ubuntu jobs: take GoogleTest from apt (`libgtest-dev`) instead of building it from the `thirdparty/googletest` submodule.

- `requirements/ubuntu.txt`: add the `libgtest-dev` apt package. On Ubuntu 22.04+ it ships with `libgtest.a` / `libgtest_main.a` and a CMake config at `/usr/lib/<triplet>/cmake/GTest/`, which `find_package(GTest REQUIRED)` resolves out of the default search path.
- `thirdparty/CMakeLists.txt`: widen the existing skip guard to also exclude Linux (`CMAKE_SYSTEM_NAME STREQUAL "Linux"`). Emscripten still builds from the submodule -- the EMSCRIPTEN branch is preserved, and the Emscripten toolchain sets `CMAKE_SYSTEM_NAME` to `Emscripten`, not `Linux`.

## Notes

- The path filter in `config.yml` (`requirements/ubuntu.txt`, `thirdparty/**`) triggers a Linux Docker image rebuild on this PR, so the Ubuntu CI exercises both the apt install and the new thirdparty CMake guard end-to-end.
- The three GTest consumers (`MRPch`, `MRTest`, `MRTestCuda`) already call `find_package(GTest REQUIRED)` themselves, and `/usr/lib/<triplet>/cmake/GTest/` is on CMake's default search path on Linux -- no top-level setup needed (matching the cleanup landed in #6174).
- Emscripten is left enabled to confirm the EMSCRIPTEN branch is unaffected; macOS, Windows, and linux-vcpkg are disabled.
