### PR TITLE
detectTunnelFaces: improvements and classification

### DIFF
--- a/source/MRMesh/MRTunnelDetector.cpp
+++ b/source/MRMesh/MRTunnelDetector.cpp
@@ -458,40 +458,46 @@ Expected<FaceBitSet> detectTunnelFaces( const MeshPart & mp, const DetectTunnelS
         auto basisTunnels = d.detect( MR::subprogress( settings.progress, initialProgress, targetProgress ) );
         if ( !basisTunnels.has_value() )
             return unexpected( basisTunnels.error() );
+        auto& allLoops = *basisTunnels;
+        const auto numBasisTunnels = allLoops.size();
+
         if ( settings.buildCoLoops )
         {
-            ParallelFor( *basisTunnels, [&]( size_t i )
+            allLoops.resize( numBasisTunnels * 3 );
+            ParallelFor( size_t( 0 ), numBasisTunnels, [&]( size_t i )
             {
-                if ( auto maybeCoLoop = findSmallestMetricCoLoop( mp.mesh.topology, (*basisTunnels)[i], metric, &activeRegion ) )
-                    (*basisTunnels)[i] = std::move( maybeCoLoop.value() );
-                else
+                if ( auto maybeCoLoop = findSmallestMetricCoLoop( mp.mesh.topology, allLoops[i], metric, &activeRegion ) )
                 {
-                    assert( false );
-                    (*basisTunnels)[i].clear();
+                    // first co-loop is always from a distinct topology class than original loop
+                    allLoops[numBasisTunnels + i] = std::move( maybeCoLoop.value() );
+
+                    // second co-loop can be from the same topology class as original loop, but with smaller metric
+                    if ( maybeCoLoop = findSmallestMetricCoLoop( mp.mesh.topology, allLoops[numBasisTunnels + i], metric, &activeRegion ) )
+                        allLoops[2*numBasisTunnels + i] = std::move( maybeCoLoop.value() );
+                    else assert( false );
                 }
+                else assert( false );
             } );
-            std::erase_if( *basisTunnels, [](const auto& v) { return v.empty(); } );
+            std::erase_if( allLoops, [](const auto& v) { return v.empty(); } );
         }
 
-        const auto numBasisTunnels = basisTunnels->size();
-
         // sort loops by the sum of the given metric in ascending order
-        sortPathsByMetric( *basisTunnels, metric );
-        for ( int i = 0; i < basisTunnels->size(); ++i )
+        sortPathsByMetric( allLoops, metric );
+        for ( int i = 0; i < allLoops.size(); ++i )
         {
             // and skip too long loops by their euclidean length, and not by the given metric
-            if ( calcPathLength( (*basisTunnels)[i], mp.mesh ) > settings.maxTunnelLength )
+            if ( calcPathLength( (allLoops)[i], mp.mesh ) > settings.maxTunnelLength )
             {
-                basisTunnels->erase( basisTunnels->begin() + i, basisTunnels->end() );
+                allLoops.erase( allLoops.begin() + i, allLoops.end() );
                 break;
             }
         }
-        if ( basisTunnels->empty() )
+        if ( allLoops.empty() )
             break;
 
         tunnelVerts.set( 0_v, tunnelVerts.size(), false );
         int numSelectedTunnels = 0;
-        for ( const auto & t : *basisTunnels )
+        for ( const auto & t : allLoops )
         {
             bool touchAlreadySelectedTunnel = false;
             for ( EdgeId e : t )
@@ -526,13 +532,14 @@ Expected<FaceBitSet> detectTunnelFaces( const MeshPart & mp, const DetectTunnelS
             addLeftBand( mp.mesh.topology, t, tunnelFaces );
             activeRegion -= tunnelFaces; // reduce region
         }
-        assert( numSelectedTunnels > 0 );
         if ( !reportProgress( settings.progress, targetProgress + 0.01f ) )
             return unexpectedOperationCanceled();
 
         initialProgress = targetProgress + 0.01f;
         targetProgress = ( ( initialProgress  + 1.0f ) * 0.5f ) - 0.01f;
 
+        if ( numSelectedTunnels == 0 )
+            break;
         if ( numSelectedTunnels >= numBasisTunnels )
             break; // maximal not-intersection set of tunnels has been used
     }

--- a/source/MRMesh/MRTunnelDetector.cpp
+++ b/source/MRMesh/MRTunnelDetector.cpp
@@ -472,8 +472,8 @@ Expected<FaceBitSet> detectTunnelFaces( const MeshPart & mp, const DetectTunnelS
                     allLoops[numBasisTunnels + i] = std::move( maybeCoLoop.value() );
 
                     // second co-loop can be from the same topology class as original loop, but with smaller metric, so replace original loop
-                    if ( maybeCoLoop = findSmallestMetricCoLoop( mp.mesh.topology, allLoops[numBasisTunnels + i], metric, &activeRegion ) )
-                        allLoops[i] = std::move( maybeCoLoop.value() );
+                    if ( auto maybeCoLoop2 = findSmallestMetricCoLoop( mp.mesh.topology, allLoops[numBasisTunnels + i], metric, &activeRegion ) )
+                        allLoops[i] = std::move( maybeCoLoop2.value() );
                     else assert( false );
                 }
                 else assert( false );

--- a/source/MRMesh/MRTunnelDetector.cpp
+++ b/source/MRMesh/MRTunnelDetector.cpp
@@ -407,6 +407,33 @@ std::vector<EdgeLoop> findShortestEquivalentLoops( const MeshPart& mp, const Edg
     return findSmallestMetricEquivalentLoops( mp.mesh.topology, loop, edgeLengthMetric( mp.mesh ), mp.region );
 }
 
+bool isLoopOuter( const Mesh& mesh, const EdgeLoop& loop )
+{
+    assert( isEdgeLoop( mesh.topology, loop ) );
+    if ( loop.empty() )
+        return false;
+
+    Vector3f sumLenPos;
+    float sumLen = 0;
+    for ( EdgeId e : loop )
+    {
+        const auto elen = mesh.edgeLength( e );
+        sumLenPos += elen * mesh.edgeCenter( e );
+        sumLen += elen;
+    }
+    const Vector3f center = sumLenPos / sumLen;
+
+    float sumMetric = 0;
+    for ( EdgeId e : loop )
+    {
+        const auto elen = mesh.edgeLength( e );
+        const auto epos = mesh.edgeCenter( e );
+        const auto enorm = mesh.pseudonormal( e );
+        sumMetric += elen * dot( epos - center, enorm );
+    }
+    return sumMetric > 0;
+}
+
 Expected<FaceBitSet> detectTunnelFaces( const MeshPart & mp, const DetectTunnelSettings & settings )
 {
     MR_TIMER;
@@ -476,6 +503,11 @@ Expected<FaceBitSet> detectTunnelFaces( const MeshPart & mp, const DetectTunnelS
                 }
             }
             if ( touchAlreadySelectedTunnel )
+                continue;
+
+            if ( settings.loopType == TunnelLoopType::Outer && !isLoopOuter( mp.mesh, t ) )
+                continue;
+            if ( settings.loopType == TunnelLoopType::Inner && isLoopOuter( mp.mesh, t ) )
                 continue;
 
             if ( settings.buildCoLoops && settings.filterEquivalentCoLoops && numSelectedTunnels > 0 )

--- a/source/MRMesh/MRTunnelDetector.cpp
+++ b/source/MRMesh/MRTunnelDetector.cpp
@@ -463,17 +463,17 @@ Expected<FaceBitSet> detectTunnelFaces( const MeshPart & mp, const DetectTunnelS
 
         if ( settings.buildCoLoops )
         {
-            allLoops.resize( numBasisTunnels * 3 );
+            allLoops.resize( numBasisTunnels * 2 );
             ParallelFor( size_t( 0 ), numBasisTunnels, [&]( size_t i )
             {
                 if ( auto maybeCoLoop = findSmallestMetricCoLoop( mp.mesh.topology, allLoops[i], metric, &activeRegion ) )
                 {
-                    // first co-loop is always from a distinct topology class than original loop
+                    // first co-loop is always from a distinct topology class than original loop, so add co-loop in the list
                     allLoops[numBasisTunnels + i] = std::move( maybeCoLoop.value() );
 
-                    // second co-loop can be from the same topology class as original loop, but with smaller metric
+                    // second co-loop can be from the same topology class as original loop, but with smaller metric, so replace original loop
                     if ( maybeCoLoop = findSmallestMetricCoLoop( mp.mesh.topology, allLoops[numBasisTunnels + i], metric, &activeRegion ) )
-                        allLoops[2*numBasisTunnels + i] = std::move( maybeCoLoop.value() );
+                        allLoops[i] = std::move( maybeCoLoop.value() );
                     else assert( false );
                 }
                 else assert( false );
@@ -540,7 +540,7 @@ Expected<FaceBitSet> detectTunnelFaces( const MeshPart & mp, const DetectTunnelS
 
         if ( numSelectedTunnels == 0 )
             break;
-        if ( numSelectedTunnels >= numBasisTunnels )
+        if ( numSelectedTunnels >= numBasisTunnels && ( !settings.buildCoLoops || settings.filterEquivalentCoLoops ) )
             break; // maximal not-intersection set of tunnels has been used
     }
 

--- a/source/MRMesh/MRTunnelDetector.h
+++ b/source/MRMesh/MRTunnelDetector.h
@@ -39,6 +39,17 @@ MRMESH_API Expected<EdgeLoop> findShortestCoLoop( const MeshPart& mp, const Edge
 /// same as \ref findSmallestMetricEquivalentLoops with euclidean edge length metric
 [[nodiscard]] MRMESH_API std::vector<EdgeLoop> findShortestEquivalentLoops( const MeshPart& mp, const EdgeLoop& loop );
 
+/// returns true if the loop mostly surrounds a mesh (loop's geometrical center is located inside of mesh at an average loop's point),
+/// or false if the loop mostly surrounds a tunnel inside mesh (loop's geometrical center is located outside of mesh at an average loop's point)
+[[nodiscard]] MRMESH_API bool isLoopOuter( const Mesh& mesh, const EdgeLoop& loop );
+
+enum class TunnelLoopType
+{
+    Any,
+    Outer, ///< handle-like
+    Inner  ///< tunnel-like
+};
+
 struct DetectTunnelSettings
 {
     /// maximal euclidean length of tunnel loops to detect
@@ -61,6 +72,9 @@ struct DetectTunnelSettings
     /// if ( buildCoLoops ) then some tunnel loops can be equivalent (e.g. they cut the same handle twice),
     /// this option activates their filtering out, but it is very slow
     bool filterEquivalentCoLoops = false;
+
+    /// selects what kind of loops to return
+    TunnelLoopType loopType = TunnelLoopType::Any;
 
     /// to report algorithm progress and cancel from outside
     ProgressCallback progress;

--- a/test_python/test_fixTunnels.py
+++ b/test_python/test_fixTunnels.py
@@ -7,6 +7,7 @@ def test_fix_tunnels():
 
     settings = mrmesh.DetectTunnelSettings()
     settings.maxTunnelLength = 100500
+    settings.filterEquivalentCoLoops = True
     tunnelFaces = mrmesh.detectTunnelFaces(torus, settings)
 
     # one circle with 2-faces width


### PR DESCRIPTION
The function `detectTunnelFaces` changes:
1. In `buildCoLoops` mode, it finds two co-loops instead of one. Although a bit slower, it typically reduces finds a better solution and requires less global iterations.
2. It can classify the loops on Outer and Inner and return only one type of them.

Result for the case from #6302:

https://github.com/user-attachments/assets/5abe094a-ba32-448f-9b3d-de0ba0049b4e

