### PR TITLE
Reduce codegen: extern template common UI::drag<> instantiations

### DIFF
--- a/source/MRViewer/MRUIStyle.cpp
+++ b/source/MRViewer/MRUIStyle.cpp
@@ -2520,3 +2520,24 @@ void saveCustomConfigModal( const CustomConfigModalSettings& settings )
 } // namespace UI
 
 }
+
+namespace MR::UI
+{
+
+// Definitions for the drag<>() instantiations declared extern template in MRUIStyle.h.
+template bool drag<NoUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const int&, const int& );
+template bool drag<NoUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const float&, const float& );
+template bool drag<NoUnit, int, float, int>( const char*, int&, float, const int&, const int&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const int&, const int& );
+template bool drag<LengthUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<LengthUnit>, ImGuiSliderFlags, const float&, const float& );
+template bool drag<LengthUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<LengthUnit>, ImGuiSliderFlags, const int&, const int& );
+template bool drag<AngleUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<AngleUnit>, ImGuiSliderFlags, const float&, const float& );
+template bool drag<AngleUnit, int, float, int>( const char*, int&, float, const int&, const int&, UnitToStringParams<AngleUnit>, ImGuiSliderFlags, const int&, const int& );
+template bool drag<RatioUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<RatioUnit>, ImGuiSliderFlags, const float&, const float& );
+template bool drag<RatioUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<RatioUnit>, ImGuiSliderFlags, const int&, const int& );
+template bool drag<PixelSizeUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<PixelSizeUnit>, ImGuiSliderFlags, const float&, const float& );
+template bool drag<PixelSizeUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<PixelSizeUnit>, ImGuiSliderFlags, const int&, const int& );
+template bool drag<MovementSpeedUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<MovementSpeedUnit>, ImGuiSliderFlags, const float&, const float& );
+template bool drag<AreaUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<AreaUnit>, ImGuiSliderFlags, const float&, const float& );
+template bool drag<InvLengthUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<InvLengthUnit>, ImGuiSliderFlags, const float&, const float& );
+
+} // namespace MR::UI

--- a/source/MRViewer/MRUIStyle.cpp
+++ b/source/MRViewer/MRUIStyle.cpp
@@ -2525,19 +2525,11 @@ namespace MR::UI
 {
 
 // Definitions for the drag<>() instantiations declared extern template in MRUIStyle.h.
-template bool drag<NoUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const int&, const int& );
-template bool drag<NoUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const float&, const float& );
-template bool drag<NoUnit, int, float, int>( const char*, int&, float, const int&, const int&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const int&, const int& );
-template bool drag<LengthUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<LengthUnit>, ImGuiSliderFlags, const float&, const float& );
-template bool drag<LengthUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<LengthUnit>, ImGuiSliderFlags, const int&, const int& );
-template bool drag<AngleUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<AngleUnit>, ImGuiSliderFlags, const float&, const float& );
-template bool drag<AngleUnit, int, float, int>( const char*, int&, float, const int&, const int&, UnitToStringParams<AngleUnit>, ImGuiSliderFlags, const int&, const int& );
-template bool drag<RatioUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<RatioUnit>, ImGuiSliderFlags, const float&, const float& );
-template bool drag<RatioUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<RatioUnit>, ImGuiSliderFlags, const int&, const int& );
-template bool drag<PixelSizeUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<PixelSizeUnit>, ImGuiSliderFlags, const float&, const float& );
-template bool drag<PixelSizeUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<PixelSizeUnit>, ImGuiSliderFlags, const int&, const int& );
-template bool drag<MovementSpeedUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<MovementSpeedUnit>, ImGuiSliderFlags, const float&, const float& );
-template bool drag<AreaUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<AreaUnit>, ImGuiSliderFlags, const float&, const float& );
-template bool drag<InvLengthUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<InvLengthUnit>, ImGuiSliderFlags, const float&, const float& );
+#define MR_X( E ) \
+    template bool drag<E, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<E>, ImGuiSliderFlags, const float&, const float& ); \
+    template bool drag<E, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<E>, ImGuiSliderFlags, const int&, const int& ); \
+    template bool drag<E, int, float, int>( const char*, int&, float, const int&, const int&, UnitToStringParams<E>, ImGuiSliderFlags, const int&, const int& );
+DETAIL_MR_UNIT_ENUMS( MR_X )
+#undef MR_X
 
 } // namespace MR::UI

--- a/source/MRViewer/MRUIStyle.h
+++ b/source/MRViewer/MRUIStyle.h
@@ -604,6 +604,24 @@ public:
     }
 };
 
+// drag<>() is heavy (its internal lambdas dominate UI codegen) and is instantiated in
+// many TUs. Declare the common scalar instantiations extern template here; they are
+// defined once in MRUIStyle.cpp. Vector overloads and rarer combos stay header-instantiated.
+extern template MRVIEWER_API bool drag<NoUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const int&, const int& );
+extern template MRVIEWER_API bool drag<NoUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const float&, const float& );
+extern template MRVIEWER_API bool drag<NoUnit, int, float, int>( const char*, int&, float, const int&, const int&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const int&, const int& );
+extern template MRVIEWER_API bool drag<LengthUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<LengthUnit>, ImGuiSliderFlags, const float&, const float& );
+extern template MRVIEWER_API bool drag<LengthUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<LengthUnit>, ImGuiSliderFlags, const int&, const int& );
+extern template MRVIEWER_API bool drag<AngleUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<AngleUnit>, ImGuiSliderFlags, const float&, const float& );
+extern template MRVIEWER_API bool drag<AngleUnit, int, float, int>( const char*, int&, float, const int&, const int&, UnitToStringParams<AngleUnit>, ImGuiSliderFlags, const int&, const int& );
+extern template MRVIEWER_API bool drag<RatioUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<RatioUnit>, ImGuiSliderFlags, const float&, const float& );
+extern template MRVIEWER_API bool drag<RatioUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<RatioUnit>, ImGuiSliderFlags, const int&, const int& );
+extern template MRVIEWER_API bool drag<PixelSizeUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<PixelSizeUnit>, ImGuiSliderFlags, const float&, const float& );
+extern template MRVIEWER_API bool drag<PixelSizeUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<PixelSizeUnit>, ImGuiSliderFlags, const int&, const int& );
+extern template MRVIEWER_API bool drag<MovementSpeedUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<MovementSpeedUnit>, ImGuiSliderFlags, const float&, const float& );
+extern template MRVIEWER_API bool drag<AreaUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<AreaUnit>, ImGuiSliderFlags, const float&, const float& );
+extern template MRVIEWER_API bool drag<InvLengthUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<InvLengthUnit>, ImGuiSliderFlags, const float&, const float& );
+
 } // namespace UI
 
 }

--- a/source/MRViewer/MRUIStyle.h
+++ b/source/MRViewer/MRUIStyle.h
@@ -604,23 +604,16 @@ public:
     }
 };
 
-// drag<>() is heavy (its internal lambdas dominate UI codegen) and is instantiated in
-// many TUs. Declare the common scalar instantiations extern template here; they are
-// defined once in MRUIStyle.cpp. Vector overloads and rarer combos stay header-instantiated.
-extern template MRVIEWER_API bool drag<NoUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const int&, const int& );
-extern template MRVIEWER_API bool drag<NoUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const float&, const float& );
-extern template MRVIEWER_API bool drag<NoUnit, int, float, int>( const char*, int&, float, const int&, const int&, UnitToStringParams<NoUnit>, ImGuiSliderFlags, const int&, const int& );
-extern template MRVIEWER_API bool drag<LengthUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<LengthUnit>, ImGuiSliderFlags, const float&, const float& );
-extern template MRVIEWER_API bool drag<LengthUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<LengthUnit>, ImGuiSliderFlags, const int&, const int& );
-extern template MRVIEWER_API bool drag<AngleUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<AngleUnit>, ImGuiSliderFlags, const float&, const float& );
-extern template MRVIEWER_API bool drag<AngleUnit, int, float, int>( const char*, int&, float, const int&, const int&, UnitToStringParams<AngleUnit>, ImGuiSliderFlags, const int&, const int& );
-extern template MRVIEWER_API bool drag<RatioUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<RatioUnit>, ImGuiSliderFlags, const float&, const float& );
-extern template MRVIEWER_API bool drag<RatioUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<RatioUnit>, ImGuiSliderFlags, const int&, const int& );
-extern template MRVIEWER_API bool drag<PixelSizeUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<PixelSizeUnit>, ImGuiSliderFlags, const float&, const float& );
-extern template MRVIEWER_API bool drag<PixelSizeUnit, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<PixelSizeUnit>, ImGuiSliderFlags, const int&, const int& );
-extern template MRVIEWER_API bool drag<MovementSpeedUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<MovementSpeedUnit>, ImGuiSliderFlags, const float&, const float& );
-extern template MRVIEWER_API bool drag<AreaUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<AreaUnit>, ImGuiSliderFlags, const float&, const float& );
-extern template MRVIEWER_API bool drag<InvLengthUnit, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<InvLengthUnit>, ImGuiSliderFlags, const float&, const float& );
+// drag<>() is heavy (its internal value-formatting lambdas, plus getDragRangeTooltip<>,
+// dominate UI code generation) and is instantiated in many TUs. Declare the common scalar
+// instantiations extern template here and define them once in MRUIStyle.cpp. Vector
+// overloads and rarer combos stay header-instantiated.
+#define MR_X( E ) \
+    extern template MRVIEWER_API bool drag<E, float, float, float>( const char*, float&, float, const float&, const float&, UnitToStringParams<E>, ImGuiSliderFlags, const float&, const float& ); \
+    extern template MRVIEWER_API bool drag<E, int, int, int>( const char*, int&, int, const int&, const int&, UnitToStringParams<E>, ImGuiSliderFlags, const int&, const int& ); \
+    extern template MRVIEWER_API bool drag<E, int, float, int>( const char*, int&, float, const int&, const int&, UnitToStringParams<E>, ImGuiSliderFlags, const int&, const int& );
+DETAIL_MR_UNIT_ENUMS( MR_X )
+#undef MR_X
 
 } // namespace UI
 


### PR DESCRIPTION
## What

Apply `extern template` to the common `UI::drag<>()` instantiations, the same way #6285 did for `MRSceneStateCheck`. `drag<>()` is declared in `MRUIStyle.h` and defined in `MRUIStyle.ipp` (included by the header), so every consuming TU code-generates its own copy — and `drag`'s internal lambdas are among the heaviest codegen in the whole build.

The common scalar combinations (unit enum × `int`/`float`, decoded from the Build Insights trace) are now declared `extern template` in `MRUIStyle.h` and defined once in `MRUIStyle.cpp`.

## Why

Build Insights showed ~120 CPU-s of code generation spread across the `drag<>` scalar instantiations, e.g.:

| instantiation | codegen | in TUs |
|---|--:|--:|
| `drag<NoUnit, int, int, int>` | ~30 s | 99 |
| `drag<LengthUnit, float, float, float>` | ~23 s | 78 |
| `drag<NoUnit, int, float, int>` | ~14 s | 49 |
| `drag<NoUnit, float, float, float>` | ~13 s | 48 |
| `drag<AngleUnit, float, float, float>` | ~7 s | 20 |
| … (Ratio/PixelSize/MovementSpeed/Area/InvLength) | | |

Each collapses to a single instantiation in `MRUIStyle.cpp` (which also pulls the nested `getDragRangeTooltip<>`/`unitWidget<>` helpers out of every consumer).

## Notes

- 14 scalar combos covered (the heavy ones). Vector overloads (`drag<E, Vector3f>`) and rare scalar/unit combos stay header-instantiated as before — `extern template` is opt-in per instantiation, so anything not listed is unaffected.
- Follows the established convention (`extern template MRVIEWER_API …` in the header; plain `template …;` in the `.cpp`).
- Compiler-agnostic, so it's a universal codegen reduction — full CI matrix runs to validate the export/import on MSVC vs visibility on GCC/Clang.
