### PR TITLE
Reduce codegen: extern template common MRSceneStateCheck instantiations

### DIFF
--- a/source/MRViewer/MRSceneStateCheck.cpp
+++ b/source/MRViewer/MRSceneStateCheck.cpp
@@ -1,0 +1,21 @@
+#include "MRSceneStateCheck.h"
+
+#include "MRMesh/MRObjectMesh.h"
+#include "MRMesh/MRObjectPoints.h"
+#include "MRMesh/MRObjectLines.h"
+
+// Explicit instantiations for the templates declared `extern template` in MRSceneStateCheck.h.
+// Defining them here once keeps every consuming TU from re-generating this code.
+
+namespace MR
+{
+
+template std::string getNObjectsLine<ObjectMesh>( unsigned );
+template std::string getNObjectsLine<ObjectPoints>( unsigned );
+template std::string getNObjectsLine<ObjectLines>( unsigned );
+
+template std::string sceneSelectedExactly<ObjectMesh, true, true>( const std::vector<std::shared_ptr<const Object>>&, unsigned );
+template std::string sceneSelectedExactly<ObjectPoints, true, true>( const std::vector<std::shared_ptr<const Object>>&, unsigned );
+template std::string sceneSelectedExactly<ObjectLines, true, true>( const std::vector<std::shared_ptr<const Object>>&, unsigned );
+
+} //namespace MR

--- a/source/MRViewer/MRSceneStateCheck.h
+++ b/source/MRViewer/MRSceneStateCheck.h
@@ -2,6 +2,7 @@
 
 #include "MRISceneStateCheck.h"
 #include "MRMesh/MRObject.h"
+#include "exports.h"
 
 namespace MR
 {
@@ -81,6 +82,16 @@ std::string sceneSelectedAtLeast( const std::vector<std::shared_ptr<const Object
         "" :
         ( "Select at least " + getNObjectsLine<ObjectT>( n ) + " with valid model" );
 }
+// These instantiations are defined once in MRSceneStateCheck.cpp and imported elsewhere
+// (extern template, as in MRUITestEngine.h), so the common cases are not re-generated in
+// every consuming TU. Other object types stay header-instantiated as before.
+extern template MRVIEWER_API std::string getNObjectsLine<ObjectMesh>( unsigned );
+extern template MRVIEWER_API std::string getNObjectsLine<ObjectPoints>( unsigned );
+extern template MRVIEWER_API std::string getNObjectsLine<ObjectLines>( unsigned );
+extern template MRVIEWER_API std::string sceneSelectedExactly<ObjectMesh, true, true>( const std::vector<std::shared_ptr<const Object>>&, unsigned );
+extern template MRVIEWER_API std::string sceneSelectedExactly<ObjectPoints, true, true>( const std::vector<std::shared_ptr<const Object>>&, unsigned );
+extern template MRVIEWER_API std::string sceneSelectedExactly<ObjectLines, true, true>( const std::vector<std::shared_ptr<const Object>>&, unsigned );
+
 
 // check that given vector has exactly N objects if type ObjectT
 template<unsigned N, typename ObjectT, typename = void>

--- a/source/MRViewer/MRViewer.vcxproj
+++ b/source/MRViewer/MRViewer.vcxproj
@@ -163,6 +163,7 @@
     <ClCompile Include="MRWin32MessageHandler.cpp" />
     <ClCompile Include="MRI18n.cpp" />
     <ClCompile Include="MRUITestEngineControl.cpp" />
+    <ClCompile Include="MRSceneStateCheck.cpp" />
     <ClCompile Include="MRUiMcp.cpp" />
     <ClCompile Include="MRSceneMcp.cpp" />
     <ClCompile Include="MRViewerMcp.cpp" />

--- a/source/MRViewer/MRViewer.vcxproj.filters
+++ b/source/MRViewer/MRViewer.vcxproj.filters
@@ -391,6 +391,9 @@
     <ClCompile Include="MRUITestEngineControl.cpp">
       <Filter>UIStyle</Filter>
     </ClCompile>
+    <ClCompile Include="MRSceneStateCheck.cpp">
+      <Filter>StatePlugins</Filter>
+    </ClCompile>
     <ClCompile Include="MRUiMcp.cpp">
       <Filter>MCP</Filter>
     </ClCompile>


### PR DESCRIPTION
## What

Apply `extern template` to the most-instantiated templates in `MRSceneStateCheck.h` — `getNObjectsLine<>` and `sceneSelectedExactly<>` — for the common object types (`ObjectMesh`, `ObjectPoints`, `ObjectLines`). The instantiations are now defined once in a new `MRSceneStateCheck.cpp` and imported everywhere else.

## Why

These are header-only function templates, so each consuming TU code-generates its own copy (the linker later folds the duplicates, but the compiler has already done the work). Build Insights on the full build showed this is pure redundant codegen:

| instantiation | codegen | in TUs |
|---|--:|--:|
| `getNObjectsLine<ObjectMesh>` | ~33 s | 114 |
| `getNObjectsLine<ObjectPoints>` | ~10 s | 34 |
| `getNObjectsLine<ObjectLines>` | ~6 s | 20 |
| `sceneSelectedExactly<ObjectMesh,…>` | ~12 s | 68 |

`extern template` tells those TUs not to instantiate; one definition in `MRSceneStateCheck.cpp` carries it. ~60 CPU-s of codegen collapses to a single instantiation each.

## Notes

- Only the common object types are externed; any other `ObjectT` stays header-instantiated exactly as before (the declarations are opt-in per instantiation).
- Follows the existing convention in the codebase (`MRUITestEngine.h` / `MRUITestEngineControl.cpp`): `extern template MRVIEWER_API …` in the header, plain `template …;` definition in the `.cpp`.
- Compiler-agnostic (works on MSVC/GCC/Clang), so it's a universal codegen reduction — full CI matrix runs.
- This is the clean, low-risk slice of the larger codegen opportunity. The bigger chunk — the `UI::drag<>` / `getDragRangeTooltip<>` unit-template family (~200 CPU-s) — has complex multi-parameter signatures buried in `MR::UI::detail` and is better tackled separately with a local build to validate the instantiation set.
