### PR TITLE
CI: speed up Windows "Setup python" by skipping redundant Chocolatey install

### DIFF
--- a/scripts/setup_win_python_reqs.py
+++ b/scripts/setup_win_python_reqs.py
@@ -23,6 +23,17 @@ def detect_vcpkg_python_version(vcpkg_root, triplet="x64-windows-meshlib"):
                 return f"3.{minor_version}"
     return None
 
+def python_version_available(version: str) -> bool:
+    try:
+        subprocess.run(
+            f"py -{version} --version",
+            shell=True, check=True,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
 def choco_install_python(version: str):
     version_nodot = version.replace('.', '')  # "3.11" -> "311"
     choco_package = f"python{version_nodot}"
@@ -38,7 +49,6 @@ def run_python_setup(py_version: str):
     try:
         print(f"Ensuring pip is available for Python {py_version}...")
         subprocess.run(f"{py_cmd} -m ensurepip --upgrade", shell=True, check=True)
-        subprocess.run(f"{py_cmd} -m pip install --upgrade pip", shell=True, check=True)
 
         requirements_file = Path(__file__).resolve().parents[1] / "requirements" / "python" / "requirements.txt"
         if requirements_file.exists():
@@ -56,5 +66,8 @@ if platform.system() == "Windows":
         detected_version = detect_vcpkg_python_version(vcpkg_root, triplet=triplet)
         if detected_version:
             print(f"Using python version {detected_version}")
-            choco_install_python(detected_version)
+            if python_version_available(detected_version):
+                print(f"Python {detected_version} already available, skipping Chocolatey install")
+            else:
+                choco_install_python(detected_version)
             run_python_setup(detected_version)


### PR DESCRIPTION
## Problem

On Windows CI the "Setup python" step took **up to ~1m20s**, but almost all of that work was redundant.

The step runs `scripts/setup_win_python_reqs.py`, which unconditionally did `choco install python3XX -y`. The GitHub/AWS runner image already ships the matching interpreter in the hosted tool cache (e.g. `C:\hostedtoolcache\windows\Python\3.12.10\x64`), and it is already used earlier in the same job. Chocolatey even reported it:

```
WARNING: Provided python InstallDir was ignored by the python installer
WARNING: Its probable that you had pre-existing python installation
WARNING: Python installed to: 'C:\hostedtoolcache\windows\Python\3.12.10\x64'
```

The choco-installed copy was never even used — `py -<version>` resolves straight back to the toolcache interpreter, where the packages actually land.

Old breakdown of the step:

| Phase | Duration |
|---|---|
| `choco install python3XX` (+ bootstrap) | ~56 s |
| `pip install --upgrade pip` (self-upgrade) | ~13 s |
| `pip install -r requirements.txt` (numpy, pytest, pytest-check) | ~7 s |

Only the last few seconds installed anything actually missing from the runner.

## Change

- Skip the Chocolatey install when `py -<version>` already resolves to a working interpreter; only fall back to `choco install` when the version is genuinely absent (keeps self-hosted/custom runners working).
- Drop the `pip install --upgrade pip` self-upgrade — `ensurepip --upgrade` already guarantees pip is present, and chasing the latest PyPI pip on every run added ~13 s for no benefit.

## Measured results

Confirmed on this PR's run vs. the latest master baseline. The choco install was skipped on **every** Windows job (including the older `windows-2022 / 2024.10.21` image, where the guard correctly detected the pre-existing Python 3.11):

```
Using python version 3.11
Python 3.11 already available, skipping Chocolatey install
```

| Config | master baseline | this PR | saved |
|---|---|---|---|
| msvc-2026 Release CMake (windows-2025) | 55 s | 14 s | ~41 s |
| msvc-2019 Debug CMake, iterator-debug | 68 s | 17 s | ~51 s |
| msvc-2026 Debug MSBuild (windows-2025) | 35 s | 15 s | ~20 s |
| msvc-2019 Release CMake (windows-2022, 2024.10.21) | 39 s | 28 s | ~11 s |

The `windows-2022 / 2024.10.21` job saves the least only because its older image ships fewer pre-installed pip deps, so the real `requirements.txt` install genuinely does more work there — not the redundant reinstall.
