### PR TITLE
Improve point cloud triangulation by re-adding triangles after deleting bad faces

### DIFF
--- a/source/MRMesh/MRMeshBuilder.cpp
+++ b/source/MRMesh/MRMeshBuilder.cpp
@@ -221,7 +221,7 @@ static FaceBitSet getLocalRegion( FaceBitSet * region, size_t tSize )
     return res;
 }
 
-static void addTrianglesSeqCore( MeshTopology& res, const Triangulation & t, const BuildSettings & settings = {} )
+static size_t addTrianglesSeqCore( MeshTopology& res, const Triangulation & t, const BuildSettings & settings = {} )
 {
     MR_TIMER;
 
@@ -230,6 +230,7 @@ static void addTrianglesSeqCore( MeshTopology& res, const Triangulation & t, con
     FaceBitSet active = getLocalRegion( settings.region, t.size() );
     // these are triangles that cannot be added even after other triangles
     FaceBitSet bad;
+    size_t triAddedTotal = 0;
     for (;;)
     {
         size_t triAddedOnThisPass = 0;
@@ -247,6 +248,7 @@ static void addTrianglesSeqCore( MeshTopology& res, const Triangulation & t, con
 
         if ( triAddedOnThisPass == 0 )
             break; // no single triangle added during the pass
+        triAddedTotal += triAddedOnThisPass;
     }
     if ( settings.region || settings.skippedFaceCount )
     {
@@ -256,6 +258,7 @@ static void addTrianglesSeqCore( MeshTopology& res, const Triangulation & t, con
         if ( settings.region )
             *settings.region = std::move( active );
     }
+    return triAddedTotal;
 }
 
 MeshTopology fromFaceSoup( const std::vector<VertId> & verts, const Vector<VertSpan, FaceId> & faces,
@@ -315,18 +318,18 @@ MeshTopology fromFaceSoup( const std::vector<VertId> & verts, const Vector<VertS
     return res;
 }
 
-void addTriangles( MeshTopology & res, const Triangulation & t, const BuildSettings & settings )
+size_t addTriangles( MeshTopology & res, const Triangulation & t, const BuildSettings & settings )
 {
     MR_TIMER;
     if ( t.empty() )
-        return;
+        return 0;
 
     // reserve enough elements for faces and vertices
     const auto maxVertId = findMaxVertId( t, settings.region );
     res.faceResize( t.size() + settings.shiftFaceId );
     res.vertResize( maxVertId + 1 );
 
-    addTrianglesSeqCore( res, t, settings );
+    return addTrianglesSeqCore( res, t, settings );
 }
 
 void addTriangles( MeshTopology & res, std::vector<VertId> & vertTriples,

--- a/source/MRMesh/MRMeshBuilder.h
+++ b/source/MRMesh/MRMeshBuilder.h
@@ -38,39 +38,39 @@ MRMESH_API MeshTopology fromTriangles( const Triangulation & t, const BuildSetti
 
 struct VertDuplication
 {
-    VertId srcVert; // original vertex before duplication
-    VertId dupVert; // new vertex after duplication
+    VertId srcVert; ///< original vertex before duplication
+    VertId dupVert; ///< new vertex after duplication
 };
 
-// resolve non-manifold vertices by creating duplicate vertices in the triangulation (which is modified)
-// `lastValidVert` is needed if `region` or `t` does not contain full mesh, then first duplicated vertex will have `lastValidVert+1` index
-// return number of duplicated vertices
+/// resolve non-manifold vertices by creating duplicate vertices in the triangulation (which is modified)
+/// `lastValidVert` is needed if `region` or `t` does not contain full mesh, then first duplicated vertex will have `lastValidVert+1` index
+/// return number of duplicated vertices
 MRMESH_API size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region = nullptr,
     std::vector<VertDuplication>* dups = nullptr, VertId lastValidVert = {} );
 
-// construct mesh topology from a set of triangles with given ids;
-// unlike simple fromTriangles() it tries to resolve non-manifold vertices by creating duplicate vertices;
-// triangulation is modified to introduce duplicates
+/// construct mesh topology from a set of triangles with given ids;
+/// unlike simple fromTriangles() it tries to resolve non-manifold vertices by creating duplicate vertices;
+/// triangulation is modified to introduce duplicates
 MRMESH_API MeshTopology fromTrianglesDuplicatingNonManifoldVertices( 
     Triangulation & t,
     std::vector<VertDuplication> * dups = nullptr,
     const BuildSettings & settings = {} );
 
-// construct mesh from point triples;
-// all coinciding points are given the same VertId in the result
+/// construct mesh from point triples;
+/// all coinciding points are given the same VertId in the result
 MRMESH_API Mesh fromPointTriples( const std::vector<Triangle3f> & posTriples );
 
-// a part of a whole mesh to be constructed
+/// a part of a whole mesh to be constructed
 struct MeshPiece
 {
-    FaceMap fmap; // face of part -> face of whole mesh
-    VertMap vmap; // vert of part -> vert of whole mesh
+    FaceMap fmap; ///< face of part -> face of whole mesh
+    VertMap vmap; ///< vert of part -> vert of whole mesh
     MeshTopology topology;
-    FaceBitSet rem; // remaining triangles of part, not in topology
+    FaceBitSet rem; ///< remaining triangles of part, not in topology
 };
 
-// construct mesh topology in parallel from given disjoint mesh pieces (which do not have any shared vertex)
-// and some additional triangles (in settings) that join the pieces
+/// construct mesh topology in parallel from given disjoint mesh pieces (which do not have any shared vertex)
+/// and some additional triangles (in settings) that join the pieces
 MRMESH_API MeshTopology fromDisjointMeshPieces(
     const Triangulation & t, VertId maxVertId,
     const std::vector<MeshPiece> & pieces,
@@ -81,10 +81,10 @@ MRMESH_API MeshTopology fromDisjointMeshPieces(
 /// \return the total number of triangles added in the topology
 MRMESH_API size_t addTriangles( MeshTopology & res, const Triangulation & t, const BuildSettings & settings = {} );
 
-// adds triangles in the existing topology, auto selecting face ids for them;
-// vertTriples on output contain the remaining triangles that could not be added into the topology right now, but may be added later when other triangles appear in the mesh
+/// adds triangles in the existing topology, auto selecting face ids for them;
+/// vertTriples on output contain the remaining triangles that could not be added into the topology right now, but may be added later when other triangles appear in the mesh
 MRMESH_API void addTriangles( MeshTopology & res, std::vector<VertId> & vertTriples,
-    FaceBitSet * createdFaces = nullptr ); //< this set receives indices of added triangles
+    FaceBitSet * createdFaces = nullptr ); ///< this set receives indices of added triangles
 
 /// construct mesh topology from face soup, where each face can have arbitrary degree (not only triangles)
 MRMESH_API MeshTopology fromFaceSoup( const std::vector<VertId> & verts, const Vector<VertSpan, FaceId> & faces,

--- a/source/MRMesh/MRMeshBuilder.h
+++ b/source/MRMesh/MRMeshBuilder.h
@@ -76,9 +76,10 @@ MRMESH_API MeshTopology fromDisjointMeshPieces(
     const std::vector<MeshPiece> & pieces,
     const BuildSettings & settings = {} );
 
-// adds triangles in the existing topology, given face indecies must be free;
-// settings.region on output contain the remaining triangles that could not be added into the topology right now, but may be added later when other triangles appear in the mesh
-MRMESH_API void addTriangles( MeshTopology & res, const Triangulation & t, const BuildSettings & settings = {} );
+/// adds triangles in the existing topology, given face indecies must be free;
+/// settings.region on output contain the remaining triangles that could not be added into the topology right now, but may be added later when other triangles appear in the mesh
+/// \return the total number of triangles added in the topology
+MRMESH_API size_t addTriangles( MeshTopology & res, const Triangulation & t, const BuildSettings & settings = {} );
 
 // adds triangles in the existing topology, auto selecting face ids for them;
 // vertTriples on output contain the remaining triangles that could not be added into the topology right now, but may be added later when other triangles appear in the mesh

--- a/source/MRMesh/MRPointCloudTriangulation.cpp
+++ b/source/MRMesh/MRPointCloudTriangulation.cpp
@@ -206,8 +206,18 @@ bool PointCloudTriangulator::makeMesh_( Triangulation && t3, Triangulation && t2
     if ( !reportProgress( progressCb, 0.2f ) )
         return false;
 
-    // remove bad triangles
-    targetMesh_.deleteFaces( findHoleComplicatingFaces( targetMesh_ ) );
+    // remove bad triangles, then try adding remaining triangles
+    for ( int i = 0; i < 3; ++i )
+    {
+        const auto badFaces = findHoleComplicatingFaces( targetMesh_ );
+        if ( badFaces.none() )
+            break;
+        targetMesh_.deleteFaces( badFaces );
+        if ( !MeshBuilder::addTriangles( targetMesh_.topology, t3, bsettings ) )
+            break;
+    }
+    if ( !reportProgress( progressCb, 0.25f ) )
+        return false;
 
     // fill small holes
     const auto maxHolePerimeterToFill = params_.critHoleLength >= 0.0f ?


### PR DESCRIPTION
### Summary

When triangulating a point cloud, `PointCloudTriangulator` deletes "bad" faces that complicate holes (`findHoleComplicatingFaces`). Previously this was done a single time, which left a hole wherever a bad face was removed.

Now, after deleting the bad faces, we re-attempt to add the remaining candidate triangles — the ones `MeshBuilder::addTriangles` could not place earlier and kept in `settings.region`. Deleting a bad face frees the edges around it, so some of those held-back triangles become insertable and can fill the gap instead of leaving a hole. This is repeated up to 3 times, stopping early when no bad faces remain or when a pass adds no new triangles.

### Changes

- `MRPointCloudTriangulation.cpp`: replace the single delete-bad-faces step with a loop (at most 3 iterations) of *delete bad faces → re-add the remaining triangles*.
- `MeshBuilder::addTriangles( MeshTopology &, const Triangulation &, ... )` now returns `size_t` — the number of triangles actually added — instead of `void`. The loop uses this to stop once a pass can no longer add anything.
- `MRMeshBuilder.h`: comments converted to Doxygen style.

### Result

Meshes triangulated from point clouds have fewer and smaller holes around the removed bad triangles.
