### PR TITLE
[experiment] profile binding template instantiation (vcpkg x64, Clang 21)

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   linux-vcpkg-build-test:
-    timeout-minutes: 50
+    timeout-minutes: 90
     runs-on: ${{ matrix.os }}
     container:
       image: meshlib/meshlib-rockylinux8-vcpkg-${{ matrix.arch }}:${{ inputs.docker_image_tag }}
@@ -186,25 +186,43 @@ jobs:
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | llvm-cxxfilt
 
-      # EXPERIMENT: profile WHICH templates dominate instantiation in the bindings compile.
-      # -ftime-trace on the compiler only (not the mrbind parser); per-template aggregation
-      # below classifies the instantiation time as MeshLib (MR::) vs libstdc++ (std::) vs
-      # pybind11, to verify what actually drives the Linux instantiation cost.
-      - name: ftn enable -ftime-trace
-        if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
-        run: echo '-ftime-trace' >> scripts/mrbind/compiler_only_flags.txt
-
       - name: Generate and build Python bindings
         if: ${{ inputs.mrbind }}
         env:
           CXX: ${{ matrix.cxx-compiler }}
         run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib
 
-      - name: ftn aggregate per-template instantiation
+      # EXPERIMENT: A/B test replacing libstdc++'s std::is_trivially_destructible<capture>
+      # (the #1 instantiation hot spot) with the clang builtin __is_trivially_destructible.
+      # Same runner, back-to-back: baseline build, patch the mrbind-pybind11 header in place,
+      # rebuild; -ftime-trace measures the instantiation drop.
+      - name: ab builtin-trait patch test
         if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
+        env:
+          CXX: ${{ matrix.cxx-compiler }}
         run: |
-          echo "FTN_PLATFORM=linux-vcpkg-x64-clang21"
-          python3 scripts/ftt_byname.py build/binds_python
+          set -e
+          echo '-ftime-trace' >> scripts/mrbind/compiler_only_flags.txt
+          MK="make -f scripts/mrbind/generate.mk MODE=none -B MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib"
+          prof() {
+            echo "AB $1 wall=$(cat /tmp/tw)s"
+            python3 scripts/ftt_aggregate.py build/binds_python | sed "s/^/AB $1 /"
+            python3 scripts/ftt_byname.py build/binds_python | grep -E "files=|^FTN cat |is_trivially_destructible<capture>" | sed "s/^/AB $1 /"
+          }
+          echo "::group::baseline build"
+          find build/binds_python -name '*.json' -delete 2>/dev/null || true
+          /usr/bin/time -o /tmp/tw -f '%e' bash -c "$MK >/tmp/base.log 2>&1" || { echo BASE_FAILED; tail -40 /tmp/base.log; exit 1; }
+          echo "::endgroup::"
+          prof BASELINE
+          echo "::group::patch header"
+          sed -i 's/std::is_trivially_destructible<capture>::value/__is_trivially_destructible(capture)/' thirdparty/mrbind-pybind11/include/pybind11/pybind11.h
+          grep -nE "__is_trivially_destructible\(capture\)|is_trivially_destructible<capture>" thirdparty/mrbind-pybind11/include/pybind11/pybind11.h || echo PATCH_NOT_APPLIED
+          echo "::endgroup::"
+          echo "::group::patched build"
+          find build/binds_python -name '*.json' -delete 2>/dev/null || true
+          /usr/bin/time -o /tmp/tw -f '%e' bash -c "$MK >/tmp/patched.log 2>&1" || { echo PATCHED_FAILED; tail -40 /tmp/patched.log; exit 1; }
+          echo "::endgroup::"
+          prof PATCHED
 
       - name: Collect Timings
         run: ./scripts/devops/collect_timing_logs.sh linux-vcpkg-${{ matrix.arch }} ${{matrix.config}} "${{matrix.compiler}}"

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -206,17 +206,20 @@ jobs:
           MK="make -f scripts/mrbind/generate.mk MODE=none -B MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib"
           prof() {
             echo "AB $1 wall=$(cat /tmp/tw)s"
-            python3 scripts/ftt_aggregate.py build/binds_python | sed "s/^/AB $1 /"
-            python3 scripts/ftt_byname.py build/binds_python | grep -E "files=|^FTN cat |is_trivially_destructible<capture>" | sed "s/^/AB $1 /"
+            python3 scripts/ftt_byname.py build/binds_python | sed "s/^/AB $1 /"
           }
           echo "::group::baseline build"
           find build/binds_python -name '*.json' -delete 2>/dev/null || true
           /usr/bin/time -o /tmp/tw -f '%e' bash -c "$MK >/tmp/base.log 2>&1" || { echo BASE_FAILED; tail -40 /tmp/base.log; exit 1; }
           echo "::endgroup::"
           prof BASELINE
-          echo "::group::patch header"
-          sed -i 's/std::is_trivially_destructible<capture>::value/__is_trivially_destructible(capture)/' thirdparty/mrbind-pybind11/include/pybind11/pybind11.h
-          grep -nE "__is_trivially_destructible\(capture\)|is_trivially_destructible<capture>" thirdparty/mrbind-pybind11/include/pybind11/pybind11.h || echo PATCH_NOT_APPLIED
+          echo "::group::patch headers (stacked builtin traits)"
+          for t in is_trivially_destructible is_trivially_copyable is_destructible is_enum is_empty is_polymorphic is_abstract is_final is_aggregate; do
+            find thirdparty/mrbind-pybind11/include -name '*.h' -exec sed -i -E "s/std::${t}<([^<>;,]+)>::value/__${t}(\1)/g" {} +
+          done
+          echo "remaining un-swapped (nested-arg) usages of these traits:"
+          grep -rhoE "std::(is_trivially_destructible|is_trivially_copyable|is_destructible|is_enum|is_empty|is_polymorphic|is_abstract|is_final|is_aggregate)<[^;]*>::value" thirdparty/mrbind-pybind11/include | wc -l
+          grep -rn "__is_trivially_destructible(capture)" thirdparty/mrbind-pybind11/include/pybind11/pybind11.h || echo PATCH_NOT_APPLIED
           echo "::endgroup::"
           echo "::group::patched build"
           find build/binds_python -name '*.json' -delete 2>/dev/null || true

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -186,11 +186,25 @@ jobs:
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | llvm-cxxfilt
 
+      # EXPERIMENT: profile WHICH templates dominate instantiation in the bindings compile.
+      # -ftime-trace on the compiler only (not the mrbind parser); per-template aggregation
+      # below classifies the instantiation time as MeshLib (MR::) vs libstdc++ (std::) vs
+      # pybind11, to verify what actually drives the Linux instantiation cost.
+      - name: ftn enable -ftime-trace
+        if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
+        run: echo '-ftime-trace' >> scripts/mrbind/compiler_only_flags.txt
+
       - name: Generate and build Python bindings
         if: ${{ inputs.mrbind }}
         env:
           CXX: ${{ matrix.cxx-compiler }}
         run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin CXX_FOR_BINDINGS=/usr/bin/clang++ DEPS_BASE_DIR=/opt/vcpkg_installed/${{ matrix.arch }}-linux-meshlib
+
+      - name: ftn aggregate per-template instantiation
+        if: ${{ inputs.mrbind && matrix.arch == 'x64' && matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
+        run: |
+          echo "FTN_PLATFORM=linux-vcpkg-x64-clang21"
+          python3 scripts/ftt_byname.py build/binds_python
 
       - name: Collect Timings
         run: ./scripts/devops/collect_timing_logs.sh linux-vcpkg-${{ matrix.arch }} ${{matrix.config}} "${{matrix.compiler}}"

--- a/scripts/ftt_byname.py
+++ b/scripts/ftt_byname.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Aggregate clang -ftime-trace InstantiateClass/InstantiateFunction events by template
+# name across all JSON files in a dir, to see WHICH templates dominate instantiation
+# (MeshLib types vs libstdc++ std::* vs pybind11 wrappers).
+import sys, json, glob, os, collections
+d = sys.argv[1] if len(sys.argv) > 1 else "."
+byname = collections.defaultdict(float)
+bycat = collections.defaultdict(float)
+nfiles = 0; total = 0.0
+
+def cat(detail):
+    for key in ("pybind11", "std::", "tl::expected", "phmap", "boost", "Eigen", "fmt::", "MR::"):
+        if key in detail:
+            return key
+    return "other"
+
+for f in glob.glob(os.path.join(d, "**", "*.json"), recursive=True):
+    try:
+        j = json.load(open(f, encoding="utf-8", errors="ignore"))
+    except Exception:
+        continue
+    ev = j.get("traceEvents")
+    if not ev:
+        continue
+    nfiles += 1
+    for e in ev:
+        if e.get("ph") == "X" and e.get("name") in ("InstantiateClass", "InstantiateFunction"):
+            dur = e.get("dur", 0)
+            det = (e.get("args") or {}).get("detail", "?")
+            byname[det] += dur; total += dur; bycat[cat(det)] += dur
+
+if total == 0:
+    print("FTN no instantiation events found"); sys.exit(0)
+print(f"FTN files={nfiles} total_instantiation_dur={total/1e6:.0f}s (nested events double-count)")
+print("FTN --- by category (share of instantiation time) ---")
+for k, v in sorted(bycat.items(), key=lambda x: -x[1]):
+    print(f"FTN cat {k}: {v/1e6:.0f}s ({100*v/total:.0f}%)")
+print("FTN --- top 30 instantiations by total dur ---")
+for det, v in sorted(byname.items(), key=lambda x: -x[1])[:30]:
+    print(f"FTN {v/1e6:7.1f}s  {det[:140]}")


### PR DESCRIPTION
## Experiment — not for merge

Verify **what actually dominates template instantiation** in the Python-bindings compile, to explain why the Linux+vcpkg bindings build does ~1.4× the compile work of the Windows build (same EPYC hardware, both ~98% core-utilized).

### Background

A clean `-ftime-trace` + core-occupancy run showed the Linux bindings compile spends its extra time mostly in **template instantiation** (`InstantiateFunction` +544 s, `InstantiateClass` +346 s vs Windows). MeshLib has **no explicit template instantiations / `extern template`** in its compile path (the 140 `MR_BIND_TEMPLATE` uses are mrbind *parser* hints only), so every binding TU instantiates implicitly on both platforms.

### What this measures

Compiles the bindings with `-ftime-trace` (compiler-only flag, not the mrbind parser) on the **vcpkg x64 Release, Clang 21** job, then aggregates the `InstantiateClass`/`InstantiateFunction` events **by template name** and classifies them as **MeshLib (`MR::`)** vs **libstdc++ (`std::`)** vs **pybind11** vs other.

### Why it matters

- If `std::*` dominates → it's libstdc++ template weight (hard to change).
- If `MR::*` dominates → MeshLib types that could be **explicitly instantiated + exported** once (and `extern template`-declared in the bindings) to stop re-instantiating them in all 36 fragments — a concrete speedup lever.
- If pybind11 dominates → the binding generation itself.

CI scoped to **linux-vcpkg only** (other platforms disabled via labels). Clang 21 in the Rocky 8 image (production toolchain, no image change).
