### PR TITLE
Reduce PLY comment telemetry noise

### DIFF
--- a/source/MRMesh/MRPly.cpp
+++ b/source/MRMesh/MRPly.cpp
@@ -20,12 +20,17 @@ namespace
 bool ignoreComment( const std::string & comment )
 {
     return comment == "File generated"
+        || comment == "-"
         || ( comment.starts_with( "Created " ) && comment.size() > 13 && comment[10] == '/' && comment[13] == '/' ) // e.g. 'Created 26/12/2019 10:15'
         || ( comment.starts_with( "Created 20" ) && comment.size() > 12 && comment[12] == '-' ) // e.g. 'Created 2025-12-19T22:09:05'
         || comment.starts_with( "#" )
+        || comment.starts_with( "--" ) // e.g. reconstruction CLI args '--depth 13', '--in /tmp/...ply'
+        || comment.ends_with( ".jpg" ) || comment.ends_with( ".jpeg" ) || comment.ends_with( ".png" ) // source image file lists
         || comment.starts_with( "Coordinate Orientation: " )
+        || comment.starts_with( "dataType " )
         || comment.starts_with( "Density: " )
         || comment.starts_with( "density: " )
+        || comment.starts_with( "epsg " ) // coordinate reference system code
         || comment.starts_with( "FOV: " )
         || comment.starts_with( "geotag " )
         || comment.starts_with( "maxx " )
@@ -48,6 +53,7 @@ bool ignoreComment( const std::string & comment )
         || comment.starts_with( "shiftx " )
         || comment.starts_with( "shifty " )
         || comment.starts_with( "shiftz " )
+        || comment.starts_with( "source " ) // e.g. 'source PortalCam' - per-instance capture metadata
         || comment.starts_with( "Timestamp: " ) // e.g. 'Timestamp: 2026-02-06 15:12:26'
         || comment.starts_with( "unit = " )
         || comment.starts_with( "Unit: " )


### PR DESCRIPTION
## Summary

`ignoreComment()` decides which PLY header `comment` lines are dropped before the rest are sent to telemetry, so that only software/version identifiers are recorded. Reviewing the collected data showed several per-instance / meaningless comment patterns still reaching telemetry. This adds skip rules for them:

- **Source-image file lists** — comments ending in `.jpg` / `.jpeg` / `.png` (e.g. photogrammetry tools dumping their matched-image list, one comment per image).
- **Reconstruction CLI arguments** — comments starting with `--` (e.g. `--depth 13`, `--trim 10.000000`, `--in /tmp/...ply` from Poisson reconstruction runs). The tool identity is still kept via its own comment (`Running Screened Poisson Reconstruction (Version 8.0)`).
- **Lone `-`**, **`epsg <code>`** (coordinate reference system), **`source <device>`** and **`dataType <device>`** (per-instance capture metadata).

## Impact

Measured against current telemetry (non-registered users, version >= `MI_2.5.8.125`):

| Pattern | Distinct values | Actions |
|---|---:|---:|
| `.jpg` / `.jpeg` / `.png` image lists | 208 | 208 |
| `--` CLI args | 11 | 45 |
| `epsg ` | 1 | 24 |
| `source ` | 3 | 24 |
| `dataType ` | 1 | 8 |
| lone `-` | 1 | 8 |
| **total dropped** | **225** | **317** |

Distinct comment values reaching telemetry drop from 323 to 98, while every software/version line is preserved.

## Notes

Build-dated software lines are intentionally kept (e.g. `Created by CloudCompare v2.14.alpha (Apr 17 2025)`, `Created in Blender version 5.1.1`) — only pure per-instance data is dropped, consistent with the STL header handling.
