### PR TITLE
ci(windows): use CUDA 12.0.1.52833 for MSVC2026 builds

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -48,9 +48,9 @@ jobs:
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
       job_upload_artifact: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
-      CUDA_VERSION: ${{ fromJSON('{"msvc-2019":"11.4.2.47141","msvc-2022":"12.0.1.52833"}')[matrix.cxx_compiler] || '13.2.0' }}
-      CUDA_MAJOR: ${{ fromJSON('{"msvc-2019":"11","msvc-2022":"12"}')[matrix.cxx_compiler] || '13' }}
-      CUDA_MINOR: ${{ fromJSON('{"msvc-2019":"4","msvc-2022":"0"}')[matrix.cxx_compiler] || '2' }}
+      CUDA_VERSION: ${{ fromJSON('{"msvc-2019":"11.4.2.47141","msvc-2022":"12.0.1.52833","msvc-2026":"12.0.1.52833"}')[matrix.cxx_compiler] || '13.2.0' }}
+      CUDA_MAJOR: ${{ fromJSON('{"msvc-2019":"11","msvc-2022":"12","msvc-2026":"12"}')[matrix.cxx_compiler] || '13' }}
+      CUDA_MINOR: ${{ fromJSON('{"msvc-2019":"4","msvc-2022":"0","msvc-2026":"0"}')[matrix.cxx_compiler] || '2' }}
       VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}
       PLATFORM_TOOLSET: ${{ fromJSON('{"msvc-2019":"v142","msvc-2022":"v143"}')[matrix.cxx_compiler] || 'v145' }}
 


### PR DESCRIPTION
## What

MSVC2026 Windows builds were using the fallback CUDA version `13.2.0`. This pins them to `12.0.1.52833` instead — the same version already used for MSVC2022.

In `.github/workflows/build-test-windows.yml`, the `CUDA_VERSION`, `CUDA_MAJOR`, and `CUDA_MINOR` env vars are selected from a per-compiler map keyed on `matrix.cxx_compiler`, falling back to `13.2.0` (major `13`, minor `2`) when the compiler isn't listed. Since `msvc-2026` had no entry, it fell through to that fallback. This adds explicit `msvc-2026` entries to all three maps so the major/minor used to build the toolkit path stay consistent with the selected version:

- `CUDA_VERSION`: `msvc-2026` → `12.0.1.52833`
- `CUDA_MAJOR`: `msvc-2026` → `12`
- `CUDA_MINOR`: `msvc-2026` → `0`

## Why

Align the MSVC2026 build leg's CUDA toolkit with MSVC2022 (`12.0.1.52833`) rather than the newer `13.2.0`.

## Scope

CI-only change, touching the Windows workflow exclusively. `disable-build-*` labels are applied for all other platforms.
