### PR TITLE
CI: unify per-OS steps in build-mrbind, fix stale MSYS2 hashes cache key

### DIFF
--- a/.github/actions/build-mrbind/action.yml
+++ b/.github/actions/build-mrbind/action.yml
@@ -9,16 +9,16 @@ inputs:
   cache-key-prefix:
     required: true
     description: >
-      Short platform/toolchain identifier (e.g. `windows-clang18`,
+      Short platform/toolchain identifier (e.g. `windows-clang22`,
       `ubuntu-clang`, `rocky-clang`, `macos-clang`). Determines the
       cache namespace so different platforms don't collide.
   build-script:
     required: true
     description: >
       Path to the build script (relative to the repo root). On Windows
-      it must be a `.bat` invoked via `call`; elsewhere a POSIX shell
-      script run directly. Hashed into the cache key and executed on
-      cache miss.
+      it must be a `.bat` (run via `cmd /c call`); elsewhere a POSIX
+      shell script run directly. Hashed into the cache key and executed
+      on cache miss.
   mrbind-dir:
     required: false
     default: thirdparty/mrbind
@@ -53,17 +53,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get MRBind submodule SHA (Windows)
-      if: ${{ runner.os == 'Windows' }}
-      id: mrbind-sha-win
-      shell: pwsh
-      run: |
-        $sha = git -C '${{ inputs.mrbind-dir }}' rev-parse HEAD
-        "sha=$sha" | Add-Content -Path $env:GITHUB_OUTPUT
-
-    - name: Get MRBind submodule SHA (Unix)
-      if: ${{ runner.os != 'Windows' }}
-      id: mrbind-sha-unix
+    - name: Get MRBind submodule SHA
+      id: mrbind-sha
       shell: bash
       run: echo "sha=$(git -C '${{ inputs.mrbind-dir }}' rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
@@ -76,23 +67,25 @@ runs:
       continue-on-error: true
       with:
         path: ${{ inputs.mrbind-dir }}/build
-        # Exactly one of the two SHA steps ran, so concatenation yields the SHA.
-        key: mrbind-build-${{ inputs.cache-key-prefix }}-${{ steps.mrbind-sha-win.outputs.sha }}${{ steps.mrbind-sha-unix.outputs.sha }}-${{ hashFiles(inputs.build-script) }}-${{ inputs.extra-cache-key }}
+        key: mrbind-build-${{ inputs.cache-key-prefix }}-${{ steps.mrbind-sha.outputs.sha }}-${{ hashFiles(inputs.build-script) }}-${{ inputs.extra-cache-key }}
 
-    - name: Build MRBind (Windows)
+    - name: Build MRBind
       # `install_mrbind_windows_msys2.bat` defaults MSYS2_DIR to
       # `C:\msys64_meshlib_mrbind` (a separate copy intended for local dev). Override
       # via the `msys2-dir` input to match where MSYS2 actually lives on the runner.
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows' }}
-      shell: cmd
+      # Only the Windows script reads MSYS2_DIR; exporting it elsewhere is harmless.
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      shell: bash
       env:
         MSYS2_DIR: ${{ inputs.msys2-dir }}
-      run: call ${{ inputs.build-script }}
-
-    - name: Build MRBind (Unix)
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != 'Windows' }}
-      shell: bash
-      run: ${{ inputs.build-script }}
+      run: |
+        if [ "$RUNNER_OS" = Windows ]; then
+          # cmd.exe needs a Windows-style path; `call` + `/c` propagate the
+          # .bat's exit code, and the environment (MSYS2_DIR) flows through.
+          cmd //c "call $(cygpath -wa '${{ inputs.build-script }}')"
+        else
+          '${{ inputs.build-script }}'
+        fi
 
     # Downstream steps only invoke the three executables (mrbind, mrbind_gen_c,
     # mrbind_gen_csharp -- see scripts/mrbind/generate.mk:191-193). Object files,
@@ -100,23 +93,17 @@ runs:
     # the cache (the build script wipes `build/` before rebuilding anyway, so we
     # don't need incremental-rebuild state either).
 
-    - name: Trim MRBind build dir before cache save (Windows)
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows' }}
-      shell: pwsh
-      run: |
-        $keep = @('mrbind.exe', 'mrbind_gen_c.exe', 'mrbind_gen_csharp.exe')
-        Get-ChildItem -LiteralPath '${{ inputs.mrbind-dir }}/build' |
-          Where-Object { $keep -notcontains $_.Name } |
-          Remove-Item -Recurse -Force
-
-    - name: Trim MRBind build dir before cache save (Unix)
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != 'Windows' }}
+    - name: Trim MRBind build dir before cache save
+      # The `.exe` names are what the Windows build produces; GNU find ships
+      # with Git Bash, so the same command works on every runner.
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         set -eu
         cd '${{ inputs.mrbind-dir }}/build'
         find . -mindepth 1 -maxdepth 1 \
           ! -name 'mrbind' ! -name 'mrbind_gen_c' ! -name 'mrbind_gen_csharp' \
+          ! -name 'mrbind.exe' ! -name 'mrbind_gen_c.exe' ! -name 'mrbind_gen_csharp.exe' \
           -exec rm -rf {} +
 
     # Stripping shrinks the cache ~5x at the cost of useful stack traces from
@@ -124,22 +111,18 @@ runs:
     # branch; mrbind is built with `RelWithDebInfo + -fstandalone-debug`, so a
     # fresh local build still gives a full-info binary.
 
-    - name: Strip MRBind binaries (macOS)
-      # -S drops debug symbols but keeps the dynamic symbol table.
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' && runner.os == 'macOS' }}
+    - name: Strip MRBind binaries
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' }}
       shell: bash
-      run: strip -S ${{ inputs.mrbind-dir }}/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp}
-
-    - name: Strip MRBind binaries (Linux)
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' && runner.os == 'Linux' }}
-      shell: bash
-      run: strip ${{ inputs.mrbind-dir }}/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp}
-
-    - name: Strip MRBind binaries (Windows)
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.strip-binaries == 'true' && runner.os == 'Windows' }}
-      shell: pwsh
       run: |
-        & '${{ inputs.msys2-dir }}\clang64\bin\strip.exe' `
-          '${{ inputs.mrbind-dir }}/build/mrbind.exe' `
-          '${{ inputs.mrbind-dir }}/build/mrbind_gen_c.exe' `
-          '${{ inputs.mrbind-dir }}/build/mrbind_gen_csharp.exe'
+        set -eu
+        case "$RUNNER_OS" in
+          # Git Bash has no `strip` of its own, so use MSYS2's.
+          Windows) strip=("$(cygpath -u '${{ inputs.msys2-dir }}')/clang64/bin/strip.exe"); ext=.exe ;;
+          # -S drops debug symbols but keeps the dynamic symbol table.
+          macOS)   strip=(strip -S); ext= ;;
+          *)       strip=(strip); ext= ;;
+        esac
+        for bin in mrbind mrbind_gen_c mrbind_gen_csharp; do
+          "${strip[@]}" "${{ inputs.mrbind-dir }}/build/$bin$ext"
+        done

--- a/.github/actions/build-mrbind/action.yml
+++ b/.github/actions/build-mrbind/action.yml
@@ -117,12 +117,13 @@ runs:
       run: |
         set -eu
         case "$RUNNER_OS" in
-          # Git Bash has no `strip` of its own, so use MSYS2's.
-          Windows) strip=("$(cygpath -u '${{ inputs.msys2-dir }}')/clang64/bin/strip.exe"); ext=.exe ;;
-          # -S drops debug symbols but keeps the dynamic symbol table.
-          macOS)   strip=(strip -S); ext= ;;
-          *)       strip=(strip); ext= ;;
+          Windows)
+            # Git Bash has no `strip` of its own, so use MSYS2's.
+            STRIP_EXE="$(cygpath -u '${{ inputs.msys2-dir }}')/clang64/bin/strip.exe"
+            "$STRIP_EXE" "${{ inputs.mrbind-dir }}"/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp}.exe ;;
+          macOS)
+            # -S drops debug symbols but keeps the dynamic symbol table.
+            strip -S "${{ inputs.mrbind-dir }}"/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp} ;;
+          *)
+            strip "${{ inputs.mrbind-dir }}"/build/{mrbind,mrbind_gen_c,mrbind_gen_csharp} ;;
         esac
-        for bin in mrbind mrbind_gen_c mrbind_gen_csharp; do
-          "${strip[@]}" "${{ inputs.mrbind-dir }}/build/$bin$ext"
-        done

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -149,9 +149,9 @@ jobs:
         if: ${{inputs.mrbind || (inputs.mrbind_c && matrix.build_system == 'CMake') || env.BUILD_C_SHARP == 'true'}}
         uses: ./.github/actions/build-mrbind
         with:
-          cache-key-prefix: windows-clang18
+          cache-key-prefix: windows-clang22
           build-script: scripts/mrbind/install_mrbind_windows_msys2.bat
-          extra-cache-key: ${{ hashFiles('scripts/mrbind/msys2_package_hashes_clang18.txt') }}
+          extra-cache-key: ${{ hashFiles('scripts/mrbind/msys2_package_hashes_clang22.txt') }}
 
       - name: Generate C bindings
         if: ${{ (inputs.mrbind_c && matrix.build_system == 'CMake') || env.BUILD_C_SHARP == 'true' }}

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -410,9 +410,9 @@ jobs:
       - name: Build MRBind
         uses: ./.github/actions/build-mrbind
         with:
-          cache-key-prefix: windows-clang18
+          cache-key-prefix: windows-clang22
           build-script: scripts/mrbind/install_mrbind_windows_msys2.bat
-          extra-cache-key: ${{ hashFiles('scripts/mrbind/msys2_package_hashes_clang18.txt') }}
+          extra-cache-key: ${{ hashFiles('scripts/mrbind/msys2_package_hashes_clang22.txt') }}
 
       - name: Generate and build MRBind bindings
         shell: cmd


### PR DESCRIPTION
Two cleanups in the mrbind CI plumbing:

#### Key mrbind caches off the existing `msys2_package_hashes_clang22.txt`

`build-test-windows.yml` and `pip-build.yml` mixed `hashFiles('scripts/mrbind/msys2_package_hashes_clang18.txt')` into `build-mrbind`'s `extra-cache-key`, but that file doesn't exist — only the clang22 one does (the reference has been stale since #6196 landed). `hashFiles()` on a missing path silently returns an empty string, so the Windows mrbind build cache never reacted to MSYS2 package updates. Both call sites now hash `msys2_package_hashes_clang22.txt`, and the `windows-clang18` cache-key prefix is renamed to `windows-clang22` to match the actually pinned toolchain.

#### Unify per-OS steps in the `build-mrbind` action

Every runner has bash (Git Bash on Windows, which ships GNU find and cygpath), so the per-OS step pairs collapse into single `shell: bash` steps — 10 steps down to 5:

- **submodule SHA** — one step instead of the pwsh/bash twins; the cache key drops the two-step output concatenation hack. The key *value* is unchanged, so previously saved caches remain valid.
- **build** — on Windows the `.bat` runs via `cmd /c call` on a `cygpath -wa`-converted path, preserving the old `shell: cmd` semantics: the script's exit code propagates, and `MSYS2_DIR` from the step env reaches the script.
- **trim before cache save** — a single `find` invocation keeping both the bare and the `.exe` executable names.
- **strip** — one step choosing the tool per `$RUNNER_OS`: MSYS2's `strip.exe` on Windows, `strip -S` on macOS, plain `strip` on Linux.

The `cmd //c "call $(cygpath -wa ...)"` invocation (env-var and exit-code propagation included) and the `find`-based trim were verified in Git Bash on a Windows machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
