### PR TITLE
fix findTriTriDistance in case of finite upDistLimitSq

### DIFF
--- a/source/MRMesh/MRTriDist.cpp
+++ b/source/MRMesh/MRTriDist.cpp
@@ -153,7 +153,9 @@ TriTriDistanceResult<T> findTriTriDistanceT( const Triangle3<T>& a, const Triang
                     res.overlap = false;
                     if ( params.canExitEarlier() )
                     {
-                        const auto planeDistSq = sqr( p - s + t );
+                        auto planeDistSq = sqr( p - s + t );
+                        if ( auto dirSq = sqr( sd.dir ) )
+                            planeDistSq /= dirSq;
                         if ( params.canExitEarlier( planeDistSq ) )
                         {
                             res.distSq = planeDistSq;

--- a/source/MRTest/MRMeshMeshDistanceLimitTests.cpp
+++ b/source/MRTest/MRMeshMeshDistanceLimitTests.cpp
@@ -20,6 +20,7 @@
 #include <MRMesh/MRMakeSphereMesh.h>
 #include <MRMesh/MRCube.h>
 #include <MRMesh/MRAffineXf3.h>
+#include <MRMesh/MRTriDist.h>
 #include <gtest/gtest.h>
 
 #include <cfloat>
@@ -421,6 +422,28 @@ TEST( MRMesh, MeshMeshDistance_OneInsideOther )
         EXPECT_FLOAT_EQ( sd.signedDist, 0.0f );
         EXPECT_EQ( sd.status, MeshMeshCollisionStatus::NotColliding );
     }
+}
+
+TEST( MRMesh, findTriTriDistance )
+{
+    const Triangle3f a =
+    {
+        Vector3f{ 74.35837f, -9.789432f, 159.f },
+        Vector3f{ 75.f, 0.f, 159.f },
+        Vector3f{ 0.f, 0.f, 159.f }
+    };
+    const Triangle3f b =
+    {
+        Vector3f{ 32.463974f, -0.012975672f, 436.5f },
+        Vector3f{ 31.64795f, -0.01495606f, 437.36945f },
+        Vector3f{ 32.438614f, -0.012028802f, 436.49982f }
+    };
+
+    const auto td0 = findTriTriDistance( a, b );
+    EXPECT_NEAR( std::sqrt( td0.distSq ), 277.5f, 0.001f );
+
+    const auto td1 = findTriTriDistance( a, b, { .upDistLimitSq = td0.distSq + 0.1f, .upLimitCheck = UpLimitCheck::GreaterOrEqual } );
+    EXPECT_EQ( td0.distSq, td1.distSq );
 }
 
 } // namespace MR


### PR DESCRIPTION
`findTriTriDistance` could return a wrong (overestimated) distance when a non-default `upDistLimitSq` was given.

In the edge-pair loop, `sd.dir` is the vector between the closest points of the two edges and is not unit length. The projections `p`, `s`, `t` are dot products with `sd.dir`, so they carry an extra factor of `|sd.dir|`, and `sqr( p - s + t )` overestimates the actual squared distance between the separating planes by `|sd.dir|²`. This inflated value was compared against `upDistLimitSq` and, on early exit, stored in `res.distSq` — so with a finite limit the function could stop early and report a distance larger than the true one (and larger than what the same call without a limit returns).

The fix divides the squared plane distance by `sqr( sd.dir )` (guarding against a zero vector), making the early-exit value a true squared distance.

Added a regression test with two triangles ~277.5 apart: the distance computed with `upDistLimitSq` slightly above the true squared distance must match the unlimited result; before the fix the early exit returned an inflated value.
