### PR TITLE
CudaBasic: do not include <vector> during kernels' compilation

### DIFF
--- a/source/MRCuda/MRCudaBasic.cuh
+++ b/source/MRCuda/MRCudaBasic.cuh
@@ -2,10 +2,11 @@
 
 #include "MRCuda.cuh"
 
+#ifndef __CUDACC__ // reduce dependency of CUDA kernels from host STL
 #include "MRMesh/MRVector.h"
+#endif
 
 #include <cstdint>
-#include <vector>
 
 namespace MR
 {
@@ -18,11 +19,10 @@ class DynamicArray
 {
 public:
     DynamicArray() = default;
+
     // malloc given size on GPU
     explicit DynamicArray( size_t size );
-    // copy given vector to GPU
-    template <typename U>
-    explicit DynamicArray( const std::vector<U>& vec );
+
     // free this array from GPU (if needed)
     ~DynamicArray();
 
@@ -31,6 +31,11 @@ public:
 
     DynamicArray( const DynamicArray& ) = delete;
     DynamicArray& operator=( const DynamicArray& other ) = delete;
+
+#ifndef __CUDACC__
+    // copy given vector to GPU
+    template <typename U>
+    explicit DynamicArray( const std::vector<U>& vec );
 
     // copy given vector to GPU (if this array was allocated with inconsistent size, free it and then malloc again)
     template <typename U>
@@ -43,15 +48,16 @@ public:
         return fromVector( vec.vec_ );
     }
 
+    // copy this GPU array to given vector
+    template <typename U>
+    cudaError_t toVector( std::vector<U>& vec ) const;
+#endif
+
     // copy given data to GPU (if this array was allocated with inconsistent size, free it and then malloc again)
     cudaError_t fromBytes( const uint8_t* data, size_t numBytes );
 
     // copy given data to CPU (data should be already allocated)
     cudaError_t toBytes( uint8_t* data );
-
-    // copy this GPU array to given vector
-    template <typename U>
-    cudaError_t toVector( std::vector<U>& vec ) const;
 
     // copy given data to GPU (truncated if the array size is smaller that the data one)
     template <typename U>

--- a/source/MRCuda/MRCudaBasic.hpp
+++ b/source/MRCuda/MRCudaBasic.hpp
@@ -41,13 +41,6 @@ DynamicArray<T>::DynamicArray( size_t size )
 }
 
 template<typename T>
-template<typename U>
-DynamicArray<T>::DynamicArray( const std::vector<U>& vec )
-{
-    fromVector( vec );
-}
-
-template<typename T>
 DynamicArray<T>::~DynamicArray()
 {
     resize( 0 );
@@ -72,6 +65,14 @@ DynamicArray<T>& DynamicArray<T>::operator=( DynamicArray&& other )
     return *this;
 }
 
+#ifndef __CUDACC__
+template<typename T>
+template<typename U>
+DynamicArray<T>::DynamicArray( const std::vector<U>& vec )
+{
+    fromVector( vec );
+}
+
 template<typename T>
 template<typename U>
 inline cudaError_t DynamicArray<T>::fromVector( const std::vector<U>& vec )
@@ -82,6 +83,15 @@ inline cudaError_t DynamicArray<T>::fromVector( const std::vector<U>& vec )
     return CUDA_LOGE( cudaMemcpy( data_, vec.data(), size_ * sizeof( T ), cudaMemcpyHostToDevice ) );
 }
 
+template<typename T>
+template<typename U>
+cudaError_t DynamicArray<T>::toVector( std::vector<U>& vec ) const
+{
+    static_assert ( sizeof( T ) == sizeof( U ) );
+    vec.resize( size_ );
+    return CUDA_LOGE( cudaMemcpy( vec.data(), data_, size_ * sizeof( T ), cudaMemcpyDeviceToHost ) );
+}
+#endif //!__CUDACC__
 
 template <typename T>
 inline cudaError_t DynamicArray<T>::fromBytes( const uint8_t* data, size_t numBytes )
@@ -131,15 +141,6 @@ cudaError_t DynamicArray<T>::resize( size_t size )
             return code;
     }
     return cudaSuccess;
-}
-
-template<typename T>
-template<typename U>
-cudaError_t DynamicArray<T>::toVector( std::vector<U>& vec ) const
-{
-    static_assert ( sizeof( T ) == sizeof( U ) );
-    vec.resize( size_ );
-    return CUDA_LOGE( cudaMemcpy( vec.data(), data_, size_ * sizeof( T ), cudaMemcpyDeviceToHost ) );
 }
 
 inline cudaError_t setToZero( DynamicArrayF& devArray )


### PR DESCRIPTION
Reduces the dependency of CUDA device code on the host STL.

`DynamicArray` previously included `<vector>` and `MRMesh/MRVector.h` and exposed several `std::vector`-based members unconditionally. These pulled the host STL into every translation unit, including the device-side kernel compilation pass where they are neither needed nor desirable.

The `std::vector`-dependent parts are now guarded with `#ifndef __CUDACC__`, so they are only visible to the host compiler:
- the `DynamicArray( const std::vector<U>& )` constructor;
- `fromVector( const std::vector<U>& )` and its `MR::Vector<U, I>` overload;
- `toVector()`;
- the `#include` of `MRMesh/MRVector.h`.

The `<vector>` include is dropped entirely. The byte-oriented API (`fromBytes`, `toBytes`, `copyFrom`, `copyTo`, `resize`, ...) remains available to both host and device passes.

No functional change for host code — the vector-based interface is unchanged when compiled by the host compiler.
