### PR TITLE
CI: use setup-vcpkg-windows action in prepare-images Windows job

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -101,7 +101,10 @@ jobs:
         with:
           vcpkg-version: ${{ matrix.vcpkg-version }}
           vcpkg-triplet: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
-          install-flags: '--write-s3 --use-s3-asset-provider'
+          # The S3 asset provider is only used for the VS2019 triplets
+          # (x64-windows-vs2019-meshlib and x64-windows-meshlib-iterator-debug);
+          # VS2022/VS2026 fetch their assets from upstream instead.
+          install-flags: ${{ (matrix.vcpkg_triplet == 'x64-windows-vs2019-meshlib' || matrix.vcpkg_triplet == 'x64-windows-meshlib-iterator-debug') && '--write-s3 --use-s3-asset-provider' || '--write-s3' }}
           internal-build: ${{ inputs.internal_build }}
 
       - name: Install CUDA

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -216,6 +216,11 @@ jobs:
     if: ${{ inputs.need_windows_vcpkg_rebuild && !inputs.disable_windows }}
     timeout-minutes: 240
     runs-on: ${{ matrix.runner }}
+    # install.bat (run inside the setup-vcpkg-windows action) picks the triplet
+    # from VCPKG_DEFAULT_TRIPLET; set it at the job level so it propagates into
+    # the composite action's steps (a step-level `env:` would not).
+    env:
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
     strategy:
       fail-fast: false
       matrix:
@@ -237,14 +242,6 @@ jobs:
             vcpkg-version: ${{ inputs.vs19_vcpkg_version }}
             vcpkg_triplet: x64-windows-meshlib-iterator-debug
     steps:
-      - name: Setup vcpkg
-        working-directory: C:\vcpkg
-        run: |
-          git fetch
-          git checkout ${{ matrix.vcpkg-version }}
-          bootstrap-vcpkg.bat
-          vcpkg.exe integrate install
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -259,7 +256,11 @@ jobs:
           retry-max-attempts: 5
 
       - name: Build and cache vcpkg
-        env:
-          VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
-        run: |
-          .\thirdparty\install.bat --write-s3 --use-s3-asset-provider
+        uses: ./.github/actions/setup-vcpkg-windows
+        with:
+          vcpkg-version: ${{ matrix.vcpkg-version }}
+          vcpkg-triplet: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
+          # The S3 asset provider is only used for the VS2019 triplets
+          # (x64-windows-vs2019-meshlib and x64-windows-meshlib-iterator-debug);
+          # VS2022/VS2026 fetch their assets from upstream instead.
+          install-flags: ${{ matrix.vs == 'vs2019' && '--write-s3 --use-s3-asset-provider' || '--write-s3' }}

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -263,4 +263,4 @@ jobs:
           # The S3 asset provider is only used for the VS2019 triplets
           # (x64-windows-vs2019-meshlib and x64-windows-meshlib-iterator-debug);
           # VS2022/VS2026 fetch their assets from upstream instead.
-          install-flags: ${{ matrix.vs == 'vs2019' && '--write-s3 --use-s3-asset-provider' || '--write-s3' }}
+          install-flags: ${{ (matrix.vcpkg_triplet == 'x64-windows-vs2019-meshlib' || matrix.vcpkg_triplet == 'x64-windows-meshlib-iterator-debug') && '--write-s3 --use-s3-asset-provider' || '--write-s3' }}


### PR DESCRIPTION
## What

Two related Windows-vcpkg CI changes:

1. Build the Windows vcpkg images in the `prepare-images` workflow through the shared `setup-vcpkg-windows` composite action instead of a bespoke setup + `install.bat` invocation.
2. Restrict the `--use-s3-asset-provider` flag to the VS2019 triplets across **every** workflow that drives that action.

## `prepare-images.yml`

- **Use the `setup-vcpkg-windows` action in the "Build and cache vcpkg" step.** The action wraps the build in a binary-cache lookup / restore / save (and runs `vcpkg integrate install`), so subsequent image rebuilds can reuse a warm cache instead of always building from source.
- **Drop the redundant "Setup vcpkg" step.** The manual `git checkout` + `bootstrap-vcpkg.bat` + `vcpkg integrate install` is now done by the action itself. Keeping it would have done a full bootstrap that the action discards on every cache hit.
- **Move `VCPKG_DEFAULT_TRIPLET` to the job level.** `install.bat` reads the triplet from this env var; a step-level `env:` on a `uses:` step does not propagate into a composite action's steps, so it has to live at the job level (same pattern as `build-test-windows.yml`). Without this, all four cells would fall back to `x64-windows-meshlib`.

## `--use-s3-asset-provider` only for VS2019 — across all workflows

The asset provider is now passed only for the VS2019 triplets — `x64-windows-vs2019-meshlib` and `x64-windows-meshlib-iterator-debug`. VS2022 / VS2026 fetch their assets from upstream. `--write-s3` is still passed for every triplet.

- `prepare-images.yml` — conditional `install-flags` (keyed on the triplet name).
- `build-test-windows.yml` — previously passed `--use-s3-asset-provider` unconditionally for all triplets; now gated on the same triplet condition.

All call sites use the identical expression — the same one the action already uses internally to select its VS2019 overlay ports. `pip-build.yml` and `update-win-version.yml` don't pass `--use-s3-asset-provider`, so they already comply and are left unchanged.

## CI

- `bump-vcpkg` label is applied so `need_windows_vcpkg_rebuild` is forced true and the `prepare-image / windows-vcpkg-build-upload` job actually runs on this PR (a CI-file-only change does not match the `windows-changes` paths filter, so it would otherwise be skipped).
- `disable-build-*` labels are applied for every platform this PR doesn't touch; Windows is left enabled.

## Notes

- AWS credentials are unchanged: the existing static-key `Configure AWS Credentials` step still runs before the action, and the action is invoked with the default `internal-build: false`, so it consumes those ambient credentials rather than assuming an OIDC role.
