### PR TITLE
Fix undefined ${manifest} in vcpkg auto-update workflow

### DIFF
--- a/.github/workflows/vcpkg-auto-update.yml
+++ b/.github/workflows/vcpkg-auto-update.yml
@@ -76,7 +76,7 @@ jobs:
           # Update the vcpkg manifest and the Windows install batch
           sed -i "s/${{ steps.extract-tag.outputs.current_vcpkg_tag }}/${{ steps.get-latest-tag.outputs.latest_vcpkg_tag }}/g" ./thirdparty/install.bat
           sed -i "s/${{ steps.extract-tag.outputs.current_vcpkg_tag }}/${{ steps.get-latest-tag.outputs.latest_vcpkg_tag }}/g" ./thirdparty/vcpkg/vcpkg.json
-          current_vcpkg_baseline=$(jq -r '.configuration["default-registry"].baseline' "${manifest}")
+          current_vcpkg_baseline=$(jq -r '.configuration["default-registry"].baseline' ./thirdparty/vcpkg/vcpkg.json)
           sed -i "s/${current_vcpkg_baseline}/${{ steps.get-latest-tag.outputs.latest_vcpkg_baseline }}/g" ./thirdparty/vcpkg/vcpkg.json
 
           # Commit the changes


### PR DESCRIPTION
## Problem

The scheduled `Update Vcpkg Tag` workflow (`update-vcpkg-tag` job) failed in the **Bump vcpkg** step with:

```
jq: error: Could not open file : No such file or directory
##[error]Process completed with exit code 2.
```

## Root cause

Introduced in #6230 ("Add experimental vcpkg manifest file", merged 2026-06-09). That PR added the manifest-baseline logic to the **Bump vcpkg** step, including a `jq` call that references an undefined `${manifest}` variable, so `jq` always receives an empty filename:

```bash
current_vcpkg_baseline=$(jq -r '.configuration["default-registry"].baseline' "${manifest}")
```

The neighboring `sed` lines added in the same hunk already hard-code the manifest path `./thirdparty/vcpkg/vcpkg.json`.

The bug stayed latent because the **Bump vcpkg** step only runs when `need_vcpkg_update == 'true'` (i.e. a newer vcpkg release exists). The Jun 14 and Jun 21 scheduled runs passed only because the tag was unchanged and the step was skipped; the Jun 28 run was the first to actually execute the line after a new release appeared, so it failed.

## Fix

Use the same hard-coded manifest path the surrounding lines use.

Verified by dispatching the workflow on this branch: the run completed successfully and produced the (previously stuck) bump PR #6337.

Workflow-only change — no build platform is affected, so all `disable-build-*` labels are applied.
