### PR TITLE
CI: pin brew on macOS to avoid surprise openssl@3 source rebuild

### DIFF
--- a/.github/actions/install-macos-thirdparty/action.yml
+++ b/.github/actions/install-macos-thirdparty/action.yml
@@ -141,6 +141,10 @@ runs:
     # so brew packages must be installed on hosted runners even on cache hit.
     - name: Install brew requirements
       shell: bash
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: '1'       # don't pull new formulae mid-job
+        HOMEBREW_NO_INSTALL_UPGRADE: '1'   # don't upgrade an already-installed keg (no openssl@3 source rebuild)
+        HOMEBREW_NO_INSTALL_CLEANUP: '1'   # don't prune the known-good keg
       run: |
         ./scripts/install_brew_requirements.sh
         ./scripts/strip_brew_dylibs.sh


### PR DESCRIPTION
## Problem

The macOS [`Install thirdparty libs`](https://github.com/MeshInspector/MeshLib/actions/runs/28443251669/job/84286213334) step failed on a self-hosted arm64 runner with `Process completed with exit code 1`.

Root cause chain:
1. The `Install brew requirements` step (in the shared composite action) runs `brew install` with **no Homebrew env guards**.
2. `brew` auto-updated and found `openssl@3` outdated (`3.6.2 → 3.6.3`), so it tried to upgrade it.
3. These runners keep Homebrew at `/Users/runner/.homebrew` (not `/opt/homebrew`), so the prebuilt bottle is rejected and `openssl@3` is **built from source**:
   > Building openssl@3 from source as the bottle needs `HOMEBREW_PREFIX=/opt/homebrew` (yours is /Users/runner/.homebrew)
4. The from-source `openssl@3` **post-install failed** (`The post-install step did not complete successfully`), so `brew` exited non-zero and the `set -e` script aborted.

This is an environment failure triggered by an incidental formula bump, not a code problem — but CI should not be fragile to it.

## Fix

Guard the step with the same `HOMEBREW_NO_*` vars already applied to the sibling `Install MRBind deps` step, so an already-installed keg is never upgraded/rebuilt mid-job:

```yaml
env:
  HOMEBREW_NO_AUTO_UPDATE: '1'
  HOMEBREW_NO_INSTALL_UPGRADE: '1'
  HOMEBREW_NO_INSTALL_CLEANUP: '1'
```

The action `install-macos-thirdparty` is shared by `build-test-macos.yml` and `pip-build.yml`, so this covers both.
