### PR TITLE
CI: speed up Linux vcpkg image builds with shared S3 binary cache (OIDC)

### DIFF
--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -195,6 +195,11 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::259351611210:role/GitHubMeshLibAwsCredsRole
+          # A cold rebuild compiles every port (~1 h). Extend the session past
+          # the job's 75 min timeout so the credentials don't expire mid-build
+          # and silently skip cache uploads. Requires the role's
+          # MaxSessionDuration to allow >= this value.
+          role-duration-seconds: 7200
           retry-max-attempts: 5
 
       - name: Build Linux vcpkg image

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -154,6 +154,10 @@ jobs:
 
   linux-vcpkg-build-upload:
     if: ${{ inputs.need_linux_vcpkg_rebuild && !inputs.disable_linux_vcpkg }}
+    # OIDC: this job assumes an AWS role to read/write the vcpkg S3 binary cache.
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 75
     strategy:
       fail-fast: false
@@ -182,20 +186,33 @@ jobs:
           username: meshlib
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Configure AWS Credentials
+        # OIDC role assumption (same role as the Windows vcpkg cache) issues
+        # temporary credentials into the step environment. They are forwarded
+        # into `docker build` below as BuildKit secrets, because `vcpkg install`
+        # runs inside the build sandbox and does not inherit the runner's AWS env.
+        uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::259351611210:role/GitHubMeshLibAwsCredsRole
+          retry-max-attempts: 5
+
       - name: Build Linux vcpkg image
-        # AWS credentials are passed as BuildKit secrets so the Dockerfile's
-        # `vcpkg install` can read/write the shared S3 binary cache and skip
-        # rebuilding unchanged ports from source. They are scoped to this step
-        # and never written to image layers. When unavailable (e.g. no secret
-        # access) the build falls back to anonymous read-only cache access.
+        # The temporary AWS credentials are passed as BuildKit secrets so the
+        # Dockerfile's `vcpkg install` can read/write the shared S3 binary cache
+        # and skip rebuilding unchanged ports. Secrets are scoped to this step
+        # and never written into image layers. If credentials are absent (e.g.
+        # no OIDC access) no secret args are passed and the build degrades to
+        # anonymous read-only cache access.
         env:
           DOCKER_BUILDKIT: 1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           secret_args=()
           if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
             secret_args+=(--secret id=AWS_ACCESS_KEY_ID --secret id=AWS_SECRET_ACCESS_KEY)
+            if [ -n "${AWS_SESSION_TOKEN}" ]; then
+              secret_args+=(--secret id=AWS_SESSION_TOKEN)
+            fi
           fi
           docker build \
             -f ./docker/${{ matrix.os }}-vcpkgDockerfile \

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -154,7 +154,6 @@ jobs:
 
   linux-vcpkg-build-upload:
     if: ${{ inputs.need_linux_vcpkg_rebuild && !inputs.disable_linux_vcpkg }}
-    # OIDC: this job assumes an AWS role to read/write the vcpkg S3 binary cache.
     permissions:
       id-token: write
       contents: read
@@ -187,28 +186,14 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Configure AWS Credentials
-        # OIDC role assumption (same role as the Windows vcpkg cache) issues
-        # temporary credentials into the step environment. They are forwarded
-        # into `docker build` below as BuildKit secrets, because `vcpkg install`
-        # runs inside the build sandbox and does not inherit the runner's AWS env.
         uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::259351611210:role/GitHubMeshLibAwsCredsRole
-          # A cold rebuild compiles every port (~1 h). Extend the session past
-          # the job's 75 min timeout so the credentials don't expire mid-build
-          # and silently skip cache uploads. Requires the role's
-          # MaxSessionDuration to allow >= this value.
           role-duration-seconds: 7200
           retry-max-attempts: 5
 
       - name: Build Linux vcpkg image
-        # The temporary AWS credentials are passed as BuildKit secrets so the
-        # Dockerfile's `vcpkg install` can read/write the shared S3 binary cache
-        # and skip rebuilding unchanged ports. Secrets are scoped to this step
-        # and never written into image layers. If credentials are absent (e.g.
-        # no OIDC access) no secret args are passed and the build degrades to
-        # anonymous read-only cache access.
         env:
           DOCKER_BUILDKIT: 1
         run: |

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -183,7 +183,26 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build Linux vcpkg image
-        run: docker build -f ./docker/${{ matrix.os }}-vcpkgDockerfile -t ${{ env.image }} --build-arg VCPKG_TRIPLET=${{ env.vcpkg_triplet }} . --progress=plain
+        # AWS credentials are passed as BuildKit secrets so the Dockerfile's
+        # `vcpkg install` can read/write the shared S3 binary cache and skip
+        # rebuilding unchanged ports from source. They are scoped to this step
+        # and never written to image layers. When unavailable (e.g. no secret
+        # access) the build falls back to anonymous read-only cache access.
+        env:
+          DOCKER_BUILDKIT: 1
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          secret_args=()
+          if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
+            secret_args+=(--secret id=AWS_ACCESS_KEY_ID --secret id=AWS_SECRET_ACCESS_KEY)
+          fi
+          docker build \
+            -f ./docker/${{ matrix.os }}-vcpkgDockerfile \
+            -t ${{ env.image }} \
+            --build-arg VCPKG_TRIPLET=${{ env.vcpkg_triplet }} \
+            "${secret_args[@]}" \
+            . --progress=plain
 
       - name: Push Linux vcpkg image
         run: docker push ${{ env.image }}

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -197,18 +197,13 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: |
-          secret_args=()
-          if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
-            secret_args+=(--secret id=AWS_ACCESS_KEY_ID --secret id=AWS_SECRET_ACCESS_KEY)
-            if [ -n "${AWS_SESSION_TOKEN}" ]; then
-              secret_args+=(--secret id=AWS_SESSION_TOKEN)
-            fi
-          fi
           docker build \
             -f ./docker/${{ matrix.os }}-vcpkgDockerfile \
             -t ${{ env.image }} \
             --build-arg VCPKG_TRIPLET=${{ env.vcpkg_triplet }} \
-            "${secret_args[@]}" \
+            --secret id=AWS_ACCESS_KEY_ID \
+            --secret id=AWS_SECRET_ACCESS_KEY \
+            --secret id=AWS_SESSION_TOKEN \
             . --progress=plain
 
       - name: Push Linux vcpkg image

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -40,6 +40,7 @@ RUN python3.12 -m venv venv && \
 COPY requirements/vcpkg-linux.txt MeshLib/requirements.txt
 COPY thirdparty/vcpkg/ports MeshLib/ports
 COPY thirdparty/vcpkg/triplets MeshLib/triplets
+COPY thirdparty/vcpkg/configure_s3_cache.sh MeshLib/configure_s3_cache.sh
 COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 ARG VCPKG_VERSION
@@ -57,28 +58,17 @@ RUN sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.o
 # build vcpkg packages
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
-# The shared S3 vcpkg binary cache (same bucket as thirdparty/install.bat:
-# s3://vcpkg-export/<version>/<triplet>/) lets unchanged ports be restored as
-# prebuilt archives instead of rebuilt from source. AWS credentials are optional
-# BuildKit secrets: present -> read-write cache, absent -> anonymous read-only.
+# Configure the shared S3 vcpkg binary cache (see configure_s3_cache.sh) so that
+# unchanged ports are restored as prebuilt archives instead of rebuilt from
+# source. AWS credentials are optional BuildKit secrets: present -> read-write
+# cache, absent -> anonymous read-only.
 RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
     --mount=type=secret,id=AWS_SESSION_TOKEN \
+    source ../MeshLib/configure_s3_cache.sh && \
     source /opt/rh/gcc-toolset-11/enable && \
     source /opt/autoconf27/enable && \
     source /root/venv/bin/activate && \
-    export AWS_DEFAULT_REGION=us-east-1 && \
-    S3_URL="s3://vcpkg-export/${VCPKG_VERSION}/${VCPKG_TRIPLET}/" && \
-    if [ -s /run/secrets/AWS_ACCESS_KEY_ID ] && [ -s /run/secrets/AWS_SECRET_ACCESS_KEY ]; then \
-        export AWS_ACCESS_KEY_ID="$(cat /run/secrets/AWS_ACCESS_KEY_ID)" && \
-        export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/AWS_SECRET_ACCESS_KEY)" && \
-        if [ -s /run/secrets/AWS_SESSION_TOKEN ]; then export AWS_SESSION_TOKEN="$(cat /run/secrets/AWS_SESSION_TOKEN)"; fi && \
-        echo "vcpkg S3 binary cache: read-write (${S3_URL})" && \
-        export VCPKG_BINARY_SOURCES="clear;x-aws,${S3_URL},readwrite" ; \
-    else \
-        echo "vcpkg S3 binary cache: anonymous read-only (${S3_URL})" && \
-        export VCPKG_BINARY_SOURCES="clear;x-aws-config,no-sign-request;x-aws,${S3_URL},read" ; \
-    fi && \
     $(: network may flake ) \
     retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports --debug $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -19,7 +19,7 @@ RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
         && \
     dnf clean all
 
-# install aws cli (used by vcpkg's x-aws S3 binary cache backend below)
+# install aws cli for vcpkg cache
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
@@ -58,10 +58,6 @@ RUN sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.o
 # build vcpkg packages
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
-# Configure the shared S3 vcpkg binary cache (see configure_s3_cache.sh) so that
-# unchanged ports are restored as prebuilt archives instead of rebuilt from
-# source. AWS credentials are optional BuildKit secrets: present -> read-write
-# cache, absent -> anonymous read-only.
 RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
     --mount=type=secret,id=AWS_SESSION_TOKEN \

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 ARG VCPKG_VERSION=2026.05.25
 ARG VCPKG_TRIPLET=x64-linux-meshlib
 

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -63,6 +63,7 @@ ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
 # BuildKit secrets: present -> read-write cache, absent -> anonymous read-only.
 RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
+    --mount=type=secret,id=AWS_SESSION_TOKEN \
     source /opt/rh/gcc-toolset-11/enable && \
     source /opt/autoconf27/enable && \
     source /root/venv/bin/activate && \
@@ -71,6 +72,7 @@ RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
     if [ -s /run/secrets/AWS_ACCESS_KEY_ID ] && [ -s /run/secrets/AWS_SECRET_ACCESS_KEY ]; then \
         export AWS_ACCESS_KEY_ID="$(cat /run/secrets/AWS_ACCESS_KEY_ID)" && \
         export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/AWS_SECRET_ACCESS_KEY)" && \
+        if [ -s /run/secrets/AWS_SESSION_TOKEN ]; then export AWS_SESSION_TOKEN="$(cat /run/secrets/AWS_SESSION_TOKEN)"; fi && \
         echo "vcpkg S3 binary cache: read-write (${S3_URL})" && \
         export VCPKG_BINARY_SOURCES="clear;x-aws,${S3_URL},readwrite" ; \
     else \

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -78,7 +78,7 @@ RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
         export VCPKG_BINARY_SOURCES="clear;x-aws-config,no-sign-request;x-aws,${S3_URL},read" ; \
     fi && \
     $(: network may flake ) \
-    retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
+    retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports --debug $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
 
 

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG VCPKG_VERSION=2026.05.25
 ARG VCPKG_TRIPLET=x64-linux-meshlib
 
@@ -17,6 +18,12 @@ RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
         autoconf2.7x autoconf-archive bison dbus-libs libtool libudev-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXtst-devel mesa-libGL-devel perl-core python3.12-pip \
         && \
     dnf clean all
+
+# install aws cli (used by vcpkg's x-aws S3 binary cache backend below)
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
+    rm -rf awscliv2.zip aws/
 
 # override system autoconf
 RUN mkdir -p /opt/autoconf27/bin/ && \
@@ -50,9 +57,26 @@ RUN sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.o
 # build vcpkg packages
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
-RUN source /opt/rh/gcc-toolset-11/enable && \
+# The shared S3 vcpkg binary cache (same bucket as thirdparty/install.bat:
+# s3://vcpkg-export/<version>/<triplet>/) lets unchanged ports be restored as
+# prebuilt archives instead of rebuilt from source. AWS credentials are optional
+# BuildKit secrets: present -> read-write cache, absent -> anonymous read-only.
+RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
+    source /opt/rh/gcc-toolset-11/enable && \
     source /opt/autoconf27/enable && \
     source /root/venv/bin/activate && \
+    export AWS_DEFAULT_REGION=us-east-1 && \
+    S3_URL="s3://vcpkg-export/${VCPKG_VERSION}/${VCPKG_TRIPLET}/" && \
+    if [ -s /run/secrets/AWS_ACCESS_KEY_ID ] && [ -s /run/secrets/AWS_SECRET_ACCESS_KEY ]; then \
+        export AWS_ACCESS_KEY_ID="$(cat /run/secrets/AWS_ACCESS_KEY_ID)" && \
+        export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/AWS_SECRET_ACCESS_KEY)" && \
+        echo "vcpkg S3 binary cache: read-write (${S3_URL})" && \
+        export VCPKG_BINARY_SOURCES="clear;x-aws,${S3_URL},readwrite" ; \
+    else \
+        echo "vcpkg S3 binary cache: anonymous read-only (${S3_URL})" && \
+        export VCPKG_BINARY_SOURCES="clear;x-aws-config,no-sign-request;x-aws,${S3_URL},read" ; \
+    fi && \
     $(: network may flake ) \
     retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -18,7 +18,7 @@ RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
         && \
     dnf clean all
 
-# install aws cli (used by vcpkg's x-aws S3 binary cache backend below)
+# install aws cli for vcpkg cache
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
@@ -47,10 +47,6 @@ RUN sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.o
 # build vcpkg packages
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
-# Configure the shared S3 vcpkg binary cache (see configure_s3_cache.sh) so that
-# unchanged ports are restored as prebuilt archives instead of rebuilt from
-# source. AWS credentials are optional BuildKit secrets: present -> read-write
-# cache, absent -> anonymous read-only.
 RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
     --mount=type=secret,id=AWS_SESSION_TOKEN \

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -52,12 +52,14 @@ ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
 # BuildKit secrets: present -> read-write cache, absent -> anonymous read-only.
 RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
+    --mount=type=secret,id=AWS_SESSION_TOKEN \
     source /opt/rh/autoconf271/enable && \
     export AWS_DEFAULT_REGION=us-east-1 && \
     S3_URL="s3://vcpkg-export/${VCPKG_VERSION}/${VCPKG_TRIPLET}/" && \
     if [ -s /run/secrets/AWS_ACCESS_KEY_ID ] && [ -s /run/secrets/AWS_SECRET_ACCESS_KEY ]; then \
         export AWS_ACCESS_KEY_ID="$(cat /run/secrets/AWS_ACCESS_KEY_ID)" && \
         export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/AWS_SECRET_ACCESS_KEY)" && \
+        if [ -s /run/secrets/AWS_SESSION_TOKEN ]; then export AWS_SESSION_TOKEN="$(cat /run/secrets/AWS_SESSION_TOKEN)"; fi && \
         echo "vcpkg S3 binary cache: read-write (${S3_URL})" && \
         export VCPKG_BINARY_SOURCES="clear;x-aws,${S3_URL},readwrite" ; \
     else \

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 ARG VCPKG_VERSION=2026.05.25
 ARG VCPKG_TRIPLET=x64-linux-meshlib
 

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -29,6 +29,7 @@ WORKDIR /root
 COPY requirements/vcpkg-linux.txt MeshLib/requirements.txt
 COPY thirdparty/vcpkg/ports MeshLib/ports
 COPY thirdparty/vcpkg/triplets MeshLib/triplets
+COPY thirdparty/vcpkg/configure_s3_cache.sh MeshLib/configure_s3_cache.sh
 COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 ARG VCPKG_VERSION
@@ -46,26 +47,15 @@ RUN sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.o
 # build vcpkg packages
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
-# The shared S3 vcpkg binary cache (same bucket as thirdparty/install.bat:
-# s3://vcpkg-export/<version>/<triplet>/) lets unchanged ports be restored as
-# prebuilt archives instead of rebuilt from source. AWS credentials are optional
-# BuildKit secrets: present -> read-write cache, absent -> anonymous read-only.
+# Configure the shared S3 vcpkg binary cache (see configure_s3_cache.sh) so that
+# unchanged ports are restored as prebuilt archives instead of rebuilt from
+# source. AWS credentials are optional BuildKit secrets: present -> read-write
+# cache, absent -> anonymous read-only.
 RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
     --mount=type=secret,id=AWS_SESSION_TOKEN \
+    source ../MeshLib/configure_s3_cache.sh && \
     source /opt/rh/autoconf271/enable && \
-    export AWS_DEFAULT_REGION=us-east-1 && \
-    S3_URL="s3://vcpkg-export/${VCPKG_VERSION}/${VCPKG_TRIPLET}/" && \
-    if [ -s /run/secrets/AWS_ACCESS_KEY_ID ] && [ -s /run/secrets/AWS_SECRET_ACCESS_KEY ]; then \
-        export AWS_ACCESS_KEY_ID="$(cat /run/secrets/AWS_ACCESS_KEY_ID)" && \
-        export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/AWS_SECRET_ACCESS_KEY)" && \
-        if [ -s /run/secrets/AWS_SESSION_TOKEN ]; then export AWS_SESSION_TOKEN="$(cat /run/secrets/AWS_SESSION_TOKEN)"; fi && \
-        echo "vcpkg S3 binary cache: read-write (${S3_URL})" && \
-        export VCPKG_BINARY_SOURCES="clear;x-aws,${S3_URL},readwrite" ; \
-    else \
-        echo "vcpkg S3 binary cache: anonymous read-only (${S3_URL})" && \
-        export VCPKG_BINARY_SOURCES="clear;x-aws-config,no-sign-request;x-aws,${S3_URL},read" ; \
-    fi && \
     $(: network may flake ) \
     retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports --debug $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -65,7 +65,7 @@ RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
         export VCPKG_BINARY_SOURCES="clear;x-aws-config,no-sign-request;x-aws,${S3_URL},read" ; \
     fi && \
     $(: network may flake ) \
-    retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
+    retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports --debug $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
 
 

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG VCPKG_VERSION=2026.05.25
 ARG VCPKG_TRIPLET=x64-linux-meshlib
 
@@ -16,6 +17,12 @@ RUN echo "install_weak_deps=false" >> /etc/dnf/dnf.conf && \
         autoconf271 autoconf-archive bison dbus-libs libtool libudev-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXtst-devel mesa-libGL-devel perl-core python3-jinja2 \
         && \
     dnf clean all
+
+# install aws cli (used by vcpkg's x-aws S3 binary cache backend below)
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
+    rm -rf awscliv2.zip aws/
 
 WORKDIR /root
 
@@ -39,7 +46,24 @@ RUN sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.o
 # build vcpkg packages
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
-RUN source /opt/rh/autoconf271/enable && \
+# The shared S3 vcpkg binary cache (same bucket as thirdparty/install.bat:
+# s3://vcpkg-export/<version>/<triplet>/) lets unchanged ports be restored as
+# prebuilt archives instead of rebuilt from source. AWS credentials are optional
+# BuildKit secrets: present -> read-write cache, absent -> anonymous read-only.
+RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
+    source /opt/rh/autoconf271/enable && \
+    export AWS_DEFAULT_REGION=us-east-1 && \
+    S3_URL="s3://vcpkg-export/${VCPKG_VERSION}/${VCPKG_TRIPLET}/" && \
+    if [ -s /run/secrets/AWS_ACCESS_KEY_ID ] && [ -s /run/secrets/AWS_SECRET_ACCESS_KEY ]; then \
+        export AWS_ACCESS_KEY_ID="$(cat /run/secrets/AWS_ACCESS_KEY_ID)" && \
+        export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/AWS_SECRET_ACCESS_KEY)" && \
+        echo "vcpkg S3 binary cache: read-write (${S3_URL})" && \
+        export VCPKG_BINARY_SOURCES="clear;x-aws,${S3_URL},readwrite" ; \
+    else \
+        echo "vcpkg S3 binary cache: anonymous read-only (${S3_URL})" && \
+        export VCPKG_BINARY_SOURCES="clear;x-aws-config,no-sign-request;x-aws,${S3_URL},read" ; \
+    fi && \
     $(: network may flake ) \
     retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt

--- a/thirdparty/vcpkg/configure_s3_cache.sh
+++ b/thirdparty/vcpkg/configure_s3_cache.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Configure VCPKG_BINARY_SOURCES to use the shared S3 vcpkg binary cache.
+#
+# Meant to be *sourced* (not executed) from the Linux vcpkg Dockerfiles, so the
+# exported variables reach the subsequent `vcpkg install`. Mirrors the Windows
+# setup in thirdparty/install.bat, using the same bucket and key layout:
+#   s3://vcpkg-export/<vcpkg version>/<triplet>/
+#
+# Requires VCPKG_VERSION and VCPKG_TRIPLET in the environment. AWS credentials
+# are read from optional BuildKit secrets (/run/secrets/AWS_*); when present the
+# cache is read-write, otherwise it falls back to anonymous read-only access.
+
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+
+S3_URL="s3://vcpkg-export/${VCPKG_VERSION}/${VCPKG_TRIPLET}/"
+
+if [ -s /run/secrets/AWS_ACCESS_KEY_ID ] && [ -s /run/secrets/AWS_SECRET_ACCESS_KEY ]; then
+    export AWS_ACCESS_KEY_ID="$(cat /run/secrets/AWS_ACCESS_KEY_ID)"
+    export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/AWS_SECRET_ACCESS_KEY)"
+    # session token is only present for temporary (OIDC) credentials
+    if [ -s /run/secrets/AWS_SESSION_TOKEN ]; then
+        export AWS_SESSION_TOKEN="$(cat /run/secrets/AWS_SESSION_TOKEN)"
+    fi
+    echo "vcpkg S3 binary cache: read-write (${S3_URL})"
+    export VCPKG_BINARY_SOURCES="clear;x-aws,${S3_URL},readwrite"
+else
+    echo "vcpkg S3 binary cache: anonymous read-only (${S3_URL})"
+    export VCPKG_BINARY_SOURCES="clear;x-aws-config,no-sign-request;x-aws,${S3_URL},read"
+fi

--- a/thirdparty/vcpkg/configure_s3_cache.sh
+++ b/thirdparty/vcpkg/configure_s3_cache.sh
@@ -1,26 +1,19 @@
 #!/bin/bash
-# Configure VCPKG_BINARY_SOURCES to use the shared S3 vcpkg binary cache.
-#
-# Meant to be *sourced* (not executed) from the Linux vcpkg Dockerfiles, so the
-# exported variables reach the subsequent `vcpkg install`. Mirrors the Windows
-# setup in thirdparty/install.bat, using the same bucket and key layout:
-#   s3://vcpkg-export/<vcpkg version>/<triplet>/
-#
-# Requires VCPKG_VERSION and VCPKG_TRIPLET in the environment. AWS credentials
-# are read from optional BuildKit secrets (/run/secrets/AWS_*); when present the
-# cache is read-write, otherwise it falls back to anonymous read-only access.
 
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 
 S3_URL="s3://vcpkg-export/${VCPKG_VERSION}/${VCPKG_TRIPLET}/"
 
+# pick up credentials from Docker secrets if available
 if [ -s /run/secrets/AWS_ACCESS_KEY_ID ] && [ -s /run/secrets/AWS_SECRET_ACCESS_KEY ]; then
     export AWS_ACCESS_KEY_ID="$(cat /run/secrets/AWS_ACCESS_KEY_ID)"
     export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/AWS_SECRET_ACCESS_KEY)"
-    # session token is only present for temporary (OIDC) credentials
     if [ -s /run/secrets/AWS_SESSION_TOKEN ]; then
         export AWS_SESSION_TOKEN="$(cat /run/secrets/AWS_SESSION_TOKEN)"
     fi
+fi
+
+if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
     echo "vcpkg S3 binary cache: read-write (${S3_URL})"
     export VCPKG_BINARY_SOURCES="clear;x-aws,${S3_URL},readwrite"
 else


### PR DESCRIPTION
## What

Speed up the Linux vcpkg image build (`linux-vcpkg-build-upload` in `prepare-images`) by reusing the shared S3 vcpkg **binary cache**, so unchanged ports are restored as prebuilt archives instead of recompiled from source.

## Why

The Windows vcpkg build already pushes/pulls a binary cache to/from `s3://vcpkg-export/<version>/<triplet>/` via `thirdparty/install.bat` (the `x-aws` backend). The Linux side builds its third-party libraries inside a Docker image and ships them baked in. Because the job runs `docker system prune --all` before/after the build, no Docker layer cache survives between runs — so every time `need_linux_vcpkg_rebuild` is true, **all** ports are rebuilt from source, even when only one changed.

This reuses the exact same cache mechanism as a build-time accelerator. The image deliverable is unchanged; only how the ports inside it are produced changes.

## How

- **`thirdparty/vcpkg/configure_s3_cache.sh` (new)** — shared helper that sets `VCPKG_BINARY_SOURCES` to the `x-aws` backend. Same bucket/key layout as `install.bat`: `s3://vcpkg-export/${VCPKG_VERSION}/${VCPKG_TRIPLET}/` (dotted version, so the Linux triplets sit alongside the Windows cache under the same `2026.05.25/` prefix; the per-triplet sub-folders never collide). Read-write when AWS credentials are present, anonymous `no-sign-request` read-only otherwise.
- **`docker/rockylinux8-vcpkgDockerfile`, `docker/rockylinux9-vcpkgDockerfile`** — install the AWS CLI in the `build` stage (the `x-aws` backend shells out to it), `COPY` + `source` the shared helper around `vcpkg install`, and pass `--debug` to `vcpkg install` (matching `install.bat`) so per-package S3 restore/upload activity is visible. Credentials arrive as optional BuildKit secrets (`/run/secrets/AWS_*`), so they never land in image layers.
- **`.github/workflows/prepare-images.yml`** — on the Linux vcpkg job: add `permissions: id-token: write`, add a `Configure AWS Credentials` step that assumes `GitHubMeshLibAwsCredsRole` via **OIDC** (the same role/bucket `setup-vcpkg-windows` already uses), enable BuildKit, and forward the temporary credentials (incl. `AWS_SESSION_TOKEN`) into `docker build` as `--secret`. `vcpkg install` runs inside the build sandbox and does not inherit the runner's AWS env, so the credentials must be injected across that boundary; OIDC only changes where they come from. Without credentials the build degrades to anonymous read-only.

## Testing / results

Editing the rockylinux vcpkg Dockerfiles flips `need_linux_vcpkg_rebuild` to true (path filter in `config.yml`), so this job runs on the PR and exercises the change end-to-end for both x64 and arm64.

- **Cold run (seeding):** built all 139 ports from source (~49 min install) and uploaded the cache:

  | Triplet | Objects | Size |
  |---|---|---|
  | `x64-linux-meshlib` | 139 | ~74 MiB |
  | `arm64-linux-meshlib` | 139 | ~72 MiB |

- **Warm run (restore):**
  ```
  Restored 139 package(s) from AWS in 5.8 min.
  Total install time: 1.7 s
  ```
  i.e. the per-port compile step dropped from ~49 min to ~0.

For comparison, the Windows triplets under the same tag total ~2.36 GiB (they cache debug + release variants); the Linux release-only cache is far smaller.

## Notes

- All non-Linux-vcpkg platforms are disabled via `disable-build-*` labels (unaffected). The new file under `thirdparty/vcpkg/` also matches the Windows path filter, but `disable-build-windows` keeps that job skipped.
- `--debug` makes the build log considerably larger — the trade-off for visible per-package cache activity, matching existing Windows behavior.
- OIDC reuses the role/trust already used by `setup-vcpkg-windows` for the same `vcpkg-export` bucket.
