### PR TITLE
ci(windows): add MSVC 2026 build/test jobs

### DIFF
--- a/.github/actions/install-cuda/action.yml
+++ b/.github/actions/install-cuda/action.yml
@@ -34,7 +34,7 @@ runs:
       id: cuda-cache
       continue-on-error: true
       with:
-        key: cuda-toolkit-subset-${{ inputs.cuda-version }}-v3
+        key: cuda-toolkit-subset-${{ inputs.cuda-version }}-v1
         path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ inputs.cuda-major }}.${{ inputs.cuda-minor }}
 
     - name: Install CUDA

--- a/.github/actions/install-cuda/action.yml
+++ b/.github/actions/install-cuda/action.yml
@@ -19,13 +19,21 @@ runs:
       run: |
         $semver = (("${{ inputs.cuda-version }}" -split '\.')[0..2]) -join '.'
         "version=$semver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        # CUDA 13 split the CRT headers (crt/host_config.h, pulled in by
+        # cuda_runtime.h) out of the nvcc package into a standalone 'crt'
+        # sub-package. Install it on 13+ so nvcc can compile; on 11/12 the
+        # crt headers ship inside nvcc and there is no 'crt' component.
+        $sub = @('nvcc', 'cudart', 'visual_studio_integration')
+        if ([int]'${{ inputs.cuda-major }}' -ge 13) { $sub += 'crt' }
+        $json = '[' + (($sub | ForEach-Object { '"' + $_ + '"' }) -join ',') + ']'
+        "sub-packages=$json" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
     - name: Restore CUDA Cache
       uses: actions/cache@v5
       id: cuda-cache
       continue-on-error: true
       with:
-        key: cuda-toolkit-subset-${{ inputs.cuda-version }}-v1
+        key: cuda-toolkit-subset-${{ inputs.cuda-version }}-v2
         path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ inputs.cuda-major }}.${{ inputs.cuda-minor }}
 
     - name: Install CUDA
@@ -34,4 +42,4 @@ runs:
       with:
         cuda: ${{ steps.cuda-semver.outputs.version }}
         method: network
-        sub-packages: '["nvcc", "cudart", "visual_studio_integration"]'
+        sub-packages: ${{ steps.cuda-semver.outputs.sub-packages }}

--- a/.github/actions/install-cuda/action.yml
+++ b/.github/actions/install-cuda/action.yml
@@ -19,12 +19,13 @@ runs:
       run: |
         $semver = (("${{ inputs.cuda-version }}" -split '\.')[0..2]) -join '.'
         "version=$semver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        # CUDA 13 split the CRT headers (crt/host_config.h, pulled in by
-        # cuda_runtime.h) out of the nvcc package into a standalone 'crt'
-        # sub-package. Install it on 13+ so nvcc can compile; on 11/12 the
-        # crt headers ship inside nvcc and there is no 'crt' component.
+        # CUDA 13 split pieces that used to live inside the nvcc package into
+        # standalone components: 'crt' (crt/host_config.h, pulled in by
+        # cuda_runtime.h) and 'nvvm' (the cicc device-compiler front-end).
+        # Install both on 13+ so nvcc can compile; on 11/12 they ship inside
+        # nvcc and no such components exist.
         $sub = @('nvcc', 'cudart', 'visual_studio_integration')
-        if ([int]'${{ inputs.cuda-major }}' -ge 13) { $sub += 'crt' }
+        if ([int]'${{ inputs.cuda-major }}' -ge 13) { $sub += 'crt', 'nvvm' }
         $json = '[' + (($sub | ForEach-Object { '"' + $_ + '"' }) -join ',') + ']'
         "sub-packages=$json" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
@@ -33,7 +34,7 @@ runs:
       id: cuda-cache
       continue-on-error: true
       with:
-        key: cuda-toolkit-subset-${{ inputs.cuda-version }}-v2
+        key: cuda-toolkit-subset-${{ inputs.cuda-version }}-v3
         path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ inputs.cuda-major }}.${{ inputs.cuda-minor }}
 
     - name: Install CUDA

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -44,21 +44,15 @@ jobs:
       contents: read  # This is required for actions/checkout
 
     env:
-      BUILD_C_SHARP: ${{ matrix.cxx_compiler == 'msvc-2022' && matrix.build_system == 'CMake' }}
+      BUILD_C_SHARP: ${{ matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'CMake' }}
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
       job_upload_artifact: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
-      # CUDA toolkit version is derived from the compiler: msvc-2019 builds pin
-      # CUDA 11.4, everything else uses CUDA 12.0.
-      CUDA_VERSION: ${{ fromJSON('["12.0.1.52833", "11.4.2.47141"]')[matrix.cxx_compiler == 'msvc-2019'] }}
-      CUDA_MAJOR: ${{ fromJSON('["12", "11"]')[matrix.cxx_compiler == 'msvc-2019'] }}
-      CUDA_MINOR: ${{ fromJSON('["0", "4"]')[matrix.cxx_compiler == 'msvc-2019'] }}
-      # MSVC toolset is pinned per compiler so a newer toolset in the same VS
-      # install isn't picked up implicitly. vcvars_ver prefix-matches an
-      # installed toolset dir (14.4 -> the installed 14.44); PlatformToolset is
-      # the stable MSBuild name.
-      VCVARS_VER: ${{ fromJSON('["14.4", "14.2"]')[matrix.cxx_compiler == 'msvc-2019'] }}
-      PLATFORM_TOOLSET: ${{ fromJSON('["v143", "v142"]')[matrix.cxx_compiler == 'msvc-2019'] }}
+      CUDA_VERSION: ${{ fromJSON('{"msvc-2019": "11.4.2.47141", "msvc-2022": "12.0.1.52833"}')[matrix.cxx_compiler] || '13.2.1' }}
+      CUDA_MAJOR: ${{ fromJSON('{"msvc-2019": "11", "msvc-2022": "12"}')[matrix.cxx_compiler] || '13' }}
+      CUDA_MINOR: ${{ fromJSON('{"msvc-2019": "4", "msvc-2022": "0"}')[matrix.cxx_compiler] || '2' }}
+      VCVARS_VER: ${{ fromJSON('{"msvc-2019": "14.2", "msvc-2022": "14.4"}')[matrix.cxx_compiler] || '14.5' }}
+      PLATFORM_TOOLSET: ${{ fromJSON('{"msvc-2019": "v142", "msvc-2022": "v143"}')[matrix.cxx_compiler] || 'v145' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -48,7 +48,7 @@ jobs:
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
       job_upload_artifact: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
-      CUDA_VERSION: ${{ fromJSON('{"msvc-2019":"11.4.2.47141","msvc-2022":"12.0.1.52833"}')[matrix.cxx_compiler] || '13.2.1' }}
+      CUDA_VERSION: ${{ fromJSON('{"msvc-2019":"11.4.2.47141","msvc-2022":"12.0.1.52833"}')[matrix.cxx_compiler] || '13.2.0' }}
       CUDA_MAJOR: ${{ fromJSON('{"msvc-2019":"11","msvc-2022":"12"}')[matrix.cxx_compiler] || '13' }}
       CUDA_MINOR: ${{ fromJSON('{"msvc-2019":"4","msvc-2022":"0"}')[matrix.cxx_compiler] || '2' }}
       VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -48,11 +48,11 @@ jobs:
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
       job_upload_artifact: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
-      CUDA_VERSION: ${{ fromJSON('{"msvc-2019": "11.4.2.47141", "msvc-2022": "12.0.1.52833"}')[matrix.cxx_compiler] || '13.2.1' }}
-      CUDA_MAJOR: ${{ fromJSON('{"msvc-2019": "11", "msvc-2022": "12"}')[matrix.cxx_compiler] || '13' }}
-      CUDA_MINOR: ${{ fromJSON('{"msvc-2019": "4", "msvc-2022": "0"}')[matrix.cxx_compiler] || '2' }}
-      VCVARS_VER: ${{ fromJSON('{"msvc-2019": "14.2", "msvc-2022": "14.4"}')[matrix.cxx_compiler] || '14.5' }}
-      PLATFORM_TOOLSET: ${{ fromJSON('{"msvc-2019": "v142", "msvc-2022": "v143"}')[matrix.cxx_compiler] || 'v145' }}
+      CUDA_VERSION: ${{ fromJSON('{"msvc-2019":"11.4.2.47141","msvc-2022":"12.0.1.52833"}')[matrix.cxx_compiler] || '13.2.1' }}
+      CUDA_MAJOR: ${{ fromJSON('{"msvc-2019":"11","msvc-2022":"12"}')[matrix.cxx_compiler] || '13' }}
+      CUDA_MINOR: ${{ fromJSON('{"msvc-2019":"4","msvc-2022":"0"}')[matrix.cxx_compiler] || '2' }}
+      VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}
+      PLATFORM_TOOLSET: ${{ fromJSON('{"msvc-2019":"v142","msvc-2022":"v143"}')[matrix.cxx_compiler] || 'v145' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/matrix/windows-full-config.json
+++ b/.github/workflows/matrix/windows-full-config.json
@@ -1,6 +1,34 @@
 {
   "include": [
     {
+      "cxx_compiler": "msvc-2026",
+      "config": "Debug",
+      "build_system": "MSBuild",
+      "vcpkg_triplet": "x64-windows-meshlib",
+      "runner": ["windows-2025"]
+    },
+    {
+      "cxx_compiler": "msvc-2026",
+      "config": "Release",
+      "build_system": "MSBuild",
+      "vcpkg_triplet": "x64-windows-meshlib",
+      "runner": ["windows-2025"]
+    },
+    {
+      "cxx_compiler": "msvc-2026",
+      "config": "Debug",
+      "build_system": "CMake",
+      "vcpkg_triplet": "x64-windows-meshlib",
+      "runner": ["windows-2025"]
+    },
+    {
+      "cxx_compiler": "msvc-2026",
+      "config": "Release",
+      "build_system": "CMake",
+      "vcpkg_triplet": "x64-windows-meshlib",
+      "runner": ["windows-2025"]
+    },
+    {
       "cxx_compiler": "msvc-2022",
       "config": "Debug",
       "build_system": "MSBuild",

--- a/.github/workflows/matrix/windows-minimal-config.json
+++ b/.github/workflows/matrix/windows-minimal-config.json
@@ -8,17 +8,17 @@
       "runner": ["windows-2022"]
     },
     {
-      "cxx_compiler": "msvc-2022",
+      "cxx_compiler": "msvc-2026",
       "config": "Debug",
       "build_system": "MSBuild",
-      "vcpkg_triplet": "x64-windows-vs2022-meshlib",
+      "vcpkg_triplet": "x64-windows-meshlib",
       "runner": ["windows-2025"]
     },
     {
-      "cxx_compiler": "msvc-2022",
+      "cxx_compiler": "msvc-2026",
       "config": "Release",
       "build_system": "CMake",
-      "vcpkg_triplet": "x64-windows-vs2022-meshlib",
+      "vcpkg_triplet": "x64-windows-meshlib",
       "runner": ["windows-2025"]
     },
     {

--- a/.github/workflows/matrix/windows-standard-config.json
+++ b/.github/workflows/matrix/windows-standard-config.json
@@ -22,10 +22,17 @@
       "runner": ["windows-2025"]
     },
     {
-      "cxx_compiler": "msvc-2022",
+      "cxx_compiler": "msvc-2026",
+      "config": "Debug",
+      "build_system": "MSBuild",
+      "vcpkg_triplet": "x64-windows-meshlib",
+      "runner": ["windows-2025"]
+    },
+    {
+      "cxx_compiler": "msvc-2026",
       "config": "Release",
       "build_system": "CMake",
-      "vcpkg_triplet": "x64-windows-vs2022-meshlib",
+      "vcpkg_triplet": "x64-windows-meshlib",
       "runner": ["windows-2025"]
     },
     {

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -199,8 +199,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - vs: vs2026
+            runner: windows-2025
+            vcpkg-version: ${{ inputs.vs22_vcpkg_version }}
+            vcpkg_triplet: x64-windows-meshlib
           - vs: vs2022
-            runner: windows-2022
+            runner: windows-2025
             vcpkg-version: ${{ inputs.vs22_vcpkg_version }}
             vcpkg_triplet: x64-windows-vs2022-meshlib
           - vs: vs2019


### PR DESCRIPTION
## Summary

Adds Windows build/test jobs for **MSVC 2026** (toolset v145) on `windows-2025` runners, alongside the existing MSVC 2019/2022 jobs.

## Changes

- **CI matrix** (`windows-{full,standard,minimal}-config.json`): add MSVC 2026 jobs covering Debug/Release × MSBuild/CMake. Some existing standard/minimal slots are repointed from msvc-2022 to msvc-2026.
- **`build-test-windows.yml`**: replace the two-way (2019 vs rest) env selection with an explicit three-way per-compiler mapping:
  - `msvc-2019` → CUDA 11.4, toolset v142, vcvars 14.2
  - `msvc-2022` → CUDA 12.0, toolset v143, vcvars 14.4
  - otherwise (`msvc-2026`) → CUDA 13.2, toolset v145, vcvars 14.5

  The C# build now runs on the msvc-2026 CMake job.
- **`install-cuda` action**: on CUDA 13+, additionally install the `crt` and `nvvm` sub-packages. In CUDA 13 these were split out of the `nvcc` package into standalone components — `crt` provides `crt/host_config.h` (pulled in by `cuda_runtime.h`) and `nvvm` provides the `cicc` device-compiler front-end. Without them MRCuda fails to build. Cache key bumped to `-v3` to invalidate previously poisoned partial-install caches.
- **`prepare-images.yml`**: add a vs2026 image-prep matrix entry and move vs2022 onto `windows-2025`.

## Test plan

- [x] All Windows `windows-build-test` jobs pass for both compilers (msvc-2022 and msvc-2026), across Debug/Release × MSBuild/CMake.
- [x] MRCuda compiles under CUDA 13.2 with the new `crt` + `nvvm` sub-packages.

### Build-step timings (msvc-2026 vs msvc-2022)

| Config | msvc-2026 | msvc-2022 |
|---|---|---|
| Debug · MSBuild | 10m05s | 9m26s |
| Debug · CMake | 14m14s | 12m39s |
| Release · MSBuild | 21m31s | 19m57s |
| Release · CMake | 27m15s | 19m49s |

msvc-2026 is modestly slower in three of four configs (7–13%); Release·CMake is the outlier (+37%).
