### PR TITLE
Detect real ARM processor name in GetCpuId()

### DIFF
--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -414,9 +414,9 @@ std::string GetCpuId()
         std::ifstream cpuinfo( "/proc/cpuinfo" );
         for ( std::string line; std::getline( cpuinfo, line ); )
         {
-            if ( line.rfind( "CPU implementer", 0 ) == 0 )
+            if ( line.starts_with( "CPU implementer" ) )
                 implementer = (int)std::strtol( line.c_str() + line.find( ':' ) + 1, nullptr, 0 );
-            else if ( line.rfind( "CPU part", 0 ) == 0 )
+            else if ( line.starts_with( "CPU part" ) )
                 part = (int)std::strtol( line.c_str() + line.find( ':' ) + 1, nullptr, 0 );
             if ( implementer >= 0 && part >= 0 )
                 break;

--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -440,18 +440,9 @@ std::string GetCpuId()
         if ( c.implementer == implementer && c.part == part )
             return c.name;
 
-    // implementer-only fallback when the exact core isn't in the table above
-    const char* vendor = nullptr;
-    switch ( implementer )
-    {
-    case 0x41: vendor = "ARM";       break;  case 0x42: vendor = "Broadcom";  break;
-    case 0x43: vendor = "Cavium";    break;  case 0x48: vendor = "HiSilicon"; break;
-    case 0x4e: vendor = "NVIDIA";    break;  case 0x51: vendor = "Qualcomm";  break;
-    case 0x53: vendor = "Samsung";   break;  case 0x56: vendor = "Marvell";   break;
-    case 0x70: vendor = "Phytium";   break;  case 0xc0: vendor = "Ampere";    break;
-    }
-    if ( vendor && part >= 0 )
-        return fmt::format( "{} ARM CPU (part {:#x})", vendor, part );
+    // unknown core: report the raw implementer/part identifiers read from /proc/cpuinfo
+    if ( implementer != -1 || part != -1 )
+        return fmt::format( "ARM CPU: {:#x}, {:#x}", implementer, part );
 
     // single-board computers (Raspberry Pi etc.) expose a device-tree model name
     {

--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -9,6 +9,7 @@
 #include "MRPch/MRSpdlog.h"
 #include "MRPch/MRSuppressWarning.h"
 #include <cstring>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 
@@ -394,8 +395,73 @@ std::string GetCpuId()
         spdlog::error("Apple sysctlbyname failed!");
     return CPUBrandString;
 #elif defined(__ARM_CPU__)
-    // TODO: https://stackoverflow.com/questions/64864035/any-cpuid-like-instruction-in-armv8
+    // ARM has no CPUID-like brand-string instruction (see
+    // https://stackoverflow.com/questions/64864035/any-cpuid-like-instruction-in-armv8 ),
+    // so the real processor name has to be obtained per platform.
+#ifdef _WIN32
+    // Windows on ARM exposes the brand string through the registry
+    wchar_t value[256] = {};
+    DWORD bufferSize = sizeof( value );
+    if ( RegGetValue( HKEY_LOCAL_MACHINE, L"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
+            L"ProcessorNameString", RRF_RT_REG_SZ, NULL, ( PVOID )&value, &bufferSize ) == ERROR_SUCCESS )
+        return Utf16ToUtf8( value );
     return "ARM CPU";
+#else
+    // On Linux we decode the CPU implementer/part pair from /proc/cpuinfo (the same data
+    // lscpu uses), and fall back to the device-tree model name for single-board computers.
+    int implementer = -1, part = -1;
+    {
+        std::ifstream cpuinfo( "/proc/cpuinfo" );
+        for ( std::string line; std::getline( cpuinfo, line ); )
+        {
+            if ( line.rfind( "CPU implementer", 0 ) == 0 )
+                implementer = (int)std::strtol( line.c_str() + line.find( ':' ) + 1, nullptr, 0 );
+            else if ( line.rfind( "CPU part", 0 ) == 0 )
+                part = (int)std::strtol( line.c_str() + line.find( ':' ) + 1, nullptr, 0 );
+            if ( implementer >= 0 && part >= 0 )
+                break;
+        }
+    }
+
+    struct ArmCpuName { int implementer, part; const char* name; };
+    static constexpr ArmCpuName armCpuNames[] = {
+        { 0x41, 0xd03, "ARM Cortex-A53" },   { 0x41, 0xd05, "ARM Cortex-A55" },
+        { 0x41, 0xd07, "ARM Cortex-A57" },   { 0x41, 0xd08, "ARM Cortex-A72" },
+        { 0x41, 0xd09, "ARM Cortex-A73" },   { 0x41, 0xd0a, "ARM Cortex-A75" },
+        { 0x41, 0xd0b, "ARM Cortex-A76" },   { 0x41, 0xd0c, "ARM Neoverse-N1" },
+        { 0x41, 0xd0d, "ARM Cortex-A77" },   { 0x41, 0xd40, "ARM Neoverse-V1" },
+        { 0x41, 0xd41, "ARM Cortex-A78" },   { 0x41, 0xd44, "ARM Cortex-X1" },
+        { 0x41, 0xd49, "ARM Neoverse-N2" },  { 0x41, 0xd4f, "ARM Neoverse-V2" },
+        { 0xc0, 0xac3, "Ampere-1" },         { 0xc0, 0xac4, "Ampere-1a" },
+        { 0x43, 0x0af, "Marvell ThunderX2" },{ 0x46, 0x001, "Fujitsu A64FX" },
+        { 0x51, 0xc01, "Qualcomm Kryo" },
+    };
+    for ( const auto& c : armCpuNames )
+        if ( c.implementer == implementer && c.part == part )
+            return c.name;
+
+    // implementer-only fallback when the exact core isn't in the table above
+    const char* vendor = nullptr;
+    switch ( implementer )
+    {
+    case 0x41: vendor = "ARM";       break;  case 0x42: vendor = "Broadcom";  break;
+    case 0x43: vendor = "Cavium";    break;  case 0x48: vendor = "HiSilicon"; break;
+    case 0x4e: vendor = "NVIDIA";    break;  case 0x51: vendor = "Qualcomm";  break;
+    case 0x53: vendor = "Samsung";   break;  case 0x56: vendor = "Marvell";   break;
+    case 0x70: vendor = "Phytium";   break;  case 0xc0: vendor = "Ampere";    break;
+    }
+    if ( vendor && part >= 0 )
+        return fmt::format( "{} ARM CPU (part {:#x})", vendor, part );
+
+    // single-board computers (Raspberry Pi etc.) expose a device-tree model name
+    {
+        std::ifstream model( "/proc/device-tree/model" );
+        if ( std::string name; std::getline( model, name ) && !name.empty() )
+            return name;
+    }
+
+    return "ARM CPU";
+#endif
 #else
     // https://stackoverflow.com/questions/850774/how-to-determine-the-hardware-cpu-and-ram-on-a-machine
     char CPUBrandString[0x40] = {};

--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -440,7 +440,20 @@ std::string GetCpuId()
         if ( c.implementer == implementer && c.part == part )
             return c.name;
 
-    // unknown core: report the raw implementer/part identifiers read from /proc/cpuinfo
+    // implementer-only fallback when the exact core isn't in the table above
+    const char* vendor = nullptr;
+    switch ( implementer )
+    {
+    case 0x41: vendor = "ARM";       break;  case 0x42: vendor = "Broadcom";  break;
+    case 0x43: vendor = "Cavium";    break;  case 0x48: vendor = "HiSilicon"; break;
+    case 0x4e: vendor = "NVIDIA";    break;  case 0x51: vendor = "Qualcomm";  break;
+    case 0x53: vendor = "Samsung";   break;  case 0x56: vendor = "Marvell";   break;
+    case 0x70: vendor = "Phytium";   break;  case 0xc0: vendor = "Ampere";    break;
+    }
+    if ( vendor && part >= 0 )
+        return fmt::format( "{} ARM CPU (part {:#x})", vendor, part );
+
+    // unknown vendor: report the raw implementer/part identifiers read from /proc/cpuinfo
     if ( implementer != -1 || part != -1 )
         return fmt::format( "ARM CPU: {:#x}, {:#x}", implementer, part );
 


### PR DESCRIPTION
## Problem

`GetCpuId()` returned the constant string `"ARM CPU"` for every non-Apple ARM processor, because ARM has no CPUID-like brand-string instruction (unlike x86, which we read via `__cpuid`, and Apple, which we read via `sysctlbyname`).

## Change

Obtain the real processor name per platform inside the `__ARM_CPU__` branch of `GetCpuId()`:

- **Windows on ARM**: read `ProcessorNameString` from `HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\0` (same registry helper already used by `GetDetailedOSName`).
- **Linux**: decode the `CPU implementer` / `CPU part` pair from `/proc/cpuinfo` (the same data `lscpu` uses), with a graceful fallback chain:
  1. **exact core name** from a small lookup table — e.g. `0x41 / 0xd0c` → `ARM Neoverse-N1` (table covers common ARMv8/v9 cores: Cortex-A5x/A7x/A78/X1, Neoverse N1/V1/N2/V2, Ampere-1, ThunderX2, A64FX, Kryo);
  2. **known vendor + raw part** when the exact core isn't tabled — e.g. `Qualcomm ARM CPU (part 0xc01)`;
  3. **raw identifiers** when the vendor isn't recognized either — e.g. `ARM CPU: 0x53, 0x1`;
  4. **device-tree model** (`/proc/device-tree/model`) for single-board computers — e.g. `Raspberry Pi 4 Model B`;
  5. `"ARM CPU"` if nothing is available.

## Notes

- The new code is entirely inside `#elif defined(__ARM_CPU__)`, so non-ARM builds are unchanged at the preprocessor level (the only always-compiled change is an added `#include <cstdlib>`). The **ubuntu-arm64** job is the only one that compiles and exercises the new branch — the other platforms are disabled.
- `__ARM_CPU__` is set only by the CMake build (`DetectPlatform.cmake`); the MSVC/vcxproj Windows build never defines it and Windows CI is x64, so the Windows-on-ARM half is defensive and not compiled by CI today.
- The Linux implementer/part strings should be eyeballed on the arm64 runner.
