### PR TITLE
MRCuda: use v143 toolset + CUDA 12.0 under VS2026 (MSBuild)

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -48,18 +48,18 @@ jobs:
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
       job_upload_artifact: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
-      # MRCuda builds with the v143 toolset under VS2026 (v145 has no CUDA support yet),
-      # which pairs with CUDA 12.0 (see source/MRCuda/MRCuda.vcxproj and source/platform.props).
-      # Only the MSBuild variant imports CUDA's MSBuild integration, so it needs CUDA 12.0;
-      # the CMake msvc-2026 build keeps CUDA 13.2.
+      # We prefer CUDA 12.0 over 13.2 (13.2 needs the newest GPUs/drivers), and CUDA 12.0 does not
+      # support the VS2026 v145 host compiler, so MRCuda builds with v143 there (see
+      # source/MRCuda/MRCuda.vcxproj and source/platform.props). Only the MSBuild variant imports
+      # CUDA's MSBuild integration, so it needs CUDA 12.0; the CMake msvc-2026 build keeps CUDA 13.2.
       CUDA_VERSION: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && '12.0.1' || fromJSON('{"msvc-2019":"11.4.2","msvc-2022":"12.0.1"}')[matrix.cxx_compiler] || '13.2.0' }}
       CUDA_MAJOR: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && '12' || fromJSON('{"msvc-2019":"11","msvc-2022":"12"}')[matrix.cxx_compiler] || '13' }}
       CUDA_MINOR: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && '0' || fromJSON('{"msvc-2019":"4","msvc-2022":"0"}')[matrix.cxx_compiler] || '2' }}
       VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}
       PLATFORM_TOOLSET: ${{ fromJSON('{"msvc-2019":"v142","msvc-2022":"v143"}')[matrix.cxx_compiler] || 'v145' }}
       # Override only MRCuda's toolset (MRCuda.vcxproj uses MRCudaPlatformToolset when set, leaving
-      # every other project on PLATFORM_TOOLSET). Under VS2026 build MRCuda with v143 + CUDA 12.0,
-      # since its default v145 toolset has no CUDA support yet. Empty = no override.
+      # every other project on PLATFORM_TOOLSET). Under VS2026 build MRCuda with v143 so it can use
+      # the preferred CUDA 12.0, which does not support the default v145 host compiler. Empty = no override.
       MRCUDA_PLATFORM_TOOLSET: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && 'v143' || '' }}
 
     steps:

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -48,19 +48,14 @@ jobs:
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
       job_upload_artifact: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
-      # We prefer CUDA 12.0 over 13.2 (13.2 needs the newest GPUs/drivers), and CUDA 12.0 does not
-      # support the VS2026 v145 host compiler, so MRCuda builds with v143 there (see
-      # source/MRCuda/MRCuda.vcxproj and source/platform.props). Only the MSBuild variant imports
-      # CUDA's MSBuild integration, so it needs CUDA 12.0; the CMake msvc-2026 build keeps CUDA 13.2.
-      CUDA_VERSION: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && '12.0.1' || fromJSON('{"msvc-2019":"11.4.2","msvc-2022":"12.0.1"}')[matrix.cxx_compiler] || '13.2.0' }}
-      CUDA_MAJOR: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && '12' || fromJSON('{"msvc-2019":"11","msvc-2022":"12"}')[matrix.cxx_compiler] || '13' }}
-      CUDA_MINOR: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && '0' || fromJSON('{"msvc-2019":"4","msvc-2022":"0"}')[matrix.cxx_compiler] || '2' }}
+      # CUDA version and the optional MRCuda toolset override are per-entry matrix attributes
+      # (see .github/workflows/matrix/windows-*.json): under VS2026 MRCuda builds with v143 +
+      # CUDA 12.0, since CUDA 13.2 (paired with v145) needs the newest GPUs/drivers and does not
+      # support the v145 host compiler. CUDA_MAJOR/CUDA_MINOR are derived from CUDA_VERSION below.
+      CUDA_VERSION: ${{ matrix.cuda_version }}
       VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}
       PLATFORM_TOOLSET: ${{ fromJSON('{"msvc-2019":"v142","msvc-2022":"v143"}')[matrix.cxx_compiler] || 'v145' }}
-      # Override only MRCuda's toolset (MRCuda.vcxproj uses MRCudaPlatformToolset when set, leaving
-      # every other project on PLATFORM_TOOLSET). Under VS2026 build MRCuda with v143 so it can use
-      # the preferred CUDA 12.0, which does not support the default v145 host compiler. Empty = no override.
-      MRCUDA_PLATFORM_TOOLSET: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && 'v143' || '' }}
+      MRCUDA_PLATFORM_TOOLSET: ${{ matrix.mrcuda_platform_toolset }}
 
     steps:
       - name: Checkout
@@ -114,6 +109,13 @@ jobs:
           # VS2022/VS2026 fetch their assets from upstream instead.
           install-flags: ${{ (matrix.vcpkg_triplet == 'x64-windows-vs2019-meshlib' || matrix.vcpkg_triplet == 'x64-windows-meshlib-iterator-debug') && '--write-s3 --use-s3-asset-provider' || '--write-s3' }}
           internal-build: ${{ inputs.internal_build }}
+
+      - name: Resolve CUDA major/minor
+        shell: bash
+        run: |
+          IFS=. read -r major minor _ <<< "$CUDA_VERSION"
+          echo "CUDA_MAJOR=$major" >> "$GITHUB_ENV"
+          echo "CUDA_MINOR=$minor" >> "$GITHUB_ENV"
 
       - name: Install CUDA
         uses: ./.github/actions/install-cuda

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -57,6 +57,10 @@ jobs:
       CUDA_MINOR: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && '0' || fromJSON('{"msvc-2019":"4","msvc-2022":"0"}')[matrix.cxx_compiler] || '2' }}
       VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}
       PLATFORM_TOOLSET: ${{ fromJSON('{"msvc-2019":"v142","msvc-2022":"v143"}')[matrix.cxx_compiler] || 'v145' }}
+      # Override only MRCuda's toolset (MRCuda.vcxproj uses MRCudaPlatformToolset when set, leaving
+      # every other project on PLATFORM_TOOLSET). Under VS2026 build MRCuda with v143 + CUDA 12.0,
+      # since its default v145 toolset has no CUDA support yet. Empty = no override.
+      MRCUDA_PLATFORM_TOOLSET: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && 'v143' || '' }}
 
     steps:
       - name: Checkout
@@ -191,7 +195,7 @@ jobs:
             if not exist source\x64 mkdir source\x64 || exit /b 1
             xcopy source\TempOutput\bin\* source\x64\${{matrix.config}}\* /s /e /i /Y || exit /b 1
           ) else (
-            msbuild -m source\MeshLib.sln -p:Configuration=${{ matrix.config }} -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }} || exit /b 1
+            msbuild -m source\MeshLib.sln -p:Configuration=${{ matrix.config }} -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }} || exit /b 1
           )
 
       - name: Generate and build Python bindings

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -48,9 +48,13 @@ jobs:
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
       job_upload_artifact: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
-      CUDA_VERSION: ${{ fromJSON('{"msvc-2019":"11.4.2","msvc-2022":"12.0.1"}')[matrix.cxx_compiler] || '13.2.0' }}
-      CUDA_MAJOR: ${{ fromJSON('{"msvc-2019":"11","msvc-2022":"12"}')[matrix.cxx_compiler] || '13' }}
-      CUDA_MINOR: ${{ fromJSON('{"msvc-2019":"4","msvc-2022":"0"}')[matrix.cxx_compiler] || '2' }}
+      # MRCuda builds with the v143 toolset under VS2026 (v145 has no CUDA support yet),
+      # which pairs with CUDA 12.0 (see source/MRCuda/MRCuda.vcxproj and source/platform.props).
+      # Only the MSBuild variant imports CUDA's MSBuild integration, so it needs CUDA 12.0;
+      # the CMake msvc-2026 build keeps CUDA 13.2.
+      CUDA_VERSION: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && '12.0.1' || fromJSON('{"msvc-2019":"11.4.2","msvc-2022":"12.0.1"}')[matrix.cxx_compiler] || '13.2.0' }}
+      CUDA_MAJOR: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && '12' || fromJSON('{"msvc-2019":"11","msvc-2022":"12"}')[matrix.cxx_compiler] || '13' }}
+      CUDA_MINOR: ${{ (matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild') && '0' || fromJSON('{"msvc-2019":"4","msvc-2022":"0"}')[matrix.cxx_compiler] || '2' }}
       VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}
       PLATFORM_TOOLSET: ${{ fromJSON('{"msvc-2019":"v142","msvc-2022":"v143"}')[matrix.cxx_compiler] || 'v145' }}
 

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -48,10 +48,6 @@ jobs:
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
       job_upload_artifact: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
-      # CUDA version and the optional MRCuda toolset override are per-entry matrix attributes
-      # (see .github/workflows/matrix/windows-*.json): under VS2026 MRCuda builds with v143 +
-      # CUDA 12.0, since CUDA 13.2 (paired with v145) needs the newest GPUs/drivers and does not
-      # support the v145 host compiler. CUDA_MAJOR/CUDA_MINOR are derived from CUDA_VERSION below.
       CUDA_VERSION: ${{ matrix.cuda_version }}
       VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}
       PLATFORM_TOOLSET: ${{ fromJSON('{"msvc-2019":"v142","msvc-2022":"v143"}')[matrix.cxx_compiler] || 'v145' }}

--- a/.github/workflows/matrix/windows-finalize-release-config.json
+++ b/.github/workflows/matrix/windows-finalize-release-config.json
@@ -5,14 +5,16 @@
       "config": "Debug",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     },
     {
       "cxx_compiler": "msvc-2019",
@@ -20,7 +22,8 @@
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib-iterator-debug",
       "upload_name": "Debug-IteratorDebug",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     }
   ]
 }

--- a/.github/workflows/matrix/windows-full-config.json
+++ b/.github/workflows/matrix/windows-full-config.json
@@ -5,84 +5,98 @@
       "config": "Debug",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1",
+      "mrcuda_platform_toolset": "v143"
     },
     {
       "cxx_compiler": "msvc-2026",
       "config": "Release",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1",
+      "mrcuda_platform_toolset": "v143"
     },
     {
       "cxx_compiler": "msvc-2026",
       "config": "Debug",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "13.2.0"
     },
     {
       "cxx_compiler": "msvc-2026",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "13.2.0"
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Debug",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1"
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1"
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Debug",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1"
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1"
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Debug",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Release",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Debug",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     },
     {
       "cxx_compiler": "msvc-2019",
@@ -90,7 +104,8 @@
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib-iterator-debug",
       "upload_name": "Debug-IteratorDebug",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     }
   ]
 }

--- a/.github/workflows/matrix/windows-minimal-config.json
+++ b/.github/workflows/matrix/windows-minimal-config.json
@@ -5,21 +5,25 @@
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     },
     {
       "cxx_compiler": "msvc-2026",
       "config": "Debug",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1",
+      "mrcuda_platform_toolset": "v143"
     },
     {
       "cxx_compiler": "msvc-2026",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "13.2.0"
     },
     {
       "cxx_compiler": "msvc-2019",
@@ -27,7 +31,8 @@
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib-iterator-debug",
       "upload_name": "Debug-IteratorDebug",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     }
   ]
 }

--- a/.github/workflows/matrix/windows-standard-config.json
+++ b/.github/workflows/matrix/windows-standard-config.json
@@ -5,35 +5,41 @@
       "config": "Debug",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     },
     {
       "cxx_compiler": "msvc-2019",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     },
     {
       "cxx_compiler": "msvc-2022",
       "config": "Release",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-vs2022-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1"
     },
     {
       "cxx_compiler": "msvc-2026",
       "config": "Debug",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1",
+      "mrcuda_platform_toolset": "v143"
     },
     {
       "cxx_compiler": "msvc-2026",
       "config": "Release",
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2025"]
+      "runner": ["windows-2025"],
+      "cuda_version": "13.2.0"
     },
     {
       "cxx_compiler": "msvc-2019",
@@ -41,7 +47,8 @@
       "build_system": "CMake",
       "vcpkg_triplet": "x64-windows-meshlib-iterator-debug",
       "upload_name": "Debug-IteratorDebug",
-      "runner": ["windows-2022"]
+      "runner": ["windows-2022"],
+      "cuda_version": "11.4.2"
     }
   ]
 }

--- a/source/MRCuda/MRCuda.vcxproj
+++ b/source/MRCuda/MRCuda.vcxproj
@@ -64,7 +64,7 @@
       <PrecompiledHeader>$(MRCudaPrecompiledHeader)</PrecompiledHeader>
       <PrecompiledHeaderFile>$(ProjectDir)..\MRPch\MRPch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(SolutionDir)TempOutput\MRPch\$(Platform)\$(Configuration)\MRPch.pch</PrecompiledHeaderOutputFile>
-      <ForcedIncludeFiles>$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(DefaultPlatformToolset)' != 'v145'">$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -88,7 +88,7 @@
       <PrecompiledHeader>$(MRCudaPrecompiledHeader)</PrecompiledHeader>
       <PrecompiledHeaderFile>$(ProjectDir)..\MRPch\MRPch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(SolutionDir)TempOutput\MRPch\$(Platform)\$(Configuration)\MRPch.pch</PrecompiledHeaderOutputFile>
-      <ForcedIncludeFiles>$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(DefaultPlatformToolset)' != 'v145'">$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/source/MRCuda/MRCuda.vcxproj
+++ b/source/MRCuda/MRCuda.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" TreatAsLocalProperty="PlatformToolset" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -27,6 +27,14 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <!-- VS2026's v145 toolset is not yet supported by the CUDA Toolkit. Build MRCuda (the
+       only project that compiles CUDA code) with the v143 toolset there; platform.props
+       pairs v143 with CUDA 12.0. Every other project keeps v145. CI passes PlatformToolset
+       to the solution build as a global MSBuild property, so it is listed in
+       TreatAsLocalProperty on the Project element above to allow this per-project override. -->
+  <PropertyGroup Label="Configuration" Condition="'$(DefaultPlatformToolset)' == 'v145'">
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(ProjectDir)\..\platform.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/source/MRCuda/MRCuda.vcxproj
+++ b/source/MRCuda/MRCuda.vcxproj
@@ -28,19 +28,9 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <!-- Build MRCuda with a different platform toolset than the rest of the solution by defining
-       the MRCudaPlatformToolset property (the build that launches MSBuild decides whether/what to
-       pass). E.g. CI passes MRCudaPlatformToolset=v143 for VS2026, whose default v145 toolset the
-       CUDA Toolkit does not yet support. The chosen toolset also selects the CUDA version via
-       platform.props (v143 -> CUDA 12.0). PlatformToolset is listed in TreatAsLocalProperty on the
-       Project element above so this value can override the global PlatformToolset passed to the
-       solution build. -->
   <PropertyGroup Label="Configuration" Condition="'$(MRCudaPlatformToolset)' != ''">
     <PlatformToolset>$(MRCudaPlatformToolset)</PlatformToolset>
   </PropertyGroup>
-  <!-- The shared MRPch.pch is built with the solution's default toolset; when MRCuda overrides
-       its toolset it cannot consume that PCH (error C1853), so skip the precompiled header and let
-       ForcedIncludeFiles pull in MRPch.h directly. -->
   <PropertyGroup>
     <MRCudaPrecompiledHeader>Use</MRCudaPrecompiledHeader>
     <MRCudaPrecompiledHeader Condition="'$(MRCudaPlatformToolset)' != ''">NotUsing</MRCudaPrecompiledHeader>

--- a/source/MRCuda/MRCuda.vcxproj
+++ b/source/MRCuda/MRCuda.vcxproj
@@ -36,6 +36,13 @@
   <PropertyGroup Label="Configuration" Condition="'$(DefaultPlatformToolset)' == 'v145'">
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
+  <!-- The shared MRPch.pch is built with the default v145 toolset, which MRCuda's v143 build
+       cannot consume (error C1853). Use the precompiled header only when not on v145; under
+       VS2026 ForcedIncludeFiles still pulls in MRPch.h directly. -->
+  <PropertyGroup>
+    <MRCudaPrecompiledHeader>Use</MRCudaPrecompiledHeader>
+    <MRCudaPrecompiledHeader Condition="'$(DefaultPlatformToolset)' == 'v145'">NotUsing</MRCudaPrecompiledHeader>
+  </PropertyGroup>
   <Import Project="$(ProjectDir)\..\platform.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -54,7 +61,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>MRCuda_EXPORTS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>$(MRCudaPrecompiledHeader)</PrecompiledHeader>
       <PrecompiledHeaderFile>$(ProjectDir)..\MRPch\MRPch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(SolutionDir)TempOutput\MRPch\$(Platform)\$(Configuration)\MRPch.pch</PrecompiledHeaderOutputFile>
       <ForcedIncludeFiles>$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
@@ -78,7 +85,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>MRCuda_EXPORTS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>$(MRCudaPrecompiledHeader)</PrecompiledHeader>
       <PrecompiledHeaderFile>$(ProjectDir)..\MRPch\MRPch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(SolutionDir)TempOutput\MRPch\$(Platform)\$(Configuration)\MRPch.pch</PrecompiledHeaderOutputFile>
       <ForcedIncludeFiles>$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>

--- a/source/MRCuda/MRCuda.vcxproj
+++ b/source/MRCuda/MRCuda.vcxproj
@@ -28,20 +28,22 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <!-- VS2026's v145 toolset is not yet supported by the CUDA Toolkit. Build MRCuda (the
-       only project that compiles CUDA code) with the v143 toolset there; platform.props
-       pairs v143 with CUDA 12.0. Every other project keeps v145. CI passes PlatformToolset
-       to the solution build as a global MSBuild property, so it is listed in
-       TreatAsLocalProperty on the Project element above to allow this per-project override. -->
-  <PropertyGroup Label="Configuration" Condition="'$(DefaultPlatformToolset)' == 'v145'">
-    <PlatformToolset>v143</PlatformToolset>
+  <!-- Build MRCuda with a different platform toolset than the rest of the solution by defining
+       the MRCudaPlatformToolset property (the build that launches MSBuild decides whether/what to
+       pass). E.g. CI passes MRCudaPlatformToolset=v143 for VS2026, whose default v145 toolset the
+       CUDA Toolkit does not yet support. The chosen toolset also selects the CUDA version via
+       platform.props (v143 -> CUDA 12.0). PlatformToolset is listed in TreatAsLocalProperty on the
+       Project element above so this value can override the global PlatformToolset passed to the
+       solution build. -->
+  <PropertyGroup Label="Configuration" Condition="'$(MRCudaPlatformToolset)' != ''">
+    <PlatformToolset>$(MRCudaPlatformToolset)</PlatformToolset>
   </PropertyGroup>
-  <!-- The shared MRPch.pch is built with the default v145 toolset, which MRCuda's v143 build
-       cannot consume (error C1853). Use the precompiled header only when not on v145; under
-       VS2026 ForcedIncludeFiles still pulls in MRPch.h directly. -->
+  <!-- The shared MRPch.pch is built with the solution's default toolset; when MRCuda overrides
+       its toolset it cannot consume that PCH (error C1853), so skip the precompiled header and let
+       ForcedIncludeFiles pull in MRPch.h directly. -->
   <PropertyGroup>
     <MRCudaPrecompiledHeader>Use</MRCudaPrecompiledHeader>
-    <MRCudaPrecompiledHeader Condition="'$(DefaultPlatformToolset)' == 'v145'">NotUsing</MRCudaPrecompiledHeader>
+    <MRCudaPrecompiledHeader Condition="'$(MRCudaPlatformToolset)' != ''">NotUsing</MRCudaPrecompiledHeader>
   </PropertyGroup>
   <Import Project="$(ProjectDir)\..\platform.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -64,7 +66,7 @@
       <PrecompiledHeader>$(MRCudaPrecompiledHeader)</PrecompiledHeader>
       <PrecompiledHeaderFile>$(ProjectDir)..\MRPch\MRPch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(SolutionDir)TempOutput\MRPch\$(Platform)\$(Configuration)\MRPch.pch</PrecompiledHeaderOutputFile>
-      <ForcedIncludeFiles Condition="'$(DefaultPlatformToolset)' != 'v145'">$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(MRCudaPlatformToolset)' == ''">$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -88,7 +90,7 @@
       <PrecompiledHeader>$(MRCudaPrecompiledHeader)</PrecompiledHeader>
       <PrecompiledHeaderFile>$(ProjectDir)..\MRPch\MRPch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(SolutionDir)TempOutput\MRPch\$(Platform)\$(Configuration)\MRPch.pch</PrecompiledHeaderOutputFile>
-      <ForcedIncludeFiles Condition="'$(DefaultPlatformToolset)' != 'v145'">$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(MRCudaPlatformToolset)' == ''">$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
## What

Under VS2026 (msvc2026) MSBuild builds, build the `MRCuda` project with the **v143** platform toolset and **CUDA 12.0**. Every other project keeps the default **v145** toolset.

## Why

We prefer CUDA 12.0 over CUDA 13.2: CUDA 13.2 (which pairs with v145) requires the newest video cards and drivers, whereas CUDA 12.0 has much broader hardware/driver compatibility. CUDA 12.0, however, does not support the VS2026 `v145` host compiler — so `MRCuda` (the only project that compiles CUDA code) must be built with the `v143` toolset. `source/platform.props` already pairs `v143` with CUDA 12.0.

## How

The decision (which toolset / CUDA version, and when) lives in the CI matrix; the project file only exposes a generic hook.

- **`source/MRCuda/MRCuda.vcxproj`** — when the `MRCudaPlatformToolset` property is non-empty, `MRCuda` uses it as its `PlatformToolset`. The project file itself contains no `v145`/`v143` knowledge. `PlatformToolset` is listed in `TreatAsLocalProperty` so this value can override the global `PlatformToolset` the solution build passes in (scoped to `MRCuda` only). When the property is set, `MRCuda` also skips the shared precompiled header and the forced `MRPch.h` include — a `v143` build cannot consume the `v145`-built `MRPch.pch` (error `C1853`); the `.cpp` files include their own headers.
- **`.github/workflows/matrix/windows-*-config.json`** — each entry carries a `cuda_version` (msvc-2019 → 11.4.2, msvc-2022 → 12.0.1, msvc-2026 CMake → 13.2.0, msvc-2026 MSBuild → 12.0.1), and the msvc-2026 MSBuild entries also carry `mrcuda_platform_toolset: v143`.
- **`.github/workflows/build-test-windows.yml`** — reads `CUDA_VERSION` and `MRCUDA_PLATFORM_TOOLSET` straight from the matrix, derives `CUDA_MAJOR`/`CUDA_MINOR` from `CUDA_VERSION` in a step, and forwards `MRCudaPlatformToolset` to the MSBuild solution build. The msvc-2026 MSBuild leg therefore installs CUDA 12.0; the msvc-2026 CMake leg keeps v145 + CUDA 13.2.

## Notes

- `MRTestCuda` imports no CUDA build customizations (it only links `MRCuda`), so it is unaffected and stays on `v145`.
- `v143`/`v145` are binary compatible (same `v14x` ABI), so mixing toolsets across the produced DLLs is safe.
- `pip-build.yml` already builds with `v143` globally, so it is unchanged.
- A local VS2026 IDE MSBuild build uses the VS2026 default (`v145`) unless the developer defines `MRCudaPlatformToolset` (for example via `-p:MRCudaPlatformToolset=v143` or a personal `CustomMRPlatform.props`). The CMake path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
