### PR TITLE
CI: log precompiled header sizes after Windows Build

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -222,31 +222,10 @@ jobs:
           )
 
       - name: Log precompiled header sizes
-        if: ${{ always() }}
         shell: pwsh
         continue-on-error: true
-        # Report the size of the precompiled headers produced by the MRPch,
-        # MRMesh and MRViewer projects so PCH growth is visible in the build log.
-        # Both build systems write under source\TempOutput: MSBuild emits one
-        # MRPch.pch per project's IntDir, CMake/Ninja emits cmake_pch.hxx.pch
-        # (only MRPch builds one; MRMesh/MRViewer REUSE_FROM it).
         run: |
-          $pchRoot = Join-Path $Env:GITHUB_WORKSPACE 'source\TempOutput'
-          if (-not (Test-Path $pchRoot)) {
-            Write-Host "Build output directory '$pchRoot' does not exist - skipping PCH size report."
-            exit 0
-          }
-          $files = Get-ChildItem -Path $pchRoot -Recurse -Filter *.pch -File -ErrorAction SilentlyContinue
-          if (-not $files) {
-            Write-Host "No .pch files found under '$pchRoot'."
-            exit 0
-          }
-          $files |
-            Sort-Object FullName |
-            Select-Object `
-              @{ N = 'Size (MB)'; E = { '{0,8:N2}' -f ($_.Length / 1MB) } },
-              @{ N = 'Path'; E = { $_.FullName.Substring($Env:GITHUB_WORKSPACE.Length + 1) } } |
-            Format-Table -AutoSize | Out-String -Width 4096 | Write-Host
+          & "$Env:GITHUB_WORKSPACE\scripts\diagnostics\windows-pch-sizes.ps1"
 
       - name: Build C bindings with MSBuild
         if: ${{ inputs.mrbind_c && matrix.build_system == 'MSBuild' }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -221,6 +221,33 @@ jobs:
             msbuild -m source\MeshLib.sln -p:Configuration=${{ matrix.config }} -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }};MR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
           )
 
+      - name: Log precompiled header sizes
+        if: ${{ always() }}
+        shell: pwsh
+        continue-on-error: true
+        # Report the size of the precompiled headers produced by the MRPch,
+        # MRMesh and MRViewer projects so PCH growth is visible in the build log.
+        # Both build systems write under source\TempOutput: MSBuild emits one
+        # MRPch.pch per project's IntDir, CMake/Ninja emits cmake_pch.hxx.pch
+        # (only MRPch builds one; MRMesh/MRViewer REUSE_FROM it).
+        run: |
+          $pchRoot = Join-Path $Env:GITHUB_WORKSPACE 'source\TempOutput'
+          if (-not (Test-Path $pchRoot)) {
+            Write-Host "Build output directory '$pchRoot' does not exist - skipping PCH size report."
+            exit 0
+          }
+          $files = Get-ChildItem -Path $pchRoot -Recurse -Filter *.pch -File -ErrorAction SilentlyContinue
+          if (-not $files) {
+            Write-Host "No .pch files found under '$pchRoot'."
+            exit 0
+          }
+          $files |
+            Sort-Object FullName |
+            Select-Object `
+              @{ N = 'Size (MB)'; E = { '{0,8:N2}' -f ($_.Length / 1MB) } },
+              @{ N = 'Path'; E = { $_.FullName.Substring($Env:GITHUB_WORKSPACE.Length + 1) } } |
+            Format-Table -AutoSize | Out-String -Width 4096 | Write-Host
+
       - name: Build C bindings with MSBuild
         if: ${{ inputs.mrbind_c && matrix.build_system == 'MSBuild' }}
         shell: cmd

--- a/scripts/diagnostics/windows-pch-sizes.ps1
+++ b/scripts/diagnostics/windows-pch-sizes.ps1
@@ -1,0 +1,27 @@
+# Report the size of the precompiled headers produced by the MRPch,
+# MRMesh and MRViewer projects so PCH growth is visible in the build log.
+# Both build systems write under source\TempOutput: MSBuild emits one
+# MRPch.pch per project's IntDir, CMake/Ninja emits cmake_pch.hxx.pch
+# (only MRPch builds one; MRMesh/MRViewer REUSE_FROM it).
+[CmdletBinding()]
+param(
+    [string]$BuildRoot = (Join-Path $Env:GITHUB_WORKSPACE 'source\TempOutput')
+)
+
+if (-not (Test-Path $BuildRoot)) {
+    Write-Host "Build output directory '$BuildRoot' does not exist - skipping PCH size report."
+    exit 0
+}
+
+$files = Get-ChildItem -Path $BuildRoot -Recurse -Filter *.pch -File -ErrorAction SilentlyContinue
+if (-not $files) {
+    Write-Host "No .pch files found under '$BuildRoot'."
+    exit 0
+}
+
+$files |
+    Sort-Object FullName |
+    Select-Object `
+        @{ N = 'Size (MB)'; E = { '{0,8:N2}' -f ($_.Length / 1MB) } },
+        @{ N = 'Path'; E = { $_.FullName } } |
+    Format-Table -AutoSize | Out-String -Width 4096 | Write-Host


### PR DESCRIPTION
Adds a step after the Windows **Build** that logs the size of every precompiled header produced by the **MRPch**, **MRMesh** and **MRViewer** projects, so PCH growth is visible directly in the build log.

### Details
- Both build systems write their PCH files under `source\TempOutput`:
  - **MSBuild** emits one `MRPch.pch` per project `IntDir` (with `MR_PCH_USE_EXTRA_HEADERS=ON`, MRMesh and MRViewer build their own; MRPch always does).
  - **CMake/Ninja** emits `cmake_pch.cxx.pch` (each of MRPch/MRMesh/MRViewer builds its own when the extra headers are on).
- A recursive `*.pch` scan covers both layouts and prints a `Size (MB)` / `Path` table. The body lives in `scripts/diagnostics/windows-pch-sizes.ps1`.
- Runs with `continue-on-error: true` so it never masks a build failure, and bails out cleanly if the build directory doesn't exist.

CI-only change; no library or product code affected. All non-Windows platforms disabled.

### Measured sizes (run [28318048245](https://github.com/MeshInspector/MeshLib/actions/runs/28318048245), MB)

**CMake / Ninja (`cmake_pch.cxx.pch`)**

| Job | MRPch | MRMesh | MRViewer |
|---|--:|--:|--:|
| msvc-2019 Debug · iterator-debug | 1,425.44 | 613.12 | 677.94 |
| msvc-2019 Debug · vs2019 | 1,395.81 | 600.94 | 665.19 |
| msvc-2019 Release · vs2019 | 1,384.81 | 596.19 | 660.25 |
| msvc-2026 Debug · meshlib | 1,253.94 | 578.06 | 627.81 |
| msvc-2026 Release · meshlib | 1,247.25 | 573.81 | 623.38 |
| msvc-2022 Debug · vs2022 | 1,230.87 | 567.88 | 617.31 |
| msvc-2022 Release · vs2022 | 1,224.12 | 563.56 | 612.75 |

**MSBuild (`MRPch.pch`)**

| Job | MRPch | MRMesh | MRViewer |
|---|--:|--:|--:|
| msvc-2019 Debug · vs2019 | 902.69 | 380.62 | 419.00 |
| msvc-2019 Release · vs2019 | 895.69 | 377.62 | 415.87 |
| msvc-2026 Debug · meshlib | 844.94 | 376.12 | 416.62 |
| msvc-2026 Release · meshlib | 840.62 | 373.44 | 413.75 |
| msvc-2022 Debug · vs2022 | 821.44 | 365.62 | 405.69 |
| msvc-2022 Release · vs2022 | 813.56 | 362.94 | 402.81 |

Notes: CMake PCHs are ~2× the MSBuild ones; MRPch is the largest (full shared header incl. OpenVDB), MRMesh drops the viewer/imgui section; msvc-2019 produces the biggest PCHs, msvc-2022 the smallest.
