### PR TITLE
ci: log precompiled-header (.gch) size on ubuntu-x64

### DIFF
--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -153,6 +153,10 @@ jobs:
             -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
             -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
 
+      - name: PCH size (diagnostic)
+        if: always()
+        run: find ./build/${{ matrix.config }} -name 'cmake_pch.hxx.gch' -exec ls -lh {} +
+
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | c++filt
 

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -154,7 +154,6 @@ jobs:
             -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
 
       - name: PCH size (diagnostic)
-        if: always()
         run: find ./build/${{ matrix.config }} -name 'cmake_pch.hxx.gch' -exec ls -lh {} +
 
       - name: MRMesh Exported Symbols


### PR DESCRIPTION
Adds a build step on the ubuntu-x64 lane that logs the precompiled-header image size (`find ./build/<config> -name cmake_pch.hxx.gch -exec ls -lh`).

On the GCC sub-lanes this reports the lean PCH (MRStdlib + MRExpected + MRHashMap); on the Clang sub-lanes (where `MR_PCH_USE_EXTRA_HEADERS` is honored) it reports the full PCH. Useful for tracking PCH growth over time — on GCC the whole image is loaded into every translation unit, so its size directly affects per-TU compile cost.

Only the ubuntu-x64 workflow is touched, so other platforms are disabled for this PR.