### PR TITLE
mrbind: log the C++ stdlib selected for bindings parsing and compilation

### DIFF
--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -808,6 +808,13 @@ endif # Linux or MacOS.
 endif # Python-only.
 
 
+# Log which C++ standard library the flags select: the parser (extra flags first, like the real parse call)
+# can differ from the compiler. Probed via $(CXX_FOR_BINDINGS); `\043` = `#`, unwritable in a Make function.
+override stdlib_macros = $(strip $(shell printf '\043include <version>\n' | $(CXX_FOR_BINDINGS) -xc++ - -E -dM $1 2>/dev/null | grep -E '^.define (__GLIBCXX__|_GLIBCXX_RELEASE|_LIBCPP_VERSION|_MSVC_STL_VERSION|_MSVC_STL_UPDATE) ' | tr '\n' ' '))
+$(info Stdlib for parsing:     $(call stdlib_macros,$(COMPILER_FLAGS_LIBCLANG) $(COMPILER_FLAGS)))
+$(info Stdlib for compilation: $(call stdlib_macros,$(COMPILER_FLAGS)))
+
+
 # Directories:
 # Temporary output.
 $(TEMP_OUTPUT_DIR):


### PR DESCRIPTION
Every bindings build now prints which C++ standard library the flags actually select, right at `generate.mk` startup:

```
Stdlib for parsing:     #define _LIBCPP_VERSION 200100
Stdlib for compilation: #define _GLIBCXX_RELEASE 11 #define __GLIBCXX__ 20230528
```

(output of the `generate-c-bindings` job — the parser targets the Emscripten sysroot's libc++ while the host compiler defaults to libstdc++, so logging the two separately is not redundant.)

## Why
Which libstdc++ the bindings compile against is an implicit driver decision (Clang picks the newest GCC installation it can find), and it recently turned out to differ from what one would assume on the `rockylinux8-vcpkg` image (#6372): the `clang-21` packages drag in a newer libstdc++ than the gcc-toolset the rest of the build uses. Until now the only way to tell was to dissect the produced `.so`. With this change the answer is one grep away in any CI log.

## How
A `stdlib_macros` helper pipes `#include <version>` through `$(CXX_FOR_BINDINGS) -E -dM` and greps the identifying macros:
- `__GLIBCXX__` / `_GLIBCXX_RELEASE` (libstdc++),
- `_LIBCPP_VERSION` (libc++),
- `_MSVC_STL_VERSION` / `_MSVC_STL_UPDATE` (MSVC STL, for the Windows cross-compile).

It runs twice: once with `$(COMPILER_FLAGS_LIBCLANG) $(COMPILER_FLAGS)` (the exact flag set and order the `mrbind` parse call gets) and once with `$(COMPILER_FLAGS)` (compilation). The probe soft-fails to an empty line (`2>/dev/null`, plain `$(shell)`) and only uses tools `generate.mk` already depends on (`printf`, `grep`, `tr`). Make quirks: `\043` in `printf` and `^.define` in the grep pattern, because a literal `#` cannot appear in a Make variable definition.

Caveat: the probe runs `$(CXX_FOR_BINDINGS)` in place of the actual `mrbind` binary; both are built from the same LLVM on all our setups, so the GCC-installation detection matches.

## Verification — full matrix, all green
Results from this PR's own CI run ([28755933600](https://github.com/MeshInspector/MeshLib/actions/runs/28755933600)); parsing == compilation everywhere except `generate-c-bindings`:

| Job | Stdlib for bindings |
|---|---|
| linux-vcpkg — all 4 (x64/arm64 × Clang 21/GCC 11) | libstdc++ GCC 15 (`__GLIBCXX__ 20260123`) |
| ubuntu-x64 u22 GCC12, ubuntu-arm64 u22 | libstdc++ GCC 12 (20230510) |
| ubuntu-x64 u24 GCC13, u24 GCC14, ubuntu-arm64 u24 | libstdc++ GCC 14 (20260202) |
| macOS arm64 Release, x64 Release | libc++ 220108 |
| macOS arm64 Debug | libc++ 220107 |
| windows msvc-2026 Release + Debug | MSVC STL 145, update 202604 |
| windows msvc-2019 Release | MSVC STL 142, update 202105 |
| generate-c-bindings | parsing: libc++ 200100 / compilation: libstdc++ GCC 11 (20230528) |

The log already earns its keep:
- It confirms #6372's premise in-log: on `rockylinux8-vcpkg`, Clang 21 selects **GCC 15's** libstdc++ for bindings in every vcpkg job, including the GCC 11 rows.
- Ubuntu 24's "GCC 13" job compiles bindings against **GCC 14's** libstdc++ (clang-18 picks the newest GCC install on the image) — same drift mechanism, previously invisible.
- macOS runners are heterogeneous (libc++ 220107 vs 220108 within one run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
