### PR TITLE
Preserve _DEBUG around the pybind11 include baked into the bindings PCH

### DIFF
--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -888,8 +888,12 @@ $($1__CombinedHeaderOutput): $($1__InputFiles) | $(TEMP_OUTPUT_DIR)
 	$(call,### Write all our headers.)
 	$$(foreach f,$($1__InputFiles),$$(file >>$$@,#include "$$f"$$(lf)))
 	$(call,### Additional headers to bake into the PCH. The condition is to speed up parsing a bit.)
+	$(call,### The pybind header sits between `pre/post_include_pybind.h`, because on MSVC Debug pybind corrupts `_DEBUG` [restores it as empty)
+	$(call,### instead of `1`, see the comments in those headers]. Without the wrappers the corrupted value gets serialized as the PCH's final)
+	$(call,### macro state, so every fragment would start with it, and anything value-sensitive [e.g. TBB's debug detection] parsed after that)
+	$(call,### point would misbehave.)
 	$(if $(is_py),\
-		$$(if $($1_PyEnablePch),$$(file >>$$@,#ifndef MR_PARSING_FOR_PB11_BINDINGS$$(lf)#include <pybind11/pybind11.h>$$(lf)#endif))\
+		$$(if $($1_PyEnablePch),$$(file >>$$@,#ifndef MR_PARSING_FOR_PB11_BINDINGS$$(lf)#include <mrbind/targets/pybind11/pre_include_pybind.h>$$(lf)#include <pybind11/pybind11.h>$$(lf)#include <mrbind/targets/pybind11/post_include_pybind.h>$$(lf)#endif))\
 		$(call,### This alternative version bakes the whole our `core.h` [which includes `<pybind11/pybind11.h>], but for some reason my measurements show it to be a tiny bit slower. Weird.)\
 		$(call,###   #ifndef MR_PARSING_FOR_PB11_BINDINGS$(lf)#define MB_PB11_STAGE -1$(lf)#include MRBIND_HEADER$(lf)#undef MB_PB11_STAGE$(lf)#endif$(lf))\
 		$(call,### Note temporarily setting `MB_PB11_STAGE=-1`, we don't want to bake any of the macros.)\


### PR DESCRIPTION
On MSVC Debug builds, pybind11 `#undef`s `_DEBUG` around its `Python.h` include (to avoid demanding `pythonXY_d.lib`) and then restores it as **empty** instead of `1` — upstream [pybind/pybind11#5136](https://github.com/pybind/pybind11/issues/5136). mrbind's binding machinery defends against this by always including pybind between `pre_include_pybind.h`/`post_include_pybind.h`, which record and restore the exact prior state of `_DEBUG`.

The combined header that `generate.mk` compiles into the bindings PCH bakes `<pybind11/pybind11.h>` **raw**, bypassing that defense. Since a PCH serializes macro state, on Windows Debug the corrupted (empty) `_DEBUG` becomes the PCH's final state, and every binding fragment starts compiling with it. The fragments' own wrapped includes can't repair it — `pre_include_pybind.h` faithfully records the already-empty value.

Nothing observable breaks **today** because the corruption happens at the very end of the PCH: everything value-sensitive (TBB's debug detection is the known victim — an empty `_DEBUG` breaks `#if _DEBUG`-style checks) was already parsed with the correct value, and include guards prevent re-parsing. But it's a tripwire: any header newly parsed after the PCH that inspects the *value* of `_DEBUG` would silently misbehave in Windows Debug binding builds.

Fix: wrap the baked include in the same `pre/post_include_pybind.h` pair. The wrappers are no-ops outside `_MSC_VER`, so non-Windows platforms are byte-for-byte unaffected; on Windows Debug the PCH now ends with `_DEBUG` correctly restored to `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
