### PR TITLE
Add experimental vcpkg manifest file

### DIFF
--- a/.github/workflows/vcpkg-auto-update.yml
+++ b/.github/workflows/vcpkg-auto-update.yml
@@ -31,6 +31,11 @@ jobs:
           latest_vcpkg_tag=$(gh api repos/microsoft/vcpkg/releases/latest --jq '.tag_name' | tr -d '"')
           echo "latest_vcpkg_tag=${latest_vcpkg_tag}" >> $GITHUB_OUTPUT
           echo "latest vcpkg tag: ${latest_vcpkg_tag}"
+
+          latest_vcpkg_baseline=$(gh api repos/microsoft/vcpkg/commits/${latest_vcpkg_tag} --jq '.sha')
+          [[ "${latest_vcpkg_baseline}" =~ ^[0-9a-f]{40}$ ]] || { echo "Failed to resolve baseline commit for ${latest_vcpkg_tag}"; exit 1; }
+          echo "latest_vcpkg_baseline=${latest_vcpkg_baseline}" >> $GITHUB_OUTPUT
+          echo "latest vcpkg baseline: ${latest_vcpkg_baseline}"
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +73,11 @@ jobs:
           find . -type f -not -path './thirdparty*' ! -path './thirdparty/install.bat' -exec \
             sed -i 's/${{ steps.extract-tag.outputs.current_vcpkg_tag }}/${{ steps.get-latest-tag.outputs.latest_vcpkg_tag }}/g' {} +
 
+          # Update the vcpkg manifest and the Windows install batch
           sed -i "s/${{ steps.extract-tag.outputs.current_vcpkg_tag }}/${{ steps.get-latest-tag.outputs.latest_vcpkg_tag }}/g" ./thirdparty/install.bat
+          sed -i "s/${{ steps.extract-tag.outputs.current_vcpkg_tag }}/${{ steps.get-latest-tag.outputs.latest_vcpkg_tag }}/g" ./thirdparty/vcpkg/vcpkg.json
+          current_vcpkg_baseline=$(jq -r '.configuration["default-registry"].baseline' "${manifest}")
+          sed -i "s/${current_vcpkg_baseline}/${{ steps.get-latest-tag.outputs.latest_vcpkg_baseline }}/g" ./thirdparty/vcpkg/vcpkg.json
 
           # Commit the changes
           git commit -am "Update vcpkg tag to ${{ steps.get-latest-tag.outputs.latest_vcpkg_tag }}"

--- a/thirdparty/vcpkg/vcpkg.json
+++ b/thirdparty/vcpkg/vcpkg.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+    "name": "meshlib",
+    "version": "3.1.2.192",
+    "description": "3d processing library",
+    "homepage": "https://meshlib.io",
+    "dependencies": [
+        "boost-algorithm",
+        "boost-dynamic-bitset",
+        "boost-functional",
+        "boost-integer",
+        "boost-locale",
+        "boost-move",
+        "boost-multiprecision",
+        "boost-program-options",
+        "boost-range",
+        "boost-serialization",
+        "boost-signals2",
+        "boost-stacktrace",
+        "boost-url",
+        "cpr",
+        "eigen3",
+        "fastmcpp",
+        "freetype",
+        "gdcm",
+        "glad",
+        "glfw3",
+        "gtest",
+        "hidapi",
+        "jsoncpp",
+        "laz-perf",
+        "libe57format",
+        "libharu",
+        "libjpeg-turbo",
+        "libzip",
+        "opencascade-minimal",
+        "openctm",
+        "openvdb",
+        "parallel-hashmap",
+        "spdlog",
+        "tbb",
+        "tiff",
+        "tinygltf",
+        "tinyxml2",
+        "tl-expected",
+        "zlib-ng",
+        {
+            "name": "dacap-clip",
+            "platform": "(linux | osx)"
+        },
+        {
+            "name": "dbus",
+            "platform": "linux",
+            "default-features": false
+        },
+        {
+            "name": "mimalloc",
+            "platform": "windows",
+            "features": [
+                "override"
+            ]
+        },
+        {
+            "name": "python3",
+            "platform": "windows"
+        }
+    ],
+    "configuration": {
+        "default-registry": {
+            "kind": "builtin",
+            "baseline": "f3e10653cc27d62a37a3763cd84b38bca07c6075",
+            "$version-tag": "2026.06.01"
+        },
+        "overlay-ports": [
+            "./ports"
+        ],
+        "overlay-triplets": [
+            "./triplets"
+        ]
+    }
+}


### PR DESCRIPTION
Manifest mode is the recommended mode for vcpkg. It allows to configure, build, and deploy a project's dependencies locally, without affecting the global vcpkg root directory. For instance, on x64 Linux, third-party dependencies can be built with a single command:
```sh
vcpkg install --host-triplet=x64-linux-meshlib --x-manifest-root=./thirdparty/vcpkg/ --x-install-root=./vcpkg_installed/
```