### PR TITLE
ci(win): produce separate VS2019/VS2022/VS2026 developer distributives

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -150,6 +150,7 @@ jobs:
     uses: ./.github/workflows/update-win-version.yml
     with:
       vs19_vcpkg_version: ${{ needs.config.outputs.vs19_vcpkg_version }}
+      vs22_vcpkg_version: ${{ needs.config.outputs.vs22_vcpkg_version }}
       app_version: ${{ needs.config.outputs.app_version }}
     secrets: inherit
 
@@ -269,7 +270,13 @@ jobs:
         run: |
           shopt -s nullglob
           for PKG_FILE in MeshLibDist*.zip ; do
-            mv "$PKG_FILE" "${PKG_FILE/Dist/Dist_${{ needs.config.outputs.app_version }}}"
+            case "$PKG_FILE" in
+              # Keep the historical layout for the iterator-debug archive:
+              # MeshLibDist-IteratorDebug.zip -> MeshLibDist_<version>-IteratorDebug.zip
+              *-IteratorDebug.zip) mv "$PKG_FILE" "${PKG_FILE/Dist/Dist_${{ needs.config.outputs.app_version }}}" ;;
+              # Per-VS archives: MeshLibDistVS19.zip -> MeshLibDistVS19_<version>.zip
+              *) mv "$PKG_FILE" "${PKG_FILE%.zip}_${{ needs.config.outputs.app_version }}.zip" ;;
+            esac
           done
           for PKG_FILE in MeshLib*.nupkg ; do
             mv "$PKG_FILE" "${PKG_FILE/MeshLib/MeshLib_${{ needs.config.outputs.app_version }}}"

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -47,7 +47,11 @@ jobs:
       BUILD_C_SHARP: ${{ matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild' }}
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
-      job_upload_artifact: ${{ inputs.upload_artifacts && matrix.cxx_compiler == 'msvc-2019' && matrix.build_system == 'CMake' }}
+      # Upload a developer distributive from every Visual Studio CMake build
+      # (VS2019/VS2022/VS2026). VS_TAG keeps their archive names distinct so
+      # update-win-version can repackage each into MeshLibDistVS{19,22,26}.zip.
+      job_upload_artifact: ${{ inputs.upload_artifacts && matrix.build_system == 'CMake' }}
+      VS_TAG: ${{ fromJSON('{"msvc-2019":"VS19","msvc-2022":"VS22"}')[matrix.cxx_compiler] || 'VS26' }}
       CUDA_VERSION: ${{ matrix.cuda_version }}
       VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}
       PLATFORM_TOOLSET: ${{ fromJSON('{"msvc-2019":"v142","msvc-2022":"v143"}')[matrix.cxx_compiler] || 'v145' }}
@@ -355,18 +359,20 @@ jobs:
         # https://github.com/actions/download-artifact#maintaining-file-permissions-and-case-sensitive-files
       - name: Archive files
         if: ${{ env.job_upload_artifact == 'true' }}
-        run: tar --format zip -c -f MREDist_${{ matrix.upload_name || matrix.config }}.zip ./source/x64/${{ matrix.config }}
+        run: tar --format zip -c -f MREDist_${{ env.VS_TAG }}_${{ matrix.upload_name || matrix.config }}.zip ./source/x64/${{ matrix.config }}
 
       - name: Archive generated C headers
-        if: ${{ env.job_upload_artifact == 'true' && matrix.config == 'Release' && inputs.mrbind_c }}
+        # The C2 headers are compiler-independent; upload them once (from VS2019)
+        # to avoid racing artifact uploads with the same name across VS builds.
+        if: ${{ env.job_upload_artifact == 'true' && matrix.cxx_compiler == 'msvc-2019' && matrix.config == 'Release' && inputs.mrbind_c }}
         run: tar --format zip -c -f MeshLibC2Headers.zip ./source/MeshLibC2/include
 
       - name: Upload Windows Binaries Archive
         if: ${{ env.job_upload_artifact == 'true' }}
         uses: actions/upload-artifact@v7
         with:
-          name: WindowsArchive_${{ matrix.upload_name || matrix.config }}
-          path: MREDist_${{ matrix.upload_name || matrix.config }}.zip
+          name: WindowsArchive_${{ env.VS_TAG }}_${{ matrix.upload_name || matrix.config }}
+          path: MREDist_${{ env.VS_TAG }}_${{ matrix.upload_name || matrix.config }}.zip
           retention-days: 1
           overwrite: true
           # The payload is already a .zip; don't re-Deflate it (no size gain).
@@ -378,11 +384,11 @@ jobs:
         uses: ./.github/actions/collect-artifact-stats
         with:
           artifact_path: ${{ github.workspace }}
-          artifact_glob: MREDist_${{ matrix.upload_name || matrix.config }}.zip
+          artifact_glob: MREDist_${{ env.VS_TAG }}_${{ matrix.upload_name || matrix.config }}.zip
           stats_file_suffix: -${{ steps.collect-runner-stats.outputs.job_id }}
 
       - name: Upload MeshLibC2 headers archive
-        if: ${{ env.job_upload_artifact == 'true' && matrix.config == 'Release' && inputs.mrbind_c }}
+        if: ${{ env.job_upload_artifact == 'true' && matrix.cxx_compiler == 'msvc-2019' && matrix.config == 'Release' && inputs.mrbind_c }}
         uses: actions/upload-artifact@v7
         with:
           name: WindowsArchive_MeshLibC2Headers

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -47,10 +47,12 @@ jobs:
       BUILD_C_SHARP: ${{ matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild' }}
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
-      # Upload a developer distributive from every Visual Studio CMake build
-      # (VS2019/VS2022/VS2026). VS_TAG keeps their archive names distinct so
+      # Upload a developer distributive per Visual Studio toolchain so
       # update-win-version can repackage each into MeshLibDistVS{19,22,26}.zip.
-      job_upload_artifact: ${{ inputs.upload_artifacts && matrix.build_system == 'CMake' }}
+      # VS2019/VS2022 ship the CMake build; VS2026 ships the MSBuild build
+      # (which also produces the C#/.NET components). VS_TAG keeps the archive
+      # names distinct.
+      job_upload_artifact: ${{ inputs.upload_artifacts && ( matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild' || matrix.cxx_compiler != 'msvc-2026' && matrix.build_system == 'CMake' ) }}
       VS_TAG: ${{ fromJSON('{"msvc-2019":"VS19","msvc-2022":"VS22"}')[matrix.cxx_compiler] || 'VS26' }}
       CUDA_VERSION: ${{ matrix.cuda_version }}
       VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}

--- a/.github/workflows/distro-release.yml
+++ b/.github/workflows/distro-release.yml
@@ -73,6 +73,7 @@ jobs:
     uses: ./.github/workflows/update-win-version.yml
     with:
       vs19_vcpkg_version: ${{ needs.config.outputs.vs19_vcpkg_version }}
+      vs22_vcpkg_version: ${{ needs.config.outputs.vs22_vcpkg_version }}
       app_version: ${{ needs.config.outputs.app_version }}
     secrets: inherit
 
@@ -97,7 +98,13 @@ jobs:
         run: |
           shopt -s nullglob
           for PKG_FILE in MeshLibDist*.zip ; do
-            mv "$PKG_FILE" "${PKG_FILE/Dist/Dist_${{ needs.config.outputs.app_version }}}"
+            case "$PKG_FILE" in
+              # Keep the historical layout for the iterator-debug archive:
+              # MeshLibDist-IteratorDebug.zip -> MeshLibDist_<version>-IteratorDebug.zip
+              *-IteratorDebug.zip) mv "$PKG_FILE" "${PKG_FILE/Dist/Dist_${{ needs.config.outputs.app_version }}}" ;;
+              # Per-VS archives: MeshLibDistVS19.zip -> MeshLibDistVS19_<version>.zip
+              *) mv "$PKG_FILE" "${PKG_FILE%.zip}_${{ needs.config.outputs.app_version }}.zip" ;;
+            esac
           done
 
       - name: Upload Distributives

--- a/.github/workflows/matrix/windows-finalize-release-config.json
+++ b/.github/workflows/matrix/windows-finalize-release-config.json
@@ -17,6 +17,38 @@
       "cuda_version": "11.4.2"
     },
     {
+      "cxx_compiler": "msvc-2022",
+      "config": "Debug",
+      "build_system": "CMake",
+      "vcpkg_triplet": "x64-windows-vs2022-meshlib",
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1"
+    },
+    {
+      "cxx_compiler": "msvc-2022",
+      "config": "Release",
+      "build_system": "CMake",
+      "vcpkg_triplet": "x64-windows-vs2022-meshlib",
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1"
+    },
+    {
+      "cxx_compiler": "msvc-2026",
+      "config": "Debug",
+      "build_system": "CMake",
+      "vcpkg_triplet": "x64-windows-meshlib",
+      "runner": ["windows-2025"],
+      "cuda_version": "13.2.0"
+    },
+    {
+      "cxx_compiler": "msvc-2026",
+      "config": "Release",
+      "build_system": "CMake",
+      "vcpkg_triplet": "x64-windows-meshlib",
+      "runner": ["windows-2025"],
+      "cuda_version": "13.2.0"
+    },
+    {
       "cxx_compiler": "msvc-2019",
       "config": "Debug",
       "build_system": "CMake",

--- a/.github/workflows/matrix/windows-finalize-release-config.json
+++ b/.github/workflows/matrix/windows-finalize-release-config.json
@@ -35,18 +35,20 @@
     {
       "cxx_compiler": "msvc-2026",
       "config": "Debug",
-      "build_system": "CMake",
+      "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
       "runner": ["windows-2025"],
-      "cuda_version": "13.2.0"
+      "cuda_version": "12.0.1",
+      "mrcuda_platform_toolset": "v143"
     },
     {
       "cxx_compiler": "msvc-2026",
       "config": "Release",
-      "build_system": "CMake",
+      "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
       "runner": ["windows-2025"],
-      "cuda_version": "13.2.0"
+      "cuda_version": "12.0.1",
+      "mrcuda_platform_toolset": "v143"
     },
     {
       "cxx_compiler": "msvc-2019",

--- a/.github/workflows/matrix/windows-standard-config.json
+++ b/.github/workflows/matrix/windows-standard-config.json
@@ -35,11 +35,12 @@
     },
     {
       "cxx_compiler": "msvc-2026",
-      "config": "Release",
-      "build_system": "CMake",
+      "config": "Debug",
+      "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
       "runner": ["windows-2025"],
-      "cuda_version": "13.2.0"
+      "cuda_version": "12.0.1",
+      "mrcuda_platform_toolset": "v143"
     },
     {
       "cxx_compiler": "msvc-2022",

--- a/.github/workflows/matrix/windows-standard-config.json
+++ b/.github/workflows/matrix/windows-standard-config.json
@@ -28,14 +28,6 @@
     {
       "cxx_compiler": "msvc-2026",
       "config": "Debug",
-      "build_system": "CMake",
-      "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2025"],
-      "cuda_version": "13.2.0"
-    },
-    {
-      "cxx_compiler": "msvc-2026",
-      "config": "Debug",
       "build_system": "MSBuild",
       "vcpkg_triplet": "x64-windows-meshlib",
       "runner": ["windows-2025"],

--- a/.github/workflows/matrix/windows-standard-config.json
+++ b/.github/workflows/matrix/windows-standard-config.json
@@ -34,6 +34,30 @@
       "cuda_version": "13.2.0"
     },
     {
+      "cxx_compiler": "msvc-2026",
+      "config": "Release",
+      "build_system": "CMake",
+      "vcpkg_triplet": "x64-windows-meshlib",
+      "runner": ["windows-2025"],
+      "cuda_version": "13.2.0"
+    },
+    {
+      "cxx_compiler": "msvc-2022",
+      "config": "Debug",
+      "build_system": "CMake",
+      "vcpkg_triplet": "x64-windows-vs2022-meshlib",
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1"
+    },
+    {
+      "cxx_compiler": "msvc-2022",
+      "config": "Release",
+      "build_system": "CMake",
+      "vcpkg_triplet": "x64-windows-vs2022-meshlib",
+      "runner": ["windows-2025"],
+      "cuda_version": "12.0.1"
+    },
+    {
       "cxx_compiler": "msvc-2019",
       "config": "Debug",
       "build_system": "CMake",

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -319,7 +319,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - dist_pattern: "MeshLibDist_${{ inputs.release_tag }}.zip"
+          - dist_pattern: "MeshLibDistVS19_${{ inputs.release_tag }}.zip"
+            config: Release
+            app_subdir: Release
+            idl: 0
+          - dist_pattern: "MeshLibDistVS22_${{ inputs.release_tag }}.zip"
+            config: Release
+            app_subdir: Release
+            idl: 0
+          - dist_pattern: "MeshLibDistVS26_${{ inputs.release_tag }}.zip"
             config: Release
             app_subdir: Release
             idl: 0

--- a/.github/workflows/update-win-version.yml
+++ b/.github/workflows/update-win-version.yml
@@ -6,6 +6,9 @@ on:
       vs19_vcpkg_version:
         required: true
         type: string
+      vs22_vcpkg_version:
+        required: true
+        type: string
       app_version:
         required: true
         type: string
@@ -17,18 +20,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # One developer distributive per Visual Studio toolchain. The MREDist_*
+        # inputs are produced by the matching VS CMake build in
+        # build-test-windows.yml (named via its VS_TAG). vcpkg_baseline selects
+        # which vcpkg version the binaries were built against.
         include:
           - vcpkg_triplet: x64-windows-vs2019-meshlib
-            extract_release: MREDist_Release.zip
-            extract_debug: MREDist_Debug.zip
-            output_zip: MeshLibDist.zip
-            artifact_name: DistributivesWin
+            vcpkg_baseline: vs19
+            extract_release: MREDist_VS19_Release.zip
+            extract_debug: MREDist_VS19_Debug.zip
+            output_zip: MeshLibDistVS19.zip
+            artifact_name: DistributivesWin-VS19
+          - vcpkg_triplet: x64-windows-vs2022-meshlib
+            vcpkg_baseline: vs22
+            extract_release: MREDist_VS22_Release.zip
+            extract_debug: MREDist_VS22_Debug.zip
+            output_zip: MeshLibDistVS22.zip
+            artifact_name: DistributivesWin-VS22
+          - vcpkg_triplet: x64-windows-meshlib
+            vcpkg_baseline: vs22
+            extract_release: MREDist_VS26_Release.zip
+            extract_debug: MREDist_VS26_Debug.zip
+            output_zip: MeshLibDistVS26.zip
+            artifact_name: DistributivesWin-VS26
           - vcpkg_triplet: x64-windows-meshlib-iterator-debug
-            extract_debug: MREDist_Debug-IteratorDebug.zip
+            vcpkg_baseline: vs19
+            extract_debug: MREDist_VS19_Debug-IteratorDebug.zip
             output_zip: MeshLibDist-IteratorDebug.zip
             artifact_name: DistributivesWin-IteratorDebug
     env:
-      vs19_vcpkg_version: ${{ inputs.vs19_vcpkg_version }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-vs2019-meshlib' }}
     steps:
       - name: Checkout
@@ -39,7 +59,7 @@ jobs:
       - name: Set up vcpkg
         uses: ./.github/actions/setup-vcpkg-windows
         with:
-          vcpkg-version: ${{ env.vs19_vcpkg_version }}
+          vcpkg-version: ${{ matrix.vcpkg_baseline == 'vs22' && inputs.vs22_vcpkg_version || inputs.vs19_vcpkg_version }}
           vcpkg-triplet: ${{ matrix.vcpkg_triplet }}
 
       - name: Download Windows Binaries Archive

--- a/scripts/devops/release_table.txt
+++ b/scripts/devops/release_table.txt
@@ -7,9 +7,21 @@
   </thead>
   <tbody>
     <tr>
-      <td align="center">Windows x64</td>
+      <td align="center">Windows x64 (Visual Studio 2019)</td>
       <td align="center">
-        <a href="RELEASE_PATH/MeshLibDist_SHORT_VERSION.zip">zip</a>
+        <a href="RELEASE_PATH/MeshLibDistVS19_SHORT_VERSION.zip">zip</a>
+      </td>
+    </tr>
+    <tr>
+      <td align="center">Windows x64 (Visual Studio 2022)</td>
+      <td align="center">
+        <a href="RELEASE_PATH/MeshLibDistVS22_SHORT_VERSION.zip">zip</a>
+      </td>
+    </tr>
+    <tr>
+      <td align="center">Windows x64 (Visual Studio 2026)</td>
+      <td align="center">
+        <a href="RELEASE_PATH/MeshLibDistVS26_SHORT_VERSION.zip">zip</a>
       </td>
     </tr>
     <tr>

--- a/scripts/make_install_folder.py
+++ b/scripts/make_install_folder.py
@@ -74,6 +74,14 @@ def copy_lib():
 	shutil.copytree(os.path.join(it.path_to_sources,'x64'),it.path_to_libs,dirs_exist_ok=True)
 	shutil.copytree(os.path.join(os.path.join(vcpkg_directory,'debug'),'lib'),os.path.join(it.path_to_libs,"Debug"),dirs_exist_ok=True)
 	shutil.copytree(os.path.join(vcpkg_directory,'lib'),os.path.join(it.path_to_libs,"Release"),dirs_exist_ok=True)
+
+	# Drop the debug-symbol cache that the .NET (C#) test run leaves under
+	# x64/<config>/sym (coreclr/ntdll/kernelbase PDBs, indexed by GUID). Its
+	# files end in .pdb so the prune below would otherwise keep them, bloating
+	# the package with system symbols that must not ship.
+	for sym_dir in glob.glob(os.path.join(it.path_to_libs, "*", "sym")):
+		shutil.rmtree(sym_dir, ignore_errors=True)
+
 	folder = os.walk(it.path_to_libs)
 	for address, dirs, files in folder:
 		for file in files:


### PR DESCRIPTION
## What

The Windows release currently ships a single developer archive,
`MeshLibDist_<ver>.zip`, built only from the VS2019 CMake build. This PR
produces three archives instead — one per Visual Studio toolchain — built under
the same circumstances (scheduled / `full-ci` / `build-release-windows` runs and
the by-tag "Windows Release by Tag" workflow):

- `MeshLibDistVS19_<ver>.zip` — what was previously `MeshLibDist_<ver>.zip` (VS2019)
- `MeshLibDistVS22_<ver>.zip` — VS2022
- `MeshLibDistVS26_<ver>.zip` — VS2026

## Changes

- **build-test-windows.yml** — upload a developer archive per toolchain:
  VS2019/VS2022 from their CMake builds, VS2026 from its **MSBuild** build (which
  also produces the C#/.NET components). A new `VS_TAG` env (`VS19`/`VS22`/`VS26`)
  is woven into the `MREDist_*` / `WindowsArchive_*` names so the per-toolchain
  archives no longer collide. The compiler-independent C2 headers archive is
  still uploaded once (from VS2019) to avoid racing same-named uploads.
- **update-win-version.yml** — one matrix leg per toolchain, each repackaging its
  archives into `MeshLibDistVS{19,22,26}.zip` using the matching vcpkg baseline
  and triplet. Adds a `vs22_vcpkg_version` input. The iterator-debug leg is
  unchanged.
- **build-test-distribute.yml / distro-release.yml** — pass `vs22_vcpkg_version`
  and rename the per-VS archives to `MeshLibDistVSxx_<ver>.zip`. The
  iterator-debug archive keeps its historical
  `MeshLibDist_<ver>-IteratorDebug.zip` name.
- **windows-standard / windows-finalize-release matrices** — add the VS2022
  CMake and VS2026 MSBuild Debug+Release legs so those paths also build all three
  archives (the full config already had them).
- **test-distribution.yml** — smoke-test all three archives.
- **release_table.txt** — link all three Windows archives in the published
  release notes.

## Validation

Labeled `full-ci` to exercise the full Windows config (all three toolchains,
Debug+Release) end-to-end, with the non-Windows platforms disabled since they are
untouched. The resulting `-pr-test` draft release should contain
`MeshLibDistVS19/VS22/VS26_<ver>.zip` plus the unchanged iterator-debug archive.

## Notes

- Downstream consumers were checked: nothing else references the old
  `MeshLibDist_<ver>.zip` name.
- On a plain `push` to master (minimal config) the broadened upload gate now also
  uploads one extra binary archive that is discarded unconsumed (same pattern as
  the pre-existing VS2019 push uploads); the per-VS distributives themselves are
  only repackaged on release runs. Happy to gate the upload on `build-release-win`
  instead if preferred.
