### PR TITLE
macos-build-test must depend on prepare-image

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -140,6 +140,7 @@ jobs:
 
   macos-build-test:
     if: ${{ needs.config.outputs.build_enable_macos == 'true' }}
+    # Gate on prepare-image like the other build jobs: generate-c-bindings needs it, and macOS downloads that job's CBindings artifact (else the 'Wait for C bindings' step times out).
     needs: [ config, prepare-image ]
     uses: ./.github/workflows/build-test-macos.yml
     with:

--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -140,7 +140,7 @@ jobs:
 
   macos-build-test:
     if: ${{ needs.config.outputs.build_enable_macos == 'true' }}
-    needs: [ config ]
+    needs: [ config, prepare-image ]
     uses: ./.github/workflows/build-test-macos.yml
     with:
       app_version:           ${{ needs.config.outputs.app_version }}


### PR DESCRIPTION
## Problem

`macos-build-test` declared `needs: [ config ]` only, while every other build-test job (`windows`, `ubuntu-x64`, `ubuntu-arm64`, `linux-vcpkg`, `emscripten`, `emscripten-c-bindings`) gates on `[ config, prepare-image ]`.

The macOS job downloads the `CBindings` artifact produced by `generate-c-bindings`, which itself `needs: [ config, prepare-image ]`. So whenever `prepare-image` actually rebuilds the Docker images (e.g. a vcpkg/toolchain bump), `generate-c-bindings` starts late, but macOS does not wait for `prepare-image` and starts immediately:

1. macOS spends ~30 min on checkout / thirdparty / MRBind / venv,
2. then hits `Wait for C bindings`, whose `wait-for-job` has a 1800 s (30 min) cap,
3. `generate-c-bindings` still hasn't finished → the wait times out and the whole macOS matrix fails.

Real failure: [run 28315942681, macОС arm64/Debug](https://github.com/MeshInspector/MeshLib/actions/runs/28315942681/job/83889128598) — `Timed out after 1800s waiting for job "generate-c-bindings"` after 31m22s of wasted runner time, across every macOS cell.

## Fix

Add `prepare-image` to `macos-build-test`'s `needs`, matching all the other build-test jobs. macOS now starts only after the images are ready, so `generate-c-bindings` is already running in parallel by the time macOS reaches `Wait for C bindings`, and the wait resolves normally instead of burning a runner for an hour and failing.

## CI note

Only the orchestration of the macOS job changes. Unaffected platforms are disabled via `disable-build-*` labels. `generate-c-bindings` and its image always run regardless (no disable condition), so the macOS → prepare-image → generate-c-bindings chain is still exercised.
