### PR TITLE
Add <sstream> to MRStdlib.h precompiled header

### DIFF
--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -27,6 +27,9 @@ IF(MR_PCH)
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRStdlib.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRExpected.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRHashMap.h>"
+        # MRMeshFwd.h is parsed in nearly every TU and is mostly forward declarations,
+        # so it adds little to the PCH image while saving a recurring parse on GCC.
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMeshFwd.h>"
     )
     return()
   endif()

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -27,9 +27,6 @@ IF(MR_PCH)
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRStdlib.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRExpected.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRHashMap.h>"
-        # MRMeshFwd.h is parsed in nearly every TU and is mostly forward declarations,
-        # so it adds little to the PCH image while saving a recurring parse on GCC.
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMeshFwd.h>"
     )
     return()
   endif()

--- a/source/MRPch/MRStdlib.h
+++ b/source/MRPch/MRStdlib.h
@@ -28,6 +28,7 @@
 #include <mutex>
 #include <ostream>
 #include <queue>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <tuple>


### PR DESCRIPTION
## What

Add `<sstream>` to `MRStdlib.h`, so string streams are parsed once into the precompiled header instead of in every translation unit that uses them.

## Why

`<sstream>` is widely included across the codebase and moderately heavy to parse, yet it was missing from the STL bundle in `MRStdlib.h`. It's a self-contained, high-fan-in standard header — a good fit for the precompiled header, and small enough to stay within the lean GCC PCH (kept compact because GCC loads the whole image into every TU). It also enters the MSVC/Clang PCH via `MRPch.h`, where it's a negligible addition to an already-large PCH.
