### PR TITLE
expandHoles function

### DIFF
--- a/source/MRMesh/MROffsetVerts.cpp
+++ b/source/MRMesh/MROffsetVerts.cpp
@@ -33,6 +33,36 @@ bool offsetVerts( Mesh& mesh, const VertMetric& offset, const ProgressCallback& 
     }, cb );
 }
 
+bool expandHoles( Mesh& mesh, float expansion, const ProgressCallback& cb )
+{
+    MR_TIMER;
+    mesh.invalidateCaches();
+
+    // prepare all shifts before modifying the points
+    VertCoords shifts( mesh.topology.vertSize() );
+    BitSetParallelFor( mesh.topology.getValidVerts(), [&]( VertId v )
+    {
+        if ( !mesh.topology.isBdVertex( v ) )
+            return;
+        const Vector3f normal = mesh.pseudonormal( v );
+        Vector3f shift;
+        for ( auto e : orgRing( mesh.topology, v ) )
+        {
+            if ( mesh.topology.left( e ) )
+                continue;
+            const auto nextPt = mesh.destPnt( e );
+            const auto prevPt = mesh.destPnt( mesh.topology.next( e ) );
+            shift += expansion * cross( nextPt - prevPt, normal ).normalized();
+        }
+        shifts[v] = shift;
+    } );
+
+    return BitSetParallelFor( mesh.topology.getValidVerts(), [&]( VertId v )
+    {
+        mesh.points[v] += shifts[v];
+    }, cb );
+}
+
 Mesh makeThickMesh( const Mesh & m, const ThickenParams & params )
 {
     MR_TIMER;

--- a/source/MRMesh/MROffsetVerts.h
+++ b/source/MRMesh/MROffsetVerts.h
@@ -12,6 +12,10 @@ namespace MR
 /// @return false if cancelled.
 MRMESH_API bool offsetVerts( Mesh& mesh, const VertMetric& offset, const ProgressCallback& cb = {} );
 
+/// Modifies \p mesh shifting each boundary vertex on the given expansion distance to make holes wider (for positive expansion values)
+/// @return false if cancelled.
+MRMESH_API bool expandHoles( Mesh& mesh, float expansion, const ProgressCallback& cb = {} );
+
 struct ThickenParams
 {
     /// the amount of offset for original mesh vertices


### PR DESCRIPTION
Adds new function `expandHoles( Mesh& mesh, float expansion, cb )` that widens all holes in the mesh by shifting each boundary vertex on given `expansion` distance (negative values make holes narrower).

The shift of a boundary vertex is directed along the cross product of the adjacent boundary edges' direction and vertex pseudonormal, so the vertex moves within the surface's tangent plane, perpendicular to the boundary. All shifts are computed first and applied afterwards to make the result independent of the vertex processing order.

The processing is done in parallel and supports cancellation via progress callback.
