### PR TITLE
Add MRFrequentHeaderOnly.h listing frequently-included header-only headers

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -47,6 +47,12 @@ jobs:
       BUILD_C_SHARP: ${{ matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild' }}
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
+      # Bake the extra MeshLib headers into the shared MRPch.pch (consumed in
+      # MRPch.h). Set job-wide for MSBuild so every project that creates or uses
+      # the PCH -- including MeshLibC2Cuda, built in its own step -- compiles with
+      # the same define; otherwise MSVC reports C4651 (and /WX makes it an error).
+      # Empty for the CMake build, which does not enable the extra-header PCH.
+      CL: ${{ matrix.build_system == 'MSBuild' && '/DMR_PCH_USE_EXTRA_HEADERS' || '' }}
       # Upload a developer distributive per Visual Studio toolchain so
       # update-win-version can repackage each into MeshLibDistVS{19,22,26}.zip.
       # VS2019/VS2022 ship the CMake build; VS2026 ships the MSBuild build
@@ -204,10 +210,6 @@ jobs:
             if not exist source\x64 mkdir source\x64 || exit /b 1
             xcopy source\TempOutput\bin\* source\x64\${{matrix.config}}\* /s /e /i /Y || exit /b 1
           ) else (
-            rem Bake the extra MeshLib headers into the shared precompiled header
-            rem (the define is consumed in MRPch.h). CL applies it to every project
-            rem that creates or uses MRPch.pch, keeping the PCH self-consistent.
-            set "CL=%CL% /DMR_PCH_USE_EXTRA_HEADERS"
             msbuild -m source\MeshLib.sln -p:Configuration=${{ matrix.config }} -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }} || exit /b 1
           )
 

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -204,6 +204,10 @@ jobs:
             if not exist source\x64 mkdir source\x64 || exit /b 1
             xcopy source\TempOutput\bin\* source\x64\${{matrix.config}}\* /s /e /i /Y || exit /b 1
           ) else (
+            rem Bake the extra MeshLib headers into the shared precompiled header
+            rem (the define is consumed in MRPch.h). CL applies it to every project
+            rem that creates or uses MRPch.pch, keeping the PCH self-consistent.
+            set "CL=%CL% /DMR_PCH_USE_EXTRA_HEADERS"
             msbuild -m source\MeshLib.sln -p:Configuration=${{ matrix.config }} -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }} || exit /b 1
           )
 

--- a/source/MRMcp/MRFastmcpp.h
+++ b/source/MRMcp/MRFastmcpp.h
@@ -2,9 +2,14 @@
 
 // Centralised fastmcpp wrapper. Both MRMcp.cpp and MRMCPGateway.cpp must pull
 // fastmcpp in before any standard library header (fastmcpp's macro tricks rely
-// on that ordering). Keep `#undef _t` next to the includes: fastmcpp uses `_t`
-// as a template parameter and our translation macro shadows it.
+// on that ordering). fastmcpp uses `_t` as a template parameter and our
+// translation macro (MRMeshFwd.h) shadows it, so suppress `_t` across the
+// fastmcpp includes. Use push_macro/pop_macro rather than a bare #undef: when
+// MRMeshFwd.h is baked into the precompiled header its `#pragma once` is already
+// satisfied, so a later #include can no longer restore `_t`; push/pop guarantees
+// the macro is reinstated for translation users (e.g. MRViewer/MRMouse.h).
 
+#pragma push_macro( "_t" )
 #undef _t
 
 #if defined( __GNUC__ )
@@ -29,3 +34,5 @@
 #elif defined( _MSC_VER )
 #pragma warning( pop )
 #endif
+
+#pragma pop_macro( "_t" )

--- a/source/MRMesh/MRFrequentHeaderOnly.h
+++ b/source/MRMesh/MRFrequentHeaderOnly.h
@@ -1,0 +1,65 @@
+#pragma once
+
+// This header aggregates MRMesh public headers that
+// 1) never use the MRMESH_API macro (directly or via sub-includes), i.e. they are effectively header-only, and
+// 2) are included (directly or indirectly) by more than 20 of MeshLib's .cpp files.
+// The number in the comment after each include is that count of including .cpp files.
+// Such headers are good candidates for precompiled-header baking.
+
+#include "MRMacros.h" // 647
+#include "MRCanonicalTypedefs.h" // 646
+#include "MRMeshFwd.h" // 646
+#include "config.h" // 646
+#include "MRUnsigned.h" // 560
+#include "MRConstants.h" // 543
+#include "MRVector3.h" // 542
+#include "MRId.h" // 497
+#include "MRphmap.h" // 469
+#include "MRResizeNoInit.h" // 462
+#include "MRVector.h" // 462
+#include "MRVector2.h" // 461
+#include "MRExpected.h" // 452
+#include "MRProgressCallback.h" // 433
+#include "MRMatrix2.h" // 381
+#include "MRMatrix3.h" // 377
+#include "MRAffineXf.h" // 371
+#include "MRVectorTraits.h" // 368
+#include "MRSegmPoint.h" // 358
+#include "MRAffineXf3.h" // 356
+#include "MRMeshPart.h" // 312
+#include "MRBox.h" // 306
+#include "MRTriPoint.h" // 304
+#include "MRVector4.h" // 263
+#include "MRWriter.h" // 257
+#include "MRMeshBuilderTypes.h" // 256
+#include "MRPlane3.h" // 212
+#include "MRViewportId.h" // 211
+#include "MRHeapBytes.h" // 208
+#include "MRFlagOperators.h" // 203
+#include "MRRenderModelParameters.h" // 195
+#include "MRSignal.h" // 192
+#include "MRFunctional.h" // 168
+#include "MRParallel.h" // 168
+#include "MRViewportProperty.h" // 148
+#include "MRLineSegm.h" // 141
+#include "MRUniquePtr.h" // 127
+#include "MRXfBasedCache.h" // 88
+#include "MRFinally.h" // 81
+#include "MRIteratorRange.h" // 78
+#include "MRPointCloudPart.h" // 72
+#include "MRMatrix4.h" // 71
+#include "MRBuffer.h" // 68
+#include "MRNoDefInit.h" // 68
+#include "MRQuaternion.h" // 68
+#include "MRCloudPartMapping.h" // 65
+#include "MRLine.h" // 63
+#include "MRLine3.h" // 56
+#include "MRMeshLoadSettings.h" // 53
+#include "MROnInit.h" // 53
+#include "MRLinesLoadSettings.h" // 47
+#include "MRPointsLoadSettings.h" // 46
+#include "MRObjectsAccess.hpp" // 42
+#include "MRAABBTreeNode.h" // 36
+#include "MRSymMatrix3.h" // 34
+#include "MRTriMath.h" // 26
+#include "MRHoleFillPlan.h" // 25

--- a/source/MRMesh/MRFrequentHeaderOnly.h
+++ b/source/MRMesh/MRFrequentHeaderOnly.h
@@ -58,7 +58,6 @@
 #include "MROnInit.h" // 53
 #include "MRLinesLoadSettings.h" // 47
 #include "MRPointsLoadSettings.h" // 46
-#include "MRObjectsAccess.hpp" // 42
 #include "MRAABBTreeNode.h" // 36
 #include "MRSymMatrix3.h" // 34
 #include "MRTriMath.h" // 26

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -16,6 +16,7 @@
     <ClInclude Include="MRCurve.h" />
     <ClInclude Include="MRDivRound.h" />
     <ClInclude Include="MRFastInt128.h" />
+    <ClInclude Include="MRFrequentHeaderOnly.h" />
     <ClInclude Include="MRHoleFillPlan.h" />
     <ClInclude Include="MRImageTransform.h" />
     <ClInclude Include="MRLinesLoadSettings.h" />

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -18,6 +18,7 @@
     <ClInclude Include="MRFastInt128.h" />
     <ClInclude Include="MRFrequentHeaderOnly.h" />
     <ClInclude Include="MRHoleFillPlan.h" />
+    <ClInclude Include="MRMeshExport.h" />
     <ClInclude Include="MRImageTransform.h" />
     <ClInclude Include="MRLinesLoadSettings.h" />
     <ClInclude Include="MRLoadedMeshData.h" />
@@ -800,7 +801,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>$(ProjectDir)..\MRPch\MRPch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(ProjectDir)..\..\thirdparty</AdditionalIncludeDirectories>
-      <ForcedIncludeFiles>$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>$(ProjectDir)..\MRPch\MRPch.h;$(ProjectDir)MRMeshExport.h</ForcedIncludeFiles>
       <PrecompiledHeaderOutputFile>$(SolutionDir)TempOutput\MRPch\$(Platform)\$(Configuration)\MRPch.pch</PrecompiledHeaderOutputFile>
     </ClCompile>
     <Link>
@@ -822,7 +823,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>$(ProjectDir)..\MRPch\MRPch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(ProjectDir)..\..\thirdparty</AdditionalIncludeDirectories>
-      <ForcedIncludeFiles>$(ProjectDir)..\MRPch\MRPch.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>$(ProjectDir)..\MRPch\MRPch.h;$(ProjectDir)MRMeshExport.h</ForcedIncludeFiles>
       <PrecompiledHeaderOutputFile>$(SolutionDir)TempOutput\MRPch\$(Platform)\$(Configuration)\MRPch.pch</PrecompiledHeaderOutputFile>
     </ClCompile>
     <Link>

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1431,6 +1431,9 @@
     <ClInclude Include="MRFrequentHeaderOnly.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="MRMeshExport.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MRParallelProgressReporter.cpp">

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1278,7 +1278,6 @@
     <ClInclude Include="MRMeshDoubleLayer.h">
       <Filter>Source Files\AABBTree</Filter>
     </ClInclude>
-    <ClInclude Include="MRTbbThreadMutex.h" />
     <ClInclude Include="MRProcessSelfTreeSubtasks.h">
       <Filter>Source Files\AABBTree</Filter>
     </ClInclude>
@@ -1318,7 +1317,6 @@
     <ClInclude Include="MROneMeshContours.h">
       <Filter>Source Files\Contours</Filter>
     </ClInclude>
-    <ClInclude Include="MRInplaceStack.h" />
     <ClInclude Include="MRUnionFindParallel.h">
       <Filter>Source Files\Basic</Filter>
     </ClInclude>
@@ -1385,7 +1383,6 @@
     <ClInclude Include="MRFormat.h">
       <Filter>Source Files\Basic</Filter>
     </ClInclude>
-    <ClInclude Include="MRFunctional.h" />
     <ClInclude Include="MRTwoLineSegmDist.h">
       <Filter>Source Files\Math</Filter>
     </ClInclude>
@@ -1421,6 +1418,18 @@
     </ClInclude>
     <ClInclude Include="MRHoleFillPlan.h">
       <Filter>Source Files\MeshAlgorithm</Filter>
+    </ClInclude>
+    <ClInclude Include="MRFunctional.h">
+      <Filter>Source Files\Basic</Filter>
+    </ClInclude>
+    <ClInclude Include="MRInplaceStack.h">
+      <Filter>Source Files\Basic</Filter>
+    </ClInclude>
+    <ClInclude Include="MRTbbThreadMutex.h">
+      <Filter>Source Files\Basic</Filter>
+    </ClInclude>
+    <ClInclude Include="MRFrequentHeaderOnly.h">
+      <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -2192,7 +2201,6 @@
     <ClCompile Include="MRMeshDoubleLayer.cpp">
       <Filter>Source Files\AABBTree</Filter>
     </ClCompile>
-    <ClCompile Include="MRTbbThreadMutex.cpp" />
     <ClCompile Include="MRProcessSelfTreeSubtasks.cpp">
       <Filter>Source Files\AABBTree</Filter>
     </ClCompile>
@@ -2271,8 +2279,6 @@
     <ClCompile Include="MRFormat.cpp">
       <Filter>Source Files\Basic</Filter>
     </ClCompile>
-    <ClCompile Include="MRParallelFor.cpp" />
-    <ClCompile Include="MRBitSetParallelFor.cpp" />
     <ClCompile Include="MRTwoLineSegmDist.cpp">
       <Filter>Source Files\Math</Filter>
     </ClCompile>
@@ -2302,6 +2308,15 @@
     </ClCompile>
     <ClCompile Include="MREdgePathsBuilder.cpp">
       <Filter>Source Files\SurfacePath</Filter>
+    </ClCompile>
+    <ClCompile Include="MRBitSetParallelFor.cpp">
+      <Filter>Source Files\Basic</Filter>
+    </ClCompile>
+    <ClCompile Include="MRParallelFor.cpp">
+      <Filter>Source Files\Basic</Filter>
+    </ClCompile>
+    <ClCompile Include="MRTbbThreadMutex.cpp">
+      <Filter>Source Files\Basic</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/source/MRMesh/MRMeshExport.h
+++ b/source/MRMesh/MRMeshExport.h
@@ -1,0 +1,9 @@
+// This header is force-included (after the precompiled MRPch.h) into every MRMesh
+// translation unit on Windows; it is not meant to be #included manually.
+//
+// When MR_PCH_USE_EXTRA_HEADERS is set, the shared precompiled header pulls in
+// MRMeshFwd.h. That precompiled header is produced by the MRPch project, which does
+// not define MRMesh_EXPORTS, so MRMESH_API is baked as __declspec(dllimport).
+// MRMesh itself must export those symbols, so restore the macro to dllexport here.
+#undef MRMESH_API
+#define MRMESH_API __declspec(dllexport)

--- a/source/MRMesh/MRMeshExport.h
+++ b/source/MRMesh/MRMeshExport.h
@@ -5,5 +5,7 @@
 // MRMeshFwd.h. That precompiled header is produced by the MRPch project, which does
 // not define MRMesh_EXPORTS, so MRMESH_API is baked as __declspec(dllimport).
 // MRMesh itself must export those symbols, so restore the macro to dllexport here.
+#ifdef _WIN32
 #undef MRMESH_API
 #define MRMESH_API __declspec(dllexport)
+#endif

--- a/source/MRPch/MRPch.h
+++ b/source/MRPch/MRPch.h
@@ -68,6 +68,9 @@
 #include "MRStdlib.h"
 
 #ifdef MR_PCH_USE_EXTRA_HEADERS
+#include "MRMesh/MRFrequentHeaderOnly.h"
+
+#ifndef _WIN32 // where MRMESH_API macro change its value depending on project
 #include "MRMesh/MRBitSetParallelFor.h"
 #include "MRMesh/MRFunctional.h"
 #include "MRMesh/MRIOFilters.h"
@@ -90,7 +93,10 @@
 #include "MRViewer/MRViewport.h"
 #include "MRViewer/MRViewer.h"
 #include "MRViewer/MRUIStyle.h"
-#endif
-#endif
+#endif //MESHLIB_NO_VIEWER
+
+#endif //!_WIN32
+
+#endif //MR_PCH_USE_EXTRA_HEADERS
 
 #pragma warning(pop)


### PR DESCRIPTION
## Summary

Adds `source/MRMesh/MRFrequentHeaderOnly.h`, a convenience aggregator of MRMesh public headers that are:

1. **Effectively header-only** — they never use the `MRMESH_API` macro, directly or through any sub-include (so they declare/define no exported symbols), and
2. **Widely included** — pulled in, directly or indirectly, by **more than 20** of MeshLib's `.cpp` files.

The number in the comment after each `#include` is the count of `.cpp` files (out of 660 under `source/`) that reach that header directly or transitively. Entries are listed in decreasing order of that count.

## Why

These headers are stable, cheaply parsable, and seen by a large fraction of translation units, which makes them good candidates for precompiled-header baking.

## Notes

- The file is not `#include`d anywhere and is not compiled (CMake globs headers into the target only for IDE/install listing), so it has no build impact.
