### PR TITLE
ci(macos): upload artifacts directly, drop Wandalen/wretry.action

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -272,16 +272,12 @@ jobs:
         if: ${{ inputs.upload_artifacts && matrix.config == 'Release' }}
         env:
           ACTIONS_ARTIFACT_UPLOAD_TIMEOUT_MS: 1800000
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/upload-artifact@v7
         with:
-          action: actions/upload-artifact@v7
-          attempt_limit: 3
-          attempt_delay: 30000 # milliseconds
-          with: |
-            name: Distributives_macos-${{matrix.arch}}
-            path: meshlib_${{matrix.arch}}.pkg
-            retention-days: 1
-            overwrite: true
+          name: Distributives_macos-${{matrix.arch}}
+          path: meshlib_${{matrix.arch}}.pkg
+          retention-days: 1
+          overwrite: true
 
       - name: Collect artifact stats
         # Mirror `Upload Macos Distribution`'s gate -- otherwise Debug jobs
@@ -308,13 +304,9 @@ jobs:
 
       - name: Upload NuGet files to Artifacts
         if: ${{ inputs.nuget_build_patch && matrix.config == 'Release' }}
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/upload-artifact@v7
         with:
-          action: actions/upload-artifact@v7
-          attempt_limit: 3
-          attempt_delay: 30000 # milliseconds
-          with: |
-            name: DotNetPatchArchiveMacOs-${{ matrix.arch }}
-            path: ./patched_content/*
-            retention-days: 1
-            overwrite: true
+          name: DotNetPatchArchiveMacOs-${{ matrix.arch }}
+          path: ./patched_content/*
+          retention-days: 1
+          overwrite: true


### PR DESCRIPTION
## What

Remove the `Wandalen/wretry.action` wrapper from the two macOS upload steps in `.github/workflows/build-test-macos.yml` and call `actions/upload-artifact@v7` directly.

## Why

`wretry.action`'s auto-generated **pre-step** git-clones the wrapped action (`actions/upload-artifact`) onto the runner before the job's main steps run. On the self-hosted macOS runners this full clone costs **~1 minute per job**, and it runs even on Debug jobs where the upload steps are gated off.

Example: in [this run](https://github.com/MeshInspector/MeshLib/actions/runs/27118403257/job/80054691863) the `Pre Upload Macos Distribution` step took ~59 s — entirely the `git clone` of `actions/upload-artifact`. The very next pre-step, `Pre Upload NuGet files to Artifacts`, wraps the same action, found it already on disk, and took 0 s.

`actions/upload-artifact@v7` is the genuine upstream v7.0.0 (introduced repo-wide by #5762); its `@actions/artifact` v2 backend already retries transient upload failures internally with backoff. The step-level retry wrapper is therefore redundant.

## Trade-off

We lose "re-run the whole action up to 3×" semantics. The internal HTTP-level retries remain and cover the common transient-network case; a hard failure of the upload action as a whole is rare.

## Testing

The changed steps are gated by `upload_artifacts` / `nuget_build_patch` (Release only), so they do not execute on normal PR CI — but the macOS build job still parses and runs the workflow, validating the YAML. The actual upload is exercised on distribute/release runs.
