### PR TITLE
MRVoxels: [experiment] overlap compile with MRMesh in MSBuild (link-only dependency)

### DIFF
--- a/source/MRVoxels/MRVoxels.vcxproj
+++ b/source/MRVoxels/MRVoxels.vcxproj
@@ -11,9 +11,6 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\MRMesh\MRMesh.vcxproj">
-      <Project>{c7780500-ca0e-4f5f-8423-d7ab06078b14}</Project>
-    </ProjectReference>
     <ProjectReference Include="..\MRPch\MRPch.vcxproj">
       <Project>{36516aee-2fb9-41c0-a176-a2d49c1c26b2}</Project>
     </ProjectReference>
@@ -153,7 +150,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)MRMesh.lib;ws2_32.lib;rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -175,10 +172,19 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)MRMesh.lib;ws2_32.lib;rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <!-- EXPERIMENT (MSBuild only): let MRVoxels TUs compile in parallel with MRMesh instead of
+       waiting for the whole MRMesh project. The MRMesh ProjectReference (which serializes the
+       build) is removed and MRMesh.lib is linked explicitly; this target only gates the LINK on
+       MRMesh being built. No Properties are passed, so global properties flow down and MSBuild
+       dedups the MRMesh build the solution is already doing (no double build, no node deadlock
+       -- MRMesh has no blocking wait of its own). -->
+  <Target Name="EnsureMRMeshBeforeLink" BeforeTargets="Link">
+    <MSBuild Projects="$(ProjectDir)..\MRMesh\MRMesh.vcxproj" Targets="Build" BuildInParallel="true" />
+  </Target>
 </Project>

--- a/source/MRVoxels/MRVoxels.vcxproj
+++ b/source/MRVoxels/MRVoxels.vcxproj
@@ -182,8 +182,8 @@
        waiting for the whole MRMesh project. The MRMesh ProjectReference (which serializes the
        build) is removed and MRMesh.lib is linked explicitly; this target only gates the LINK on
        MRMesh being built. No Properties are passed, so global properties flow down and MSBuild
-       dedups the MRMesh build the solution is already doing (no double build, no node deadlock
-       -- MRMesh has no blocking wait of its own). -->
+       dedups the MRMesh build the solution is already doing (no double build, and no node
+       deadlock since MRMesh has no blocking wait of its own). -->
   <Target Name="EnsureMRMeshBeforeLink" BeforeTargets="Link">
     <MSBuild Projects="$(ProjectDir)..\MRMesh\MRMesh.vcxproj" Targets="Build" BuildInParallel="true" />
   </Target>


### PR DESCRIPTION
## Experiment

In **MSBuild**, a `<ProjectReference>` serializes the *entire* referenced project before the referencing one starts — so MRVoxels' TUs don't begin compiling until MRMesh is fully built and linked. But MRVoxels' TUs only need MRMesh **headers**; only MRVoxels' **link** needs `MRMesh.lib`.

This PR makes MRVoxels' compilation overlap MRMesh's:

- **Removes** the MRMesh `ProjectReference` (it's what imposes the build ordering).
- **Links `MRMesh.lib` explicitly** via `$(OutDir)MRMesh.lib`.
- **Gates only the `Link` step** on MRMesh, with a `BeforeTargets="Link"` MSBuild task. It passes no `Properties`, so the global properties flow down and MSBuild **dedups** the MRMesh build the solution is already running (no double build; MRMesh has no blocking wait of its own, so no node-pool deadlock).

**MSBuild only** — CMake/Ninja already schedule at TU granularity across projects, so this serialization doesn't exist there. Non-Windows lanes are disabled accordingly.

## Why / what to measure

MRVoxels sits on the dependency chain (MRViewer/MRPlugins/MRTest follow it), and on master MSBuild fully serializes MRMesh → MRVoxels. The question is whether letting MRVoxels' ~40–70 s of compile overlap MRMesh's ~80 s actually shortens the full-build wall — or whether the cores are already saturated by the other independent projects (the full build measured ~96% parallel efficiency), in which case it won't help. This PR is to measure that directly.

Not necessarily for merge — it's a scheduling experiment, and it trades some incremental-build/IDE correctness (MSBuild no longer auto-rebuilds MRVoxels when MRMesh changes via the reference) for the overlap.
