### PR TITLE
CI: gate manylinux pip jobs on the linux-vcpkg toggle, not ubuntu

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -384,8 +384,7 @@ jobs:
     uses: ./.github/workflows/pip-build.yml
     with:
       vcpkg_docker_image_tag: ${{ needs.config.outputs.vcpkg_docker_image_tag }}
-      disable_ubuntu_x64:   ${{ needs.config.outputs.build_enable_ubuntu_x64 != 'true' }}
-      disable_ubuntu_arm64: ${{ needs.config.outputs.build_enable_ubuntu_arm64 != 'true' }}
+      disable_manylinux:    ${{ needs.config.outputs.build_enable_linux_vcpkg != 'true' }}
       disable_macos:        ${{ needs.config.outputs.build_enable_macos != 'true' }}
       disable_windows:      ${{ needs.config.outputs.build_enable_windows != 'true' }}
 

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -31,11 +31,9 @@ on:
         default: false
         required: false
         type: boolean
-      disable_ubuntu_x64:
-        default: false
-        required: false
-        type: boolean
-      disable_ubuntu_arm64:
+      # keyed to the linux-vcpkg platform toggle, not ubuntu: manylinux builds in the
+      # rockylinux8-vcpkg image, whose branch tag only exists when linux-vcpkg is enabled (#6091)
+      disable_manylinux:
         default: false
         required: false
         type: boolean
@@ -85,12 +83,10 @@ jobs:
                   runner: ubuntu-24.04-arm
                   compiler: /usr/bin/clang++
                   container-prefix: arm64v8/
-            - if: ${{ inputs.disable_ubuntu_x64 }}
+            - if: ${{ inputs.disable_manylinux }}
               exclude:
-                platform: x86_64
-            - if: ${{ inputs.disable_ubuntu_arm64 }}
-              exclude:
-                platform: aarch64
+                - platform: x86_64
+                - platform: aarch64
 
       - id: test-matrix
         uses: ./.github/actions/matrix-builder
@@ -132,12 +128,10 @@ jobs:
                   os: "fedora:42"
                 - py-version: "3.14"
                   os: "ubuntu:25.10"
-            - if: ${{ inputs.disable_ubuntu_x64 }}
+            - if: ${{ inputs.disable_manylinux }}
               exclude:
-                platform: x86_64
-            - if: ${{ inputs.disable_ubuntu_arm64 }}
-              exclude:
-                platform: aarch64
+                - platform: x86_64
+                - platform: aarch64
 
   generate-c-bindings:
     needs: setup


### PR DESCRIPTION
The manylinux pip jobs have built in the **rockylinux8-vcpkg** image since #4842 (July 2025), but their disable flags were still wired to the **ubuntu** platform toggles — a fossil from the pre-Rocky days, carried into #6091 when pip-build first learned to respect `disable-build-*` labels. The point of those flags is image availability (#6091's motivating failure: a disabled platform's branch-tagged image is never built by prepare-image, and pulling it dies with `manifest unknown`), and the image the manylinux jobs actually pull is governed by **linux-vcpkg**, not ubuntu. Under the old wiring, `disable-build-linux-vcpkg` + `test-pip-build` could still reproduce the missing-image failure, while `disable-build-ubuntu-*` needlessly skipped pip jobs that don't touch ubuntu images.

## What changed
- `pip-build.yml`: inputs `disable_ubuntu_x64` + `disable_ubuntu_arm64` → single `disable_manylinux` (the image toggle has no per-arch split); the two matrix-builder rules in each of `manylinux-pip-build` / `manylinux-pip-test` collapse into one rule with a list-form `exclude`.
- `build-test-distribute.yml`: feeds it from `build_enable_linux_vcpkg` instead of the two ubuntu outputs.

**Behavior change:** `disable-build-ubuntu-{x64,arm64}` labels no longer affect the pip pipeline; `disable-build-linux-vcpkg` now disables both manylinux arches (build + tests).

## Verification
This PR carries `test-pip-build` **plus** `disable-build-ubuntu-x64`/`-arm64` labels — under the old wiring that combination skips all manylinux jobs, so the pass gate is exactly the new behavior: `manylinux-pip-build` and `manylinux-pip-test` must run (and pass) on both arches. macOS/windows pip jobs stay disabled via their unchanged toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
