### PR TITLE
Define MR_PCH_USE_EXTRA_HEADERS in macOS CI builds

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -169,6 +169,7 @@ jobs:
             -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
             -DMR_CXX_STANDARD=23
             -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
+            -DMR_PCH_USE_EXTRA_HEADERS=ON
 
       - name: MRMesh Exported Symbols
         run: |

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -188,11 +188,13 @@ jobs:
           if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
             call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
             cmake --version || exit /b 1
-            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} || exit /b 1
+            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} -DMR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
             cmake --build source\TempOutput -j || exit /b 1
             if not exist source\x64 mkdir source\x64 || exit /b 1
             xcopy source\TempOutput\bin\* source\x64\${{matrix.config}}\* /s /e /i /Y || exit /b 1
           ) else (
+            rem add frequently used MeshLib headers to the precompiled header, see MRPch.h
+            set CL=/DMR_PCH_USE_EXTRA_HEADERS
             msbuild -m source\MeshLib.sln -p:Configuration=${{ matrix.config }} -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }} || exit /b 1
           )
 

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -188,13 +188,11 @@ jobs:
           if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
             call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
             cmake --version || exit /b 1
-            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} -DMR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
+            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} || exit /b 1
             cmake --build source\TempOutput -j || exit /b 1
             if not exist source\x64 mkdir source\x64 || exit /b 1
             xcopy source\TempOutput\bin\* source\x64\${{matrix.config}}\* /s /e /i /Y || exit /b 1
           ) else (
-            rem add frequently used MeshLib headers to the precompiled header, see MRPch.h
-            set CL=/DMR_PCH_USE_EXTRA_HEADERS
             msbuild -m source\MeshLib.sln -p:Configuration=${{ matrix.config }} -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }} || exit /b 1
           )
 

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -402,6 +402,9 @@ jobs:
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
       - name: Build
+        env:
+          # add frequently used MeshLib headers to the precompiled header (see MRPch.h)
+          CL: /DMR_PCH_USE_EXTRA_HEADERS
         run: msbuild -m source\MeshLib.sln -p:Configuration=Release -p:VcpkgTriplet=${{ env.VCPKG_DEFAULT_TRIPLET }} -p:PlatformToolset=${{ env.PLATFORM_TOOLSET }} -p:MRCudaPlatformToolset=${{ env.CUDA_PLATFORM_TOOLSET }}
 
       - name: Install MSYS2 for MRBind
@@ -528,6 +531,7 @@ jobs:
           CMAKE_CXX_COMPILER: /usr/bin/clang++
           MR_CMAKE_OPTIONS: >
             -DMRVIEWER_NO_GTK=ON
+            -DMR_PCH_USE_EXTRA_HEADERS=ON
           # not realy needed
           CMAKE_C_COMPILER: /usr/bin/clang
 

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -402,9 +402,6 @@ jobs:
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
       - name: Build
-        env:
-          # add frequently used MeshLib headers to the precompiled header (see MRPch.h)
-          CL: /DMR_PCH_USE_EXTRA_HEADERS
         run: msbuild -m source\MeshLib.sln -p:Configuration=Release -p:VcpkgTriplet=${{ env.VCPKG_DEFAULT_TRIPLET }} -p:PlatformToolset=${{ env.PLATFORM_TOOLSET }} -p:MRCudaPlatformToolset=${{ env.CUDA_PLATFORM_TOOLSET }}
 
       - name: Install MSYS2 for MRBind


### PR DESCRIPTION
`MR_PCH_USE_EXTRA_HEADERS=ON` (adds frequently used MeshLib headers to the precompiled header, see `MRPch.h`) was already enabled in the Emscripten, Linux vcpkg, Ubuntu x64/arm64, manylinux pip, and docs CMake builds. This PR enables it in the macOS builds as well:

- **build-test-macos.yml** — added `-DMR_PCH_USE_EXTRA_HEADERS=ON` to `MR_CMAKE_OPTIONS` of the Build step
- **pip-build.yml** (`macos-pip-build`) — same

### Build time

Measured on the arm64 Debug job, the only macOS configuration running on a self-hosted runner with repeatable timings (the other jobs run on GitHub-hosted runners whose run-to-run variance is too high for a single-run comparison):

| | Build step |
|---|---|
| master, last 8 runs | 123–127 s (median 125 s) |
| this PR | **116 s** |

### Why not on Windows

An earlier revision of this PR also enabled the option in the Windows CMake and MSBuild builds, and they all failed: on MSVC the shared PCH is compiled in MRPch without `MRMesh_EXPORTS`, so the extra MeshLib headers are baked into the PCH with `MRMESH_API` = `__declspec(dllimport)`. MRMesh then reuses that PCH to compile its own sources, and defining functions that the PCH already declared dllimport fails with C2491 ("definition of dllimport function not allowed") and C4273 ("inconsistent dll linkage", an error under `/WX`). On Clang/AppleClang/GCC the option is safe because `MRMESH_API` expands to the same visibility attribute whether the library is being built or consumed.

Not changed (the MeshLib PCH is not compiled there): example builds in `test-distribution.yml`, the C/C++ example builds in `build-test-windows.yml`, and the `example_plugin.sln` build in `update-win-version.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
