### PR TITLE
DIAG (do not merge): OpenVDB/Boost.IOStreams + lean-PCH macro parity probe

### DIFF
--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -129,6 +129,10 @@ jobs:
             cp -r scripts/mrbind/cuda_placeholder_generated_c/{include,src} source/MeshLibC2Cuda
           fi
 
+      - name: DIAG image (pre-build, libopenvdb)
+        if: ${{ always() }}
+        run: python3 scripts/diag_pch.py
+
       - name: Build
         run: ./scripts/build_source.sh
         env:
@@ -145,6 +149,11 @@ jobs:
             -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
             -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
             -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: DIAG compile_commands (post-build, macro parity)
+        if: ${{ always() }}
+        run: python3 scripts/diag_pch.py
 
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | c++filt

--- a/cmake/Modules/CompilerOptions.cmake
+++ b/cmake/Modules/CompilerOptions.cmake
@@ -1,8 +1,14 @@
 # this file must be included AFTER the `project' command because it relies on the detected compiler information
 
 set(MR_PCH_DEFAULT OFF)
-# for GCC and Clang<15 builds: PCH not only does not give any speedup, but even vice versa
+# MSVC and Clang>=15: the full precompiled header speeds the build up.
+# Clang<15: PCH not only does not give any speedup, but even vice versa.
+# GCC: the full PCH also slowed the build down (GCC loads the whole PCH image in
+# every TU), so MRPch.h precompiles only a lean subset of near-universally used
+# headers there (see MR_PCH_LEAN in MRPch.h).
 IF((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang") AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
+  set(MR_PCH_DEFAULT ON)
+ELSEIF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(MR_PCH_DEFAULT ON)
 ELSEIF(MSVC)
   set(MR_PCH_DEFAULT ON)

--- a/cmake/Modules/CompilerOptions.cmake
+++ b/cmake/Modules/CompilerOptions.cmake
@@ -200,6 +200,15 @@ IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
 ENDIF()
 
+# GCC>=13 at -O3 reports a false-positive array-bounds error in fmt 9's float
+# formatting (__builtin_memmove inlined from bigint::operator= via
+# format_dragon) — but only when the TU is compiled behind the precompiled
+# header; the same code builds clean without PCH, so the warning stays enabled
+# for non-PCH GCC builds.
+IF(MR_PCH_LEAN AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds")
+ENDIF()
+
 # more info: https://bugs.openjdk.org/browse/JDK-8244653
 IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11 AND CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64|arm64)")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")

--- a/cmake/Modules/CompilerOptions.cmake
+++ b/cmake/Modules/CompilerOptions.cmake
@@ -200,13 +200,14 @@ IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
 ENDIF()
 
-# GCC>=13 at -O3 reports a false-positive array-bounds error in fmt 9's float
-# formatting (__builtin_memmove inlined from bigint::operator= via
-# format_dragon) — but only when the TU is compiled behind the precompiled
-# header; the same code builds clean without PCH, so the warning stays enabled
-# for non-PCH GCC builds.
+# GCC>=13 at -O3 reports false-positive array-bounds and stringop-overflow
+# errors in fmt 9's float formatting (__builtin_memmove inlined from
+# bigint::operator= via format_dragon; fmt >= 10 suppresses both in its own
+# headers) — but only when the TU is compiled behind the precompiled header;
+# the same code builds clean without PCH, so the warnings stay enabled for
+# non-PCH GCC builds.
 IF(MR_PCH_LEAN AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds -Wno-stringop-overflow")
 ENDIF()
 
 # more info: https://bugs.openjdk.org/browse/JDK-8244653

--- a/cmake/Modules/CompilerOptions.cmake
+++ b/cmake/Modules/CompilerOptions.cmake
@@ -14,6 +14,13 @@ ELSEIF(MSVC)
   set(MR_PCH_DEFAULT ON)
 ENDIF()
 set(MR_PCH ${MR_PCH_DEFAULT} CACHE BOOL "Enable precompiled headers")
+# Mirrors MR_PCH_LEAN in MRPch.h. GCC refuses to use a PCH in a TU that lacks
+# any macro that was defined when the PCH was built, so in lean mode the MRPch
+# target must not carry compile definitions that REUSE_FROM consumers don't share.
+set(MR_PCH_LEAN OFF)
+IF(MR_PCH AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(MR_PCH_LEAN ON)
+ENDIF()
 IF(MR_PCH AND NOT MR_EMSCRIPTEN AND NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 ENDIF()

--- a/cmake/Modules/CompilerOptions.cmake
+++ b/cmake/Modules/CompilerOptions.cmake
@@ -200,16 +200,6 @@ IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
 ENDIF()
 
-# GCC>=13 at -O3 reports false-positive array-bounds and stringop-overflow
-# errors in fmt 9's float formatting (__builtin_memmove inlined from
-# bigint::operator= via format_dragon; fmt >= 10 suppresses both in its own
-# headers) — but only when the TU is compiled behind the precompiled header;
-# the same code builds clean without PCH, so the warnings stay enabled for
-# non-PCH GCC builds.
-IF(MR_PCH_LEAN AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds -Wno-stringop-overflow")
-ENDIF()
-
 # more info: https://bugs.openjdk.org/browse/JDK-8244653
 IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11 AND CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64|arm64)")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")

--- a/scripts/diag_pch.py
+++ b/scripts/diag_pch.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# DIAGNOSTIC ONLY (not for merge). Traces the OpenVDB -> Boost.IOStreams ->
+# _FILE_OFFSET_BITS chain and the lean-PCH macro parity in this CI image, to
+# explain why a lean GCC PCH reused across targets does or does not hit
+# -Werror=invalid-pch. Prints to stdout; never fails the step.
+import json, os, subprocess
+
+def sh(cmd):
+    try:
+        return subprocess.run(cmd, shell=True, capture_output=True,
+                              text=True, timeout=180).stdout
+    except Exception as e:
+        return f"<error: {e}>"
+
+print("########## 1. baked libopenvdb.so -> does it link boost_iostreams? ##########", flush=True)
+sos = [s for s in sh("find / -xdev -name 'libopenvdb.so*' 2>/dev/null").split() if s]
+if not sos:
+    print("  (no libopenvdb.so found)")
+for so in sorted(set(os.path.realpath(s) for s in sos)):
+    needed = sh(f"objdump -p '{so}' 2>/dev/null | grep NEEDED")
+    print(f"--- {so}")
+    print(f"    boost_iostreams in NEEDED: {'YES (delayed-loading)' if 'boost_iostreams' in needed else 'no'}")
+    for line in needed.splitlines():
+        if 'boost' in line.lower() or 'iostreams' in line.lower():
+            print("   ", line.strip())
+
+print("\n########## 2. libboost_iostreams present in image? ##########", flush=True)
+print(sh("find / -xdev -name 'libboost_iostreams*' 2>/dev/null") or "  (none)")
+
+print("\n########## 3. OPENVDB_USE_DELAYED_LOADING define in openvdb headers? ##########", flush=True)
+print(sh("grep -rln 'OPENVDB_USE_DELAYED_LOADING' "
+         "$(find / -xdev -path '*openvdb*' -name '*.h' 2>/dev/null) 2>/dev/null | head")
+      or "  (not found in headers)")
+
+print("\n########## 4. compile_commands.json macro parity per target ##########", flush=True)
+ccs = [c for c in sh("find . -name compile_commands.json 2>/dev/null").split() if c]
+print("  compile_commands.json:", ccs or "(none yet -- pre-build run)")
+want = ('MRPch', 'MRVoxels', 'MRMesh', 'MRViewer', 'MRPlugins', 'MRDental', 'MRInspector')
+if ccs:
+    try:
+        d = json.load(open(ccs[0]))
+        seen = {}
+        for e in d:
+            f = e.get('file', '')
+            cmd = e.get('command') or ' '.join(e.get('arguments', []))
+            for w in want:
+                if f"/{w}/" in f and w not in seen:
+                    seen[w] = dict(
+                        DELAYED='OPENVDB_USE_DELAYED_LOADING' in cmd,
+                        FILE_OFFSET_BITS='_FILE_OFFSET_BITS' in cmd,
+                        BOOST_IOSTREAMS='BOOST_IOSTREAMS' in cmd,
+                        reuses_pch=('cmake_pch' in cmd),
+                    )
+        for w in want:
+            print(f"  {w:12}: {seen.get(w, '(no TU in this build)')}")
+    except Exception as ex:
+        print("  parse error:", ex)
+print("\n########## diag done ##########", flush=True)

--- a/source/MRMCPGateway/CMakeLists.txt
+++ b/source/MRMCPGateway/CMakeLists.txt
@@ -45,6 +45,21 @@ IF(MR_PCH)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DFMT_SHARED /DSPDLOG_COMPILED_LIB /DSPDLOG_FMT_EXTERNAL /DSPDLOG_SHARED_LIB")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /DTBB_USE_DEBUG")
   endif()
+  if(MR_PCH_LEAN)
+    # GCC likewise refuses a PCH built with macros the TU doesn't define. This
+    # target links no MeshLib libraries, so it cannot inherit fmt/spdlog/TBB
+    # interface definitions (FMT_SHARED, SPDLOG_*, ...) transitively like the
+    # other REUSE_FROM consumers do; link the same targets the lean MRPch uses
+    # so the definitions match exactly on every dependency flavor.
+    find_package(fmt 8 REQUIRED)
+    find_package(spdlog 1.9 REQUIRED)
+    find_package(TBB 2020.1 COMPONENTS tbb REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+      fmt::fmt
+      spdlog::spdlog
+      TBB::tbb
+    )
+  endif()
   target_precompile_headers(${PROJECT_NAME} REUSE_FROM MRPch)
 ENDIF()
 

--- a/source/MRMCPGateway/CMakeLists.txt
+++ b/source/MRMCPGateway/CMakeLists.txt
@@ -45,21 +45,6 @@ IF(MR_PCH)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DFMT_SHARED /DSPDLOG_COMPILED_LIB /DSPDLOG_FMT_EXTERNAL /DSPDLOG_SHARED_LIB")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /DTBB_USE_DEBUG")
   endif()
-  if(MR_PCH_LEAN)
-    # GCC likewise refuses a PCH built with macros the TU doesn't define. This
-    # target links no MeshLib libraries, so it cannot inherit fmt/spdlog/TBB
-    # interface definitions (FMT_SHARED, SPDLOG_*, ...) transitively like the
-    # other REUSE_FROM consumers do; link the same targets the lean MRPch uses
-    # so the definitions match exactly on every dependency flavor.
-    find_package(fmt 8 REQUIRED)
-    find_package(spdlog 1.9 REQUIRED)
-    find_package(TBB 2020.1 COMPONENTS tbb REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PRIVATE
-      fmt::fmt
-      spdlog::spdlog
-      TBB::tbb
-    )
-  endif()
   target_precompile_headers(${PROJECT_NAME} REUSE_FROM MRPch)
 ENDIF()
 

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -45,24 +45,13 @@ IF(MR_PCH)
       target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest)
     ENDIF()
   ELSE()
-    # The lean PCH contains tl::expected, parallel-hashmap, TBB and spdlog.
-    # tl::expected is header-only with no interface compile definitions; its
-    # include root also provides parallel-hashmap in vcpkg builds, where the
-    # vendored thirdparty/parallel-hashmap directory is not populated.
-    # fmt/spdlog/TBB interface definitions (FMT_SHARED, SPDLOG_*, ...) reach
-    # every REUSE_FROM consumer through MRMesh's PUBLIC links, keeping the PCH
-    # macro parity that GCC requires — except MRMCPGateway, which links the
-    # same targets explicitly for that reason.
-    find_package(fmt 8 REQUIRED)
-    find_package(spdlog 1.9 REQUIRED)
-    find_package(TBB 2020.1 COMPONENTS tbb REQUIRED)
+    # The lean PCH still contains tl::expected and parallel-hashmap. tl::expected
+    # is header-only with no interface compile definitions, so it cannot break
+    # the PCH macro parity lean mode requires; its include root also provides
+    # parallel-hashmap in vcpkg builds, where the vendored
+    # thirdparty/parallel-hashmap directory is not populated.
     find_package(tl-expected REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PRIVATE
-      fmt::fmt
-      spdlog::spdlog
-      TBB::tbb
-      tl::expected
-    )
+    target_link_libraries(${PROJECT_NAME} PRIVATE tl::expected)
   ENDIF()
 
   # TODO: CMake config

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -12,32 +12,38 @@ install(
 IF(MR_PCH)
   add_library(${PROJECT_NAME} STATIC "MRPch.cpp" ${HEADERS})
 
-  # Emscripten's Boost package doesn't contain CMake config files
-  # on other systems the module mode shows a warning
-  IF(NOT EMSCRIPTEN)
-    find_package(Boost 1.73 CONFIG COMPONENTS headers REQUIRED)
-  ELSE()
-    find_package(Boost 1.73 REQUIRED)
-  ENDIF()
-  find_package(Eigen3 REQUIRED)
-  find_package(fmt 8 REQUIRED)
-  find_package(JsonCpp REQUIRED)
-  find_package(spdlog 1.9 REQUIRED)
-  find_package(TBB 2020.1 COMPONENTS tbb REQUIRED)
+  # The lean PCH (see MR_PCH_LEAN in MRPch.h) contains no third-party headers
+  # except parallel-hashmap and tl::expected, so it needs none of these
+  # dependencies — and must not inherit their interface compile definitions
+  # (e.g. FMT_SHARED), which GCC would require in every TU that uses the PCH.
+  IF(NOT MR_PCH_LEAN)
+    # Emscripten's Boost package doesn't contain CMake config files
+    # on other systems the module mode shows a warning
+    IF(NOT EMSCRIPTEN)
+      find_package(Boost 1.73 CONFIG COMPONENTS headers REQUIRED)
+    ELSE()
+      find_package(Boost 1.73 REQUIRED)
+    ENDIF()
+    find_package(Eigen3 REQUIRED)
+    find_package(fmt 8 REQUIRED)
+    find_package(JsonCpp REQUIRED)
+    find_package(spdlog 1.9 REQUIRED)
+    find_package(TBB 2020.1 COMPONENTS tbb REQUIRED)
 
-  target_link_libraries(${PROJECT_NAME} PRIVATE
-    Boost::boost
-    Eigen3::Eigen
-    fmt::fmt
-    JsonCpp::JsonCpp
-    spdlog::spdlog
-    TBB::tbb
-  )
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+      Boost::boost
+      Eigen3::Eigen
+      fmt::fmt
+      JsonCpp::JsonCpp
+      spdlog::spdlog
+      TBB::tbb
+    )
 
-  # GTest module defines a macro for MRMesh and PCH must match it (but not for MSVC)
-  IF(BUILD_TESTING AND NOT MRMESH_NO_GTEST AND NOT MSVC)
-    find_package(GTest REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest)
+    # GTest module defines a macro for MRMesh and PCH must match it (but not for MSVC)
+    IF(BUILD_TESTING AND NOT MRMESH_NO_GTEST AND NOT MSVC)
+      find_package(GTest REQUIRED)
+      target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest)
+    ENDIF()
   ENDIF()
 
   # TODO: CMake config
@@ -55,13 +61,13 @@ IF(MR_PCH)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
   ENDIF()
 
-  IF(MR_PCH_USE_EXTRA_HEADERS)
+  IF(MR_PCH_USE_EXTRA_HEADERS AND NOT MR_PCH_LEAN)
     target_compile_definitions(${PROJECT_NAME} PRIVATE MR_PCH_USE_EXTRA_HEADERS)
   ENDIF()
-  IF(NOT MESHLIB_BUILD_MRVIEWER)
+  IF(NOT MESHLIB_BUILD_MRVIEWER AND NOT MR_PCH_LEAN)
     target_compile_definitions(${PROJECT_NAME} PRIVATE MESHLIB_NO_VIEWER)
   ENDIF()
-  IF(MR_PCH_USE_EXTRA_HEADERS AND MESHLIB_BUILD_MRVIEWER)
+  IF(MR_PCH_USE_EXTRA_HEADERS AND MESHLIB_BUILD_MRVIEWER AND NOT MR_PCH_LEAN)
     target_link_libraries(${PROJECT_NAME} PUBLIC imgui)
   ENDIF()
 
@@ -71,7 +77,9 @@ IF(MR_PCH)
 
   # `dladdr` in our patched `PYBIND11_MODULE(...)` needs this.
   # Also needed for `Boost.Stacktrace` apparently.
-  IF(NOT WIN32)
+  # Not in lean mode: the lean PCH needs neither, and on Linux the consuming
+  # targets don't define _GNU_SOURCE, which would invalidate the PCH for GCC.
+  IF(NOT WIN32 AND NOT MR_PCH_LEAN)
     target_compile_definitions(${PROJECT_NAME} PUBLIC _GNU_SOURCE)
   ENDIF()
 ENDIF()

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -44,6 +44,14 @@ IF(MR_PCH)
       find_package(GTest REQUIRED)
       target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest)
     ENDIF()
+  ELSE()
+    # The lean PCH still contains tl::expected and parallel-hashmap. tl::expected
+    # is header-only with no interface compile definitions, so it cannot break
+    # the PCH macro parity lean mode requires; its include root also provides
+    # parallel-hashmap in vcpkg builds, where the vendored
+    # thirdparty/parallel-hashmap directory is not populated.
+    find_package(tl-expected REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PRIVATE tl::expected)
   ENDIF()
 
   # TODO: CMake config

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -45,13 +45,24 @@ IF(MR_PCH)
       target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest)
     ENDIF()
   ELSE()
-    # The lean PCH still contains tl::expected and parallel-hashmap. tl::expected
-    # is header-only with no interface compile definitions, so it cannot break
-    # the PCH macro parity lean mode requires; its include root also provides
-    # parallel-hashmap in vcpkg builds, where the vendored
-    # thirdparty/parallel-hashmap directory is not populated.
+    # The lean PCH contains tl::expected, parallel-hashmap, TBB and spdlog.
+    # tl::expected is header-only with no interface compile definitions; its
+    # include root also provides parallel-hashmap in vcpkg builds, where the
+    # vendored thirdparty/parallel-hashmap directory is not populated.
+    # fmt/spdlog/TBB interface definitions (FMT_SHARED, SPDLOG_*, ...) reach
+    # every REUSE_FROM consumer through MRMesh's PUBLIC links, keeping the PCH
+    # macro parity that GCC requires — except MRMCPGateway, which links the
+    # same targets explicitly for that reason.
+    find_package(fmt 8 REQUIRED)
+    find_package(spdlog 1.9 REQUIRED)
+    find_package(TBB 2020.1 COMPONENTS tbb REQUIRED)
     find_package(tl-expected REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PRIVATE tl::expected)
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+      fmt::fmt
+      spdlog::spdlog
+      TBB::tbb
+      tl::expected
+    )
   ENDIF()
 
   # TODO: CMake config

--- a/source/MRPch/MRFmt.h
+++ b/source/MRPch/MRFmt.h
@@ -2,9 +2,23 @@
 
 #pragma warning(push)
 #pragma warning(disable:4275) // non dll-interface class 'std::runtime_error' used as base for dll-interface class 'fmt::v10::format_error'
+// GCC >= 13 at -O3 reports false-positive array-bounds and stringop-overflow
+// errors in fmt 9's float formatting (__builtin_memmove inlined from
+// bigint::operator= via format_dragon) when the TU is compiled behind a
+// precompiled header; fmt >= 10 suppresses these in its own headers.
+// The pragma region covers fmt's inline definitions, so the suppression
+// applies only to code inlined from fmt and not to the rest of the TU.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 13
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 #include <spdlog/tweakme.h>
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/fmt/ostr.h>
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 13
+#pragma GCC diagnostic pop
+#endif
 #pragma warning(pop)
 
 #include "MRPch/MRBindingMacros.h"

--- a/source/MRPch/MRPch.h
+++ b/source/MRPch/MRPch.h
@@ -3,7 +3,8 @@
 // GCC's PCH is a monolithic dump of the compiler's memory image that every TU
 // loads back in full, so headers that most TUs never reach (e.g. Eigen: ~5% of
 // TUs) cost more to load than they save in parsing. For GCC, precompile only
-// the headers reachable from roughly half of all TUs or more.
+// the widely used headers: STL, parallel-hashmap, tl::expected, <filesystem>
+// (45-98% TU reach) plus TBB and spdlog (30% / 25%).
 #if defined(__GNUC__) && !defined(__clang__)
 #define MR_PCH_LEAN 1
 #else
@@ -43,8 +44,8 @@
 #pragma warning(pop)
 
 #include "MRJson.h"
-#include "MRSpdlog.h"
 #endif // !MR_PCH_LEAN
+#include "MRSpdlog.h"
 #include "MRSuppressWarning.h"
 
 #include "MRWinapi.h"
@@ -70,8 +71,6 @@
 #pragma warning(pop)
 #endif
 
-#include "MRTBB.h"
-
 #ifndef MESHLIB_NO_VIEWER
 #ifdef __EMSCRIPTEN__
 #include <GLES3/gl3.h>
@@ -82,6 +81,8 @@
 #endif
 
 #endif // !MR_PCH_LEAN
+
+#include "MRTBB.h"
 
 #include <algorithm>
 #include <array>

--- a/source/MRPch/MRPch.h
+++ b/source/MRPch/MRPch.h
@@ -1,12 +1,25 @@
 #pragma once
 
+// GCC's PCH is a monolithic dump of the compiler's memory image that every TU
+// loads back in full, so headers that most TUs never reach (e.g. Eigen: ~5% of
+// TUs) cost more to load than they save in parsing. For GCC, precompile only
+// the headers reachable from roughly half of all TUs or more.
+#if defined(__GNUC__) && !defined(__clang__)
+#define MR_PCH_LEAN 1
+#else
+#define MR_PCH_LEAN 0
+#endif
+
 #pragma warning(push)
 #pragma warning(disable: 4820) //#pragma warning: N bytes padding added after data member
 
+#if !MR_PCH_LEAN
 #include "MREigen.h"
+#endif
 #include "MRHashMap.h"
 #include "MRExpected.h"
 
+#if !MR_PCH_LEAN
 #pragma warning(push)
 #pragma warning(disable: 4619) // #pragma warning: there is no warning number
 #pragma warning(disable: 4643) // Forward declaring 'align_val_t' in namespace std is not permitted by the C++ Standard.
@@ -31,6 +44,7 @@
 
 #include "MRJson.h"
 #include "MRSpdlog.h"
+#endif // !MR_PCH_LEAN
 #include "MRSuppressWarning.h"
 
 #include "MRWinapi.h"
@@ -38,6 +52,8 @@
 #include <shlobj.h>
 #include <commdlg.h>
 #endif
+
+#if !MR_PCH_LEAN
 
 #ifndef __EMSCRIPTEN__
 #include <fmt/chrono.h>
@@ -64,6 +80,8 @@
 #endif
 #include <GLFW/glfw3.h>
 #endif
+
+#endif // !MR_PCH_LEAN
 
 #include <algorithm>
 #include <array>
@@ -102,7 +120,7 @@
 #include <vector>
 #include <version>
 
-#ifdef MR_PCH_USE_EXTRA_HEADERS
+#if defined(MR_PCH_USE_EXTRA_HEADERS) && !MR_PCH_LEAN
 #include "MRMesh/MRBitSetParallelFor.h"
 #include "MRMesh/MRFunctional.h"
 #include "MRMesh/MRIOFilters.h"

--- a/source/MRPch/MRPch.h
+++ b/source/MRPch/MRPch.h
@@ -3,8 +3,7 @@
 // GCC's PCH is a monolithic dump of the compiler's memory image that every TU
 // loads back in full, so headers that most TUs never reach (e.g. Eigen: ~5% of
 // TUs) cost more to load than they save in parsing. For GCC, precompile only
-// the widely used headers: STL, parallel-hashmap, tl::expected, <filesystem>
-// (45-98% TU reach) plus TBB and spdlog (30% / 25%).
+// the headers reachable from roughly half of all TUs or more.
 #if defined(__GNUC__) && !defined(__clang__)
 #define MR_PCH_LEAN 1
 #else
@@ -44,8 +43,8 @@
 #pragma warning(pop)
 
 #include "MRJson.h"
-#endif // !MR_PCH_LEAN
 #include "MRSpdlog.h"
+#endif // !MR_PCH_LEAN
 #include "MRSuppressWarning.h"
 
 #include "MRWinapi.h"
@@ -71,6 +70,8 @@
 #pragma warning(pop)
 #endif
 
+#include "MRTBB.h"
+
 #ifndef MESHLIB_NO_VIEWER
 #ifdef __EMSCRIPTEN__
 #include <GLES3/gl3.h>
@@ -81,8 +82,6 @@
 #endif
 
 #endif // !MR_PCH_LEAN
-
-#include "MRTBB.h"
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
## Diagnostic PR — DO NOT MERGE

Branched off #6248 (lean GCC PCH). Adds `scripts/diag_pch.py` + two CI steps on the GCC ubuntu-x64 lanes to answer one open question from the MeshInspectorCode validation: **why does enabling a lean GCC PCH break a downstream consumer (`MRPlugins`) with `-Werror=invalid-pch` on `_FILE_OFFSET_BITS`, while MeshLib's own build stays green** — even though MeshLib's `MRVoxels` PUBLIC-links OpenVDB and also `REUSE_FROM MRPch`.

The probe prints, inside this image:
1. whether the baked `libopenvdb.so` links `boost_iostreams` (i.e. OpenVDB delayed-loading, which pulls `Boost::iostreams` → `_FILE_OFFSET_BITS=64` into the `OpenVDB::openvdb` interface);
2. per-target (`MRPch`/`MRVoxels`/`MRMesh`/...) whether the compile command carries `OPENVDB_USE_DELAYED_LOADING` / `_FILE_OFFSET_BITS` and whether it reuses the PCH.

Compared against the same probe in the `meshinspector` image (MeshInspectorCode#7423), this pins the difference. Delete the branch when done.
