### PR TITLE
get-aws-instance-type: add 2s timeout to Windows metadata requests

### DIFF
--- a/.github/actions/get-aws-instance-type/action.yml
+++ b/.github/actions/get-aws-instance-type/action.yml
@@ -33,9 +33,11 @@ runs:
       shell: powershell
       run: |
         try {
-            $Token = Invoke-RestMethod -Uri "http://169.254.169.254/latest/api/token" -Method PUT -Headers @{ "X-aws-ec2-metadata-token-ttl-seconds" = "10" }
-            $InstanceType = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-type" -Headers @{ "X-aws-ec2-metadata-token" = $Token }
-            $InstanceLifeCycle = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-life-cycle" -Headers @{ "X-aws-ec2-metadata-token" = $Token }
+            # -TimeoutSec bounds each request so a non-EC2 runner fails fast instead of
+            # waiting out the ~21s OS TCP connect timeout on the unreachable link-local IP.
+            $Token = Invoke-RestMethod -Uri "http://169.254.169.254/latest/api/token" -Method PUT -Headers @{ "X-aws-ec2-metadata-token-ttl-seconds" = "10" } -TimeoutSec 2
+            $InstanceType = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-type" -Headers @{ "X-aws-ec2-metadata-token" = $Token } -TimeoutSec 2
+            $InstanceLifeCycle = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-life-cycle" -Headers @{ "X-aws-ec2-metadata-token" = $Token } -TimeoutSec 2
             # if not an EC2 instance
             if ($null -eq $InstanceType) { $InstanceType = "self-hosted" }
             if ($null -eq $InstanceLifeCycle) { $InstanceType = "self-hosted" }


### PR DESCRIPTION
## Problem

On self-hosted **Windows** runners that are not EC2 instances, the "Get AWS instance type" step takes ~21 seconds.

The bash branch of the action already bounds each request with `--connect-timeout 1 --max-time 2`, so it fails fast when the EC2 metadata service is unreachable. The Windows branch's `Invoke-RestMethod` calls had **no timeout**, so the first request (the token `PUT` to the link-local IP `169.254.169.254`) sits in the OS TCP connect black-hole until Windows gives up after ~21s, then throws into the `catch`. That ~21s is the entire cost of the step on non-EC2 runners.

## Fix

Add `-TimeoutSec 2` to each of the three `Invoke-RestMethod` calls, mirroring the `--max-time 2` already used in the bash branch.

- Off-EC2: the token request throws after 2s instead of 21s, so the step drops from ~21s to ~2s.
- On real EC2 runners: IMDS answers in well under 100 ms, so the timeout is never approached and behavior is unchanged.

## Testing

Only the Windows branch is touched, so all non-Windows platforms are disabled via `disable-build-*` labels. Windows build is left enabled to confirm the action still works.
