### PR TITLE
[diagnostic] Build raw shim for patchelf 639 fixture (do not merge)

### DIFF
--- a/.github/workflows/patchelf-639-fixture.yml
+++ b/.github/workflows/patchelf-639-fixture.yml
@@ -1,0 +1,77 @@
+name: patchelf-639-fixture
+
+# Throwaway diagnostic (NOT for merge).
+#
+# Builds the raw libpybind11nonlimitedapi_meshlib_3.12.so in the
+# rockylinux8-vcpkg image (clang-21 / lld-21) - the exact toolchain that
+# produced the crashing layout in https://github.com/NixOS/patchelf/issues/639
+# (.init packed right after the program-header table). Standard clang/lld/bfd/
+# gold and the auditwheel-repaired PyPI wheel do NOT reproduce that layout, so
+# we need the genuine pre-packaging build output to hand to patchelf PR #652 as
+# a regression fixture and to confirm the fix on the real binary.
+#
+# The artifact uploaded here is the un-patchelf'd cmake output (before
+# auditwheel / linuxdeploy run their own --set-rpath).
+
+on:
+  push:
+    branches: [patchelf-639-shim-fixture]
+  workflow_dispatch:
+
+jobs:
+  build-shim:
+    runs-on: ubuntu-latest
+    container:
+      image: meshlib/meshlib-rockylinux8-vcpkg-x64:latest
+      options: --user root
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout mrbind-pybind11 submodule
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/thirdparty/mrbind-pybind11"
+          git submodule update --init --depth 1 thirdparty/mrbind-pybind11
+
+      - name: Toolchain info
+        run: |
+          CXX="$(command -v clang++ || command -v clang++-21)"
+          echo "CXX=$CXX"; "$CXX" --version
+          (ld.lld --version || ld.lld-21 --version) 2>/dev/null || true
+          python3.12 --version; which python3.12
+
+      - name: Build shim (clang-21 + lld, SUFFIX=meshlib, Python 3.12)
+        run: |
+          CXX="$(command -v clang++ || command -v clang++-21)"
+          cmake -G Ninja -S thirdparty/mrbind-pybind11/source/non_limited_api -B build-shim \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER="$CXX" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+            -DPython_EXECUTABLE=/usr/bin/python3.12 \
+            -DPYBIND11_NONLIMITEDAPI_SUFFIX=meshlib \
+            -DPYBIND11_NONLIMITEDAPI_PYTHON_MIN_VERSION_HEX=0x030800f0
+          cmake --build build-shim -j"$(nproc)"
+          echo "=== built ==="
+          find build-shim -name '*.so' -printf '%p (%s bytes)\n'
+
+      - name: Show layout (.init offset vs PHT is the #639 trigger signal)
+        run: |
+          shim="$(find build-shim -name 'libpybind11nonlimitedapi_meshlib_3.12.so' | head -1)"
+          echo "shim=$shim"
+          readelf -hW "$shim" | grep -iE 'program headers|entry point'
+          echo "--- program headers ---"
+          readelf -lW "$shim" | sed -n '/Program Headers/,/Section to Segment/p'
+          echo "--- key sections (.init should be near the PHT to trigger) ---"
+          readelf -SW "$shim" | awk 'NR<=5 || /\.(init|fini|note|plt|text|dynstr|dynsym|gnu\.hash)\b/'
+          readelf -dW "$shim" | grep -iE 'INIT|RUNPATH|RPATH' || true
+
+      - name: Upload raw shim
+        uses: actions/upload-artifact@v4
+        with:
+          name: shim-rockylinux8-clang21
+          path: |
+            build-shim/**/libpybind11nonlimitedapi_meshlib_3.12.so
+            build-shim/**/libpybind11nonlimitedapi_stubs.so
+          if-no-files-found: error

--- a/.github/workflows/patchelf-639-fixture.yml
+++ b/.github/workflows/patchelf-639-fixture.yml
@@ -2,18 +2,16 @@ name: patchelf-639-fixture
 
 # Throwaway diagnostic (NOT for merge).
 #
-# Reproduces the genuine crashing layout of libpybind11nonlimitedapi_meshlib_3.12.so
-# from https://github.com/NixOS/patchelf/issues/639 by running MeshLib's REAL
-# shim build (full build_source.sh + `make shims` via generate.mk) in the
-# rockylinux8-vcpkg image (clang-21/lld-21), with the
-# `-Wl,-z,separate-loadable-segments` workaround (generate.mk) reverted on this
-# branch. Standalone cmake builds and the auditwheel-repaired wheel do NOT
-# reproduce it; the real generate.mk link (-shared, -lMRPython, -lopenvdb
-# -lTKernel -ljsoncpp, libpython, -flto=thin -Oz -s) does.
+# The patchelf#639 crash needs the shim's .init packed right after the PHT.
+# Toolchain is unchanged since May (clang/lld 21.1.8), but the mrbind-pybind11
+# shim source (non_limited_api.cpp / .h) changed between the May submodule pin
+# (e5169301, in use when #639 reproduced) and current master (b747f677).
 #
-# Scoped to x86_64 + Python 3.12 to keep it cheap. Uploads the raw, un-patchelf'd
-# shim so it can verify patchelf PR #652 and serve as the missing regression
-# fixture.
+# This isolates that single variable: build the shim standalone (clang-21/lld)
+# from BOTH pins in the rockylinux8-vcpkg image and compare .init placement. If
+# the MAY source puts .init next to the PHT and current source doesn't, the shim
+# source change is what made the bug stop reproducing - and the MAY .so is the
+# triggering fixture.
 
 on:
   push:
@@ -21,82 +19,63 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-shim:
-    timeout-minutes: 90
+  shim-source-diff:
     runs-on: ubuntu-latest
     container:
       image: meshlib/meshlib-rockylinux8-vcpkg-x64:latest
       options: --user root
-    env:
-      CXX_BIND: /usr/bin/clang++
     steps:
-      - name: Work-around possible permission issues
-        shell: bash
+      - name: Toolchain info
         run: |
-          if test -d "$GITHUB_WORKSPACE" && test -n "$(find "$GITHUB_WORKSPACE" -user root)"; then
-            mv "$GITHUB_WORKSPACE" "${GITHUB_WORKSPACE}_${RANDOM}"
-            mkdir "$GITHUB_WORKSPACE"
-          fi
+          CXX="$(command -v clang++ || command -v clang++-21)"; echo "CXX=$CXX"; "$CXX" --version | head -1
+          (ld.lld --version || ld.lld-21 --version) 2>/dev/null | head -1 || true
+          python3.12 --version
 
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Checkout third-party submodules
+      - name: Build shim standalone for MAY vs NOW mrbind-pybind11 source
         run: |
-          export HOME=${RUNNER_TEMP}
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          for sm in imgui parallel-hashmap mrbind-pybind11 mrbind; do
-            git config --global --add safe.directory "$GITHUB_WORKSPACE/thirdparty/$sm"
-          done
-          git config --global --add safe.directory "$GITHUB_WORKSPACE/thirdparty/mrbind/deps/cppdecl"
-          bash scripts/retry.sh -- git submodule update --init --depth 1 \
-            thirdparty/imgui thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
-          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
+          set -e
+          CXX="$(command -v clang++ || command -v clang++-21)"
+          PYINC="$(python3.12 -c 'import sysconfig; print(sysconfig.get_path("include"))')"
+          LIBDIR="$(python3.12 -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')"
+          PYLIB="$LIBDIR/libpython3.12.so"
+          [ -e "$PYLIB" ] || PYLIB="$LIBDIR/$(python3.12 -c 'import sysconfig; print(sysconfig.get_config_var("LDLIBRARY"))')"
+          mkdir -p /tmp/out
 
-      - name: Confirm workaround is reverted
-        run: grep -n "separate-loadable-segments" scripts/mrbind/generate.mk || echo "workaround line not active (good)"
+          init_off() { readelf -SW "$1" | awk '{for(i=1;i<=NF;i++) if($i==".init") print $(i+2)}'; }
 
-      - name: Build MeshLib (full, Release) - needed for libMRPython.so + stub
-        run: ./scripts/build_source.sh
-        env:
-          MESHLIB_BUILD_RELEASE: "ON"
-          MESHLIB_BUILD_DEBUG: "OFF"
-          CMAKE_CXX_COMPILER: /usr/bin/clang++
-          MR_CMAKE_OPTIONS: >
-            -DMRVIEWER_NO_GTK=ON
-            -DMR_PCH_USE_EXTRA_HEADERS=ON
-            -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-11/root/usr/bin/g++
+          build_one() {
+            tag="$1"; pin="$2"
+            git clone -q https://github.com/MeshInspector/mrbind-pybind11 "/tmp/mp-$tag"
+            git -C "/tmp/mp-$tag" checkout -q "$pin"
+            cmake -G Ninja -S "/tmp/mp-$tag/source/non_limited_api" -B "/tmp/b-$tag" \
+              -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER="$CXX" \
+              -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+              -DPython_EXECUTABLE=/usr/bin/python3.12 -DPython_INCLUDE_DIR="$PYINC" -DPython_LIBRARY="$PYLIB" \
+              -DPYBIND11_NONLIMITEDAPI_SUFFIX=meshlib -DPYBIND11_NONLIMITEDAPI_PYTHON_MIN_VERSION_HEX=0x030800f0 >/dev/null
+            cmake --build "/tmp/b-$tag" -j"$(nproc)" >/dev/null
+            so="$(find "/tmp/b-$tag" -name 'libpybind11nonlimitedapi_meshlib_3.12.so' | head -1)"
+            cp "$so" "/tmp/out/shim-$tag.so"
+            echo "================ $tag  ($pin) ================"
+            echo "  .init sh_addr = $(init_off "$so")   (PHDR ends ~0x230)"
+            echo "  -- LOAD/PHDR segments --"
+            readelf -lW "$so" | awk '/Type +Offset/{p=1} p&&/LOAD|PHDR/{print "   "$0} /Section to Segment/{p=0}'
+            echo "  -- section order (first executable run) --"
+            readelf -lW "$so" | awk '/02 +/{print "   exec-seg:",$0}' | head -1
+            echo "  -- key sections --"
+            readelf -SW "$so" | awk '/\.(init|note|plt|text|dynstr|dynsym)\b/{print "   "$0}' | head
+            echo
+          }
 
-      - name: Install uv (Python version management)
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+          build_one MAY e51693015e81b3fc927f1b442c024b62e35996b8
+          build_one NOW b747f677ab30ec62aca834c78383cd92c90e6b32
 
-      - name: Build the shim via generate.mk (the real link path) for Python 3.12
-        run: |
-          export PKG_CONFIG_PATH=$(uv run --python 3.12 "${PWD}/scripts/wheel/get_sysconfig_var.py" LIBPC)
-          make shims -f scripts/mrbind/generate.mk -B --trace \
-            FOR_WHEEL=1 \
-            CXX_FOR_ABI=/usr/bin/clang++ \
-            CXX_FOR_BINDINGS=/usr/bin/clang++ \
-            DEPS_BASE_DIR=${VCPKG_INSTALLED_DIR}/${VCPKG_TRIPLET} \
-            PYTHON_VERSIONS=3.12
+          echo "==================== SUMMARY ===================="
+          for t in MAY NOW; do echo "  $t: .init = $(init_off "/tmp/out/shim-$t.so")"; done
+          echo "(low .init, just past the PHT ~0x230, = #639-triggering layout)"
 
-      - name: Locate + dump layout (.init offset vs PHT is the #639 signal)
-        run: |
-          shim="$(find . -name 'libpybind11nonlimitedapi_meshlib_3.12.so' | head -1)"
-          echo "shim=$shim"; ls -l "$shim"
-          readelf -hW "$shim" | grep -iE 'program headers|entry point'
-          echo "--- program headers ---"
-          readelf -lW "$shim" | sed -n '/Program Headers/,/Section to Segment/p'
-          echo "--- key sections (.init near the PHT => triggers) ---"
-          readelf -SW "$shim" | awk 'NR<=5 || /\.(init|fini|note|plt|text|dynstr|dynsym|gnu\.hash)\b/'
-          readelf -dW "$shim" | grep -iE 'INIT|RUNPATH|RPATH|NEEDED' || true
-          mkdir -p /tmp/out && cp "$shim" /tmp/out/
-          stub="$(find . -name 'libpybind11nonlimitedapi_stubs*.so' | head -1)"
-          [ -n "$stub" ] && cp "$stub" /tmp/out/ || true
-
-      - name: Upload raw (un-patchelf'd) shim
+      - name: Upload both shims
         uses: actions/upload-artifact@v4
         with:
-          name: shim-real-rockylinux8-clang21-no-workaround
+          name: shim-source-may-vs-now
           path: /tmp/out/*.so
           if-no-files-found: error

--- a/.github/workflows/patchelf-639-fixture.yml
+++ b/.github/workflows/patchelf-639-fixture.yml
@@ -44,12 +44,22 @@ jobs:
       - name: Build shim (clang-21 + lld, SUFFIX=meshlib, Python 3.12)
         run: |
           CXX="$(command -v clang++ || command -v clang++-21)"
+          PYINC="$(python3.12 -c 'import sysconfig; print(sysconfig.get_path("include"))')"
+          LIBDIR="$(python3.12 -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')"
+          PYLIB="$LIBDIR/libpython3.12.so"
+          if [ ! -e "$PYLIB" ]; then
+            PYLIB="$LIBDIR/$(python3.12 -c 'import sysconfig; print(sysconfig.get_config_var("LDLIBRARY"))')"
+          fi
+          echo "PYINC=$PYINC"; ls -l "$PYINC/Python.h"
+          echo "PYLIB=$PYLIB"; ls -l "$PYLIB"
           cmake -G Ninja -S thirdparty/mrbind-pybind11/source/non_limited_api -B build-shim \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_COMPILER="$CXX" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" \
             -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
             -DPython_EXECUTABLE=/usr/bin/python3.12 \
+            -DPython_INCLUDE_DIR="$PYINC" \
+            -DPython_LIBRARY="$PYLIB" \
             -DPYBIND11_NONLIMITEDAPI_SUFFIX=meshlib \
             -DPYBIND11_NONLIMITEDAPI_PYTHON_MIN_VERSION_HEX=0x030800f0
           cmake --build build-shim -j"$(nproc)"

--- a/.github/workflows/patchelf-639-fixture.yml
+++ b/.github/workflows/patchelf-639-fixture.yml
@@ -52,11 +52,15 @@ jobs:
           fi
           echo "PYINC=$PYINC"; ls -l "$PYINC/Python.h"
           echo "PYLIB=$PYLIB"; ls -l "$PYLIB"
+          # Mirror generate.mk's release shim flags (-Oz -flto=thin -s, lld),
+          # but WITHOUT the -Wl,-z,separate-loadable-segments workaround that
+          # generate.mk:731 added for #639 - we want the pre-workaround layout.
           cmake -G Ninja -S thirdparty/mrbind-pybind11/source/non_limited_api -B build-shim \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_COMPILER="$CXX" \
-            -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" \
-            -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+            -DCMAKE_CXX_FLAGS="-Oz -flto=thin -DNDEBUG" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld -Oz -flto=thin -s" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld -Oz -flto=thin -s" \
             -DPython_EXECUTABLE=/usr/bin/python3.12 \
             -DPython_INCLUDE_DIR="$PYINC" \
             -DPython_LIBRARY="$PYLIB" \

--- a/.github/workflows/patchelf-639-fixture.yml
+++ b/.github/workflows/patchelf-639-fixture.yml
@@ -2,16 +2,18 @@ name: patchelf-639-fixture
 
 # Throwaway diagnostic (NOT for merge).
 #
-# Builds the raw libpybind11nonlimitedapi_meshlib_3.12.so in the
-# rockylinux8-vcpkg image (clang-21 / lld-21) - the exact toolchain that
-# produced the crashing layout in https://github.com/NixOS/patchelf/issues/639
-# (.init packed right after the program-header table). Standard clang/lld/bfd/
-# gold and the auditwheel-repaired PyPI wheel do NOT reproduce that layout, so
-# we need the genuine pre-packaging build output to hand to patchelf PR #652 as
-# a regression fixture and to confirm the fix on the real binary.
+# Reproduces the genuine crashing layout of libpybind11nonlimitedapi_meshlib_3.12.so
+# from https://github.com/NixOS/patchelf/issues/639 by running MeshLib's REAL
+# shim build (full build_source.sh + `make shims` via generate.mk) in the
+# rockylinux8-vcpkg image (clang-21/lld-21), with the
+# `-Wl,-z,separate-loadable-segments` workaround (generate.mk) reverted on this
+# branch. Standalone cmake builds and the auditwheel-repaired wheel do NOT
+# reproduce it; the real generate.mk link (-shared, -lMRPython, -lopenvdb
+# -lTKernel -ljsoncpp, libpython, -flto=thin -Oz -s) does.
 #
-# The artifact uploaded here is the un-patchelf'd cmake output (before
-# auditwheel / linuxdeploy run their own --set-rpath).
+# Scoped to x86_64 + Python 3.12 to keep it cheap. Uploads the raw, un-patchelf'd
+# shim so it can verify patchelf PR #652 and serve as the missing regression
+# fixture.
 
 on:
   push:
@@ -20,72 +22,81 @@ on:
 
 jobs:
   build-shim:
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     container:
       image: meshlib/meshlib-rockylinux8-vcpkg-x64:latest
       options: --user root
+    env:
+      CXX_BIND: /usr/bin/clang++
     steps:
+      - name: Work-around possible permission issues
+        shell: bash
+        run: |
+          if test -d "$GITHUB_WORKSPACE" && test -n "$(find "$GITHUB_WORKSPACE" -user root)"; then
+            mv "$GITHUB_WORKSPACE" "${GITHUB_WORKSPACE}_${RANDOM}"
+            mkdir "$GITHUB_WORKSPACE"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Checkout mrbind-pybind11 submodule
+      - name: Checkout third-party submodules
         run: |
+          export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE/thirdparty/mrbind-pybind11"
-          git submodule update --init --depth 1 thirdparty/mrbind-pybind11
+          for sm in imgui parallel-hashmap mrbind-pybind11 mrbind; do
+            git config --global --add safe.directory "$GITHUB_WORKSPACE/thirdparty/$sm"
+          done
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/thirdparty/mrbind/deps/cppdecl"
+          bash scripts/retry.sh -- git submodule update --init --depth 1 \
+            thirdparty/imgui thirdparty/parallel-hashmap thirdparty/mrbind-pybind11 thirdparty/mrbind
+          bash scripts/retry.sh -- git -C thirdparty/mrbind submodule update --init --depth 1 deps/cppdecl
 
-      - name: Toolchain info
-        run: |
-          CXX="$(command -v clang++ || command -v clang++-21)"
-          echo "CXX=$CXX"; "$CXX" --version
-          (ld.lld --version || ld.lld-21 --version) 2>/dev/null || true
-          python3.12 --version; which python3.12
+      - name: Confirm workaround is reverted
+        run: grep -n "separate-loadable-segments" scripts/mrbind/generate.mk || echo "workaround line not active (good)"
 
-      - name: Build shim (clang-21 + lld, SUFFIX=meshlib, Python 3.12)
-        run: |
-          CXX="$(command -v clang++ || command -v clang++-21)"
-          PYINC="$(python3.12 -c 'import sysconfig; print(sysconfig.get_path("include"))')"
-          LIBDIR="$(python3.12 -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')"
-          PYLIB="$LIBDIR/libpython3.12.so"
-          if [ ! -e "$PYLIB" ]; then
-            PYLIB="$LIBDIR/$(python3.12 -c 'import sysconfig; print(sysconfig.get_config_var("LDLIBRARY"))')"
-          fi
-          echo "PYINC=$PYINC"; ls -l "$PYINC/Python.h"
-          echo "PYLIB=$PYLIB"; ls -l "$PYLIB"
-          # Mirror generate.mk's release shim flags (-Oz -flto=thin -s, lld),
-          # but WITHOUT the -Wl,-z,separate-loadable-segments workaround that
-          # generate.mk:731 added for #639 - we want the pre-workaround layout.
-          cmake -G Ninja -S thirdparty/mrbind-pybind11/source/non_limited_api -B build-shim \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CXX_COMPILER="$CXX" \
-            -DCMAKE_CXX_FLAGS="-Oz -flto=thin -DNDEBUG" \
-            -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld -Oz -flto=thin -s" \
-            -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld -Oz -flto=thin -s" \
-            -DPython_EXECUTABLE=/usr/bin/python3.12 \
-            -DPython_INCLUDE_DIR="$PYINC" \
-            -DPython_LIBRARY="$PYLIB" \
-            -DPYBIND11_NONLIMITEDAPI_SUFFIX=meshlib \
-            -DPYBIND11_NONLIMITEDAPI_PYTHON_MIN_VERSION_HEX=0x030800f0
-          cmake --build build-shim -j"$(nproc)"
-          echo "=== built ==="
-          find build-shim -name '*.so' -printf '%p (%s bytes)\n'
+      - name: Build MeshLib (full, Release) - needed for libMRPython.so + stub
+        run: ./scripts/build_source.sh
+        env:
+          MESHLIB_BUILD_RELEASE: "ON"
+          MESHLIB_BUILD_DEBUG: "OFF"
+          CMAKE_CXX_COMPILER: /usr/bin/clang++
+          MR_CMAKE_OPTIONS: >
+            -DMRVIEWER_NO_GTK=ON
+            -DMR_PCH_USE_EXTRA_HEADERS=ON
+            -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-11/root/usr/bin/g++
 
-      - name: Show layout (.init offset vs PHT is the #639 trigger signal)
+      - name: Install uv (Python version management)
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+
+      - name: Build the shim via generate.mk (the real link path) for Python 3.12
         run: |
-          shim="$(find build-shim -name 'libpybind11nonlimitedapi_meshlib_3.12.so' | head -1)"
-          echo "shim=$shim"
+          export PKG_CONFIG_PATH=$(uv run --python 3.12 "${PWD}/scripts/wheel/get_sysconfig_var.py" LIBPC)
+          make shims -f scripts/mrbind/generate.mk -B --trace \
+            FOR_WHEEL=1 \
+            CXX_FOR_ABI=/usr/bin/clang++ \
+            CXX_FOR_BINDINGS=/usr/bin/clang++ \
+            DEPS_BASE_DIR=${VCPKG_INSTALLED_DIR}/${VCPKG_TRIPLET} \
+            PYTHON_VERSIONS=3.12
+
+      - name: Locate + dump layout (.init offset vs PHT is the #639 signal)
+        run: |
+          shim="$(find . -name 'libpybind11nonlimitedapi_meshlib_3.12.so' | head -1)"
+          echo "shim=$shim"; ls -l "$shim"
           readelf -hW "$shim" | grep -iE 'program headers|entry point'
           echo "--- program headers ---"
           readelf -lW "$shim" | sed -n '/Program Headers/,/Section to Segment/p'
-          echo "--- key sections (.init should be near the PHT to trigger) ---"
+          echo "--- key sections (.init near the PHT => triggers) ---"
           readelf -SW "$shim" | awk 'NR<=5 || /\.(init|fini|note|plt|text|dynstr|dynsym|gnu\.hash)\b/'
-          readelf -dW "$shim" | grep -iE 'INIT|RUNPATH|RPATH' || true
+          readelf -dW "$shim" | grep -iE 'INIT|RUNPATH|RPATH|NEEDED' || true
+          mkdir -p /tmp/out && cp "$shim" /tmp/out/
+          stub="$(find . -name 'libpybind11nonlimitedapi_stubs*.so' | head -1)"
+          [ -n "$stub" ] && cp "$stub" /tmp/out/ || true
 
-      - name: Upload raw shim
+      - name: Upload raw (un-patchelf'd) shim
         uses: actions/upload-artifact@v4
         with:
-          name: shim-rockylinux8-clang21
-          path: |
-            build-shim/**/libpybind11nonlimitedapi_meshlib_3.12.so
-            build-shim/**/libpybind11nonlimitedapi_stubs.so
+          name: shim-real-rockylinux8-clang21-no-workaround
+          path: /tmp/out/*.so
           if-no-files-found: error

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -733,7 +733,9 @@ endif # Windows
 ifneq ($(IS_LINUX),)
 COMPILER_FLAGS += -I/usr/include/jsoncpp -isystem/usr/include/freetype2 -isystem/usr/include/gdcm-3.0
 # Work around patchelf bug: https://github.com/NixOS/patchelf/issues/639
-LINKER_FLAGS += -Wl,-z,separate-loadable-segments
+# TEMPORARILY REVERTED (diagnostic branch) to reproduce the triggering layout
+# for verifying patchelf PR #652. DO NOT MERGE.
+# LINKER_FLAGS += -Wl,-z,separate-loadable-segments
 endif
 
 # MacOS.


### PR DESCRIPTION
## What

Throwaway diagnostic workflow (**not for merge**) that builds the raw
`libpybind11nonlimitedapi_meshlib_3.12.so` in the `rockylinux8-vcpkg` image
(clang-21 / lld-21) and uploads the un-packaged cmake output as an artifact.

## Why

We filed an upstream patchelf issue (NixOS/patchelf, issue 639): `patchelf --set-rpath`
relocates `.init` but leaves `DT_INIT` stale, so the loader jumps to a dead
address and the library SIGSEGVs on `dlopen`. The upstream fix (patchelf PR 652)
ships without a regression test because its author could not synthesize a
triggering binary.

The trigger needs `.init` packed right after the program-header table.
Verified that this layout is **not** produced by stock clang/lld, bfd, gold,
`lld --no-rosegment`, or by the auditwheel-repaired PyPI wheel (where `.init`
ends up at a high offset). It only appears in the genuine `rockylinux8-vcpkg`
clang-21 build output, before auditwheel/linuxdeploy re-lay-out the file.

This workflow captures that genuine artifact so we can confirm the upstream
patchelf fix on the real MeshLib binary and offer it upstream as the missing
regression fixture.

The disable-build labels are set because this PR touches no platform build.
