### PR TITLE
ci(unity): run unity-nuget-test on full-ci PRs, not only nightly

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -279,7 +279,17 @@ jobs:
           failOnError: false
 
   windows-unity-test:
-    if: ${{ needs.config.outputs.run_unity_nuget_test == 'true' }}
+    # Run whenever full-ci is requested and the Windows build is enabled, provided the
+    # NuGet package was actually built and uploaded to the release. `!cancelled()` keeps
+    # this job from being auto-skipped: without a status function the implicit success()
+    # gate skips it whenever a disabled platform (e.g. emscripten) is reached transitively
+    # through `upload-distributions`, which is why it never ran on pull_request events.
+    if: >-
+      ${{ !cancelled()
+        && needs.config.outputs.run_unity_nuget_test == 'true'
+        && needs.config.outputs.build_enable_windows == 'true'
+        && needs.create-nuget-package.result == 'success'
+        && needs.upload-distributions.result == 'success' }}
     needs:
       - config
       - windows-build-test


### PR DESCRIPTION
## Problem

`windows-unity-test` (the `unity-nuget-test` job) only ever ran on the nightly `schedule`. On `pull_request` runs it was **silently skipped** — even with the `full-ci` label, where `run_unity_nuget_test` resolves to `true`.

Root cause: the job's `if:` was `${{ needs.config.outputs.run_unity_nuget_test == 'true' }}`, with no status-check function. GitHub therefore applies the implicit `success()` gate over the whole `needs` graph. That gate skips the job whenever any transitively-needed platform build is skipped. On PRs the unaffected platforms (e.g. emscripten) are disabled, and that skip flows through `upload-distributions` (which itself survives via `!cancelled()`) down to the Unity test — so it never ran.

This is the same chain that hid the missing C# bindings until the nightly: PR #6193 fixed the packaging, but the Unity test could not be exercised on the PR to confirm it.

## Change

Gate `windows-unity-test` on `!cancelled()` plus explicit conditions instead of relying on the implicit `success()`:

- `run_unity_nuget_test == 'true'` — full-ci requested (or schedule)
- `build_enable_windows == 'true'` — Windows build not disabled
- `create-nuget-package.result == 'success'` — the NuGet package was built
- `upload-distributions.result == 'success'` — the package was uploaded to the release

Adding `!cancelled()` removes the implicit skip-propagation, so disabling unrelated platforms no longer suppresses the Unity test. The explicit `result == 'success'` checks keep it from running when the package it consumes is missing.

Net effect: with `full-ci` present and the Windows build enabled, the Unity test runs on PRs — not only on the nightly.

## Validation

This PR is labelled `full-ci` with Windows / linux-vcpkg / macOS enabled (the minimum the NuGet package needs) and ubuntu / emscripten disabled, so its own CI run exercises `windows-unity-test` end-to-end.
