### PR TITLE
ci(vcpkg): rebuild from source when restored cache is empty

### DIFF
--- a/.github/actions/setup-vcpkg-windows/action.yml
+++ b/.github/actions/setup-vcpkg-windows/action.yml
@@ -64,7 +64,9 @@ runs:
       shell: pwsh
       run: |
         if (Test-Path C:\vcpkg) {
-          Move-Item C:\vcpkg "C:\vcpkg-stash-$(New-Guid)" -Force
+          $stash = "C:\vcpkg-stash-$(New-Guid)"
+          Move-Item C:\vcpkg $stash -Force
+          "VCPKG_STASH=$stash" | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
         }
 
     - name: Restore Vcpkg Cache
@@ -74,6 +76,27 @@ runs:
         key: ${{ env.VCPKG_CACHE_KEY }}
         path: |
           C:\vcpkg\*
+
+    # Guard against a "cache hit" that restored an empty or incomplete tree —
+    # a known actions/cache flake on Windows where the step reports the cache
+    # as restored but tar extraction silently dropped files. If the installed
+    # root for this triplet is missing, discard the bad restore, put the
+    # runner's pristine vcpkg clone back, and fall through to the build path.
+    - name: Verify Restored Vcpkg Cache
+      if: ${{ env.VCPKG_CACHE_HIT == 'true' }}
+      shell: pwsh
+      run: |
+        $sentinel = "C:\vcpkg\installed\${{ inputs.vcpkg-triplet }}"
+        if ((Test-Path $sentinel) -and (Get-ChildItem -Force $sentinel | Select-Object -First 1)) {
+          Write-Host "Restored cache verified: '$sentinel' exists and is non-empty."
+        } else {
+          Write-Warning "Cache hit but '$sentinel' is missing or empty — treating as a cache miss and rebuilding from source."
+          if (Test-Path C:\vcpkg) { Remove-Item C:\vcpkg -Recurse -Force -ErrorAction SilentlyContinue }
+          if ($env:VCPKG_STASH -and (Test-Path $env:VCPKG_STASH)) {
+            Move-Item $env:VCPKG_STASH C:\vcpkg -Force
+          }
+          "VCPKG_CACHE_HIT=false" | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+        }
 
     # ----- cache MISS path: clean + checkout + bootstrap + install + trim + save -----
     - name: Clean Vcpkg Directory


### PR DESCRIPTION
## Problem

On Windows, `actions/cache` intermittently reports a **cache hit** and logs the entry as *restored* while the underlying `tar` extraction silently drops files, leaving `C:\vcpkg` without the installed packages. The `setup-vcpkg-windows` composite action trusted the hit, skipped the build-from-source path, and then failed at `vcpkg integrate install` — every downstream step (build, tests, bindings) was skipped.

Example: [run 26776556739, attempt 1, `msvc-2026 / Release / CMake / x64-windows-meshlib`](https://github.com/MeshInspector/MeshLib/actions/runs/26776556739/job/78929646514). The `Diagnostic — vcpkg installed tree` step right after the "restored" cache hit showed every installed dir absent:

```
--- C:\vcpkg\installed\x64-windows-meshlib\bin ---        (directory not present)
--- C:\vcpkg\installed\x64-windows-meshlib\lib ---        (directory not present)
```

A sibling job in the same run hit the same cache key and restored it fine, so the cache entry itself was good — this is the well-known flaky/partial-extraction behaviour of `actions/cache` on Windows (see e.g. actions/toolkit#632, actions/cache#1251).

## Fix

After the cache-hit restore, verify the sentinel path `C:\vcpkg\installed\<triplet>` exists and is non-empty. If it is missing or empty:

- discard the incomplete `C:\vcpkg`,
- move the runner's pristine vcpkg clone (stashed earlier) back into place,
- clear `VCPKG_CACHE_HIT` so the existing miss path rebuilds from source and re-saves the cache.

This turns a structurally-broken "hit" into a normal miss instead of a hard failure. The happy path (good cache hit) is unchanged.

To support the rollback, the stash step now records its destination in `VCPKG_STASH`.
