### PR TITLE
ci(windows): package C# NuGet bindings on msvc-2026 job (fixes unity-nuget-test)

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -378,7 +378,7 @@ jobs:
           compression-level: 0
 
       - name: Create and fix fake Wheel for NuGet
-        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
+        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
         run: |
           py -3 -m venv wheel_venv
           wheel_venv\Scripts\Activate
@@ -386,7 +386,7 @@ jobs:
           py -3 ./scripts/nuget_patch/patch_library_deps.py ./patched_content/ ./source/x64/Release/MeshLibC2.dll ./source/x64/Release/MeshLibC2Cuda.dll
 
       - name: Upload NuGet files to Artifacts
-        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
+        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: DotNetPatchArchiveWindows-x64
@@ -395,7 +395,7 @@ jobs:
           overwrite: true
 
       - name: Upload NuGet library DLL and XML to Artifacts
-        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
+        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: DotNetDllXml


### PR DESCRIPTION
## Problem

The nightly `windows-unity-test / unity-nuget-test` job started failing on 2026-05-31 (last green: the 2026-05-30 nightly). The Unity project fails to compile:

```
Assets\test_script.cs(8,9):  error CS0246: The type or namespace name 'MR' could not be found
Assets\test_script.cs(8,38): error CS0246: The type or namespace name 'MR' could not be found
Scripts have compiler errors.
```

Unity then hangs in batchmode and the step times out after 10 minutes (so the "timed out" annotation is a symptom, not the cause).

## Root cause

#6190 ("ci(windows): add MSVC 2026 build/test jobs") repointed the C# build flag to the new compiler:

```yaml
BUILD_C_SHARP: ${{ matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'CMake' }}   # was msvc-2022
```

But the three steps that package the managed bindings into the NuGet were left gated on `msvc-2022`:

- `Create and fix fake Wheel for NuGet`
- `Upload NuGet files to Artifacts`
- `Upload NuGet library DLL and XML to Artifacts` (uploads `MRDotNet2.dll` / `.xml`)

Their condition became:

```yaml
if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
```

`cxx_compiler == 'msvc-2022'` **and** `BUILD_C_SHARP == true` (which now requires `msvc-2026`) can never both hold, so these steps never run. The managed `MRDotNet2.dll` is built (on the msvc-2026 job) but never uploaded, so `create-nuget-package` assembles a `.nupkg` with the native runtimes but **without the managed `MR` bindings** — and the Unity test that references namespace `MR` can't compile.

## Fix

Gate the three packaging steps on `msvc-2026` so they run on the same job where `BUILD_C_SHARP` is true. One-line change per step.

## Test plan

- [ ] `full-ci` label triggers `create-nuget-package` + `windows-unity-test / unity-nuget-test`.
- [ ] The produced `.nupkg` contains the managed `MRDotNet2.dll`.
- [ ] `unity-nuget-test` compiles `test_script.cs` (no CS0246) and passes.
