### PR TITLE
closestPointsParams function

### DIFF
--- a/source/MRMesh/MRIntersection.h
+++ b/source/MRMesh/MRIntersection.h
@@ -123,11 +123,12 @@ std::optional<T> distance( const Plane3<T>& plane, const Line3<T>& line,
     return std::abs( dot( line.p, plane.n ) - plane.d );
 }
 
-/// finds the closest points between two lines in 3D;
+/// finds the closest points between two lines in 3D and returns their parameters
+/// (tha can be passed to Line::operator() to get the points) on the original lines;
 /// for parallel lines the selection is arbitrary;
 /// \return two equal points if the lines intersect
 template<typename T>
-LineSegm3<T> closestPoints( const Line3<T>& line1, const Line3<T>& line2 )
+std::pair<T,T> closestPointsParams( const Line3<T>& line1, const Line3<T>& line2 )
 {
     const auto d11 = line1.d.lengthSq();
     const auto d12 = dot( line1.d, line2.d );
@@ -136,7 +137,7 @@ LineSegm3<T> closestPoints( const Line3<T>& line1, const Line3<T>& line2 )
     if ( det == 0 )
     {
         // lines are parallel
-        return { line1.p, line2.project( line1.p ) };
+        return { T(0), line2.projectionParam( line1.p ) };
     }
 
     const auto dp = line2.p - line1.p;
@@ -144,7 +145,17 @@ LineSegm3<T> closestPoints( const Line3<T>& line1, const Line3<T>& line2 )
     const auto y = dot( dp, line2.d ) / det;
     const auto a = d12 * y - d22 * x;
     const auto b = d11 * y - d12 * x;
-    return { line1( a ), line2( b ) };
+    return { a, b };
+}
+
+/// finds the closest points between two lines in 3D;
+/// for parallel lines the selection is arbitrary;
+/// \return two equal points if the lines intersect
+template<typename T>
+LineSegm3<T> closestPoints( const Line3<T>& line1, const Line3<T>& line2 )
+{
+    const auto pp = closestPointsParams( line1, line2 );
+    return { line1( pp.first ), line2( pp.second ) };
 }
 
 /// finds the closest points between an infinite line and finite line segment in 3D;

--- a/source/MRMesh/MRIntersection.h
+++ b/source/MRMesh/MRIntersection.h
@@ -124,7 +124,7 @@ std::optional<T> distance( const Plane3<T>& plane, const Line3<T>& line,
 }
 
 /// finds the closest points between two lines in 3D and returns their parameters
-/// (tha can be passed to Line::operator() to get the points) on the original lines;
+/// (that can be passed to Line::operator() to get the points) on the original lines;
 /// for parallel lines the selection is arbitrary;
 /// \return two equal points if the lines intersect
 template<typename T>

--- a/source/MRMesh/MRLine.h
+++ b/source/MRMesh/MRLine.h
@@ -29,13 +29,18 @@ struct Line
 
     /// returns same line represented with flipped direction of d-vector
     [[nodiscard]] Line operator -() const { return Line( p, -d ); }
+
     /// returns same representation
     [[nodiscard]] const Line & operator +() const { return *this; }
+
     /// returns same line represented with unit d-vector
     [[nodiscard]] Line normalized() const { return { p, d.normalized() }; }
 
-    /// finds the closest point on line
-    [[nodiscard]] V project( const V & x ) const { return p + dot( d, x - p ) / d.lengthSq() * d; }
+    /// finds the parameter of the closest point to the given one on this line
+    [[nodiscard]] T projectionParam( const V & x ) const { return dot( d, x - p ) / d.lengthSq(); }
+
+    /// finds the closest point to the given one on this line
+    [[nodiscard]] V project( const V & x ) const { return operator()( projectionParam( x ) ); }
 
     friend std::ostream& operator<<( std::ostream& s, const Line& l )
     {


### PR DESCRIPTION
Sometimes the caller needs not the closest points between two lines themselves, but their parameters on the lines (e.g. to compare positions along a line or to clamp them to a segment). This PR exposes such parameter-based API:

* New `Line::projectionParam( x )` returns the parameter of the projection of a given point on the line; `Line::project( x )` is now implemented via it.
* New `closestPointsParams( line1, line2 )` returns the pair of parameters of the closest points on the original lines (they can be passed to `Line::operator()` to get the points); `closestPoints( line1, line2 )` is now implemented via it.

No behavior changes in the existing functions.
