### PR TITLE
Migrate Windows CI to windows-2025 runners

### DIFF
--- a/.github/actions/locate-visual-studio/action.yml
+++ b/.github/actions/locate-visual-studio/action.yml
@@ -1,0 +1,32 @@
+name: 'Locate Visual Studio'
+description: 'Resolve the Visual Studio install path at runtime via vswhere. Exports it as the VC_PATH environment variable (and a `path` output) for later steps.'
+
+outputs:
+  path:
+    description: 'Absolute path to the latest Visual Studio installation.'
+    value: ${{ steps.locate.outputs.path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Locate Visual Studio
+      id: locate
+      # Resolve the VS install path at runtime via vswhere instead of
+      # hardcoding an edition/year that may not exist on a given runner image.
+      # vswhere ships with the VS Installer at a fixed location. The result is
+      # exported as VC_PATH (env) and a `path` output for later steps.
+      shell: pwsh
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        if (-not (Test-Path $vswhere)) {
+          Write-Error "vswhere.exe not found at $vswhere"
+          exit 1
+        }
+        $vcPath = & $vswhere -latest -products * -property installationPath
+        if (-not $vcPath) {
+          Write-Error "Visual Studio installation not found via vswhere"
+          exit 1
+        }
+        Write-Host "Found Visual Studio at: $vcPath"
+        "VC_PATH=$vcPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "path=$vcPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append

--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -155,7 +155,7 @@ jobs:
       - linux-vcpkg-build-test
       - macos-build-test
     timeout-minutes: 20
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
      - name: Checkout
        uses: actions/checkout@v6

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -65,23 +65,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Locate Visual Studio
-        # Resolve the VS install path at runtime via vswhere instead of
-        # hardcoding it in the matrix. vswhere ships with the VS Installer at a
-        # fixed location. The result is exported as VC_PATH for later steps.
-        shell: pwsh
-        run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          if (-not (Test-Path $vswhere)) {
-            Write-Error "vswhere.exe not found at $vswhere"
-            exit 1
-          }
-          $vcPath = & $vswhere -latest -products * -property installationPath
-          if (-not $vcPath) {
-            Write-Error "Visual Studio installation not found via vswhere"
-            exit 1
-          }
-          Write-Host "Found Visual Studio at: $vcPath"
-          "VC_PATH=$vcPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+        uses: ./.github/actions/locate-visual-studio
 
       - name: Checkout third-party submodules
         shell: bash

--- a/.github/workflows/matrix/windows-full-config.json
+++ b/.github/workflows/matrix/windows-full-config.json
@@ -5,28 +5,28 @@
       "config": "Debug",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2025"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2025"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Debug",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2025"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2025"]
     },
     {
       "cxx_compiler": "msvc-2019",

--- a/.github/workflows/matrix/windows-minimal-config.json
+++ b/.github/workflows/matrix/windows-minimal-config.json
@@ -12,14 +12,14 @@
       "config": "Debug",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2025"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2025"]
     },
     {
       "cxx_compiler": "msvc-2019",

--- a/.github/workflows/matrix/windows-standard-config.json
+++ b/.github/workflows/matrix/windows-standard-config.json
@@ -19,14 +19,14 @@
       "config": "Release",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2025"]
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2025"]
     },
     {
       "cxx_compiler": "msvc-2019",

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -380,23 +380,7 @@ jobs:
           ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Locate Visual Studio
-        # Resolve the VS install path at runtime via vswhere instead of
-        # hardcoding it. vswhere ships with the VS Installer at a fixed
-        # location. The result is exported as VC_PATH for later steps.
-        shell: pwsh
-        run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          if (-not (Test-Path $vswhere)) {
-            Write-Error "vswhere.exe not found at $vswhere"
-            exit 1
-          }
-          $vcPath = & $vswhere -latest -products * -property installationPath
-          if (-not $vcPath) {
-            Write-Error "Visual Studio installation not found via vswhere"
-            exit 1
-          }
-          Write-Host "Found Visual Studio at: $vcPath"
-          "VC_PATH=$vcPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+        uses: ./.github/actions/locate-visual-studio
 
       - name: Set up vcpkg
         uses: ./.github/actions/setup-vcpkg-windows

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -369,6 +369,25 @@ jobs:
           submodules: recursive
           ref: ${{needs.setup.outputs.version_tag}}
 
+      - name: Locate Visual Studio
+        # Resolve the VS install path at runtime via vswhere instead of
+        # hardcoding it. vswhere ships with the VS Installer at a fixed
+        # location. The result is exported as VC_PATH for later steps.
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            Write-Error "vswhere.exe not found at $vswhere"
+            exit 1
+          }
+          $vcPath = & $vswhere -latest -products * -property installationPath
+          if (-not $vcPath) {
+            Write-Error "Visual Studio installation not found via vswhere"
+            exit 1
+          }
+          Write-Host "Found Visual Studio at: $vcPath"
+          "VC_PATH=$vcPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Set up vcpkg
         uses: ./.github/actions/setup-vcpkg-windows
         with:
@@ -397,7 +416,7 @@ jobs:
         run: |
           $x = (dir $env:CUDA_PATH -dir -recurse -depth 2).where({$_.name -eq 'visual_studio_integration'}).fullname
           $y = (dir $x -dir -recurse).where({$_.name -eq 'MSBuildExtensions'}).fullname + '\*'
-          (gi 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\*\BuildCustomizations').fullname.foreach({cp $y $_})
+          (gi '${{ env.VC_PATH }}\MSBuild\Microsoft\VC\*\BuildCustomizations').fullname.foreach({cp $y $_})
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
@@ -420,7 +439,7 @@ jobs:
         env:
           MSYS2_DIR: C:\msys64
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64
+          call "${{ env.VC_PATH }}\Common7\Tools\VsDevCmd.bat" -arch=amd64
           call ./scripts/mrbind/generate_win.bat -B --trace FOR_WHEEL=1
 
       - name: Run Test

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -363,12 +363,6 @@ jobs:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
     env:
-      # Pin the VS2022 vcpkg triplet and matching MSVC toolset. windows-2025 may
-      # default to a newer toolset, but v143 is what matches the CUDA 12.0
-      # BuildCustomizations (MRCudaVersion in source/platform.props) and the
-      # x64-windows-vs2022-meshlib triplet's VCPKG_PLATFORM_TOOLSET. vcvars_ver
-      # 14.4 prefix-matches the installed 14.4x toolset dir; PlatformToolset is
-      # the stable MSBuild name.
       VCPKG_DEFAULT_TRIPLET: x64-windows-vs2022-meshlib
       VCVARS_VER: '14.4'
       PLATFORM_TOOLSET: v143
@@ -645,9 +639,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
-      # Test the wheel on both the image that built it (windows-2025) and the
-      # previous one (windows-2022) to catch wheels that only run on a fresh
-      # hosted image.
       matrix:
         runner: [windows-2022, windows-2025]
     steps:

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -356,7 +356,7 @@ jobs:
     needs: setup
     if: ${{ inputs.disable_windows != true }}
     timeout-minutes: 90
-    runs-on:  [windows-2022]
+    runs-on:  [windows-2025]
     strategy:
       fail-fast: false
     permissions:

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -642,7 +642,14 @@ jobs:
     needs: [windows-pip-build]
     if: ${{ inputs.disable_windows != true }}
     timeout-minutes: 90
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      # Test the wheel on both the image that built it (windows-2025) and the
+      # previous one (windows-2022) to catch wheels that only run on a fresh
+      # hosted image.
+      matrix:
+        runner: [windows-2022, windows-2025]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -362,6 +362,16 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
+    env:
+      # Pin the VS2022 vcpkg triplet and matching MSVC toolset. windows-2025 may
+      # default to a newer toolset, but v143 is what matches the CUDA 12.0
+      # BuildCustomizations (MRCudaVersion in source/platform.props) and the
+      # x64-windows-vs2022-meshlib triplet's VCPKG_PLATFORM_TOOLSET. vcvars_ver
+      # 14.4 prefix-matches the installed 14.4x toolset dir; PlatformToolset is
+      # the stable MSBuild name.
+      VCPKG_DEFAULT_TRIPLET: x64-windows-vs2022-meshlib
+      VCVARS_VER: '14.4'
+      PLATFORM_TOOLSET: v143
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -392,6 +402,7 @@ jobs:
         uses: ./.github/actions/setup-vcpkg-windows
         with:
           vcpkg-version: ${{ env.VCPKG-VERSION }}
+          vcpkg-triplet: ${{ env.VCPKG_DEFAULT_TRIPLET }}
           install-flags: '--write-s3'
           internal-build: 'true'
 
@@ -422,7 +433,7 @@ jobs:
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
       - name: Build
-        run: msbuild -m  source\MeshLib.sln -p:Configuration=Release
+        run: msbuild -m source\MeshLib.sln -p:Configuration=Release -p:VcpkgTriplet=${{ env.VCPKG_DEFAULT_TRIPLET }} -p:PlatformToolset=${{ env.PLATFORM_TOOLSET }}
 
       - name: Install MSYS2 for MRBind
         uses: ./.github/actions/install-msys2-mrbind
@@ -439,7 +450,7 @@ jobs:
         env:
           MSYS2_DIR: C:\msys64
         run: |
-          call "${{ env.VC_PATH }}\Common7\Tools\VsDevCmd.bat" -arch=amd64
+          call "${{ env.VC_PATH }}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }}
           call ./scripts/mrbind/generate_win.bat -B --trace FOR_WHEEL=1
 
       - name: Run Test

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -313,7 +313,7 @@ jobs:
 
   windows-test:
     if: ${{ inputs.test_windows }}
-    runs-on: windows-2022
+    runs-on: windows-2025
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/update-win-version.yml
+++ b/.github/workflows/update-win-version.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   update-win-version:
     timeout-minutes: 60
-    runs-on: windows-2022
+    runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Move the Windows CI from `windows-2022` to `windows-2025` GitHub-hosted runners, plus the fixes needed to build cleanly on the newer image.

- **Switch runners to `windows-2025`** across `build-test-distribute.yml`, `test-distribution.yml`, `update-win-version.yml`, and the `windows-*-config.json` build matrices (the VS2022 entries; VS2019 entries stay on `windows-2022`).
- **Locate Visual Studio at runtime via `vswhere`** instead of hardcoding `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\...`, which does not exist on `windows-2025`. Extracted into a reusable composite action `.github/actions/locate-visual-studio` (exports `VC_PATH`), now used by both `build-test-windows.yml` and `pip-build.yml`.
- **Pin the `x64-windows-vs2022-meshlib` vcpkg triplet + `v143` toolset** (`vcvars_ver=14.4`) in the `windows-pip-build` job. `windows-2025` would otherwise default to a newer toolset; `v143` keeps `MRCudaVersion` at 12.0 (`source/platform.props`) to match the installed CUDA 12.0 and the triplet's prebuilt deps. The triplet is wired through vcpkg setup, the MSBuild build, and the MRBind generate step.
- **Run `windows-pip-test` on both `windows-2022` and `windows-2025`** (matrix) so the wheel is exercised on the image that built it and the previous one.

## Test plan

- [x] `build-test-windows` matrix builds pass on `windows-2025`
- [x] `windows-pip-build` builds the wheel and bindings with the VS2022/v143 toolchain
- [x] `windows-pip-test` passes on both `windows-2022` and `windows-2025`

