### PR TITLE
triangulateHoles function

### DIFF
--- a/source/MRMesh/MRPointCloudTriangulation.cpp
+++ b/source/MRMesh/MRPointCloudTriangulation.cpp
@@ -256,6 +256,12 @@ std::optional<Mesh> triangulatePointCloud( const PointCloud& pointCloud, const T
     return {};
 }
 
+bool triangulateHoles( Mesh & mesh, const TriangulateHolesParams& params, const ProgressCallback& progressCb )
+{
+    PointCloud empty;
+    return fillHolesWithExtraPoints( mesh, empty, params, progressCb );
+}
+
 bool fillHolesWithExtraPoints( Mesh & mesh, PointCloud& extraPoints,
     const FillHolesWithExtraPointsParams& params, const ProgressCallback& progressCb )
 {

--- a/source/MRMesh/MRPointCloudTriangulation.h
+++ b/source/MRMesh/MRPointCloudTriangulation.h
@@ -87,7 +87,7 @@ struct TriangulationParameters
     const TriangulationParameters& params = {}, const ProgressCallback& progressCb = {} );
 
 /// \ingroup PointCloudTriangulationGroup
-struct FillHolesWithExtraPointsParams
+struct TriangulateHolesParams
 {
     TriangulationParameters triangulation;
 
@@ -95,6 +95,14 @@ struct FillHolesWithExtraPointsParams
     /// otherwise only vertices from modifyBdVertices can get new triangles
     const VertBitSet* modifyBdVertices = nullptr;
 };
+
+/// fills the holes in the mesh by adding triangles to it with the vertices in existing boundary vertices
+/// \ingroup PointCloudTriangulationGroup
+/// \return false if the operation was canceled or incorrect input
+[[nodiscard]] MRMESH_API bool triangulateHoles( Mesh & mesh,
+    const TriangulateHolesParams& params = {}, const ProgressCallback& progressCb = {} );
+
+using FillHolesWithExtraPointsParams = TriangulateHolesParams;
 
 /// fills the holes in the mesh by adding triangles to it with the vertices in existing boundary vertices or given extra points (in any combination)
 /// \ingroup PointCloudTriangulationGroup

--- a/test_regression/test_algorithms/test_triangulate_holes.py
+++ b/test_regression/test_algorithms/test_triangulate_holes.py
@@ -1,0 +1,32 @@
+from module_helper import *
+from pathlib import Path
+from pytest_check import check
+from constants import test_files_path
+
+import pytest
+
+
+@pytest.mark.smoke
+def test_triangulate_holes():
+    """
+    Test triangulateHoles algorithm.
+    The input is a sphere split into 4 separate open pieces (4 holes, 4 components).
+    triangulateHoles must fill all the holes, producing a closed mesh
+    consisting of a single connected component.
+    """
+    # Load input mesh
+    input_folder = Path(test_files_path) / "algorithms" / "triangulate_holes"
+    mesh = mrmeshpy.loadMesh(input_folder / "Sphere4pieces.ctm")
+
+    # Fill all the holes of the mesh
+    res = mrmeshpy.triangulateHoles(mesh)
+
+    # === Verification
+    with check:
+        assert res, "triangulateHoles should succeed (return True)"
+    with check:
+        num_holes = mesh.topology.findNumHoles()
+        assert num_holes == 0, f"Resulting mesh must be closed (no holes), actual number of holes is {num_holes}"
+    with check:
+        num_components = mrmeshpy.MeshComponents.getNumComponents(mesh)
+        assert num_components == 1, f"Resulting mesh must have a single connected component, actual value is {num_components}"


### PR DESCRIPTION
Adds a `triangulateHoles` function that fills all holes in a mesh by triangulating their boundaries, without requiring any extra points.

It is a thin convenience wrapper over `fillHolesWithExtraPoints` called with an empty point cloud:

```cpp
[[nodiscard]] MRMESH_API bool triangulateHoles( Mesh& mesh,
    const TriangulateHolesParams& params = {},
    const ProgressCallback& progressCb = {} );
```

The parameter struct `FillHolesWithExtraPointsParams` is renamed to `TriangulateHolesParams` since it is now shared by both entry points; `using FillHolesWithExtraPointsParams = TriangulateHolesParams;` is kept as an alias for backward compatibility.

### Python regression test

Adds `test_regression/test_algorithms/test_triangulate_holes.py`, which:

1. opens `Sphere4pieces.ctm` — a sphere split into 4 separate open pieces (4 holes, 4 connected components);
2. calls the new `triangulateHoles`;
3. verifies the resulting mesh is closed (`mesh.topology.findNumHoles() == 0`) and consists of a single connected component (`MeshComponents.getNumComponents(mesh) == 1`).

The `Sphere4pieces.ctm` fixture is added to MeshLibTestData under `algorithms/triangulate_holes/`.
