### PR TITLE
Register custom pytest marks to silence PytestUnknownMarkWarning

### DIFF
--- a/test_regression/pytest.ini
+++ b/test_regression/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 addopts = -v --tb=short --show-capture=no
+markers =
+    smoke: quick subset of tests for a fast smoke check
+    timeout: per-test timeout in seconds (requires the pytest-timeout plugin)


### PR DESCRIPTION
## Problem

The **Python Regression tests** step prints many warnings like:

```
PytestUnknownMarkWarning: Unknown pytest.mark.smoke - is this a typo?
You can register custom marks to avoid this warning - for details, see
https://docs.pytest.org/en/stable/how-to/mark.html
```

`test_regression/pytest.ini` had no `markers` section, so pytest does not recognize the custom marks used in the suite and warns once per use.

Marks in use:
- `smoke` — custom, **unregistered** (36 tests) → the warning above.
- `timeout` — provided by the `pytest-timeout` plugin, not present in `requirements/python/requirements.txt`, so it is also unregistered.
- `parametrize`, `skipif` — pytest built-ins, no warning.

## Fix

Register both custom marks in `pytest.ini`. This only silences the warnings; it does not change test selection (`-m smoke` / `-m "not smoke"` behave exactly as before).

## Note (out of scope)

Registering `timeout` silences its warning, but the `@pytest.mark.timeout(5)` in `test_regression/test_issues/test_e57_to_ctm.py` is currently a no-op because `pytest-timeout` is not installed. If that timeout should actually be enforced, `pytest-timeout` needs to be added to requirements — left as a possible follow-up.

## CI

Pure test-config change, identical across platforms. Left ubuntu-x64 enabled to confirm the regression step runs warning-free; other platforms disabled via labels.
