### PR TITLE
mrbind: pass -Wno-enum-constexpr-conversion only to old Clang (18, 19)

### DIFF
--- a/scripts/mrbind/common_compiler_parser_flags.txt
+++ b/scripts/mrbind/common_compiler_parser_flags.txt
@@ -1,5 +1,4 @@
 -std=c++23
 -Wno-nonportable-include-path
--Wno-enum-constexpr-conversion
 -Wno-deprecated-enum-enum-conversion
 -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -579,6 +579,10 @@ COMPILER_FLAGS := $(ABI_COMPAT_FLAG) $(EXTRA_CFLAGS) $(call load_file,$(makefile
 # Add `-frelaxed-template-template-args` if Clang is old enough to support it. Newer versions have this behavior by default.
 # Clang 18 and older need this flag. Clang 19 and 20 do the right thing by default, but still allow the flag with a deprecation warning. Clang 21 and newer consider this an unknown flag and error.
 COMPILER_FLAGS += $(shell $(CXX_FOR_BINDINGS) --help | grep -o -- -frelaxed-template-template-args)
+# `-Wno-enum-constexpr-conversion` is only needed by the older Clang versions (18, 19); pass it only there.
+ifneq ($(filter 18 19,$(call safe_shell,$(CXX_FOR_BINDINGS) -dumpversion | cut -d. -f1)),)
+COMPILER_FLAGS += -Wno-enum-constexpr-conversion
+endif
 ifneq ($(DEPS_INCLUDE_DIR),)
 # Required for vcpkg environments
 COMPILER_FLAGS += -I$(DEPS_INCLUDE_DIR)/eigen3


### PR DESCRIPTION
Extracted from #4750.

`-Wno-enum-constexpr-conversion` is only needed by the older Clang versions we use as parsers, so it shouldn't be passed unconditionally. This moves it out of the always-on `common_compiler_parser_flags.txt` and adds it in `generate.mk` only when `CXX_FOR_BINDINGS` reports Clang 18 or 19:

```
ifneq ($(filter 18 19,$(call safe_shell,$(CXX_FOR_BINDINGS) -dumpversion | cut -d. -f1)),)
COMPILER_FLAGS += -Wno-enum-constexpr-conversion
endif
```

This mirrors how the neighboring `-frelaxed-template-template-args` is already gated to older Clang.

### Scope note
The original change in #4750 also moved `-frelaxed-template-template-args`. That flag is **already** handled on master (added conditionally via `clang --help`), so this PR touches only `-Wno-enum-constexpr-conversion`.

It does mean the flag is no longer passed to the Clang 21 (Linux vcpkg) and Clang 22 (macOS / Windows) binding builds — CI on those platforms confirms they still build without it.
