### PR TITLE
Use lightweight <iosfwd> instead of stream headers

### DIFF
--- a/source/MRIOExtras/MR3mf.cpp
+++ b/source/MRIOExtras/MR3mf.cpp
@@ -26,6 +26,7 @@
 #include <charconv>
 #include <cmath>
 #include <unordered_map>
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRIOExtras/MRStep.cpp
+++ b/source/MRIOExtras/MRStep.cpp
@@ -14,6 +14,7 @@
 
 #include "MRPch/MRSpdlog.h"
 #include "MRPch/MRSuppressWarning.h"
+#include <fstream>
 
 MR_SUPPRESS_WARNING_PUSH
 MR_SUPPRESS_WARNING( "-Wdeprecated-declarations", 4996 )

--- a/source/MRMesh/MRGcodeLoad.h
+++ b/source/MRMesh/MRGcodeLoad.h
@@ -4,7 +4,7 @@
 #include "MRProgressCallback.h"
 #include "MRExpected.h"
 #include <filesystem>
-#include <istream>
+#include <iosfwd>
 #include <string>
 
 namespace MR

--- a/source/MRMesh/MRIOParsing.cpp
+++ b/source/MRMesh/MRIOParsing.cpp
@@ -6,6 +6,7 @@
 #include "MRPch/MRTBB.h"
 
 #include <boost/spirit/home/x3.hpp>
+#include <istream>
 
 // helper macro to make code cleaner
 #define floatT real_parser<T>{}

--- a/source/MRMesh/MRIOParsing.h
+++ b/source/MRMesh/MRIOParsing.h
@@ -3,7 +3,7 @@
 #include "MRExpected.h"
 #include "MRBuffer.h"
 #include "MRPch/MRBindingMacros.h"
-#include <istream>
+#include <iosfwd>
 
 namespace MR
 {

--- a/source/MRMesh/MRLinesLoad.h
+++ b/source/MRMesh/MRLinesLoad.h
@@ -6,7 +6,7 @@
 #include "MRExpected.h"
 #include "MRLinesLoadSettings.h"
 #include <filesystem>
-#include <istream>
+#include <iosfwd>
 #include <string>
 
 namespace MR

--- a/source/MRMesh/MRLinesSave.h
+++ b/source/MRMesh/MRLinesSave.h
@@ -4,7 +4,7 @@
 #include "MRIOFilters.h"
 #include "MRSaveSettings.h"
 #include <filesystem>
-#include <ostream>
+#include <iosfwd>
 
 namespace MR
 {

--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -27,6 +27,7 @@
 #include <bit>
 #include <future>
 #include <sstream>
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRMesh/MRMeshLoad.h
+++ b/source/MRMesh/MRMeshLoad.h
@@ -7,7 +7,7 @@
 #include "MRExpected.h"
 #include "MRMeshLoadSettings.h"
 #include <filesystem>
-#include <istream>
+#include <iosfwd>
 #include <string>
 
 namespace MR

--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -21,6 +21,7 @@
 #include <boost/spirit/home/x3.hpp>
 
 #include <map>
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRMesh/MRMeshLoadObj.h
+++ b/source/MRMesh/MRMeshLoadObj.h
@@ -8,7 +8,7 @@
 #include "MRAffineXf3.h"
 #include "MRLoadedObjects.h"
 #include <filesystem>
-#include <istream>
+#include <iosfwd>
 #include <string>
 
 namespace MR

--- a/source/MRMesh/MRMeshSave.cpp
+++ b/source/MRMesh/MRMeshSave.cpp
@@ -10,6 +10,7 @@
 #include "MRMeshTexture.h"
 #include "MRImageSave.h"
 #include "MRSerializer.h"
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRMesh/MRMeshSave.h
+++ b/source/MRMesh/MRMeshSave.h
@@ -5,7 +5,7 @@
 #include "MRIOFilters.h"
 #include "MRSaveSettings.h"
 #include <filesystem>
-#include <ostream>
+#include <iosfwd>
 
 namespace MR
 {

--- a/source/MRMesh/MRMeshSave3mf.cpp
+++ b/source/MRMesh/MRMeshSave3mf.cpp
@@ -7,6 +7,7 @@
 #include "MRZip.h"
 #include "MRTimer.h"
 #include "MRPch/MRFmt.h"
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRMesh/MRMeshSaveObj.cpp
+++ b/source/MRMesh/MRMeshSaveObj.cpp
@@ -2,6 +2,7 @@
 #include "MRMeshSave.h"
 #include "MRStringConvert.h"
 #include "MRColor.h"
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRMesh/MRMeshSaveObj.h
+++ b/source/MRMesh/MRMeshSaveObj.h
@@ -4,7 +4,7 @@
 #include "MRAffineXf3.h"
 #include "MRExpected.h"
 #include <filesystem>
-#include <ostream>
+#include <iosfwd>
 #include <string>
 
 namespace MR

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -15,6 +15,8 @@
 #include "MRPartMappingAdapters.h"
 #include <atomic>
 #include <initializer_list>
+#include <istream>
+#include <ostream>
 
 namespace MR
 {

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -9,7 +9,7 @@
 #include "MRProgressCallback.h"
 #include "MRExpected.h"
 #include "MREnums.h"
-#include <fstream>
+#include <iosfwd>
 
 namespace MR
 {

--- a/source/MRMesh/MRPly.cpp
+++ b/source/MRMesh/MRPly.cpp
@@ -8,6 +8,7 @@
 #include "MRMeshTexture.h"
 #include "MRTelemetry.h"
 #include "MRTimer.h"
+#include <istream>
 
 namespace MR
 {

--- a/source/MRMesh/MRPointsSave.h
+++ b/source/MRMesh/MRPointsSave.h
@@ -6,7 +6,7 @@
 #include "MRIOFilters.h"
 #include "MRSaveSettings.h"
 #include <filesystem>
-#include <ostream>
+#include <iosfwd>
 
 namespace MR
 {

--- a/source/MRMesh/MRPolylineTopology.cpp
+++ b/source/MRMesh/MRPolylineTopology.cpp
@@ -3,6 +3,8 @@
 #include "MRMapEdge.h"
 #include "MRParallelFor.h"
 #include "MRTimer.h"
+#include <istream>
+#include <ostream>
 
 namespace MR
 {

--- a/source/MRMesh/MRProgressReadWrite.cpp
+++ b/source/MRMesh/MRProgressReadWrite.cpp
@@ -1,4 +1,6 @@
 #include "MRProgressReadWrite.h"
+#include <istream>
+#include <ostream>
 
 namespace MR
 {

--- a/source/MRMesh/MRProgressReadWrite.h
+++ b/source/MRMesh/MRProgressReadWrite.h
@@ -1,8 +1,7 @@
 #pragma once
 #include "MRProgressCallback.h"
 #include "MRMeshFwd.h"
-#include <ostream>
-#include <istream>
+#include <iosfwd>
 
 namespace MR
 {

--- a/source/MRMesh/MRRegularMapMesher.cpp
+++ b/source/MRMesh/MRRegularMapMesher.cpp
@@ -1,6 +1,7 @@
 #include "MRRegularMapMesher.h"
 #include "MRRegularGridMesh.h"
 #include "MRMesh.h"
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRMesh/MRSerializer.cpp
+++ b/source/MRMesh/MRSerializer.cpp
@@ -26,6 +26,7 @@
 #include "MRPch/MRJson.h"
 
 #include <streambuf>
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRMesh/MRZlib.cpp
+++ b/source/MRMesh/MRZlib.cpp
@@ -5,6 +5,8 @@
 #include <zlib-ng.h>
 
 #include <cassert>
+#include <istream>
+#include <ostream>
 
 namespace
 {

--- a/source/MRSymbolMesh/MRSymbolMesh.cpp
+++ b/source/MRSymbolMesh/MRSymbolMesh.cpp
@@ -18,6 +18,7 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_OUTLINE_H
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRTest/MRPointCloudVariadicOffsetTests.cpp
+++ b/source/MRTest/MRPointCloudVariadicOffsetTests.cpp
@@ -10,6 +10,7 @@
 #include <MRMesh/MRParallelFor.h>
 #include <MRMesh/MRTorus.h>
 #include <MRMesh/MRMakeSphereMesh.h>
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -51,6 +51,7 @@
 #include <imgui_internal.h> // needed here to fix items dialogs windows positions
 #include <misc/freetype/imgui_freetype.h> // for proper font loading
 #include <regex>
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRVoxels/MRDicom.cpp
+++ b/source/MRVoxels/MRDicom.cpp
@@ -29,6 +29,7 @@
 #pragma warning(pop)
 
 #include <variant>
+#include <fstream>
 
 namespace MR
 {

--- a/source/MRVoxels/MRVoxelGraphCut.cpp
+++ b/source/MRVoxels/MRVoxelGraphCut.cpp
@@ -13,6 +13,7 @@
 
 #include <array>
 #include <cfloat>
+#include <fstream>
 
 namespace MR
 {


### PR DESCRIPTION
## Summary

Replace the heavyweight `<istream>` / `<ostream>` / `<fstream>` standard-library includes with the forward-declaration-only `<iosfwd>` in public I/O headers. These headers only mention `std::istream` / `std::ostream` through references and pointers in their function signatures, so a forward declaration is sufficient — they don't need the full stream class definitions.

Since `<iosfwd>` is far cheaper to parse than the full stream headers, this trims preprocessing/compile cost for every translation unit that pulls in these widely-included headers.

## Details

Headers switched to `<iosfwd>`: `MRGcodeLoad.h`, `MRIOParsing.h`, `MRLinesLoad.h`, `MRLinesSave.h`, `MRMeshLoad.h`, `MRMeshLoadObj.h`, `MRMeshSave.h`, `MRMeshSaveObj.h`, `MRMeshTopology.h`, `MRPointsSave.h`, `MRProgressReadWrite.h`.

Notably `MRMeshTopology.h` used to include `<fstream>`, and since `MRMesh.h` includes it, `<fstream>` was effectively available everywhere by transitive inclusion. Dropping that means `.cpp` files that actually perform stream I/O now have to include the concrete header themselves, following include-what-you-use:

- `<fstream>` where `std::ifstream` / `std::ofstream` objects are constructed: `MRMeshLoad.cpp`, `MRMeshLoadObj.cpp`, `MRMeshSave.cpp`, `MRMeshSave3mf.cpp`, `MRMeshSaveObj.cpp`, `MRSerializer.cpp`, `MRRegularMapMesher.cpp`, `MRIOExtras/MR3mf.cpp`, `MRIOExtras/MRStep.cpp`, `MRSymbolMesh/MRSymbolMesh.cpp`, `MRViewer/MRRibbonMenu.cpp`, `MRVoxels/MRDicom.cpp`, `MRVoxels/MRVoxelGraphCut.cpp`, `MRTest/MRPointCloudVariadicOffsetTests.cpp`.
- `<istream>` where `std::istream` member functions are called: `MRIOParsing.cpp`, `MRPly.cpp`.
- `<istream>` and `<ostream>` where both directions are used: `MRMeshTopology.cpp`, `MRPolylineTopology.cpp`, `MRProgressReadWrite.cpp`, `MRZlib.cpp`.
