### PR TITLE
experiment: trim rarely-used headers from PCH STL bundle (not for merge)

### DIFF
--- a/source/MRPch/MRStdlib.h
+++ b/source/MRPch/MRStdlib.h
@@ -7,7 +7,6 @@
 #include <cfloat>
 #include <chrono>
 #include <cmath>
-#include <codecvt>
 #include <compare>
 #include <cstddef>
 #include <cstdint>
@@ -16,8 +15,6 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
-#include <future>
-#include <iomanip>
 #include <iostream>
 #include <istream>
 #include <iterator>
@@ -32,7 +29,6 @@
 #include <string>
 #include <thread>
 #include <tuple>
-#include <typeindex>
 #include <unordered_map>
 #include <variant>
 #include <vector>


### PR DESCRIPTION
Throwaway experiment. Drops `<future>`, `<codecvt>`, `<iomanip>`, `<typeindex>` from `MRStdlib.h` (5/2/1/3 direct users) to measure (a) how much the GCC `.gch` shrinks and (b) whether the GCC build speeds up (smaller image loaded per TU). The PCH-size step runs unconditionally here so the size is captured even if a consumer TU implicitly relied on one of these via the PCH. Only ubuntu-x64 runs.