### PR TITLE
[experiment] linux-vcpkg: build Python bindings with Clang 18 (timing)

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -201,9 +201,9 @@ jobs:
           CXX: ${{ matrix.cxx-compiler }}
         run: |
           echo "SCHED_CORES nproc=$(nproc) cpuinfo=$(grep -c ^processor /proc/cpuinfo) mem=$(free -g | awk 'NR==2{print $2}')G"
-          # coarse -ftime-trace: cumulative per-activity Totals stay complete, but few
-          # timeline events => negligible I/O overhead (compiler-only flag, not the parser)
-          echo '-ftime-trace -ftime-trace-granularity=100000' >> scripts/mrbind/compiler_only_flags.txt
+          # detailed -ftime-trace (compiler-only flag, not the parser): full per-TU timeline,
+          # uploaded below as an artifact for offline expert analysis.
+          echo '-ftime-trace' >> scripts/mrbind/compiler_only_flags.txt
           ( for i in $(seq 1 1500); do
               printf '%s %s\n' "$(date +%s)" "$(ps -e -o comm= | grep -cE 'clang|lld|mrbind')"
               sleep 1
@@ -215,6 +215,14 @@ jobs:
           echo "FTR_PLATFORM=linux-vcpkg-x64"
           python3 scripts/ftt_aggregate.py build/binds_python
           python3 scripts/sched_analyze.py /tmp/sched.txt
+
+      - name: Upload ftime-trace (linux)
+        if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ftime-trace-linux-vcpkg-x64-clang18
+          path: build/binds_python/*.json
+          retention-days: 5
 
       - name: Collect Timings
         run: ./scripts/devops/collect_timing_logs.sh linux-vcpkg-${{ matrix.arch }} ${{matrix.config}} "${{matrix.compiler}}"

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -84,6 +84,21 @@ jobs:
       AWS_EC2_METADATA_DISABLED: true
 
     steps:
+      - name: PROBE clang availability (temporary — stops the job on purpose)
+        run: |
+          set +e
+          cat /etc/os-release | grep -E "PRETTY_NAME|VERSION_ID"
+          echo "=== current clang ==="; clang++ --version | head -2; command -v clang++ clang++-21 clang++-18
+          echo "=== llvm-toolset module streams ==="
+          dnf -y --enablerepo='*' module list llvm-toolset
+          echo "=== module info ==="
+          dnf -y --enablerepo='*' module info llvm-toolset
+          echo "=== showduplicates for clang-family ==="
+          dnf --showduplicates --enablerepo='*' list clang clang-devel llvm-devel lld compiler-rt 2>/dev/null
+          echo "=== repoquery: which repo serves each clang-family pkg ==="
+          dnf repoquery --enablerepo='*' --qf '%{name}-%{version}-%{release} @%{reponame}' clang clang-devel llvm-devel lld 2>/dev/null | sort -u
+          exit 1
+
       - name: Enable GCC 11 toolset
         run: |
           source /opt/rh/gcc-toolset-11/enable

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -186,11 +186,23 @@ jobs:
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | llvm-cxxfilt
 
+      # EXPERIMENT: emit clang -ftime-trace for the bindings COMPILE only (compiler_only_flags.txt
+      # feeds the compiler, not the mrbind parser) to break down where time goes.
+      - name: ftt enable -ftime-trace
+        if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
+        run: echo '-ftime-trace -ftime-trace-granularity=200' >> scripts/mrbind/compiler_only_flags.txt
+
       - name: Generate and build Python bindings
         if: ${{ inputs.mrbind }}
         env:
           CXX: ${{ matrix.cxx-compiler }}
         run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib
+
+      - name: ftt aggregate -ftime-trace
+        if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
+        run: |
+          echo "FTT_PLATFORM=linux-vcpkg-x64-clang18"
+          python3 scripts/ftt_aggregate.py build/binds_python
 
       - name: Collect Timings
         run: ./scripts/devops/collect_timing_logs.sh linux-vcpkg-${{ matrix.arch }} ${{matrix.config}} "${{matrix.compiler}}"
@@ -315,30 +327,3 @@ jobs:
           name: DotNetPatchArchiveLinux-${{ matrix.arch }}
           path: ./patched_content/*
           retention-days: 1
-
-      # EXPERIMENT: paired same-runner timing of the bindings build with Clang 18 vs 21.
-      # Image is Clang 18 -> time a full build, then swap the image's Clang to 21
-      # (parallel-installable from Rocky AppStream), rebuild mrbind against it, time again.
-      # Same machine back-to-back => runner noise cancels. Runs LAST: the swap removes
-      # clang-18 that earlier steps depend on.
-      - name: A/B paired compiler timing (Clang 18 vs 21)
-        if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
-        run: |
-          set -e
-          MK="make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib"
-          echo "::group::clang-18 full bindings build (timed)"
-          export CXX=/usr/bin/clang++-18
-          /usr/bin/time -o /tmp/t18 -f '%e' bash -c "$MK CXX_FOR_BINDINGS=/usr/bin/clang++-18 >/tmp/b18.log 2>&1" || { echo CLANG18_FAILED; tail -40 /tmp/b18.log; exit 1; }
-          echo "::endgroup::"
-          echo "::group::swap image clang 18 -> 21"
-          retry.sh -- dnf -y install --allowerasing 'clang-21.1.8*' 'clang-devel-21.1.8*' 'lld-21.1.8*' 'llvm-devel-21.1.8*'
-          /usr/bin/clang++-21 --version | head -1
-          echo "::endgroup::"
-          echo "::group::rebuild mrbind against clang-21"
-          bash scripts/mrbind/install_mrbind_rockylinux.sh >/tmp/mrbind21.log 2>&1 || { echo MRBIND21_FAILED; tail -40 /tmp/mrbind21.log; exit 1; }
-          echo "::endgroup::"
-          echo "::group::clang-21 full bindings build (timed)"
-          export CXX=/usr/bin/clang++-21
-          /usr/bin/time -o /tmp/t21 -f '%e' bash -c "$MK CXX_FOR_BINDINGS=/usr/bin/clang++-21 >/tmp/b21.log 2>&1" || { echo CLANG21_FAILED; tail -40 /tmp/b21.log; exit 1; }
-          echo "::endgroup::"
-          echo "AB_RESULT clang18=$(cat /tmp/t18)s clang21=$(cat /tmp/t21)s"

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -201,6 +201,9 @@ jobs:
           CXX: ${{ matrix.cxx-compiler }}
         run: |
           echo "SCHED_CORES nproc=$(nproc) cpuinfo=$(grep -c ^processor /proc/cpuinfo) mem=$(free -g | awk 'NR==2{print $2}')G"
+          # coarse -ftime-trace: cumulative per-activity Totals stay complete, but few
+          # timeline events => negligible I/O overhead (compiler-only flag, not the parser)
+          echo '-ftime-trace -ftime-trace-granularity=100000' >> scripts/mrbind/compiler_only_flags.txt
           ( for i in $(seq 1 1500); do
               printf '%s %s\n' "$(date +%s)" "$(ps -e -o comm= | grep -cE 'clang|lld|mrbind')"
               sleep 1
@@ -209,6 +212,8 @@ jobs:
           /usr/bin/time -o /tmp/tw -f '%e' bash -c "make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib >/tmp/build.txt 2>&1" || true
           kill $SP 2>/dev/null || true
           echo "SCHED_WALL=$(cat /tmp/tw)s"
+          echo "FTR_PLATFORM=linux-vcpkg-x64"
+          python3 scripts/ftt_aggregate.py build/binds_python
           python3 scripts/sched_analyze.py /tmp/sched.txt
 
       - name: Collect Timings

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -186,23 +186,21 @@ jobs:
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | llvm-cxxfilt
 
-      # EXPERIMENT: emit clang -ftime-trace for the bindings COMPILE only (compiler_only_flags.txt
-      # feeds the compiler, not the mrbind parser) to break down where time goes.
-      - name: ftt enable -ftime-trace
-        if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
-        run: echo '-ftime-trace -ftime-trace-granularity=200' >> scripts/mrbind/compiler_only_flags.txt
-
       - name: Generate and build Python bindings
         if: ${{ inputs.mrbind }}
         env:
           CXX: ${{ matrix.cxx-compiler }}
         run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib
 
-      - name: ftt aggregate -ftime-trace
+      # EXPERIMENT: time the mrbind PARSE phase alone (re-build only the *.generated.cpp
+      # targets => libclang parses all headers, no fragment compile/link).
+      - name: measure parse phase
         if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
+        env:
+          CXX: ${{ matrix.cxx-compiler }}
         run: |
-          echo "FTT_PLATFORM=linux-vcpkg-x64-clang18"
-          python3 scripts/ftt_aggregate.py build/binds_python
+          /usr/bin/time -o /tmp/tp -f '%e' bash -c "make -f scripts/mrbind/generate.mk MODE=none -B MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib build/binds_python/mrmesh.generated.cpp build/binds_python/mrcuda.generated.cpp >/tmp/parse.log 2>&1" || { echo PARSE_FAILED; tail -30 /tmp/parse.log; exit 1; }
+          echo "PARSE_SECONDS_linux_vcpkg_x64=$(cat /tmp/tp)"
 
       - name: Collect Timings
         run: ./scripts/devops/collect_timing_logs.sh linux-vcpkg-${{ matrix.arch }} ${{matrix.config}} "${{matrix.compiler}}"

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -186,11 +186,32 @@ jobs:
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | llvm-cxxfilt
 
+      # EXPERIMENT (x64 only): the rockylinux8-vcpkg image only ships Clang 21, so the
+      # bindings are normally compiled with /usr/bin/clang++ (= clang 21). The native
+      # Ubuntu jobs compile the bindings with clang 18. Install upstream Clang 18.1.8
+      # here (ubuntu-18.04 build runs on Rocky 8's glibc 2.28; extracted to /opt so it
+      # does not conflict with the EPEL clang 21) so we can measure how much of the
+      # vcpkg vs ubuntu bindings-build-time gap is due to the compiler version alone.
+      - name: Install Clang 18 for bindings (experiment)
+        if: ${{ inputs.mrbind && matrix.arch == 'x64' }}
+        run: |
+          mkdir -p /opt/clang18
+          curl -fSL --retry 3 --retry-delay 5 -o /tmp/clang18.tar.xz \
+            https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+          tar -xJf /tmp/clang18.tar.xz -C /opt/clang18 --strip-components=1
+          rm -f /tmp/clang18.tar.xz
+          /opt/clang18/bin/clang++ --version
+
       - name: Generate and build Python bindings
         if: ${{ inputs.mrbind }}
         env:
           CXX: ${{ matrix.cxx-compiler }}
-        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib
+          # EXPERIMENT: on x64 use the freshly installed Clang 18 (matching the Ubuntu
+          # jobs); arm64 keeps the image default (/usr/bin/clang++ = clang 21).
+          CXX_FOR_BINDINGS: ${{ matrix.arch == 'x64' && '/opt/clang18/bin/clang++' || '/usr/bin/clang++' }}
+        run: |
+          export PATH="${{ matrix.arch == 'x64' && '/opt/clang18/bin:' || '' }}${PATH}"
+          make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=${CXX_FOR_BINDINGS} DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib
 
       - name: Collect Timings
         run: ./scripts/devops/collect_timing_logs.sh linux-vcpkg-${{ matrix.arch }} ${{matrix.config}} "${{matrix.compiler}}"

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -192,15 +192,24 @@ jobs:
           CXX: ${{ matrix.cxx-compiler }}
         run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib
 
-      # EXPERIMENT: time the mrbind PARSE phase alone (re-build only the *.generated.cpp
-      # targets => libclang parses all headers, no fragment compile/link).
-      - name: measure parse phase
+      # EXPERIMENT: schedule analysis - sample core occupancy (running compiler/linker
+      # processes) once per second across a clean bindings rebuild, to find idle/serial
+      # segments (parse, PCH, link, fragment tail) that waste the 4 cores.
+      - name: schedule analysis
         if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
         env:
           CXX: ${{ matrix.cxx-compiler }}
         run: |
-          /usr/bin/time -o /tmp/tp -f '%e' bash -c "make -f scripts/mrbind/generate.mk MODE=none -B MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib build/binds_python/mrmesh.generated.cpp build/binds_python/mrcuda.generated.cpp >/tmp/parse.log 2>&1" || { echo PARSE_FAILED; tail -30 /tmp/parse.log; exit 1; }
-          echo "PARSE_SECONDS_linux_vcpkg_x64=$(cat /tmp/tp)"
+          echo "SCHED_CORES nproc=$(nproc) cpuinfo=$(grep -c ^processor /proc/cpuinfo) mem=$(free -g | awk 'NR==2{print $2}')G"
+          ( for i in $(seq 1 1500); do
+              printf '%s %s\n' "$(date +%s)" "$(ps -e -o comm= | grep -cE 'clang|lld|mrbind')"
+              sleep 1
+            done ) > /tmp/sched.txt &
+          SP=$!
+          /usr/bin/time -o /tmp/tw -f '%e' bash -c "make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib >/tmp/build.txt 2>&1" || true
+          kill $SP 2>/dev/null || true
+          echo "SCHED_WALL=$(cat /tmp/tw)s"
+          python3 scripts/sched_analyze.py /tmp/sched.txt
 
       - name: Collect Timings
         run: ./scripts/devops/collect_timing_logs.sh linux-vcpkg-${{ matrix.arch }} ${{matrix.config}} "${{matrix.compiler}}"

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -47,22 +47,22 @@ jobs:
       matrix:
         config: [Debug, Release]
         arch: [x64, arm64]
-        compiler: [Clang 21, GCC 11]
+        compiler: [Clang 18, GCC 11]
         full_config_build:
           - ${{ fromJSON( inputs.full_config_build ) }}
         exclude:
-          # Do not run Debug Clang 21 build on every commit (but only once a day)
+          # Do not run Debug Clang 18 build on every commit (but only once a day)
           - full_config_build: false
-            compiler: Clang 21
+            compiler: Clang 18
             config: Debug
           # Do not run Release GCC 11 build on every commit (but only once a day)
           - full_config_build: false
             compiler: GCC 11
             config: Release
         include:
-          - compiler: Clang 21
-            cxx-compiler: /usr/bin/clang++-21
-            c-compiler: /usr/bin/clang-21
+          - compiler: Clang 18
+            cxx-compiler: /usr/bin/clang++-18
+            c-compiler: /usr/bin/clang-18
             cxx-standard: 23
           - compiler: GCC 11
             cxx-compiler: /opt/rh/gcc-toolset-11/root/usr/bin/g++
@@ -84,24 +84,6 @@ jobs:
       AWS_EC2_METADATA_DISABLED: true
 
     steps:
-      - name: PROBE clang availability (temporary — stops the job on purpose)
-        run: |
-          set +e
-          DR="--disablerepo=media-*"
-          F="grep -viE media|cdrom|cdrecorder|Couldnt|mirrors|Metadata|metadata|^Last|MB/s|kB/s|^\s*$"
-          echo "=== os + current clang ==="
-          grep -E "PRETTY_NAME|VERSION_ID" /etc/os-release; clang++ --version | head -1
-          echo "=== repolist ==="; dnf $DR repolist 2>/dev/null
-          echo "=== llvm-toolset module streams (all) ==="
-          dnf $DR module list llvm-toolset 2>/dev/null | grep -viE "media|cdrom|Couldn|mirror|Metadata|MB/s|kB/s"
-          echo "=== showduplicates clang-family (all enabled repos) ==="
-          dnf $DR --showduplicates list clang clang-devel llvm-devel lld 2>/dev/null | grep -aiE "clang|llvm|lld|Available|Installed"
-          echo "=== repoquery clang*/llvm-toolset across enabled repos ==="
-          dnf $DR repoquery --qf '%{name}-%{version}-%{release} @%{reponame}' 'clang' 'clang-devel' 'llvm-devel' 'lld' 'clang1[6789]*' 'llvm1[6789]*' 2>/dev/null | sort -u
-          echo "=== EPEL only ==="
-          dnf --disablerepo=* --enablerepo=epel --showduplicates list 'clang*' 'llvm*' 2>/dev/null | grep -aiE "clang|llvm" | head -40
-          exit 1
-
       - name: Enable GCC 11 toolset
         run: |
           source /opt/rh/gcc-toolset-11/enable
@@ -204,35 +186,11 @@ jobs:
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | llvm-cxxfilt
 
-      # EXPERIMENT (x64 only): the rockylinux8-vcpkg image only ships Clang 21, so the
-      # bindings are normally compiled with /usr/bin/clang++ (= clang 21). The native
-      # Ubuntu jobs compile the bindings with clang 18. Install upstream Clang 18.1.8
-      # here (ubuntu-18.04 build runs on Rocky 8's glibc 2.28; extracted to /opt so it
-      # does not conflict with the EPEL clang 21) so we can measure how much of the
-      # vcpkg vs ubuntu bindings-build-time gap is due to the compiler version alone.
-      - name: Install Clang 18 for bindings (experiment)
-        if: ${{ inputs.mrbind && matrix.arch == 'x64' }}
-        run: |
-          # The upstream LLVM 18.1.8 (ubuntu-18.04) binaries link against libtinfo.so.5,
-          # which Rocky 8 does not ship (it has libtinfo.so.6) — provide the compat lib.
-          retry.sh -- dnf -y install ncurses-compat-libs
-          mkdir -p /opt/clang18
-          curl -fSL --retry 3 --retry-delay 5 -o /tmp/clang18.tar.xz \
-            https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-          tar -xJf /tmp/clang18.tar.xz -C /opt/clang18 --strip-components=1
-          rm -f /tmp/clang18.tar.xz
-          /opt/clang18/bin/clang++ --version
-
       - name: Generate and build Python bindings
         if: ${{ inputs.mrbind }}
         env:
           CXX: ${{ matrix.cxx-compiler }}
-          # EXPERIMENT: on x64 use the freshly installed Clang 18 (matching the Ubuntu
-          # jobs); arm64 keeps the image default (/usr/bin/clang++ = clang 21).
-          CXX_FOR_BINDINGS: ${{ matrix.arch == 'x64' && '/opt/clang18/bin/clang++' || '/usr/bin/clang++' }}
-        run: |
-          export PATH="${{ matrix.arch == 'x64' && '/opt/clang18/bin:' || '' }}${PATH}"
-          make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=${CXX_FOR_BINDINGS} DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib
+        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib
 
       - name: Collect Timings
         run: ./scripts/devops/collect_timing_logs.sh linux-vcpkg-${{ matrix.arch }} ${{matrix.config}} "${{matrix.compiler}}"
@@ -289,19 +247,19 @@ jobs:
           cat unit_tests_report.csv
 
       - name: Create Package
-        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
+        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
         run: |
           ./scripts/distribution_vcpkg.sh ${{ inputs.app_version }}
           mv meshlib_linux-vcpkg.tar.xz meshlib_linux-vcpkg-${{ matrix.arch }}.tar.xz
 
       - name: Extract Package
-        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
+        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
         run: |
           mkdir meshlib_install
           tar -xf meshlib_linux-vcpkg-${{ matrix.arch }}.tar.xz -C meshlib_install
 
       - name: Build C++ examples
-        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
+        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
         run: |
           cmake \
             -S examples/cpp-examples \
@@ -313,7 +271,7 @@ jobs:
             --parallel $(nproc)
 
       - name: Build C examples
-        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21'}}
+        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 18'}}
         run: |
           cmake \
             -S examples/c-examples \
@@ -325,7 +283,7 @@ jobs:
             --parallel $(nproc)
 
       - name: Upload vcpkg Distribution
-        if: ${{ inputs.upload_artifacts && matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
+        if: ${{ inputs.upload_artifacts && matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
         uses: actions/upload-artifact@v7
         with:
           name: Distributives_linux-vcpkg-${{ matrix.arch }}
@@ -333,7 +291,7 @@ jobs:
           retention-days: 1
 
       - name: Collect artifact stats
-        if: ${{ inputs.internal_build && inputs.upload_artifacts && matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
+        if: ${{ inputs.internal_build && inputs.upload_artifacts && matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
         continue-on-error: true
         uses: ./.github/actions/collect-artifact-stats
         with:
@@ -342,7 +300,7 @@ jobs:
           stats_file_suffix: -${{ steps.collect-runner-stats.outputs.job_id }}
 
       - name: Create and fix fake Wheel for NuGet
-        if: ${{ inputs.nuget_build_patch && matrix.compiler == 'Clang 21' && matrix.config == 'Release' }}
+        if: ${{ inputs.nuget_build_patch && matrix.compiler == 'Clang 18' && matrix.config == 'Release' }}
         shell: bash
         run: |
           python3 -m venv ./wheel_venv
@@ -351,7 +309,7 @@ jobs:
           python3 ./scripts/nuget_patch/patch_library_deps.py ./patched_content/ ./build/Release/bin/lib{MeshLibC2,MeshLibC2Cuda}.so
 
       - name: Upload NuGet files to Artifacts
-        if: ${{ inputs.nuget_build_patch && matrix.compiler == 'Clang 21' && matrix.config == 'Release' }}
+        if: ${{ inputs.nuget_build_patch && matrix.compiler == 'Clang 18' && matrix.config == 'Release' }}
         uses: actions/upload-artifact@v7
         with:
           name: DotNetPatchArchiveLinux-${{ matrix.arch }}

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -195,6 +195,9 @@ jobs:
       - name: Install Clang 18 for bindings (experiment)
         if: ${{ inputs.mrbind && matrix.arch == 'x64' }}
         run: |
+          # The upstream LLVM 18.1.8 (ubuntu-18.04) binaries link against libtinfo.so.5,
+          # which Rocky 8 does not ship (it has libtinfo.so.6) — provide the compat lib.
+          retry.sh -- dnf -y install ncurses-compat-libs
           mkdir -p /opt/clang18
           curl -fSL --retry 3 --retry-delay 5 -o /tmp/clang18.tar.xz \
             https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   linux-vcpkg-build-test:
-    timeout-minutes: 50
+    timeout-minutes: 90
     runs-on: ${{ matrix.os }}
     container:
       image: meshlib/meshlib-rockylinux8-vcpkg-${{ matrix.arch }}:${{ inputs.docker_image_tag }}

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -87,16 +87,19 @@ jobs:
       - name: PROBE clang availability (temporary — stops the job on purpose)
         run: |
           set +e
-          cat /etc/os-release | grep -E "PRETTY_NAME|VERSION_ID"
-          echo "=== current clang ==="; clang++ --version | head -2; command -v clang++ clang++-21 clang++-18
-          echo "=== llvm-toolset module streams ==="
-          dnf -y --enablerepo='*' module list llvm-toolset
-          echo "=== module info ==="
-          dnf -y --enablerepo='*' module info llvm-toolset
-          echo "=== showduplicates for clang-family ==="
-          dnf --showduplicates --enablerepo='*' list clang clang-devel llvm-devel lld compiler-rt 2>/dev/null
-          echo "=== repoquery: which repo serves each clang-family pkg ==="
-          dnf repoquery --enablerepo='*' --qf '%{name}-%{version}-%{release} @%{reponame}' clang clang-devel llvm-devel lld 2>/dev/null | sort -u
+          DR="--disablerepo=media-*"
+          F="grep -viE media|cdrom|cdrecorder|Couldnt|mirrors|Metadata|metadata|^Last|MB/s|kB/s|^\s*$"
+          echo "=== os + current clang ==="
+          grep -E "PRETTY_NAME|VERSION_ID" /etc/os-release; clang++ --version | head -1
+          echo "=== repolist ==="; dnf $DR repolist 2>/dev/null
+          echo "=== llvm-toolset module streams (all) ==="
+          dnf $DR module list llvm-toolset 2>/dev/null | grep -viE "media|cdrom|Couldn|mirror|Metadata|MB/s|kB/s"
+          echo "=== showduplicates clang-family (all enabled repos) ==="
+          dnf $DR --showduplicates list clang clang-devel llvm-devel lld 2>/dev/null | grep -aiE "clang|llvm|lld|Available|Installed"
+          echo "=== repoquery clang*/llvm-toolset across enabled repos ==="
+          dnf $DR repoquery --qf '%{name}-%{version}-%{release} @%{reponame}' 'clang' 'clang-devel' 'llvm-devel' 'lld' 'clang1[6789]*' 'llvm1[6789]*' 2>/dev/null | sort -u
+          echo "=== EPEL only ==="
+          dnf --disablerepo=* --enablerepo=epel --showduplicates list 'clang*' 'llvm*' 2>/dev/null | grep -aiE "clang|llvm" | head -40
           exit 1
 
       - name: Enable GCC 11 toolset

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -315,3 +315,30 @@ jobs:
           name: DotNetPatchArchiveLinux-${{ matrix.arch }}
           path: ./patched_content/*
           retention-days: 1
+
+      # EXPERIMENT: paired same-runner timing of the bindings build with Clang 18 vs 21.
+      # Image is Clang 18 -> time a full build, then swap the image's Clang to 21
+      # (parallel-installable from Rocky AppStream), rebuild mrbind against it, time again.
+      # Same machine back-to-back => runner noise cancels. Runs LAST: the swap removes
+      # clang-18 that earlier steps depend on.
+      - name: A/B paired compiler timing (Clang 18 vs 21)
+        if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 18' }}
+        run: |
+          set -e
+          MK="make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib"
+          echo "::group::clang-18 full bindings build (timed)"
+          export CXX=/usr/bin/clang++-18
+          /usr/bin/time -o /tmp/t18 -f '%e' bash -c "$MK CXX_FOR_BINDINGS=/usr/bin/clang++-18 >/tmp/b18.log 2>&1" || { echo CLANG18_FAILED; tail -40 /tmp/b18.log; exit 1; }
+          echo "::endgroup::"
+          echo "::group::swap image clang 18 -> 21"
+          retry.sh -- dnf -y install --allowerasing 'clang-21.1.8*' 'clang-devel-21.1.8*' 'lld-21.1.8*' 'llvm-devel-21.1.8*'
+          /usr/bin/clang++-21 --version | head -1
+          echo "::endgroup::"
+          echo "::group::rebuild mrbind against clang-21"
+          bash scripts/mrbind/install_mrbind_rockylinux.sh >/tmp/mrbind21.log 2>&1 || { echo MRBIND21_FAILED; tail -40 /tmp/mrbind21.log; exit 1; }
+          echo "::endgroup::"
+          echo "::group::clang-21 full bindings build (timed)"
+          export CXX=/usr/bin/clang++-21
+          /usr/bin/time -o /tmp/t21 -f '%e' bash -c "$MK CXX_FOR_BINDINGS=/usr/bin/clang++-21 >/tmp/b21.log 2>&1" || { echo CLANG21_FAILED; tail -40 /tmp/b21.log; exit 1; }
+          echo "::endgroup::"
+          echo "AB_RESULT clang18=$(cat /tmp/t18)s clang21=$(cat /tmp/t21)s"

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -233,11 +233,6 @@ jobs:
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
         run: msbuild -m source\MeshLibC2Cuda\MeshLibC2Cuda.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=x64 -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }}
 
-      - name: ftt enable -ftime-trace
-        if: ${{ inputs.mrbind && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && matrix.build_system == 'CMake' }}
-        shell: bash
-        run: echo '-ftime-trace -ftime-trace-granularity=200' >> scripts/mrbind/compiler_only_flags.txt
-
       - name: Generate and build Python bindings
         if: ${{inputs.mrbind && matrix.vcpkg_triplet != 'x64-windows-meshlib-iterator-debug'}}
         shell: cmd
@@ -250,12 +245,19 @@ jobs:
           call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           call ./scripts/mrbind/generate_win.bat -B --trace MODE=none VS_MODE=${{matrix.config}} || exit /b 1
 
-      - name: ftt aggregate -ftime-trace
+      # EXPERIMENT: time the mrbind PARSE phase alone (re-build only the *.generated.cpp
+      # targets). generate_win.bat already wraps `time make ...`, so the msys2 `time`
+      # prints a `real` line for the parse.
+      - name: measure parse phase
         if: ${{ inputs.mrbind && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && matrix.build_system == 'CMake' }}
-        shell: pwsh
+        shell: cmd
+        env:
+          MSYS2_DIR: C:\msys64
         run: |
-          Write-Output "FTT_PLATFORM=windows-x64-msvc2022-cmake"
-          python scripts/ftt_aggregate.py source/TempOutput/Bindings_python/x64/Release
+          echo PARSE_PHASE_WINDOWS_START
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          call ./scripts/mrbind/generate_win.bat -B MODE=none VS_MODE=${{matrix.config}} source/TempOutput/Bindings_python/x64/${{matrix.config}}/mrmesh.generated.cpp source/TempOutput/Bindings_python/x64/${{matrix.config}}/mrcuda.generated.cpp || exit /b 1
+          echo PARSE_PHASE_WINDOWS_END
 
       - name: Diagnostic — output bin DLL inventory + MRMesh imports
         if: ${{ always() }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -255,8 +255,8 @@ jobs:
         run: |
           Write-Output "SCHED_WIN_CORES NUMBER_OF_PROCESSORS=$env:NUMBER_OF_PROCESSORS"
           Get-CimInstance Win32_Processor | ForEach-Object { Write-Output "SCHED_WIN_CPU cores=$($_.NumberOfCores) logical=$($_.NumberOfLogicalProcessors)" }
-          # coarse -ftime-trace (compiler-only flag): complete per-activity Totals, negligible I/O
-          Add-Content scripts/mrbind/compiler_only_flags.txt "`n-ftime-trace -ftime-trace-granularity=100000"
+          # detailed -ftime-trace (compiler-only flag): full per-TU timeline, uploaded as artifact
+          Add-Content scripts/mrbind/compiler_only_flags.txt "`n-ftime-trace"
           $sampler = Start-Job -ScriptBlock {
             1..1500 | ForEach-Object {
               $c = @(Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.Name -match 'clang|lld|mrbind' }).Count
@@ -269,6 +269,14 @@ jobs:
           Write-Output "FTR_PLATFORM=windows-x64"
           python scripts/ftt_aggregate.py source/TempOutput/Bindings_python/x64/${{matrix.config}}
           python scripts/sched_analyze.py sched_win.txt
+
+      - name: Upload ftime-trace (windows)
+        if: ${{ inputs.mrbind && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && matrix.build_system == 'CMake' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ftime-trace-windows-x64-msvc2022
+          path: source/TempOutput/Bindings_python/x64/${{matrix.config}}/*.json
+          retention-days: 5
 
       - name: Diagnostic — output bin DLL inventory + MRMesh imports
         if: ${{ always() }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -255,6 +255,8 @@ jobs:
         run: |
           Write-Output "SCHED_WIN_CORES NUMBER_OF_PROCESSORS=$env:NUMBER_OF_PROCESSORS"
           Get-CimInstance Win32_Processor | ForEach-Object { Write-Output "SCHED_WIN_CPU cores=$($_.NumberOfCores) logical=$($_.NumberOfLogicalProcessors)" }
+          # coarse -ftime-trace (compiler-only flag): complete per-activity Totals, negligible I/O
+          Add-Content scripts/mrbind/compiler_only_flags.txt "`n-ftime-trace -ftime-trace-granularity=100000"
           $sampler = Start-Job -ScriptBlock {
             1..1500 | ForEach-Object {
               $c = @(Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.Name -match 'clang|lld|mrbind' }).Count
@@ -264,6 +266,8 @@ jobs:
           cmd /c 'call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} && call scripts\mrbind\generate_win.bat -B MODE=none VS_MODE=${{matrix.config}}'
           Stop-Job $sampler
           Receive-Job $sampler | Set-Content sched_win.txt
+          Write-Output "FTR_PLATFORM=windows-x64"
+          python scripts/ftt_aggregate.py source/TempOutput/Bindings_python/x64/${{matrix.config}}
           python scripts/sched_analyze.py sched_win.txt
 
       - name: Diagnostic — output bin DLL inventory + MRMesh imports

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -245,19 +245,26 @@ jobs:
           call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           call ./scripts/mrbind/generate_win.bat -B --trace MODE=none VS_MODE=${{matrix.config}} || exit /b 1
 
-      # EXPERIMENT: time the mrbind PARSE phase alone (re-build only the *.generated.cpp
-      # targets). generate_win.bat already wraps `time make ...`, so the msys2 `time`
-      # prints a `real` line for the parse.
-      - name: measure parse phase
+      # EXPERIMENT: schedule analysis - core count + sample running compiler procs once
+      # per second across a clean bindings rebuild, to compare parallelism with Linux.
+      - name: schedule analysis (windows)
         if: ${{ inputs.mrbind && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && matrix.build_system == 'CMake' }}
-        shell: cmd
+        shell: pwsh
         env:
           MSYS2_DIR: C:\msys64
         run: |
-          echo PARSE_PHASE_WINDOWS_START
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
-          call ./scripts/mrbind/generate_win.bat -B MODE=none VS_MODE=${{matrix.config}} source/TempOutput/Bindings_python/x64/${{matrix.config}}/mrmesh.generated.cpp source/TempOutput/Bindings_python/x64/${{matrix.config}}/mrcuda.generated.cpp || exit /b 1
-          echo PARSE_PHASE_WINDOWS_END
+          Write-Output "SCHED_WIN_CORES NUMBER_OF_PROCESSORS=$env:NUMBER_OF_PROCESSORS"
+          Get-CimInstance Win32_Processor | ForEach-Object { Write-Output "SCHED_WIN_CPU cores=$($_.NumberOfCores) logical=$($_.NumberOfLogicalProcessors)" }
+          $sampler = Start-Job -ScriptBlock {
+            1..1500 | ForEach-Object {
+              $c = @(Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.Name -match 'clang|lld|mrbind' }).Count
+              "$_ $c"; Start-Sleep -Seconds 1
+            }
+          }
+          cmd /c 'call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} && call scripts\mrbind\generate_win.bat -B MODE=none VS_MODE=${{matrix.config}}'
+          Stop-Job $sampler
+          Receive-Job $sampler | Set-Content sched_win.txt
+          python scripts/sched_analyze.py sched_win.txt
 
       - name: Diagnostic — output bin DLL inventory + MRMesh imports
         if: ${{ always() }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -233,6 +233,11 @@ jobs:
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
         run: msbuild -m source\MeshLibC2Cuda\MeshLibC2Cuda.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=x64 -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }}
 
+      - name: ftt enable -ftime-trace
+        if: ${{ inputs.mrbind && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && matrix.build_system == 'CMake' }}
+        shell: bash
+        run: echo '-ftime-trace -ftime-trace-granularity=200' >> scripts/mrbind/compiler_only_flags.txt
+
       - name: Generate and build Python bindings
         if: ${{inputs.mrbind && matrix.vcpkg_triplet != 'x64-windows-meshlib-iterator-debug'}}
         shell: cmd
@@ -244,6 +249,13 @@ jobs:
         run: |
           call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           call ./scripts/mrbind/generate_win.bat -B --trace MODE=none VS_MODE=${{matrix.config}} || exit /b 1
+
+      - name: ftt aggregate -ftime-trace
+        if: ${{ inputs.mrbind && matrix.cxx_compiler == 'msvc-2022' && matrix.config == 'Release' && matrix.build_system == 'CMake' }}
+        shell: pwsh
+        run: |
+          Write-Output "FTT_PLATFORM=windows-x64-msvc2022-cmake"
+          python scripts/ftt_aggregate.py source/TempOutput/Bindings_python/x64/Release
 
       - name: Diagnostic — output bin DLL inventory + MRMesh imports
         if: ${{ always() }}

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -21,7 +21,7 @@ RUN <<EOF
     retry.sh -- dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${CUDA_REPO_ARCH}/cuda-rhel8.repo
     retry.sh -- dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
     retry.sh -- dnf -y install --enablerepo powertools \
-        git cmake gcc-toolset-11 ninja-build clang-devel-21* \
+        git cmake gcc-toolset-11 ninja-build clang-devel-18.1.8* \
         $(: minimal CUDA toolkit - nvcc, cudart ) \
         cuda-nvcc-12-0 cuda-cudart-devel-12-0 cuda-driver-devel-12-0 cuda-cuxxfilt-12-0 \
         $(: vcpkg requirements ) \
@@ -29,7 +29,7 @@ RUN <<EOF
         $(: vcpkg package requirements ) \
         autoconf2.7x autoconf-archive bison dbus-libs libtool libudev-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXtst-devel mesa-libGL-devel perl-core \
         $(: mrbind requirements ) \
-        lld-21* llvm-devel-21* python3.12-devel which zlib-devel \
+        lld-18.1.8* llvm-devel-18.1.8* python3.12-devel which zlib-devel \
         $(: CI environment ) \
         gh time python3.12-pip rpm-build xorg-x11-server-Xvfb mesa-dri-drivers gettext
     dnf clean all

--- a/scripts/ftt_aggregate.py
+++ b/scripts/ftt_aggregate.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Aggregate clang -ftime-trace JSON files in a directory and print per-category totals.
+# Sums the per-TU "Total <Category>" roll-up events (durations in microseconds) across
+# all translation units, so we can see where compile time goes (header parsing vs
+# template instantiation vs codegen) summed over the whole bindings build.
+import sys, json, glob, os, collections
+
+d = sys.argv[1] if len(sys.argv) > 1 else "."
+tot = collections.defaultdict(float)
+n = 0
+for f in glob.glob(os.path.join(d, "**", "*.json"), recursive=True):
+    try:
+        j = json.load(open(f, encoding="utf-8", errors="ignore"))
+    except Exception:
+        continue
+    evs = j.get("traceEvents")
+    if not evs:
+        continue
+    hit = False
+    for e in evs:
+        nm = e.get("name", "")
+        if nm.startswith("Total "):
+            tot[nm] += e.get("dur", 0)
+            hit = True
+    if hit:
+        n += 1
+
+print("FTT_FILES=%d  DIR=%s" % (n, d))
+order = ["Total ExecuteCompiler", "Total Frontend", "Total Backend",
+         "Total Source", "Total ParseClass",
+         "Total InstantiateClass", "Total InstantiateFunction",
+         "Total PerformPendingInstantiations",
+         "Total CodeGen Function", "Total OptModule", "Total OptFunction",
+         "Total CodeGenPasses", "Total RunPass"]
+seen = set()
+for k in order:
+    if k in tot:
+        print("FTT|%s|%.1f" % (k, tot[k] / 1e6)); seen.add(k)
+for k in sorted(tot, key=lambda x: -tot[x]):
+    if k not in seen and tot[k] > 3e6:
+        print("FTT|%s|%.1f" % (k, tot[k] / 1e6))

--- a/scripts/sched_analyze.py
+++ b/scripts/sched_analyze.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Read a sampler file of "<epoch> <num_running_compiler_procs>" lines and report
+# core-occupancy stats for a (4-core) build: utilization, time at each parallelism
+# level, idle (<=1) vs saturated (>=4) seconds.
+import sys, collections
+cores = 4
+path = sys.argv[1] if len(sys.argv) > 1 else "/tmp/sched.txt"
+ts = []
+for line in open(path):
+    p = line.split()
+    if len(p) == 2:
+        try: ts.append((int(p[0]), int(p[1])))
+        except ValueError: pass
+n = len(ts)
+if not n:
+    print("SCHED no samples"); sys.exit(0)
+busy = sum(min(b, cores) for _, b in ts)
+ideal = cores * n
+hist = collections.Counter(b for _, b in ts)
+print(f"SCHED samples={n}s util={100*busy/ideal:.0f}% busy={busy} ideal={ideal} core-s")
+for k in sorted(hist):
+    print(f"SCHED par={k}: {hist[k]}s")
+print(f"SCHED idle(par<=1)={sum(1 for _,b in ts if b<=1)}s  saturated(par>={cores})={sum(1 for _,b in ts if b>=cores)}s")
+# wasted core-seconds vs a perfectly-parallel build of the same work
+print(f"SCHED wasted_core_s={ideal-busy}  (if fully parallel, wall ~= {busy/cores:.0f}s vs actual {n}s)")


### PR DESCRIPTION
## Experiment — not for merge

Measure how much of the **linux-vcpkg vs ubuntu** "Generate and build Python bindings" time gap is caused by the **compiler version**.

### Background

Across 10 runs, the vcpkg bindings step (x64, Release) runs ~1.5 min slower than the native Ubuntu jobs on identical 4-core/16 GB runners. The native Ubuntu images compile the bindings with **clang-18**; the `rockylinux8-vcpkg` image uses **clang-21**. This isolates the compiler version.

### Approach

The bindings toolchain requires the **mrbind parser (libclang) and the compiler to be the same Clang version** — `generate.mk` feeds one shared `-resource-dir` to both. So you can't swap just the bindings compiler; you must change the image's Clang (mrbind then rebuilds against it). (An earlier attempt to drop in an upstream clang-18 tarball at runtime failed for exactly this reason — libclang-21 parser vs clang-18 resource headers → core dump.)

Rocky 8 AppStream carries Clang **17.0.6 / 18.1.8 / 19.1.7 / 20.1.8 / 21.1.8** as parallel-installable packages, so this just swaps the image's pinned version:

- `rockylinux8-vcpkgDockerfile`: install `clang-devel`/`lld`/`llvm-devel` **18.1.8** instead of 21.
- matrix `Clang 21` → `Clang 18` (compiler label + `clang++-18`/`clang-18` paths).

Result: mrbind builds against libclang-18 and the bindings compile with clang-18 — a consistent toolchain, like the Ubuntu jobs. Affects both x64 and arm64 vcpkg jobs. Triggers a vcpkg image rebuild.

### Read-out

Compare the **"Generate and build Python bindings"** step on the `linux-vcpkg (x64, …, Clang 18, …)` jobs against the master baseline median of **11:06** (vcpkg x64 Release, then clang-21). A drop toward the Ubuntu ~9:46 suggests the compiler version is the driver.

CI is scoped to **linux-vcpkg only** (all other platforms disabled via labels).
