### PR TITLE
CI: Add base stage to Docker images

### DIFF
--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -1,20 +1,26 @@
 # syntax=docker/dockerfile:1.6
 
+
 FROM emscripten/emsdk:4.0.10-arm64 AS base
 
 RUN <<EOF
     set -e
+    # configure timezone
     export DEBIAN_FRONTEND=noninteractive
     export DEBCONF_NONINTERACTIVE_SEEN=true
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections
     echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
+    # use more reliable mirror
     sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
+    # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
         tzdata git pkg-config ninja-build gettext
+    # clean downloaded files
     apt-get clean
     rm -rf /var/lib/apt/lists/*
 EOF
+
 
 FROM base AS builder
 
@@ -25,6 +31,7 @@ COPY . .
 ENV MR_STATE=DOCKER_BUILD
 ENV MR_EMSCRIPTEN=ON
 
+# 32-bit multi-threaded
 RUN <<EOF
     set -e
     ./scripts/build_thirdparty.sh
@@ -32,18 +39,19 @@ RUN <<EOF
     rm -rf bin include lib share thirdparty_build
 EOF
 
-ENV MR_EMSCRIPTEN_SINGLE=ON
+# 32-bit single-threaded
 RUN <<EOF
     set -e
+    export MR_EMSCRIPTEN_SINGLE=ON
     ./scripts/build_thirdparty.sh
     ./scripts/cmake_install.sh /opt/meshlib-thirdparty/emscripten-single
     rm -rf bin include lib share thirdparty_build
 EOF
 
-ENV MR_EMSCRIPTEN_SINGLE=OFF
-ENV MR_EMSCRIPTEN_WASM64=ON
+# 64-bit multi-threaded
 RUN <<EOF
     set -e
+    export MR_EMSCRIPTEN_WASM64=ON
     ./scripts/build_thirdparty.sh
     ./scripts/cmake_install.sh /opt/meshlib-thirdparty/emscripten-wasm64
     rm -rf bin include lib share thirdparty_build

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -1,46 +1,30 @@
 # syntax=docker/dockerfile:1.6
 
-# Multi-stage build:
-#   builder: heavy thirdparty work for all three Emscripten variants.
-#   final:   runtime image containing only the installed artifacts.
-#
-# The builder stage is discarded at push time, so the MeshLib source tree
-# (COPY . .), thirdparty_build/ scratch, builder-only apt packages, and any
-# other incidental build residue never land in the pushed image. Only the
-# three /usr/local/lib/emscripten* install trees cross the stage boundary.
-#
-# Install paths are preserved, so build-test-emscripten.yml needs no changes.
+FROM emscripten/emsdk:4.0.10-arm64 AS base
 
-## ============================================================================
-## Stage 1: builder
-## ============================================================================
-FROM emscripten/emsdk:4.0.10-arm64 AS builder
-
-# Minimal apt set required by ./scripts/build_thirdparty.sh.
-# No firefox/xvfb/dbus here — those are test-runtime only, not build deps.
 RUN <<EOF
     set -e
     export DEBIAN_FRONTEND=noninteractive
+    export DEBCONF_NONINTERACTIVE_SEEN=true
+    echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections
+    echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
     sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        git pkg-config ninja-build gettext
+        tzdata git pkg-config ninja-build gettext
     apt-get clean
     rm -rf /var/lib/apt/lists/*
 EOF
 
+FROM base AS builder
+
 WORKDIR /home/MeshLib
 
-# Full source tree (including submodules checked out by actions/checkout) is
-# needed to run the thirdparty build scripts. This layer is only in the
-# builder stage and does NOT propagate to the final image.
 COPY . .
 
 ENV MR_STATE=DOCKER_BUILD
 ENV MR_EMSCRIPTEN=ON
 
-# Stage the three installs under /opt/meshlib-thirdparty so the COPY --from=
-# in the final stage is unambiguous about what to pick up.
 RUN <<EOF
     set -e
     ./scripts/build_thirdparty.sh
@@ -66,27 +50,8 @@ RUN <<EOF
 EOF
 
 
-## ============================================================================
-## Stage 2: final runtime image
-## ============================================================================
-FROM emscripten/emsdk:4.0.10-arm64
+FROM base
 
-RUN <<EOF
-    set -e
-    export DEBIAN_FRONTEND=noninteractive
-    export DEBCONF_NONINTERACTIVE_SEEN=true
-    echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections
-    echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
-    sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
-    apt-get update -qqy
-    apt-get install -qqy --no-install-recommends \
-        tzdata git pkg-config ninja-build gettext
-    apt-get clean
-    rm -rf /var/lib/apt/lists/*
-EOF
-
-# Pull only the compiled thirdparty trees from the builder. Target paths
-# match what build-test-emscripten.yml's matrix.thirdparty-dir already expects.
 COPY --from=builder /opt/meshlib-thirdparty/emscripten        /usr/local/lib/emscripten
 COPY --from=builder /opt/meshlib-thirdparty/emscripten-single /usr/local/lib/emscripten-single
 COPY --from=builder /opt/meshlib-thirdparty/emscripten-wasm64 /usr/local/lib/emscripten-wasm64
@@ -97,7 +62,7 @@ RUN <<EOF
     set -e
     groupadd -g 1001 user
     useradd -m -u 1001 -g user -s /bin/bash user
-    sudo chmod -R 777 /emsdk/upstream/emscripten/
+    chmod -R 777 /emsdk/upstream/emscripten/
 EOF
 
 # Change to non-root privilege

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -77,8 +77,8 @@ RUN <<EOF
     cd vcpkg
     ./bootstrap-vcpkg.sh -disableMetrics
     # replace the original source URL with a faster mirror's one
-    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' vcpkg/ports/vcpkg-make/portfile.cmake
-    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' vcpkg/ports/gettext/portfile.cmake
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' ports/vcpkg-make/portfile.cmake
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' ports/gettext/portfile.cmake
 EOF
 
 WORKDIR /root/vcpkg

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -9,11 +9,21 @@ COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 RUN <<EOF
     set -e
+    # don't install excess dependencies
     echo "install_weak_deps=false" >> /etc/dnf/dnf.conf
+    # configure CUDA repo
+    case "$(uname -m)" in
+        x86_64)  CUDA_REPO_ARCH=x86_64 ;;
+        aarch64) CUDA_REPO_ARCH=sbsa ;;
+    esac
     # network may flake
-    retry.sh -- dnf -y install epel-release
+    retry.sh -- dnf -y install 'dnf-command(config-manager)' epel-release
+    retry.sh -- dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${CUDA_REPO_ARCH}/cuda-rhel8.repo
+    retry.sh -- dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
     retry.sh -- dnf -y install --enablerepo powertools \
         git cmake gcc-toolset-11 ninja-build clang-devel-21* \
+        $(: minimal CUDA toolkit - nvcc, cudart ) \
+        cuda-nvcc-12-0 cuda-cudart-devel-12-0 cuda-driver-devel-12-0 cuda-cuxxfilt-12-0 \
         $(: vcpkg requirements ) \
         curl zip unzip tar \
         $(: vcpkg package requirements ) \
@@ -21,46 +31,15 @@ RUN <<EOF
         $(: mrbind requirements ) \
         lld-21* llvm-devel-21* python3.12-devel which zlib-devel \
         $(: CI environment ) \
-        time python3.12-pip rpm-build xorg-x11-server-Xvfb mesa-dri-drivers gettext
+        gh time python3.12-pip rpm-build xorg-x11-server-Xvfb mesa-dri-drivers gettext
     dnf clean all
-EOF
-
-# install minimal CUDA 12.0 toolkit (nvcc + cudart)
-RUN <<EOF
-    set -e
-    retry.sh -- dnf -y install 'dnf-command(config-manager)'
-    case "$(uname -m)" in
-        x86_64)  CUDA_REPO_ARCH=x86_64 ;;
-        aarch64) CUDA_REPO_ARCH=sbsa ;;
-        *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
-    esac
-    retry.sh -- dnf config-manager --add-repo "https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${CUDA_REPO_ARCH}/cuda-rhel8.repo"
-    retry.sh -- dnf -y install \
-        cuda-nvcc-12-0 \
-        cuda-cudart-12-0 \
-        cuda-cudart-devel-12-0 \
-        cuda-driver-devel-12-0 \
-        cuda-cuxxfilt-12-0
-    dnf clean all
-EOF
-ENV PATH=/usr/local/cuda/bin:$PATH
-
-# install github-cli
-RUN <<EOF
-    set -e
-    retry.sh -- dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-    retry.sh -- dnf -y install gh
-    dnf clean all
-EOF
-
-# install aws cli
-RUN <<EOF
-    set -e
+    # install aws cli
     curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
     unzip awscliv2.zip
     ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
     rm -rf awscliv2.zip aws/
 EOF
+ENV PATH=/usr/local/cuda/bin:$PATH
 
 
 FROM base AS build
@@ -97,16 +76,12 @@ RUN <<EOF
     git clone https://github.com/microsoft/vcpkg.git --branch $VCPKG_VERSION --single-branch
     cd vcpkg
     ./bootstrap-vcpkg.sh -disableMetrics
+    # replace the original source URL with a faster mirror's one
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' /vcpkports/vcpkg-make/portfile.cmake
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' /vcpkports/gettext/portfile.cmake
 EOF
 
 WORKDIR /root/vcpkg
-
-# replace the original source URL with a faster mirror's one
-RUN <<EOF
-    set -e
-    sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.org/|' ports/vcpkg-make/portfile.cmake
-    sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.org/|' ports/gettext/portfile.cmake
-EOF
 
 # build vcpkg packages
 ARG VCPKG_TRIPLET
@@ -115,14 +90,18 @@ RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
     --mount=type=secret,id=AWS_SESSION_TOKEN <<EOF
     set -e
-    source ../MeshLib/configure_s3_cache.sh
+    source /root/MeshLib/configure_s3_cache.sh
     source /opt/rh/gcc-toolset-11/enable
     source /opt/autoconf27/enable
     source /root/venv/bin/activate
+    export VCPKG_DEFAULT_HOST_TRIPLET=${VCPKG_TRIPLET}
+    export VCPKG_OVERLAY_PORTS=/root/MeshLib/ports
+    export VCPKG_OVERLAY_TRIPLETS=/root/MeshLib/triplets
     # network may flake
-    retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports --debug $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
+    retry.sh -- \
+        ./vcpkg install --debug $(cat /root/MeshLib/requirements.txt | tr '\n' ' ')
+    ./vcpkg export --x-all-installed --raw --output=vcpkg --output-dir=/opt
 EOF
-RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
 
 
 FROM base AS production

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -3,7 +3,7 @@ ARG VCPKG_VERSION=2026.05.25
 ARG VCPKG_TRIPLET=x64-linux-meshlib
 
 
-FROM rockylinux:8 AS build
+FROM rockylinux:8 AS base
 
 COPY scripts/retry.sh /usr/local/bin/retry.sh
 
@@ -17,102 +17,7 @@ RUN <<EOF
         $(: vcpkg requirements ) \
         curl zip unzip tar \
         $(: vcpkg package requirements ) \
-        autoconf2.7x autoconf-archive bison dbus-libs libtool libudev-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXtst-devel mesa-libGL-devel perl-core python3.12-pip
-    dnf clean all
-EOF
-
-# install aws cli for vcpkg cache
-RUN <<EOF
-    set -e
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
-    unzip awscliv2.zip
-    ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
-    rm -rf awscliv2.zip aws/
-EOF
-
-# override system autoconf
-RUN <<EOF
-    set -e
-    mkdir -p /opt/autoconf27/bin/
-    for APP in autoconf autoheader autom4te autoreconf autoscan autoupdate ifnames; do
-        ln -s /usr/bin/${APP}27 /opt/autoconf27/bin/${APP}
-    done
-    echo 'export PATH=/opt/autoconf27/bin:$PATH' > /opt/autoconf27/enable
-EOF
-
-WORKDIR /root
-
-# install vcpkg Python dependencies
-RUN <<EOF
-    set -e
-    python3.12 -m venv venv
-    source venv/bin/activate
-    pip install jinja2
-EOF
-
-COPY requirements/vcpkg-linux.txt MeshLib/requirements.txt
-COPY thirdparty/vcpkg/ports MeshLib/ports
-COPY thirdparty/vcpkg/triplets MeshLib/triplets
-COPY thirdparty/vcpkg/configure_s3_cache.sh MeshLib/configure_s3_cache.sh
-COPY scripts/retry.sh /usr/local/bin/retry.sh
-
-ARG VCPKG_VERSION
-ENV VCPKG_VERSION=$VCPKG_VERSION
-RUN <<EOF
-    set -e
-    git clone https://github.com/microsoft/vcpkg.git --branch $VCPKG_VERSION --single-branch
-    cd vcpkg
-    ./bootstrap-vcpkg.sh -disableMetrics
-EOF
-
-WORKDIR /root/vcpkg
-
-# replace the original source URL with a faster mirror's one
-RUN <<EOF
-    set -e
-    sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.org/|' ports/vcpkg-make/portfile.cmake
-    sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.org/|' ports/gettext/portfile.cmake
-EOF
-
-# build vcpkg packages
-ARG VCPKG_TRIPLET
-ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
-RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
-    --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
-    --mount=type=secret,id=AWS_SESSION_TOKEN <<EOF
-    set -e
-    source ../MeshLib/configure_s3_cache.sh
-    source /opt/rh/gcc-toolset-11/enable
-    source /opt/autoconf27/enable
-    source /root/venv/bin/activate
-    # network may flake
-    retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports --debug $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
-EOF
-RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
-
-
-FROM rockylinux:8 AS production
-
-COPY --from=build /opt/vcpkg /opt/vcpkg
-COPY scripts/retry.sh /usr/local/bin/retry.sh
-
-ENV MR_STATE=DOCKER_BUILD
-ENV MESHLIB_USE_VCPKG=ON
-ENV VCPKG_ROOT=/opt/vcpkg
-
-ARG VCPKG_TRIPLET
-ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
-
-RUN <<EOF
-    set -e
-    echo "install_weak_deps=false" >> /etc/dnf/dnf.conf
-    # network may flake
-    retry.sh -- dnf -y install --enablerepo powertools \
-        git cmake gcc-toolset-11 ninja-build clang-devel-21* \
-        $(: vcpkg requirements ) \
-        curl zip unzip tar \
-        $(: vcpkg package requirements ) \
-        autoconf-archive bison dbus-libs libtool libudev-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXtst-devel mesa-libGL-devel perl-core \
+        autoconf2.7x autoconf-archive bison dbus-libs libtool libudev-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXtst-devel mesa-libGL-devel perl-core \
         $(: mrbind requirements ) \
         lld-21* llvm-devel-21* python3.12-devel which zlib-devel \
         $(: CI environment ) \
@@ -156,3 +61,77 @@ RUN <<EOF
     ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
     rm -rf awscliv2.zip aws/
 EOF
+
+
+FROM base AS build
+
+# override system autoconf
+RUN <<EOF
+    set -e
+    mkdir -p /opt/autoconf27/bin/
+    for APP in autoconf autoheader autom4te autoreconf autoscan autoupdate ifnames; do
+        ln -s /usr/bin/${APP}27 /opt/autoconf27/bin/${APP}
+    done
+    echo 'export PATH=/opt/autoconf27/bin:$PATH' > /opt/autoconf27/enable
+EOF
+
+WORKDIR /root
+
+# install vcpkg Python dependencies
+RUN <<EOF
+    set -e
+    python3.12 -m venv venv
+    source venv/bin/activate
+    pip install jinja2
+EOF
+
+COPY requirements/vcpkg-linux.txt MeshLib/requirements.txt
+COPY thirdparty/vcpkg/ports MeshLib/ports
+COPY thirdparty/vcpkg/triplets MeshLib/triplets
+COPY thirdparty/vcpkg/configure_s3_cache.sh MeshLib/configure_s3_cache.sh
+
+ARG VCPKG_VERSION
+ENV VCPKG_VERSION=$VCPKG_VERSION
+RUN <<EOF
+    set -e
+    git clone https://github.com/microsoft/vcpkg.git --branch $VCPKG_VERSION --single-branch
+    cd vcpkg
+    ./bootstrap-vcpkg.sh -disableMetrics
+EOF
+
+WORKDIR /root/vcpkg
+
+# replace the original source URL with a faster mirror's one
+RUN <<EOF
+    set -e
+    sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.org/|' ports/vcpkg-make/portfile.cmake
+    sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.org/|' ports/gettext/portfile.cmake
+EOF
+
+# build vcpkg packages
+ARG VCPKG_TRIPLET
+ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
+RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
+    --mount=type=secret,id=AWS_SESSION_TOKEN <<EOF
+    set -e
+    source ../MeshLib/configure_s3_cache.sh
+    source /opt/rh/gcc-toolset-11/enable
+    source /opt/autoconf27/enable
+    source /root/venv/bin/activate
+    # network may flake
+    retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports --debug $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
+EOF
+RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
+
+
+FROM base AS production
+
+COPY --from=build /opt/vcpkg /opt/vcpkg
+
+ENV MR_STATE=DOCKER_BUILD
+ENV MESHLIB_USE_VCPKG=ON
+ENV VCPKG_ROOT=/opt/vcpkg
+
+ARG VCPKG_TRIPLET
+ENV VCPKG_TRIPLET=$VCPKG_TRIPLET

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -77,8 +77,8 @@ RUN <<EOF
     cd vcpkg
     ./bootstrap-vcpkg.sh -disableMetrics
     # replace the original source URL with a faster mirror's one
-    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' /vcpkports/vcpkg-make/portfile.cmake
-    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' /vcpkports/gettext/portfile.cmake
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' vcpkg/ports/vcpkg-make/portfile.cmake
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' vcpkg/ports/gettext/portfile.cmake
 EOF
 
 WORKDIR /root/vcpkg

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -59,8 +59,8 @@ RUN <<EOF
     cd vcpkg
     ./bootstrap-vcpkg.sh -disableMetrics
     # replace the original source URL with a faster mirror's one
-    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' /vcpkports/vcpkg-make/portfile.cmake
-    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' /vcpkports/gettext/portfile.cmake
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' vcpkg/ports/vcpkg-make/portfile.cmake
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' vcpkg/ports/gettext/portfile.cmake
 EOF
 
 WORKDIR /root/vcpkg

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -59,8 +59,8 @@ RUN <<EOF
     cd vcpkg
     ./bootstrap-vcpkg.sh -disableMetrics
     # replace the original source URL with a faster mirror's one
-    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' vcpkg/ports/vcpkg-make/portfile.cmake
-    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' vcpkg/ports/gettext/portfile.cmake
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' ports/vcpkg-make/portfile.cmake
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' ports/gettext/portfile.cmake
 EOF
 
 WORKDIR /root/vcpkg

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -3,7 +3,7 @@ ARG VCPKG_VERSION=2026.05.25
 ARG VCPKG_TRIPLET=x64-linux-meshlib
 
 
-FROM rockylinux:9 AS build
+FROM rockylinux:9 AS base
 
 COPY scripts/retry.sh /usr/local/bin/retry.sh
 
@@ -16,11 +16,43 @@ RUN <<EOF
         $(: vcpkg requirements ) \
         curl-minimal zip unzip tar \
         $(: vcpkg package requirements ) \
-        autoconf271 autoconf-archive bison dbus-libs libtool libudev-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXtst-devel mesa-libGL-devel perl-core python3-jinja2
+        autoconf271 autoconf-archive bison dbus-libs libtool libudev-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXtst-devel mesa-libGL-devel perl-core python3-jinja2 \
+        $(: mrbind requirements ) \
+        lld llvm-devel python3-devel which zlib-devel \
+        $(: CI environment ) \
+        time python3-pip rpm-build xorg-x11-server-Xvfb mesa-dri-drivers gettext
     dnf clean all
 EOF
 
-# install aws cli for vcpkg cache
+# install minimal CUDA 12.0 toolkit (nvcc + cudart)
+RUN <<EOF
+    set -e
+    retry.sh -- dnf -y install 'dnf-command(config-manager)'
+    case "$(uname -m)" in
+        x86_64)  CUDA_REPO_ARCH=x86_64 ;;
+        aarch64) CUDA_REPO_ARCH=sbsa ;;
+        *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+    esac
+    retry.sh -- dnf config-manager --add-repo "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${CUDA_REPO_ARCH}/cuda-rhel9.repo"
+    retry.sh -- dnf -y install \
+        cuda-nvcc-12-0 \
+        cuda-cudart-12-0 \
+        cuda-cudart-devel-12-0 \
+        cuda-driver-devel-12-0 \
+        cuda-cuxxfilt-12-0
+    dnf clean all
+EOF
+ENV PATH=/usr/local/cuda/bin:$PATH
+
+# install github-cli
+RUN <<EOF
+    set -e
+    retry.sh -- dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+    retry.sh -- dnf -y install gh
+    dnf clean all
+EOF
+
+# install aws cli
 RUN <<EOF
     set -e
     curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
@@ -29,13 +61,15 @@ RUN <<EOF
     rm -rf awscliv2.zip aws/
 EOF
 
+
+FROM base AS build
+
 WORKDIR /root
 
 COPY requirements/vcpkg-linux.txt MeshLib/requirements.txt
 COPY thirdparty/vcpkg/ports MeshLib/ports
 COPY thirdparty/vcpkg/triplets MeshLib/triplets
 COPY thirdparty/vcpkg/configure_s3_cache.sh MeshLib/configure_s3_cache.sh
-COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 ARG VCPKG_VERSION
 ENV VCPKG_VERSION=$VCPKG_VERSION
@@ -70,10 +104,9 @@ EOF
 RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
 
 
-FROM nvidia/cuda:12.0.1-devel-rockylinux9 AS production
+FROM base AS production
 
 COPY --from=build /opt/vcpkg /opt/vcpkg
-COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 ENV MR_STATE=DOCKER_BUILD
 ENV MESHLIB_USE_VCPKG=ON
@@ -81,38 +114,3 @@ ENV VCPKG_ROOT=/opt/vcpkg
 
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
-
-RUN <<EOF
-    set -e
-    echo "install_weak_deps=false" >> /etc/dnf/dnf.conf
-    # network may flake
-    retry.sh -- dnf -y install --enablerepo crb \
-        git cmake ninja-build clang-devel \
-        $(: vcpkg requirements ) \
-        curl-minimal zip unzip tar \
-        $(: vcpkg package requirements ) \
-        autoconf-archive bison dbus-libs libtool libudev-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXtst-devel mesa-libGL-devel perl-core python3-jinja2 \
-        $(: mrbind requirements ) \
-        lld llvm-devel python3-devel which zlib-devel \
-        $(: CI environment ) \
-        time python3-pip rpm-build xorg-x11-server-Xvfb mesa-dri-drivers gettext
-    dnf clean all
-EOF
-
-# install github-cli
-RUN <<EOF
-    set -e
-    retry.sh -- dnf -y install 'dnf-command(config-manager)'
-    retry.sh -- dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-    retry.sh -- dnf -y install gh
-    dnf clean all
-EOF
-
-# install aws cli
-RUN <<EOF
-    set -e
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
-    unzip awscliv2.zip
-    ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
-    rm -rf awscliv2.zip aws/
-EOF

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -9,10 +9,21 @@ COPY scripts/retry.sh /usr/local/bin/retry.sh
 
 RUN <<EOF
     set -e
+    # don't install excess dependencies
     echo "install_weak_deps=false" >> /etc/dnf/dnf.conf
+    # configure CUDA repo
+    case "$(uname -m)" in
+        x86_64)  CUDA_REPO_ARCH=x86_64 ;;
+        aarch64) CUDA_REPO_ARCH=sbsa ;;
+    esac
     # network may flake
+    retry.sh -- dnf -y install 'dnf-command(config-manager)'
+    retry.sh -- dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${CUDA_REPO_ARCH}/cuda-rhel9.repo
+    retry.sh -- dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
     retry.sh -- dnf -y install --enablerepo crb \
         git cmake ninja-build clang-devel \
+        $(: minimal CUDA toolkit - nvcc, cudart ) \
+        cuda-nvcc-12-0 cuda-cudart-devel-12-0 cuda-driver-devel-12-0 cuda-cuxxfilt-12-0 \
         $(: vcpkg requirements ) \
         curl-minimal zip unzip tar \
         $(: vcpkg package requirements ) \
@@ -20,46 +31,15 @@ RUN <<EOF
         $(: mrbind requirements ) \
         lld llvm-devel python3-devel which zlib-devel \
         $(: CI environment ) \
-        time python3-pip rpm-build xorg-x11-server-Xvfb mesa-dri-drivers gettext
+        gh time python3-pip rpm-build xorg-x11-server-Xvfb mesa-dri-drivers gettext
     dnf clean all
-EOF
-
-# install minimal CUDA 12.0 toolkit (nvcc + cudart)
-RUN <<EOF
-    set -e
-    retry.sh -- dnf -y install 'dnf-command(config-manager)'
-    case "$(uname -m)" in
-        x86_64)  CUDA_REPO_ARCH=x86_64 ;;
-        aarch64) CUDA_REPO_ARCH=sbsa ;;
-        *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
-    esac
-    retry.sh -- dnf config-manager --add-repo "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${CUDA_REPO_ARCH}/cuda-rhel9.repo"
-    retry.sh -- dnf -y install \
-        cuda-nvcc-12-0 \
-        cuda-cudart-12-0 \
-        cuda-cudart-devel-12-0 \
-        cuda-driver-devel-12-0 \
-        cuda-cuxxfilt-12-0
-    dnf clean all
-EOF
-ENV PATH=/usr/local/cuda/bin:$PATH
-
-# install github-cli
-RUN <<EOF
-    set -e
-    retry.sh -- dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-    retry.sh -- dnf -y install gh
-    dnf clean all
-EOF
-
-# install aws cli
-RUN <<EOF
-    set -e
+    # install aws cli
     curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
     unzip awscliv2.zip
     ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
     rm -rf awscliv2.zip aws/
 EOF
+ENV PATH=/usr/local/cuda/bin:$PATH
 
 
 FROM base AS build
@@ -78,16 +58,12 @@ RUN <<EOF
     git clone https://github.com/microsoft/vcpkg.git --branch $VCPKG_VERSION --single-branch
     cd vcpkg
     ./bootstrap-vcpkg.sh -disableMetrics
+    # replace the original source URL with a faster mirror's one
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' /vcpkports/vcpkg-make/portfile.cmake
+    sed -i 's https://ftp.gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/ ' /vcpkports/gettext/portfile.cmake
 EOF
 
 WORKDIR /root/vcpkg
-
-# replace the original source URL with a faster mirror's one
-RUN <<EOF
-    set -e
-    sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.org/|' ports/vcpkg-make/portfile.cmake
-    sed -i 's|https://ftp.gnu.org/|https://www.mirrorservice.org/sites/ftp.gnu.org/|' ports/gettext/portfile.cmake
-EOF
 
 # build vcpkg packages
 ARG VCPKG_TRIPLET
@@ -96,12 +72,16 @@ RUN --mount=type=secret,id=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
     --mount=type=secret,id=AWS_SESSION_TOKEN <<EOF
     set -e
-    source ../MeshLib/configure_s3_cache.sh
+    source /root/MeshLib/configure_s3_cache.sh
     source /opt/rh/autoconf271/enable
+    export VCPKG_DEFAULT_HOST_TRIPLET=${VCPKG_TRIPLET}
+    export VCPKG_OVERLAY_PORTS=/root/MeshLib/ports
+    export VCPKG_OVERLAY_TRIPLETS=/root/MeshLib/triplets
     # network may flake
-    retry.sh -- ./vcpkg install --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --overlay-ports=../MeshLib/ports --debug $(cat ../MeshLib/requirements.txt | tr '\n' ' ')
+    retry.sh -- \
+        ./vcpkg install --debug $(cat /root/MeshLib/requirements.txt | tr '\n' ' ')
+    ./vcpkg export --x-all-installed --raw --output=vcpkg --output-dir=/opt
 EOF
-RUN ./vcpkg export --host-triplet=${VCPKG_TRIPLET} --overlay-triplets=../MeshLib/triplets --x-all-installed --raw --output=vcpkg --output-dir=/opt
 
 
 FROM base AS production

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -1,38 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM ubuntu:22.04 AS build
 
-# update and install req
-RUN <<EOF
-    set -e
-    export DEBIAN_FRONTEND=noninteractive
-    export DEBCONF_NONINTERACTIVE_SEEN=true
-    echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections
-    echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
-    sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
-    apt-get update -qqy
-    apt-get install -qqy --no-install-recommends \
-        tzdata git sudo time ninja-build
-    apt-get clean
-    rm -rf /var/lib/apt/lists/*
-EOF
-
-RUN mkdir /home/MeshLib
-WORKDIR "/home/MeshLib"
-
-# copy files
-COPY .git .git
-COPY cmake cmake
-COPY thirdparty thirdparty
-COPY scripts scripts
-COPY source source
-COPY requirements requirements
-
-# build and install thirdparty
-ENV MR_STATE=DOCKER_BUILD
-RUN ./scripts/build_thirdparty.sh
-
-
-FROM ubuntu:22.04 AS production
+FROM ubuntu:22.04 AS base
 
 RUN mkdir /usr/local/lib/meshlib-thirdparty-lib/
 WORKDIR "/usr/local/lib/meshlib-thirdparty-lib/"
@@ -41,14 +9,9 @@ COPY scripts/install_apt_requirements.sh scripts/install_apt_requirements.sh
 COPY scripts/install_apt_cuda.sh scripts/install_apt_cuda.sh
 COPY scripts/mrbind/install_deps_ubuntu.sh scripts/mrbind/install_deps_ubuntu.sh
 COPY scripts/mrbind/clang_version.txt scripts/mrbind/clang_version.txt
-COPY scripts/install_thirdparty.sh scripts/install_thirdparty.sh
 COPY requirements requirements
 COPY scripts/mrbind-pybind11/python_versions.txt scripts/mrbind-pybind11/python_versions.txt
 COPY scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
-
-COPY --from=build /home/MeshLib/lib /usr/local/lib/meshlib-thirdparty-lib/lib
-COPY --from=build /home/MeshLib/include /usr/local/lib/meshlib-thirdparty-lib/include
-COPY --from=build /home/MeshLib/share /usr/local/lib/meshlib-thirdparty-lib/share
 
 ENV MR_STATE=DOCKER_BUILD
 
@@ -67,19 +30,12 @@ RUN <<EOF
     ./scripts/install_apt_cuda.sh
     ./scripts/mrbind/install_deps_ubuntu.sh
     ./scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
     apt-get update -y
     apt-get install -y gh g++-12 clang-14
     apt-get clean
     rm -rf /var/lib/apt/lists/*
-EOF
-
-RUN <<EOF
-    set -e
-    ./scripts/install_thirdparty.sh
-    echo '/usr/local/lib' | tee -a /etc/ld.so.conf
-    sudo ldconfig
 EOF
 
 # install aws cli
@@ -93,7 +49,42 @@ RUN <<EOF
     esac
     curl "$ARCH_URL" -o "awscliv2.zip"
     unzip awscliv2.zip
-    sudo ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
+    ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
+EOF
+
+
+FROM base AS build
+
+RUN mkdir /home/MeshLib
+WORKDIR "/home/MeshLib"
+
+# copy files
+COPY .git .git
+COPY cmake cmake
+COPY thirdparty thirdparty
+COPY scripts scripts
+COPY source source
+COPY requirements requirements
+
+# build and install thirdparty
+RUN ./scripts/build_thirdparty.sh
+
+
+FROM base AS production
+
+WORKDIR "/usr/local/lib/meshlib-thirdparty-lib/"
+
+COPY scripts/install_thirdparty.sh scripts/install_thirdparty.sh
+
+COPY --from=build /home/MeshLib/lib /usr/local/lib/meshlib-thirdparty-lib/lib
+COPY --from=build /home/MeshLib/include /usr/local/lib/meshlib-thirdparty-lib/include
+COPY --from=build /home/MeshLib/share /usr/local/lib/meshlib-thirdparty-lib/share
+
+RUN <<EOF
+    set -e
+    ./scripts/install_thirdparty.sh
+    echo '/usr/local/lib' | tee -a /etc/ld.so.conf
+    ldconfig
 EOF
 
 # Add a new user "actions-runner" with user id 8877

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -26,6 +26,9 @@ RUN <<EOF
     echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
     # use more reliable mirror
     sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
+    # install prerequisites for additional repos
+    apt update
+    apt install -y software-properties-common curl
     # configure GitHub repo
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
 
+
 FROM ubuntu:22.04 AS base
 
 RUN mkdir /usr/local/lib/meshlib-thirdparty-lib/
@@ -18,38 +19,33 @@ ENV MR_STATE=DOCKER_BUILD
 # update and install req
 RUN <<EOF
     set -e
+    # configure timezone
     export DEBIAN_FRONTEND=noninteractive
     export DEBCONF_NONINTERACTIVE_SEEN=true
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections
     echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
+    # use more reliable mirror
     sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
+    # configure GitHub repo
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
+    # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
+        gh g++-12 clang-14 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
     ./scripts/install_apt_requirements.sh
     ./scripts/install_apt_cuda.sh
     ./scripts/mrbind/install_deps_ubuntu.sh
     ./scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
-    apt-get update -y
-    apt-get install -y gh g++-12 clang-14
+    # clean downloaded files
     apt-get clean
     rm -rf /var/lib/apt/lists/*
-EOF
-
-# install aws cli
-RUN <<EOF
-    set -e
-    ARCH=$(uname -m)
-    case $ARCH in
-        x86_64) ARCH_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" ;;
-        aarch64) ARCH_URL="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" ;;
-        *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
-    esac
-    curl "$ARCH_URL" -o "awscliv2.zip"
+    # install aws cli
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
     unzip awscliv2.zip
     ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
+    rm -rf awscliv2.zip aws/
 EOF
 
 

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -1,39 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM ubuntu:24.04 AS build
 
-
-# update and install req
-RUN <<EOF
-    set -e
-    export DEBIAN_FRONTEND=noninteractive
-    export DEBCONF_NONINTERACTIVE_SEEN=true
-    echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections
-    echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
-    sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list.d/ubuntu.sources
-    apt-get update -qqy
-    apt-get install -qqy --no-install-recommends \
-        tzdata git sudo time ninja-build
-    apt-get clean
-    rm -rf /var/lib/apt/lists/*
-EOF
-
-RUN mkdir /home/MeshLib
-WORKDIR "/home/MeshLib"
-
-# copy files
-COPY .git .git
-COPY cmake cmake
-COPY thirdparty thirdparty
-COPY scripts scripts
-COPY source source
-COPY requirements requirements
-
-# build and install thirdparty
-ENV MR_STATE=DOCKER_BUILD
-RUN ./scripts/build_thirdparty.sh
-
-
-FROM ubuntu:24.04 AS production
+FROM ubuntu:24.04 AS base
 
 RUN mkdir /usr/local/lib/meshlib-thirdparty-lib/
 WORKDIR "/usr/local/lib/meshlib-thirdparty-lib/"
@@ -42,14 +9,9 @@ COPY scripts/install_apt_requirements.sh scripts/install_apt_requirements.sh
 COPY scripts/install_apt_cuda.sh scripts/install_apt_cuda.sh
 COPY scripts/mrbind/install_deps_ubuntu.sh scripts/mrbind/install_deps_ubuntu.sh
 COPY scripts/mrbind/clang_version.txt scripts/mrbind/clang_version.txt
-COPY scripts/install_thirdparty.sh scripts/install_thirdparty.sh
 COPY requirements requirements
 COPY scripts/mrbind-pybind11/python_versions.txt scripts/mrbind-pybind11/python_versions.txt
 COPY scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
-
-COPY --from=build /home/MeshLib/lib /usr/local/lib/meshlib-thirdparty-lib/lib
-COPY --from=build /home/MeshLib/include /usr/local/lib/meshlib-thirdparty-lib/include
-COPY --from=build /home/MeshLib/share /usr/local/lib/meshlib-thirdparty-lib/share
 
 ENV MR_STATE=DOCKER_BUILD
 
@@ -68,19 +30,12 @@ RUN <<EOF
     ./scripts/install_apt_cuda.sh
     ./scripts/mrbind/install_deps_ubuntu.sh
     ./scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
     apt-get update -y
     apt-get install -y gh g++-13 clang-18
     apt-get clean
     rm -rf /var/lib/apt/lists/*
-EOF
-
-RUN <<EOF
-    set -e
-    ./scripts/install_thirdparty.sh
-    echo '/usr/local/lib' | tee -a /etc/ld.so.conf
-    sudo ldconfig
 EOF
 
 # install gcc-14
@@ -106,7 +61,42 @@ RUN <<EOF
     esac
     curl "$ARCH_URL" -o "awscliv2.zip"
     unzip awscliv2.zip
-    sudo ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
+    ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
+EOF
+
+
+FROM base AS build
+
+RUN mkdir /home/MeshLib
+WORKDIR "/home/MeshLib"
+
+# copy files
+COPY .git .git
+COPY cmake cmake
+COPY thirdparty thirdparty
+COPY scripts scripts
+COPY source source
+COPY requirements requirements
+
+# build and install thirdparty
+RUN ./scripts/build_thirdparty.sh
+
+
+FROM base AS production
+
+WORKDIR "/usr/local/lib/meshlib-thirdparty-lib/"
+
+COPY scripts/install_thirdparty.sh scripts/install_thirdparty.sh
+
+COPY --from=build /home/MeshLib/lib /usr/local/lib/meshlib-thirdparty-lib/lib
+COPY --from=build /home/MeshLib/include /usr/local/lib/meshlib-thirdparty-lib/include
+COPY --from=build /home/MeshLib/share /usr/local/lib/meshlib-thirdparty-lib/share
+
+RUN <<EOF
+    set -e
+    ./scripts/install_thirdparty.sh
+    echo '/usr/local/lib' | tee -a /etc/ld.so.conf
+    ldconfig
 EOF
 
 # Add a new user "actions-runner" with user id 8877

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -26,12 +26,13 @@ RUN <<EOF
     echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
     # use more reliable mirror
     sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list.d/ubuntu.sources
+    # install prerequisites for additional repos
+    apt update
+    apt install -y software-properties-common curl
     # configure GitHub repo
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
     # configure Ubuntu Toolchain repo
-    apt update
-    apt install -y software-properties-common
     add-apt-repository -y ppa:ubuntu-toolchain-r/test
     # install packages
     apt-get update -qqy

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
 
+
 FROM ubuntu:24.04 AS base
 
 RUN mkdir /usr/local/lib/meshlib-thirdparty-lib/
@@ -18,50 +19,37 @@ ENV MR_STATE=DOCKER_BUILD
 # update and install req
 RUN <<EOF
     set -e
+    # configure timezone
     export DEBIAN_FRONTEND=noninteractive
     export DEBCONF_NONINTERACTIVE_SEEN=true
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections
     echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
+    # use more reliable mirror
     sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list.d/ubuntu.sources
+    # configure GitHub repo
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
+    # configure Ubuntu Toolchain repo
+    apt update
+    apt install -y software-properties-common
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
+        gh g++-13 gcc-14 g++-14 clang-18 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
     ./scripts/install_apt_requirements.sh
     ./scripts/install_apt_cuda.sh
     ./scripts/mrbind/install_deps_ubuntu.sh
     ./scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
-    apt-get update -y
-    apt-get install -y gh g++-13 clang-18
+    # clean downloaded files
     apt-get clean
     rm -rf /var/lib/apt/lists/*
-EOF
-
-# install gcc-14
-RUN <<EOF
-    set -e
-    apt update
-    apt install -y software-properties-common
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test
-    apt update
-    apt install -y gcc-14 g++-14
-    apt clean
-    rm -rf /var/lib/apt/lists/*
-EOF
-
-# install aws cli
-RUN <<EOF
-    set -e
-    ARCH=$(uname -m)
-    case $ARCH in
-        x86_64) ARCH_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" ;;
-        aarch64) ARCH_URL="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" ;;
-        *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
-    esac
-    curl "$ARCH_URL" -o "awscliv2.zip"
+    # install aws cli
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
     unzip awscliv2.zip
     ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
+    rm -rf awscliv2.zip aws/
 EOF
 
 


### PR DESCRIPTION
Our Docker images consist of two stages, 'build' and 'production', and both of them install system packages, most of which are shared. This change adds an additional 'base' stage with the package installation reused by remaining stages. The main advantages:
- The time spent on downloading and installing packages is reduced.
- The affect of possible network issues is reduced too.

## Image size impact (Docker Hub, compressed/download size)

`latest` = master, `feature-docker_base_stage` = this PR.

| Image (arch) | master `latest` | this PR | Δ |
|---|--:|--:|--:|
| ubuntu22 (amd64) | 1385.9 MB | 1174.6 MB | −211.3 MB (−15.2%) |
| ubuntu24 (amd64) | 1334.4 MB | 1164.1 MB | −170.3 MB (−12.8%) |
| ubuntu22-arm64 | 1325.8 MB | 1121.3 MB | −204.5 MB (−15.4%) |
| ubuntu24-arm64 | 1220.5 MB | 1067.5 MB | −153.0 MB (−12.5%) |
| emscripten-arm64 | 835.7 MB | 835.7 MB | 0 (unchanged) |
| rockylinux8-vcpkg-x64 | 1095.3 MB | 1070.9 MB | −24.4 MB (−2.2%) |
| rockylinux8-vcpkg-arm64 | 1043.7 MB | 1019.5 MB | −24.2 MB (−2.3%) |

Aggregate across the seven rebuilt images: ~8241 MB → ~7454 MB (**−788 MB, −9.6%**). No image grows.

`rockylinux9-vcpkg` is edited too but isn't in the active build matrix, so there's no published image to compare.
