### PR TITLE
CI: keep CBindings artifact so failed build jobs can be re-run

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -455,12 +455,11 @@ jobs:
           name: PythonStubs
           failOnError: false
 
-      - name: Delete C bindings
-        if: needs.update-dev-documentation.result == 'success'
-        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
-        with:
-          name: CBindings
-          failOnError: false
+      # NOTE: intentionally NOT deleting the CBindings artifact here.
+      # It already has retention-days: 1 (see generate-c-bindings.yml), and keeping it for
+      # that window lets us re-run individual failed build jobs — a partial re-run does not
+      # re-run generate-c-bindings, so the artifact would otherwise be gone and the re-run
+      # would fail at "Download C bindings" with "Artifact not found for name: CBindings".
 
       - name: Delete Csharp bindings
         if: needs.update-dev-documentation.result == 'success'


### PR DESCRIPTION
## Problem

Re-running an individual failed build job fails at the **Download C bindings** step with:

```
##[error]Unable to download artifact(s): Artifact not found for name: CBindings
```

The `CBindings` artifact is produced once per run by the `generate-c-bindings` job and downloaded by every platform build job. The `update-artifacts` job then deletes it via the **Delete C bindings** cleanup step (once `update-dev-documentation` succeeds).

A *partial* re-run (re-running only the failed jobs) does **not** re-run the already-successful `generate-c-bindings` job, so the artifact is gone — and the re-run can never succeed. This was seen e.g. when a cancelled macOS x64 job was re-run hours later.

## Change

Remove the **Delete C bindings** step from the `update-artifacts` job.

The artifact already carries `retention-days: 1` (set in `generate-c-bindings.yml`), so storage stays bounded and it auto-expires within a day — which is a sufficient window for re-running failed jobs. The explicit delete is therefore unnecessary and only blocks re-runs.

A comment is left in place of the removed step so the asymmetry with the neighbouring `Delete Python Stubs` / `Delete Csharp bindings` steps is intentional and documented.

## Notes

- `CsharpBindings` is **not** affected: it is produced/consumed on the docs/pip path, not downloaded by the platform build jobs, so its delete step does not block build-job re-runs.
- No platform build logic changed; this only touches the post-build cleanup phase.
