### PR TITLE
Add aws-user and github-user to CI docker images, drop --user root

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -41,7 +41,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       image: meshlib/meshlib-rockylinux8-vcpkg-${{ matrix.arch }}:${{ inputs.docker_image_tag }}
-      options: --user root
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -37,7 +37,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     container:
       image: meshlib/meshlib-${{matrix.os}}-arm64:${{inputs.docker_image_tag}}
-      options: --user root
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -40,7 +40,6 @@ jobs:
     runs-on: [ubuntu-latest]
     container:
       image: meshlib/meshlib-${{matrix.os}}:${{inputs.docker_image_tag}}
-      options: --user root
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( inputs.config_matrix ) }}

--- a/.github/workflows/generate-c-bindings.yml
+++ b/.github/workflows/generate-c-bindings.yml
@@ -19,7 +19,6 @@ jobs:
       contents: read  # This is required for actions/checkout
     container:
       image: meshlib/meshlib-emscripten-generate-c-bindings-arm64:${{inputs.docker_image_tag}}
-      options: --user root
 
     steps:
       - name: Checkout

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -77,7 +77,7 @@ jobs:
             - extend:
                 - platform: x86_64
                   os: rockylinux8-vcpkg-x64
-                  container-options: "--user root"
+                  container-options: " "
                   runner: ubuntu-latest
                   compiler: /usr/bin/clang++
                   container-prefix: ""
@@ -112,7 +112,7 @@ jobs:
           rules: |
             - extend:
                 - platform: x86_64
-                  container-options: "--user root"
+                  container-options: " "
                   runner: ubuntu-latest
                   compiler: /usr/bin/clang++
                   container-prefix: ""

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -77,13 +77,11 @@ jobs:
             - extend:
                 - platform: x86_64
                   os: rockylinux8-vcpkg-x64
-                  container-options: " "
                   runner: ubuntu-latest
                   compiler: /usr/bin/clang++
                   container-prefix: ""
                 - platform: aarch64
                   os: rockylinux8-vcpkg-arm64
-                  container-options: " "
                   runner: ubuntu-24.04-arm
                   compiler: /usr/bin/clang++
                   container-prefix: arm64v8/
@@ -112,12 +110,10 @@ jobs:
           rules: |
             - extend:
                 - platform: x86_64
-                  container-options: " "
                   runner: ubuntu-latest
                   compiler: /usr/bin/clang++
                   container-prefix: ""
                 - platform: aarch64
-                  container-options: " "
                   runner: ubuntu-24.04-arm
                   compiler: /usr/bin/clang++
                   container-prefix: arm64v8/
@@ -159,7 +155,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: meshlib/meshlib-${{ matrix.os }}:${{ inputs.vcpkg_docker_image_tag || 'latest' }}
-      options: ${{ matrix.container-options }}
     strategy:
       fail-fast: false
       # `include` enumerates the per-platform combos, surviving platforms
@@ -584,7 +579,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.container-prefix }}${{ matrix.os }}
-      options: ${{ matrix.container-options }}
     strategy:
       fail-fast: false
       # `include` is the cartesian product (surviving platforms x

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -32,7 +32,7 @@ jobs:
         include:
           - platform: "x86_64"
             runner: ubuntu-latest
-            container-options: "--user root"
+            container-options: " "
             container-prefix: ""
           - platform: "aarch64"
             runner: ubuntu-24.04-arm

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{matrix.container-prefix}}${{matrix.os}}
-      options: ${{ matrix.container-options }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,11 +31,9 @@ jobs:
         include:
           - platform: "x86_64"
             runner: ubuntu-latest
-            container-options: " "
             container-prefix: ""
           - platform: "aarch64"
             runner: ubuntu-24.04-arm
-            container-options: " " # empty
             container-prefix: "arm64v8/"
           - os: "ubuntu:20.04"
             py-version: "3.8"

--- a/.github/workflows/update-docs-manual.yml
+++ b/.github/workflows/update-docs-manual.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     container:
       image: meshlib/meshlib-ubuntu22-arm64:latest
-      options: --user root
     strategy:
       fail-fast: false
     env:

--- a/docker/emscripten-build-c-bindingsDockerfile
+++ b/docker/emscripten-build-c-bindingsDockerfile
@@ -59,14 +59,8 @@ FROM base
 COPY --from=builder /opt/meshlib-thirdparty/emscripten        /usr/local/lib/emscripten
 COPY --from=builder /opt/meshlib-thirdparty/emscripten-single /usr/local/lib/emscripten-single
 
-# Setup non-root user (use 1001 to play nicely with actions/checkout@v4)
-# https://github.com/actions/checkout/issues/1014
-RUN <<EOF
-    set -e
-    groupadd -g 1001 user
-    useradd -m -u 1001 -g user -s /bin/bash user
-    chmod -R 777 /emsdk/upstream/emscripten/
-EOF
+RUN chmod -R 777 /emsdk/upstream/emscripten/
 
-# Change to non-root privilege
-USER user
+RUN useradd -u 8877 -m aws-user
+RUN useradd -u 1001 -m github-user
+USER github-user

--- a/docker/emscripten-generate-c-bindingsDockerfile
+++ b/docker/emscripten-generate-c-bindingsDockerfile
@@ -21,3 +21,7 @@ RUN <<EOF
     apt-get clean
     rm -rf /var/lib/apt/lists/*
 EOF
+
+RUN useradd -u 8877 -m aws-user
+RUN useradd -u 1001 -m github-user
+USER github-user

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -65,14 +65,8 @@ COPY --from=builder /opt/meshlib-thirdparty/emscripten        /usr/local/lib/ems
 COPY --from=builder /opt/meshlib-thirdparty/emscripten-single /usr/local/lib/emscripten-single
 COPY --from=builder /opt/meshlib-thirdparty/emscripten-wasm64 /usr/local/lib/emscripten-wasm64
 
-# Setup non-root user (use 1001 to play nicely with actions/checkout@v4)
-# https://github.com/actions/checkout/issues/1014
-RUN <<EOF
-    set -e
-    groupadd -g 1001 user
-    useradd -m -u 1001 -g user -s /bin/bash user
-    chmod -R 777 /emsdk/upstream/emscripten/
-EOF
+RUN chmod -R 777 /emsdk/upstream/emscripten/
 
-# Change to non-root privilege
-USER user
+RUN useradd -u 8877 -m aws-user
+RUN useradd -u 1001 -m github-user
+USER github-user

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -105,3 +105,7 @@ ENV VCPKG_INSTALLED_DIR=/opt/vcpkg_installed
 
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
+
+RUN useradd -u 8877 -m aws-user
+RUN useradd -u 1001 -m github-user
+USER github-user

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -94,3 +94,7 @@ ENV VCPKG_ROOT=/opt/vcpkg
 
 ARG VCPKG_TRIPLET
 ENV VCPKG_TRIPLET=$VCPKG_TRIPLET
+
+RUN useradd -u 8877 -m aws-user
+RUN useradd -u 1001 -m github-user
+USER github-user

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -87,8 +87,6 @@ RUN <<EOF
     ldconfig
 EOF
 
-# Add a new user "actions-runner" with user id 8877
-RUN useradd -u 8877 -m user
-
-# Change to non-root privilege
-USER user
+RUN useradd -u 8877 -m aws-user
+RUN useradd -u 1001 -m github-user
+USER github-user

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -89,8 +89,6 @@ RUN <<EOF
     ldconfig
 EOF
 
-# Add a new user "actions-runner" with user id 8877
-RUN useradd -u 8877 -m user
-
-# Change to non-root privilege
-USER user
+RUN useradd -u 8877 -m aws-user
+RUN useradd -u 1001 -m github-user
+USER github-user


### PR DESCRIPTION
All CI docker images now end with the same two non-root users, and `github-user` (UID 1001) is the default:

```
RUN useradd -u 8877 -m aws-user
RUN useradd -u 1001 -m github-user
USER github-user
```

UID 1001 matches the `runner` user on GitHub-hosted runners, so job containers can write to the runner-mounted directories (`_runner_file_commands`, workspace) without running as root; `aws-user` keeps UID 8877 available for self-hosted runners via an explicit `--user aws-user`.

Accordingly, `options: --user root` is removed from all workflows (`build-test-ubuntu-x64`, `build-test-ubuntu-arm64`, `build-test-linux-vcpkg`, `generate-c-bindings`, `update-docs-manual`), and the `container-options` matrix plumbing in `pip-build` and `release-tests` is dropped entirely — every container now runs as its image's default user. For the stock distro images used in pip tests this is no behavior change (their default user is already root); MeshLib images now run as `github-user`.

Changes for the previously existing users:
- `ubuntu22`/`ubuntu24` had `user` (UID 8877, default): renamed to `aws-user`, default is now `github-user`.
- `emscripten`/`emscripten-build-c-bindings` had `user` (UID 1001, default): renamed to `github-user`, same UID, so the effective runtime user is unchanged.
- `emscripten-generate-c-bindings` and `rockylinux8/9-vcpkg` had no user (ran as root, or with `--user root`): they now default to `github-user`.
