### PR TITLE
PlanarTriangulation: decouple SweepLineQueue from Contours2f

### DIFF
--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -957,8 +957,9 @@ void SweepLineQueue::initMeshByContours_( const std::vector<int>& contourSizes )
     {
         if ( contSize > 3 )
         {
+            // allocate input vertices; their coordinates are set by precisePredicates in the same order
             for ( int i = 0; i + 1 < contSize; ++i )
-                tp_.addVertId();
+                (void)tp_.addVertId();
         }
     }
 

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -46,6 +46,8 @@ struct SweepLinePredicates
     // orientation of b around pivot relative to the direction the sweep arrives from
     // (i.e. ccw with the first point placed far behind pivot, opposite to the sweep)
     std::function<bool( VertId b, VertId pivot )> ccwFromBehind;
+    // store the position of input vertex v, identified by its (contourId, pointId) in the source contours
+    std::function<void( VertId v, int contourId, int pointId )> addInputPoint;
     // compute and store the position of intersection vertex v of segments (a,b) and (c,d)
     std::function<void( VertId v, VertId a, VertId b, VertId c, VertId d )> addIntersectionPoint;
     // position of vertex v in the output mesh
@@ -102,16 +104,12 @@ static SweepLinePredicates precisePredicates( const Contours2f& contours )
         base.x -= 10000; // far behind pivot along -X, matching the historical sweep reference
         return MR::ccw( { PreciseVertCoords2{ VertId{}, base }, { b, ( *pts )[b] }, { pivot, ( *pts )[pivot] } } );
     };
-    // ingest input vertex positions in the same VertId order initMeshByContours_ assigns them
-    // (closedness already asserted, and pts reserved, in the box/pointsSize loop above)
-    VertId inV{ 0 };
-    for ( const auto& cont : contours )
+    // resolve an input vertex by (contourId, pointId); initMeshByContours_ drives the order, so
+    // `contours` only needs to outlive construction (every caller passes its own input by reference)
+    p.addInputPoint = [&contours, pts, toInt] ( VertId v, int contourId, int pointId )
     {
-        if ( cont.size() <= 3 )
-            continue;
-        for ( int i = 0; i + 1 < int( cont.size() ); ++i )
-            pts->autoResizeSet( inV++, toInt( cont[i] ) );
-    }
+        pts->autoResizeSet( v, toInt( contours[contourId][pointId] ) );
+    };
     p.addIntersectionPoint = [pts] ( VertId v, VertId a, VertId b, VertId c, VertId d )
     {
         pts->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( ( *pts )[a], ( *pts )[b], ( *pts )[c], ( *pts )[d] ) );
@@ -953,13 +951,15 @@ void SweepLineQueue::checkIntersection_( int i )
 void SweepLineQueue::initMeshByContours_( const std::vector<int>& contourSizes )
 {
     MR_TIMER;
-    for ( int contSize : contourSizes )
+    for ( int contourId = 0; contourId < int( contourSizes.size() ); ++contourId )
     {
-        if ( contSize > 3 )
+        if ( contourSizes[contourId] > 3 )
         {
-            // allocate input vertices; their coordinates are set by precisePredicates in the same order
-            for ( int i = 0; i + 1 < contSize; ++i )
-                (void)tp_.addVertId();
+            for ( int pointId = 0; pointId + 1 < contourSizes[contourId]; ++pointId )
+            {
+                VertId v = tp_.addVertId();
+                predicates_.addInputPoint( v, contourId, pointId );
+            }
         }
     }
 

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -46,8 +46,6 @@ struct SweepLinePredicates
     // orientation of b around pivot relative to the direction the sweep arrives from
     // (i.e. ccw with the first point placed far behind pivot, opposite to the sweep)
     std::function<bool( VertId b, VertId pivot )> ccwFromBehind;
-    // store the position of input vertex v taken from its source coordinate
-    std::function<void( VertId v, const Vector2f& coord )> addInputPoint;
     // compute and store the position of intersection vertex v of segments (a,b) and (c,d)
     std::function<void( VertId v, VertId a, VertId b, VertId c, VertId d )> addIntersectionPoint;
     // position of vertex v in the output mesh
@@ -104,10 +102,16 @@ static SweepLinePredicates precisePredicates( const Contours2f& contours )
         base.x -= 10000; // far behind pivot along -X, matching the historical sweep reference
         return MR::ccw( { PreciseVertCoords2{ VertId{}, base }, { b, ( *pts )[b] }, { pivot, ( *pts )[pivot] } } );
     };
-    p.addInputPoint = [pts, toInt] ( VertId v, const Vector2f& coord )
+    // ingest input vertex positions in the same VertId order initMeshByContours_ assigns them
+    // (closedness already asserted, and pts reserved, in the box/pointsSize loop above)
+    VertId inV{ 0 };
+    for ( const auto& cont : contours )
     {
-        pts->autoResizeSet( v, toInt( coord ) );
-    };
+        if ( cont.size() <= 3 )
+            continue;
+        for ( int i = 0; i + 1 < int( cont.size() ); ++i )
+            pts->autoResizeSet( inV++, toInt( cont[i] ) );
+    }
     p.addIntersectionPoint = [pts] ( VertId v, VertId a, VertId b, VertId c, VertId d )
     {
         pts->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( ( *pts )[a], ( *pts )[b], ( *pts )[c], ( *pts )[d] ) );
@@ -117,6 +121,15 @@ static SweepLinePredicates precisePredicates( const Contours2f& contours )
         return to3dim( toFloat( ( *pts )[v] ) );
     };
     return p;
+}
+
+// per-contour vertex counts; lets the queue build the initial edge loops independently of coordinate dimension
+static std::vector<int> getContourSizes( const Contours2f& contours )
+{
+    std::vector<int> sizes( contours.size() );
+    for ( int i = 0; i < int( contours.size() ); ++i )
+        sizes[i] = int( contours[i].size() );
+    return sizes;
 }
 
 int findClosestToFront( const MeshTopology& tp, const SweepLinePredicates& predicates,
@@ -214,7 +227,7 @@ public:
     // constructor makes initial mesh which simply contain input contours as edges
     // if holesVertId is null - merge all vertices with same coordinates
     // otherwise only merge the ones with same initial vertId
-    SweepLineQueue( const Contours2f& contours, const SweepLineParams& params );
+    SweepLineQueue( SweepLinePredicates predicates, std::vector<int> contourSizes, const SweepLineParams& params );
 
     size_t vertSize() const { return tp_.vertSize(); }
     std::optional<Mesh> run( IntersectionsMap* interMap = nullptr );
@@ -231,7 +244,7 @@ private:
 
 // INITIALIZATION CLASS BLOCK
     // make base mesh only containing input contours as edge loops
-    void initMeshByContours_( const Contours2f& contours );
+    void initMeshByContours_( const std::vector<int>& contourSizes );
     // merge same points on base mesh
     void mergeSamePoints_( const HolesVertIds* holesVertId );
     void mergeSinglePare_( VertId unique, VertId same );
@@ -357,11 +370,11 @@ private:
     void checkIntersection_( int indexLower );
 };
 
-SweepLineQueue::SweepLineQueue( const Contours2f& contours, const SweepLineParams& params ) :
-    predicates_{ precisePredicates( contours ) },
+SweepLineQueue::SweepLineQueue( SweepLinePredicates predicates, std::vector<int> contourSizes, const SweepLineParams& params ) :
+    predicates_{ std::move( predicates ) },
     params_{ params }
 {
-    initMeshByContours_( contours );
+    initMeshByContours_( contourSizes );
     mergeSamePoints_( params.holesVertId );
     setupStartVertices_();
 }
@@ -422,11 +435,11 @@ void SweepLineQueue::injectIntersections( IntersectionsMap* interMap )
             mapVal.uOrg = tp_.org( inter.upper );
             mapVal.uDest = tp_.dest( inter.upper );
 
-            auto iP = to2dim( predicates_.point( inter.vId ) );
-            auto lO = to2dim( predicates_.point( mapVal.lOrg ) );
-            auto lD = to2dim( predicates_.point( mapVal.lDest ) );
-            auto uO = to2dim( predicates_.point( mapVal.uOrg ) );
-            auto uD = to2dim( predicates_.point( mapVal.uDest ) );
+            auto iP = predicates_.point( inter.vId );
+            auto lO = predicates_.point( mapVal.lOrg );
+            auto lD = predicates_.point( mapVal.lDest );
+            auto uO = predicates_.point( mapVal.uOrg );
+            auto uD = predicates_.point( mapVal.uDest );
             auto lVec = ( lD - lO );
             auto uVec = ( uD - uO );
             auto lVecLSq = lVec.lengthSq();
@@ -937,34 +950,30 @@ void SweepLineQueue::checkIntersection_( int i )
     activeSweepEdges_[i + 1].lowerInfo.interVertId = interInfo.vId;
 }
 
-void SweepLineQueue::initMeshByContours_( const Contours2f& contours )
+void SweepLineQueue::initMeshByContours_( const std::vector<int>& contourSizes )
 {
     MR_TIMER;
-    for ( const auto& c : contours )
+    for ( int contSize : contourSizes )
     {
-        if ( c.size() > 3 )
+        if ( contSize > 3 )
         {
-            assert( c.front() == c.back() );
-            for ( int i = 0; i + 1 < c.size(); ++i )
-            {
-                VertId v = tp_.addVertId();
-                predicates_.addInputPoint( v, c[i] );
-            }
+            for ( int i = 0; i + 1 < contSize; ++i )
+                tp_.addVertId();
         }
     }
 
     int boundId = -1;
     if ( params_.outBoundaries )
-        params_.outBoundaries->resize( contours.size() );
+        params_.outBoundaries->resize( contourSizes.size() );
 
     int firstVert = 0;
-    for ( const auto& c : contours )
+    for ( int contSize : contourSizes )
     {
         ++boundId;
-        if ( c.size() <= 3 )
+        if ( contSize <= 3 )
             continue;
 
-        int size = int( c.size() ) - 1;
+        int size = contSize - 1;
 
         if ( params_.outBoundaries )
             ( *params_.outBoundaries )[boundId].resize( size );
@@ -1315,7 +1324,7 @@ HolesVertIds findHoleVertIdsByHoleEdges( const MeshTopology& tp, const std::vect
 
 Mesh getOutlineMesh( const Contours2f& conts, IntersectionsMap* interMap /*= nullptr */, const BaseOutlineParameters& params )
 {
-    SweepLineQueue triangulator( conts, { nullptr, false, params.innerType, true, params.allowMerge } );
+    SweepLineQueue triangulator( precisePredicates( conts ), getContourSizes( conts ), { nullptr, false, params.innerType, true, params.allowMerge } );
 
     if ( interMap )
         interMap->shift = triangulator.vertSize();
@@ -1386,7 +1395,7 @@ Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVe
 {
     if ( contours.empty() )
         return {};
-    SweepLineQueue triangulator( contours, { holeVertsIds, false, WindingMode::NonZero } );
+    SweepLineQueue triangulator( precisePredicates( contours ), getContourSizes( contours ), { holeVertsIds, false, WindingMode::NonZero } );
     auto res = triangulator.run();
     assert( res );
     if ( res )
@@ -1405,7 +1414,7 @@ std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours, con
 {
     if ( contours.empty() )
         return Mesh();
-    SweepLineQueue triangulator( contours, { holeVertsIds, true, WindingMode::NonZero, false, true, outBoundaries } );
+    SweepLineQueue triangulator( precisePredicates( contours ), getContourSizes( contours ), { holeVertsIds, true, WindingMode::NonZero, false, true, outBoundaries } );
     return triangulator.run();
 }
 


### PR DESCRIPTION
Next step after #6294 (injectable sweep-line predicates) toward triangulating in input mesh space without a projection round-trip.

`SweepLineQueue` no longer takes `Contours2f` directly:
- constructed from an injected `SweepLinePredicates` plus per-contour vertex counts;
- input-point ingestion moved into the predicate factory;
- intersection-ratio math computed in 3D — identical for the default predicates, which return z = 0.

Pure refactor: the 2D entry points build the same precise predicates, so triangulation output is unchanged. This isolates the coordinate representation so a later `meshSpacePredicates` can feed the same sweep-line from the input mesh's own 3D coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
