### PR TITLE
Bump actions/upload-artifact to v7 in stats-collecting actions

### DIFF
--- a/.github/actions/collect-artifact-stats/action.yml
+++ b/.github/actions/collect-artifact-stats/action.yml
@@ -28,7 +28,7 @@ runs:
       run: ""
 
     - name: Upload artifact stats
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ArtifactStats${{ inputs.stats_file_suffix }}
         path: "${{ runner.temp }}/ArtifactStats${{ inputs.stats_file_suffix }}.json"

--- a/.github/actions/collect-runner-stats/action.yml
+++ b/.github/actions/collect-runner-stats/action.yml
@@ -63,7 +63,7 @@ runs:
       run: ""
 
     - name: Upload sys stats
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: RunnerSysStats-${{ steps.fetch_job_id.outputs.job_id }}
         path: "${{ runner.temp }}/RunnerSysStats-${{ steps.fetch_job_id.outputs.job_id }}.json"


### PR DESCRIPTION
## Why

Every job in a scheduled run (e.g. [this one](https://github.com/MeshInspector/MeshLib/actions/runs/28693034908)) emits a warning annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/upload-artifact@v4.

GitHub [deprecated the Node.js 20 action runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), and `upload-artifact@v4` still targets it. The workflows themselves were already bumped to `upload-artifact@v7` / `download-artifact@v8`; the only remaining `@v4` uses were in the two stats-collecting composite actions. `collect-runner-stats` runs at the end of nearly every job, hence ~41 warnings per run.

## What

Bump `actions/upload-artifact` from `v4` to `v7` in `collect-runner-stats` and `collect-artifact-stats`. The inputs used (`name`, `path`, `retention-days`) are unchanged between these versions.

Only ubuntu-x64 is built here — enough to confirm the warnings are gone from its jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
