### PR TITLE
projectSpline: fix self-intersecting projection; add cut-by-spline regression test

### DIFF
--- a/source/MRMesh/MRMeshTriPoint.cpp
+++ b/source/MRMesh/MRMeshTriPoint.cpp
@@ -84,6 +84,15 @@ std::array<WeightedVertex, 3> MeshTriPoint::getWeightedVerts( const MeshTopology
     };
 }
 
+float MeshTriPoint::interpolate( const MeshTopology & topology, const VertScalars & field ) const
+{
+    float res = 0;
+    for ( const auto & wv : getWeightedVerts( topology ) )
+        if ( wv.weight > 0 )
+            res += wv.weight * field[wv.v];
+    return res;
+}
+
 bool same( const MeshTopology & topology, const MeshTriPoint& lhs, const MeshTriPoint & rhs )
 {
     if ( !lhs )

--- a/source/MRMesh/MRMeshTriPoint.h
+++ b/source/MRMesh/MRMeshTriPoint.h
@@ -67,6 +67,9 @@ struct MeshTriPoint
     /// returns three weighted triangle's vertices with the sum of not-negative weights equal to 1, and the largest weight in the closest vertex
     [[nodiscard]] MRMESH_API std::array<WeightedVertex, 3> getWeightedVerts( const MeshTopology & topology ) const;
 
+    /// linearly interpolates the values given in vertices to find the field's value at this point
+    [[nodiscard]] MRMESH_API float interpolate( const MeshTopology & topology, const VertScalars & field ) const;
+
     /// returns true if two points are equal including equal not-unique representation
     [[nodiscard]] bool operator==( const MeshTriPoint& rhs ) const = default;
 };

--- a/source/MRMesh/MRSplineProject.cpp
+++ b/source/MRMesh/MRSplineProject.cpp
@@ -75,7 +75,10 @@ std::vector<MeshTriPoint> projectSplineAsMTP( const Mesh& mesh, const MarkedCont
         // note that geoPath[midPointId] is not exactly in the center of the path, and approximated distances are not symmetric
         const auto surfDist = computeSurfaceDistances( mesh, std::vector<MeshTriPoint>{ geoPath[midPointId] },
             std::vector<MeshTriPoint>{ p0.mtp, p1.mtp } );
-        const auto regionBetweenMarks = facesWithinRange( mesh.topology, surfDist, geoPathLen ); // geoPathLen / 2 is not enough
+        const auto range = std::max( 
+            p0.mtp.interpolate( mesh.topology, surfDist ),
+            p1.mtp.interpolate( mesh.topology, surfDist ) );
+        const auto regionBetweenMarks = facesWithinRange( mesh.topology, surfDist, range );
         assert( regionBetweenMarks.any() );
         for ( auto i = i0 + 1; i < i1; ++i )
             res[i] = mesh.projectPoint( spline.contour[i], FLT_MAX, &regionBetweenMarks ).mtp;

--- a/source/MRMesh/MRSplineProject.cpp
+++ b/source/MRMesh/MRSplineProject.cpp
@@ -72,8 +72,10 @@ std::vector<MeshTriPoint> projectSplineAsMTP( const Mesh& mesh, const MarkedCont
         const auto geoPathAsContour = geodesicPathToContour3f( mesh, geoPath );
         const auto geoPathLen = calcLength( geoPathAsContour );
         const auto midPointId = findContourPointByLength( geoPathAsContour, geoPathLen / 2 );
-        const auto surfDist = computeSurfaceDistances( mesh, geoPath[midPointId], geoPathLen / 2 );
-        const auto regionBetweenMarks = facesWithinRange( mesh.topology, surfDist, geoPathLen / 2 );
+        // note that geoPath[midPointId] is not exactly in the center of the path, and approximated distances are not symmetric
+        const auto surfDist = computeSurfaceDistances( mesh, std::vector<MeshTriPoint>{ geoPath[midPointId] },
+            std::vector<MeshTriPoint>{ p0.mtp, p1.mtp } );
+        const auto regionBetweenMarks = facesWithinRange( mesh.topology, surfDist, geoPathLen ); // geoPathLen / 2 is not enough
         assert( regionBetweenMarks.any() );
         for ( auto i = i0 + 1; i < i1; ++i )
             res[i] = mesh.projectPoint( spline.contour[i], FLT_MAX, &regionBetweenMarks ).mtp;

--- a/source/MRMesh/MRSurfaceDistance.cpp
+++ b/source/MRMesh/MRSurfaceDistance.cpp
@@ -127,4 +127,40 @@ VertScalars computeSurfaceDistances( const Mesh& mesh, const std::vector<MeshTri
     return b.takeDistanceMap();
 }
 
+VertScalars computeSurfaceDistances( const Mesh& mesh, const std::vector<MeshTriPoint>& starts, const std::vector<MeshTriPoint>& ends,
+    const VertBitSet* region, bool * endReached, int maxVertUpdates )
+{
+    MR_TIMER;
+
+    SurfaceDistanceBuilder b( mesh, region );
+    b.setMaxVertUpdates( maxVertUpdates );
+    for ( const auto& triPoint : starts )
+        b.addStart( triPoint );
+
+    VertBitSet stopVerts;
+    for ( const auto & end : ends )
+        mesh.topology.forEachVertex( end, [&]( VertId v )
+        {
+            stopVerts.autoResizeSet( v );
+        } );
+    auto numStopVerts = stopVerts.count();
+
+    if ( endReached )
+        *endReached = true;
+    while ( numStopVerts > 0 )
+    {
+        auto v = b.growOne();
+        if ( !v )
+        {
+            if ( endReached )
+                *endReached = false;
+            break;
+        }
+
+        if ( stopVerts.test_set( v, false ) )
+            --numStopVerts;
+    }
+    return b.takeDistanceMap();
+}
+
 } //namespace MR

--- a/source/MRMesh/MRSurfaceDistance.h
+++ b/source/MRMesh/MRSurfaceDistance.h
@@ -30,7 +30,7 @@ MRMESH_API VertScalars computeSurfaceDistances( const Mesh& mesh, const HashMap<
 
 /// computes path distance in mesh vertices from given start point, stopping when all vertices in the face where end is located are reached;
 /// \details considered paths can go either along edges or straightly within triangles
-/// \param endReached if pointer provided it will receive where a path from start to end exists
+/// \param endReached if pointer provided it will receive whether a path from start to end exists
 MRMESH_API VertScalars computeSurfaceDistances( const Mesh& mesh, const MeshTriPoint & start, const MeshTriPoint & end, 
     const VertBitSet* region = nullptr, bool * endReached = nullptr, int maxVertUpdates = 3 );
 
@@ -43,6 +43,13 @@ MRMESH_API VertScalars computeSurfaceDistances( const Mesh& mesh, const MeshTriP
 /// considered paths can go either along edges or straightly within triangles
 MRMESH_API VertScalars computeSurfaceDistances( const Mesh& mesh, const std::vector<MeshTriPoint>& starts, float maxDist = FLT_MAX,
                                                          const VertBitSet* region = nullptr, int maxVertUpdates = 3 );
+
+/// computes path distances in mesh vertices from given start points,
+/// stopping when all vertices of all faces containing \param ends are reached;
+/// considered paths can go either along edges or straightly within triangles
+/// \param endReached if pointer provided it will receive whether a path from start to end exists
+MRMESH_API VertScalars computeSurfaceDistances( const Mesh& mesh, const std::vector<MeshTriPoint>& starts, const std::vector<MeshTriPoint>& ends,
+    const VertBitSet* region = nullptr, bool * endReached = nullptr, int maxVertUpdates = 3 );
 
 /// \}
 

--- a/test_regression/test_algorithms/test_cut_by_spline.py
+++ b/test_regression/test_algorithms/test_cut_by_spline.py
@@ -42,7 +42,7 @@ def test_cut_by_spline_without_projection_self_intersects():
 
 
 @pytest.mark.smoke
-def test_cut_by_spline_with_projection(tmp_path):
+def test_cut_by_spline_with_projection():
     """
     Projecting the spline onto the mesh surface with projectSpline before cutting
     removes the self-intersections, so the cut succeeds.
@@ -50,12 +50,5 @@ def test_cut_by_spline_with_projection(tmp_path):
     mesh = mm.loadMesh(input_folder / "toothex.ctm")
     spline = _make_spline(mesh)
     projected_contour = mm.projectSpline(mesh, spline)
-
-    # Dump both contours (raw makeSpline output and the projectSpline output) for
-    # offline analysis. Saved before the cut so they survive a failure; uploaded to
-    # S3 when the PR carries the `upload-test-artifacts` label.
-    mm.saveLines(mm.Polyline3(spline.contour), tmp_path / "make_spline.mrlines")
-    mm.saveLines(mm.Polyline3(projected_contour), tmp_path / "project_spline.mrlines")
-
     left_faces = mm.cutMeshByContour(mesh, projected_contour)
     assert left_faces.count() > 0

--- a/test_regression/test_algorithms/test_cut_by_spline.py
+++ b/test_regression/test_algorithms/test_cut_by_spline.py
@@ -42,7 +42,7 @@ def test_cut_by_spline_without_projection_self_intersects():
 
 
 @pytest.mark.smoke
-def test_cut_by_spline_with_projection():
+def test_cut_by_spline_with_projection(tmp_path):
     """
     Projecting the spline onto the mesh surface with projectSpline before cutting
     removes the self-intersections, so the cut succeeds.
@@ -50,5 +50,12 @@ def test_cut_by_spline_with_projection():
     mesh = mm.loadMesh(input_folder / "toothex.ctm")
     spline = _make_spline(mesh)
     projected_contour = mm.projectSpline(mesh, spline)
+
+    # Dump both contours (raw makeSpline output and the projectSpline output) for
+    # offline analysis. Saved before the cut so they survive a failure; uploaded to
+    # S3 when the PR carries the `upload-test-artifacts` label.
+    mm.saveLines(mm.Polyline3(spline.contour), tmp_path / "make_spline.mrlines")
+    mm.saveLines(mm.Polyline3(projected_contour), tmp_path / "project_spline.mrlines")
+
     left_faces = mm.cutMeshByContour(mesh, projected_contour)
     assert left_faces.count() > 0

--- a/test_regression/test_algorithms/test_cut_by_spline.py
+++ b/test_regression/test_algorithms/test_cut_by_spline.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import meshlib.mrmeshpy as mm
+import pytest
+from constants import test_files_path
+from module_helper import *
+
+input_folder = Path(test_files_path) / "algorithms" / "cut_by_spline"
+
+
+def _make_spline(mesh):
+    # Control points form an already-closed contour (last point repeats the first).
+    control_points = mm.loadPoints(input_folder / "control_points_closed.xyz").points.vec
+
+    # Project the control points onto the mesh and gather surface normals there.
+    contour_points = mm.Contour3f()
+    contour_normals = mm.Contour3f()
+    for point in control_points:
+        mtp = mm.findProjection(point, mesh).mtp
+        contour_points.append(mesh.triPoint(mtp))
+        contour_normals.append(mesh.normal(mtp))
+
+    settings = mm.SplineSettings()
+    settings.normals = contour_normals
+    settings.controlStability = 2
+    settings.iterations = 1
+    settings.normalsAffectShape = True
+    settings.samplingStep = 0.1
+    return mm.makeSpline(contour_points, settings)
+
+
+@pytest.mark.smoke
+def test_cut_by_spline_without_projection_self_intersects():
+    """
+    The spline returned by makeSpline does not lie exactly on the mesh surface,
+    so cutting the mesh directly by it fails with a self-intersection error.
+    """
+    mesh = mm.loadMesh(input_folder / "toothex.ctm")
+    spline = _make_spline(mesh)
+    with pytest.raises(RuntimeError, match="self intersections"):
+        mm.cutMeshByContour(mesh, spline.contour)
+
+
+@pytest.mark.smoke
+def test_cut_by_spline_with_projection():
+    """
+    Projecting the spline onto the mesh surface with projectSpline before cutting
+    removes the self-intersections, so the cut succeeds.
+    """
+    mesh = mm.loadMesh(input_folder / "toothex.ctm")
+    spline = _make_spline(mesh)
+    projected_contour = mm.projectSpline(mesh, spline)
+    left_faces = mm.cutMeshByContour(mesh, projected_contour)
+    assert left_faces.count() > 0


### PR DESCRIPTION
Fixes the self-intersections produced by `projectSpline` (#6277) and adds a Python regression test for the cut-by-spline workflow.

## projectSpline fix

When projecting a spline onto a mesh, every point between two consecutive control points is projected within the face region around the geodesic path connecting them. That region was computed from an approximate path mid-point with a radius of only half the geodesic length — too small, so interior points were projected into a too-narrow region and the resulting contour self-intersected, which made `cutMeshByContour` reject it.

The region is now sized to actually reach both control points:
- surface distances are computed from the path mid-point to *both* control points (the mid-point is only approximately centered, and the approximate distances are not symmetric);
- the region radius is taken as the larger of the interpolated distances at the two control points, so both ends are always covered.

Supporting additions:
- `MeshTriPoint::interpolate` — linearly interpolate a per-vertex field at a triangle point;
- a `computeSurfaceDistances(mesh, starts, ends, ...)` overload — distances from the start points, stopping once all faces containing the end points are reached.

## Regression test

`test_regression/test_algorithms/test_cut_by_spline.py` builds a spline on the `toothex.ctm` tooth mesh from an already-closed set of control points and checks both directions:
- `test_cut_by_spline_without_projection_self_intersects` — cutting directly by the raw `makeSpline` contour raises `Cannot cut mesh because of contour self intersections` (the spline floats off the surface);
- `test_cut_by_spline_with_projection` — inserting `projectSpline` before the cut makes it succeed.

Both are marked `@pytest.mark.smoke`. The fixture is added to MeshLibTestData under `algorithms/cut_by_spline/` (`toothex.ctm` + `control_points_closed.xyz`) and the `test_data` submodule is bumped accordingly.
