### PR TITLE
CI(Windows): pin msvc-2022 toolset to v143 / vcvars_ver=14.4

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -53,6 +53,12 @@ jobs:
       CUDA_VERSION: ${{ fromJSON('["12.0.1.52833", "11.4.2.47141"]')[matrix.cxx_compiler == 'msvc-2019'] }}
       CUDA_MAJOR: ${{ fromJSON('["12", "11"]')[matrix.cxx_compiler == 'msvc-2019'] }}
       CUDA_MINOR: ${{ fromJSON('["0", "4"]')[matrix.cxx_compiler == 'msvc-2019'] }}
+      # MSVC toolset is pinned per compiler so a newer toolset in the same VS
+      # install isn't picked up implicitly. vcvars_ver prefix-matches an
+      # installed toolset dir (14.4 -> the installed 14.44); PlatformToolset is
+      # the stable MSBuild name.
+      VCVARS_VER: ${{ fromJSON('["14.4", "14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
+      PLATFORM_TOOLSET: ${{ fromJSON('["v143", "v142"]')[matrix.cxx_compiler == 'msvc-2019'] }}
 
     steps:
       - name: Checkout
@@ -179,7 +185,7 @@ jobs:
           MSYS2_DIR: C:\msys64
         # Note that `\` doesn't work here as a line continuation, and will lead to weird errors.
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }}
           call ./scripts/mrbind/generate_win.bat -B --trace TARGET=c
 
         # This consumes the JSON created by generating the C bindings.
@@ -190,7 +196,7 @@ jobs:
           MSYS2_DIR: C:\msys64
         # Note that `\` doesn't work here as a line continuation, and will lead to weird errors.
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }}
           call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}}
           dotnet build examples/c-sharp-examples -c ${{matrix.config}}
 
@@ -205,14 +211,14 @@ jobs:
         # blocks in cmd.exe (e.g. it failed to catch a ninja build failure).
         run: |
           if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
-            call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
+            call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
             cmake --version || exit /b 1
             cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} || exit /b 1
             cmake --build source\TempOutput -j || exit /b 1
             if not exist source\x64 mkdir source\x64 || exit /b 1
             xcopy source\TempOutput\bin\* source\x64\${{matrix.config}}\* /s /e /i /Y || exit /b 1
           ) else (
-            msbuild -m source\MeshLib.sln -p:Configuration=${{ matrix.config }} -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%${{ fromJSON('[";PlatformToolset=v143", ";PlatformToolset=v142"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
+            msbuild -m source\MeshLib.sln -p:Configuration=${{ matrix.config }} -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }} || exit /b 1
           )
 
       - name: Generate and build Python bindings
@@ -222,7 +228,7 @@ jobs:
           MSYS2_DIR: C:\msys64
         # Note that `\` doesn't work here as a line continuation, and will lead to weird errors.
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }}
           call ./scripts/mrbind/generate_win.bat -B --trace MODE=none VS_MODE=${{matrix.config}}
 
       - name: Diagnostic — output bin DLL inventory + MRMesh imports
@@ -323,7 +329,7 @@ jobs:
           rem VsDevCmd.bat overrides VCPKG_ROOT with the VS-bundled vcpkg; preserve the
           rem step env: value so MESHLIB_INCLUDE_DIRS resolves to the project vcpkg.
           set "PROJ_VCPKG_ROOT=%VCPKG_ROOT%"
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           set "VCPKG_ROOT=%PROJ_VCPKG_ROOT%"
           cmake --version || exit /b 1
           cmake ^
@@ -339,7 +345,7 @@ jobs:
         if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
         shell: cmd
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           cmake --version || exit /b 1
           cmake ^
             -S examples/c-examples ^

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -179,7 +179,7 @@ jobs:
           MSYS2_DIR: C:\msys64
         # Note that `\` doesn't work here as a line continuation, and will lead to weird errors.
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
           call ./scripts/mrbind/generate_win.bat -B --trace TARGET=c
 
         # This consumes the JSON created by generating the C bindings.
@@ -190,7 +190,7 @@ jobs:
           MSYS2_DIR: C:\msys64
         # Note that `\` doesn't work here as a line continuation, and will lead to weird errors.
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
           call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}}
           dotnet build examples/c-sharp-examples -c ${{matrix.config}}
 
@@ -205,14 +205,14 @@ jobs:
         # blocks in cmd.exe (e.g. it failed to catch a ninja build failure).
         run: |
           if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
-            call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
+            call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
             cmake --version || exit /b 1
             cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} || exit /b 1
             cmake --build source\TempOutput -j || exit /b 1
             if not exist source\x64 mkdir source\x64 || exit /b 1
             xcopy source\TempOutput\bin\* source\x64\${{matrix.config}}\* /s /e /i /Y || exit /b 1
           ) else (
-            msbuild -m source\MeshLib.sln -p:Configuration=${{ matrix.config }} -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%${{ fromJSON('["", ";PlatformToolset=v142"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
+            msbuild -m source\MeshLib.sln -p:Configuration=${{ matrix.config }} -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%${{ fromJSON('[";PlatformToolset=v143", ";PlatformToolset=v142"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
           )
 
       - name: Generate and build Python bindings
@@ -222,7 +222,7 @@ jobs:
           MSYS2_DIR: C:\msys64
         # Note that `\` doesn't work here as a line continuation, and will lead to weird errors.
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
           call ./scripts/mrbind/generate_win.bat -B --trace MODE=none VS_MODE=${{matrix.config}}
 
       - name: Diagnostic — output bin DLL inventory + MRMesh imports
@@ -323,7 +323,7 @@ jobs:
           rem VsDevCmd.bat overrides VCPKG_ROOT with the VS-bundled vcpkg; preserve the
           rem step env: value so MESHLIB_INCLUDE_DIRS resolves to the project vcpkg.
           set "PROJ_VCPKG_ROOT=%VCPKG_ROOT%"
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
           set "VCPKG_ROOT=%PROJ_VCPKG_ROOT%"
           cmake --version || exit /b 1
           cmake ^
@@ -339,7 +339,7 @@ jobs:
         if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
         shell: cmd
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 ${{ fromJSON('["-vcvars_ver=14.4", "-vcvars_ver=14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }} || exit /b 1
           cmake --version || exit /b 1
           cmake ^
             -S examples/c-examples ^


### PR DESCRIPTION
## Summary

Pin the MSVC toolset explicitly on the **msvc-2022** Windows leg so a newer compiler shipped inside the same Visual Studio install can't be picked up implicitly on an AMI bump. The msvc-2019 leg was already pinned (`14.2` / `v142`); this brings msvc-2022 to `14.4` / `v143`.

The per-compiler values are derived into two job-level env vars using the same `fromJSON([...])[cxx_compiler == 'msvc-2019']` idiom already used for `CUDA_VERSION`, so they live in one place:

- `VCVARS_VER` → `-vcvars_ver` at all 6 `VsDevCmd.bat` call sites (C/C# bindings, CMake build, Python bindings, C++/C examples).
- `PLATFORM_TOOLSET` → `;PlatformToolset=` on the MSBuild leg.

Note on `14.4` (not `14.3`): `-vcvars_ver` prefix-matches an installed MSVC toolset directory, and the v143 line moved into the 14.4x numbering. The runner currently installs `14.44`, which `14.4` resolves to. `PlatformToolset=v143` is the stable MSBuild name and is unaffected.

## Test plan

Verified on the PR (minimal) Windows config — log lines confirm the resolved toolset per leg:

- [x] msvc-2022 CMake (Release) — `-vcvars_ver=14.4` resolves to `MSVC 19.44.35227.0` (`VC\Tools\MSVC\14.44.35207`)
- [x] msvc-2022 MSBuild (Debug) — built with `;PlatformToolset=v143` against `14.44.35207`
- [x] msvc-2019 CMake (Release + iterator-debug) unchanged — `-vcvars_ver=14.2` resolves to `MSVC 19.29.30159.0` (`14.29.30133`)
- [x] MRBind C / C# / Python bindings generate and build green on the affected legs

Full per-config matrix (Debug+Release × CMake+MSBuild, both compilers) runs on `master` after merge.
