### PR TITLE
CI: fix wait-for-job matching the wrong job (substring -> exact)

### DIFF
--- a/.github/actions/wait-for-job/action.yml
+++ b/.github/actions/wait-for-job/action.yml
@@ -22,10 +22,11 @@ inputs:
   job-name:
     required: true
     description: >
-      Name of the job to wait for, matched as a substring of the run's job
-      names. A substring is used so reusable-workflow jobs (displayed as
-      "caller-job / inner-job") match on their caller-job name -- e.g.
-      `generate-c-bindings` matches `generate-c-bindings / generate-c-bindings`.
+      Name of the job to wait for. Matched against the run's job names either
+      exactly, or -- for reusable-workflow jobs, displayed as
+      "caller-job / inner-job" -- on the caller-job segment before " / ". So
+      `generate-c-bindings` matches `generate-c-bindings / generate-c-bindings`
+      but not an unrelated `prepare-image / ... (emscripten-generate-c-bindings, ...)`.
   timeout-seconds:
     required: false
     default: '1800'
@@ -67,7 +68,13 @@ runs:
               github.rest.actions.listJobsForWorkflowRun,
               { owner, repo, run_id: runId, per_page: 100 },
             ));
-            const job = jobs && jobs.find((j) => j.name.includes(jobName));
+            // Match the job exactly, or by caller-job segment for reusable-
+            // workflow jobs (displayed as "caller-job / inner-job"). A plain
+            // substring would wrongly match unrelated jobs -- e.g. a prepare-
+            // image matrix job "... (emscripten-generate-c-bindings, arm64)".
+            const job = jobs && jobs.find(
+              (j) => j.name === jobName || j.name.startsWith(jobName + ' / '),
+            );
             if (job && job.status === 'completed') {
               if (job.conclusion === 'success') {
                 core.info(`Job "${job.name}" finished successfully.`);


### PR DESCRIPTION
## Problem

The `wait-for-job` action (added in #6279) matched the target job with a plain substring:

```js
jobs.find((j) => j.name.includes(jobName))
```

With `job-name: generate-c-bindings` that also matches the **prepare-image** job
`prepare-image / linux-image-build-upload (emscripten-generate-c-bindings, arm64)` — its matrix entry name contains the string (it builds the docker image `generate-c-bindings` runs in).

Because the build-test jobs `needs: prepare-image`, that job is already `success` by the time the wait runs, so the wait matched it and returned immediately — **never actually waiting for the real `generate-c-bindings` job**. It hasn't caused download failures yet only because generation normally finishes before a build reaches the download step anyway, but the guard was effectively a no-op (seen in [this run](https://github.com/MeshInspector/MeshLib/actions/runs/27769304224/job/82164675191): "Wait for C bindings" succeeded before `generate-c-bindings` had even started).

## Fix

Match the job name precisely — exactly, or by the caller-job segment before `" / "` for reusable-workflow jobs (displayed as `caller-job / inner-job`):

```js
jobs.find((j) => j.name === jobName || j.name.startsWith(jobName + ' / '))
```

So `generate-c-bindings` matches `generate-c-bindings / generate-c-bindings` but not `prepare-image / ... (emscripten-generate-c-bindings, ...)`. The `job-name` input doc is updated to spell out the matching rule.

One-file change to the shared action, so it affects every platform's wait — all platforms run to validate.
