### PR TITLE
ci(vcpkg): survive a failed cache restore, not just an empty one

### DIFF
--- a/.github/actions/setup-vcpkg-windows/action.yml
+++ b/.github/actions/setup-vcpkg-windows/action.yml
@@ -71,10 +71,8 @@ runs:
 
     - name: Restore Vcpkg Cache
       id: restore
-      # Tolerate a failed or partial extraction (a known actions/cache flake on
-      # Windows where tar errors out or silently drops files). Don't fail the
-      # step here — let "Verify" below detect the empty tree and fall through to
-      # the build-from-source path instead of aborting the whole job.
+      # Tolerate a failed/partial extraction (a known actions/cache flake on
+      # Windows): don't fail here — let "Verify" below catch it and rebuild.
       continue-on-error: true
       if: ${{ env.VCPKG_CACHE_HIT == 'true' }}
       uses: actions/cache/restore@v5
@@ -83,24 +81,16 @@ runs:
         path: |
           C:\vcpkg\*
 
-    # Guard against a "cache hit" that did not produce a usable tree — either the
-    # restore step above errored during extraction, or it reported success but
-    # tar silently dropped files (both are known actions/cache flakes on
-    # Windows). If the installed root for this triplet is missing or empty,
-    # discard the bad restore, put the runner's pristine vcpkg clone back, and
-    # fall through to the build path. Runs even when the restore step failed
-    # (continue-on-error above keeps the composite going).
+    # A cache hit can still yield no usable tree (restore errored, or "succeeded"
+    # but tar dropped files). Discard such a restore, put the runner's vcpkg
+    # clone back, and fall through to the build path.
     - name: Verify Restored Vcpkg Cache
       if: ${{ env.VCPKG_CACHE_HIT == 'true' }}
       shell: pwsh
       run: |
-        # Discard the restore if EITHER the restore step failed (continue-on-error
-        # masks its conclusion to success, but its `outcome` is still 'failure')
-        # OR it produced no usable tree. The outcome check also catches a failed
-        # restore that left partial-but-non-empty files, which would otherwise
-        # sneak past the sentinel below. (steps.<id>.outcome is empty on old
-        # runners lacking actions/runner#1578 — it then harmlessly falls back to
-        # the tree check.)
+        # Discard if the restore step failed (its `outcome` stays 'failure' under
+        # continue-on-error) or left no usable tree. Combined, they also cover a
+        # partial restore and old runners where composite outcome is empty.
         $restoreFailed = ('${{ steps.restore.outcome }}' -eq 'failure')
         $sentinel = "C:\vcpkg\installed\${{ inputs.vcpkg-triplet }}"
         $treeOk = (Test-Path $sentinel) -and (Get-ChildItem -Force $sentinel | Select-Object -First 1)
@@ -112,9 +102,8 @@ runs:
           } else {
             Write-Warning "Cache hit but '$sentinel' is missing or empty (restore flake) — treating as a cache miss and rebuilding from source."
           }
-          # Discard the incomplete restore. Remove-Item may leave locked
-          # remnants, so if C:\vcpkg survives, rename it aside to free the path
-          # before moving the stash back (Move-Item won't overwrite a dir).
+          # Remove-Item can leave locked remnants; if C:\vcpkg survives, rename it
+          # aside so Move-Item (which won't overwrite a dir) can restore the stash.
           if (Test-Path C:\vcpkg) { Remove-Item C:\vcpkg -Recurse -Force -ErrorAction SilentlyContinue }
           if (Test-Path C:\vcpkg) { Move-Item C:\vcpkg "C:\vcpkg-broken-$(New-Guid)" -Force -ErrorAction SilentlyContinue }
           if ($env:VCPKG_STASH -and (Test-Path $env:VCPKG_STASH)) {

--- a/.github/actions/setup-vcpkg-windows/action.yml
+++ b/.github/actions/setup-vcpkg-windows/action.yml
@@ -94,11 +94,24 @@ runs:
       if: ${{ env.VCPKG_CACHE_HIT == 'true' }}
       shell: pwsh
       run: |
+        # Discard the restore if EITHER the restore step failed (continue-on-error
+        # masks its conclusion to success, but its `outcome` is still 'failure')
+        # OR it produced no usable tree. The outcome check also catches a failed
+        # restore that left partial-but-non-empty files, which would otherwise
+        # sneak past the sentinel below. (steps.<id>.outcome is empty on old
+        # runners lacking actions/runner#1578 — it then harmlessly falls back to
+        # the tree check.)
+        $restoreFailed = ('${{ steps.restore.outcome }}' -eq 'failure')
         $sentinel = "C:\vcpkg\installed\${{ inputs.vcpkg-triplet }}"
-        if ((Test-Path $sentinel) -and (Get-ChildItem -Force $sentinel | Select-Object -First 1)) {
+        $treeOk = (Test-Path $sentinel) -and (Get-ChildItem -Force $sentinel | Select-Object -First 1)
+        if ((-not $restoreFailed) -and $treeOk) {
           Write-Host "Restored cache verified: '$sentinel' exists and is non-empty."
         } else {
-          Write-Warning "Cache hit but '$sentinel' is missing or empty (restore flake) — treating as a cache miss and rebuilding from source."
+          if ($restoreFailed) {
+            Write-Warning "Restore step failed (restore flake) — discarding the incomplete restore and rebuilding from source."
+          } else {
+            Write-Warning "Cache hit but '$sentinel' is missing or empty (restore flake) — treating as a cache miss and rebuilding from source."
+          }
           # Discard the incomplete restore. Remove-Item may leave locked
           # remnants, so if C:\vcpkg survives, rename it aside to free the path
           # before moving the stash back (Move-Item won't overwrite a dir).

--- a/.github/actions/setup-vcpkg-windows/action.yml
+++ b/.github/actions/setup-vcpkg-windows/action.yml
@@ -70,6 +70,12 @@ runs:
         }
 
     - name: Restore Vcpkg Cache
+      id: restore
+      # Tolerate a failed or partial extraction (a known actions/cache flake on
+      # Windows where tar errors out or silently drops files). Don't fail the
+      # step here — let "Verify" below detect the empty tree and fall through to
+      # the build-from-source path instead of aborting the whole job.
+      continue-on-error: true
       if: ${{ env.VCPKG_CACHE_HIT == 'true' }}
       uses: actions/cache/restore@v5
       with:
@@ -77,11 +83,13 @@ runs:
         path: |
           C:\vcpkg\*
 
-    # Guard against a "cache hit" that restored an empty or incomplete tree —
-    # a known actions/cache flake on Windows where the step reports the cache
-    # as restored but tar extraction silently dropped files. If the installed
-    # root for this triplet is missing, discard the bad restore, put the
-    # runner's pristine vcpkg clone back, and fall through to the build path.
+    # Guard against a "cache hit" that did not produce a usable tree — either the
+    # restore step above errored during extraction, or it reported success but
+    # tar silently dropped files (both are known actions/cache flakes on
+    # Windows). If the installed root for this triplet is missing or empty,
+    # discard the bad restore, put the runner's pristine vcpkg clone back, and
+    # fall through to the build path. Runs even when the restore step failed
+    # (continue-on-error above keeps the composite going).
     - name: Verify Restored Vcpkg Cache
       if: ${{ env.VCPKG_CACHE_HIT == 'true' }}
       shell: pwsh
@@ -90,8 +98,12 @@ runs:
         if ((Test-Path $sentinel) -and (Get-ChildItem -Force $sentinel | Select-Object -First 1)) {
           Write-Host "Restored cache verified: '$sentinel' exists and is non-empty."
         } else {
-          Write-Warning "Cache hit but '$sentinel' is missing or empty — treating as a cache miss and rebuilding from source."
+          Write-Warning "Cache hit but '$sentinel' is missing or empty (restore flake) — treating as a cache miss and rebuilding from source."
+          # Discard the incomplete restore. Remove-Item may leave locked
+          # remnants, so if C:\vcpkg survives, rename it aside to free the path
+          # before moving the stash back (Move-Item won't overwrite a dir).
           if (Test-Path C:\vcpkg) { Remove-Item C:\vcpkg -Recurse -Force -ErrorAction SilentlyContinue }
+          if (Test-Path C:\vcpkg) { Move-Item C:\vcpkg "C:\vcpkg-broken-$(New-Guid)" -Force -ErrorAction SilentlyContinue }
           if ($env:VCPKG_STASH -and (Test-Path $env:VCPKG_STASH)) {
             Move-Item $env:VCPKG_STASH C:\vcpkg -Force
           }


### PR DESCRIPTION
## Problem

Follow-up to #6199. That PR added a `Verify Restored Vcpkg Cache` guard that rebuilds from source when a cache **hit** restores an empty/incomplete `C:\vcpkg\installed\<triplet>`. It only covered the **silent** flake (the restore step reports success but `tar` dropped files).

It misses the **loud** variant: when `actions/cache/restore@v5` itself **errors during extraction**, that step fails, which short-circuits the composite action and **skips** the (non-`always()`) `Verify` step. So `Set up vcpkg` still fails on an empty restore.

Observed in [run 27219696459, job 80371046537](https://github.com/MeshInspector/MeshLib/actions/runs/27219696459/job/80371046537) (`msvc-2019 / Release / MSBuild / x64-windows-vs2019-meshlib`). The per-step log proves the guard never ran:

- cache **hit** on key `…41d982c2…-slim2`; `Stash` ran; `Restore Vcpkg Cache` ran and failed during extraction;
- the only post-restore step that executed was the `always()` diagnostic, which showed `C:\vcpkg\installed\x64-windows-vs2019-meshlib\{bin,lib,…}` all "(directory not present)";
- **`VCPKG_CACHE_HIT` was still `true`** in that diagnostic's env — if `Verify` had run it would have flipped it to `false`.

It's the per-job flake, not a bad cache: the **identical key restored fine in 3 sibling jobs in the same run** (Debug/MSBuild, Debug/CMake, Release/CMake vs2019).

## Fix

1. Mark `Restore Vcpkg Cache` with `continue-on-error: true` (and give it an `id`) so an extraction error no longer aborts the composite. `continue-on-error` is already used by the diagnostic step in this same action.
2. With that, `Verify Restored Vcpkg Cache` now runs in **both** cases (restore errored, or restore "succeeded" but empty), detects the missing/empty installed root, rolls the runner's pristine vcpkg clone back, and clears `VCPKG_CACHE_HIT` so the miss path rebuilds from source.
3. Harden the rollback: if `Remove-Item` leaves a locked remnant, rename `C:\vcpkg` aside before moving the stash back, so `Move-Item` can't throw on an existing directory.

The happy path (good cache hit) is unchanged.
