### PR TITLE
Add SceneStateAtMostCheck helper

### DIFF
--- a/doxygen/general_pages/StatePluginsHelp.dox
+++ b/doxygen/general_pages/StatePluginsHelp.dox
@@ -11,7 +11,7 @@ It has base functions:
 \b Available \b function - \ref ISceneStateCheck interface function that block plugin in UI
 
 \parblock
-\note This fuction can be inherited from some helper classes \ref SceneStateExactCheck \ref SceneStateAtLeastCheck \ref SceneStateOrCheck \ref SceneStateAndCheck
+\note This fuction can be inherited from some helper classes \ref SceneStateExactCheck \ref SceneStateAtLeastCheck \ref SceneStateAtMostCheck \ref SceneStateOrCheck \ref SceneStateAndCheck
 \endparblock
 
 \code

--- a/source/MRViewer/MRSceneStateCheck.h
+++ b/source/MRViewer/MRSceneStateCheck.h
@@ -82,6 +82,32 @@ std::string sceneSelectedAtLeast( const std::vector<std::shared_ptr<const Object
         "" :
         ( "Select at least " + getNObjectsLine<ObjectT>( n ) + " with valid model" );
 }
+
+// checks that given vector has at most N objects if type ObjectT
+// returns error message if requirements are not satisfied
+template<typename ObjectT, bool visualRepresentationCheck, bool modelCheck>
+std::string sceneSelectedAtMost( const std::vector<std::shared_ptr<const Object>>& objs, unsigned n )
+{
+    unsigned i = 0;
+    for ( const auto& obj : objs )
+    {
+        auto tObj = dynamic_cast<const ObjectT*>( obj.get() );
+        if ( !tObj )
+            continue;
+
+        if constexpr ( modelCheck )
+            if ( !tObj->hasModel() )
+                continue;
+
+        if constexpr ( visualRepresentationCheck )
+            if ( !tObj->hasVisualRepresentation() )
+                continue;
+        ++i;
+    }
+    return ( i <= n ) ?
+        "" :
+        ( "Select at most " + getNObjectsLine<ObjectT>( n ) );
+}
 // These instantiations are defined once in MRSceneStateCheck.cpp and imported elsewhere
 // (extern template, as in MRUITestEngine.h), so the common cases are not re-generated in
 // every consuming TU. Other object types stay header-instantiated as before.
@@ -158,6 +184,40 @@ public:
     virtual std::string isAvailable( const std::vector<std::shared_ptr<const Object>>& objs ) const override
     {
         return sceneSelectedAtLeast<ObjectT, false, false>( objs, N );
+    }
+};
+
+// checks that given vector has at most N objects if type ObjectT
+template<unsigned N, typename ObjectT, typename = void>
+class SceneStateAtMostCheck : virtual public ISceneStateCheck
+{
+public:
+    virtual ~SceneStateAtMostCheck() = default;
+    virtual std::string isAvailable( const std::vector<std::shared_ptr<const Object>>& objs ) const override
+    {
+        return sceneSelectedAtMost<ObjectT, true, true>( objs, N );
+    }
+};
+
+template<unsigned N, typename ObjectT>
+class SceneStateAtMostCheck<N, ObjectT, NoVisualRepresentationCheck> : virtual public ISceneStateCheck
+{
+public:
+    virtual ~SceneStateAtMostCheck() = default;
+    virtual std::string isAvailable( const std::vector<std::shared_ptr<const Object>>& objs ) const override
+    {
+        return sceneSelectedAtMost<ObjectT, false, true>( objs, N );
+    }
+};
+
+template<unsigned N, typename ObjectT>
+class SceneStateAtMostCheck<N, ObjectT, NoModelCheck> : virtual public ISceneStateCheck
+{
+public:
+    virtual ~SceneStateAtMostCheck() = default;
+    virtual std::string isAvailable( const std::vector<std::shared_ptr<const Object>>& objs ) const override
+    {
+        return sceneSelectedAtMost<ObjectT, false, false>( objs, N );
     }
 };
 


### PR DESCRIPTION
## Summary

Adds `SceneStateAtMostCheck`, a helper base class for plugins/menu items that should be available only when **at most** N objects of a given type are selected — the symmetric counterpart to the existing `SceneStateAtLeastCheck`.

## Details

- New counting helper `sceneSelectedAtMost<ObjectT, visualRepresentationCheck, modelCheck>()` in `MRSceneStateCheck.h`. Like `sceneSelectedAtLeast`, it counts only the selected objects that pass the type/model/visual-representation checks (others are skipped) and succeeds when that count is `<= N`, otherwise returns `"Select at most <N objects>"`.
- New `SceneStateAtMostCheck<N, ObjectT>` class with the same three forms as `SceneStateAtLeastCheck`: default (model + visual checks), `NoVisualRepresentationCheck`, and `NoModelCheck` specializations.
- Mentions the new helper in `StatePluginsHelp.dox` alongside the other `SceneState*Check` classes.

Header-only template code, structurally identical to `SceneStateAtLeastCheck`; not instantiated anywhere yet, so no behavioral change to existing plugins.

## CI

Portable template code with no platform-specific paths. Building on **windows** (MSVC) and **ubuntu-x64** (GCC) covers both major toolchains where template-specialization differences would surface; the remaining platforms are disabled via labels.
