### PR TITLE
Pass a list, not a generator, to parametrize in test_boolean

### DIFF
--- a/test_regression/test_algorithms/test_boolean.py
+++ b/test_regression/test_algorithms/test_boolean.py
@@ -9,7 +9,7 @@ import pytest
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("input_case", ["sphere", "fox"])
-@pytest.mark.parametrize("operation_type", (x for x in mrmeshpy.BooleanOperation.__members__.keys() if x != "Count"))
+@pytest.mark.parametrize("operation_type", [x for x in mrmeshpy.BooleanOperation.__members__.keys() if x != "Count"])
 def test_boolean(tmp_path, operation_type, input_case):
     """
     Test boolean algorithm with all operation types


### PR DESCRIPTION
Follow-up to #6333.

## Problem

After #6333 registered the custom marks, the **Python Regression tests** step still emits one warning per run:

```
PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
Test: test_algorithms/test_boolean.py::test_boolean, argvalues type: generator
```

`test_boolean` passes a **generator expression** as `argvalues` to `@pytest.mark.parametrize`. pytest consumes it during collection and warns that non-Collection iterables are deprecated (and will be removed in pytest 10).

## Fix

Use a list comprehension instead of a generator expression — one character change (`(...)` → `[...]`). This is the only generator-based `parametrize` call in the suite, so the regression step is now warning-free (`39 -> 0` since master, combined with #6333).

## CI

Pure test-config change, identical across platforms. Left ubuntu-x64 enabled to confirm the regression step runs warning-free; other platforms disabled via labels.
