### PR TITLE
fix: quote URL in OpenLink so query strings survive the shell

### DIFF
--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -312,10 +312,21 @@ void OpenLink( const std::string& url )
     EM_ASM( open_link( UTF8ToString( $0 ) ), url.c_str() );
 #pragma clang diagnostic pop
 #else
+    // Single-quote the URL so the shell does not interpret characters common in query strings
+    // ('&', '?', ';', spaces, ...). Without quoting, everything after the first '&' is parsed as a
+    // separate command and dropped, truncating the opened URL.
+    const auto quoteForShell = []( const std::string& s )
+    {
+        std::string result = "'";
+        for ( char c : s )
+            result += ( c == '\'' ) ? std::string( "'\\''" ) : std::string( 1, c );
+        result += '\'';
+        return result;
+    };
 #ifdef __APPLE__
-    auto openres = system( ( "open " + url ).c_str() );
+    auto openres = system( ( "open " + quoteForShell( url ) ).c_str() );
 #else
-    auto openres = system( ( "xdg-open " + url + " &" ).c_str() );
+    auto openres = system( ( "xdg-open " + quoteForShell( url ) + " &" ).c_str() );
 #endif
     if ( openres == -1 )
     {


### PR DESCRIPTION
## Problem

On macOS and Linux, `OpenLink` passes the URL to the shell unquoted:

```cpp
system( ( "open " + url ).c_str() );          // macOS
system( ( "xdg-open " + url + " &" ).c_str() ); // Linux
```

`system()` runs `/bin/sh -c "<string>"`, so unquoted `&` in a query string is treated as the shell's background-command operator. A URL like:

```
https://example.com/page?a=1&b=2&c=3
```

is parsed by the shell as three commands — `open https://example.com/page?a=1` (backgrounded), then `b=2` and `c=3` as no-op variable assignments. The browser only ever receives `https://example.com/page?a=1`; **every query parameter after the first is silently dropped.** Other shell metacharacters (`;`, spaces, `?` globbing) are mishandled similarly.

Windows is unaffected — `ShellExecuteA` receives the URL as a single argument with no shell involved.

## Fix

Single-quote the URL argument (escaping any embedded single quote as `'\''`) so the shell treats it literally:

```cpp
const auto quoteForShell = []( const std::string& s ) { /* wrap in '...' , escape ' */ };
system( ( "open " + quoteForShell( url ) ).c_str() );
system( ( "xdg-open " + quoteForShell( url ) + " &" ).c_str() );
```

## Verification

Reproduced and confirmed the fix at the shell level with `/bin/sh`:

```
$ sh -c "echo https://example.com/page?a=1&b=2&c=3"
https://example.com/page?a=1                      # truncated at first &

$ sh -c "echo 'https://example.com/page?a=1&b=2&c=3'"
https://example.com/page?a=1&b=2&c=3              # full URL preserved
```

Affects macOS + Linux only (Windows path unchanged).
