### PR TITLE
MRVoxels: export-instantiate openvdb::FloatGrid to cut tree codegen

### DIFF
--- a/source/MRVoxels/CMakeLists.txt
+++ b/source/MRVoxels/CMakeLists.txt
@@ -12,6 +12,15 @@ file(GLOB HEADERS "*.h")
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
 
+# The openvdb::FloatGrid explicit instantiation must be EXPORTED from libMRVoxels so downstream
+# modules (which see it as `extern template`) can link it. A visibility attribute on the (already
+# defined) openvdb type is a GCC error, so export it by compiling just this TU with default
+# visibility (the rest of the library stays -fvisibility=hidden). MSVC uses __declspec instead.
+IF(NOT MSVC)
+  set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/MRVDBFloatGridInstantiation.cpp"
+    PROPERTIES COMPILE_OPTIONS "-fvisibility=default")
+ENDIF()
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config_cmake.h.in ${CMAKE_CURRENT_SOURCE_DIR}/config_cmake.h)
 
 find_package(OpenVDB 10 REQUIRED)

--- a/source/MRVoxels/CMakeLists.txt
+++ b/source/MRVoxels/CMakeLists.txt
@@ -17,8 +17,13 @@ add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
 # defined) openvdb type is a GCC error, so export it by compiling just this TU with default
 # visibility (the rest of the library stays -fvisibility=hidden). MSVC uses __declspec instead.
 IF(NOT MSVC)
+  # The instantiation TU is built -fvisibility=default to export the symbols; that must not mix
+  # with a PCH built -fvisibility=hidden (Clang: "visibility differs in PCH vs current file"), so
+  # this TU also opts out of the precompiled header.
   set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/MRVDBFloatGridInstantiation.cpp"
-    PROPERTIES COMPILE_OPTIONS "-fvisibility=default")
+    PROPERTIES
+      COMPILE_OPTIONS "-fvisibility=default"
+      SKIP_PRECOMPILE_HEADERS ON)
 ENDIF()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config_cmake.h.in ${CMAKE_CURRENT_SOURCE_DIR}/config_cmake.h)

--- a/source/MRVoxels/MROpenVDB.h
+++ b/source/MRVoxels/MROpenVDB.h
@@ -2,6 +2,7 @@
 
 #include <MRPch/MRSuppressWarning.h>
 #include <MRPch/MRTBB.h>
+#include <MRVoxels/MRVoxelsFwd.h> // for MRVOXELS_API
 
 #ifndef M_PI
 #define M_PI   3.1415926535897932384626433832795
@@ -95,6 +96,20 @@ namespace OPENVDB_VERSION_NAME
 #include <openvdb/tools/VolumeToMesh.h>
 #include <openvdb/tools/Dense.h>
 #include <openvdb/tools/Filter.h>
+
+// Emit the heavy openvdb::FloatGrid tree codegen once -- in MRVDBFloatGridInstantiation.cpp,
+// exported from MRVoxels -- and import it in every other TU instead of regenerating it per TU.
+// The raw tree nodes cannot be explicitly instantiated (LeafNode::str() references a missing
+// operator<< for LeafBuffer), but instantiating Grid + Tree homes the node methods reached
+// through them. FloatTree = tree::Tree4<float,5,4,3>::Type.
+#ifdef MR_VOXELS_INSTANTIATE_FLOATGRID
+#define MR_VDB_INSTANTIATE template        // the single definition (MRVDBFloatGridInstantiation.cpp)
+#else
+#define MR_VDB_INSTANTIATE extern template // every other TU skips the codegen and links to the above
+#endif
+MR_VDB_INSTANTIATE class MRVOXELS_API openvdb::tree::Tree<openvdb::tree::RootNode<openvdb::tree::InternalNode<openvdb::tree::InternalNode<openvdb::tree::LeafNode<float, 3>, 4>, 5>>>;
+MR_VDB_INSTANTIATE class MRVOXELS_API openvdb::Grid<openvdb::FloatTree>;
+#undef MR_VDB_INSTANTIATE
 
 MR_SUPPRESS_WARNING_POP
 

--- a/source/MRVoxels/MROpenVDB.h
+++ b/source/MRVoxels/MROpenVDB.h
@@ -102,14 +102,24 @@ namespace OPENVDB_VERSION_NAME
 // The raw tree nodes cannot be explicitly instantiated (LeafNode::str() references a missing
 // operator<< for LeafBuffer), but instantiating Grid + Tree homes the node methods reached
 // through them. FloatTree = tree::Tree4<float,5,4,3>::Type.
-#ifdef MR_VOXELS_INSTANTIATE_FLOATGRID
-#define MR_VDB_INSTANTIATE template        // the single definition (MRVDBFloatGridInstantiation.cpp)
+// dllexport and `extern template` are incompatible (C4910), so the linkage is split three ways:
+// the one definition (in MRVDBFloatGridInstantiation.cpp) exports it; MRVoxels's other TUs use a
+// plain `extern template` (intra-DLL link); downstream consumers import it. On non-Windows
+// MRVOXELS_API (visibility) handles the export and a plain extern handles the rest.
+#if defined(MR_VOXELS_INSTANTIATE_FLOATGRID)
+#define MR_VDB_INST template
+#define MR_VDB_API MRVOXELS_API                          // single definition: dllexport / visibility-default
+#elif defined(_WIN32) && !defined(MRVoxels_EXPORTS)
+#define MR_VDB_INST extern template
+#define MR_VDB_API __declspec(dllimport)                 // downstream consumers import from MRVoxels
 #else
-#define MR_VDB_INSTANTIATE extern template // every other TU skips the codegen and links to the above
+#define MR_VDB_INST extern template
+#define MR_VDB_API                                       // MRVoxels intra-DLL, and all non-Windows externs
 #endif
-MR_VDB_INSTANTIATE class MRVOXELS_API openvdb::tree::Tree<openvdb::tree::RootNode<openvdb::tree::InternalNode<openvdb::tree::InternalNode<openvdb::tree::LeafNode<float, 3>, 4>, 5>>>;
-MR_VDB_INSTANTIATE class MRVOXELS_API openvdb::Grid<openvdb::FloatTree>;
-#undef MR_VDB_INSTANTIATE
+MR_VDB_INST class MR_VDB_API openvdb::tree::Tree<openvdb::tree::RootNode<openvdb::tree::InternalNode<openvdb::tree::InternalNode<openvdb::tree::LeafNode<float, 3>, 4>, 5>>>;
+MR_VDB_INST class MR_VDB_API openvdb::Grid<openvdb::FloatTree>;
+#undef MR_VDB_INST
+#undef MR_VDB_API
 
 MR_SUPPRESS_WARNING_POP
 

--- a/source/MRVoxels/MROpenVDB.h
+++ b/source/MRVoxels/MROpenVDB.h
@@ -102,22 +102,35 @@ namespace OPENVDB_VERSION_NAME
 // The raw tree nodes cannot be explicitly instantiated (LeafNode::str() references a missing
 // operator<< for LeafBuffer), but instantiating Grid + Tree homes the node methods reached
 // through them. FloatTree = tree::Tree4<float,5,4,3>::Type.
-// dllexport and `extern template` are incompatible (C4910), so the linkage is split three ways:
-// the one definition (in MRVDBFloatGridInstantiation.cpp) exports it; MRVoxels's other TUs use a
-// plain `extern template` (intra-DLL link); downstream consumers import it. On non-Windows
-// MRVOXELS_API (visibility) handles the export and a plain extern handles the rest.
+// Linkage is split three ways -- each platform rejects a different naive form:
+//  - the one definition (MRVDBFloatGridInstantiation.cpp) is exported: __declspec(dllexport) on
+//    Windows, a `#pragma GCC visibility push(default)` elsewhere (a visibility *attribute* on an
+//    already-defined type is a GCC error; dllexport + extern is C4910 on MSVC);
+//  - MRVoxels's other TUs use a plain `extern template` (intra-module link);
+//  - downstream consumers import: __declspec(dllimport) on Windows, plain extern elsewhere.
 #if defined(MR_VOXELS_INSTANTIATE_FLOATGRID)
 #define MR_VDB_INST template
-#define MR_VDB_API MRVOXELS_API                          // single definition: dllexport / visibility-default
+#if defined(_WIN32)
+#define MR_VDB_API __declspec(dllexport)
+#else
+#define MR_VDB_API
+#endif
 #elif defined(_WIN32) && !defined(MRVoxels_EXPORTS)
 #define MR_VDB_INST extern template
-#define MR_VDB_API __declspec(dllimport)                 // downstream consumers import from MRVoxels
+#define MR_VDB_API __declspec(dllimport)
 #else
 #define MR_VDB_INST extern template
-#define MR_VDB_API                                       // MRVoxels intra-DLL, and all non-Windows externs
+#define MR_VDB_API
+#endif
+
+#if defined(MR_VOXELS_INSTANTIATE_FLOATGRID) && !defined(_WIN32)
+#pragma GCC visibility push(default)
 #endif
 MR_VDB_INST class MR_VDB_API openvdb::tree::Tree<openvdb::tree::RootNode<openvdb::tree::InternalNode<openvdb::tree::InternalNode<openvdb::tree::LeafNode<float, 3>, 4>, 5>>>;
 MR_VDB_INST class MR_VDB_API openvdb::Grid<openvdb::FloatTree>;
+#if defined(MR_VOXELS_INSTANTIATE_FLOATGRID) && !defined(_WIN32)
+#pragma GCC visibility pop
+#endif
 #undef MR_VDB_INST
 #undef MR_VDB_API
 

--- a/source/MRVoxels/MROpenVDB.h
+++ b/source/MRVoxels/MROpenVDB.h
@@ -104,8 +104,9 @@ namespace OPENVDB_VERSION_NAME
 // through them. FloatTree = tree::Tree4<float,5,4,3>::Type.
 // Linkage is split three ways -- each platform rejects a different naive form:
 //  - the one definition (MRVDBFloatGridInstantiation.cpp) is exported: __declspec(dllexport) on
-//    Windows, a `#pragma GCC visibility push(default)` elsewhere (a visibility *attribute* on an
-//    already-defined type is a GCC error; dllexport + extern is C4910 on MSVC);
+//    Windows; elsewhere a visibility *attribute* on an already-defined type is a GCC error, so
+//    that TU is compiled with -fvisibility=default instead (see MRVoxels/CMakeLists.txt). dllexport
+//    + extern is C4910 on MSVC, hence the split.
 //  - MRVoxels's other TUs use a plain `extern template` (intra-module link);
 //  - downstream consumers import: __declspec(dllimport) on Windows, plain extern elsewhere.
 #if defined(MR_VOXELS_INSTANTIATE_FLOATGRID)
@@ -123,14 +124,8 @@ namespace OPENVDB_VERSION_NAME
 #define MR_VDB_API
 #endif
 
-#if defined(MR_VOXELS_INSTANTIATE_FLOATGRID) && !defined(_WIN32)
-#pragma GCC visibility push(default)
-#endif
 MR_VDB_INST class MR_VDB_API openvdb::tree::Tree<openvdb::tree::RootNode<openvdb::tree::InternalNode<openvdb::tree::InternalNode<openvdb::tree::LeafNode<float, 3>, 4>, 5>>>;
 MR_VDB_INST class MR_VDB_API openvdb::Grid<openvdb::FloatTree>;
-#if defined(MR_VOXELS_INSTANTIATE_FLOATGRID) && !defined(_WIN32)
-#pragma GCC visibility pop
-#endif
 #undef MR_VDB_INST
 #undef MR_VDB_API
 

--- a/source/MRVoxels/MRVDBFloatGridInstantiation.cpp
+++ b/source/MRVoxels/MRVDBFloatGridInstantiation.cpp
@@ -1,0 +1,5 @@
+// Single TU that emits the explicit instantiation of the openvdb::FloatGrid tree hierarchy
+// (exported from MRVoxels). Defining MR_VOXELS_INSTANTIATE_FLOATGRID makes MROpenVDB.h emit the
+// definitions instead of extern-template declarations; every other TU links to the copy here.
+#define MR_VOXELS_INSTANTIATE_FLOATGRID
+#include <MRVoxels/MROpenVDB.h>

--- a/source/MRVoxels/MRVoxels.vcxproj
+++ b/source/MRVoxels/MRVoxels.vcxproj
@@ -44,6 +44,7 @@
     <ClCompile Include="MRTetrisNesting.cpp" />
     <ClCompile Include="MRToolPath.cpp" />
     <ClCompile Include="MRVDBConversions.cpp" />
+    <ClCompile Include="MRVDBFloatGridInstantiation.cpp" />
     <ClCompile Include="MRVolumeSegment.cpp" />
     <ClCompile Include="MRVoxelGraphCut.cpp" />
     <ClCompile Include="MRVoxelPath.cpp" />


### PR DESCRIPTION
## What

Instantiate the `openvdb::FloatGrid` tree hierarchy **once**, exported from MRVoxels, instead of regenerating it in every translation unit that uses a `FloatGrid`.

- **`MRVDBFloatGridInstantiation.cpp`** (new) emits `template class MRVOXELS_API openvdb::Grid<FloatTree>;` + its `Tree` — exported from MRVoxels.
- **`MROpenVDB.h`** declares them `extern template class MRVOXELS_API ...`, so every other TU — in MRVoxels **and** in downstream consumers (plugins, MeshInspectorCode) — skips the codegen and links to the single exported copy.

## Why

Once the OpenVDB headers are parsed, the dominant remaining compile cost in the voxels TUs is regenerating the `FloatGrid` tree codegen (`RootNode`/`InternalNode`/`LeafNode`/`Tree` — `readTopology`/`fill`/`lookup`/iterators) in every TU. Homing it once removes that duplication.

## Design notes

- **Only `Grid` and `Tree` are instantiated.** The raw tree nodes cannot be explicitly instantiated — `LeafNode::str()` references a non-existent `operator<<` for `LeafBuffer` (which is why OpenVDB itself never instantiates them). Instantiating `Grid` + `Tree` transitively homes the node methods reached through them.
- The vcpkg OpenVDB is built **without** `OPENVDB_USE_EXPLICIT_INSTANTIATION` (its lib carries no such symbols), so enabling that macro would link-fail — we emit our own.
- **Exported** via `MRVOXELS_API` so downstream consumers benefit too — cross-platform (dllexport/dllimport on Windows, default visibility elsewhere). OpenVDB's template classes aren't API-marked, so this is legal even with the DLL OpenVDB build; the instantiation sits inside `MROpenVDB.h`'s existing warning suppression (C4251/C4275).
- **Independent of the precompiled header** — works on every compiler and with `MR_PCH=OFF`.

The instantiation was verified to compile against vcpkg OpenVDB 12 (MSVC); CI validates the full matrix and the link.
