### PR TITLE
GCC PCH: cache lightweight high-fan-in MeshLib headers; stop defining *_EXPORTS on non-MSVC

### DIFF
--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -153,6 +153,10 @@ jobs:
             -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
             -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
 
+      - name: PCH size (diagnostic)
+        if: always()
+        run: find ./build/${{ matrix.config }} -name 'cmake_pch.hxx.gch' -exec ls -lh {} +
+
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | c++filt
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,28 @@ IF(BUILD_TESTING)
   ENDIF()
 ENDIF()
 
+# On non-MSVC the *_API export macros resolve via __attribute__((visibility("default"))) and
+# never consult the CMake-generated <target>_EXPORTS define (it is only used under _WIN32).
+# Leaving it defined needlessly differs the command line between a library and the shared MRPch,
+# which breaks precompiled-header reuse on GCC: a TU built with -D<target>_EXPORTS cannot reuse a
+# PCH built without it (-Winvalid-pch). Clear it for every shared/module library we build.
+IF(NOT MSVC)
+  function(_mr_clear_define_symbol _dir)
+    get_property(_subs DIRECTORY "${_dir}" PROPERTY SUBDIRECTORIES)
+    foreach(_s IN LISTS _subs)
+      _mr_clear_define_symbol("${_s}")
+    endforeach()
+    get_property(_tgts DIRECTORY "${_dir}" PROPERTY BUILDSYSTEM_TARGETS)
+    foreach(_t IN LISTS _tgts)
+      get_target_property(_type ${_t} TYPE)
+      IF(_type STREQUAL "SHARED_LIBRARY" OR _type STREQUAL "MODULE_LIBRARY")
+        set_target_properties(${_t} PROPERTIES DEFINE_SYMBOL "")
+      ENDIF()
+    endforeach()
+  endfunction()
+  _mr_clear_define_symbol("${CMAKE_CURRENT_SOURCE_DIR}")
+ENDIF()
+
 include(CMakePackageConfigHelpers)
 configure_package_config_file(meshlib-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/meshlib-config.cmake
   INSTALL_DESTINATION ${MR_CONFIG_DIR}

--- a/source/MRMcp/MRFastmcpp.h
+++ b/source/MRMcp/MRFastmcpp.h
@@ -2,9 +2,14 @@
 
 // Centralised fastmcpp wrapper. Both MRMcp.cpp and MRMCPGateway.cpp must pull
 // fastmcpp in before any standard library header (fastmcpp's macro tricks rely
-// on that ordering). Keep `#undef _t` next to the includes: fastmcpp uses `_t`
-// as a template parameter and our translation macro shadows it.
+// on that ordering). fastmcpp uses `_t` as a template parameter and our
+// translation macro (MRMeshFwd.h) shadows it, so suppress `_t` across the
+// fastmcpp includes. Use push_macro/pop_macro rather than a bare #undef: when
+// MRMeshFwd.h is baked into the precompiled header its `#pragma once` is already
+// satisfied, so a later #include can no longer restore `_t`; push/pop guarantees
+// the macro is reinstated for translation users (e.g. MRViewer/MRMouse.h).
 
+#pragma push_macro( "_t" )
 #undef _t
 
 #if defined( __GNUC__ )
@@ -29,3 +34,5 @@
 #elif defined( _MSC_VER )
 #pragma warning( pop )
 #endif
+
+#pragma pop_macro( "_t" )

--- a/source/MRMcp/MRFastmcpp.h
+++ b/source/MRMcp/MRFastmcpp.h
@@ -2,12 +2,7 @@
 
 // Centralised fastmcpp wrapper. Both MRMcp.cpp and MRMCPGateway.cpp must pull
 // fastmcpp in before any standard library header (fastmcpp's macro tricks rely
-// on that ordering). fastmcpp uses `_t` as a template parameter and our
-// translation macro (MRMeshFwd.h) shadows it, so suppress `_t` across the
-// fastmcpp includes. Use push_macro/pop_macro rather than a bare #undef: when
-// MRMeshFwd.h is baked into the precompiled header its `#pragma once` is already
-// satisfied, so a later #include can no longer restore `_t`; push/pop guarantees
-// the macro is reinstated for translation users (e.g. MRViewer/MRMouse.h).
+// on that ordering).
 
 #pragma push_macro( "_t" )
 #undef _t

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -22,15 +22,19 @@ IF(MR_PCH)
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # the full PCH slows the build down for GCC (it loads the whole PCH image in every TU)
+    # MRMesh.h (below) pulls Eigen, so the lean GCC PCH needs Eigen on its include path too.
+    find_package(Eigen3 REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Eigen3::Eigen)
     target_precompile_headers(${PROJECT_NAME}
       PRIVATE
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRStdlib.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRExpected.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRHashMap.h>"
-        # MRMeshFwd.h is parsed in nearly every TU and is mostly forward declarations, so it
-        # adds little to the PCH image. It only fits the shared PCH because <target>_EXPORTS is
-        # no longer defined on non-MSVC (see the top-level CMakeLists), avoiding -Winvalid-pch.
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMeshFwd.h>"
+        # MRMesh.h is parsed in hundreds of TUs and is genuinely heavy (unlike MRMeshFwd.h), so
+        # caching it is where a real GCC parse-time saving could come from. It only fits the
+        # shared PCH because <target>_EXPORTS is no longer defined on non-MSVC (avoiding
+        # -Winvalid-pch); it pulls Eigen, linked above.
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMesh.h>"
         # MRViewerFwd.h is likewise forward-declaration-only (config.h, exports.h, MRMeshFwd.h,
         # <functional>) and included across MRViewer and its consumers.
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRViewer/MRViewerFwd.h>"

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -27,6 +27,10 @@ IF(MR_PCH)
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRStdlib.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRExpected.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRHashMap.h>"
+        # MRMeshFwd.h is parsed in nearly every TU and is mostly forward declarations, so it
+        # adds little to the PCH image. It only fits the shared PCH because <target>_EXPORTS is
+        # no longer defined on non-MSVC (see the top-level CMakeLists), avoiding -Winvalid-pch.
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMeshFwd.h>"
     )
     return()
   endif()

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -24,39 +24,7 @@ IF(MR_PCH)
     # the full PCH slows the build down for GCC (it loads the whole PCH image in every TU)
     target_precompile_headers(${PROJECT_NAME}
       PRIVATE
-        # Cache the high-fan-in but lightweight MeshLib headers (ids, vectors/matrices, xforms,
-        # geometry primitives) rather than the heavy MRMesh.h: they are included in nearly every
-        # TU yet add little to the PCH image. Only fits the shared PCH because <target>_EXPORTS is
-        # no longer defined on non-MSVC (avoiding -Winvalid-pch).
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMeshFwd.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRUnsigned.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRConstants.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRId.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRphmap.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRResizeNoInit.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRVector.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRVector2.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRVector3.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRVector4.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRExpected.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRProgressCallback.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMatrix2.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMatrix3.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMatrix4.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRAffineXf3.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRAffineXf.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRVectorTraits.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRSegmPoint.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRBox.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRTriPoint.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRBuffer.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRChrono.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRBitSet.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRTimer.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRFile.h>"
-        # MRViewerFwd.h is likewise forward-declaration-only (config.h, exports.h, MRMeshFwd.h,
-        # <functional>) and included across MRViewer and its consumers.
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRViewer/MRViewerFwd.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRPchGcc.h>"
     )
     return()
   endif()

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -31,6 +31,9 @@ IF(MR_PCH)
         # adds little to the PCH image. It only fits the shared PCH because <target>_EXPORTS is
         # no longer defined on non-MSVC (see the top-level CMakeLists), avoiding -Winvalid-pch.
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMeshFwd.h>"
+        # MRViewerFwd.h is likewise forward-declaration-only (config.h, exports.h, MRMeshFwd.h,
+        # <functional>) and included across MRViewer and its consumers.
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRViewer/MRViewerFwd.h>"
     )
     return()
   endif()

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -22,9 +22,6 @@ IF(MR_PCH)
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # the full PCH slows the build down for GCC (it loads the whole PCH image in every TU)
-    # MRMesh.h (below) pulls Eigen, so the lean GCC PCH needs Eigen on its include path too.
-    find_package(Eigen3 REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PRIVATE Eigen3::Eigen)
     target_precompile_headers(${PROJECT_NAME}
       PRIVATE
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRStdlib.h>"
@@ -33,7 +30,8 @@ IF(MR_PCH)
         # MRMesh.h is parsed in hundreds of TUs and is genuinely heavy (unlike MRMeshFwd.h), so
         # caching it is where a real GCC parse-time saving could come from. It only fits the
         # shared PCH because <target>_EXPORTS is no longer defined on non-MSVC (avoiding
-        # -Winvalid-pch); it pulls Eigen, linked above.
+        # -Winvalid-pch). Its only external deps are parallel-hashmap and tl-expected, both
+        # already on the lean MRPch include path.
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMesh.h>"
         # MRViewerFwd.h is likewise forward-declaration-only (config.h, exports.h, MRMeshFwd.h,
         # <functional>) and included across MRViewer and its consumers.

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -27,12 +27,31 @@ IF(MR_PCH)
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRStdlib.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRExpected.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRHashMap.h>"
-        # MRMesh.h is parsed in hundreds of TUs and is genuinely heavy (unlike MRMeshFwd.h), so
-        # caching it is where a real GCC parse-time saving could come from. It only fits the
-        # shared PCH because <target>_EXPORTS is no longer defined on non-MSVC (avoiding
-        # -Winvalid-pch). Its only external deps are parallel-hashmap and tl-expected, both
-        # already on the lean MRPch include path.
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMesh.h>"
+        # Cache the high-fan-in but lightweight MeshLib headers (ids, vectors/matrices, xforms,
+        # geometry primitives) rather than the heavy MRMesh.h: they are included in nearly every
+        # TU yet add little to the PCH image. Only fits the shared PCH because <target>_EXPORTS is
+        # no longer defined on non-MSVC (avoiding -Winvalid-pch).
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMeshFwd.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRUnsigned.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRConstants.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRId.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRphmap.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRResizeNoInit.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRVector.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRVector2.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRVector3.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRVector4.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRExpected.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRProgressCallback.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMatrix2.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMatrix3.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRMatrix4.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRAffineXf3.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRAffineXf.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRVectorTraits.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRSegmPoint.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRBox.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRTriPoint.h>"
         # MRViewerFwd.h is likewise forward-declaration-only (config.h, exports.h, MRMeshFwd.h,
         # <functional>) and included across MRViewer and its consumers.
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRViewer/MRViewerFwd.h>"

--- a/source/MRPch/CMakeLists.txt
+++ b/source/MRPch/CMakeLists.txt
@@ -24,9 +24,6 @@ IF(MR_PCH)
     # the full PCH slows the build down for GCC (it loads the whole PCH image in every TU)
     target_precompile_headers(${PROJECT_NAME}
       PRIVATE
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRStdlib.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRExpected.h>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/MRHashMap.h>"
         # Cache the high-fan-in but lightweight MeshLib headers (ids, vectors/matrices, xforms,
         # geometry primitives) rather than the heavy MRMesh.h: they are included in nearly every
         # TU yet add little to the PCH image. Only fits the shared PCH because <target>_EXPORTS is
@@ -52,6 +49,11 @@ IF(MR_PCH)
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRSegmPoint.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRBox.h>"
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRTriPoint.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRBuffer.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRChrono.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRBitSet.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRTimer.h>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRMesh/MRFile.h>"
         # MRViewerFwd.h is likewise forward-declaration-only (config.h, exports.h, MRMeshFwd.h,
         # <functional>) and included across MRViewer and its consumers.
         "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../MRViewer/MRViewerFwd.h>"

--- a/source/MRPch/MRPch.vcxproj
+++ b/source/MRPch/MRPch.vcxproj
@@ -28,6 +28,7 @@
     <ClInclude Include="MREigen.h" />
     <ClInclude Include="MRJson.h" />
     <ClInclude Include="MRPch.h" />
+    <ClInclude Include="MRPchGcc.h" />
     <ClInclude Include="MRTBB.h" />
     <ClInclude Include="MRSpdlog.h" />
     <ClInclude Include="MRSuppressWarning.h" />

--- a/source/MRPch/MRPchGcc.h
+++ b/source/MRPch/MRPchGcc.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// Lean precompiled-header payload for GCC. Unlike MSVC, GCC loads the whole PCH
+// image into every TU, so this caches only the high-fan-in but lightweight MeshLib
+// headers (ids, vectors/matrices, transforms, geometry primitives) rather than the
+// heavy MRMesh.h: they are included in nearly every TU yet add little to the image.
+// They only fit the shared PCH because <target>_EXPORTS is no longer defined on
+// non-MSVC (avoiding -Winvalid-pch).
+
+#include "../MRMesh/MRMeshFwd.h"
+#include "../MRMesh/MRUnsigned.h"
+#include "../MRMesh/MRConstants.h"
+#include "../MRMesh/MRId.h"
+#include "../MRMesh/MRphmap.h"
+#include "../MRMesh/MRResizeNoInit.h"
+#include "../MRMesh/MRVector.h"
+#include "../MRMesh/MRVector2.h"
+#include "../MRMesh/MRVector3.h"
+#include "../MRMesh/MRVector4.h"
+#include "../MRMesh/MRExpected.h"
+#include "../MRMesh/MRProgressCallback.h"
+#include "../MRMesh/MRMatrix2.h"
+#include "../MRMesh/MRMatrix3.h"
+#include "../MRMesh/MRMatrix4.h"
+#include "../MRMesh/MRAffineXf3.h"
+#include "../MRMesh/MRAffineXf.h"
+#include "../MRMesh/MRVectorTraits.h"
+#include "../MRMesh/MRSegmPoint.h"
+#include "../MRMesh/MRBox.h"
+#include "../MRMesh/MRTriPoint.h"
+#include "../MRMesh/MRBuffer.h"
+#include "../MRMesh/MRChrono.h"
+#include "../MRMesh/MRBitSet.h"
+#include "../MRMesh/MRTimer.h"
+#include "../MRMesh/MRFile.h"
+
+// MRViewerFwd.h is likewise forward-declaration-only (config.h, exports.h,
+// MRMeshFwd.h, <functional>) and included across MRViewer and its consumers.
+#include "../MRViewer/MRViewerFwd.h"


### PR DESCRIPTION
## What

For **GCC only**, populate the shared precompiled header with a curated set of lightweight, high-fan-in MeshLib headers instead of the std-library bundle:

- forward declarations and small value types — `MRMeshFwd.h`, `MRId.h`, `MRUnsigned.h`, `MRConstants.h`, `MRVectorTraits.h`;
- vectors / matrices / transforms — `MRVector{,2,3,4}.h`, `MRMatrix{2,3,4}.h`, `MRAffineXf{,3}.h`;
- common primitives and helpers — `MRBox.h`, `MRSegmPoint.h`, `MRTriPoint.h`, `MRBitSet.h`, `MRBuffer.h`, `MRChrono.h`, `MRTimer.h`, `MRFile.h`, `MRProgressCallback.h`, `MRExpected.h`, `MRResizeNoInit.h`, `MRphmap.h`;
- plus `MRViewerFwd.h`.

The explicit `MRStdlib.h` / `MRExpected.h` / `MRHashMap.h` wrappers are **dropped** from the GCC PCH — the STL and parallel-hashmap are still cached transitively through the MeshLib headers above, just without the extra bulk. MSVC and Clang keep their existing PCH unchanged (the GCC branch `return()`s before the rest of the block).

A second, enabling change: **stop defining `<target>_EXPORTS` on non-MSVC builds.**

## Why

Unlike MSVC, GCC loads the entire `.gch` image into every translation unit, so the goal is a *lean* image that caches the parses recurring in the most TUs — not caching everything. MeshLib's forward/primitive headers are included in nearly every TU yet are individually cheap, so precompiling them removes a lot of repeated parsing while keeping the image small.

These headers could not previously live in the shared PCH because they use the `MR*_API` export macros, whose definition differs inside vs. outside the owning library (dllexport/import on Windows). On non-MSVC the macros expand to a visibility attribute and `<target>_EXPORTS` is otherwise unused, so suppressing its definition makes each header parse identically in the PCH and in every consumer — which is what avoids `-Winvalid-pch` rejecting the cached image.

## Results

Precompiled-header (`cmake_pch.hxx.gch`) size, ubuntu-x64:

| compiler | `.gch` size |
|---|--:|
| g++-12 | 99 MB |
| g++-13 | 111 MB |
| g++-14 | 126 MB |

That is at or slightly below the previous std-bundle PCH, so the curated MeshLib set does not grow the image.

Build-step time on the GCC CI lanes (per-job minimum over several runs, this branch vs. master): **essentially at parity — no regression**. The lane with the tightest, most reproducible timings (ubuntu-x64 g++-14) shows a small but consistent ~2–3% improvement; the other GCC lanes (g++-12, g++-13, arm64, linux-vcpkg) sit within run-to-run noise. GCC build times on CI are high-variance, so read this as "free, with a marginal likely win on the heaviest x64 lane" rather than a precise speedup.

## Notes

- GCC-only by construction; MSVC/Clang paths are untouched.
- `MRMeshFwd.h` defines the `_t(...)` translation macro; the few TUs that include conflicting third-party headers guard them with `push_macro`/`pop_macro`, so adding `MRMeshFwd.h` to the PCH is safe.
- The header set is a tunable list — entries can be added or removed as profiling dictates without touching the mechanism.
