### PR TITLE
getDeviceInfo: different errors for no vs old CUDA driver

### DIFF
--- a/source/MRCuda/MRCudaBasic.cpp
+++ b/source/MRCuda/MRCudaBasic.cpp
@@ -15,6 +15,11 @@ namespace Cuda
 
 Expected<DeviceInfo> getDeviceInfo()
 {
+    int drv = 0;
+    CUDA_RETURN_UNEXPECTED( cudaDriverGetVersion( &drv ) );
+    if ( drv <= 0 )
+        return MR::unexpected( "NVIDIA GPU error: no CUDA driver found" );
+
     int n;
     CUDA_RETURN_UNEXPECTED( cudaGetDeviceCount( &n ) );
     if ( n <= 0 )

--- a/source/MRCuda/MRCudaBasic.cpp
+++ b/source/MRCuda/MRCudaBasic.cpp
@@ -20,10 +20,16 @@ Expected<DeviceInfo> getDeviceInfo()
     if ( res.driverVersion <= 0 )
         return MR::unexpected( "NVIDIA GPU error: no CUDA driver found" );
 
-    int n;
-    CUDA_RETURN_UNEXPECTED( cudaGetDeviceCount( &n ) );
-    if ( n <= 0 )
-        return MR::unexpected( "NVIDIA GPU error: no CUDA-capable device found" );
+    {
+        int n = 0;
+        auto code = cudaGetDeviceCount( &n );
+        if ( code != cudaSuccess || n <= 0 )
+        {
+            auto err = ( code != cudaSuccess ) ? MR::Cuda::getError( code ) : "NVIDIA GPU error: no capable device found";
+            err += fmt::format( ", CUDA driver {}.{}", res.driverVersion / 1000, ( res.driverVersion % 1000 ) / 10 );
+            return MR::unexpected( err );
+        }
+    }
 
     CUDA_RETURN_UNEXPECTED( cudaRuntimeGetVersion( &res.runtimeVersion ) );
 

--- a/source/MRCuda/MRCudaBasic.cpp
+++ b/source/MRCuda/MRCudaBasic.cpp
@@ -15,18 +15,16 @@ namespace Cuda
 
 Expected<DeviceInfo> getDeviceInfo()
 {
-    int drv = 0;
-    CUDA_RETURN_UNEXPECTED( cudaDriverGetVersion( &drv ) );
-    if ( drv <= 0 )
+    DeviceInfo res;
+    CUDA_RETURN_UNEXPECTED( cudaDriverGetVersion( &res.driverVersion ) );
+    if ( res.driverVersion <= 0 )
         return MR::unexpected( "NVIDIA GPU error: no CUDA driver found" );
 
     int n;
     CUDA_RETURN_UNEXPECTED( cudaGetDeviceCount( &n ) );
     if ( n <= 0 )
-        return MR::unexpected( "NVIDIA GPU error: no single device" );
+        return MR::unexpected( "NVIDIA GPU error: no CUDA-capable device found" );
 
-    DeviceInfo res;
-    CUDA_RETURN_UNEXPECTED( cudaDriverGetVersion( &res.driverVersion ) );
     CUDA_RETURN_UNEXPECTED( cudaRuntimeGetVersion( &res.runtimeVersion ) );
 
     cudaDeviceProp prop;


### PR DESCRIPTION
## Problem

On a computer **without any NVIDIA card/driver**, `cudaGetDeviceCount` returns `cudaErrorInsufficientDriver` — *"CUDA driver version is insufficient for CUDA runtime version"*. That's the **same** error reported when a real NVIDIA GPU is present but its driver is merely **too old** for our CUDA runtime. So the two very different situations produced an identical, misleading message, and the user couldn't tell whether they need to *install* a driver or *update* one.

## Fix

Query `cudaDriverGetVersion()` first, before `cudaGetDeviceCount()`. Unlike `cudaGetDeviceCount`, it returns `cudaSuccess` even when no driver is installed — it just reports the version as `0` via its out-parameter. So:

- `driverVersion <= 0` ⇒ **no CUDA driver installed at all** → reported as a distinct error and we stop early.
- After that early return, a failure from `cudaGetDeviceCount` means the driver is present but unusable (too old, or no device).

The installed **CUDA driver version is appended** to the device-detection error text, so the message is self-diagnosing (e.g. the user can see their driver only supports CUDA 11.4 while the build needs 12.x).

## Resulting `getDeviceInfo()` errors

| Situation | Message |
|---|---|
| No CUDA driver installed | `NVIDIA GPU error: no CUDA driver found` |
| Driver present but too old | `NVIDIA GPU error: CUDA driver version is insufficient for CUDA runtime version, CUDA driver 11.4` |
| Driver OK, but no GPU | `NVIDIA GPU error: no capable device found, CUDA driver 12.2` |

No functional change for machines with a working CUDA GPU.
