### PR TITLE
CI: build Python bindings with the Build compiler (GCC 13+) instead of always Clang

### DIFF
--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -181,7 +181,9 @@ jobs:
           # `-fpch-codegen` hits clang defect llvm/llvm-project#203691 on libstdc++-12 (a `<filesystem>`
           # internal homed into the PCH object but never emitted, surfaces at import time). Disable on ubuntu22.
           PCH_CODEGEN: ${{ matrix.os == 'ubuntu22' && '0' || '1' }}
-        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin PCH_CODEGEN=${{env.PCH_CODEGEN}}
+        # Build the bindings with the same compiler as the `Build` step. For GCC lanes this means GCC;
+        # for Clang lanes we keep the pinned Clang (clang_version.txt) the bindings are known to build with.
+        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin ${{ matrix.compiler == 'GCC' && format('CXX_FOR_BINDINGS={0}', matrix.cxx-compiler) || '' }} PCH_CODEGEN=${{env.PCH_CODEGEN}}
 
       - name: Create Python Stubs
         if: ${{ inputs.mrbind && matrix.os == 'ubuntu22' && matrix.config == 'Release' && matrix.compiler == 'Clang' }}

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -159,7 +159,9 @@ jobs:
           PCH_CODEGEN: ${{ matrix.os == 'ubuntu22' && '0' || '1' }}
         # Build the bindings with the same compiler as the `Build` step. For GCC lanes this means GCC;
         # for Clang lanes we keep the pinned Clang (clang_version.txt) the bindings are known to build with.
-        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin ${{ matrix.compiler == 'GCC' && format('CXX_FOR_BINDINGS={0}', matrix.cxx-compiler) || '' }} ENABLE_CUDA=${{env.ENABLE_CUDA}} PCH_CODEGEN=${{env.PCH_CODEGEN}}
+        # g++-12 is excluded: it rejects mrbind's local-lambda function pointers as non-type template
+        # arguments ("_FUN has no linkage"); GCC 13+ accept them (C++17 relaxed the linkage requirement).
+        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin ${{ (matrix.compiler == 'GCC' && matrix.cxx-compiler != '/usr/bin/g++-12') && format('CXX_FOR_BINDINGS={0}', matrix.cxx-compiler) || '' }} ENABLE_CUDA=${{env.ENABLE_CUDA}} PCH_CODEGEN=${{env.PCH_CODEGEN}}
 
       - name: Collect Timings
         run: ./scripts/devops/collect_timing_logs.sh ${{matrix.os}} ${{matrix.config}} "${{matrix.cxx-compiler}}"

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -157,7 +157,9 @@ jobs:
           # `-fpch-codegen` hits clang defect llvm/llvm-project#203691 on libstdc++-12 (a `<filesystem>`
           # internal homed into the PCH object but never emitted, surfaces at import time). Disable on ubuntu22.
           PCH_CODEGEN: ${{ matrix.os == 'ubuntu22' && '0' || '1' }}
-        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin ENABLE_CUDA=${{env.ENABLE_CUDA}} PCH_CODEGEN=${{env.PCH_CODEGEN}}
+        # Build the bindings with the same compiler as the `Build` step. For GCC lanes this means GCC;
+        # for Clang lanes we keep the pinned Clang (clang_version.txt) the bindings are known to build with.
+        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin ${{ matrix.compiler == 'GCC' && format('CXX_FOR_BINDINGS={0}', matrix.cxx-compiler) || '' }} ENABLE_CUDA=${{env.ENABLE_CUDA}} PCH_CODEGEN=${{env.PCH_CODEGEN}}
 
       - name: Collect Timings
         run: ./scripts/devops/collect_timing_logs.sh ${{matrix.os}} ${{matrix.config}} "${{matrix.cxx-compiler}}"

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -665,7 +665,10 @@ endif # TARGETING_EMSCRIPTEN
 
 
 
-LINKER := $(CXX_FOR_BINDINGS) -fuse-ld=lld
+# Use lld only with Clang: it lives in Clang's own bindir (not on PATH), so GCC's collect2 can't find it
+# via `-fuse-ld=lld` and fails with "cannot find 'ld'". This mirrors MeshLib's CMake, which only switches
+# to lld for Clang; the GCC build (and now GCC bindings) use GCC's default linker.
+LINKER := $(CXX_FOR_BINDINGS) $(if $(CXX_FOR_BINDINGS_IS_CLANG),-fuse-ld=lld)
 # Unsure if `-dynamiclib` vs `-shared` makes any difference on MacOS. I'm using the former because that's what CMake does.
 # No $(PYTHON_LDFLAGS) here, that's only for our patched Pybind library.
 LINKER_FLAGS := $(EXTRA_LDFLAGS) $(if $(DEPS_LIB_DIR),-L$(DEPS_LIB_DIR)) $(if $(DEPS_BASE_DIR),-L$(DEPS_BASE_DIR)/lib) -L$(MESHLIB_SHLIB_DIR) $(if $(is_py),-lMRPython) $(if $(IS_MACOS),-dynamiclib,-shared) $(call load_file,$(makefile_dir)linker_flags.txt)

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -246,6 +246,19 @@ else
 CXX_FOR_BINDINGS := clang++-$(strip $(file <$(makefile_dir)clang_version.txt))
 endif
 
+# Detect whether the bindings compiler (the one that compiles and links the generated bindings) is Clang.
+# Several flags below are Clang-specific. When the bindings are built with a non-Clang compiler -- e.g. GCC,
+# to match a GCC `Build` step via `CXX_FOR_BINDINGS=/usr/bin/g++-NN` -- those flags must be skipped.
+# Note that the parser always runs under libclang regardless of this; only the compile/link uses this compiler.
+override CXX_FOR_BINDINGS_IS_CLANG := $(findstring clang,$(shell $(CXX_FOR_BINDINGS) --version))
+# GCC older than 13 spells C++23 as `-std=c++2b`. Our flags hardcode `-std=c++23` (accepted by Clang and by
+# GCC 13+); detect when the bindings compiler rejects it so the compile step can fall back to `-std=c++2b`.
+ifeq ($(CXX_FOR_BINDINGS_IS_CLANG),)
+override BINDINGS_REPLACE_CXX23 := $(shell $(CXX_FOR_BINDINGS) -std=c++23 -xc++ -E /dev/null >/dev/null 2>&1 || echo 1)
+endif
+# Replace `-std=c++23` with `-std=c++2b` in $1 when the bindings compiler needs it; a no-op otherwise.
+override apply_bindings_cxx_std = $(if $(BINDINGS_REPLACE_CXX23),$(subst -std=c++23,-std=c++2b,$1),$1)
+
 
 # Source directory of MRBind.
 MRBIND_SOURCE := $(makefile_dir)../../thirdparty/mrbind
@@ -293,9 +306,13 @@ ifeq ($(IS_WINDOWS),)# If not on Windows:
 $(call safe_shell_exec,which $(CXX_FOR_ABI) >/dev/null 2>/dev/null)# Make sure this compiler exists.
 ifneq ($(shell echo "template <typename T> void foo() requires true {} template void foo<int>();" | $(CXX_FOR_ABI) -xc++ - -std=c++20 -S -o - | grep -m1 '\b_Z3fooIiEvvQLb1E\b')$(filter 0,$(.SHELLSTATUS)),)
 $(info ABI check: $(CXX_FOR_ABI) DOES mangle C++20 constraints into the function names.)
-else
+else ifneq ($(CXX_FOR_BINDINGS_IS_CLANG),)
 $(info ABI check: $(CXX_FOR_ABI) DOESN'T mangle C++20 constraints into the function names, enabling `-fclang-abi-compat=17`)
 ABI_COMPAT_FLAG := -fclang-abi-compat=17
+else
+# `-fclang-abi-compat` is Clang-only. When the bindings are compiled with the same (non-Clang) compiler as
+# MeshLib itself, their ABIs already match natively, so no compatibility flag is needed.
+$(info ABI check: $(CXX_FOR_ABI) DOESN'T mangle C++20 constraints, but bindings compiler `$(CXX_FOR_BINDINGS)` is not Clang; `-fclang-abi-compat` is not applicable.)
 endif
 endif
 
@@ -419,7 +436,9 @@ $(info Shared library name pattern: $(SHIM_SHLIB_NAMING))
 
 # Enable PCH.
 # Not all modules we build use PCHs even if this is true. But if this is false, PCHs are disabled for all modules.
-ENABLE_PCH := 1
+# Default to off for non-Clang compilers: the baked-PCH + fragment scheme below relies on Clang's lenient PCH
+# handling (the `-DMB_FRAGMENT=...` macros differ per fragment), which GCC's stricter PCH would reject.
+ENABLE_PCH := $(if $(CXX_FOR_BINDINGS_IS_CLANG),1,0)
 override ENABLE_PCH := $(filter-out 0,$(ENABLE_PCH))
 
 # Enables the `-fpch-codegen` flag for the PCH. This is faster but sometimes doesn't work because of Clang bugs.
@@ -430,7 +449,8 @@ override PCH_CODEGEN := $(filter-out 0,$(PCH_CODEGEN))
 
 # Those are passed when compiling the PCH. Can be empty.
 # If this is non-empty and has any flags other than `-fpch-instantiate-templates`, we compile an additional `.o` for the PCH and link it into the module.
-PCH_CODEGEN_FLAGS := -fpch-debuginfo -fpch-instantiate-templates $(if $(PCH_CODEGEN),-fpch-codegen)
+# The `-fpch-*` flags are Clang-only, so leave them empty for non-Clang compilers (PCH itself is also disabled there).
+PCH_CODEGEN_FLAGS := $(if $(CXX_FOR_BINDINGS_IS_CLANG),-fpch-debuginfo -fpch-instantiate-templates $(if $(PCH_CODEGEN),-fpch-codegen))
 
 
 
@@ -653,7 +673,10 @@ LINKER_FLAGS := $(EXTRA_LDFLAGS) $(if $(DEPS_LIB_DIR),-L$(DEPS_LIB_DIR)) $(if $(
 # Set resource directory. Otherwise e.g. `offsetof` becomes non-constexpr,
 #   because the header override with it being constexpr is in this resource directory.
 # We certainly need this on Windows and MacOS. It's not strictly necessary on Ubuntu, but is needed on Arch, so better make it unconditional.
+# `-resource-dir` / `-print-resource-dir` are Clang-only; GCC locates its own internal headers, so skip it there.
+ifneq ($(CXX_FOR_BINDINGS_IS_CLANG),)
 COMPILER_FLAGS += -resource-dir=$(strip $(call safe_shell,$(CXX_FOR_BINDINGS) -print-resource-dir))
+endif
 
 
 MRBIND_GEN_C_FLAGS := $(call load_file,$(makefile_dir)mrbind_gen_c_flags.txt)
@@ -875,7 +898,8 @@ $(if $($1_PyNumFragments),,$(call var,$1_PyNumFragments := 1))
 $(call var,$1_CompilerFlagsPython := -DPy_LIMITED_API=$(python_min_version_hex) $(call get_python_cflags,$(PYTHON_HEADER_VERSION)))
 
 # Compiler + compiler-only flags, adjusted per module. Don't use those for parsing.
-$(call var,$1_CompilerFlagsFixed := $($1_CompilerFlagsPython) $(COMPILER_FLAGS) -DMB_PB11_MODULE_NAME=$($1_PyName) $(if $($1_PyDependsOn),-DMB_PB11_MODULE_DEPS=$(call quote,$(subst $(space),$(comma),$(patsubst %,"%",$($1_PyDependsOn))))))
+# `apply_bindings_cxx_std` adapts the `-std=c++23` spelling for the compile step when the bindings compiler needs it (older GCC).
+$(call var,$1_CompilerFlagsFixed := $($1_CompilerFlagsPython) $(call apply_bindings_cxx_std,$(COMPILER_FLAGS)) -DMB_PB11_MODULE_NAME=$($1_PyName) $(if $($1_PyDependsOn),-DMB_PB11_MODULE_DEPS=$(call quote,$(subst $(space),$(comma),$(patsubst %,"%",$($1_PyDependsOn))))))
 endef
 $(foreach x,$(MODULES),$(eval $(call module_snippet_vars_py,$x)))
 endif # $(TARGET) == python

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -436,9 +436,10 @@ $(info Shared library name pattern: $(SHIM_SHLIB_NAMING))
 
 # Enable PCH.
 # Not all modules we build use PCHs even if this is true. But if this is false, PCHs are disabled for all modules.
-# Default to off for non-Clang compilers: the baked-PCH + fragment scheme below relies on Clang's lenient PCH
-# handling (the `-DMB_FRAGMENT=...` macros differ per fragment), which GCC's stricter PCH would reject.
-ENABLE_PCH := $(if $(CXX_FOR_BINDINGS_IS_CLANG),1,0)
+# Used with GCC too: it gets a plain `.gch` (the Clang-only `-fpch-*` codegen flags are dropped below). The
+# per-fragment `-DMB_FRAGMENT=...` macros don't appear in the baked headers, so GCC accepts the shared PCH;
+# without it GCC re-parses the whole pybind/MeshLib header set per fragment, which is far slower.
+ENABLE_PCH := 1
 override ENABLE_PCH := $(filter-out 0,$(ENABLE_PCH))
 
 # Enables the `-fpch-codegen` flag for the PCH. This is faster but sometimes doesn't work because of Clang bugs.

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -757,6 +757,15 @@ ifneq ($(IS_LINUX),)
 COMPILER_FLAGS += -I/usr/include/jsoncpp -isystem/usr/include/freetype2 -isystem/usr/include/gdcm-3.0
 # Work around patchelf bug: https://github.com/NixOS/patchelf/issues/639
 LINKER_FLAGS += -Wl,-z,separate-loadable-segments
+# On AArch64, GCC defaults to out-of-line atomics, emitting calls to libgcc's `__aarch64_ldadd*` helpers.
+# In this huge, unoptimized (MODE=none) binding module those calls overflow the +-128MB `BL` range
+# (`relocation truncated to fit: R_AARCH64_CALL26`). Inline the atomics so there are no such calls.
+# GCC-only (Clang doesn't hit this) and aarch64-only (the flag is AArch64-specific).
+ifeq ($(CXX_FOR_BINDINGS_IS_CLANG),)
+ifneq ($(filter aarch64%,$(shell uname -m)),)
+COMPILER_FLAGS += -mno-outline-atomics
+endif
+endif
 endif
 
 # MacOS.


### PR DESCRIPTION
## What

The **Generate and build Python bindings** CI step previously compiled the bindings with **Clang on every lane** — even where the **Build** step built MeshLib with **GCC**. There, the Clang-built bindings were only made ABI-compatible with GCC via `-fclang-abi-compat`.

This builds the bindings with the **same compiler as the Build step**: GCC on the GCC Ubuntu lanes, so the bindings' ABI matches MeshLib natively instead of relying on the compat shim.

## Scope

| lane | bindings compiler |
|---|---|
| ubuntu24 x64 — g++-13, g++-14 | **GCC** |
| ubuntu24 arm64 — g++-14 | **GCC** |
| ubuntu22 x64 — g++-12 | Clang (excluded — see below) |
| Windows / macOS / vcpkg / emscripten / all Clang lanes | Clang (unchanged) |

**g++-12 is excluded:** mrbind passes local-lambda function pointers as non-type template arguments, which GCC < 13 rejects (`'…_FUN' is not a valid template argument … has no linkage`) because the C++17 relaxation of the NTTP linkage requirement isn't implemented there. GCC ≥ 13 and Clang accept it, so g++-12 keeps building bindings with the pinned Clang.

## Changes

`scripts/mrbind/generate.mk` now tolerates a non-Clang `CXX_FOR_BINDINGS` (the workflow passes `CXX_FOR_BINDINGS=<matrix compiler>` on the GCC lanes):

- detect whether the bindings compiler is Clang and skip the Clang-only flags for GCC: `-resource-dir`, `-fclang-abi-compat`, `-fpch-*` codegen, and `-fuse-ld=lld` (GCC uses its default linker, matching how the GCC Build links MeshLib);
- fall back `-std=c++23` → `-std=c++2b` for the compile step when the compiler doesn't accept the `c++23` spelling (older GCC); the parser always runs under libclang, which does accept it;
- on **aarch64 + GCC**, pass `-mno-outline-atomics`: the huge unoptimized (`MODE=none`) binding module otherwise overflows the ±128 MB `BL` range with calls to libgcc's `__aarch64_ldadd*` out-of-line atomic helpers (`relocation truncated to fit: R_AARCH64_CALL26`).

The Clang path is unchanged by construction — every gate collapses to its original value when the bindings compiler is Clang.

## Dependency

Requires the GCC `MB_PB11_OFFSETOF` fix in mrbind (GCC rejects `_Pragma` in expression context, which mrbind's offsetof macro used): MeshInspector/mrbind#37 (merged). The `thirdparty/mrbind` submodule is bumped to the merged master commit.

## Cost

Bindings step vs the previous Clang+PCH build: roughly **+3–5 min** on the x64 GCC lanes and **~+13 min** on arm64 g++-14 — GCC compiles this template-heavy pybind code noticeably slower than Clang, and PCH doesn't claw it back the way it does for Clang. The Build step is unchanged.

## Validation

Full platform matrix green — Windows, macOS, linux-vcpkg, emscripten, ubuntu-x64 and ubuntu-arm64 — confirming the Clang lanes are unaffected, alongside the new GCC-built bindings on the Ubuntu GCC lanes.
