### PR TITLE
CI: retry collect_ci_stats and report API errors clearly

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -398,7 +398,7 @@ jobs:
           GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
           GIT_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 scripts/devops/collect_ci_stats.py
+        run: bash scripts/retry.sh -- python3 scripts/devops/collect_ci_stats.py
 
   update-artifacts:
     timeout-minutes: 15

--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -398,7 +398,7 @@ jobs:
           GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
           GIT_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash scripts/retry.sh -- python3 scripts/devops/collect_ci_stats.py
+        run: python3 scripts/devops/collect_ci_stats.py
 
   update-artifacts:
     timeout-minutes: 15

--- a/scripts/devops/collect_ci_stats.py
+++ b/scripts/devops/collect_ci_stats.py
@@ -95,11 +95,15 @@ def parse_jobs(jobs: List[dict]):
     ]
 
 def fetch_jobs(repo: str, run_id: str):
-    return requests.get(f'https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs', headers={
+    resp = requests.get(f'https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs', headers={
         'Accept': 'application/vnd.github.v3+json',
         'Authorization': f'Bearer {os.environ.get("GITHUB_TOKEN")}',
         'X-GitHub-Api-Version': '2022-11-28',
     })
+    # Report a clear HTTP error (rate limit, auth, transient 5xx) and exit non-zero
+    # instead of a later KeyError on resp.json()['jobs']; this also lets retry.sh retry.
+    resp.raise_for_status()
+    return resp
 
 def sign_api_request(url, method, headers, body, region, service):
     # Use the credentials from the assumed role

--- a/scripts/devops/collect_ci_stats.py
+++ b/scripts/devops/collect_ci_stats.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import os
 import pprint
+import time
 from pathlib import Path
 from typing import List
 
@@ -94,16 +95,24 @@ def parse_jobs(jobs: List[dict]):
         if job is not None
     ]
 
-def fetch_jobs(repo: str, run_id: str):
-    resp = requests.get(f'https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs', headers={
+def fetch_jobs(repo: str, run_id: str, attempts=3, cooldown=30):
+    url = f'https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs'
+    headers = {
         'Accept': 'application/vnd.github.v3+json',
         'Authorization': f'Bearer {os.environ.get("GITHUB_TOKEN")}',
         'X-GitHub-Api-Version': '2022-11-28',
-    })
-    # Report a clear HTTP error (rate limit, auth, transient 5xx) and exit non-zero
-    # instead of a later KeyError on resp.json()['jobs']; this also lets retry.sh retry.
-    resp.raise_for_status()
-    return resp
+    }
+    for attempt in range(1, attempts + 1):
+        try:
+            resp = requests.get(url, headers=headers)
+        except requests.exceptions.RequestException as e:
+            if attempt == attempts:
+                raise
+            print(f'fetch_jobs: attempt {attempt}/{attempts} failed ({e}); retrying in {cooldown}s...')
+            time.sleep(cooldown)
+            continue
+        resp.raise_for_status()
+        return resp
 
 def sign_api_request(url, method, headers, body, region, service):
     # Use the credentials from the assumed role


### PR DESCRIPTION
## Problem

The `collect-stats` job fails intermittently with:

```
Traceback (most recent call last):
  File "scripts/devops/collect_ci_stats.py", line 136, in <module>
    'jobs':        parse_jobs(resp.json()['jobs']),
KeyError: 'jobs'
```

`fetch_jobs()` indexes `resp.json()['jobs']` without checking the HTTP status. When the GitHub jobs API returns a non-200 body (auth failure, server error, transient network hiccup), there is no `jobs` key, so the real cause is masked by an opaque `KeyError`.

## Fix

`fetch_jobs()` now handles failures explicitly:

- **Transient network errors** (connection reset, timeout, DNS) are retried — a loop around `requests.get` catches `requests.exceptions.RequestException`, retrying 3 times with a 30s cooldown before giving up.
- **Genuine HTTP errors** (auth failure, server errors) fail fast — `resp.raise_for_status()` sits outside the retry loop, so an error response is reported immediately with a clear message instead of being blindly retried or surfacing later as `KeyError: 'jobs'`.

The job is best-effort (`continue-on-error: true`), so this does not change merge gating; it just makes the telemetry resilient to flaky network calls and gives a readable error when the API genuinely fails.

## CI scope

Touches only the stats-collection script — no platform build output is affected. Disabled all build platforms except ubuntu-x64, which is kept enabled so the `collect-stats` job has real jobs/artifacts to exercise the change against.
