### PR TITLE
Build face connected-components UnionFind in parallel (lock-free)

### DIFF
--- a/source/MRMesh/MRBooleanOperation.cpp
+++ b/source/MRMesh/MRBooleanOperation.cpp
@@ -14,6 +14,7 @@
 #include "MREdgeMetric.h"
 #include "MRRegionBoundary.h"
 #include "MREdgeIterator.h"
+#include "MRUnionFindParallel.h"
 
 namespace MR
 {
@@ -29,7 +30,7 @@ std::optional<FaceBitSet> findMeshPart( const Mesh& origin,
     bool mergeAllNonIntersectingComponents, const BooleanInternalParameters& intParams )
 {
     MR_TIMER;
-    UnionFind<FaceId> unionFind;
+    BaseUnionFind<FaceId> unionFind;
     if ( cutPaths.empty() )
         unionFind = MeshComponents::getUnionFindStructureFaces( origin );
     else
@@ -51,6 +52,8 @@ std::optional<FaceBitSet> findMeshPart( const Mesh& origin,
     AffineXf3f a2b = rigidB2A ? rigidB2A->inverse() : AffineXf3f();
     bool needRightPart = needInsideComps != originIsA;
 
+    updateRootsParallel( unionFind );
+
     FaceId leftRoot;  // root of the components to the left of cutPaths
     FaceId rightRoot; // root of the components to the right of cutPaths
     if ( !cutPaths.empty() )
@@ -60,9 +63,9 @@ std::optional<FaceBitSet> findMeshPart( const Mesh& origin,
             for ( auto e : path )
             {
                 if ( auto l = origin.topology.left( e ) )
-                    leftRoot = leftRoot ? unionFind.unite( leftRoot, l ).first : unionFind.find( l );
+                    leftRoot = leftRoot ? unionFind.uniteUnbalanced( leftRoot, l ).first : unionFind.find( l );
                 if ( auto r = origin.topology.right( e ) )
-                    rightRoot = rightRoot ? unionFind.unite( rightRoot, r ).first : unionFind.find( r );
+                    rightRoot = rightRoot ? unionFind.uniteUnbalanced( rightRoot, r ).first : unionFind.find( r );
             }
 
         // if last unite merged left and right, we need to update roots
@@ -95,12 +98,12 @@ std::optional<FaceBitSet> findMeshPart( const Mesh& origin,
             if ( mergeAllNonIntersectingComponents ||
                 isNonIntersectingInside( origin, f, otherPtr ? *otherPtr : otherMesh, originIsA ? rigidB2A : &a2b ) == needInsideComps )
             {
-                includeRoot = includeRoot ? unionFind.unite( includeRoot, f ).first : unionFind.find( f );
+                includeRoot = includeRoot ? unionFind.uniteUnbalanced( includeRoot, f ).first : unionFind.find( f );
                 res.set( f );
             }
             else
             {
-                excludeRoot = excludeRoot ? unionFind.unite( excludeRoot, f ).first : unionFind.find( f );
+                excludeRoot = excludeRoot ? unionFind.uniteUnbalanced( excludeRoot, f ).first : unionFind.find( f );
             }
         }
     }

--- a/source/MRMesh/MRBooleanOperation.cpp
+++ b/source/MRMesh/MRBooleanOperation.cpp
@@ -52,8 +52,6 @@ std::optional<FaceBitSet> findMeshPart( const Mesh& origin,
     AffineXf3f a2b = rigidB2A ? rigidB2A->inverse() : AffineXf3f();
     bool needRightPart = needInsideComps != originIsA;
 
-    updateRootsParallel( unionFind );
-
     FaceId leftRoot;  // root of the components to the left of cutPaths
     FaceId rightRoot; // root of the components to the right of cutPaths
     if ( !cutPaths.empty() )
@@ -77,6 +75,8 @@ std::optional<FaceBitSet> findMeshPart( const Mesh& origin,
         if ( leftRoot && leftRoot == rightRoot )
             return std::nullopt;
     }
+
+    updateRootsParallel( unionFind );
 
     // find correct part
     auto includeRoot = needRightPart ? rightRoot : leftRoot;

--- a/source/MRMesh/MRMeshComponents.cpp
+++ b/source/MRMesh/MRMeshComponents.cpp
@@ -523,25 +523,15 @@ static void getUnionFindStructureFacesPerEdge( const MeshTopology& topology, con
 
     if ( numThreads > 1 )
     {
-        auto inRange = [&] ( FaceId f, UndirectedEdgeId beg, UndirectedEdgeId end )->bool
-        {
-            for ( auto e : leftRing( topology, f ) )
-                if ( e.undirected() < beg || e.undirected() >= end )
-                    return false;
-            return true;
-        };
-
+        // single lock-free pass over all edges: each edge is united atomically (see UnionFind::uniteAtomic),
+        // so there is no interior/boundary classification and no sequential tail; processing order is irrelevant
         const size_t undirSize = topology.undirectedEdgeSize();
-        UndirectedEdgeBitSet lastPassEdges( undirSize );
-        tbb::parallel_for( tbb::blocked_range( size_t( 0 ), lastPassEdges.num_blocks(), 64 ),
-            [&] ( const tbb::blocked_range<size_t>& blockRange )
+        tbb::parallel_for( tbb::blocked_range<size_t>( size_t( 0 ), undirSize ),
+            [&] ( const tbb::blocked_range<size_t>& range )
         {
-            auto beginBit = UndirectedEdgeId( blockRange.begin() * UndirectedEdgeBitSet::bits_per_block );
-            auto endBit = UndirectedEdgeId( blockRange.end() * UndirectedEdgeBitSet::bits_per_block );
-            for ( UndirectedEdgeId ue = beginBit; ue < endBit; ++ue )
+            for ( size_t i = range.begin(); i < range.end(); ++i )
             {
-                if ( ue >= undirSize )
-                    return;
+                UndirectedEdgeId ue( i );
                 if ( isCompBd && isCompBd->test( ue ) )
                     continue;
                 auto l = topology.left( ue );
@@ -550,25 +540,9 @@ static void getUnionFindStructureFacesPerEdge( const MeshTopology& topology, con
                 auto r = topology.right( ue );
                 if ( !region.test( r ) )
                     continue;
-                if ( inRange( l, beginBit, endBit ) && inRange( r, beginBit, endBit ) )
-                    res.unite( l, r );
-                else
-                    lastPassEdges.set( ue );
+                res.uniteAtomic( l, r );
             }
         } );
-
-        for ( auto ue : lastPassEdges )
-        {
-            if ( isCompBd && isCompBd->test( ue ) )
-                continue;
-            auto l = topology.left( ue );
-            if ( !region.test( l ) )
-                continue;
-            auto r = topology.right( ue );
-            if ( !region.test( r ) )
-                continue;
-            res.unite( l, r );
-        }
     }
     else
     {

--- a/source/MRMesh/MRMeshComponents.cpp
+++ b/source/MRMesh/MRMeshComponents.cpp
@@ -505,42 +505,23 @@ std::vector<MR::FaceBitSet> getAllComponents( const MeshPart& meshPart, FaceInci
     return getAllComponents( meshPart, INT_MAX, incidence, isCompBd ).first;
 }
 
-static void getUnionFindStructureFacesPerEdge( const MeshTopology& topology, const FaceBitSet* region0, const UndirectedEdgeBitSet * isCompBd, ParallelUnionFind<FaceId>& res )
+static void getUnionFindStructureFacesPerEdge( const MeshTopology& topology, const FaceBitSet* region0, const UndirectedEdgeBitSet* isCompBd, ParallelUnionFind<FaceId>& res )
 {
     MR_TIMER;
 
     const FaceBitSet& region = topology.getFaceIds( region0 );
     const auto numFaces = region.find_last() + 1;
     res.reset( numFaces );
-    const auto numThreads = int( tbb::global_control::active_value( tbb::global_control::max_allowed_parallelism ) );
 
-    if ( numThreads > 1 )
+    // single lock-free pass over all edges: each edge is united atomically (see ParallelUnionFind::uniteAtomic),
+    // so there is no interior/boundary classification and no sequential tail; processing order is irrelevant
+    const size_t undirSize = topology.undirectedEdgeSize();
+    tbb::parallel_for( tbb::blocked_range<size_t>( size_t( 0 ), undirSize ),
+        [&] ( const tbb::blocked_range<size_t>& range )
     {
-        // single lock-free pass over all edges: each edge is united atomically (see ParallelUnionFind::uniteAtomic),
-        // so there is no interior/boundary classification and no sequential tail; processing order is irrelevant
-        const size_t undirSize = topology.undirectedEdgeSize();
-        tbb::parallel_for( tbb::blocked_range<size_t>( size_t( 0 ), undirSize ),
-            [&] ( const tbb::blocked_range<size_t>& range )
+        for ( size_t i = range.begin(); i < range.end(); ++i )
         {
-            for ( size_t i = range.begin(); i < range.end(); ++i )
-            {
-                UndirectedEdgeId ue( i );
-                if ( isCompBd && isCompBd->test( ue ) )
-                    continue;
-                auto l = topology.left( ue );
-                if ( !region.test( l ) )
-                    continue;
-                auto r = topology.right( ue );
-                if ( !region.test( r ) )
-                    continue;
-                res.uniteAtomic( l, r );
-            }
-        } );
-    }
-    else
-    {
-        for ( auto ue : undirectedEdges( topology ) )
-        {
+            UndirectedEdgeId ue( i );
             if ( isCompBd && isCompBd->test( ue ) )
                 continue;
             auto l = topology.left( ue );
@@ -551,6 +532,28 @@ static void getUnionFindStructureFacesPerEdge( const MeshTopology& topology, con
                 continue;
             res.uniteAtomic( l, r );
         }
+    } );
+}
+
+static void getUnionFindStructureFacesPerEdge( const MeshTopology& topology, const FaceBitSet* region0, const UndirectedEdgeBitSet* isCompBd, UnionFind<FaceId>& res )
+{
+    MR_TIMER;
+
+    const FaceBitSet& region = topology.getFaceIds( region0 );
+    const auto numFaces = region.find_last() + 1;
+    res.reset( numFaces );
+
+    for ( auto ue : undirectedEdges( topology ) )
+    {
+        if ( isCompBd && isCompBd->test( ue ) )
+            continue;
+        auto l = topology.left( ue );
+        if ( !region.test( l ) )
+            continue;
+        auto r = topology.right( ue );
+        if ( !region.test( r ) )
+            continue;
+        res.unite( l, r );
     }
 }
 
@@ -772,9 +775,19 @@ void excludeFullySelectedComponents( const Mesh& mesh, VertBitSet& selection )
 
 BaseUnionFind<FaceId> getUnionFindStructureFacesPerEdge( const MeshTopology& topology, const FaceBitSet* region, const UndirectedEdgeBitSet * isCompBd )
 {
-    ParallelUnionFind<FaceId> res;
-    getUnionFindStructureFacesPerEdge( topology, region, isCompBd, res );
-    return res;
+    const auto numThreads = int( tbb::global_control::active_value( tbb::global_control::max_allowed_parallelism ) );
+    if ( numThreads > 1 )
+    {
+        ParallelUnionFind<FaceId> res;
+        getUnionFindStructureFacesPerEdge( topology, region, isCompBd, res );
+        return res;
+    }
+    else
+    {
+        UnionFind<FaceId> res;
+        getUnionFindStructureFacesPerEdge( topology, region, isCompBd, res );
+        return res;
+    }
 }
 
 BaseUnionFind<FaceId> getUnionFindStructureFacesPerEdge( const MeshPart& meshPart, const UndirectedEdgeBitSet * isCompBd )

--- a/source/MRMesh/MRMeshComponents.cpp
+++ b/source/MRMesh/MRMeshComponents.cpp
@@ -179,25 +179,18 @@ FaceBitSet getComponents( const MeshTopology& topology, const FaceBitSet & seeds
     auto unionFindStruct = getUnionFindStructureFaces( topology, region0, incidence, isCompBd );
     const FaceBitSet& region = topology.getFaceIds( region0 );
 
-    FaceId faceRoot;
+    const auto& allRoots = unionFindStruct.roots();
+    // collect the roots of all components that contain a seed
+    FaceBitSet seedRoots( allRoots.size() );
     for ( auto s : seeds )
-    {
-        if ( faceRoot < 0 )
-            faceRoot = unionFindStruct.find( s );
-        else
-            faceRoot = unionFindStruct.unite( faceRoot, s ).first;
-    }
+        seedRoots.set( allRoots[s] );
 
-    if ( faceRoot )
+    res.resize( allRoots.size() );
+    BitSetParallelFor( region, [&]( FaceId f )
     {
-        const auto& allRoots = unionFindStruct.roots();
-        res.resize( allRoots.size() );
-        BitSetParallelFor( region, [&]( FaceId f )
-        {
-            if ( allRoots[f] == faceRoot )
-                res.set( f );
-        } );
-    }
+        if ( seedRoots.test( allRoots[f] ) )
+            res.set( f );
+    } );
     return res;
 }
 
@@ -292,7 +285,7 @@ FaceBitSet getLargeByAreaSmoothComponents( const MeshPart& mp, float minArea, fl
     return MeshComponents::getLargeByAreaComponents( mp, unionFind, minArea, outBdEdgesBetweenLargeComps );
 }
 
-FaceBitSet getLargeByAreaComponents( const MeshPart& mp, UnionFind<FaceId> & unionFind, float minArea,
+FaceBitSet getLargeByAreaComponents( const MeshPart& mp, BaseUnionFind<FaceId> & unionFind, float minArea,
     UndirectedEdgeBitSet * outBdEdgesBetweenLargeComps )
 {
     MR_TIMER;
@@ -512,7 +505,7 @@ std::vector<MR::FaceBitSet> getAllComponents( const MeshPart& meshPart, FaceInci
     return getAllComponents( meshPart, INT_MAX, incidence, isCompBd ).first;
 }
 
-static void getUnionFindStructureFacesPerEdge( const MeshTopology& topology, const FaceBitSet* region0, const UndirectedEdgeBitSet * isCompBd, UnionFind<FaceId>& res )
+static void getUnionFindStructureFacesPerEdge( const MeshTopology& topology, const FaceBitSet* region0, const UndirectedEdgeBitSet * isCompBd, ParallelUnionFind<FaceId>& res )
 {
     MR_TIMER;
 
@@ -523,7 +516,7 @@ static void getUnionFindStructureFacesPerEdge( const MeshTopology& topology, con
 
     if ( numThreads > 1 )
     {
-        // single lock-free pass over all edges: each edge is united atomically (see UnionFind::uniteAtomic),
+        // single lock-free pass over all edges: each edge is united atomically (see ParallelUnionFind::uniteAtomic),
         // so there is no interior/boundary classification and no sequential tail; processing order is irrelevant
         const size_t undirSize = topology.undirectedEdgeSize();
         tbb::parallel_for( tbb::blocked_range<size_t>( size_t( 0 ), undirSize ),
@@ -556,7 +549,7 @@ static void getUnionFindStructureFacesPerEdge( const MeshTopology& topology, con
             auto r = topology.right( ue );
             if ( !region.test( r ) )
                 continue;
-            res.unite( l, r );
+            res.uniteAtomic( l, r );
         }
     }
 }
@@ -584,7 +577,7 @@ std::pair<Face2RegionMap, int> getFacePairRegionMap( const Mesh& mesh, const std
         fs.set( f.bFace );
     }
 
-    auto unionFindStruct = getUnionFindStructureFaces( { mesh, &fs }, incidence, isCompBd );
+    UnionFind<FaceId> unionFindStruct( getUnionFindStructureFaces( { mesh, &fs }, incidence, isCompBd ) );
 
     for ( const auto & f : facePairs )
         unionFindStruct.unite( f.aFace, f.bFace );
@@ -777,29 +770,28 @@ void excludeFullySelectedComponents( const Mesh& mesh, VertBitSet& selection )
     }
 }
 
-UnionFind<FaceId> getUnionFindStructureFacesPerEdge( const MeshTopology& topology, const FaceBitSet* region, const UndirectedEdgeBitSet * isCompBd )
+BaseUnionFind<FaceId> getUnionFindStructureFacesPerEdge( const MeshTopology& topology, const FaceBitSet* region, const UndirectedEdgeBitSet * isCompBd )
 {
-    UnionFind<FaceId> res;
+    ParallelUnionFind<FaceId> res;
     getUnionFindStructureFacesPerEdge( topology, region, isCompBd, res );
     return res;
 }
 
-UnionFind<FaceId> getUnionFindStructureFacesPerEdge( const MeshPart& meshPart, const UndirectedEdgeBitSet * isCompBd )
+BaseUnionFind<FaceId> getUnionFindStructureFacesPerEdge( const MeshPart& meshPart, const UndirectedEdgeBitSet * isCompBd )
 {
     return getUnionFindStructureFacesPerEdge( meshPart.mesh.topology, meshPart.region, isCompBd );
 }
 
-UnionFind<FaceId> getUnionFindStructureFaces( const MeshTopology& topology, const FaceBitSet* region0, FaceIncidence incidence, const UndirectedEdgeBitSet * isCompBd )
+BaseUnionFind<FaceId> getUnionFindStructureFaces( const MeshTopology& topology, const FaceBitSet* region0, FaceIncidence incidence, const UndirectedEdgeBitSet * isCompBd )
 {
-    UnionFind<FaceId> res;
     if ( incidence == FaceIncidence::PerEdge )
         return getUnionFindStructureFacesPerEdge( topology, region0, isCompBd );
 
     MR_TIMER;
     assert( !isCompBd );
-    const FaceBitSet& region = topology.getFaceIds( region0 );
-    res.reset( region.find_last() + 1 );
     assert ( incidence == FaceIncidence::PerVertex );
+    const FaceBitSet& region = topology.getFaceIds( region0 );
+    UnionFind<FaceId> res( region.find_last() + 1 );
     VertBitSet store;
     for ( auto v : getIncidentVerts( topology, region0, store ) )
     {
@@ -820,7 +812,7 @@ UnionFind<FaceId> getUnionFindStructureFaces( const MeshTopology& topology, cons
     return res;
 }
 
-UnionFind<FaceId> getUnionFindStructureFaces( const MeshPart& meshPart, FaceIncidence incidence, const UndirectedEdgeBitSet * isCompBd )
+BaseUnionFind<FaceId> getUnionFindStructureFaces( const MeshPart& meshPart, FaceIncidence incidence, const UndirectedEdgeBitSet * isCompBd )
 {
     return getUnionFindStructureFaces( meshPart.mesh.topology, meshPart.region, incidence, isCompBd );
 }
@@ -1002,14 +994,7 @@ UnionFind<UndirectedEdgeId> getUnionFindStructureUndirectedEdges( const Mesh& me
     }
 
     if ( allPointToRoots )
-    {
-        tbb::parallel_for( tbb::blocked_range( 0_ue, UndirectedEdgeId( res.size() ) ),
-            [&] ( const tbb::blocked_range<UndirectedEdgeId>& range )
-        {
-            for ( UndirectedEdgeId ue = range.begin(); ue < range.end(); ++ue )
-                res.findUpdateRange( ue, range.begin(), range.end() );
-        } );
-    }
+        updateRootsParallel( res );
 
     return res;
 }

--- a/source/MRMesh/MRMeshComponents.h
+++ b/source/MRMesh/MRMeshComponents.h
@@ -52,7 +52,7 @@ enum FaceIncidence
 [[nodiscard]] MRMESH_API FaceBitSet getLargeByAreaComponents( const MeshPart& meshPart, float minArea, const UndirectedEdgeBitSet * isCompBd );
 
 /// given prepared union-find structure returns the union of connected components, each having at least given area
-[[nodiscard]] MRMESH_API FaceBitSet getLargeByAreaComponents( const MeshPart& meshPart, UnionFind<FaceId> & unionFind, float minArea,
+[[nodiscard]] MRMESH_API FaceBitSet getLargeByAreaComponents( const MeshPart& meshPart, BaseUnionFind<FaceId> & unionFind, float minArea,
     UndirectedEdgeBitSet * outBdEdgesBetweenLargeComps = nullptr );
 
 struct ExpandToComponentsParams
@@ -171,13 +171,13 @@ struct LargeByAreaComponentsSettings
 MRMESH_API void excludeFullySelectedComponents( const Mesh& mesh, VertBitSet& selection );
 
 /// gets union-find structure for faces with different options of face-connectivity
-[[nodiscard]] MRMESH_API UnionFind<FaceId> getUnionFindStructureFaces( const MeshPart& meshPart, FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {} );
-[[nodiscard]] MRMESH_API UnionFind<FaceId> getUnionFindStructureFaces( const MeshTopology& topology, const FaceBitSet* region = nullptr, FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {} );
+[[nodiscard]] MRMESH_API BaseUnionFind<FaceId> getUnionFindStructureFaces( const MeshPart& meshPart, FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {} );
+[[nodiscard]] MRMESH_API BaseUnionFind<FaceId> getUnionFindStructureFaces( const MeshTopology& topology, const FaceBitSet* region = nullptr, FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {} );
 
 /// gets union-find structure for faces with connectivity by shared edge, and optional edge predicate whether to skip uniting components over it
 /// it is guaranteed that isCompBd is invoked in a thread-safe manner (that left and right face are always processed by one thread)
-[[nodiscard]] MRMESH_API UnionFind<FaceId> getUnionFindStructureFacesPerEdge( const MeshPart& meshPart, const UndirectedEdgeBitSet * isCompBd = {} );
-[[nodiscard]] MRMESH_API UnionFind<FaceId> getUnionFindStructureFacesPerEdge( const MeshTopology& topology, const FaceBitSet* region = nullptr, const UndirectedEdgeBitSet * isCompBd = {} );
+[[nodiscard]] MRMESH_API BaseUnionFind<FaceId> getUnionFindStructureFacesPerEdge( const MeshPart& meshPart, const UndirectedEdgeBitSet * isCompBd = {} );
+[[nodiscard]] MRMESH_API BaseUnionFind<FaceId> getUnionFindStructureFacesPerEdge( const MeshTopology& topology, const FaceBitSet* region = nullptr, const UndirectedEdgeBitSet * isCompBd = {} );
 
 /// gets union-find structure for vertices
 [[nodiscard]] MRMESH_API UnionFind<VertId> getUnionFindStructureVerts( const Mesh& mesh, const VertBitSet* region = nullptr );

--- a/source/MRMesh/MRUnionFind.h
+++ b/source/MRMesh/MRUnionFind.h
@@ -8,25 +8,24 @@
 namespace MR
 {
 
-/** 
- * \brief Union-find data structure for representing disjoin sets of elements with few very quick operations:
- * 1) union of two sets in one,
- * 2) checking whether two elements pertain to the same set,
- * 3) finding representative element (root) of each set by any set's element
+/**
+ * \brief base of union-find data structures: stores only the parent forest and the operations
+ * that depend on it alone, so it is shared by the sequential UnionFind and the ParallelUnionFind
  * \tparam I is the identifier of a set's element, e.g. FaceId
  * \ingroup BasicGroup
  */
 template <typename I>
-class UnionFind
+class BaseUnionFind
 {
 public:
     /// the type that can hold the number of elements of the maximal set (e.g. int for FaceId and size_t for VoxelId)
     using SizeType = typename I::ValueType;
 
-    UnionFind() = default;
-
-    /// creates union-find with given number of elements, each element is the only one in its disjoint set
-    explicit UnionFind( size_t size ) { reset( size ); }
+    BaseUnionFind() = default;
+    BaseUnionFind( const BaseUnionFind & ) = default;
+    BaseUnionFind( BaseUnionFind && ) noexcept = default;
+    BaseUnionFind & operator =( const BaseUnionFind & ) = default;
+    BaseUnionFind & operator =( BaseUnionFind && ) noexcept = default;
 
     /// returns the number of elements in union-find
     auto size() const { return parents_.size(); }
@@ -39,60 +38,26 @@ public:
         parents_.reserve( size );
         for ( I i{ size_t( 0 ) }; i < size; ++i )
             parents_.push_back( i );
-        sizes_.clear();
-        sizes_.resize( size, 1 );
     }
 
-    /// unite two elements,
-    /// \return first: new common root, second: true = union was done, false = first and second were already united
-    std::pair<I,bool> unite( I first, I second )
+    /// unites the two sets containing given elements WITHOUT balancing by set size (BaseUnionFind keeps no sizes):
+    /// it simply attaches one set's root under the other's, so chained calls can build taller trees.
+    /// Prefer UnionFind::unite, which selects the new root by set size, when many unions follow one another.
+    /// \return first: new common root, second: true if the union was done (false if already in one set)
+    std::pair<I, bool> uniteUnbalanced( I first, I second )
     {
         auto firstRoot = updateRoot_( first );
         auto secondRoot = updateRoot_( second );
         if ( firstRoot == secondRoot )
             return { firstRoot, false };
-        /// select root by size for best performance
-        if ( sizes_[firstRoot] < sizes_[secondRoot] )
-        {
-            parents_[firstRoot] = secondRoot;
-            sizes_[secondRoot] += sizes_[firstRoot];
-            return { secondRoot, true };
-        }
-        else
-        {
-            parents_[secondRoot] = firstRoot;
-            sizes_[firstRoot] += sizes_[secondRoot];
-            return { firstRoot, true };
-        }
-    }
-
-    /// thread-safe version of unite() for parallel construction of the structure:
-    /// links by element id (the smaller id becomes the common root) using lock-free path halving;
-    /// unlike unite() it does NOT maintain component sizes, so sizeOfComp() is invalid after any uniteAtomic() call
-    void uniteAtomic( I first, I second )
-    {
-        for ( ;; )
-        {
-            first = findAtomic_( first );
-            second = findAtomic_( second );
-            if ( first == second )
-                return; // already in the same set
-            // attach the larger id under the smaller, so the root of a set is always its minimal id
-            if ( first < second )
-                std::swap( first, second );
-            // the exchange succeeds only while first is still a root
-            if ( casAtomic_<std::memory_order_acq_rel>( parents_[first], first, second ) )
-                return;
-            // first is no longer a root (another thread linked it first): retry
-        }
+        parents_[firstRoot] = secondRoot;
+        return { secondRoot, true };
     }
 
     /// returns true if given two elements are from one set
     bool united( I first, I second )
     {
-        auto firstRoot = updateRoot_( first );
-        auto secondRoot = updateRoot_( second );
-        return firstRoot == secondRoot;
+        return updateRoot_( first ) == updateRoot_( second );
     }
 
     /// returns true if given element is the root of some set
@@ -121,10 +86,7 @@ public:
     /// gets the parents of all elements as is
     const Vector<I, I> & parents() const { return parents_; }
 
-    /// returns the number of elements in the set containing given element
-    SizeType sizeOfComp( I a ) { return sizes_[ find( a ) ]; }
-
-private:
+protected:
     /// finds the root of the set containing given element without optimizing data structure updates
     I findRootNoUpdate_( I a ) const
     {
@@ -133,58 +95,12 @@ private:
         return r;
     }
 
-    // Lock-free primitives on one parent slot, used by uniteAtomic()/findAtomic_().
-    // std::atomic_ref is used where the standard library provides it (MSVC, libstdc++, recent libc++);
-    // otherwise we fall back to compiler atomic builtins (e.g. Apple clang, whose libc++ lacks atomic_ref).
-    static I loadAtomic_( I& slot )
-    {
-#ifdef __cpp_lib_atomic_ref
-        return I( std::atomic_ref<typename I::ValueType>( slot.get() ).load( std::memory_order_relaxed ) );
-#else
-        return I( __atomic_load_n( &slot.get(), __ATOMIC_RELAXED ) );
-#endif
-    }
-
-    // single attempt slot: expected -> desired with the given success ordering; returns true on success.
-    // Used both for the union link (acq_rel) and for best-effort path halving (relaxed); a lost halving
-    // race is harmless, so the same primitive serves both with the ordering chosen per call site.
-    template <std::memory_order Success>
-    static bool casAtomic_( I& slot, I expected, I desired )
-    {
-        using T = typename I::ValueType;
-        T exp = expected.get();
-#ifdef __cpp_lib_atomic_ref
-        return std::atomic_ref<T>( slot.get() ).compare_exchange_strong( exp, desired.get(), Success, std::memory_order_relaxed );
-#else
-        constexpr int success = Success == std::memory_order_relaxed ? __ATOMIC_RELAXED : __ATOMIC_ACQ_REL;
-        return __atomic_compare_exchange_n( &slot.get(), &exp, desired.get(), false, success, __ATOMIC_RELAXED );
-#endif
-    }
-
-    /// lock-free find of the set's root with best-effort path halving;
-    /// safe to call concurrently with uniteAtomic() running on the same structure
-    I findAtomic_( I a )
-    {
-        for ( ;; )
-        {
-            I p = loadAtomic_( parents_[a] );
-            if ( p == a )
-                return a; // a is a root
-            I gp = loadAtomic_( parents_[p] );
-            if ( p == gp )
-                return p; // p is a root
-            // point a to its grandparent (best-effort: a lost race just means another thread already shortened the path)
-            casAtomic_<std::memory_order_relaxed>( parents_[a], p, gp );
-            a = gp;
-        }
-    }
-
     /// sets new root \param r for the element \param a and all its ancestors, returns new root \param r
     I updateRoot_( I a, const I r )
     {
         // update parents
-        while ( a != r ) 
-        { 
+        while ( a != r )
+        {
             I b = r;
             std::swap( parents_[a], b );
             a = b;
@@ -201,7 +117,7 @@ private:
         assert( begin < end );
         // update parents
         while ( a != r )
-        { 
+        {
             if ( a >= begin && a < end )
             {
                 I b = r;
@@ -216,9 +132,168 @@ private:
 
     /// parent element of each element
     Vector<I, I> parents_;
+};
 
+/**
+ * \brief Union-find data structure for representing disjoint sets of elements with few very quick operations:
+ * 1) union of two sets in one,
+ * 2) checking whether two elements pertain to the same set,
+ * 3) finding representative element (root) of each set by any set's element.
+ * Sequential implementation that selects the root of a united pair by set size for best performance.
+ * \tparam I is the identifier of a set's element, e.g. FaceId
+ * \ingroup BasicGroup
+ */
+template <typename I>
+class UnionFind : public BaseUnionFind<I>
+{
+public:
+    /// the type that can hold the number of elements of the maximal set (e.g. int for FaceId and size_t for VoxelId)
+    using SizeType = typename I::ValueType;
+
+    UnionFind() = default;
+
+    /// creates union-find with given number of elements, each element is the only one in its disjoint set
+    explicit UnionFind( size_t size ) { reset( size ); }
+
+    /// adopts the parent forest of a base/parallel union-find and (re)computes set sizes,
+    /// so the result supports the full sequential interface (e.g. unite, sizeOfComp)
+    explicit UnionFind( BaseUnionFind<I> && base ) : BaseUnionFind<I>( std::move( base ) )
+    {
+        sizes_.resize( this->parents_.size(), SizeType( 0 ) );
+        for ( I i{ size_t( 0 ) }; i < this->parents_.size(); ++i )
+            ++sizes_[ this->findRootNoUpdate_( i ) ];
+    }
+
+    /// resets union-find to represent given number of elements, each element is the only one in its disjoint set
+    void reset( size_t size )
+    {
+        BaseUnionFind<I>::reset( size );
+        sizes_.clear();
+        sizes_.resize( size, 1 );
+    }
+
+    /// unite two elements,
+    /// \return first: new common root, second: true = union was done, false = first and second were already united
+    std::pair<I,bool> unite( I first, I second )
+    {
+        auto firstRoot = this->updateRoot_( first );
+        auto secondRoot = this->updateRoot_( second );
+        if ( firstRoot == secondRoot )
+            return { firstRoot, false };
+        /// select root by size for best performance
+        if ( sizes_[firstRoot] < sizes_[secondRoot] )
+        {
+            this->parents_[firstRoot] = secondRoot;
+            sizes_[secondRoot] += sizes_[firstRoot];
+            return { secondRoot, true };
+        }
+        else
+        {
+            this->parents_[secondRoot] = firstRoot;
+            sizes_[firstRoot] += sizes_[secondRoot];
+            return { firstRoot, true };
+        }
+    }
+
+    /// returns the number of elements in the set containing given element
+    SizeType sizeOfComp( I a ) { return sizes_[ this->find( a ) ]; }
+
+private:
     /// size of each set, contain valid values only for sets' roots
     Vector<SizeType, I> sizes_;
+};
+
+/**
+ * \brief Union-find that supports lock-free concurrent construction via uniteAtomic().
+ * It links by element id (the smaller id becomes the set root), which keeps the forest acyclic without
+ * locks; consequently it does not maintain set sizes (use BaseUnionFind::roots() to read the result).
+ * \tparam I is the identifier of a set's element, e.g. FaceId
+ * \ingroup BasicGroup
+ */
+template <typename I>
+class ParallelUnionFind : public BaseUnionFind<I>
+{
+public:
+    ParallelUnionFind() = default;
+
+    /// creates union-find with given number of elements, each element is the only one in its disjoint set
+    explicit ParallelUnionFind( size_t size ) { this->reset( size ); }
+
+    /// thread-safe unite for parallel construction: links by element id (the smaller id becomes the common root)
+    /// using lock-free path halving; may be called concurrently for any pair of elements
+    void uniteAtomic( I first, I second )
+    {
+        for ( ;; )
+        {
+            first = findAtomic_( first );
+            second = findAtomic_( second );
+            if ( first == second )
+                return; // already in the same set
+            // attach the larger id under the smaller, so the root of a set is always its minimal id
+            if ( first < second )
+                std::swap( first, second );
+            // the exchange succeeds only while first is still a root
+            if ( casStrong_( this->parents_[first], first, second ) )
+                return;
+            // first is no longer a root (another thread linked it first): retry
+        }
+    }
+
+private:
+    // Lock-free primitives on one parent slot. std::atomic_ref is used where the standard library provides it
+    // (MSVC, libstdc++, recent libc++); otherwise we fall back to compiler atomic builtins (e.g. Apple clang,
+    // whose libc++ lacks atomic_ref).
+
+    /// relaxed atomic load of a parent slot
+    static I loadAtomic_( I& slot )
+    {
+#ifdef __cpp_lib_atomic_ref
+        return I( std::atomic_ref<typename I::ValueType>( slot.get() ).load( std::memory_order_relaxed ) );
+#else
+        return I( __atomic_load_n( &slot.get(), __ATOMIC_RELAXED ) );
+#endif
+    }
+
+    /// best-effort path-halving swap (slot: expected -> desired); weak and relaxed, a lost race is harmless
+    static void casWeak_( I& slot, I expected, I desired )
+    {
+        using T = typename I::ValueType;
+        T exp = expected.get();
+#ifdef __cpp_lib_atomic_ref
+        std::atomic_ref<T>( slot.get() ).compare_exchange_weak( exp, desired.get(), std::memory_order_relaxed );
+#else
+        __atomic_compare_exchange_n( &slot.get(), &exp, desired.get(), true, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+#endif
+    }
+
+    /// linking swap (slot: expected -> desired) once; returns true on success, acquire-release on success
+    static bool casStrong_( I& slot, I expected, I desired )
+    {
+        using T = typename I::ValueType;
+        T exp = expected.get();
+#ifdef __cpp_lib_atomic_ref
+        return std::atomic_ref<T>( slot.get() ).compare_exchange_strong( exp, desired.get(), std::memory_order_acq_rel, std::memory_order_relaxed );
+#else
+        return __atomic_compare_exchange_n( &slot.get(), &exp, desired.get(), false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED );
+#endif
+    }
+
+    /// lock-free find of the set's root with best-effort path halving
+    I findAtomic_( I a )
+    {
+        for ( ;; )
+        {
+            I p = loadAtomic_( this->parents_[a] );
+            if ( p == a )
+                return a; // a is a root
+            I gp = loadAtomic_( this->parents_[p] );
+            if ( p == gp )
+                return p; // p is a root
+            // point a to its grandparent (best-effort: a lost race just means another thread already shortened the path)
+            casWeak_( this->parents_[a], p, gp );
+            a = gp;
+        }
+    }
 };
 
 } //namespace MR

--- a/source/MRMesh/MRUnionFind.h
+++ b/source/MRMesh/MRUnionFind.h
@@ -2,6 +2,7 @@
 
 #include "MRVector.h"
 #include "MRTimer.h"
+#include <atomic>
 #include <utility>
 
 namespace MR
@@ -65,6 +66,29 @@ public:
         }
     }
 
+    /// thread-safe version of unite() for parallel construction of the structure:
+    /// links by element id (the smaller id becomes the common root) using lock-free path halving;
+    /// unlike unite() it does NOT maintain component sizes, so sizeOfComp() is invalid after any uniteAtomic() call
+    void uniteAtomic( I first, I second )
+    {
+        for ( ;; )
+        {
+            first = findAtomic_( first );
+            second = findAtomic_( second );
+            if ( first == second )
+                return; // already in the same set
+            // attach the larger id under the smaller, so the root of a set is always its minimal id
+            if ( first < second )
+                std::swap( first, second );
+            std::atomic_ref<I> parentOfFirst( parents_[first] );
+            I expected = first; // the exchange succeeds only while first is still a root
+            if ( parentOfFirst.compare_exchange_strong( expected, second,
+                    std::memory_order_acq_rel, std::memory_order_relaxed ) )
+                return;
+            // first is no longer a root (another thread linked it first): retry
+        }
+    }
+
     /// returns true if given two elements are from one set
     bool united( I first, I second )
     {
@@ -109,6 +133,25 @@ private:
         I r = parents_[a];
         for ( I e = a; e != r; r = parents_[e = r] ) {}
         return r;
+    }
+
+    /// lock-free find of the set's root with best-effort path halving;
+    /// safe to call concurrently with uniteAtomic() running on the same structure
+    I findAtomic_( I a )
+    {
+        for ( ;; )
+        {
+            std::atomic_ref<I> parentOfA( parents_[a] );
+            I p = parentOfA.load( std::memory_order_relaxed );
+            if ( p == a )
+                return a; // a is a root
+            I gp = std::atomic_ref<I>( parents_[p] ).load( std::memory_order_relaxed );
+            if ( p == gp )
+                return p; // p is a root
+            // make a point to its grandparent; a failed exchange only means another thread already shortened the path
+            parentOfA.compare_exchange_weak( p, gp, std::memory_order_relaxed );
+            a = gp;
+        }
     }
 
     /// sets new root \param r for the element \param a and all its ancestors, returns new root \param r

--- a/source/MRMesh/MRUnionFind.h
+++ b/source/MRMesh/MRUnionFind.h
@@ -80,10 +80,8 @@ public:
             // attach the larger id under the smaller, so the root of a set is always its minimal id
             if ( first < second )
                 std::swap( first, second );
-            std::atomic_ref<I> parentOfFirst( parents_[first] );
-            I expected = first; // the exchange succeeds only while first is still a root
-            if ( parentOfFirst.compare_exchange_strong( expected, second,
-                    std::memory_order_acq_rel, std::memory_order_relaxed ) )
+            // the exchange succeeds only while first is still a root
+            if ( casAtomic_( parents_[first], first, second ) )
                 return;
             // first is no longer a root (another thread linked it first): retry
         }
@@ -135,21 +133,57 @@ private:
         return r;
     }
 
+    // Lock-free primitives on one parent slot, used by uniteAtomic()/findAtomic_().
+    // std::atomic_ref is used where the standard library provides it (MSVC, libstdc++, recent libc++);
+    // otherwise we fall back to compiler atomic builtins (e.g. Apple clang, whose libc++ lacks atomic_ref).
+    static I loadAtomic_( I& slot )
+    {
+        using T = typename I::ValueType;
+#ifdef __cpp_lib_atomic_ref
+        return I( std::atomic_ref<T>( slot.get() ).load( std::memory_order_relaxed ) );
+#else
+        return I( __atomic_load_n( &slot.get(), __ATOMIC_RELAXED ) );
+#endif
+    }
+
+    // best-effort single attempt slot: expected -> desired (path halving; a failed swap is harmless)
+    static void halveAtomic_( I& slot, I expected, I desired )
+    {
+        using T = typename I::ValueType;
+        T exp = expected.get();
+#ifdef __cpp_lib_atomic_ref
+        std::atomic_ref<T>( slot.get() ).compare_exchange_weak( exp, desired.get(), std::memory_order_relaxed );
+#else
+        __atomic_compare_exchange_n( &slot.get(), &exp, desired.get(), true, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+#endif
+    }
+
+    // attempts slot: expected -> desired once, returns true on success (acquire-release on success)
+    static bool casAtomic_( I& slot, I expected, I desired )
+    {
+        using T = typename I::ValueType;
+        T exp = expected.get();
+#ifdef __cpp_lib_atomic_ref
+        return std::atomic_ref<T>( slot.get() ).compare_exchange_strong( exp, desired.get(), std::memory_order_acq_rel, std::memory_order_relaxed );
+#else
+        return __atomic_compare_exchange_n( &slot.get(), &exp, desired.get(), false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED );
+#endif
+    }
+
     /// lock-free find of the set's root with best-effort path halving;
     /// safe to call concurrently with uniteAtomic() running on the same structure
     I findAtomic_( I a )
     {
         for ( ;; )
         {
-            std::atomic_ref<I> parentOfA( parents_[a] );
-            I p = parentOfA.load( std::memory_order_relaxed );
+            I p = loadAtomic_( parents_[a] );
             if ( p == a )
                 return a; // a is a root
-            I gp = std::atomic_ref<I>( parents_[p] ).load( std::memory_order_relaxed );
+            I gp = loadAtomic_( parents_[p] );
             if ( p == gp )
                 return p; // p is a root
-            // make a point to its grandparent; a failed exchange only means another thread already shortened the path
-            parentOfA.compare_exchange_weak( p, gp, std::memory_order_relaxed );
+            // make a point to its grandparent; a failed swap only means another thread already shortened the path
+            halveAtomic_( parents_[a], p, gp );
             a = gp;
         }
     }

--- a/source/MRMesh/MRUnionFind.h
+++ b/source/MRMesh/MRUnionFind.h
@@ -81,7 +81,7 @@ public:
             if ( first < second )
                 std::swap( first, second );
             // the exchange succeeds only while first is still a root
-            if ( casAtomic_( parents_[first], first, second ) )
+            if ( casAtomic_<std::memory_order_acq_rel>( parents_[first], first, second ) )
                 return;
             // first is no longer a root (another thread linked it first): retry
         }
@@ -145,27 +145,19 @@ private:
 #endif
     }
 
-    // best-effort single attempt slot: expected -> desired (path halving; a failed swap is harmless)
-    static void halveAtomic_( I& slot, I expected, I desired )
-    {
-        using T = typename I::ValueType;
-        T exp = expected.get();
-#ifdef __cpp_lib_atomic_ref
-        std::atomic_ref<T>( slot.get() ).compare_exchange_weak( exp, desired.get(), std::memory_order_relaxed );
-#else
-        __atomic_compare_exchange_n( &slot.get(), &exp, desired.get(), true, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-#endif
-    }
-
-    // attempts slot: expected -> desired once, returns true on success (acquire-release on success)
+    // single attempt slot: expected -> desired with the given success ordering; returns true on success.
+    // Used both for the union link (acq_rel) and for best-effort path halving (relaxed); a lost halving
+    // race is harmless, so the same primitive serves both with the ordering chosen per call site.
+    template <std::memory_order Success>
     static bool casAtomic_( I& slot, I expected, I desired )
     {
         using T = typename I::ValueType;
         T exp = expected.get();
 #ifdef __cpp_lib_atomic_ref
-        return std::atomic_ref<T>( slot.get() ).compare_exchange_strong( exp, desired.get(), std::memory_order_acq_rel, std::memory_order_relaxed );
+        return std::atomic_ref<T>( slot.get() ).compare_exchange_strong( exp, desired.get(), Success, std::memory_order_relaxed );
 #else
-        return __atomic_compare_exchange_n( &slot.get(), &exp, desired.get(), false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED );
+        constexpr int success = Success == std::memory_order_relaxed ? __ATOMIC_RELAXED : __ATOMIC_ACQ_REL;
+        return __atomic_compare_exchange_n( &slot.get(), &exp, desired.get(), false, success, __ATOMIC_RELAXED );
 #endif
     }
 
@@ -181,8 +173,8 @@ private:
             I gp = loadAtomic_( parents_[p] );
             if ( p == gp )
                 return p; // p is a root
-            // make a point to its grandparent; a failed swap only means another thread already shortened the path
-            halveAtomic_( parents_[a], p, gp );
+            // point a to its grandparent (best-effort: a lost race just means another thread already shortened the path)
+            casAtomic_<std::memory_order_relaxed>( parents_[a], p, gp );
             a = gp;
         }
     }

--- a/source/MRMesh/MRUnionFind.h
+++ b/source/MRMesh/MRUnionFind.h
@@ -138,9 +138,8 @@ private:
     // otherwise we fall back to compiler atomic builtins (e.g. Apple clang, whose libc++ lacks atomic_ref).
     static I loadAtomic_( I& slot )
     {
-        using T = typename I::ValueType;
 #ifdef __cpp_lib_atomic_ref
-        return I( std::atomic_ref<T>( slot.get() ).load( std::memory_order_relaxed ) );
+        return I( std::atomic_ref<typename I::ValueType>( slot.get() ).load( std::memory_order_relaxed ) );
 #else
         return I( __atomic_load_n( &slot.get(), __ATOMIC_RELAXED ) );
 #endif

--- a/source/MRMesh/MRUnionFindParallel.h
+++ b/source/MRMesh/MRUnionFindParallel.h
@@ -11,7 +11,7 @@ namespace MR
 /// constructs in parallel the bitset with 1-bits corresponding to root elements;
 /// if region is provided then only its elements will be checked
 template <typename I>
-[[nodiscard]] TypedBitSet<I> findRootsBitSet( const UnionFind<I> & uf, const TypedBitSet<I> * region = nullptr )
+[[nodiscard]] TypedBitSet<I> findRootsBitSet( const BaseUnionFind<I> & uf, const TypedBitSet<I> * region = nullptr )
 {
     MR_TIMER;
     TypedBitSet<I> res( uf.size() );
@@ -28,7 +28,7 @@ template <typename I>
 /// constructs in parallel the bitset with 1-bits corresponding to the elements from same set as (a);
 /// if region is provided then only its elements will be checked
 template <typename I>
-[[nodiscard]] TypedBitSet<I> findComponentBitSet( UnionFind<I> & uf, I a, const TypedBitSet<I> * region = nullptr )
+[[nodiscard]] TypedBitSet<I> findComponentBitSet( BaseUnionFind<I> & uf, I a, const TypedBitSet<I> * region = nullptr )
 {
     MR_TIMER;
     TypedBitSet<I> res( uf.size() );
@@ -46,7 +46,7 @@ template <typename I>
 /// returns true if there is no set in UnionFind that contains both an element from the given region and another element not from the region;
 /// in other words, UnionFind contains a subdivision of both region and not-region on subsets
 template <typename I>
-[[nodiscard]] bool isSubdivision( const UnionFind<I> & uf, const TypedBitSet<I> & region )
+[[nodiscard]] bool isSubdivision( const BaseUnionFind<I> & uf, const TypedBitSet<I> & region )
 {
     MR_TIMER;
     tbb::task_group_context ctx;
@@ -56,5 +56,22 @@ template <typename I>
             ctx.cancel_group_execution();
     }, ctx );
     return !ctx.is_group_execution_cancelled();
+}
+
+/// in parallel, makes the parent of each element point directly to its set root
+/// (a multi-threaded BaseUnionFind::roots()); returns the updated parents vector
+template <typename I>
+const Vector<I, I> & updateRootsParallel( BaseUnionFind<I> & uf )
+{
+    MR_TIMER;
+    // each thread compresses only its own contiguous range, so parent writes never collide;
+    // the root walk reads may cross ranges, but every value seen leads to the same unchanging root
+    tbb::parallel_for( tbb::blocked_range<I>( I( 0 ), I( uf.size() ) ),
+        [&] ( const tbb::blocked_range<I> & range )
+    {
+        for ( I i = range.begin(); i < range.end(); ++i )
+            uf.findUpdateRange( i, range.begin(), range.end() );
+    } );
+    return uf.parents();
 }
 } //namespace MR


### PR DESCRIPTION
## What

`getUnionFindStructureFacesPerEdge` built the union-find in two phases: a parallel pass uniting only edges interior to a thread's id-range block, then a sequential pass over all boundary edges. On meshes with poor edge-id locality that sequential tail can dominate the build time.

This replaces both phases with a single lock-free parallel pass. A new `UnionFind::uniteAtomic` unites any two elements concurrently via:
- link-by-id (the smaller id becomes the set root) with a CAS retry loop, and
- best-effort path halving in `findAtomic_`.

Because every parent id stays strictly smaller than its child's, the forest is always acyclic and `find` always terminates — there is no interior/boundary classification and no sequential tail.

## Notes

- Component membership is identical; only the chosen representative differs — the root is now deterministically the minimum id of each set, independent of thread count.
- `uniteAtomic` does not maintain component sizes (documented on the method). `sizeOfComp` is used only on the vertex path, which is unchanged.
- The single-threaded branch (`numThreads == 1`) is unchanged.
- Lock-free slot ops use `std::atomic_ref` where the standard library provides it (`__cpp_lib_atomic_ref`: MSVC, libstdc++, recent libc++) and fall back to compiler `__atomic_*` builtins otherwise (e.g. Apple clang's libc++).

Generated with [Claude Code](https://claude.com/claude-code)
