### PR TITLE
Build MSBuild CUDA for the same GPU architectures as CMake

### DIFF
--- a/source/MRCuda/MRCuda.vcxproj
+++ b/source/MRCuda/MRCuda.vcxproj
@@ -66,9 +66,7 @@
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
-      <!-- Clear the default (compute_52,sm_52); MRCudaGencode in AdditionalOptions supplies the architectures. -->
-      <CodeGeneration Condition="'$(MRCudaGencode)' != ''" />
-      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler $(MRCudaGencode) %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler %(AdditionalOptions)</AdditionalOptions>
       <AdditionalCompilerOptions>/wd4514 /wd4574 /wd4668 /wd5039</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
@@ -94,9 +92,7 @@
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
-      <!-- Clear the default (compute_52,sm_52); MRCudaGencode in AdditionalOptions supplies the architectures. -->
-      <CodeGeneration Condition="'$(MRCudaGencode)' != ''" />
-      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler $(MRCudaGencode) %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler %(AdditionalOptions)</AdditionalOptions>
       <AdditionalCompilerOptions>/wd4514 /wd4574 /wd4668 /wd5039</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>

--- a/source/MRCuda/MRCuda.vcxproj
+++ b/source/MRCuda/MRCuda.vcxproj
@@ -66,7 +66,9 @@
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
-      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler %(AdditionalOptions)</AdditionalOptions>
+      <!-- Clear the default (compute_52,sm_52); MRCudaGencode in AdditionalOptions supplies the architectures. -->
+      <CodeGeneration Condition="'$(MRCudaGencode)' != ''" />
+      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler $(MRCudaGencode) %(AdditionalOptions)</AdditionalOptions>
       <AdditionalCompilerOptions>/wd4514 /wd4574 /wd4668 /wd5039</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
@@ -92,7 +94,9 @@
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
-      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler %(AdditionalOptions)</AdditionalOptions>
+      <!-- Clear the default (compute_52,sm_52); MRCudaGencode in AdditionalOptions supplies the architectures. -->
+      <CodeGeneration Condition="'$(MRCudaGencode)' != ''" />
+      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler $(MRCudaGencode) %(AdditionalOptions)</AdditionalOptions>
       <AdditionalCompilerOptions>/wd4514 /wd4574 /wd4668 /wd5039</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>

--- a/source/platform.props
+++ b/source/platform.props
@@ -22,12 +22,17 @@
     <PreferredToolArchitecture>x86</PreferredToolArchitecture> <!-- Using 32-bit build tools reduces memory consumption and fixes error C3859: Failed to create virtual memory for PCH -->
   </PropertyGroup>
   <Import Project="$(CustomPlatfotmPropertyDir)\CustomMRPlatform.props" Condition="'$(CustomPlatfotmPropertyDir)' != ''"/>
-  <!-- The same GPU architectures as in the CMake build (cmake/Modules/ConfigureCuda.cmake): SASS for
-       every listed architecture plus PTX for the newest one (JIT on newer GPUs). Raw -gencode flags,
-       because the CodeGeneration property cannot express SASS-only entries on CUDA 11.4. -->
+  <!-- Remaining GPU architectures to match the CMake build (cmake/Modules/ConfigureCuda.cmake): the CUDA
+       props' unconditional default CodeGeneration (compute_52,sm_52; compute_75,sm_75 on CUDA 13+) already
+       supplies the oldest SASS+PTX; these add the newer SASS targets plus PTX for the newest one. -->
   <PropertyGroup Condition="'$(MRCudaGencode)' == '' AND '$(MRCudaVersion)' != ''">
-    <MRCudaGencode Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MRCudaVersion), '13.0'))">-gencode arch=compute_75,code=sm_75 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_120,code=[sm_120,compute_120]</MRCudaGencode>
-    <MRCudaGencode Condition="'$(MRCudaGencode)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals($(MRCudaVersion), '12.0'))">-gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=[sm_89,compute_89]</MRCudaGencode>
-    <MRCudaGencode Condition="'$(MRCudaGencode)' == ''">-gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=[sm_75,compute_75]</MRCudaGencode>
+    <MRCudaGencode Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MRCudaVersion), '13.0'))">-gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_120,code=[sm_120,compute_120]</MRCudaGencode>
+    <MRCudaGencode Condition="'$(MRCudaGencode)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals($(MRCudaVersion), '12.0'))">-gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=[sm_89,compute_89]</MRCudaGencode>
+    <MRCudaGencode Condition="'$(MRCudaGencode)' == ''">-gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=[sm_75,compute_75]</MRCudaGencode>
   </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(MRCudaGencode)' != ''">
+    <CudaCompile>
+      <AdditionalOptions>%(AdditionalOptions) $(MRCudaGencode)</AdditionalOptions>
+    </CudaCompile>
+  </ItemDefinitionGroup>
 </Project>

--- a/source/platform.props
+++ b/source/platform.props
@@ -22,4 +22,12 @@
     <PreferredToolArchitecture>x86</PreferredToolArchitecture> <!-- Using 32-bit build tools reduces memory consumption and fixes error C3859: Failed to create virtual memory for PCH -->
   </PropertyGroup>
   <Import Project="$(CustomPlatfotmPropertyDir)\CustomMRPlatform.props" Condition="'$(CustomPlatfotmPropertyDir)' != ''"/>
+  <!-- The same GPU architectures as in the CMake build (cmake/Modules/ConfigureCuda.cmake): SASS for
+       every listed architecture plus PTX for the newest one (JIT on newer GPUs). Raw -gencode flags,
+       because the CodeGeneration property cannot express SASS-only entries on CUDA 11.4. -->
+  <PropertyGroup Condition="'$(MRCudaGencode)' == '' AND '$(MRCudaVersion)' != ''">
+    <MRCudaGencode Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MRCudaVersion), '13.0'))">-gencode arch=compute_75,code=sm_75 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_120,code=[sm_120,compute_120]</MRCudaGencode>
+    <MRCudaGencode Condition="'$(MRCudaGencode)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals($(MRCudaVersion), '12.0'))">-gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=[sm_89,compute_89]</MRCudaGencode>
+    <MRCudaGencode Condition="'$(MRCudaGencode)' == ''">-gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=[sm_75,compute_75]</MRCudaGencode>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
The MSBuild build of MRCuda never set `CodeGeneration`, so it fell back to the default from NVIDIA's `CUDA <ver>.props`: `compute_52,sm_52` on CUDA 11.4/12.0 and `compute_75,sm_75` on CUDA 13.2. The shipped binaries carried native SASS for that single old architecture plus its PTX, so every modern GPU JIT-compiled the PTX at first kernel load (startup delay) and then ran code not tuned for its architecture.

This PR makes MSBuild target the same GPU architectures as the CMake build (`cmake/Modules/ConfigureCuda.cmake`). The change lives entirely in `platform.props`, so any CUDA project that imports it (and chains `%(AdditionalOptions)` in its `CudaCompile` blocks, as MRCuda.vcxproj does) inherits the architectures automatically — including CUDA projects in dependent repositories; MRCuda.vcxproj itself is untouched.

`platform.props` defines `MRCudaGencode` from `MRCudaVersion` and injects it via a `CudaCompile` item definition. NVIDIA's default `CodeGeneration` (defined unconditionally in the CUDA props, which are imported after `platform.props`, so it cannot be overridden from there) is left in place: it always supplies the oldest architecture of the corresponding CMake set, and `MRCudaGencode` adds the remaining ones plus PTX for the newest:

| CUDA (toolset) | from default CodeGeneration | added by MRCudaGencode |
|---|---|---|
| 11.4 (v142) | SASS 52 + PTX 52 | SASS 60, 61, 70, 75 + PTX 75 |
| 12.0 (v143) | SASS 52 + PTX 52 | SASS 60, 61, 70, 75, 86, 89 + PTX 89 |
| 13.2 (v145) | SASS 75 + PTX 75 | SASS 86, 89, 120 + PTX 120 |

The only difference from the CMake fatbins is one extra embedded PTX for that oldest architecture (the driver always JIT-picks the newest compatible PTX, so behavior is identical). A custom `MRCudaVersion` (via `CustomMRPlatform.props`) that matches no branch leaves `MRCudaGencode` empty and keeps the stock behavior.

Verified locally on the v143/CUDA 12.0 and v145/CUDA 13.2 paths: `cuobjdump` on the produced objects shows the full CMake set (e.g. 7 SASS cubins + sm_52/sm_89 PTX for CUDA 12.0). The previous revision of this PR (same architectures via explicit flags in MRCuda.vcxproj) passed full CI on all six MSBuild jobs including msvc-2019/CUDA 11.4.

Cost, measured on `MRCudaFastWindingNumber.cu` with CUDA 12.0: compile time 3.8 s → 10.9 s per `.cu` file (the arch-independent host compile and CUDA front-end run once; only ptx/sass generation multiplies), object size 115 KB → ~460 KB. In exchange, no JIT delay at first use and arch-tuned kernels on all supported GPUs, same as the CMake-built packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
