### PR TITLE
CI: derive Windows test_artifacts_path from matrix fields

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -303,7 +303,7 @@ jobs:
           build_config: ${{ matrix.config }}
           pytest_args: "${{ env.BUILD_C_SHARP == 'true' && env.PYTEST_C_SHARP_ARGS || '' }} --run-cuda=negative --junit-xml=../unit_tests_report_regression.xml"
           smoke: ${{ !inputs.full_config_build && matrix.config == 'Debug' }}
-          test_artifacts_path: ${{ matrix.test_artifacts_path }}
+          test_artifacts_path: windows/${{ matrix.vcpkg_triplet }}/${{ matrix.config }}/${{ matrix.build_system }}
           upload_test_artifacts: ${{ inputs.upload_test_artifacts }}
 
       - name: Generate Test Performance Report

--- a/.github/workflows/matrix/windows-finalize-release-config.json
+++ b/.github/workflows/matrix/windows-finalize-release-config.json
@@ -5,16 +5,14 @@
       "config": "Debug",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Debug"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Release"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2019",
@@ -22,8 +20,7 @@
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib-iterator-debug",
       "upload_name": "Debug-IteratorDebug",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Debug-IteratorDebug"
+      "runner": ["windows-2022"]
     }
   ]
 }

--- a/.github/workflows/matrix/windows-full-config.json
+++ b/.github/workflows/matrix/windows-full-config.json
@@ -5,64 +5,56 @@
       "config": "Debug",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2022/Debug"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2022/Release"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Debug",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2022/Debug"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2022/Release"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Debug",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Debug"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Release",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Release"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Debug",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Debug"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Release"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2019",
@@ -70,8 +62,7 @@
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib-iterator-debug",
       "upload_name": "Debug-IteratorDebug",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Debug-IteratorDebug"
+      "runner": ["windows-2022"]
     }
   ]
 }

--- a/.github/workflows/matrix/windows-minimal-config.json
+++ b/.github/workflows/matrix/windows-minimal-config.json
@@ -5,24 +5,21 @@
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Release"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Debug",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2022/Debug"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2022/Debug"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2019",
@@ -30,8 +27,7 @@
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib-iterator-debug",
       "upload_name": "Debug-IteratorDebug",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Debug-IteratorDebug"
+      "runner": ["windows-2022"]
     }
   ]
 }

--- a/.github/workflows/matrix/windows-standard-config.json
+++ b/.github/workflows/matrix/windows-standard-config.json
@@ -5,32 +5,28 @@
       "config": "Debug",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Debug"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Release"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2022/Release"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2022/Release"
+      "runner": ["windows-2022"]
     },
     {
       "cxx_compiler": "msvc-2019",
@@ -38,8 +34,7 @@
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib-iterator-debug",
       "upload_name": "Debug-IteratorDebug",
-      "runner": ["windows-2022"],
-      "test_artifacts_path": "windows/windows-2019/Debug-IteratorDebug"
+      "runner": ["windows-2022"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove the per-entry `test_artifacts_path` from all four `windows-*-config.json` matrix files.
- Compute the S3 upload path in `build-test-windows.yml` instead, as `windows/{vcpkg_triplet}/{config}/{build_system}`.

## Why
The path was hand-maintained in each matrix entry. Besides being redundant (every component already exists as a matrix field), the old values had a real collision: in `windows-minimal-config.json` two distinct jobs (msvc-2022 Debug/MSBuild and msvc-2022 Release/CMake) both mapped to `windows/windows-2022/Debug`, so their Python regression artifacts overwrote each other in S3. Deriving from `vcpkg_triplet`/`config`/`build_system` yields a unique path per job in every config.

## Path mapping
The artifact upload (`Copy test artifacts to S3`) only runs for non-`iterator-debug` triplets, so only those entries produce a path. Computed (verified unique within each config):

- **full**: 8 paths — `windows/{x64-windows-meshlib | x64-windows-vs2019-meshlib}/{Debug | Release}/{MSBuild | CMake}`
- **standard**: 4 paths
- **minimal**: 3 paths
- **finalize-release**: 2 paths

## Test plan — verified in [run 26679736956](https://github.com/MeshInspector/MeshLib/actions/runs/26679736956)
- [x] `full-ci` ran the full Windows matrix; all 9 jobs succeeded.
- [x] `upload-test-artifacts` triggered `Copy test artifacts to S3 (Windows)` in each of the 8 non-iterator-debug jobs, uploading to the new `windows/{vcpkg_triplet}/{config}/{build_system}` path. Confirmed from the logs the 8 paths are all distinct (no overwrite):
  - `windows/x64-windows-meshlib/Debug/MSBuild`
  - `windows/x64-windows-meshlib/Release/MSBuild`
  - `windows/x64-windows-meshlib/Debug/CMake`
  - `windows/x64-windows-meshlib/Release/CMake`
  - `windows/x64-windows-vs2019-meshlib/Debug/MSBuild`
  - `windows/x64-windows-vs2019-meshlib/Release/MSBuild`
  - `windows/x64-windows-vs2019-meshlib/Debug/CMake`
  - `windows/x64-windows-vs2019-meshlib/Release/CMake`
- [x] The `iterator-debug` job correctly skipped the regression/upload steps (no path needed).
- [x] Non-Windows platforms intentionally disabled for this PR (Windows-only change) — all skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
