### PR TITLE
CI(windows): fail fast in cmd generate steps with `|| exit /b 1`

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -181,10 +181,13 @@ jobs:
         env:
           MSYS2_DIR: C:\msys64
         # Note that `\` doesn't work here as a line continuation, and will lead to weird errors.
+        # `|| exit /b 1` after each command: cmd.exe does not stop on a failed
+        # command, so without these a generate_win.bat failure would be masked
+        # by the following dotnet build (see the Build step's note below).
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }}
-          call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}}
-          dotnet build examples/c-sharp-examples -c ${{matrix.config}}
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}} || exit /b 1
+          dotnet build examples/c-sharp-examples -c ${{matrix.config}} || exit /b 1
 
       - name: Build
         shell: cmd
@@ -229,9 +232,11 @@ jobs:
         env:
           MSYS2_DIR: C:\msys64
         # Note that `\` doesn't work here as a line continuation, and will lead to weird errors.
+        # `|| exit /b 1` — cmd.exe does not stop on a failed command, so guard each
+        # one to fail the step on a generation error instead of swallowing it.
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }}
-          call ./scripts/mrbind/generate_win.bat -B --trace MODE=none VS_MODE=${{matrix.config}}
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          call ./scripts/mrbind/generate_win.bat -B --trace MODE=none VS_MODE=${{matrix.config}} || exit /b 1
 
       - name: Diagnostic — output bin DLL inventory + MRMesh imports
         if: ${{ always() }}

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -424,9 +424,11 @@ jobs:
         shell: cmd
         env:
           MSYS2_DIR: C:\msys64
+        # `|| exit /b 1` — cmd.exe does not stop on a failed command, so guard each
+        # one to fail the step on a generation error instead of swallowing it.
         run: |
-          call "${{ env.VC_PATH }}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }}
-          call ./scripts/mrbind/generate_win.bat -B --trace FOR_WHEEL=1
+          call "${{ env.VC_PATH }}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          call ./scripts/mrbind/generate_win.bat -B --trace FOR_WHEEL=1 || exit /b 1
 
       - name: Run Test
         working-directory: source\x64\Release


### PR DESCRIPTION
## Problem

The **Generate C# bindings** step in `build-test-windows` runs three commands in a single `cmd` script:

```cmd
call …\VsDevCmd.bat …
call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp …
dotnet build examples/c-sharp-examples …
```

`cmd.exe` does **not** stop on a failed command, and GitHub takes the step's pass/fail from the **last** command's exit code only. So when `generate_win.bat` failed (e.g. `mrbind_gen_csharp` crashing with `STATUS_DLL_NOT_FOUND`), the script fell through to `dotnet build`, which then failed with a **misleading** error:

```
error CS0246: The type or namespace name 'MR' could not be found
```

(The generator's `--clean-output-dir` had already wiped `source/MRDotNet2/src` before crashing, so the `MR` binding sources were gone.) The real generation failure was swallowed and re-reported as a C# compile error several lines later.

## Fix

Guard each command with `|| exit /b 1`, exactly as the neighboring **Build** step already does (build-test-windows.yml — *"`|| exit /b 1` is used instead of `if errorlevel 1 exit 1`…"*). Now the step fails immediately at the actual error instead of masking it.

Applied to all three `cmd`-shell generation steps:
- `build-test-windows.yml` → **Generate C# bindings** (the one that exhibited the masking) and **Generate and build Python bindings**
- `pip-build.yml` → **Generate and build MRBind bindings**

The C# step is the only one where a failure was truly *masked* (a later `dotnet build` follows). In the other two, `generate_win.bat` is the last command so its code already propagates — they get the guards for consistency and to also catch a `VsDevCmd` failure.

This is a pure robustness change: on a healthy build all commands succeed and the guards are no-ops.
