### PR TITLE
ci(windows): build pip wheel with VS2026

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -360,9 +360,10 @@ jobs:
       CUDA-VERSION: '12.0.1'
       CUDA-MAJOR: '12'
       CUDA-MINOR: '0'
-      VCPKG_DEFAULT_TRIPLET: x64-windows-vs2022-meshlib
-      VCVARS_VER: '14.4'
-      PLATFORM_TOOLSET: v143
+      VCPKG_DEFAULT_TRIPLET: x64-windows-meshlib
+      VCVARS_VER: '14.5'
+      PLATFORM_TOOLSET: v145
+      CUDA_PLATFORM_TOOLSET: v143
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -401,7 +402,7 @@ jobs:
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
       - name: Build
-        run: msbuild -m source\MeshLib.sln -p:Configuration=Release -p:VcpkgTriplet=${{ env.VCPKG_DEFAULT_TRIPLET }} -p:PlatformToolset=${{ env.PLATFORM_TOOLSET }}
+        run: msbuild -m source\MeshLib.sln -p:Configuration=Release -p:VcpkgTriplet=${{ env.VCPKG_DEFAULT_TRIPLET }} -p:PlatformToolset=${{ env.PLATFORM_TOOLSET }} -p:MRCudaPlatformToolset=${{ env.CUDA_PLATFORM_TOOLSET }}
 
       - name: Install MSYS2 for MRBind
         uses: ./.github/actions/install-msys2-mrbind


### PR DESCRIPTION
## What

Build the Windows pip wheel with **VS2026** (toolset **v145**) instead of VS2022 (v143). Only `MRCuda` stays on **v143** + **CUDA 12.0**, same as on the main CI (#6233).

## Changes

All in the `windows-pip-build` job of `pip-build.yml`:

- `PLATFORM_TOOLSET`: `v143` → `v145`, `VCVARS_VER`: `14.4` → `14.5` — the solution now builds with the VS2026 toolset.
- `VCPKG_DEFAULT_TRIPLET`: `x64-windows-vs2022-meshlib` → `x64-windows-meshlib` — the vs2022 triplet (#6188) exists only to pin `VCPKG_PLATFORM_TOOLSET` to `v143`; dropping the pin lets vcpkg dependencies build with the newest installed toolset (v145).
- New `CUDA_PLATFORM_TOOLSET: v143` env, forwarded to the solution build as `-p:MRCudaPlatformToolset=v143` — keeps `MRCuda` on v143, because CUDA 12.0 (which the job continues to install for broad hardware/driver compatibility) does not support the v145 host compiler. The `MRCudaPlatformToolset` hook was introduced in #6233.

`v143` and `v145` share the `v14x` ABI, so the v143-built `MRCuda.dll` mixes safely with the v145-built rest of the wheel.

## Test plan

- [x] `windows-pip-build` passes — the wheel builds with VS2026.
- [x] `windows-pip-test` passes on both `windows-2022` and `windows-2025`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
