### PR TITLE
CI: archive Windows binaries with 7z (.7z) instead of zip

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -329,11 +329,14 @@ jobs:
         # https://github.com/actions/download-artifact#maintaining-file-permissions-and-case-sensitive-files
       - name: Archive files
         if: ${{ env.job_upload_artifact == 'true' }}
-        run: 7z a MREDist_${{ matrix.upload_name || matrix.config }}.7z ./source/x64/${{ matrix.config }}
+        # No leading ./ : 7-Zip anchors at it and would store paths as Release\...
+        # (dropping the source/x64/ prefix). Without it the full relative path is kept,
+        # so extraction recreates source/x64/<config>/... as make_install_folder expects.
+        run: 7z a MREDist_${{ matrix.upload_name || matrix.config }}.7z source/x64/${{ matrix.config }}
 
       - name: Archive generated C headers
         if: ${{ env.job_upload_artifact == 'true' && matrix.config == 'Release' && inputs.mrbind_c }}
-        run: 7z a MeshLibC2Headers.7z ./source/MeshLibC2/include
+        run: 7z a MeshLibC2Headers.7z source/MeshLibC2/include
 
       - name: Upload Windows Binaries Archive
         if: ${{ env.job_upload_artifact == 'true' }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -329,18 +329,18 @@ jobs:
         # https://github.com/actions/download-artifact#maintaining-file-permissions-and-case-sensitive-files
       - name: Archive files
         if: ${{ env.job_upload_artifact == 'true' }}
-        run: tar -a -c -f MREDist_${{ matrix.upload_name || matrix.config }}.tar.xz ./source/x64/${{ matrix.config }}
+        run: 7z a MREDist_${{ matrix.upload_name || matrix.config }}.7z ./source/x64/${{ matrix.config }}
 
       - name: Archive generated C headers
         if: ${{ env.job_upload_artifact == 'true' && matrix.config == 'Release' && inputs.mrbind_c }}
-        run: tar -a -c -f MeshLibC2Headers.tar.xz ./source/MeshLibC2/include
+        run: 7z a MeshLibC2Headers.7z ./source/MeshLibC2/include
 
       - name: Upload Windows Binaries Archive
         if: ${{ env.job_upload_artifact == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: WindowsArchive_${{ matrix.upload_name || matrix.config }}
-          path: MREDist_${{ matrix.upload_name || matrix.config }}.tar.xz
+          path: MREDist_${{ matrix.upload_name || matrix.config }}.7z
           retention-days: 1
           overwrite: true
 
@@ -350,7 +350,7 @@ jobs:
         uses: ./.github/actions/collect-artifact-stats
         with:
           artifact_path: ${{ github.workspace }}
-          artifact_glob: MREDist_${{ matrix.upload_name || matrix.config }}.tar.xz
+          artifact_glob: MREDist_${{ matrix.upload_name || matrix.config }}.7z
           stats_file_suffix: -${{ steps.collect-runner-stats.outputs.job_id }}
 
       - name: Upload MeshLibC2 headers archive
@@ -358,7 +358,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: WindowsArchive_MeshLibC2Headers
-          path: MeshLibC2Headers.tar.xz
+          path: MeshLibC2Headers.7z
           retention-days: 1
           overwrite: true
 

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -329,18 +329,18 @@ jobs:
         # https://github.com/actions/download-artifact#maintaining-file-permissions-and-case-sensitive-files
       - name: Archive files
         if: ${{ env.job_upload_artifact == 'true' }}
-        run: tar -a -c -f MREDist_${{ matrix.upload_name || matrix.config }}.zip ./source/x64/${{ matrix.config }}
+        run: tar -a -c -f MREDist_${{ matrix.upload_name || matrix.config }}.tar.xz ./source/x64/${{ matrix.config }}
 
       - name: Archive generated C headers
         if: ${{ env.job_upload_artifact == 'true' && matrix.config == 'Release' && inputs.mrbind_c }}
-        run: tar -a -c -f MeshLibC2Headers.zip ./source/MeshLibC2/include
+        run: tar -a -c -f MeshLibC2Headers.tar.xz ./source/MeshLibC2/include
 
       - name: Upload Windows Binaries Archive
         if: ${{ env.job_upload_artifact == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: WindowsArchive_${{ matrix.upload_name || matrix.config }}
-          path: MREDist_${{ matrix.upload_name || matrix.config }}.zip
+          path: MREDist_${{ matrix.upload_name || matrix.config }}.tar.xz
           retention-days: 1
           overwrite: true
 
@@ -350,7 +350,7 @@ jobs:
         uses: ./.github/actions/collect-artifact-stats
         with:
           artifact_path: ${{ github.workspace }}
-          artifact_glob: MREDist_${{ matrix.upload_name || matrix.config }}.zip
+          artifact_glob: MREDist_${{ matrix.upload_name || matrix.config }}.tar.xz
           stats_file_suffix: -${{ steps.collect-runner-stats.outputs.job_id }}
 
       - name: Upload MeshLibC2 headers archive
@@ -358,7 +358,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: WindowsArchive_MeshLibC2Headers
-          path: MeshLibC2Headers.zip
+          path: MeshLibC2Headers.tar.xz
           retention-days: 1
           overwrite: true
 

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -346,6 +346,8 @@ jobs:
           path: MREDist_${{ matrix.upload_name || matrix.config }}.7z
           retention-days: 1
           overwrite: true
+          # The payload is already a .7z; don't re-Deflate it (no size gain).
+          compression-level: 0
 
       - name: Collect artifact stats
         if: ${{ inputs.internal_build && env.job_upload_artifact == 'true' }}
@@ -364,6 +366,8 @@ jobs:
           path: MeshLibC2Headers.7z
           retention-days: 1
           overwrite: true
+          # The payload is already a .7z; don't re-Deflate it (no size gain).
+          compression-level: 0
 
       - name: Create and fix fake Wheel for NuGet
         if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}

--- a/.github/workflows/update-win-version.yml
+++ b/.github/workflows/update-win-version.yml
@@ -19,12 +19,12 @@ jobs:
       matrix:
         include:
           - vcpkg_triplet: x64-windows-vs2019-meshlib
-            extract_release: MREDist_Release.zip
-            extract_debug: MREDist_Debug.zip
+            extract_release: MREDist_Release.tar.xz
+            extract_debug: MREDist_Debug.tar.xz
             output_zip: MeshLibDist.zip
             artifact_name: DistributivesWin
           - vcpkg_triplet: x64-windows-meshlib-iterator-debug
-            extract_debug: MREDist_Debug-IteratorDebug.zip
+            extract_debug: MREDist_Debug-IteratorDebug.tar.xz
             output_zip: MeshLibDist-IteratorDebug.zip
             artifact_name: DistributivesWin-IteratorDebug
     env:
@@ -50,11 +50,11 @@ jobs:
 
       - name: Extract Windows Binaries
         run: |
-          if ("${{ matrix.extract_release }}") { 
-            tar -xvzf ${{ matrix.extract_release }} 
+          if ("${{ matrix.extract_release }}") {
+            tar -xvf ${{ matrix.extract_release }}
           }
-          tar -xvzf ${{ matrix.extract_debug }}
-          tar -xvzf MeshLibC2Headers.zip
+          tar -xvf ${{ matrix.extract_debug }}
+          tar -xvf MeshLibC2Headers.tar.xz
 
       - name: Make Install Folder
         run: py -3.10 scripts\make_install_folder.py ${{ inputs.app_version }} ${{ matrix.vcpkg_triplet }}

--- a/.github/workflows/update-win-version.yml
+++ b/.github/workflows/update-win-version.yml
@@ -19,12 +19,12 @@ jobs:
       matrix:
         include:
           - vcpkg_triplet: x64-windows-vs2019-meshlib
-            extract_release: MREDist_Release.tar.xz
-            extract_debug: MREDist_Debug.tar.xz
+            extract_release: MREDist_Release.7z
+            extract_debug: MREDist_Debug.7z
             output_zip: MeshLibDist.zip
             artifact_name: DistributivesWin
           - vcpkg_triplet: x64-windows-meshlib-iterator-debug
-            extract_debug: MREDist_Debug-IteratorDebug.tar.xz
+            extract_debug: MREDist_Debug-IteratorDebug.7z
             output_zip: MeshLibDist-IteratorDebug.zip
             artifact_name: DistributivesWin-IteratorDebug
     env:
@@ -51,10 +51,10 @@ jobs:
       - name: Extract Windows Binaries
         run: |
           if ("${{ matrix.extract_release }}") {
-            tar -xvf ${{ matrix.extract_release }}
+            7z x -y ${{ matrix.extract_release }}
           }
-          tar -xvf ${{ matrix.extract_debug }}
-          tar -xvf MeshLibC2Headers.tar.xz
+          7z x -y ${{ matrix.extract_debug }}
+          7z x -y MeshLibC2Headers.7z
 
       - name: Make Install Folder
         run: py -3.10 scripts\make_install_folder.py ${{ inputs.app_version }} ${{ matrix.vcpkg_triplet }}


### PR DESCRIPTION
## Summary

The Windows CI archives the freshly built binaries (`MREDist_*`, `MeshLibC2Headers`) so the `update-win-version` job can repackage them into the distribution. These intermediate archives were created with `tar -a -c -f <name>.zip`, which on the Windows runners produces a real Deflate ZIP (libarchive's bsdtar picks the zip format from the `.zip` suffix). This switches them to `7z` / `.7z` (LZMA2), which compresses the same content significantly smaller.

## Changes

- `build-test-windows.yml`: create `MREDist_*.7z` and `MeshLibC2Headers.7z` with `7z a` (replacing `tar -a`), and update the matching `upload-artifact` paths and the `collect-artifact-stats` glob.
- `update-win-version.yml`: consume the renamed archives — the matrix `extract_release` / `extract_debug` entries now point at `.7z`, and extraction uses `7z x -y` instead of `tar -xvzf`.

The archive paths are passed to `7z a` without a leading `./`: with `./`, 7-Zip anchors there and stores entries as `<config>/...`, dropping the `source/x64/` prefix that `make_install_folder.py` expects. Without it the full `source/x64/<config>/...` layout is preserved.

The Python-produced distribution zips (`MeshLibDist.zip`, `MeshLibDist-IteratorDebug.zip`) are unchanged.

## Results (measured on CI)

Archive sizes drop ~41% overall:

| Archive | `.zip` (master) | `.7z` (this PR) | saved |
|---|--:|--:|--:|
| MREDist_Release | 119.6 MB | 69.4 MB | -42% |
| MREDist_Debug | 298.5 MB | 174.2 MB | -42% |
| MREDist_Debug-IteratorDebug | 225.4 MB | 134.7 MB | -40% |
| MeshLibC2Headers | 2.37 MB | 0.88 MB | -63% |
| **Total** | **645.9 MB** | **379.2 MB** | **-41%** |

Timing trade-off:

- Compression (per build leg, run in parallel) is ~3x slower: Release 18s -> 52s, Debug 54s -> 151s, IteratorDebug 38s -> 118s. This is the cost of LZMA2 vs Deflate; since the legs run concurrently, the net pipeline impact is roughly the largest single delta.
- Decompression in `update-win-version` is unchanged (~5-7s either way).

## Test plan

Labels were added so the changed steps actually run on this PR:

- `upload-binaries` + `build-release-windows` — exercise the Windows archive creation (producer) and the `update-win-version` extraction (consumer).
- `disable-build-*` for every non-Windows platform, since this change is Windows-only.
