### PR TITLE
MRCuda: use PCH in MSBuild

### DIFF
--- a/source/MRCuda/MRCuda.vcxproj
+++ b/source/MRCuda/MRCuda.vcxproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(ProjectDir)\..\platform.props" />
@@ -44,7 +44,12 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>MRCuda_EXPORTS;WIN32;WIN64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MRCuda_EXPORTS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>$(ProjectDir)..\MRPch\MRPch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(SolutionDir)TempOutput\MRPch\$(Platform)\$(Configuration)\MRPch.pch</PrecompiledHeaderOutputFile>
+      <ForcedIncludeFiles>$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -55,6 +60,7 @@
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
       <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalCompilerOptions>/wd4514 /wd4574 /wd4668 /wd5039</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -62,7 +68,12 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>MRCuda_EXPORTS;WIN32;WIN64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MRCuda_EXPORTS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>$(ProjectDir)..\MRPch\MRPch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(SolutionDir)TempOutput\MRPch\$(Platform)\$(Configuration)\MRPch.pch</PrecompiledHeaderOutputFile>
+      <ForcedIncludeFiles>$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -75,6 +86,7 @@
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
       <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalCompilerOptions>/wd4514 /wd4574 /wd4668 /wd5039</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -145,6 +157,9 @@
   <ItemGroup>
     <ProjectReference Include="..\MRMesh\MRMesh.vcxproj">
       <Project>{c7780500-ca0e-4f5f-8423-d7ab06078b14}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\MRPch\MRPch.vcxproj">
+      <Project>{36516aee-2fb9-41c0-a176-a2d49c1c26b2}</Project>
     </ProjectReference>
     <ProjectReference Include="..\MRVoxels\MRVoxels.vcxproj">
       <Project>{7cc4f0fe-ace6-4441-9dd7-296066b6d69f}</Project>


### PR DESCRIPTION
### Summary

Enable the shared `MRPch` precompiled header for the **MRCuda** project in the MSBuild (Visual Studio) build, so MRCuda is compiled the same way under both build systems.

The CMake build already reuses `MRPch` for `MRCuda` (`TARGET_PRECOMPILE_HEADERS(... REUSE_FROM MRPch)`, logged as `MRCuda: using PCH` at configure time). Until now the MSBuild project compiled MRCuda without the PCH; this brings it in line.

### How the shared PCH works here

`MRPch.pch` is built once by the `MRPch` project and consumed by every other project via the same `PrecompiledHeaderOutputFile` path. A project can only reuse that `.pch` if its compiler command line matches the options `MRPch` used to build it — otherwise the compiler rejects the header (`C2855` / `C4005` / `C4652`, treated as errors under our warnings-as-errors policy). Most of this diff is bringing MRCuda's options into that required agreement, i.e. the same configuration every other consumer — including the existing CUDA project `MRTestCuda` — already uses.

### Changes

All in `source/MRCuda/MRCuda.vcxproj`:

- **Use the shared PCH** in Debug and Release: `PrecompiledHeader=Use`, `MRPch.h` as the forced include, and the standard `TempOutput\MRPch\$(Platform)\$(Configuration)\MRPch.pch` output path.
- **Add a project reference to `MRPch.vcxproj`** so it builds first and the `.pch` exists before MRCuda compiles.
- **Enable `SDLCheck`** — `MRPch` builds the PCH with `/sdl`, which the compiler expands internally to the `/d1safedelete` code-gen flag. Without a matching `/sdl`, MRCuda fails with `C2855: command-line option '/d1safedelete' inconsistent with precompiled header`.
- **Disable `WholeProgramOptimization` in Release** to match `MRPch` (built without `/GL`); otherwise `C4652: '/GL' inconsistent with precompiled header`.
- **Drop the redundant `WIN32;WIN64` defines** — they're already provided by the Windows SDK (`WIN32` via `minwindef.h`; `_WIN64` is predefined for x64). Defining them on the command line while the PCH already carries `WIN32` from the SDK triggers `C4005: 'WIN32' macro redefinition`.
- **Suppress a few host-compiler warnings on the CUDA compile path** (`/wd4514 /wd4574 /wd4668 /wd5039`) so `.cu` host compilation also passes under the warnings-as-errors policy.

### Build time

No measurable net change to Windows MSBuild build times — per-config differences versus master stay within run-to-run CI variance, since MRCuda is a small module relative to the full solution. The change is for build-system consistency, not a timing win.
