### PR TITLE
MRCuda: rename RuntimeInfo to DeviceInfo; report GPU name and total memory

### DIFF
--- a/source/MRCuda/MRCudaBasic.cpp
+++ b/source/MRCuda/MRCudaBasic.cpp
@@ -13,22 +13,28 @@ namespace MR
 namespace Cuda
 {
 
-Expected<RuntimeInfo> getRuntimeInfo()
+Expected<DeviceInfo> getDeviceInfo()
 {
     int n;
     CUDA_RETURN_UNEXPECTED( cudaGetDeviceCount( &n ) );
     if ( n <= 0 )
         return MR::unexpected( "NVIDIA GPU error: no single device" );
 
-    RuntimeInfo res;
+    DeviceInfo res;
     CUDA_RETURN_UNEXPECTED( cudaDriverGetVersion( &res.driverVersion ) );
     CUDA_RETURN_UNEXPECTED( cudaRuntimeGetVersion( &res.runtimeVersion ) );
-    CUDA_RETURN_UNEXPECTED( cudaDeviceGetAttribute( &res.computeMajor, cudaDevAttrComputeCapabilityMajor, 0 ) );
-    CUDA_RETURN_UNEXPECTED( cudaDeviceGetAttribute( &res.computeMinor, cudaDevAttrComputeCapabilityMinor, 0 ) );
+
+    cudaDeviceProp prop;
+    CUDA_RETURN_UNEXPECTED( cudaGetDeviceProperties( &prop, 0 ) );
+    res.computeMajor = prop.major;
+    res.computeMinor = prop.minor;
+    res.totalGlobalMem = prop.totalGlobalMem;
+    res.name = prop.name;
+
     return res;
 }
 
-bool RuntimeInfo::fitForComputations() const
+bool DeviceInfo::fitForComputations() const
 {
     // according to https://en.wikipedia.org/wiki/CUDA Compute Capability (CUDA SDK support vs. Microarchitecture) table
     if ( runtimeVersion / 1000 >= 12 && computeMajor < 5 )
@@ -41,7 +47,7 @@ bool RuntimeInfo::fitForComputations() const
 
 bool isCudaAvailable( int* driverVersionOut, int* runtimeVersionOut, int* computeMajorOut, int* computeMinorOut )
 {
-     auto info = MR::Cuda::getRuntimeInfo();
+     auto info = MR::Cuda::getDeviceInfo();
      if ( !info )
          return false;
 

--- a/source/MRCuda/MRCudaBasic.h
+++ b/source/MRCuda/MRCudaBasic.h
@@ -11,12 +11,12 @@ namespace MR
 namespace Cuda
 {
 
-struct RuntimeInfo
+struct DeviceInfo
 {
-    /// maximum driver supported version
+    /// maximum CUDA version supported by the driver
     int driverVersion = 0;
 
-    /// current runtime version
+    /// application's CUDA version
     int runtimeVersion = 0;
 
     /// compute capability major version
@@ -25,12 +25,18 @@ struct RuntimeInfo
     /// compute capability minor version
     int computeMinor = 0;
 
+    /// global memory on device in bytes (not all is available for our process)
+    size_t totalGlobalMem = 0;
+
+    /// name of the device
+    std::string name;
+
     /// returns true if all versions pass the checks
     [[nodiscard]] MRCUDA_API bool fitForComputations() const;
 };
 
 /// Returns an error if CUDA is not available
-MRCUDA_API Expected<RuntimeInfo> getRuntimeInfo();
+MRCUDA_API Expected<DeviceInfo> getDeviceInfo();
 
 /// Returns true if Cuda is present on this GPU
 /// optional out maximum driver supported version

--- a/source/MRTestCuda/MRTestCuda.cpp
+++ b/source/MRTestCuda/MRTestCuda.cpp
@@ -8,7 +8,7 @@ int main( int argc, char** argv )
 {
     MR::setupLoggerByDefault();
 
-    auto info = MR::Cuda::getRuntimeInfo();
+    auto info = MR::Cuda::getDeviceInfo();
     if ( !info )
     {
         spdlog::critical( "CUDA error: {}", info.error() );


### PR DESCRIPTION
### Summary

Extends the information that `MRCuda` reports about the local GPU, and renames the API to better reflect that it describes the *device* rather than just runtime versions.

### Changes

- Renamed `Cuda::RuntimeInfo` → `Cuda::DeviceInfo` and `Cuda::getRuntimeInfo()` → `Cuda::getDeviceInfo()`.
- Added two fields to the struct:
  - `size_t totalGlobalMem` — total global memory on the device in bytes (not all of it is available to our process).
  - `std::string name` — device name.
- These fields plus the compute capability are now read from a single `cudaGetDeviceProperties()` call, replacing the separate `cudaDeviceGetAttribute()` calls.
- Clarified the doc comments: `driverVersion` is the maximum CUDA version supported by the driver, `runtimeVersion` is the application's CUDA version.
- Updated callers (`isCudaAvailable`, `MRTestCuda`) to the renamed function.
