### PR TITLE
CI: skip distribution upload & tests when a build failed

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -226,12 +226,26 @@ jobs:
          failOnError: false
 
   upload-distributions:
-    if: ${{ !cancelled() && needs.config.outputs.upload_artifacts == 'true' }}
+    # Skip publishing whenever any platform build failed: a failed build never produced its
+    # distributive, so there is nothing to upload and the downstream `test-distribution` job
+    # would otherwise fail with "no assets to download". Skipped builds (disabled platforms)
+    # have result 'skipped', not 'failure', so they keep this job running for the platforms
+    # that did build.
+    if: >-
+      ${{ !cancelled()
+        && needs.config.outputs.upload_artifacts == 'true'
+        && needs.windows-build-test.result != 'failure'
+        && needs.ubuntu-x64-build-test.result != 'failure'
+        && needs.ubuntu-arm64-build-test.result != 'failure'
+        && needs.linux-vcpkg-build-test.result != 'failure'
+        && needs.emscripten-build-test.result != 'failure'
+        && needs.macos-build-test.result != 'failure' }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
     needs:
       - config
       - versioning-and-release-url
+      - windows-build-test
       - update-win-version
       - create-nuget-package
       - ubuntu-x64-build-test
@@ -300,7 +314,10 @@ jobs:
       release_tag: ${{ needs.config.outputs.release_tag }}
 
   test-distribution:
-    if: ${{ !cancelled() && needs.config.outputs.upload_artifacts == 'true' }}
+    # Only test the distribution once it was actually published. When a build fails,
+    # `upload-distributions` is skipped (see above), so require its success here as well —
+    # otherwise this job runs against an empty release and fails with "no assets to download".
+    if: ${{ !cancelled() && needs.config.outputs.upload_artifacts == 'true' && needs.upload-distributions.result == 'success' }}
     needs: [ config, upload-distributions ]
     uses: ./.github/workflows/test-distribution.yml
     with:

--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -226,11 +226,7 @@ jobs:
          failOnError: false
 
   upload-distributions:
-    # Skip publishing whenever any platform build failed: a failed build never produced its
-    # distributive, so there is nothing to upload and the downstream `test-distribution` job
-    # would otherwise fail with "no assets to download". Skipped builds (disabled platforms)
-    # have result 'skipped', not 'failure', so they keep this job running for the platforms
-    # that did build.
+    # Don't publish if any build failed (its distributive is missing); skipped builds are fine.
     if: >-
       ${{ !cancelled()
         && needs.config.outputs.upload_artifacts == 'true'
@@ -314,9 +310,7 @@ jobs:
       release_tag: ${{ needs.config.outputs.release_tag }}
 
   test-distribution:
-    # Only test the distribution once it was actually published. When a build fails,
-    # `upload-distributions` is skipped (see above), so require its success here as well —
-    # otherwise this job runs against an empty release and fails with "no assets to download".
+    # Skip if publishing was skipped, so we don't test against an empty release.
     if: ${{ !cancelled() && needs.config.outputs.upload_artifacts == 'true' && needs.upload-distributions.result == 'success' }}
     needs: [ config, upload-distributions ]
     uses: ./.github/workflows/test-distribution.yml


### PR DESCRIPTION
## Problem

`upload-distributions` and `test-distribution` are gated only by `!cancelled()`, so they run even when a platform build **failed**.

When a build fails, its distributive is never produced: `update-win-version` (which packages the Windows `WindowsArchive_*` artifacts into `MeshLibDist*.zip` / `DistributivesWin*`) is auto-skipped, because it `needs: windows-build-test` and has no `!cancelled()`/`always()`. With nothing named `Distributives*` to download, `upload-distributions` publishes nothing to the release, and `test-distribution / windows-test` then fails at the "Download Distributive" step with:

```
no assets to download
##[error]Process completed with exit code 1.
```

So a real build failure is hidden behind a confusing "no assets to download" error in a downstream test job. Example: run [27219696459](https://github.com/MeshInspector/MeshLib/actions/runs/27219696459) — the `msvc-2019 / Release / MSBuild` leg failed, and both `windows-test` jobs went red for this reason instead of the build failure standing on its own.

## Change

- **`upload-distributions`**: add `windows-build-test` to `needs` and skip the job whenever any build job has a `failure` result. Skipped builds (disabled platforms via `disable-build-*`) have result `skipped`, not `failure`, so publishing still runs for the platforms that did build.
- **`test-distribution`**: additionally require `upload-distributions` to have succeeded, so it is skipped — rather than failing against an empty release — when publishing was skipped.

This mirrors the existing `needs.<job>.result == 'success'` idiom already used by `windows-unity-test` in the same workflow.

## Effect

- A build failure now skips distribution upload and tests, leaving the build failure as the visible error.
- Successful runs and disabled-platform runs are unaffected (skipped ≠ failed).
