### PR TITLE
Revert patchelf #639 workaround (-Wl,-z,separate-loadable-segments)

### DIFF
--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -732,8 +732,6 @@ endif # Windows
 # Linux.
 ifneq ($(IS_LINUX),)
 COMPILER_FLAGS += -I/usr/include/jsoncpp -isystem/usr/include/freetype2 -isystem/usr/include/gdcm-3.0
-# Work around patchelf bug: https://github.com/NixOS/patchelf/issues/639
-LINKER_FLAGS += -Wl,-z,separate-loadable-segments
 endif
 
 # MacOS.


### PR DESCRIPTION
## What

Reverts the Linux-only `-Wl,-z,separate-loadable-segments` flag added to the
Python shim link in `scripts/mrbind/generate.mk` as a workaround for
[NixOS/patchelf#639](https://github.com/NixOS/patchelf/issues/639).

## Why

[patchelf#639](https://github.com/NixOS/patchelf/issues/639): `patchelf --set-rpath` relocated `.init` in
`libpybind11nonlimitedapi_meshlib_*.so` but left `DT_INIT` pointing at the old
address, so the loader jumped to a dead address and the library SIGSEGV'd on
`dlopen`. patchelf [PR#652](https://github.com/NixOS/patchelf/pull/652) fixes the root cause.

Investigation found the crashing layout (`.init` packed right after the
program-header table) is **no longer emitted** by the current
`rockylinux8-vcpkg` clang-21 / lld-21 toolchain — verified by building the real
shim (full `make shims`, all deps, workaround reverted): `.init` now lands in
the RX segment far from the PHT, which patchelf handles safely. So the
workaround appears unnecessary on the current toolchain.

This PR removes it and lets CI confirm: `test-pip-build` builds the x64 wheel
**without** the workaround, and `verify-meshlib-python-import` imports
`meshlib.mrmeshpy` (which `dlopen`s the shim). Green = the workaround is no
longer needed; a `dlopen` SIGSEGV = it still is.

## Notes

- Pairs with patchelf#652; ideally merge once that fix is released so we stay
  protected if a future lld re-emits the tight layout.
- arm64 / Windows / macOS / emscripten disabled: the workaround is Linux-shim
  only and x86_64 is the platform the issue was reported on.
