### PR TITLE
Report arch/OS from User-Agent Client Hints in WASM mode

### DIFF
--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -94,41 +94,45 @@ void removeOldLogs( const std::filesystem::path& dir, int hours = 24 )
 
 #ifdef __EMSCRIPTEN__
 
-// User-Agent Client Hints (getHighEntropyValues) is asynchronous and Chromium-only, so it
-// cannot be read inline from the synchronous functions below. Kick the query off once at
-// startup and cache the result on the Emscripten Module object; the getters then read
-// individual fields from the cache, falling back gracefully when it is absent.
-EM_JS( void, mrRequestUserAgentData, (), {
-    if ( typeof navigator != "undefined" && navigator.userAgentData &&
-         navigator.userAgentData.getHighEntropyValues )
-    {
-        navigator.userAgentData
-            .getHighEntropyValues( [ "architecture", "bitness", "platformVersion" ] )
-            .then( function( ua ) { Module.mrUserAgentData = ua; } );
-    }
-} );
-
-// returns a malloc'ed UTF-8 copy of Module.mrUserAgentData[field], or an empty string when
-// the field (or the whole cached object) is not available
-EM_JS( char*, mrUserAgentField, ( const char* field ), {
-    var ua = Module.mrUserAgentData;
-    var key = UTF8ToString( field );
-    return stringToNewUTF8( ( ua && ua[key] ) ? String( ua[key] ) : "" );
-} );
-
 namespace
 {
 
-std::string userAgentField( const char* field )
+enum UserAgentField { uaArchitecture, uaBitness, uaPlatform, uaPlatformVersion };
+
+// User-Agent Client Hints (getHighEntropyValues) is asynchronous and Chromium-only, so it
+// cannot be read inline from the synchronous functions below. Kick the query off once at
+// startup and cache the result on the Emscripten Module object; userAgentField() then reads
+// individual fields synchronously, falling back gracefully when the cache is absent.
+void requestUserAgentData()
 {
-    char* p = mrUserAgentField( field );
+    EM_ASM( {
+        if ( typeof navigator != "undefined" && navigator.userAgentData &&
+             navigator.userAgentData.getHighEntropyValues )
+        {
+            navigator.userAgentData
+                .getHighEntropyValues( [ "architecture", "bitness", "platformVersion" ] )
+                .then( function( ua ) { Module.mrUserAgentData = ua; } );
+        }
+    } );
+}
+
+// returns Module.mrUserAgentData[<field>] or an empty string when the field (or the whole
+// cached object) is not available. The field is selected by integer index rather than a
+// string pointer, so nothing but an int crosses the JS boundary (MEMORY64-safe).
+std::string userAgentField( UserAgentField field )
+{
+    char* p = (char*)EM_ASM_PTR( {
+        var ua = Module.mrUserAgentData;
+        var key = "architecture bitness platform platformVersion".split( " " )[$0];
+        return stringToNewUTF8( ( ua && ua[key] ) ? String( ua[key] ) : "" );
+    }, field );
     std::string res = p ? p : std::string();
     free( p );
     return res;
 }
 
 // fire the asynchronous query during static initialization, before any getter is called
-[[maybe_unused]] const bool g_userAgentDataRequested = [] { mrRequestUserAgentData(); return true; }();
+[[maybe_unused]] const bool g_userAgentDataRequested = [] { requestUserAgentData(); return true; }();
 
 }
 
@@ -431,9 +435,9 @@ std::string GetCpuId()
     // architecture and bitness via User-Agent Client Hints (Chromium only). Fall back to a
     // generic name when those are unavailable (e.g. Firefox/Safari).
     std::string res = "Web Browser";
-    if ( const std::string arch = userAgentField( "architecture" ); !arch.empty() )
+    if ( const std::string arch = userAgentField( uaArchitecture ); !arch.empty() )
     {
-        const std::string bitness = userAgentField( "bitness" );
+        const std::string bitness = userAgentField( uaBitness );
         res = bitness.empty() ? arch : arch + ", " + bitness + "-bit";
     }
     if constexpr ( sizeof( void* ) == 8 )
@@ -584,9 +588,9 @@ std::string GetDetailedOSName()
 #ifdef __EMSCRIPTEN__
     // Prefer the real OS name/version from User-Agent Client Hints (Chromium only);
     // otherwise report the wasm build configuration as before.
-    if ( const std::string platform = userAgentField( "platform" ); !platform.empty() )
+    if ( const std::string platform = userAgentField( uaPlatform ); !platform.empty() )
     {
-        const std::string version = userAgentField( "platformVersion" );
+        const std::string version = userAgentField( uaPlatformVersion );
         return version.empty() ? platform : platform + ", " + version;
     }
 #ifdef __EMSCRIPTEN_PTHREADS__

--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -97,11 +97,9 @@ void removeOldLogs( const std::filesystem::path& dir, int hours = 24 )
 namespace
 {
 
-enum UserAgentField { uaArchitecture, uaBitness, uaPlatform, uaPlatformVersion };
-
 // User-Agent Client Hints (getHighEntropyValues) is asynchronous and Chromium-only, so it
 // cannot be read inline from the synchronous functions below. Kick the query off once at
-// startup and cache the result on the Emscripten Module object; userAgentField() then reads
+// startup and cache the result on the Emscripten Module object; the ua*() getters then read
 // individual fields synchronously, falling back gracefully when the cache is absent.
 void requestUserAgentData()
 {
@@ -116,19 +114,49 @@ void requestUserAgentData()
     } );
 }
 
-// returns Module.mrUserAgentData[<field>] or an empty string when the field (or the whole
-// cached object) is not available. The field is selected by integer index rather than a
-// string pointer, so nothing but an int crosses the JS boundary (MEMORY64-safe).
-std::string userAgentField( UserAgentField field )
+// takes ownership of a malloc'ed UTF-8 string returned from JS and frees it
+std::string takeJsString( char* p )
 {
-    char* p = (char*)EM_ASM_PTR( {
-        var ua = Module.mrUserAgentData;
-        var key = "architecture bitness platform platformVersion".split( " " )[$0];
-        return stringToNewUTF8( ( ua && ua[key] ) ? String( ua[key] ) : "" );
-    }, field );
     std::string res = p ? p : std::string();
     free( p );
     return res;
+}
+
+// Each getter returns the cached field, or an empty string when the field (or the whole
+// cached object) is unavailable. The field name is hard-coded in every getter, so nothing
+// crosses the JS boundary: no pointer argument (which would arrive as a BigInt under
+// MEMORY64) and no "$" placeholder (MRMesh is built with -pedantic-errors, which rejects
+// "$" in identifiers). The string is returned via EM_ASM_PTR, correct for both memory models.
+std::string uaArchitecture()
+{
+    return takeJsString( (char*)EM_ASM_PTR( {
+        var u = Module.mrUserAgentData;
+        return stringToNewUTF8( ( u && u.architecture ) ? String( u.architecture ) : "" );
+    } ) );
+}
+
+std::string uaBitness()
+{
+    return takeJsString( (char*)EM_ASM_PTR( {
+        var u = Module.mrUserAgentData;
+        return stringToNewUTF8( ( u && u.bitness ) ? String( u.bitness ) : "" );
+    } ) );
+}
+
+std::string uaPlatform()
+{
+    return takeJsString( (char*)EM_ASM_PTR( {
+        var u = Module.mrUserAgentData;
+        return stringToNewUTF8( ( u && u.platform ) ? String( u.platform ) : "" );
+    } ) );
+}
+
+std::string uaPlatformVersion()
+{
+    return takeJsString( (char*)EM_ASM_PTR( {
+        var u = Module.mrUserAgentData;
+        return stringToNewUTF8( ( u && u.platformVersion ) ? String( u.platformVersion ) : "" );
+    } ) );
 }
 
 // fire the asynchronous query during static initialization, before any getter is called
@@ -435,9 +463,9 @@ std::string GetCpuId()
     // architecture and bitness via User-Agent Client Hints (Chromium only). Fall back to a
     // generic name when those are unavailable (e.g. Firefox/Safari).
     std::string res = "Web Browser";
-    if ( const std::string arch = userAgentField( uaArchitecture ); !arch.empty() )
+    if ( const std::string arch = uaArchitecture(); !arch.empty() )
     {
-        const std::string bitness = userAgentField( uaBitness );
+        const std::string bitness = uaBitness();
         res = bitness.empty() ? arch : arch + ", " + bitness + "-bit";
     }
     if constexpr ( sizeof( void* ) == 8 )
@@ -588,9 +616,9 @@ std::string GetDetailedOSName()
 #ifdef __EMSCRIPTEN__
     // Prefer the real OS name/version from User-Agent Client Hints (Chromium only);
     // otherwise report the wasm build configuration as before.
-    if ( const std::string platform = userAgentField( uaPlatform ); !platform.empty() )
+    if ( const std::string platform = uaPlatform(); !platform.empty() )
     {
-        const std::string version = userAgentField( uaPlatformVersion );
+        const std::string version = uaPlatformVersion();
         return version.empty() ? platform : platform + ", " + version;
     }
 #ifdef __EMSCRIPTEN_PTHREADS__

--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -92,6 +92,48 @@ void removeOldLogs( const std::filesystem::path& dir, int hours = 24 )
 
 }
 
+#ifdef __EMSCRIPTEN__
+
+// User-Agent Client Hints (getHighEntropyValues) is asynchronous and Chromium-only, so it
+// cannot be read inline from the synchronous functions below. Kick the query off once at
+// startup and cache the result on the Emscripten Module object; the getters then read
+// individual fields from the cache, falling back gracefully when it is absent.
+EM_JS( void, mrRequestUserAgentData, (), {
+    if ( typeof navigator != "undefined" && navigator.userAgentData &&
+         navigator.userAgentData.getHighEntropyValues )
+    {
+        navigator.userAgentData
+            .getHighEntropyValues( [ "architecture", "bitness", "platformVersion" ] )
+            .then( function( ua ) { Module.mrUserAgentData = ua; } );
+    }
+} );
+
+// returns a malloc'ed UTF-8 copy of Module.mrUserAgentData[field], or an empty string when
+// the field (or the whole cached object) is not available
+EM_JS( char*, mrUserAgentField, ( const char* field ), {
+    var ua = Module.mrUserAgentData;
+    var key = UTF8ToString( field );
+    return stringToNewUTF8( ( ua && ua[key] ) ? String( ua[key] ) : "" );
+} );
+
+namespace
+{
+
+std::string userAgentField( const char* field )
+{
+    char* p = mrUserAgentField( field );
+    std::string res = p ? p : std::string();
+    free( p );
+    return res;
+}
+
+// fire the asynchronous query during static initialization, before any getter is called
+[[maybe_unused]] const bool g_userAgentDataRequested = [] { mrRequestUserAgentData(); return true; }();
+
+}
+
+#endif
+
 namespace MR
 {
 
@@ -385,9 +427,18 @@ std::filesystem::path GetWindowsInstallDirectory()
 std::string GetCpuId()
 {
 #ifdef __EMSCRIPTEN__
+    // The browser sandbox hides the host CPU model; the most it exposes is the coarse
+    // architecture and bitness via User-Agent Client Hints (Chromium only). Fall back to a
+    // generic name when those are unavailable (e.g. Firefox/Safari).
+    std::string res = "Web Browser";
+    if ( const std::string arch = userAgentField( "architecture" ); !arch.empty() )
+    {
+        const std::string bitness = userAgentField( "bitness" );
+        res = bitness.empty() ? arch : arch + ", " + bitness + "-bit";
+    }
     if constexpr ( sizeof( void* ) == 8 )
-        return "Web Browser (Memory64 enabled)";
-    return "Web Browser";
+        res += " (Memory64 enabled)";
+    return res;
 #elif defined(__APPLE__)
     char CPUBrandString[0x40] = {};
     size_t size = sizeof(CPUBrandString);
@@ -531,6 +582,13 @@ std::string GetDetailedOSName()
     return winName;
 #else
 #ifdef __EMSCRIPTEN__
+    // Prefer the real OS name/version from User-Agent Client Hints (Chromium only);
+    // otherwise report the wasm build configuration as before.
+    if ( const std::string platform = userAgentField( "platform" ); !platform.empty() )
+    {
+        const std::string version = userAgentField( "platformVersion" );
+        return version.empty() ? platform : platform + ", " + version;
+    }
 #ifdef __EMSCRIPTEN_PTHREADS__
     if constexpr ( sizeof( void* ) == 8 )
         return "wasm64-mt";


### PR DESCRIPTION
## Problem

In Emscripten builds `GetCpuId()` and `GetDetailedOSName()` returned fixed strings — `"Web Browser"` / `"Web Browser (Memory64 enabled)"` and `"wasm32-mt"` / `"wasm64-mt"` / … — because the browser sandbox exposes none of the hardware sources used on the native platforms.

## Change

The browser *does* expose a little host info via **User-Agent Client Hints** (`navigator.userAgentData.getHighEntropyValues`). Use it to enrich both strings:

- **`GetCpuId()`** → `"<architecture>, <bitness>-bit"`, e.g. `arm, 64-bit`. The `(Memory64 enabled)` suffix is preserved (so a Memory64 build reports `arm, 64-bit (Memory64 enabled)`).
- **`GetDetailedOSName()`** → `"<platform>, <platformVersion>"`, e.g. `macOS, 14.5.0`.

`getHighEntropyValues()` is **asynchronous** and **Chromium-only**, so it can't be read inline from these synchronous functions. The query is fired **once during static initialization** and the result cached on the Emscripten `Module` object; the getters then read individual fields synchronously via `EM_JS`. When the data is unavailable — Firefox/Safari (no `userAgentData`), a non-secure context, or the promise hasn't resolved yet — each getter **falls back to the previous constant** (`"Web Browser"` / the `wasm*-mt` build string), so there is no regression.

## Notes

- All new code is inside `#ifdef __EMSCRIPTEN__`, so only the **emscripten** build is affected; the other platforms are disabled on this PR.
- The architecture is coarse (`"arm"` / `"x86"`, never a CPU brand string) — that's the most the browser reveals; this is the same sandbox limitation discussed for ARM.
- The cache lives on the main thread's `Module`; a call from a worker thread that lacks the cached object simply takes the fallback. The runtime string isn't observable from CI (no browser), so the emscripten job validates that it **compiles and links** (in particular that the `EM_JS` string-marshalling symbols resolve).
