### PR TITLE
CI: use 32-bit hosted toolchain for all VsDevCmd.bat calls

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -195,7 +195,7 @@ jobs:
         #   by the following dotnet build (see the Build step's note below).
         # `CSHARP_STATIC_DLLIMPORT=1` is used to build the version of the bindings that's suitable for use in Wasm in Unity.
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=x86 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}} || exit /b 1
           call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}} CSHARP_STATIC_DLLIMPORT=1 || exit /b 1
           dotnet build examples/c-sharp-examples -c ${{matrix.config}} || exit /b 1
@@ -246,7 +246,7 @@ jobs:
         # `|| exit /b 1` — cmd.exe does not stop on a failed command, so guard each
         # one to fail the step on a generation error instead of swallowing it.
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=x86 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           call ./scripts/mrbind/generate_win.bat -B --trace MODE=none VS_MODE=${{matrix.config}} || exit /b 1
 
       - name: Diagnostic — output bin DLL inventory + MRMesh imports
@@ -347,7 +347,7 @@ jobs:
           rem VsDevCmd.bat overrides VCPKG_ROOT with the VS-bundled vcpkg; preserve the
           rem step env: value so MESHLIB_INCLUDE_DIRS resolves to the project vcpkg.
           set "PROJ_VCPKG_ROOT=%VCPKG_ROOT%"
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=x86 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           set "VCPKG_ROOT=%PROJ_VCPKG_ROOT%"
           cmake --version || exit /b 1
           cmake ^
@@ -363,7 +363,7 @@ jobs:
         if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
         shell: cmd
         run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=x86 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           cmake --version || exit /b 1
           cmake ^
             -S examples/c-examples ^

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -211,7 +211,7 @@ jobs:
         # blocks in cmd.exe (e.g. it failed to catch a ninja build failure).
         run: |
           if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
-            call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+            call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=x86 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
             cmake --version || exit /b 1
             cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} -DMR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
             cmake --build source\TempOutput -j || exit /b 1

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -430,7 +430,7 @@ jobs:
         # `|| exit /b 1` — cmd.exe does not stop on a failed command, so guard each
         # one to fail the step on a generation error instead of swallowing it.
         run: |
-          call "${{ env.VC_PATH }}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          call "${{ env.VC_PATH }}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=x86 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           call ./scripts/mrbind/generate_win.bat -B --trace FOR_WHEEL=1 || exit /b 1
 
       - name: Run Test


### PR DESCRIPTION
## What

The CMake/Ninja Windows builds configure the MSVC environment via:

```
VsDevCmd.bat -arch=amd64
```

`-arch` sets the **target** architecture but leaves the **host** tools at the OS default (amd64), so these builds use the **64-bit hosted** compiler and linker.

The MSBuild build of `MeshLib.sln` instead uses the **32-bit hosted** toolchain, selected by `<PreferredToolArchitecture>x86</PreferredToolArchitecture>` in `source/platform.props`.

This PR adds `-host_arch=x86` to **every** `VsDevCmd.bat` call across the workflows so they cross-compile with the 32-bit hosted tools (x86 host → x64 target), matching the MSBuild toolchain. The produced binaries stay **x64** (`-arch=amd64` is unchanged).

## Call sites updated

`.github/workflows/build-test-windows.yml`:
- Generate C# bindings
- Build (main MeshLib CMake/Ninja build)
- (C bindings env setup)
- Build C++ examples
- Build C examples

`.github/workflows/pip-build.yml`:
- Windows wheel build

## Notes

- **Why VsDevCmd, not a CMake flag**: these are Ninja builds, so the host toolchain comes from the vcvars environment — the `-T host=x86` toolset spec only works with the Visual Studio generator, which MeshLib doesn't use here.
- The 32-bit hosted `cl.exe` has a ~4 GB address-space limit, but this matches what the MSBuild build already runs, so behavior is at parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## PCH size impact (32-bit vs 64-bit hosted toolchain)

The PCH-size logging from [#6340](https://github.com/MeshInspector/MeshLib/pull/6340) gives a clean before/after, since the only difference is this PR's `-host_arch=x86`:

- **Baseline** (64-bit hosted, master without this change): run [28318048245](https://github.com/MeshInspector/MeshLib/actions/runs/28318048245)
- **This PR** (32-bit hosted): run [28330270559](https://github.com/MeshInspector/MeshLib/actions/runs/28330270559)

**CMake / Ninja — PCHs shrink ~37%** (the path this PR changes), sizes in MB:

| Job | MRPch (64-bit → 32-bit) | MRMesh | MRViewer |
|---|---|---|---|
| msvc-2019 Debug · iterator-debug | 1,425.44 → 899.19 (−36.9%) | 613.12 → 373.75 | 677.94 → 411.94 |
| msvc-2019 Debug · vs2019 | 1,395.81 → 881.62 (−36.8%) | 600.94 → 366.06 | 665.19 → 403.94 |
| msvc-2019 Release · vs2019 | 1,384.81 → 874.69 (−36.8%) | 596.19 → 363.06 | 660.25 → 400.87 |
| msvc-2026 Debug · meshlib | 1,253.94 → 790.37 (−37.0%) | 578.06 → 352.37 | 627.81 → 383.06 |
| msvc-2026 Release · meshlib | 1,247.25 → 786.19 (−37.0%) | 573.81 → 349.75 | 623.38 → 380.31 |
| msvc-2022 Debug · vs2022 | 1,230.87 → 777.69 (−36.8%) | 567.88 → 346.19 | 617.31 → 376.75 |
| msvc-2022 Release · vs2022 | 1,224.12 → 773.44 (−36.8%) | 563.56 → 343.50 | 612.75 → 373.94 |

**MSBuild — unchanged** (already 32-bit hosted via `PreferredToolArchitecture=x86`), every value matches byte-for-byte, e.g. MRPch: msvc-2019 Debug 902.69, msvc-2026 Release 840.62, msvc-2022 Release 813.56.

This confirms the toolchain switch takes effect (only the CMake path moves) and is a nice side benefit: the 32-bit hosted compiler emits PCHs ~37% smaller, bringing the CMake builds in line with the (smaller) MSBuild PCHs.
