### PR TITLE
CI: macOS: Move dylib stripping from install script

### DIFF
--- a/.github/actions/install-macos-thirdparty/action.yml
+++ b/.github/actions/install-macos-thirdparty/action.yml
@@ -141,7 +141,9 @@ runs:
     # so brew packages must be installed on hosted runners even on cache hit.
     - name: Install brew requirements
       shell: bash
-      run: ./scripts/install_brew_requirements.sh
+      run: |
+        ./scripts/install_brew_requirements.sh
+        ./scripts/strip_brew_dylibs.sh
 
     - name: Build thirdparty libs
       if: ${{ steps.thirdparty-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Create virtualenv
         run: |
-          python3 -m venv .venv
+          python3.10 -m venv .venv
           . .venv/bin/activate
           echo PATH=$PATH >> $GITHUB_ENV
 

--- a/scripts/install_brew_requirements.sh
+++ b/scripts/install_brew_requirements.sh
@@ -1,4 +1,12 @@
-#!/bin/bash
+#!/bin/bash -i
+# expand aliases defined in ~/.bashrc
+# this and -i flag may be required for multi-user configurations where brew is declared as an alias for a more complicated command
+# some examples:
+# - https://dev.to/cerico/using-brew-in-a-multi-user-system-2lnl
+# - https://www.codejam.info/2021/11/homebrew-multi-user.html
+shopt -s expand_aliases
+
+set -e
 
 # This script installs requirements by `brew` if not already installed
 
@@ -8,27 +16,7 @@ if [ -n "$MESHLIB_EXTRA_BREW_REQUIREMENTS" ] ; then
   MESHLIB_BREW_REQUIREMENTS=$MESHLIB_BREW_REQUIREMENTS$'\n'$MESHLIB_EXTRA_BREW_REQUIREMENTS
 fi
 
+
 brew install --quiet $(echo "$MESHLIB_BREW_REQUIREMENTS" | tr '\n' ' ')
-
+# FIXME: build w/o pybind11
 brew install --quiet pybind11
-
-# Strip dylibs we'll bundle (brew keeps full symbol tables for symbolication).
-# Per-file loop, not `find -exec ... +`: strip prints a sig-invalidation warning
-# and exits 1 on signed dylibs, which would abort the whole batched invocation
-# and leave later files unstripped. codesign re-signs ad-hoc so dyld doesn't
-# SIGKILL on load.
-BREW_PREFIX=$(brew --prefix)
-find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' -print0 | while IFS= read -r -d '' f; do
-  chmod u+w "$f"
-  strip -x "$f" 2>/dev/null || true
-  codesign --force --sign - "$f" 2>/dev/null || true
-done
-
-# check and upgrade python3 pip
-python3.10 -m ensurepip --upgrade
-python3.10 -m pip install --upgrade pip
-
-# install requirements for python libs
-python3.10 -m pip install -r requirements/python/requirements.txt
-
-exit 0

--- a/scripts/run_python_test_script.py
+++ b/scripts/run_python_test_script.py
@@ -39,36 +39,9 @@ parser.add_argument("-a", dest="pytest_args", type=str,
 args = parser.parse_args()
 print(args)
 
-python_cmds = ["py -3.11"]
+python_cmds = ["python3"]
 platformSystem = platform.system()
-
-if platformSystem == 'Linux':
-    python_cmds = ["python3"]
-
-    os_name = ""
-    os_version = ""
-    if os.path.exists('/etc/os-release'):
-        lines = open('/etc/os-release').read().split('\n')
-        for line in lines:
-            if line.startswith('NAME='):
-                os_name = line.split('=')[-1].replace('"', '')
-            if line.startswith('VERSION_ID='):
-                os_version = line.split('=')[-1].replace('"', '')
-
-    if "ubuntu" in os_name.lower():
-        python_cmds = ["python3"] # use the same python version as in venv
-    elif "fedora" in os_name.lower():
-        if os_version.startswith("35"):
-            python_cmds = ["python3.9"]
-        elif os_version.startswith("37"):
-            python_cmds = ["python3.11"]
-        elif os_version.startswith("39"):
-            python_cmds = ["python3.12"]
-
-elif platformSystem == 'Darwin':
-    python_cmds = ["python3.10"]
-
-elif platformSystem == "Windows":
+if platformSystem == "Windows":
     python_cmds = ["py -3"]
     vcpkg_root = get_vcpkg_root_from_where()
     if vcpkg_root:

--- a/scripts/strip_brew_dylibs.sh
+++ b/scripts/strip_brew_dylibs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Strip dylibs we'll bundle (brew keeps full symbol tables for symbolication).
 # NOTE: `strip` prints a sig-invalidation warning and exits 1 on signed dylibs.

--- a/scripts/strip_brew_dylibs.sh
+++ b/scripts/strip_brew_dylibs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Strip dylibs we'll bundle (brew keeps full symbol tables for symbolication).
+# NOTE: `strip` prints a sig-invalidation warning and exits 1 on signed dylibs.
+BREW_PREFIX=$(brew --prefix)
+find "$BREW_PREFIX/Cellar" -type f -name '*.dylib' -print0 | while IFS= read -r -d '' f; do
+  chmod u+w "$f"
+  strip -x "$f" 2>/dev/null || true
+  codesign --force --sign - "$f" 2>/dev/null || true
+done


### PR DESCRIPTION
To bundle Homebrew libraries correctly we strip and resign them. This happens in install_brew_requirements.sh affecting third-party users' Homebrew instances as well which is undesirable. This change moves the stripping part to a separate script called directly by a dedicated GitHub action. Also remove installing Python requirements as they're already handled in CI.