### PR TITLE
CI: fetch regression test data from MeshLibTestData submodule instead of S3

### DIFF
--- a/.github/actions/python-regression-tests/action.yml
+++ b/.github/actions/python-regression-tests/action.yml
@@ -54,7 +54,16 @@ runs:
     # is pinned by the submodule commit, replacing the former S3 path + actions/cache.
     - name: Fetch test data submodule
       shell: bash
-      run: bash scripts/retry.sh -- git submodule update --init --checkout --depth 1 test_data
+      run: |
+        # Linux jobs run in containers where the checked-out repo is owned by a
+        # different user than the step, so git refuses to operate on it. Mirror the
+        # workflows' own checkout-submodule setup before fetching. Windows/macOS
+        # runners are not containerized and do not need this.
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          export HOME="${RUNNER_TEMP}"
+          git config --global --add safe.directory '*'
+        fi
+        bash scripts/retry.sh -- git submodule update --init --checkout --depth 1 test_data
 
     - name: Python Regression Tests
       if: ${{ runner.os != 'Windows' }}

--- a/.github/actions/python-regression-tests/action.yml
+++ b/.github/actions/python-regression-tests/action.yml
@@ -46,19 +46,11 @@ runs:
         Write-Output "test_artifacts_path: ${{ inputs.test_artifacts_path }}"
         Write-Output "upload_test_artifacts: ${{ inputs.upload_test_artifacts }}"
 
-    # Test input data lives in the MeshLibTestData submodule, mounted at test_data/
-    # (the suite reads it via test_files_path = "../test_data", see
-    # test_regression/constants.py). The submodule is declared with `update = none`
-    # in .gitmodules so ordinary recursive/true checkouts (pip-build, prepare-images)
-    # skip its ~100 MiB; we fetch it explicitly here with --checkout. The data version
-    # is pinned by the submodule commit, replacing the former S3 path + actions/cache.
+    # test_data is declared with `update = none`, so fetch it explicitly with --checkout.
     - name: Fetch test data submodule
       shell: bash
       run: |
-        # Linux jobs run in containers where the checked-out repo is owned by a
-        # different user than the step, so git refuses to operate on it. Mirror the
-        # workflows' own checkout-submodule setup before fetching. Windows/macOS
-        # runners are not containerized and do not need this.
+        # Linux jobs run in containers and need safe.directory set first.
         if [ "$RUNNER_OS" = "Linux" ]; then
           export HOME="${RUNNER_TEMP}"
           git config --global --add safe.directory '*'
@@ -85,8 +77,6 @@ runs:
         -s ${{ inputs.smoke }}
         -a='${{ inputs.pytest_args }}'
 
-    # AWS credentials are only needed to upload test artifacts; configure them
-    # solely in that case so the data-fetch path no longer depends on AWS.
     - name: Configure AWS Credentials
       if: ${{ fromJSON( inputs.upload_test_artifacts ) && !cancelled() }}
       uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0

--- a/.github/actions/python-regression-tests/action.yml
+++ b/.github/actions/python-regression-tests/action.yml
@@ -1,10 +1,6 @@
 name: Python regression tests
 
 inputs:
-  autotest_data_s3_url:
-    required: false
-    type: string
-    default: "s3://data-autotest/test_data_2025-05-13"
   build_config:
     description: "Build config (Release, Debug)"
     required: true
@@ -33,7 +29,6 @@ runs:
       shell: bash
       run: |
         echo << EOF
-        autotest_data_s3_url: ${{ inputs.autotest_data_s3_url }}
         build_config: ${{ inputs.build_config }}
         pytest_args: ${{ inputs.pytest_args }}
         smoke: ${{ inputs.smoke }}
@@ -45,36 +40,21 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       shell: powershell
       run: |
-        Write-Output "autotest_data_s3_url: ${{ inputs.autotest_data_s3_url }}"
         Write-Output "build_config: ${{ inputs.build_config }}"
         Write-Output "pytest_args: ${{ inputs.pytest_args }}"
         Write-Output "smoke: ${{ inputs.smoke }}"
         Write-Output "test_artifacts_path: ${{ inputs.test_artifacts_path }}"
         Write-Output "upload_test_artifacts: ${{ inputs.upload_test_artifacts }}"
 
-    # cache management: https://github.com/MeshInspector/MeshLib/actions/caches
-    - name: Cache autotest data from S3 Tests
-      uses: actions/cache@v4
-      with:
-        path: test_data
-        key: ${{ inputs.autotest_data_s3_url }}
-
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
-      with:
-        role-to-assume: arn:aws:iam::259351611210:role/GitHubMeshLibAwsCredsRole
-        aws-region: us-east-1
-        retry-max-attempts: 5
-
-    - name: Copy autotest data from S3 Tests
-      if: ${{ runner.os != 'Windows' }}
+    # Test input data lives in the MeshLibTestData submodule, mounted at test_data/
+    # (the suite reads it via test_files_path = "../test_data", see
+    # test_regression/constants.py). The submodule is declared with `update = none`
+    # in .gitmodules so ordinary recursive/true checkouts (pip-build, prepare-images)
+    # skip its ~100 MiB; we fetch it explicitly here with --checkout. The data version
+    # is pinned by the submodule commit, replacing the former S3 path + actions/cache.
+    - name: Fetch test data submodule
       shell: bash
-      run: aws s3 sync ${{ inputs.autotest_data_s3_url }} test_data --delete --no-sign-request --size-only
-
-    - name: Copy autotest data from S3 Tests (Windows)
-      if: ${{ runner.os == 'Windows' }}
-      shell: powershell
-      run: aws s3 sync ${{ inputs.autotest_data_s3_url }} test_data --delete --no-sign-request --size-only
+      run: bash scripts/retry.sh -- git submodule update --init --checkout --depth 1 test_data
 
     - name: Python Regression Tests
       if: ${{ runner.os != 'Windows' }}
@@ -85,7 +65,7 @@ runs:
         -d '../test_regression'
         -s ${{ inputs.smoke }}
         -a='${{ inputs.pytest_args }}'
-        
+
     - name: Python Regression Tests (Windows)
       if: ${{ runner.os == 'Windows' }}
       shell: powershell
@@ -95,6 +75,16 @@ runs:
         -d '..\test_regression'
         -s ${{ inputs.smoke }}
         -a='${{ inputs.pytest_args }}'
+
+    # AWS credentials are only needed to upload test artifacts; configure them
+    # solely in that case so the data-fetch path no longer depends on AWS.
+    - name: Configure AWS Credentials
+      if: ${{ fromJSON( inputs.upload_test_artifacts ) && !cancelled() }}
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+      with:
+        role-to-assume: arn:aws:iam::259351611210:role/GitHubMeshLibAwsCredsRole
+        aws-region: us-east-1
+        retry-max-attempts: 5
 
     - name: Copy test artifacts to S3
       if: ${{ fromJSON( inputs.upload_test_artifacts ) && !cancelled() && runner.os != 'Windows' }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ include/*
 share/*
 bin/*
 thirdparty_build/*
-/test_data
 .vscode/*
 distr/*
 *.log

--- a/.gitmodules
+++ b/.gitmodules
@@ -88,3 +88,8 @@
 [submodule "thirdparty/zlib-ng"]
 	path = thirdparty/zlib-ng
 	url = https://github.com/zlib-ng/zlib-ng.git
+[submodule "test_data"]
+	path = test_data
+	url = https://github.com/MeshInspector/MeshLibTestData.git
+	update = none
+	shallow = true


### PR DESCRIPTION
## What

Source the Python regression-test input data from a new git submodule,
**[`MeshInspector/MeshLibTestData`](https://github.com/MeshInspector/MeshLibTestData)**
(mounted at `test_data/`), instead of downloading it from S3.

Previously the `python-regression-tests` composite action restored `test_data/` from
`actions/cache` (keyed on the S3 URL) and reconciled it with
`aws s3 sync s3://data-autotest/test_data_2025-05-13`. This PR replaces that with a
submodule fetch. `MeshLibTestData` is a verbatim, byte-for-byte snapshot of
`s3://data-autotest/test_data_2025-05-13` (397 files, ~104 MiB; plain git, no LFS).

## Why

- **Drop the runtime dependency on AWS S3** for fetching test inputs.
- **Simpler, explicit versioning** — the data version is pinned by the submodule commit
  instead of a hard-coded S3 URL, so a data update and the code that needs it can land in
  one pull request.

## How

- **`.gitmodules`**: add `test_data` with `update = none` so ordinary
  `submodules: recursive`/`true` checkouts (`pip-build`, `prepare-images`) skip its
  ~100 MiB. The regression action fetches it explicitly with
  `git submodule update --init --checkout --depth 1 test_data` (`--checkout` overrides
  `update = none`).
- **`python-regression-tests/action.yml`**: remove the `autotest_data_s3_url` input, the
  `actions/cache` step and the two `aws s3 sync` steps; fetch the submodule instead. AWS
  credentials are now configured only when uploading test artifacts. On Linux the fetch
  step first sets `safe.directory` (the same way the workflows' own checkout-submodule
  steps do), because those jobs run in containers where the repo is owned by a different
  user than the step.
- **`.gitignore`**: drop `/test_data` (now a tracked submodule).

No test changes — the suite still reads inputs from `../test_data`
(`test_regression/constants.py`).

## Measured impact

Data-acquisition time (the part this PR changes) per regression job, this PR vs `master`.
The pytest run itself is unchanged (within run-to-run variance), and AWS is no longer
touched on the data path.

| Job | Runner | `master` (cache + AWS + `s3 sync`) | this PR (`git submodule update`) |
|---|---|--:|--:|
| windows msvc-2019 Release | GitHub-hosted | ~23.8s | ~2.3s |
| linux-vcpkg x64 Release | container | ~5.2s | ~1.9s |
| macos arm64 Release | GitHub-hosted | ~6.4s | ~2.8s |
| macos arm64 Debug | self-hosted | ~20.0s | ~0.2s |

- The large Windows win is because `aws s3 sync` takes ~20s there even on a cache hit
  (slow tree walk/stat under the Windows AWS CLI); on Linux/macOS it was only ~2s.
- On the **permanent self-hosted runner**, the submodule is **reused** across runs
  (`.git/modules/test_data` persists), so the fetch is a ~0.2s no-op with no download —
  versus ~20s of cache restore + S3 sync before. GitHub-hosted / container runners are
  fresh each run and do a full (shallow) ~2s clone.

## Notes

- `disable-build-emscripten` applied: emscripten does not run regression tests, so it is
  unaffected by this change.
- The artifact **upload** to `s3://test-artifacts-git/...` is intentionally unchanged
  (separate concern, still gated on `upload_test_artifacts`).
- Data integrity: the snapshot repo uses `.gitattributes` `* -text` and every file was
  verified byte-identical to S3, so ASCII fixtures (`.asc` / `.xyz` / ASCII `.ply`) keep
  exact bytes.
