### PR TITLE
Prepend mimalloc lib in EXE link order; add MRTest gate

### DIFF
--- a/cmake/Modules/MimallocRedirect.cmake
+++ b/cmake/Modules/MimallocRedirect.cmake
@@ -1,17 +1,28 @@
 # mr_win32_enable_mimalloc_redirect(<target>)
 #
-# Enable mimalloc's transparent allocator redirect for a Windows executable:
-# link the dynamic mimalloc and force-keep the mi_version symbol so that
-# mimalloc.dll is loaded early enough for mimalloc-redirect.dll to take over the
-# CRT allocator process-wide (covering all allocations, including those made
-# inside MRMesh and the other MeshLib DLLs).
+# Enable mimalloc's transparent allocator redirect for a Windows executable.
+# Two conditions must hold for the redirect to engage at runtime:
+#   1. /INCLUDE:mi_version pulls mimalloc.dll into the EXE's import table.
+#   2. mimalloc.dll must be the FIRST entry in the EXE's import table so
+#      mimalloc-redirect.dll loads before ucrtbase.dll. We achieve this by
+#      prepending mimalloc to LINK_LIBRARIES; otherwise libs that transitively
+#      pull ucrtbase (cpr, gmock, libcurl, ...) come earlier in the link order,
+#      ucrtbase initializes first, and mimalloc-redirect bails with "standard
+#      malloc is _not_ redirected!".
 #
-# This is a Windows-only, executable-only mechanism; guard the call with
-# if(WIN32). Linking the imported mimalloc target lets CMake resolve the
-# version-specific import library name for us. (Emscripten links mimalloc via
-# -sMALLOC=mimalloc instead, see ConfigureEmscripten.cmake.)
+# This is a Windows-only, EXE-only mechanism; guard the call with if(WIN32).
+# The MSBuild equivalent lives at MeshLib/source/MimallocRedirect.props.
+# Linking the imported mimalloc target lets CMake resolve the version-specific
+# import lib name (mimalloc.lib for 2.x, mimalloc.dll.lib for 3.x).
+# (Emscripten links mimalloc via -sMALLOC=mimalloc instead, see
+# ConfigureEmscripten.cmake.)
 function(mr_win32_enable_mimalloc_redirect target)
   find_package(mimalloc CONFIG REQUIRED)
-  target_link_libraries(${target} PRIVATE mimalloc)
+  get_target_property(_existing_libs ${target} LINK_LIBRARIES)
+  if(_existing_libs)
+    set_property(TARGET ${target} PROPERTY LINK_LIBRARIES mimalloc ${_existing_libs})
+  else()
+    set_property(TARGET ${target} PROPERTY LINK_LIBRARIES mimalloc)
+  endif()
   target_link_options(${target} PRIVATE "/INCLUDE:mi_version")
 endfunction()

--- a/source/MRTest/MRMimallocRedirectTests.cpp
+++ b/source/MRTest/MRMimallocRedirectTests.cpp
@@ -5,8 +5,12 @@
 #include <cstdlib>
 #include <string_view>
 
-extern "C" int mi_is_redirected( void );
-extern "C" int mi_is_in_heap_region( const void* p );
+// mimalloc.h declares these as `bool`. Matching the actual return type is
+// critical: MSVC returns `bool` in the low byte of EAX, so reading the call
+// site as `int` picks up garbage in the upper 24 bits (e.g. -980287487).
+// Local Debug happened to zero those bits; Release CI didn't.
+extern "C" bool mi_is_redirected();
+extern "C" bool mi_is_in_heap_region( const void* p );
 
 namespace MR
 {
@@ -23,11 +27,11 @@ TEST( MRMesh, MimallocRedirectActive )
         GTEST_SKIP() << "MIMALLOC_DISABLE_REDIRECT=1; redirect intentionally disabled.";
     }
 
-    EXPECT_EQ( mi_is_redirected(), 1 );
+    EXPECT_TRUE( mi_is_redirected() );
 
     void* p = std::malloc( 64 );
     ASSERT_NE( p, nullptr );
-    EXPECT_EQ( mi_is_in_heap_region( p ), 1 );
+    EXPECT_TRUE( mi_is_in_heap_region( p ) );
     std::free( p );
 }
 

--- a/source/MRTest/MRMimallocRedirectTests.cpp
+++ b/source/MRTest/MRMimallocRedirectTests.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+
+#ifdef _WIN32
+
+#include <cstdlib>
+#include <string_view>
+
+extern "C" int mi_is_redirected( void );
+extern "C" int mi_is_in_heap_region( const void* p );
+
+namespace MR
+{
+
+// Verifies mimalloc's transparent CRT-allocator redirect engaged for this EXE.
+// Wired in MeshLib/source/MimallocRedirect.props (MSBuild) and
+// MeshLib/cmake/Modules/MimallocRedirect.cmake (CMake). Skipped when
+// MIMALLOC_DISABLE_REDIRECT=1 (mimalloc's own runtime kill-switch).
+TEST( MRMesh, MimallocRedirectActive )
+{
+    if ( const char* disable = std::getenv( "MIMALLOC_DISABLE_REDIRECT" );
+         disable && std::string_view( disable ) == "1" )
+    {
+        GTEST_SKIP() << "MIMALLOC_DISABLE_REDIRECT=1; redirect intentionally disabled.";
+    }
+
+    EXPECT_EQ( mi_is_redirected(), 1 );
+
+    void* p = std::malloc( 64 );
+    ASSERT_NE( p, nullptr );
+    EXPECT_EQ( mi_is_in_heap_region( p ), 1 );
+    std::free( p );
+}
+
+} // namespace MR
+
+#endif // _WIN32

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -117,6 +117,7 @@
     <ClCompile Include="MRTupleBindingsTests.cpp" />
     <ClCompile Include="MRViewportIdTests.cpp" />
     <ClCompile Include="MRVolumeIndexerTests.cpp" />
+    <ClCompile Include="MRMimallocRedirectTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\thirdparty\pybind11nonlimitedapi_stubs.vcxproj">
@@ -181,6 +182,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <Import Project="$(ProjectDir)\..\common.props" />
+  <Import Project="$(ProjectDir)\..\MimallocRedirect.props" />
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -199,8 +201,6 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- Force-keep mi_version so mimalloc.dll loads and mimalloc-redirect.dll redirects the allocator to mimalloc. -->
-      <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -224,8 +224,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- Force-keep mi_version so mimalloc.dll loads and mimalloc-redirect.dll redirects the allocator to mimalloc. -->
-      <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -325,6 +325,9 @@
     <ClCompile Include="MRVolumeIndexerTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRMimallocRedirectTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" />

--- a/source/MRViewerApp/MRViewerApp.vcxproj
+++ b/source/MRViewerApp/MRViewerApp.vcxproj
@@ -69,6 +69,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <Import Project="$(ProjectDir)\..\common.props" />
+  <Import Project="$(ProjectDir)\..\MimallocRedirect.props" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>$(MeshLibProjectName)</TargetName>
@@ -93,8 +94,6 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- Force-keep mi_version so mimalloc.dll loads and mimalloc-redirect.dll redirects the allocator to mimalloc. -->
-      <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -119,8 +118,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <!-- Force-keep mi_version so mimalloc.dll loads and mimalloc-redirect.dll redirects the allocator to mimalloc. -->
-      <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/source/MimallocRedirect.props
+++ b/source/MimallocRedirect.props
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Windows EXE-only: configure mimalloc's transparent CRT-allocator redirect.
+    Import this from EXE .vcxproj files AFTER common.props (which sets
+    $(VcpkgCurrentInstalledDir)). Never import from DLL .vcxproj — the redirect
+    works only at the EXE image level (the TLS callback must beat ucrtbase init,
+    and DLL TLS callbacks fire too late).
+
+    Two conditions must hold for the redirect to engage at runtime:
+      1. /INCLUDE:mi_version pulls mimalloc.dll into the EXE's import table.
+      2. mimalloc.dll must be the FIRST entry in the EXE's import table so
+         mimalloc-redirect.dll loads before ucrtbase.dll. Putting the import lib
+         first in AdditionalDependencies achieves this. /INCLUDE alone is not
+         enough — other libs (cpr, gmock, libcurl, ...) otherwise come earlier
+         in the link order and drag ucrtbase in first; mimalloc-redirect then
+         bails with "initialized after ucrtbase.dll … standard malloc is _not_
+         redirected!".
+
+    Lib name varies by mimalloc major version (2.x: mimalloc(-debug).lib,
+    3.x: mimalloc(-debug).dll.lib). Probe both with Exists() so the file works
+    against either vcpkg snapshot without per-runner edits.
+
+    Verified by MRTest's MRMesh.MimallocRedirectActive unit test (gated by
+    MIMALLOC_DISABLE_REDIRECT env var). See also MimallocRedirect.cmake for the
+    CMake equivalent.
+  -->
+  <PropertyGroup>
+    <MimallocDebugLib Condition="Exists('$(VcpkgCurrentInstalledDir)\debug\lib\mimalloc-debug.dll.lib')">mimalloc-debug.dll.lib</MimallocDebugLib>
+    <MimallocDebugLib Condition="'$(MimallocDebugLib)'=='' AND Exists('$(VcpkgCurrentInstalledDir)\debug\lib\mimalloc-debug.lib')">mimalloc-debug.lib</MimallocDebugLib>
+    <MimallocReleaseLib Condition="Exists('$(VcpkgCurrentInstalledDir)\lib\mimalloc.dll.lib')">mimalloc.dll.lib</MimallocReleaseLib>
+    <MimallocReleaseLib Condition="'$(MimallocReleaseLib)'=='' AND Exists('$(VcpkgCurrentInstalledDir)\lib\mimalloc.lib')">mimalloc.lib</MimallocReleaseLib>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Link>
+      <AdditionalDependencies>$(MimallocDebugLib);%(AdditionalDependencies)</AdditionalDependencies>
+      <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Link>
+      <AdditionalDependencies>$(MimallocReleaseLib);%(AdditionalDependencies)</AdditionalDependencies>
+      <ForceSymbolReferences>mi_version;%(ForceSymbolReferences)</ForceSymbolReferences>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
## Summary

- `<ForceSymbolReferences>mi_version` pulls `mimalloc.dll` into the EXE import table but doesn't control its position. With other libs (cpr/gmock/libcurl/fmt/jsoncpp) added by vcpkg's auto-link in alphabetical order, `mimalloc-debug.dll` landed at position 7 in `MRTest.exe`; the loader resolved `ucrtbase` before `mimalloc-redirect.dll`, the redirect bailed with `standard malloc is _not_ redirected!`, and `mi_is_redirected()` returned `0`.
- New shared `source/MimallocRedirect.props` prepends the mimalloc import lib to `<AdditionalDependencies>` so it becomes the first PE import. `Exists()` probes pick `mimalloc(-debug).dll.lib` (3.x) or `mimalloc(-debug).lib` (2.x) so the same props works against any vcpkg snapshot — sidesteps the lib-name version trap that previously affected the older-vcpkg runner.
- `cmake/Modules/MimallocRedirect.cmake` mirrors the prepend on the CMake side via `set_property` + reordered `LINK_LIBRARIES` (call-site order no longer matters).
- New `MRMesh.MimallocRedirectActive` gtest in `MeshLib/source/MRTest/MRMimallocRedirectTests.cpp` asserts `mi_is_redirected() == 1` and `mi_is_in_heap_region(malloc(64)) == 1`. Skipped when `MIMALLOC_DISABLE_REDIRECT=1` (mimalloc's own kill-switch).

Verified locally on Debug|x64: `dumpbin /imports MRTest.exe` shows `mimalloc-debug.dll` as the first entry; full MRTest suite is 295/295 green. The MRApp side (MeshInspector.exe) is wired up via a matching change in the consumer repo, with the submodule pointer bumped to this commit there.

## Test plan

- [ ] CI: all Windows configs green (this PR is labeled `full-ci` + `disable-build-*` for every non-Windows platform to focus coverage).
- [ ] Older-vcpkg runners (mimalloc 2.x): `Exists()` probe falls through to the `.lib` (not `.dll.lib`) variant; no `LNK1181`.
- [ ] `MRMesh.MimallocRedirectActive` passes.
- [ ] Negative manual check: `set MIMALLOC_DISABLE_REDIRECT=1 && MRTest.exe --gtest_filter=MRMesh.MimallocRedirectActive` → SKIPPED.