### PR TITLE
CI: archive Windows binaries as zip instead of 7z (faster compression)

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -337,24 +337,21 @@ jobs:
         # https://github.com/actions/download-artifact#maintaining-file-permissions-and-case-sensitive-files
       - name: Archive files
         if: ${{ env.job_upload_artifact == 'true' }}
-        # No leading ./ : 7-Zip anchors at it and would store paths as Release\...
-        # (dropping the source/x64/ prefix). Without it the full relative path is kept,
-        # so extraction recreates source/x64/<config>/... as make_install_folder expects.
-        run: 7z a MREDist_${{ matrix.upload_name || matrix.config }}.7z source/x64/${{ matrix.config }}
+        run: tar --format zip -c -f MREDist_${{ matrix.upload_name || matrix.config }}.zip ./source/x64/${{ matrix.config }}
 
       - name: Archive generated C headers
         if: ${{ env.job_upload_artifact == 'true' && matrix.config == 'Release' && inputs.mrbind_c }}
-        run: 7z a MeshLibC2Headers.7z source/MeshLibC2/include
+        run: tar --format zip -c -f MeshLibC2Headers.zip ./source/MeshLibC2/include
 
       - name: Upload Windows Binaries Archive
         if: ${{ env.job_upload_artifact == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: WindowsArchive_${{ matrix.upload_name || matrix.config }}
-          path: MREDist_${{ matrix.upload_name || matrix.config }}.7z
+          path: MREDist_${{ matrix.upload_name || matrix.config }}.zip
           retention-days: 1
           overwrite: true
-          # The payload is already a .7z; don't re-Deflate it (no size gain).
+          # The payload is already a .zip; don't re-Deflate it (no size gain).
           compression-level: 0
 
       - name: Collect artifact stats
@@ -363,7 +360,7 @@ jobs:
         uses: ./.github/actions/collect-artifact-stats
         with:
           artifact_path: ${{ github.workspace }}
-          artifact_glob: MREDist_${{ matrix.upload_name || matrix.config }}.7z
+          artifact_glob: MREDist_${{ matrix.upload_name || matrix.config }}.zip
           stats_file_suffix: -${{ steps.collect-runner-stats.outputs.job_id }}
 
       - name: Upload MeshLibC2 headers archive
@@ -371,10 +368,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: WindowsArchive_MeshLibC2Headers
-          path: MeshLibC2Headers.7z
+          path: MeshLibC2Headers.zip
           retention-days: 1
           overwrite: true
-          # The payload is already a .7z; don't re-Deflate it (no size gain).
+          # The payload is already a .zip; don't re-Deflate it (no size gain).
           compression-level: 0
 
       - name: Create and fix fake Wheel for NuGet

--- a/.github/workflows/update-win-version.yml
+++ b/.github/workflows/update-win-version.yml
@@ -19,12 +19,12 @@ jobs:
       matrix:
         include:
           - vcpkg_triplet: x64-windows-vs2019-meshlib
-            extract_release: MREDist_Release.7z
-            extract_debug: MREDist_Debug.7z
+            extract_release: MREDist_Release.zip
+            extract_debug: MREDist_Debug.zip
             output_zip: MeshLibDist.zip
             artifact_name: DistributivesWin
           - vcpkg_triplet: x64-windows-meshlib-iterator-debug
-            extract_debug: MREDist_Debug-IteratorDebug.7z
+            extract_debug: MREDist_Debug-IteratorDebug.zip
             output_zip: MeshLibDist-IteratorDebug.zip
             artifact_name: DistributivesWin-IteratorDebug
     env:
@@ -50,11 +50,11 @@ jobs:
 
       - name: Extract Windows Binaries
         run: |
-          if ("${{ matrix.extract_release }}") {
-            7z x -y ${{ matrix.extract_release }}
+          if ("${{ matrix.extract_release }}") { 
+            tar -xvzf ${{ matrix.extract_release }} 
           }
-          7z x -y ${{ matrix.extract_debug }}
-          7z x -y MeshLibC2Headers.7z
+          tar -xvzf ${{ matrix.extract_debug }}
+          tar -xvzf MeshLibC2Headers.zip
 
       - name: Make Install Folder
         run: py -3.10 scripts\make_install_folder.py ${{ inputs.app_version }} ${{ matrix.vcpkg_triplet }}


### PR DESCRIPTION
## What

Switch the Windows binary archives from `7z` to `zip` (created with `tar --format zip`):

- `build-test-windows.yml`: `MREDist_<config>` and `MeshLibC2Headers` are now archived with `tar --format zip` and uploaded as `.zip`.
- `update-win-version.yml`: the consuming job extracts them with `tar -xvzf` instead of `7z x`.

## Why

`zip` compression is much faster than `7z` on these archives, shortening the Windows build jobs, and it relies only on the built-in `tar` (no `7z` CLI dependency).

## Trade-off

`zip` produces a larger archive than `7z`. These are intermediate artifacts (`retention-days: 1`, deleted by the cleanup job once consumed), so the extra size only affects in-run upload/download, not long-term storage.

## Measured (Release config, same windows-2022 / vs2019 runner)

| | 7z (master) | zip (this PR) |
|---|---|---|
| `Archive files` step | ~58 s | ~18 s |
| `MREDist_Release` size | ~69 MiB | ~119 MiB |

## Verification

Full round-trip green in CI: archives created with `tar --format zip`, uploaded, downloaded by `update-win-version`, extracted with `tar -xvzf`, install folder built, and distribution tests passed.
