### PR TITLE
printStacktraceOnCrash improvements for Windows

### DIFF
--- a/source/MRMesh/MRStacktrace.cpp
+++ b/source/MRMesh/MRStacktrace.cpp
@@ -25,19 +25,24 @@ namespace MR
 
 void printStacktraceOnCrash()
 {
+    std::signal( SIGABRT, crashSignalHandler );
+
+#ifndef _WIN32
+    //on Windows we use WindowsExceptionsLogger instead of the following signals
     std::signal( SIGTERM, crashSignalHandler );
     std::signal( SIGSEGV, crashSignalHandler );
     std::signal( SIGINT, crashSignalHandler );
     std::signal( SIGILL, crashSignalHandler );
-    std::signal( SIGABRT, crashSignalHandler );
     std::signal( SIGFPE, crashSignalHandler );
-#ifndef _WIN32
+
+    // these signals are not present in Microsoft's implementation
     std::signal( SIGHUP,  crashSignalHandler );
     std::signal( SIGQUIT, crashSignalHandler );
     std::signal( SIGBUS,  crashSignalHandler );
     std::signal( SIGSYS,  crashSignalHandler );
     std::signal( SIGUSR1, crashSignalHandler );
     std::signal( SIGUSR2, crashSignalHandler );
+
     // cpp-httplib relies on SIGPIPE being ignored process-wide so socket
     // writes to a disconnected peer return EPIPE instead of terminating the process.
     std::signal( SIGPIPE, SIG_IGN );

--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -617,9 +617,7 @@ void setupLoggerByDefault( const std::function<void()>& customLogSinkAdder )
         logger->sinks().clear(); // clear all sinks when setting default logger
 
 #ifndef __EMSCRIPTEN__
-#ifndef _WIN32 //on Windows we use WindowsExceptionsLogger instead
     printStacktraceOnCrash();
-#endif
 #endif //__EMSCRIPTEN__
     redirectSTDStreamsToLogger();
 


### PR DESCRIPTION
## Summary

On Windows, `printStacktraceOnCrash()` was never installed — crash logging relied entirely on `WindowsExceptionsLogger`. That handler catches structured (SEH) exceptions such as access violations, but it is compiled only in release builds (`_WIN32 && NDEBUG`) and never intercepts `abort()` / `SIGABRT`. As a result, aborts (failed assertions, `std::terminate`, unhandled C++ exceptions, etc.) produced no stacktrace in the log on Windows.

This PR installs a `SIGABRT` handler on Windows so such crashes are logged, while leaving the remaining crash conditions to `WindowsExceptionsLogger`.

## Changes

- **`MRStacktrace.cpp`** — register the `SIGABRT` handler on all platforms (including Windows). The other standard signals (`SIGTERM`, `SIGSEGV`, `SIGINT`, `SIGILL`, `SIGFPE`) are now registered only on non-Windows, since `WindowsExceptionsLogger` covers those cases on Windows. Added comments documenting the split.
- **`MRSystem.cpp`** — `setupLoggerByDefault()` now calls `printStacktraceOnCrash()` on Windows too (removed the `#ifndef _WIN32` guard).
