### PR TITLE
Fall back to the CUDA_PATH toolkit when the preferred CUDA version is not installed

### DIFF
--- a/doxygen/general_pages/CppSetupGuide.dox
+++ b/doxygen/general_pages/CppSetupGuide.dox
@@ -41,10 +41,12 @@ xcopy C:\meshlib-built\install\app\$(Configuration)\*.dll $(TargetDir)
    - Include support for the C++ programming language.
    - Ensure the English language pack is installed (required for `vcpkg`).
  3. **CUDA Toolkit**
-  - For **Visual Studio 2019**: Install [CUDA v11.4](https://developer.nvidia.com/cuda-11-4-0-download-archive)
-  - For **Visual Studio 2022**: Install [CUDA v12.0](https://developer.nvidia.com/cuda-12-0-0-download-archive)
-  - For **Visual Studio 2026**: Install [CUDA v13.2](https://developer.nvidia.com/cuda-13-2-0-download-archive)
- \n Choose the appropriate version based on your Visual Studio installation.
+  - Recommended CUDA versions (the ones MeshLib CI builds with):
+   - For **Visual Studio 2019**: Install [CUDA v11.4](https://developer.nvidia.com/cuda-11-4-0-download-archive)
+   - For **Visual Studio 2022**: Install [CUDA v12.0](https://developer.nvidia.com/cuda-12-0-0-download-archive)
+   - For **Visual Studio 2026**: Install [CUDA v13.2](https://developer.nvidia.com/cuda-13-2-0-download-archive)
+  - Other CUDA versions work as well: if the recommended one is not installed, the build automatically falls back to the toolkit pointed to by the `CUDA_PATH` environment variable, which the NVIDIA installer keeps at the latest installed version.
+  - In the CUDA installer, keep the **Visual Studio Integration** component enabled: the Visual Studio build needs it.
  4. **vcpkg**
   - To install `vcpkg`, follow these steps:
    1. **Open a command prompt (CMD) or PowerShell window**.

--- a/source/platform.props
+++ b/source/platform.props
@@ -22,6 +22,13 @@
     <PreferredToolArchitecture>x86</PreferredToolArchitecture> <!-- Using 32-bit build tools reduces memory consumption and fixes error C3859: Failed to create virtual memory for PCH -->
   </PropertyGroup>
   <Import Project="$(CustomPlatfotmPropertyDir)\CustomMRPlatform.props" Condition="'$(CustomPlatfotmPropertyDir)' != ''"/>
+  <!-- If the CUDA version selected above has no MSBuild integration in this Visual Studio, fall back
+       to the toolkit pointed to by the CUDA_PATH environment variable (the NVIDIA installer keeps it
+       at the latest installed version), when that version's integration is present. -->
+  <PropertyGroup Condition="('$(MRCudaVersion)' == '' OR !Exists('$(VCTargetsPath)\BuildCustomizations\CUDA $(MRCudaVersion).props')) AND '$(CUDA_PATH)' != ''">
+    <_MRCudaVersionFromCudaPath>$([System.IO.Path]::GetFileName('$(CUDA_PATH)').TrimStart('v'))</_MRCudaVersionFromCudaPath>
+    <MRCudaVersion Condition="Exists('$(VCTargetsPath)\BuildCustomizations\CUDA $(_MRCudaVersionFromCudaPath).props')">$(_MRCudaVersionFromCudaPath)</MRCudaVersion>
+  </PropertyGroup>
   <!-- Remaining GPU architectures to match the CMake build (cmake/Modules/ConfigureCuda.cmake): the CUDA
        props' unconditional default CodeGeneration (compute_52,sm_52; compute_75,sm_75 on CUDA 13+) already
        supplies the oldest SASS+PTX; these add the newer SASS targets plus PTX for the newest one. -->


### PR DESCRIPTION
`platform.props` hard-selects the CUDA version per platform toolset (v142 → 11.4, v143 → 12.0, v145 → 13.2). If a user doesn't have exactly that version, the build fails with MSB4019 on the `CUDA $(MRCudaVersion).props` import even when a perfectly usable newer toolkit is installed.

This PR adds an evaluation-time fallback: when the selected version's MSBuild integration is absent from the running Visual Studio, `MRCudaVersion` is re-pointed to the toolkit referenced by the `CUDA_PATH` environment variable (the NVIDIA installer keeps it at the latest installed version), provided that version's VS integration is present. So a machine with only CUDA 13.3 installed now builds with 13.3 instead of erroring.

Details:

- The hard mapping stays the preference: when the mapped version is installed (as in CI, which installs it explicitly), nothing changes. This avoids silently switching toolkits on machines that have several CUDA versions installed.
- The check runs at evaluation time (property functions + `Exists()`), which is required because the CUDA props import itself happens during evaluation — a target-based detection would run too late.
- `MRCudaGencode` (#6359) picks up the fallback version automatically via its version-range conditions, e.g. a 13.x fallback gets the `75/86/89/120` architecture set.
- If neither the mapped version nor the `CUDA_PATH` version has its integration installed (or `CUDA_PATH` is unset), the behavior is exactly as before: MSB4019 naming the missing props file.
- Also covers the case of a future toolset with no mapping yet (`MRCudaVersion` empty): the `CUDA_PATH` version is used if its integration is installed.

Verified locally: with the mapped version present the selection is unchanged (12.0 for v143); with the mapping temporarily pointed at a non-installed 12.9 and `CUDA_PATH=v13.2`, evaluation selects 13.2 and MRCuda compiles end-to-end with the CUDA 13 architecture set; with `CUDA_PATH` pointing at a toolkit without VS integration (or unset), the original MSB4019 remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
