### PR TITLE
CI: unify rocky8 vcpkg image with the tag-alias scheme (drop tag-vcpkg-latest)

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -28,7 +28,7 @@ on:
         value: ${{ jobs.prepare-config.outputs.linux-changes == 'true' && github.event_name != 'schedule' }}
       need_linux_vcpkg_rebuild:
         description:
-        value: ${{ jobs.prepare-config.outputs.vcpkg-image-missing == 'true' }}
+        value: ${{ jobs.prepare-config.outputs.linux-vcpkg-changes == 'true' && github.event_name != 'schedule' }}
       need_windows_vcpkg_rebuild:
         description:
         value: ${{ ( jobs.prepare-config.outputs.windows-changes == 'true' || jobs.prepare-config.outputs.tag-bump-vcpkg == 'true' ) && github.event_name != 'schedule' && jobs.prepare-config.outputs.tag-skip-image-rebuild != 'true' }}
@@ -90,7 +90,6 @@ jobs:
       release_tag:              ${{ steps.version-tag.outputs.release_tag }}
       linux-changes:            ${{ steps.linux-changes.outputs.src }}
       linux-vcpkg-changes:      ${{ steps.linux-vcpkg-changes.outputs.src }}
-      vcpkg-image-missing:      ${{ steps.check-vcpkg-image.outputs.missing }}
       ubuntu_x64_config_matrix: ${{ steps.set-ubuntu-x64-matrix.outputs.matrix }}
       windows_x64_config_matrix: ${{ steps.set-windows-x64-matrix.outputs.matrix }}
       vcpkg-docker-image-tag:   ${{ steps.select-vcpkg-docker-image-tag.outputs.image_tag }}
@@ -257,26 +256,13 @@ jobs:
       - name: Select vcpkg Docker image tag
         id: select-vcpkg-docker-image-tag
         run: |
-          IMAGE_TAG=source-checksum-$(git ls-files -s -- \
-            docker/rockylinux8-vcpkgDockerfile \
-            docker/rockylinux9-vcpkgDockerfile \
-            thirdparty/vcpkg \
-            | git hash-object --stdin | cut -c1-16)
-          echo "image_tag=${IMAGE_TAG}"
-          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-
-      - name: Check vcpkg Docker image presence
-        id: check-vcpkg-image
-        env:
-          IMAGE_TAG: ${{ steps.select-vcpkg-docker-image-tag.outputs.image_tag }}
-        run: |
-          if scripts/docker_image_exists.sh \
-            "meshlib/meshlib-rockylinux8-vcpkg-x64:${IMAGE_TAG}" \
-            "meshlib/meshlib-rockylinux8-vcpkg-arm64:${IMAGE_TAG}"; then
-            echo "missing=false" >> $GITHUB_OUTPUT
+          if [[ ${{ steps.linux-vcpkg-changes.outputs.src }} == 'true' ]] && [[ ${{ github.event_name }} != 'push' && ${{ github.event_name }} != 'schedule' ]]; then
+            # https://stackoverflow.com/q/58033366/7325599
+            IMAGE_TAG=$(echo "${{ github.head_ref || github.ref_name }}" | sed -r 's/[^a-zA-Z0-9._-]+/-/g')
           else
-            echo "missing=true" >> $GITHUB_OUTPUT
+            IMAGE_TAG="latest"
           fi
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
       - name: Checkout full history
         if: ${{ env.upload_artifacts == 'true' }}

--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -207,46 +207,33 @@ jobs:
           role-duration-seconds: 7200
           retry-max-attempts: 5
 
-      - name: Build Linux vcpkg image
+      # Build the image only if its content-addressed tag isn't already in the
+      # registry (reused across PR commits and after merge), then point the
+      # conventional tag (latest on master, branch-name on a PR) at it so the
+      # build-test jobs pull it unchanged.
+      - name: Build, push and tag Linux vcpkg image
         env:
           DOCKER_BUILDKIT: 1
         run: |
-          docker build \
-            -f ./docker/${{ matrix.os }}-vcpkgDockerfile \
-            -t ${{ env.image }} \
-            --build-arg VCPKG_TRIPLET=${{ env.vcpkg_triplet }} \
-            --secret id=AWS_ACCESS_KEY_ID \
-            --secret id=AWS_SECRET_ACCESS_KEY \
-            --secret id=AWS_SESSION_TOKEN \
-            . --progress=plain
-
-      - name: Push Linux vcpkg image
-        run: docker push ${{ env.image }}
+          repo="${image%:*}"
+          tag=$(scripts/devops/docker_image_source_checksum.sh ${{ matrix.os }}-vcpkg)
+          if scripts/docker_image_exists.sh "${repo}:${tag}"; then
+            echo "Reusing existing ${repo}:${tag}"
+          else
+            docker build \
+              -f ./docker/${{ matrix.os }}-vcpkgDockerfile \
+              -t "${repo}:${tag}" \
+              --build-arg VCPKG_TRIPLET=${{ env.vcpkg_triplet }} \
+              --secret id=AWS_ACCESS_KEY_ID \
+              --secret id=AWS_SECRET_ACCESS_KEY \
+              --secret id=AWS_SESSION_TOKEN \
+              . --progress=plain
+            docker push "${repo}:${tag}"
+          fi
+          docker buildx imagetools create -t "${image}" "${repo}:${tag}"
 
       - name: Remove unused Docker data
         run: docker system prune --force --all --volumes
-
-  # Repoint `:latest` at master's current content-addressed vcpkg image, so
-  # the pip-build `:latest` fallback stays current even when the build above
-  # was skipped via reuse.
-  tag-vcpkg-latest:
-    needs: linux-vcpkg-build-upload
-    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/master' && !inputs.disable_linux_vcpkg && (needs.linux-vcpkg-build-upload.result == 'success' || needs.linux-vcpkg-build-upload.result == 'skipped') }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ x64, arm64 ]
-    steps:
-      - name: Login to DockerHub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          username: meshlib
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Point :latest at the content-addressed vcpkg image
-        run: |
-          repo="meshlib/meshlib-rockylinux8-vcpkg-${{ matrix.arch }}"
-          docker buildx imagetools create -t "${repo}:latest" "${repo}:${{ inputs.vcpkg_docker_image_tag }}"
 
   windows-vcpkg-build-upload:
     if: ${{ inputs.need_windows_vcpkg_rebuild && !inputs.disable_windows }}

--- a/scripts/devops/docker_image_source_checksum.sh
+++ b/scripts/devops/docker_image_source_checksum.sh
@@ -37,6 +37,8 @@ case "${distro}" in
     files=( "docker/${distro}Dockerfile" "${common[@]}" "${emscripten[@]}" ) ;;
   emscripten-generate-c-bindings)
     files=( "docker/${distro}Dockerfile" "${generate[@]}" ) ;;
+  rockylinux8-vcpkg|rockylinux9-vcpkg)
+    files=( docker/rockylinux8-vcpkgDockerfile docker/rockylinux9-vcpkgDockerfile thirdparty/vcpkg ) ;;
   *)
     echo "unknown distro: ${distro}" >&2
     exit 1 ;;


### PR DESCRIPTION
## What

Unify the rocky8 **vcpkg** image with the tag-alias scheme the ubuntu/emscripten images use ([#6348](https://github.com/MeshInspector/MeshLib/pull/6348)), and **delete the special `tag-vcpkg-latest` job**.

Before, the vcpkg family used a different design from #6344: consumers pulled the content-hash tag *directly*, `:latest` wasn't in the CI consume path, and a separate `always()`-on-master job repointed `:latest` for the `pip-build` fallback. Now it works exactly like the other images.

## How

- **`config.yml`**
  - `vcpkg_docker_image_tag` is again the **conventional** tag — `latest` on master/schedule, sanitized branch-name on a PR (mirrors `docker_image_tag`).
  - `need_linux_vcpkg_rebuild` is **path-based** (`linux-vcpkg-changes && != schedule`), mirroring `need_linux_image_rebuild`.
  - Removed the config-level existence probe (`check-vcpkg-image` step + `vcpkg-image-missing` output) — existence is now decided inside the build job.
- **`prepare-images.yml`**
  - `linux-vcpkg-build-upload` computes the checksum (`docker_image_source_checksum.sh rockylinux8-vcpkg`), **builds + pushes only if absent**, then `docker buildx imagetools create` **aliases the conventional tag** onto it (server-side). The vcpkg `docker build` keeps its `--build-arg VCPKG_TRIPLET` and AWS `--secret` mounts.
  - **Deleted `tag-vcpkg-latest`** — `:latest` is now maintained inline by the build-or-alias step on master, just like ubuntu/emscripten.
- **`docker_image_source_checksum.sh`** — added the `rockylinux8-vcpkg`/`rockylinux9-vcpkg` case (the rocky vcpkg Dockerfiles + `thirdparty/vcpkg`).

Consumers (`build-test-linux-vcpkg`, `pip-build`) are unchanged — they already take the tag as an input; it's just the conventional tag now instead of the raw hash, and `pip-build`'s `|| 'latest'` fallback still resolves to the inline-maintained `:latest`.

## Net effect

Both Linux image families now share one scheme — consume a conventional tag, dedup by content hash inside `prepare-images`, alias inline — so there's no longer a vcpkg-only `:latest` job.

## Testing

`linux-vcpkg` left enabled (others disabled). Note: this PR touches only workflow/script files, none matching `linux-vcpkg-changes`, so `need_linux_vcpkg_rebuild` is false here and the build-or-alias path isn't exercised on this PR (the consumer pulls the existing `:latest`); it runs on the next change touching `docker/*-vcpkgDockerfile` or `thirdparty/vcpkg` — the build-or-alias logic itself is the same already-validated pattern as #6348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
