### PR TITLE
ci: pass 3-part CUDA semver to install-cuda action

### DIFF
--- a/.github/actions/install-cuda/action.yml
+++ b/.github/actions/install-cuda/action.yml
@@ -2,7 +2,7 @@ name: 'Install CUDA Toolkit (subset)'
 description: 'Restore the cached CUDA toolkit (or install the nvcc/cudart/visual_studio_integration sub-packages on miss) at the standard NVIDIA install path.'
 inputs:
   cuda-version:
-    description: 'Full chocolatey-style CUDA version (e.g. 12.0.1.52833). The trailing build number is stripped before being passed to Jimver/cuda-toolkit.'
+    description: 'CUDA version as major.minor.patch (e.g. 12.0.1), passed as-is to Jimver/cuda-toolkit.'
     required: true
   cuda-major:
     description: 'CUDA major version (e.g. 12).'
@@ -13,12 +13,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Resolve CUDA semver
-      id: cuda-semver
+    - name: Resolve CUDA sub-packages
+      id: cuda-sub-packages
       shell: pwsh
       run: |
-        $semver = (("${{ inputs.cuda-version }}" -split '\.')[0..2]) -join '.'
-        "version=$semver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         # CUDA 13 split pieces that used to live inside the nvcc package into
         # standalone components: 'crt' (crt/host_config.h, pulled in by
         # cuda_runtime.h) and 'nvvm' (the cicc device-compiler front-end).
@@ -41,6 +39,6 @@ runs:
       if: steps.cuda-cache.outputs.cache-hit != 'true'
       uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
       with:
-        cuda: ${{ steps.cuda-semver.outputs.version }}
+        cuda: ${{ inputs.cuda-version }}
         method: network
-        sub-packages: ${{ steps.cuda-semver.outputs.sub-packages }}
+        sub-packages: ${{ steps.cuda-sub-packages.outputs.sub-packages }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -48,7 +48,7 @@ jobs:
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
       job_upload_artifact: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
-      CUDA_VERSION: ${{ fromJSON('{"msvc-2019":"11.4.2.47141","msvc-2022":"12.0.1.52833"}')[matrix.cxx_compiler] || '13.2.0' }}
+      CUDA_VERSION: ${{ fromJSON('{"msvc-2019":"11.4.2","msvc-2022":"12.0.1"}')[matrix.cxx_compiler] || '13.2.0' }}
       CUDA_MAJOR: ${{ fromJSON('{"msvc-2019":"11","msvc-2022":"12"}')[matrix.cxx_compiler] || '13' }}
       CUDA_MINOR: ${{ fromJSON('{"msvc-2019":"4","msvc-2022":"0"}')[matrix.cxx_compiler] || '2' }}
       VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -357,7 +357,7 @@ jobs:
       contents: read  # This is required for actions/checkout
     env:
       VCPKG-VERSION: '2026.06.01'
-      CUDA-VERSION: '12.0.1.52833'
+      CUDA-VERSION: '12.0.1'
       CUDA-MAJOR: '12'
       CUDA-MINOR: '0'
       VCPKG_DEFAULT_TRIPLET: x64-windows-vs2022-meshlib


### PR DESCRIPTION
## What

The `install-cuda` composite action now accepts a plain `major.minor.patch` CUDA version (e.g. `12.0.1`) and passes it straight to `Jimver/cuda-toolkit`, instead of taking a chocolatey-style 4-part string (e.g. `12.0.1.52833`) and stripping the trailing build number itself.

## Why

`Jimver/cuda-toolkit` only accepts 3-part semver. Previously the action ran a PowerShell pre-step:

```pwsh
$semver = (("12.0.1.52833" -split '\.')[0..2]) -join '.'   # -> 12.0.1
```

The 4-part build number was never needed by the installer — it only fed that strip step and the cache key. Supplying the semver directly removes a moving part: callers now state exactly the version that gets installed.

## Changes

- **`.github/actions/install-cuda/action.yml`** — drop the `$semver` strip; pass `inputs.cuda-version` directly to `Jimver/cuda-toolkit`. The remaining PowerShell step only computes the sub-package list, so it is renamed `Resolve CUDA sub-packages`. Input description updated.
- **`.github/workflows/build-test-windows.yml`** — `11.4.2.47141` → `11.4.2`, `12.0.1.52833` → `12.0.1` (the `13.2.0` default was already 3-part).
- **`.github/workflows/pip-build.yml`** — `12.0.1.52833` → `12.0.1`.

## Notes

- The cache key (`cuda-toolkit-subset-<version>-v1`) now drops the build number, so the first Windows run on each branch repopulates the CUDA cache once; subsequent runs hit normally.
- Windows-only change. `test-pip-build` is enabled so the changed `pip-build.yml` CUDA path is exercised; unaffected platforms are disabled.
