### PR TITLE
PlanarTriangulation: injectable sweep-line predicates + tbb::parallel_sort

### DIFF
--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -58,11 +58,20 @@ struct SweepLinePredicates
 static SweepLinePredicates precisePredicates( const Contours2f& contours )
 {
     Box3f box;
+    int pointsSize = 0;
     for ( const auto& cont : contours )
+    {
         for ( const auto& p : cont )
             box.include( to3dim( p ) );
+        if ( cont.size() > 3 )
+        {
+            assert( cont.front() == cont.back() );
+            pointsSize += int( cont.size() ) - 1;
+        }
+    }
 
     auto pts = std::make_shared<Vector<Vector2i, VertId>>();
+    pts->reserve( pointsSize );
     auto toInt = [conv = getToIntConverter( Box3d( box ) )] ( const Vector2f& coord )
     {
         return to2dim( conv( to3dim( coord ) ) );

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -17,9 +17,12 @@
 #include "MR2to3.h"
 #include "MRBitSetParallelFor.h"
 #include "MRPrecisePredicates2.h"
+#include "MRPch/MRTBB.h"
 #include <queue>
 #include <algorithm>
 #include <limits>
+#include <memory>
+#include <tuple>
 
 namespace MR
 {
@@ -27,16 +30,93 @@ namespace MR
 namespace PlanarTriangulation
 {
 
-int findClosestToFront( const MeshTopology& tp, const Vector<Vector3i, VertId>& pts,
+// All coordinate-dependent operations of the sweep-line triangulation, factored out so a caller
+// can supply alternative geometry. The default implementation is precisePredicates() below, which
+// reproduces the historical exact-integer simulation-of-simplicity behavior.
+struct SweepLinePredicates
+{
+    // strict order of vertices along the sweep direction (sweep advances toward the greater vertex)
+    std::function<bool( VertId l, VertId r )> less;
+    // strict lexicographic order of positions; used only to group coincident vertices before merging
+    std::function<bool( VertId l, VertId r )> less2d;
+    // whether two vertices share exactly the same position
+    std::function<bool( VertId l, VertId r )> samePos;
+    // orientation predicate, equivalent to MR::ccw( { a, b, c } )
+    std::function<bool( VertId a, VertId b, VertId c )> ccw;
+    // orientation of b around pivot relative to the direction the sweep arrives from
+    // (i.e. ccw with the first point placed far behind pivot, opposite to the sweep)
+    std::function<bool( VertId b, VertId pivot )> ccwFromBehind;
+    // store the position of input vertex v taken from its source coordinate
+    std::function<void( VertId v, const Vector2f& coord )> addInputPoint;
+    // compute and store the position of intersection vertex v of segments (a,b) and (c,d)
+    std::function<void( VertId v, VertId a, VertId b, VertId c, VertId d )> addIntersectionPoint;
+    // position of vertex v in the output mesh
+    std::function<Vector3f( VertId v )> point;
+};
+
+// default predicates: exact integer arithmetic with simulation-of-simplicity (historical behavior)
+static SweepLinePredicates precisePredicates( const Contours2f& contours )
+{
+    Box3f box;
+    for ( const auto& cont : contours )
+        for ( const auto& p : cont )
+            box.include( to3dim( p ) );
+
+    auto pts = std::make_shared<Vector<Vector2i, VertId>>();
+    auto toInt = [conv = getToIntConverter( Box3d( box ) )] ( const Vector2f& coord )
+    {
+        return to2dim( conv( to3dim( coord ) ) );
+    };
+    auto toFloat = [conv = getToFloatConverter( Box3d( box ) )] ( const Vector2i& coord )
+    {
+        return to2dim( conv( to3dim( coord ) ) );
+    };
+
+    SweepLinePredicates p;
+    p.less = [pts] ( VertId l, VertId r )
+    {
+        return smaller( { .id = l, .pt = ( *pts )[l].x }, { .id = r, .pt = ( *pts )[r].x } );
+    };
+    p.less2d = [pts] ( VertId l, VertId r )
+    {
+        return std::tuple( ( *pts )[l].x, ( *pts )[l].y ) < std::tuple( ( *pts )[r].x, ( *pts )[r].y );
+    };
+    p.samePos = [pts] ( VertId l, VertId r )
+    {
+        return ( *pts )[l] == ( *pts )[r];
+    };
+    p.ccw = [pts] ( VertId a, VertId b, VertId c )
+    {
+        return MR::ccw( { PreciseVertCoords2{ a, ( *pts )[a] }, { b, ( *pts )[b] }, { c, ( *pts )[c] } } );
+    };
+    p.ccwFromBehind = [pts] ( VertId b, VertId pivot )
+    {
+        Vector2i base = ( *pts )[pivot];
+        base.x -= 10000; // far behind pivot along -X, matching the historical sweep reference
+        return MR::ccw( { PreciseVertCoords2{ VertId{}, base }, { b, ( *pts )[b] }, { pivot, ( *pts )[pivot] } } );
+    };
+    p.addInputPoint = [pts, toInt] ( VertId v, const Vector2f& coord )
+    {
+        pts->autoResizeSet( v, toInt( coord ) );
+    };
+    p.addIntersectionPoint = [pts] ( VertId v, VertId a, VertId b, VertId c, VertId d )
+    {
+        pts->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( ( *pts )[a], ( *pts )[b], ( *pts )[c], ( *pts )[d] ) );
+    };
+    p.point = [pts, toFloat] ( VertId v )
+    {
+        return to3dim( toFloat( ( *pts )[v] ) );
+    };
+    return p;
+}
+
+int findClosestToFront( const MeshTopology& tp, const SweepLinePredicates& predicates,
     const std::vector<EdgeId>& edges, bool left )
 {
     if ( edges.size() == 2 )
         return 1;
-    std::array<PreciseVertCoords2, 3> pvc;
-    auto org = tp.org( edges[1] );
-    pvc[2].id = org;
-    pvc[2].pt = to2dim( pts[org] );
-    PreciseVertCoords2 baseVertCoord;
+    const VertId org = tp.org( edges[1] );
+    VertId baseId; // origin of the reference ray; invalid => the ray points against the sweep
     if ( edges[0] )
     {
         auto dest = tp.dest( edges[0] );
@@ -45,15 +125,13 @@ int findClosestToFront( const MeshTopology& tp, const Vector<Vector3i, VertId>& 
             if ( dest == tp.dest( edges[i] ) )
                 return i;
         }
-        baseVertCoord.id = dest;
-        baseVertCoord.pt = to2dim( pts[dest] );
+        baseId = dest;
     }
-    else
+    // orientation of vertex x around org relative to the reference ray
+    auto ccwFromBase = [&] ( VertId x )
     {
-        baseVertCoord.id = VertId{}; // -1
-        baseVertCoord.pt = pvc[2].pt;
-        baseVertCoord.pt.x -= 10000; // -X vec
-    }
+        return baseId.valid() ? predicates.ccw( baseId, x, org ) : predicates.ccwFromBehind( x, org );
+    };
     auto getNextI = [&] ( int i, bool prev )
     {
         if ( prev )
@@ -71,29 +149,19 @@ int findClosestToFront( const MeshTopology& tp, const Vector<Vector3i, VertId>& 
     };
     for ( int i = 1; ; )
     {
-        pvc[0] = baseVertCoord;
-
-        auto dest = tp.dest( edges[i] );
-        pvc[1].id = dest;
-        pvc[1].pt = to2dim( pts[dest] );
-        PreciseVertCoords2 coordI = pvc[1];
-
-        bool ccwBI = ccw( pvc );
+        const VertId destI = tp.dest( edges[i] );
+        bool ccwBI = ccwFromBase( destI );
         int nextI = getNextI( i, ccwBI );
 
-        dest = tp.dest( edges[nextI] );
-        pvc[1].id = dest;
-        pvc[1].pt = to2dim( pts[dest] );
-
-        bool ccwBIn = ccw( pvc );
+        const VertId destNextI = tp.dest( edges[nextI] );
+        bool ccwBIn = ccwFromBase( destNextI );
 
         if ( ccwBI && !ccwBIn )
             return left ? i : nextI;
         if ( !ccwBI && ccwBIn )
             return left ? nextI : i;
 
-        pvc[0] = coordI;
-        bool ccwIIn = ccw( pvc );
+        bool ccwIIn = predicates.ccw( destI, destNextI, org );
 
         if ( ccwBI && ccwIIn )
             return left ? i : nextI;
@@ -148,15 +216,9 @@ public:
     Mesh triangulate();
 private:
     MeshTopology tp_;
-    Vector<Vector3i, VertId> pts_;
-    CoordinateConverters2 converters_;
+    SweepLinePredicates predicates_;
 
     SweepLineParams params_;
-
-    bool less_( VertId l, VertId r ) const
-    {
-        return smaller( { .id = l,.pt = pts_[l].x }, { .id = r,.pt = pts_[r].x } );
-    }
 
 // INITIALIZATION CLASS BLOCK
     // make base mesh only containing input contours as edge loops
@@ -280,27 +342,16 @@ private:
     };
     using IntersectionMap = HashMap<EdgePair, IntersectionInfo>;
     IntersectionMap intersectionsMap_; // needed to prevent recreation of same vertices multiple times
+    // whether segments (aOrg,aDest) and (bOrg,bDest) properly intersect, via the injected ccw
+    bool doSegmentSegmentIntersect_( VertId aOrg, VertId aDest, VertId bOrg, VertId bDest ) const;
     void checkIntersection_( int index, bool lower );
     void checkIntersection_( int indexLower );
 };
 
 SweepLineQueue::SweepLineQueue( const Contours2f& contours, const SweepLineParams& params ) :
+    predicates_{ precisePredicates( contours ) },
     params_{ params }
 {
-    Box3f box;
-    for ( const auto& cont : contours )
-        for ( const auto& p : cont )
-            box.include( to3dim( p ) );
-
-    converters_.toInt = [conv = getToIntConverter( Box3d( box ) )] ( const Vector2f& coord )
-    {
-        return to2dim( conv( to3dim( coord ) ) );
-    };
-    converters_.toFloat = [conv = getToFloatConverter( Box3d( box ) )] ( const Vector2i& coord )
-    {
-        return to2dim( conv( to3dim( coord ) ) );
-    };
-
     initMeshByContours_( contours );
     mergeSamePoints_( params.holesVertId );
     setupStartVertices_();
@@ -362,11 +413,11 @@ void SweepLineQueue::injectIntersections( IntersectionsMap* interMap )
             mapVal.uOrg = tp_.org( inter.upper );
             mapVal.uDest = tp_.dest( inter.upper );
 
-            auto iP = converters_.toFloat( to2dim( pts_[inter.vId] ) );
-            auto lO = converters_.toFloat( to2dim( pts_[mapVal.lOrg] ) );
-            auto lD = converters_.toFloat( to2dim( pts_[mapVal.lDest] ) );
-            auto uO = converters_.toFloat( to2dim( pts_[mapVal.uOrg] ) );
-            auto uD = converters_.toFloat( to2dim( pts_[mapVal.uDest] ) );
+            auto iP = to2dim( predicates_.point( inter.vId ) );
+            auto lO = to2dim( predicates_.point( mapVal.lOrg ) );
+            auto lD = to2dim( predicates_.point( mapVal.lDest ) );
+            auto uO = to2dim( predicates_.point( mapVal.uOrg ) );
+            auto uD = to2dim( predicates_.point( mapVal.uDest ) );
             auto lVec = ( lD - lO );
             auto uVec = ( uD - uO );
             auto lVecLSq = lVec.lengthSq();
@@ -472,10 +523,10 @@ Mesh SweepLineQueue::triangulate()
     }
     Mesh mesh;
     mesh.topology = std::move( tp_ );
-    mesh.points.resize( pts_.size() );
+    mesh.points.resize( mesh.topology.vertSize() );
     BitSetParallelFor( mesh.topology.getValidVerts(), [&] ( VertId v )
     {
-        mesh.points[v] = to3dim(converters_.toFloat(to2dim(pts_[v])));
+        mesh.points[v] = predicates_.point( v );
     } );
     if ( !params_.needOutline )
     {
@@ -492,7 +543,7 @@ void SweepLineQueue::setupStartVertices_()
         bool startVert = true;
         for ( auto e : orgRing( tp_, v ) )
         {
-            if ( less_( tp_.dest( e ), v ) )
+            if ( predicates_.less( tp_.dest( e ), v ) )
             {
                 startVert = false;
                 break;
@@ -509,7 +560,7 @@ void SweepLineQueue::setupStartVertices_()
 
     std::sort( startVerts_.begin(), startVerts_.end(), [&] ( VertId l, VertId r )
     {
-        return less_( l, r );
+        return predicates_.less( l, r );
     } );
 }
 
@@ -548,7 +599,7 @@ SweepLineQueue::Event SweepLineQueue::getNext_()
         }
         if ( stage_ != Stage::Intersections || !activeSweep.upperInfo.interVertId )
             continue;
-        if ( !minInter || less_( activeSweep.upperInfo.interVertId, minInter ) )
+        if ( !minInter || predicates_.less( activeSweep.upperInfo.interVertId, minInter ) )
         {
             minInter = activeSweep.upperInfo.interVertId;
             minInterIndex = i;
@@ -559,7 +610,7 @@ SweepLineQueue::Event SweepLineQueue::getNext_()
     {
         if ( tp_.dest( activeSweepEdges_[minInterIndex].edgeId ) == nextVertId ||
             tp_.dest( activeSweepEdges_[minInterIndex + 1].edgeId ) == nextVertId ||
-            less_( minInter, nextVertId ) )
+            predicates_.less( minInter, nextVertId ) )
         {
             outEvent.type = EventType::Intersection;
             outEvent.index = minInterIndex;
@@ -599,17 +650,13 @@ bool SweepLineQueue::isIntersectionValid_( int indexLower )
 int SweepLineQueue::findStartIndex_()
 {
     int activeVPosition{ INT_MAX };// index of first edge, under activeV (INT_MAX - all edges are lower, -1 - all edges are upper)
-    std::array<PreciseVertCoords2, 3> pvc;
-    pvc[1].id = startVerts_[startVertIndex_];
-    pvc[1].pt = to2dim( pts_[pvc[1].id] );
+    const VertId activeV = startVerts_[startVertIndex_];
     for ( int i = 0; i < activeSweepEdges_.size(); ++i )
     {
-        pvc[0].id = tp_.org( activeSweepEdges_[i].edgeId );
-        pvc[2].id = tp_.dest( activeSweepEdges_[i].edgeId );
-        pvc[0].pt = to2dim( pts_[pvc[0].id] );
-        pvc[2].pt = to2dim( pts_[pvc[2].id] );
+        const VertId org = tp_.org( activeSweepEdges_[i].edgeId );
+        const VertId dest = tp_.dest( activeSweepEdges_[i].edgeId );
 
-        if ( activeVPosition == INT_MAX && ccw( pvc ) )
+        if ( activeVPosition == INT_MAX && predicates_.ccw( org, activeV, dest ) )
             activeVPosition = i - 1;
     }
 
@@ -634,7 +681,7 @@ void SweepLineQueue::updateStartRightGoingCache_()
     int pos = -1;
     if ( stage_ == Stage::Intersections )
     {
-        pos = findClosestToFront( tp_, pts_, findClosestCache_, true ) - 1;
+        pos = findClosestToFront( tp_, predicates_, findClosestCache_, true ) - 1;
         assert( pos > -1 );
         startVertLowestRight_[startVertIndex_] = rightGoingCache_[pos].edgeId;
     }
@@ -681,7 +728,7 @@ void SweepLineQueue::processStartEvent_( int index )
         {
             auto lowerOrg = tp_.org( activeSweepEdges_[index - 1].edgeId );
             auto upperOrg = tp_.org( activeSweepEdges_[index].edgeId );
-            if ( less_( lowerOrg, upperOrg ) )
+            if ( predicates_.less( lowerOrg, upperOrg ) )
                 helperId = tp_.prev( activeSweepEdges_[index].edgeId );
             else
                 helperId = activeSweepEdges_[index - 1].edgeId;
@@ -838,28 +885,32 @@ void SweepLineQueue::checkIntersection_( int index, bool lower )
         return checkIntersection_( index );
 }
 
+bool SweepLineQueue::doSegmentSegmentIntersect_( VertId aOrg, VertId aDest, VertId bOrg, VertId bDest ) const
+{
+    // segments intersect iff each separates the endpoints of the other;
+    // predicate-based equivalent of MR::doSegmentSegmentIntersect (cIsLeftFromAB is unused here)
+    const bool abc = predicates_.ccw( aOrg, aDest, bOrg );
+    const bool abd = predicates_.ccw( aOrg, aDest, bDest );
+    if ( abc == abd )
+        return false; // segment (bOrg,bDest) is on one side of line (aOrg,aDest)
+    const bool cda = predicates_.ccw( bOrg, bDest, aOrg );
+    const bool cdb = predicates_.ccw( bOrg, bDest, aDest );
+    return cda != cdb; // equal => segment (aOrg,aDest) is on one side of line (bOrg,bDest)
+}
+
 void SweepLineQueue::checkIntersection_( int i )
 {
     assert( i >= 0 && i + 1 < activeSweepEdges_.size() );
 
-    // fill up
-    std::array<PreciseVertCoords2, 4> pvc;
-    auto org1 = tp_.org( activeSweepEdges_[i].edgeId );
-    auto dest1 = tp_.dest( activeSweepEdges_[i].edgeId );
-    auto org2 = tp_.org( activeSweepEdges_[i + 1].edgeId );
-    auto dest2 = tp_.dest( activeSweepEdges_[i + 1].edgeId );
+    const VertId org1 = tp_.org( activeSweepEdges_[i].edgeId );
+    const VertId dest1 = tp_.dest( activeSweepEdges_[i].edgeId );
+    const VertId org2 = tp_.org( activeSweepEdges_[i + 1].edgeId );
+    const VertId dest2 = tp_.dest( activeSweepEdges_[i + 1].edgeId );
     bool canIntersect = org1 != org2 && dest1 != dest2;
     if ( !canIntersect || !org1 || !org2 || !dest1 || !dest2 )
         return;
 
-    pvc[0].id = org1; pvc[1].id = dest1;
-    pvc[2].id = org2; pvc[3].id = dest2;
-
-    for ( int p = 0; p < 4; ++p )
-        pvc[p].pt = to2dim( pts_[pvc[p].id] );
-
-    auto haveInter = doSegmentSegmentIntersect( pvc );
-    if ( !haveInter.doIntersect )
+    if ( !doSegmentSegmentIntersect_( org1, dest1, org2, dest2 ) )
         return;
 
     auto minEdgeId = std::min( activeSweepEdges_[i].edgeId, activeSweepEdges_[i + 1].edgeId );
@@ -868,8 +919,7 @@ void SweepLineQueue::checkIntersection_( int i )
     if ( !interInfo )
     {
         interInfo.vId = tp_.addVertId();
-        pts_.autoResizeSet( interInfo.vId,
-            to3dim( findSegmentSegmentIntersectionPrecise( pvc[0].pt, pvc[1].pt, pvc[2].pt, pvc[3].pt ) ) );
+        predicates_.addIntersectionPoint( interInfo.vId, org1, dest1, org2, dest2 );
     }
     else if ( interInfo.processed )
         return;
@@ -881,24 +931,15 @@ void SweepLineQueue::checkIntersection_( int i )
 void SweepLineQueue::initMeshByContours_( const Contours2f& contours )
 {
     MR_TIMER;
-    int pointsSize = 0;
     for ( const auto& c : contours )
     {
         if ( c.size() > 3 )
         {
             assert( c.front() == c.back() );
-            pointsSize += ( int( c.size() ) - 1 );
-        }
-    }
-    pts_.reserve( pointsSize );
-    for ( const auto& c : contours )
-    {
-        if ( c.size() > 3 )
-        {
             for ( int i = 0; i + 1 < c.size(); ++i )
             {
                 VertId v = tp_.addVertId();
-                pts_.autoResizeSet( v, to3dim( converters_.toInt( c[i] ) ) );
+                predicates_.addInputPoint( v, c[i] );
             }
         }
     }
@@ -946,16 +987,20 @@ void SweepLineQueue::mergeSamePoints_( const HolesVertIds* holesVertId )
         }
         return ( *holesVertId )[holeId][patchId];
     };
-    sortedVerts_.reserve( pts_.size() );
-    for ( int i = 0; i < pts_.size(); ++i )
+    sortedVerts_.reserve( tp_.vertSize() );
+    for ( int i = 0; i < tp_.vertSize(); ++i )
         sortedVerts_.emplace_back( VertId( i ) );
     if ( !holesVertId )
-        std::sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r ) { return less_( l, r ); } );
+        tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r ) { return predicates_.less( l, r ); } );
     else
     {
-        std::sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r )
+        tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r )
         {
-            return std::tuple( pts_[l].x, pts_[l].y, findRealVertId( l ) ) < std::tuple( pts_[r].x, pts_[r].y, findRealVertId( r ) );
+            if ( predicates_.less2d( l, r ) )
+                return true;
+            if ( predicates_.less2d( r, l ) )
+                return false;
+            return findRealVertId( l ) < findRealVertId( r );
         } );
     }
 
@@ -968,7 +1013,7 @@ void SweepLineQueue::mergeSamePoints_( const HolesVertIds* holesVertId )
     int prevUnique = 0;
     for ( int i = 1; i < sortedVerts_.size(); ++i )
     {
-        bool sameIntCoord = pts_[sortedVerts_[i]] == pts_[sortedVerts_[prevUnique]];
+        bool sameIntCoord = predicates_.samePos( sortedVerts_[i], sortedVerts_[prevUnique] );
         if ( !sameIntCoord )
         {
             prevUnique = i;
@@ -980,7 +1025,7 @@ void SweepLineQueue::mergeSamePoints_( const HolesVertIds* holesVertId )
     }
 
     if ( holesVertId ) // sort with correct indices in case of other way sort before
-        std::sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r ) { return less_( l, r ); } );
+        tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r ) { return predicates_.less( l, r ); } );
 
     windingInfo_.resize( tp_.undirectedEdgeSize() );
     if ( !params_.abortWhenIntersect || !holesVertId )
@@ -1021,7 +1066,7 @@ void SweepLineQueue::mergeSinglePare_( VertId unique, VertId same )
         {
             findClosestCache_.emplace_back( eUnique );
         }
-        auto minEUnique = findClosestCache_[findClosestToFront( tp_, pts_, findClosestCache_, false )];
+        auto minEUnique = findClosestCache_[findClosestToFront( tp_, predicates_, findClosestCache_, false )];
         auto prev = tp_.prev( eSame );
         if ( prev != eSame )
             tp_.splice( prev, eSame );
@@ -1120,7 +1165,7 @@ void SweepLineQueue::triangulateMonotoneBlock_( EdgeId holeEdgeId )
     auto holeLoop = trackRightBoundaryLoop( tp_, holeEdgeId );
     auto lessPred = [&] ( EdgeId l, EdgeId r )
     {
-        return less_( tp_.org( l ) , tp_.org( r ) );
+        return predicates_.less( tp_.org( l ) , tp_.org( r ) );
     };
     auto minMaxIt = std::minmax_element( holeLoop.begin(), holeLoop.end(), lessPred );
 
@@ -1132,13 +1177,7 @@ void SweepLineQueue::triangulateMonotoneBlock_( EdgeId holeEdgeId )
 
     auto isReflex = [&] ( int prev, int cur, int next, bool lowerChain )
     {
-        std::array<PreciseVertCoords2, 3> pvc;
-        pvc[2].id = tp_.org( holeLoop[cur] );
-        pvc[0].id = tp_.org( holeLoop[prev] );
-        pvc[1].id = tp_.org( holeLoop[next] );
-        for ( int i = 0; i < 3; ++i )
-            pvc[i].pt = to2dim( pts_[pvc[i].id] );
-        return ccw( pvc ) == lowerChain;
+        return predicates_.ccw( tp_.org( holeLoop[prev] ), tp_.org( holeLoop[next] ), tp_.org( holeLoop[cur] ) ) == lowerChain;
     };
 
     auto addDiagonal = [&] ( int cur, int prev, bool lowerChain )->bool

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -3,6 +3,7 @@
 #include <MRMesh/MRBox.h>
 #include <MRMesh/MRContour.h>
 #include <MRMesh/MRVector2.h>
+#include <MRMesh/MRConstants.h>
 #include <MRMesh/MRTorus.h>
 #include <MRMesh/MRExtractIsolines.h>
 #include <MRMesh/MRAffineXf3.h>
@@ -39,8 +40,6 @@ TEST( MRMesh, PlanarTriangulation )
 namespace
 {
 
-constexpr double cBenchPi = 3.14159265358979323846;
-
 // circle of n points (closed: first == last)
 Contour2d benchCircle( int n, double r, const Vector2d& center )
 {
@@ -48,7 +47,7 @@ Contour2d benchCircle( int n, double r, const Vector2d& center )
     cont.reserve( n + 1 );
     for ( int i = 0; i < n; ++i )
     {
-        const double a = 2.0 * cBenchPi * i / n;
+        const double a = 2.0 * PI * i / n;
         cont.push_back( center + Vector2d( r * std::cos( a ), r * std::sin( a ) ) );
     }
     cont.push_back( cont.front() );
@@ -63,7 +62,7 @@ Contour2d benchStar( int n, int step, double r, const Vector2d& center )
     for ( int i = 0; i < n; ++i )
     {
         const int idx = ( i * step ) % n;
-        const double a = 2.0 * cBenchPi * idx / n;
+        const double a = 2.0 * PI * idx / n;
         cont.push_back( center + Vector2d( r * std::cos( a ), r * std::sin( a ) ) );
     }
     cont.push_back( cont.front() );

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -2,7 +2,17 @@
 #include <MRMesh/MRMesh.h>
 #include <MRMesh/MRContour.h>
 #include <MRMesh/MRVector2.h>
+#include <MRMesh/MRTorus.h>
+#include <MRMesh/MRExtractIsolines.h>
+#include <MRMesh/MRAffineXf3.h>
+#include <MRSymbolMesh/MRSymbolMesh.h>
 #include <gtest/gtest.h>
+#include <chrono>
+#include <algorithm>
+#include <vector>
+#include <functional>
+#include <cstdio>
+#include <cmath>
 
 namespace MR
 {
@@ -23,6 +33,191 @@ TEST( MRMesh, PlanarTriangulation )
     // Must not contain degenerate faces
     EXPECT_TRUE( mesh.triangleAspectRatio( 0_f ) < 10.0f );
     EXPECT_TRUE( mesh.triangleAspectRatio( 1_f ) < 10.0f );
+}
+
+namespace
+{
+
+constexpr double cBenchPi = 3.14159265358979323846;
+
+// circle of n points (closed: first == last)
+Contour2d benchCircle( int n, double r, const Vector2d& center )
+{
+    Contour2d cont;
+    cont.reserve( n + 1 );
+    for ( int i = 0; i < n; ++i )
+    {
+        const double a = 2.0 * cBenchPi * i / n;
+        cont.push_back( center + Vector2d( r * std::cos( a ), r * std::sin( a ) ) );
+    }
+    cont.push_back( cont.front() );
+    return cont;
+}
+
+// star polygon {n/step} as a single self-intersecting closed contour (needs gcd(n,step)==1)
+Contour2d benchStar( int n, int step, double r, const Vector2d& center )
+{
+    Contour2d cont;
+    cont.reserve( n + 1 );
+    for ( int i = 0; i < n; ++i )
+    {
+        const int idx = ( i * step ) % n;
+        const double a = 2.0 * cBenchPi * idx / n;
+        cont.push_back( center + Vector2d( r * std::cos( a ), r * std::sin( a ) ) );
+    }
+    cont.push_back( cont.front() );
+    return cont;
+}
+
+template <typename Contours>
+size_t countVerts( const Contours& cs )
+{
+    size_t n = 0;
+    for ( const auto& c : cs )
+        n += c.size();
+    return n;
+}
+
+template <typename Contours>
+double triangulateOnceMs( const Contours& conts )
+{
+    const auto t0 = std::chrono::steady_clock::now();
+    Mesh m = PlanarTriangulation::triangulateContours( conts );
+    const auto t1 = std::chrono::steady_clock::now();
+    volatile size_t sink = m.topology.faceSize();
+    (void)sink;
+    return std::chrono::duration<double, std::milli>( t1 - t0 ).count();
+}
+
+// runs `once` (returns elapsed ms) warmup+iters times, prints min/median/mean
+void runBench( const char* name, size_t nverts, int warmup, int iters, const std::function<double()>& once )
+{
+    for ( int i = 0; i < warmup; ++i )
+        once();
+    std::vector<double> ts;
+    ts.reserve( iters );
+    for ( int i = 0; i < iters; ++i )
+        ts.push_back( once() );
+    std::sort( ts.begin(), ts.end() );
+    double sum = 0.0;
+    for ( double t : ts )
+        sum += t;
+    std::printf( "[BENCH] %-22s verts=%-8zu min=%9.3f median=%9.3f mean=%9.3f ms\n",
+        name, nverts, ts.front(), ts[ts.size() / 2], sum / ts.size() );
+    std::fflush( stdout );
+}
+
+} // anonymous namespace
+
+// local A/B benchmark for the SweepLineQueue predicate refactor; opt-in:
+//   MRTest.exe --gtest_also_run_disabled_tests --gtest_filter=*PlanarTriangulationBench*
+// Order matters for interleaved (DLL-swap) A/B: the priority sort-bound workload runs
+// FIRST (measured from a cool CPU), the heavy sort-insensitive control runs LAST.
+TEST( MRMesh, DISABLED_PlanarTriangulationBench )
+{
+    constexpr int warmup = 3, iters = 30;
+
+    // 1) one big circle: single large monotone polygon -> dominated by the `less` sort.
+    //    This is the path the predicate refactor regressed and parallel_sort targets.
+    {
+        Contours2d conts{ benchCircle( 100000, 1.0, Vector2d() ) };
+        runBench( "one-big-circle", countVerts( conts ), warmup, iters,
+            [&] { return triangulateOnceMs( conts ); } );
+    }
+
+    // 2) many disjoint circles: sort/sweep/monotone bound (stresses `less` + `ccw`, ~no intersections)
+    {
+        Contours2d conts;
+        constexpr int grid = 24, ptsPer = 48;
+        for ( int gx = 0; gx < grid; ++gx )
+            for ( int gy = 0; gy < grid; ++gy )
+                conts.push_back( benchCircle( ptsPer, 0.4, Vector2d( double( gx ), double( gy ) ) ) );
+        runBench( "disjoint-circles", countVerts( conts ), warmup, iters,
+            [&] { return triangulateOnceMs( conts ); } );
+    }
+
+    // 3) grid of overlapping circles: many cross-contour intersections
+    {
+        Contours2d conts;
+        constexpr int grid = 10, ptsPer = 40;
+        for ( int gx = 0; gx < grid; ++gx )
+            for ( int gy = 0; gy < grid; ++gy )
+                conts.push_back( benchCircle( ptsPer, 0.5, Vector2d( 0.8 * gx, 0.8 * gy ) ) );
+        runBench( "overlapping-circles", countVerts( conts ), warmup, iters,
+            [&] { return triangulateOnceMs( conts ); } );
+    }
+
+    // 4) single heavily self-intersecting star polygon
+    {
+        Contours2d conts{ benchStar( 101, 10, 1.0, Vector2d() ) }; // gcd(101,10)==1 -> one loop
+        runBench( "self-intersecting-star", countVerts( conts ), warmup, iters,
+            [&] { return triangulateOnceMs( conts ); } );
+    }
+
+    // 5) text outlines: many contours, letters with holes (multi-contour + winding)
+    {
+        SymbolMeshParams sp;
+        sp.text = "MeshLib planar triangulation 0123456789 quick brown fox";
+        auto exp = createSymbolContours( sp );
+        if ( exp.has_value() && !exp->empty() )
+        {
+            const Contours2f& tc = *exp;
+            runBench( "text-symbols", countVerts( tc ), warmup, iters,
+                [&] { return triangulateOnceMs( tc ); } );
+        }
+        else
+            std::printf( "[BENCH] text-symbols           SKIPPED (createSymbolContours failed)\n" );
+    }
+
+    // 6) CONTROL: real cross-sections of a torus. Each slice contour is small, so the per-slice
+    //    sort is below parallel_sort's serial cutoff -> this workload is ~insensitive to the sort
+    //    change. If interleaved A/B shows B ~= M here, the measurement method is validated.
+    //    Runs LAST because it is the heaviest (CPU-heating) workload.
+    {
+        const Mesh torus = makeTorus( 2.0f, 0.7f, 256, 64 );
+        const Box3f bb = torus.computeBoundingBox();
+        std::vector<Contours2f> slices;
+        constexpr int nSlices = 16;
+        for ( int i = 1; i < nSlices; ++i )
+        {
+            const float z = bb.min.z + ( bb.max.z - bb.min.z ) * float( i ) / float( nSlices );
+            const PlaneSections sec = extractXYPlaneSections( torus, z );
+            Contours2f cs = planeSectionsToContours2f( torus, sec, AffineXf3f() );
+            Contours2f closed;
+            for ( auto& c : cs )
+                if ( c.size() >= 3 )
+                {
+                    if ( c.front() != c.back() )
+                        c.push_back( c.front() );
+                    closed.push_back( std::move( c ) );
+                }
+            if ( !closed.empty() )
+                slices.push_back( std::move( closed ) );
+        }
+        size_t nv = 0;
+        for ( const auto& s : slices )
+            nv += countVerts( s );
+        auto once = [&] ()
+        {
+            double ms = 0.0;
+            size_t faces = 0;
+            for ( const auto& s : slices )
+            {
+                const auto t0 = std::chrono::steady_clock::now();
+                Mesh m = PlanarTriangulation::triangulateContours( s );
+                const auto t1 = std::chrono::steady_clock::now();
+                ms += std::chrono::duration<double, std::milli>( t1 - t0 ).count();
+                faces += m.topology.faceSize();
+            }
+            volatile size_t sink = faces;
+            (void)sink;
+            return ms;
+        };
+        if ( !slices.empty() )
+            runBench( "mesh-slices(torus)", nv, warmup, iters, once );
+        else
+            std::printf( "[BENCH] mesh-slices(torus)     SKIPPED (no sections)\n" );
+    }
 }
 
 } //namespace MR

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -1,5 +1,6 @@
 #include <MRMesh/MR2DContoursTriangulation.h>
 #include <MRMesh/MRMesh.h>
+#include <MRMesh/MRBox.h>
 #include <MRMesh/MRContour.h>
 #include <MRMesh/MRVector2.h>
 #include <MRMesh/MRTorus.h>


### PR DESCRIPTION
## Summary

Extracts the coordinate/precision-dependent geometry operations of `PlanarTriangulation::SweepLineQueue` into a `SweepLinePredicates` struct (`less` / `ccw` / segment-segment intersection / integer-float point conversions), built by `precisePredicates()`. The default preserves the current exact-integer simulation-of-simplicity behavior, so the change is behavior-preserving.

This is the seam for a planned follow-up that lets callers supply their own predicates (generic point/precision type). No public API changes in this PR.

`doSegmentSegmentIntersect` is also pulled into a `SweepLineQueue::doSegmentSegmentIntersect_` member expressed on top of the injected `ccw`, instead of being inlined at the call site.

## parallel_sort

Routing the per-vertex `less` comparator through `std::function` adds dispatch cost to the vertex sort. Switching the full-vertex sorts in `mergeSamePoints_` to `tbb::parallel_sort` more than offsets that, so the refactored path is faster than the previous `std::sort` code on sort-bound inputs.

## Performance

Local interleaved A/B (same machine; baseline = previous `std::sort`; rounds alternated to cancel thermal/load drift; a sort-insensitive torus-slice workload used as a control to validate the measurement):

| workload | before | after | delta |
|---|---|---|---|
| one big circle, 100k pts | 21.2 ms | 19.1 ms | -10% |
| many disjoint circles, 28k | 13.1 ms | 12.0 ms | -8% |
| overlapping circles, 4.1k | 4.11 ms | 3.96 ms | -4% |
| text outlines, 5k | 3.93 ms | 3.85 ms | -2% |
| self-intersecting star | 0.60 ms | 0.60 ms | ~0 |

Faster on large sort-bound contours, neutral where the work isn't sort-dominated.

## Tests

Existing `PlanarTriangulation`, `DistanceMapContours`, `fillContours2D`, and `MarkedContour` pass unchanged.

Adds an opt-in `DISABLED_PlanarTriangulationBench` (run with `--gtest_also_run_disabled_tests --gtest_filter=*PlanarTriangulationBench*`) covering disjoint / overlapping / self-intersecting / text contours plus a torus-slice control. It does not run in normal CI. Happy to drop it if you would prefer not to carry a benchmark in MRTest.
