### PR TITLE
ci: stub GDCM tool binaries to silence find_package(GDCM) warnings

### DIFF
--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -38,6 +38,11 @@ RUN <<EOF
         gh g++-12 clang-14 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
     ./scripts/install_apt_requirements.sh
+    # Stub the GDCM CLI tools (they ship in libgdcm-tools, which we don't
+    # install) so find_package(GDCM) stops warning about missing imported
+    # target executables; MeshLib only links the GDCM libraries, never the
+    # tools, so empty stubs are inert. (bash for brace expansion.)
+    bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh
     ./scripts/mrbind/install_deps_ubuntu.sh
     ./scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -38,10 +38,6 @@ RUN <<EOF
         gh g++-12 clang-14 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
     ./scripts/install_apt_requirements.sh
-    # Stub the GDCM CLI tools (they ship in libgdcm-tools, which we don't
-    # install) so find_package(GDCM) stops warning about missing imported
-    # target executables; MeshLib only links the GDCM libraries, never the
-    # tools, so empty stubs are inert. (bash for brace expansion.)
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh
     ./scripts/mrbind/install_deps_ubuntu.sh

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -40,10 +40,6 @@ RUN <<EOF
         gh g++-13 gcc-14 g++-14 clang-18 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
     ./scripts/install_apt_requirements.sh
-    # Stub the GDCM CLI tools (they ship in libgdcm-tools, which we don't
-    # install) so find_package(GDCM) stops warning about missing imported
-    # target executables; MeshLib only links the GDCM libraries, never the
-    # tools, so empty stubs are inert. (bash for brace expansion.)
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh
     ./scripts/mrbind/install_deps_ubuntu.sh

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -40,6 +40,11 @@ RUN <<EOF
         gh g++-13 gcc-14 g++-14 clang-18 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
     ./scripts/install_apt_requirements.sh
+    # Stub the GDCM CLI tools (they ship in libgdcm-tools, which we don't
+    # install) so find_package(GDCM) stops warning about missing imported
+    # target executables; MeshLib only links the GDCM libraries, never the
+    # tools, so empty stubs are inert. (bash for brace expansion.)
+    bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh
     ./scripts/mrbind/install_deps_ubuntu.sh
     ./scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh


### PR DESCRIPTION
## What

Create empty stub files for the GDCM CLI tools in the ubuntu22 / ubuntu24 Docker images.

## Why

`libgdcm-dev`'s `GDCMTargets.cmake` declares **imported executable targets** (`gdcmdump`, `gdcmconv`, `gdcmanon`, `gdcmraw`, `gdcmscanner`, … 15 tools) pointing at `/usr/bin/gdcm*`. Those CLI tools actually ship in the separate **`libgdcm-tools`** package, which the images don't install. So CMake prints, on **every** `find_package(GDCM)` call:

```
-- The imported target "gdcmdump" references the file "/usr/bin/gdcmdump" but this file does not exist.
```

…one line per tool — 14 on ubuntu22, 15 on ubuntu24 — in every ubuntu-x64 and ubuntu-arm64 build job.

## How

`touch` empty stubs in the image so the file-existence check inside `GDCMTargets.cmake` passes. MeshLib only **links** the GDCM libraries and never invokes the CLI tools, so the empty stubs are inert. Both Dockerfiles get the same set (`gdcmclean` only matters on ubuntu24 — a harmless extra stub on ubuntu22). `bash -c` is used for brace expansion since the `RUN` heredoc runs under `/bin/sh` (dash).

## Result (measured)

ubuntu22 x64 `find_package(GDCM)` imported-target warnings: **19 → 5**.

The removed 14 are exactly the `/usr/bin/gdcm*` CLI tools this stub targets. The remaining 5 (`vtkgdcm`, `vtkgdcmJava`, `vtkgdcmPython`, `vtkgdcmPythonD`, `vtkgdcmsharpglue`) are a different class — they reference VTK / Java / Python / C# **binding shared libraries** (`.so`) from subpackages we don't install, not `/usr/bin` executables, so they are intentionally left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
