### PR TITLE
ci: extract setup-cuda composite action

### DIFF
--- a/.github/actions/setup-cuda/action.yml
+++ b/.github/actions/setup-cuda/action.yml
@@ -1,0 +1,40 @@
+name: 'Set up CUDA'
+description: 'Export the CUDA toolkit environment variables (CUDA_PATH / CUDA_PATH_Vx_y / PATH) for an already-installed toolkit and, optionally, copy CUDA''s MSBuild integration files into Visual Studio.'
+inputs:
+  cuda-major:
+    description: 'CUDA major version (e.g. 12).'
+    required: true
+  cuda-minor:
+    description: 'CUDA minor version (e.g. 0).'
+    required: true
+  install-vs-integration:
+    description: >
+      Copy CUDA''s MSBuild BuildCustomizations into Visual Studio. Only needed
+      for MSBuild-based builds (CMake builds invoke nvcc directly). Requires
+      VC_PATH to be set, e.g. by the locate-visual-studio action.
+    required: false
+    default: 'true'
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup CUDA
+      shell: pwsh
+      run: |
+        $cudaRoot = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ inputs.cuda-major }}.${{ inputs.cuda-minor }}"
+        "CUDA_PATH=$cudaRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "CUDA_PATH_V${{ inputs.cuda-major }}_${{ inputs.cuda-minor }}=$cudaRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "CUDA_PATH_VX_Y=CUDA_PATH_V${{ inputs.cuda-major }}_${{ inputs.cuda-minor }}" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "$cudaRoot\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+    - name: Install Visual Studio Integration
+      # CUDA's MSBuild integration files are only consumed by the MSBuild
+      # variant (source/MRCuda/MRCuda.vcxproj imports
+      # `$(VCTargetsPath)\BuildCustomizations\CUDA $(MRCudaVersion).props`).
+      # The CMake variants use `project(MRCuda CXX CUDA)` and call nvcc
+      # directly, so this step is a no-op for them.
+      if: ${{ inputs.install-vs-integration == 'true' }}
+      shell: pwsh
+      run: |
+        $x = (dir $env:CUDA_PATH -dir -recurse -depth 2).where({$_.name -eq 'visual_studio_integration'}).fullname
+        $y = (dir $x -dir -recurse).where({$_.name -eq 'MSBuildExtensions'}).fullname + '\*'
+        (gi "$env:VC_PATH\MSBuild\Microsoft\VC\*\BuildCustomizations").fullname.foreach({cp $y $_})

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -114,25 +114,13 @@ jobs:
           cuda-major: ${{ env.CUDA_MAJOR }}
           cuda-minor: ${{ env.CUDA_MINOR }}
 
-      - name: Setup CUDA
-        shell: cmd
-        run: |
-          echo>>%GITHUB_ENV% CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ env.CUDA_MAJOR }}.${{ env.CUDA_MINOR }}
-          echo>>%GITHUB_ENV% CUDA_PATH_V${{ env.CUDA_MAJOR }}_${{ env.CUDA_MINOR }}=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ env.CUDA_MAJOR }}.${{ env.CUDA_MINOR }}
-          echo>>%GITHUB_ENV% CUDA_PATH_VX_Y=CUDA_PATH_V${{ env.CUDA_MAJOR }}_${{ env.CUDA_MINOR }}
-          echo>>%GITHUB_PATH% C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ env.CUDA_MAJOR }}.${{ env.CUDA_MINOR }}\bin
-
-      - name: Install Visual Studio Integration
-        # CUDA's MSBuild integration files are only consumed by the MSBuild
-        # variant (source/MRCuda/MRCuda.vcxproj imports
-        # `$(VCTargetsPath)\BuildCustomizations\CUDA $(MRCudaVersion).props`).
-        # The CMake variants use `project(MRCuda CXX CUDA)` and call nvcc
-        # directly, so this step is a no-op for them.
-        if: ${{ matrix.build_system == 'MSBuild' }}
-        run: |
-          $x = (dir $env:CUDA_PATH -dir -recurse -depth 2).where({$_.name -eq 'visual_studio_integration'}).fullname
-          $y = (dir $x -dir -recurse).where({$_.name -eq 'MSBuildExtensions'}).fullname + '\*'
-          (gi '${{env.VC_PATH}}\MSBuild\Microsoft\VC\*\BuildCustomizations').fullname.foreach({cp $y $_})
+      - name: Set up CUDA
+        uses: ./.github/actions/setup-cuda
+        with:
+          cuda-major: ${{ env.CUDA_MAJOR }}
+          cuda-minor: ${{ env.CUDA_MINOR }}
+          # MSBuild consumes CUDA's BuildCustomizations; CMake calls nvcc directly.
+          install-vs-integration: ${{ matrix.build_system == 'MSBuild' }}
 
       - name: Setup python
         run: py -3 scripts\setup_win_python_reqs.py

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -391,18 +391,11 @@ jobs:
           cuda-major: ${{ env.CUDA-MAJOR }}
           cuda-minor: ${{ env.CUDA-MINOR }}
 
-      - name: Setup CUDA
-        run: |
-          "CUDA_PATH=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v${{ env.CUDA-MAJOR }}.${{ env.CUDA-MINOR }}" >> $env:GITHUB_ENV
-          "CUDA_PATH_V${{ env.CUDA-MAJOR }}_${{ env.CUDA-MINOR }}=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v${{ env.CUDA-MAJOR }}.${{ env.CUDA-MINOR }}" >> $env:GITHUB_ENV
-          "CUDA_PATH_VX_Y=CUDA_PATH_V${{ env.CUDA-MAJOR }}_${{ env.CUDA-MINOR }}" >> $env:GITHUB_ENV
-          "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v${{ env.CUDA-MAJOR }}.${{ env.CUDA-MINOR }}\\bin" >> $env:GITHUB_PATH
-
-      - name: Install Visual Studio Integration
-        run: |
-          $x = (dir $env:CUDA_PATH -dir -recurse -depth 2).where({$_.name -eq 'visual_studio_integration'}).fullname
-          $y = (dir $x -dir -recurse).where({$_.name -eq 'MSBuildExtensions'}).fullname + '\*'
-          (gi '${{ env.VC_PATH }}\MSBuild\Microsoft\VC\*\BuildCustomizations').fullname.foreach({cp $y $_})
+      - name: Set up CUDA
+        uses: ./.github/actions/setup-cuda
+        with:
+          cuda-major: ${{ env.CUDA-MAJOR }}
+          cuda-minor: ${{ env.CUDA-MINOR }}
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0


### PR DESCRIPTION
## What

Extract the duplicated **Setup CUDA** and **Install Visual Studio Integration** steps from `build-test-windows.yml` and `pip-build.yml` into a new reusable composite action `.github/actions/setup-cuda`.

## Why

Both Windows jobs hand-rolled the same two steps:

- **Setup CUDA** — export `CUDA_PATH`, `CUDA_PATH_Vx_y`, `CUDA_PATH_VX_Y` and prepend `…\bin` to `PATH` for an already-installed toolkit.
- **Install Visual Studio Integration** — copy CUDA's `MSBuildExtensions` (`BuildCustomizations`) into the located Visual Studio install.

They had drifted apart (one used `cmd`, the other `pwsh`; env-var input names differed), which is exactly the kind of thing a shared action prevents.

## The action

`setup-cuda` takes:

| input | required | default | notes |
|-------|----------|---------|-------|
| `cuda-major` | yes | — | e.g. `12` |
| `cuda-minor` | yes | — | e.g. `0` |
| `install-vs-integration` | no | `true` | copy CUDA's MSBuild BuildCustomizations into VS; requires `VC_PATH` (set by `locate-visual-studio`) |

The VS-integration step is gated on `install-vs-integration` so the existing per-build-system behavior is preserved:

- **build-test-windows.yml** passes `install-vs-integration: ${{ matrix.build_system == 'MSBuild' }}` — CMake builds invoke `nvcc` directly and don't consume the BuildCustomizations, so the step stays a no-op there (same `if:` condition as before, just relocated into the action input).
- **pip-build.yml** is MSBuild-only and keeps the default (`true`).

## Notes

- The env export is unified on `pwsh`. The path now uses single backslashes; the doubled backslashes in pip-build's previous `pwsh` variant were literal but tolerated by the Windows path APIs, so behavior is unchanged.
- The `install-cuda` action (which actually downloads/caches the toolkit) is untouched and still runs immediately before `setup-cuda` in both jobs.

## Testing

Non-Windows platforms are disabled for this CI run since the change is Windows-only. `test-pip-build` is enabled so the modified `pip-build.yml` Windows job is exercised.
