### PR TITLE
CI: source-checksum tag for rocky8 vcpkg Docker image (reuse across PR/master)

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -28,7 +28,9 @@ on:
         value: ${{ jobs.prepare-config.outputs.linux-changes == 'true' && github.event_name != 'schedule' && jobs.prepare-config.outputs.tag-skip-image-rebuild != 'true' }}
       need_linux_vcpkg_rebuild:
         description:
-        value: ${{ jobs.prepare-config.outputs.linux-vcpkg-changes == 'true' && github.event_name != 'schedule' && jobs.prepare-config.outputs.tag-skip-image-rebuild != 'true' }}
+        # Content-addressed tag (see select-vcpkg-docker-image-tag): rebuild
+        # iff the image is absent from the registry, regardless of the event.
+        value: ${{ jobs.prepare-config.outputs.vcpkg-image-missing == 'true' && jobs.prepare-config.outputs.tag-skip-image-rebuild != 'true' }}
       need_windows_vcpkg_rebuild:
         description:
         value: ${{ ( jobs.prepare-config.outputs.windows-changes == 'true' || jobs.prepare-config.outputs.tag-bump-vcpkg == 'true' ) && github.event_name != 'schedule' && jobs.prepare-config.outputs.tag-skip-image-rebuild != 'true' }}
@@ -90,6 +92,7 @@ jobs:
       release_tag:              ${{ steps.version-tag.outputs.release_tag }}
       linux-changes:            ${{ steps.linux-changes.outputs.src }}
       linux-vcpkg-changes:      ${{ steps.linux-vcpkg-changes.outputs.src }}
+      vcpkg-image-missing:      ${{ steps.check-vcpkg-image.outputs.missing }}
       ubuntu_x64_config_matrix: ${{ steps.set-ubuntu-x64-matrix.outputs.matrix }}
       windows_x64_config_matrix: ${{ steps.set-windows-x64-matrix.outputs.matrix }}
       vcpkg-docker-image-tag:   ${{ steps.select-vcpkg-docker-image-tag.outputs.image_tag }}
@@ -253,16 +256,51 @@ jobs:
           fi
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
+      # Content-addressed vcpkg image tag: a hash of everything the image is
+      # built from — the rockylinux vcpkg Dockerfiles plus the tracked vcpkg
+      # overlay (ports, triplets, and vcpkg.json, whose builtin-baseline pins
+      # the vcpkg version the Dockerfile checks out). `git ls-files -s` emits
+      # "<mode> <object-sha> <stage> <path>" straight from the index, so the
+      # tag changes whenever any of those blobs changes, with no working-tree
+      # read. Same inputs -> same tag, which lets a PR-built image be reused
+      # as-is once the PR merges, and lets commits that don't touch these
+      # files skip the image rebuild entirely.
       - name: Select vcpkg Docker image tag
         id: select-vcpkg-docker-image-tag
         run: |
-          if [[ ${{ steps.linux-vcpkg-changes.outputs.src }} == 'true' ]] && [[ ${{ github.event_name }} != 'push' && ${{ github.event_name }} != 'schedule' ]]; then
-            # https://stackoverflow.com/q/58033366/7325599
-            IMAGE_TAG=$(echo "${{ github.head_ref || github.ref_name }}" | sed -r 's/[^a-zA-Z0-9._-]+/-/g')
-          else
-            IMAGE_TAG="latest"
-          fi
+          IMAGE_TAG=$(git ls-files -s -- \
+            docker/rockylinux8-vcpkgDockerfile \
+            docker/rockylinux9-vcpkgDockerfile \
+            thirdparty/vcpkg \
+            | git hash-object --stdin | cut -c1-16)
+          echo "image_tag=${IMAGE_TAG}"
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+
+      # Rebuild the vcpkg image only when its content-addressed tag is absent
+      # from the registry (for either arch). Anonymous pull-scoped token — the
+      # meshlib images are public (the build jobs pull them with no creds).
+      - name: Check vcpkg Docker image presence
+        id: check-vcpkg-image
+        env:
+          IMAGE_TAG: ${{ steps.select-vcpkg-docker-image-tag.outputs.image_tag }}
+        run: |
+          missing=false
+          for arch in x64 arm64; do
+            repo="meshlib/meshlib-rockylinux8-vcpkg-${arch}"
+            token=$(curl -fsSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull" | jq -r .token)
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              -H "Authorization: Bearer ${token}" \
+              -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+              -H "Accept: application/vnd.oci.image.index.v1+json" \
+              "https://registry-1.docker.io/v2/${repo}/manifests/${IMAGE_TAG}")
+            echo "  ${repo}:${IMAGE_TAG} -> HTTP ${code}"
+            if [ "${code}" != "200" ]; then
+              missing=true
+            fi
+          done
+          echo "missing=${missing}"
+          echo "missing=${missing}" >> $GITHUB_OUTPUT
 
       - name: Checkout full history
         if: ${{ env.upload_artifacts == 'true' }}

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Select vcpkg Docker image tag
         id: select-vcpkg-docker-image-tag
         run: |
-          IMAGE_TAG=vcpkg-$(git ls-files -s -- \
+          IMAGE_TAG=source-checksum-$(git ls-files -s -- \
             docker/rockylinux8-vcpkgDockerfile \
             docker/rockylinux9-vcpkgDockerfile \
             thirdparty/vcpkg \

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -28,8 +28,6 @@ on:
         value: ${{ jobs.prepare-config.outputs.linux-changes == 'true' && github.event_name != 'schedule' && jobs.prepare-config.outputs.tag-skip-image-rebuild != 'true' }}
       need_linux_vcpkg_rebuild:
         description:
-        # Content-addressed tag (see select-vcpkg-docker-image-tag): rebuild
-        # iff the image is absent from the registry, regardless of the event.
         value: ${{ jobs.prepare-config.outputs.vcpkg-image-missing == 'true' && jobs.prepare-config.outputs.tag-skip-image-rebuild != 'true' }}
       need_windows_vcpkg_rebuild:
         description:
@@ -256,19 +254,10 @@ jobs:
           fi
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
-      # Content-addressed vcpkg image tag: a hash of everything the image is
-      # built from — the rockylinux vcpkg Dockerfiles plus the tracked vcpkg
-      # overlay (ports, triplets, and vcpkg.json, whose builtin-baseline pins
-      # the vcpkg version the Dockerfile checks out). `git ls-files -s` emits
-      # "<mode> <object-sha> <stage> <path>" straight from the index, so the
-      # tag changes whenever any of those blobs changes, with no working-tree
-      # read. Same inputs -> same tag, which lets a PR-built image be reused
-      # as-is once the PR merges, and lets commits that don't touch these
-      # files skip the image rebuild entirely.
       - name: Select vcpkg Docker image tag
         id: select-vcpkg-docker-image-tag
         run: |
-          IMAGE_TAG=$(git ls-files -s -- \
+          IMAGE_TAG=vcpkg-$(git ls-files -s -- \
             docker/rockylinux8-vcpkgDockerfile \
             docker/rockylinux9-vcpkgDockerfile \
             thirdparty/vcpkg \
@@ -276,30 +265,14 @@ jobs:
           echo "image_tag=${IMAGE_TAG}"
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
-      # Rebuild the vcpkg image only when its content-addressed tag is absent
-      # from the registry (for either arch). Anonymous pull-scoped token — the
-      # meshlib images are public (the build jobs pull them with no creds).
       - name: Check vcpkg Docker image presence
         id: check-vcpkg-image
         env:
           IMAGE_TAG: ${{ steps.select-vcpkg-docker-image-tag.outputs.image_tag }}
         run: |
-          missing=false
-          for arch in x64 arm64; do
-            repo="meshlib/meshlib-rockylinux8-vcpkg-${arch}"
-            token=$(curl -fsSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull" | jq -r .token)
-            code=$(curl -s -o /dev/null -w '%{http_code}' \
-              -H "Authorization: Bearer ${token}" \
-              -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
-              -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
-              -H "Accept: application/vnd.oci.image.index.v1+json" \
-              "https://registry-1.docker.io/v2/${repo}/manifests/${IMAGE_TAG}")
-            echo "  ${repo}:${IMAGE_TAG} -> HTTP ${code}"
-            if [ "${code}" != "200" ]; then
-              missing=true
-            fi
-          done
-          echo "missing=${missing}"
+          missing=$(scripts/docker_image_missing.sh \
+            "meshlib/meshlib-rockylinux8-vcpkg-x64:${IMAGE_TAG}" \
+            "meshlib/meshlib-rockylinux8-vcpkg-arm64:${IMAGE_TAG}")
           echo "missing=${missing}" >> $GITHUB_OUTPUT
 
       - name: Checkout full history

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -270,10 +270,13 @@ jobs:
         env:
           IMAGE_TAG: ${{ steps.select-vcpkg-docker-image-tag.outputs.image_tag }}
         run: |
-          missing=$(scripts/docker_image_missing.sh \
+          if scripts/docker_image_exists.sh \
             "meshlib/meshlib-rockylinux8-vcpkg-x64:${IMAGE_TAG}" \
-            "meshlib/meshlib-rockylinux8-vcpkg-arm64:${IMAGE_TAG}")
-          echo "missing=${missing}" >> $GITHUB_OUTPUT
+            "meshlib/meshlib-rockylinux8-vcpkg-arm64:${IMAGE_TAG}"; then
+            echo "missing=false" >> $GITHUB_OUTPUT
+          else
+            echo "missing=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Checkout full history
         if: ${{ env.upload_artifacts == 'true' }}

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -216,12 +216,9 @@ jobs:
       - name: Remove unused Docker data
         run: docker system prune --force --all --volumes
 
-  # Keep the floating `:latest` vcpkg tag pointing at master's current
-  # content-addressed image. The build job above is skipped on master whenever
-  # the image was already built by the PR (reuse), so `:latest` must be
-  # refreshed here independently — otherwise standalone pip-build runs, which
-  # fall back to `:latest`, would keep pulling a stale image. `imagetools
-  # create` retags server-side: no pull, no rebuild.
+  # Repoint `:latest` at master's current content-addressed vcpkg image, so
+  # the pip-build `:latest` fallback stays current even when the build above
+  # was skipped via reuse. Server-side retag: no pull, no rebuild.
   tag-vcpkg-latest:
     needs: linux-vcpkg-build-upload
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/master' && !inputs.disable_linux_vcpkg && (needs.linux-vcpkg-build-upload.result == 'success' || needs.linux-vcpkg-build-upload.result == 'skipped') }}

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -216,6 +216,31 @@ jobs:
       - name: Remove unused Docker data
         run: docker system prune --force --all --volumes
 
+  # Keep the floating `:latest` vcpkg tag pointing at master's current
+  # content-addressed image. The build job above is skipped on master whenever
+  # the image was already built by the PR (reuse), so `:latest` must be
+  # refreshed here independently — otherwise standalone pip-build runs, which
+  # fall back to `:latest`, would keep pulling a stale image. `imagetools
+  # create` retags server-side: no pull, no rebuild.
+  tag-vcpkg-latest:
+    needs: linux-vcpkg-build-upload
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/master' && !inputs.disable_linux_vcpkg && (needs.linux-vcpkg-build-upload.result == 'success' || needs.linux-vcpkg-build-upload.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ x64, arm64 ]
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: meshlib
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Point :latest at the content-addressed vcpkg image
+        run: |
+          repo="meshlib/meshlib-rockylinux8-vcpkg-${{ matrix.arch }}"
+          docker buildx imagetools create -t "${repo}:latest" "${repo}:${{ inputs.vcpkg_docker_image_tag }}"
+
   windows-vcpkg-build-upload:
     if: ${{ inputs.need_windows_vcpkg_rebuild && !inputs.disable_windows }}
     timeout-minutes: 240

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -218,7 +218,7 @@ jobs:
 
   # Repoint `:latest` at master's current content-addressed vcpkg image, so
   # the pip-build `:latest` fallback stays current even when the build above
-  # was skipped via reuse. Server-side retag: no pull, no rebuild.
+  # was skipped via reuse.
   tag-vcpkg-latest:
     needs: linux-vcpkg-build-upload
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/master' && !inputs.disable_linux_vcpkg && (needs.linux-vcpkg-build-upload.result == 'success' || needs.linux-vcpkg-build-upload.result == 'skipped') }}

--- a/scripts/docker_image_exists.sh
+++ b/scripts/docker_image_exists.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Print "true" if any of the given public Docker Hub image references
-# (repo:tag) is absent from the registry, otherwise "false".
-# Usage: docker_image_missing.sh repo:tag [repo:tag ...]
+# Exit 0 if every given public Docker Hub image reference (repo:tag) exists in
+# the registry; exit 1 if any is missing.
+# Usage: docker_image_exists.sh repo:tag [repo:tag ...]
 set -euo pipefail
 
-missing=false
 for ref in "$@"; do
   repo="${ref%:*}"
   tag="${ref##*:}"
@@ -15,9 +14,5 @@ for ref in "$@"; do
     -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
     -H "Accept: application/vnd.oci.image.index.v1+json" \
     "https://registry-1.docker.io/v2/${repo}/manifests/${tag}")
-  echo "  ${ref} -> HTTP ${code}" >&2
-  if [ "${code}" != "200" ]; then
-    missing=true
-  fi
+  [ "${code}" = "200" ] || exit 1
 done
-echo "${missing}"

--- a/scripts/docker_image_missing.sh
+++ b/scripts/docker_image_missing.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Print "true" if any of the given public Docker Hub image references
+# (repo:tag) is absent from the registry, otherwise "false".
+# Usage: docker_image_missing.sh repo:tag [repo:tag ...]
+set -euo pipefail
+
+missing=false
+for ref in "$@"; do
+  repo="${ref%:*}"
+  tag="${ref##*:}"
+  token=$(curl -fsSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull" | jq -r .token)
+  code=$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+    -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+    -H "Accept: application/vnd.oci.image.index.v1+json" \
+    "https://registry-1.docker.io/v2/${repo}/manifests/${tag}")
+  echo "  ${ref} -> HTTP ${code}" >&2
+  if [ "${code}" != "200" ]; then
+    missing=true
+  fi
+done
+echo "${missing}"


### PR DESCRIPTION
## What

Tag the **rockylinux8 vcpkg Docker image** by a **checksum of its build inputs** instead of `latest` / sanitized branch name. The tag is `source-checksum-<hash>`, where the hash covers everything the image is built from:

- `docker/rockylinux8-vcpkgDockerfile`, `docker/rockylinux9-vcpkgDockerfile`
- the tracked vcpkg overlay under `thirdparty/vcpkg` (ports, triplets, and `vcpkg.json` — whose `builtin-baseline` pins the vcpkg version the Dockerfile checks out)

Computed in `config.yml` as:

```sh
IMAGE_TAG=source-checksum-$(git ls-files -s -- \
  docker/rockylinux8-vcpkgDockerfile docker/rockylinux9-vcpkgDockerfile thirdparty/vcpkg \
  | git hash-object --stdin | cut -c1-16)
```

`git ls-files -s` emits each blob's mode + object SHA straight from the index (no working-tree read), so the tag changes iff one of those inputs changes.

## Why

Rebuild is now driven by **registry presence of the checksum tag**, not by a path-diff against the PR base. That gives two things:

1. **Reuse across merge** — a PR that rebuilds the image produces tag `H`; once merged, master computes the same `H`, finds it already pushed, and **skips the rebuild**.
2. **No spurious rebuilds** — commits that don't change the image inputs resolve to an already-present tag and skip the rebuild, even on a PR that touched those files in an earlier commit.

## How

- **`config.yml`**
  - `select-vcpkg-docker-image-tag` → `source-checksum-<hash>` (above).
  - `check-vcpkg-image` → calls `scripts/docker_image_exists.sh` for both arches (anonymous DockerHub manifest probe — the `meshlib/*` images are public); sets `vcpkg-image-missing` from its exit status.
  - `need_linux_vcpkg_rebuild` now keys off `vcpkg-image-missing` instead of the `linux-vcpkg-changes` path filter (the `tag-skip-image-rebuild` override is kept; the `!= 'schedule'` guard is dropped — presence is the correct signal on every event).
- **`scripts/docker_image_exists.sh`** (new) — exits `0` if every given `repo:tag` exists in the registry, `1` if any is missing. Fail-safe: any error (`set -euo pipefail`) is treated as missing → rebuild.
- **`prepare-images.yml`** — new `tag-vcpkg-latest` job repoints `:latest` at the checksum image on master pushes via `docker buildx imagetools create`, so standalone `pip-build` runs that fall back to `:latest` stay current even when the build was skipped via reuse.

## Scope

Limited to the rocky8 vcpkg image (`vcpkg_docker_image_tag`). The ubuntu/emscripten images (`docker_image_tag`) keep the existing `latest`/branch scheme for now — the same mechanism extends to them as a follow-up (their dependency set is broader: Dockerfiles + several `requirements/*` and `scripts/*` files).

> [!NOTE]
> Checksum tags are immutable and accumulate in DockerHub with no automatic cleanup (the inactive-image retention policy is not in effect, and there's no enforced storage cap). A scheduled GC of old checksum tags — keeping `:latest` and master's current hash — is a possible follow-up.

## Testing

Only `linux-vcpkg` is left enabled; all other platforms are disabled via `disable-build-*` labels since they don't exercise this path. Verified end to end across runs:

- **cache miss** (first run / new prefix) → `check-vcpkg-image` reports missing → `linux-vcpkg-build-upload` builds and pushes the checksum-tagged image → `linux-vcpkg-build-test` (all 4 configs) pulls it and passes.
- **cache hit** (no-op commit) → `linux-vcpkg-build-upload` **skips** while `linux-vcpkg-build-test` reuses the existing image and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
