### PR TITLE
CI(windows): install MSYS2 inside build-mrbind, only on cache miss

### DIFF
--- a/.github/actions/build-mrbind/action.yml
+++ b/.github/actions/build-mrbind/action.yml
@@ -49,6 +49,16 @@ inputs:
       `install-msys2-mrbind` puts it). Override when MSYS2 is installed
       elsewhere -- e.g. `C:\msys64_meshlib_mrbind` for runners pre-baked
       with the bat script's default layout.
+  install-msys2:
+    required: false
+    default: 'false'
+    description: >
+      Windows-only. When `'true'`, install and sha256-verify the pinned
+      clang-22 MSYS2 toolchain (via the `install-msys2-mrbind` action) before
+      building -- but only on cache miss, since a cache-restored mrbind needs
+      no toolchain to rebuild. Leave `'false'` (the default) on runners that
+      already provide MSYS2 (e.g. MeshInspectorCode's self-hosted AMI), which
+      must NOT run the install step.
 
 runs:
   using: composite
@@ -68,6 +78,14 @@ runs:
       with:
         path: ${{ inputs.mrbind-dir }}/build
         key: mrbind-build-${{ inputs.cache-key-prefix }}-${{ steps.mrbind-sha.outputs.sha }}-${{ hashFiles(inputs.build-script) }}-${{ inputs.extra-cache-key }}
+
+    - name: Install MSYS2 for MRBind
+      # MSYS2 is only needed to *build* mrbind, so skip it whenever the build
+      # cache hit. Gated on `install-msys2` so callers that ship their own MSYS2
+      # (MeshInspectorCode's self-hosted AMI) keep using it. The action is
+      # Windows-only; the `runner.os` guard keeps non-Windows callers safe.
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.install-msys2 == 'true' && runner.os == 'Windows' }}
+      uses: ./.github/actions/install-msys2-mrbind
 
     - name: Build MRBind
       # `install_mrbind_windows_msys2.bat` defaults MSYS2_DIR to

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -147,10 +147,6 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Install MSYS2 for MRBind
-        if: ${{inputs.mrbind || (inputs.mrbind_c && matrix.build_system == 'CMake') || env.BUILD_C_SHARP == 'true'}}
-        uses: ./.github/actions/install-msys2-mrbind
-
       - name: Build MRBind
         if: ${{inputs.mrbind || (inputs.mrbind_c && matrix.build_system == 'CMake') || env.BUILD_C_SHARP == 'true'}}
         uses: ./.github/actions/build-mrbind
@@ -158,6 +154,9 @@ jobs:
           cache-key-prefix: windows-clang22
           build-script: scripts/mrbind/install_mrbind_windows_msys2.bat
           extra-cache-key: ${{ hashFiles('scripts/mrbind/msys2_package_hashes_clang22.txt') }}
+          # Install the pinned MSYS2 toolchain in-action, but only on cache miss
+          # (a cache-restored mrbind needs no toolchain to rebuild).
+          install-msys2: true
 
       - name: Download C bindings
         if: ${{ inputs.mrbind_c || env.BUILD_C_SHARP == 'true' }}

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -410,15 +410,15 @@ jobs:
       - name: Build
         run: msbuild -m source\MeshLib.sln -p:Configuration=Release -p:VcpkgTriplet=${{ env.VCPKG_DEFAULT_TRIPLET }} -p:PlatformToolset=${{ env.PLATFORM_TOOLSET }} -p:MRCudaPlatformToolset=${{ env.CUDA_PLATFORM_TOOLSET }}
 
-      - name: Install MSYS2 for MRBind
-        uses: ./.github/actions/install-msys2-mrbind
-
       - name: Build MRBind
         uses: ./.github/actions/build-mrbind
         with:
           cache-key-prefix: windows-clang22
           build-script: scripts/mrbind/install_mrbind_windows_msys2.bat
           extra-cache-key: ${{ hashFiles('scripts/mrbind/msys2_package_hashes_clang22.txt') }}
+          # Install the pinned MSYS2 toolchain in-action, but only on cache miss
+          # (a cache-restored mrbind needs no toolchain to rebuild).
+          install-msys2: true
 
       - name: Generate and build MRBind bindings
         shell: cmd


### PR DESCRIPTION
## What

Move the **Install MSYS2 for MRBind** step out of `build-test-windows` and into the `build-mrbind` composite action, and run it **only on a cache miss**.

MSYS2 (the pinned clang-22 toolchain) is only needed to *build* mrbind. When the mrbind build is restored from cache, building is skipped — so installing MSYS2 was wasted work on every cache-hit job. Folding the install into `build-mrbind` lets it reuse the action's existing `cache-hit` gate.

## How

- `build-mrbind/action.yml`: new opt-in input `install-msys2` (default `'false'`). When `'true'`, the action runs `install-msys2-mrbind` between the cache-restore and build steps, gated on `cache-hit != 'true'` (plus a defensive `runner.os == 'Windows'`).
- `build-test-windows.yml`: drop the standalone install step; pass `install-msys2: true` to `build-mrbind`.

## Why opt-in (default off)

`build-mrbind` is a shared action. The default keeps every other consumer unchanged:

- **MeshInspectorCode** calls `build-mrbind` for its Windows job but ships its own MSYS2 via the self-hosted AMI (`C:\msys64_meshlib_mrbind`) and deliberately skips the install — it never sets the input.
- The Linux / macOS / ARM callers and `pip-build.yml` (which keeps its own separate install step) are unaffected.

## Note for review

This assumes the pinned MSYS2 toolchain is needed only to *build* mrbind, not by the downstream binding-generation / `GETTEXT_ROOT` steps when mrbind is cache-restored. CI here exercises both the cache-miss (first run) and cache-hit (re-run) paths.
