### PR TITLE
Fix meshconv crash/failure on multi-object scene files

### DIFF
--- a/source/meshconv/meshconv.cpp
+++ b/source/meshconv/meshconv.cpp
@@ -131,11 +131,11 @@ MR::Expected<MR::ObjectPtr> combineObjs( const std::vector<std::shared_ptr<MR::O
 
     for ( int i = 0; i < objsQueue.size(); ++i )
     {
-        auto& objPtr = objsQueue[i];
+        auto objPtr = objsQueue[i]; // copy the shared_ptr: push_back below may reallocate objsQueue, invalidating a reference
         for ( auto& newPtr : objPtr->children() )
             objsQueue.push_back( newPtr );
 
-        if ( objPtr->typeName() == MR::Object::StaticTypeName() )
+        if ( std::string_view( objPtr->typeName() ) == MR::Object::StaticTypeName() ) // compare by content: typeName() is const char* and may differ in address across the DLL boundary
             continue;
 
         if ( auto objMesh = std::dynamic_pointer_cast< MR::ObjectMesh >( objPtr ) )


### PR DESCRIPTION
## Problem

`combineObjs()` in `source/meshconv/meshconv.cpp` crashed or failed on any multi-object scene file. STEP files trigger this because their loader produces a plain `Object` root that wraps the meshes. Both bugs were reproduced on Windows (Release/x64, VS2022) loading a 25-solid STEP file.

## Bug 1 — dangling reference / use-after-free

```cpp
auto& objPtr = objsQueue[i];              // reference into the vector
for ( auto& newPtr : objPtr->children() )
    objsQueue.push_back( newPtr );        // may REALLOCATE objsQueue -> objPtr dangles
if ( objPtr->typeName() == ... )          // use-after-free
```

The `push_back` can reallocate `objsQueue`, leaving `objPtr` (a reference into it) dangling; the subsequent dereferences are use-after-free. Narrow trees happen to survive; a wide tree (a container with many children) reliably crashes with access violation `0xC0000005`.

Fix: copy the `shared_ptr` by value — `auto objPtr = objsQueue[i];` (cheap).

## Bug 2 — pointer comparison of `typeName()`

```cpp
if ( objPtr->typeName() == MR::Object::StaticTypeName() )
    continue;
```

`Object::typeName()` returns `const char*`, so this compares pointers, not string content. For a plain `Object` loaded via `MRMesh.dll`, the two `"Object"` literals have different addresses across the call site / DLL boundary, so the comparison is `false` even though the content is equal. The plain-`Object` scene root is therefore not skipped, falls through to the final `else`, and `combineObjs` returns `Error: File contains unsupported objects!` — rejecting every scene-graph file with a non-mesh root.

Fix: compare by content with `std::string_view` (no allocation; already in scope via `MRObject.h`).

## Audit

Checked the other `typeName()` / `StaticTypeName()` comparison sites in the codebase — all are safe because each compares against a `std::string` / `const std::string&` LHS (content comparison):

- `MRViewer/MRRibbonSceneObjectsListDrawer.cpp` (`name` / `typeName` are `std::string`)
- `MRMesh/MRSceneLoad.cpp` (`typeName` is `std::string`)

meshconv was the only site comparing a raw `const char*`.

## Verification

Built the `meshconv` project (Release/x64) and ran it on a 25-solid STEP file:

```
Loading "Vessel_simp.stp"...
Loaded successfully in 0.52s
num vertices: 37030
num edges:    105180
num faces:    70120
Saving "out.stl"...
Saved successfully
```

Exit code 0; output is a valid binary STL with exactly 70120 triangles. Before the fix this crashed (wide tree) / errored with "unsupported objects!".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
