### PR TITLE
CI: capture CPU model in runner's system stats

### DIFF
--- a/scripts/devops/collect_ci_stats.py
+++ b/scripts/devops/collect_ci_stats.py
@@ -73,6 +73,7 @@ def parse_job(job: dict):
             'runner_type':       runner_type,
             'runner_name':       runner_name,
             'runner_cpu_count':  runner_stats['cpu_count'],
+            'runner_cpu_model':  runner_stats.get('cpu_model'),
             'runner_ram_mb':     runner_stats['ram_mb'],
             'build_system':      runner_stats['build_system'],
             'aws_instance_type': runner_stats['aws_instance_type'],

--- a/scripts/devops/collect_runner_sys_stats.py
+++ b/scripts/devops/collect_runner_sys_stats.py
@@ -20,6 +20,29 @@ def get_ram_amount():
     else:
         raise RuntimeError(f"Unknown system: {system}")
 
+def get_cpu_model():
+    system = platform.system()
+    if system == "Darwin":
+        output = subprocess.check_output(['sysctl', '-n', 'machdep.cpu.brand_string'], text=True)
+        return output.strip()
+    elif system == "Linux":
+        with open('/proc/cpuinfo') as f:
+            for line in f:
+                if line.startswith('model name'):
+                    return line.split(':', 1)[1].strip()
+        # ARM kernels report implementer/part ids instead of a model name; lscpu decodes them
+        output = subprocess.check_output(['lscpu'], text=True)
+        for line in output.splitlines():
+            if line.startswith('Model name:'):
+                return line.split(':', 1)[1].strip()
+        return None
+    elif system == "Windows":
+        ps_command = "(Get-CimInstance Win32_Processor).Name"
+        output = subprocess.check_output(['powershell', '-Command', ps_command], text=True)
+        return output.strip().splitlines()[0]
+    else:
+        raise RuntimeError(f"Unknown system: {system}")
+
 def get_compiler_id(compiler_path):
     # work-around for Windows runners
     if compiler_path.startswith("msvc-"):
@@ -67,12 +90,19 @@ if __name__ == "__main__":
 
         aws_instance_type = os.environ.get('AWS_INSTANCE_TYPE', '').lower()
 
+        try:
+            cpu_model = get_cpu_model()
+        except Exception as e:
+            print(f"Failed to get CPU model: {e}")
+            cpu_model = None
+
         results = {
             'target_os': os.environ.get('TARGET_OS'),
             'target_arch': os.environ.get('TARGET_ARCH'),
             'compiler': compiler_id,
             'build_config': os.environ.get('BUILD_CONFIG').lower(),
             'cpu_count': cpu_count,
+            'cpu_model': cpu_model,
             'ram_mb': ram_amount,
             'build_system': build_system,
             'aws_instance_type': aws_instance_type or None,

--- a/scripts/devops/collect_runner_sys_stats.py
+++ b/scripts/devops/collect_runner_sys_stats.py
@@ -26,11 +26,6 @@ def get_cpu_model():
         output = subprocess.check_output(['sysctl', '-n', 'machdep.cpu.brand_string'], text=True)
         return output.strip()
     elif system == "Linux":
-        with open('/proc/cpuinfo') as f:
-            for line in f:
-                if line.startswith('model name'):
-                    return line.split(':', 1)[1].strip()
-        # ARM kernels report implementer/part ids instead of a model name; lscpu decodes them
         output = subprocess.check_output(['lscpu'], text=True)
         for line in output.splitlines():
             if line.startswith('Model name:'):
@@ -90,11 +85,7 @@ if __name__ == "__main__":
 
         aws_instance_type = os.environ.get('AWS_INSTANCE_TYPE', '').lower()
 
-        try:
-            cpu_model = get_cpu_model()
-        except Exception as e:
-            print(f"Failed to get CPU model: {e}")
-            cpu_model = None
+        cpu_model = get_cpu_model()
 
         results = {
             'target_os': os.environ.get('TARGET_OS'),


### PR DESCRIPTION
The "Collect runner's system stats" step now captures the runner's CPU model:

- **macOS**: `sysctl -n machdep.cpu.brand_string`
- **Linux**: `Model name` from `lscpu` (on ARM it decodes the implementer/part ids to a name like `Neoverse-N2`)
- **Windows**: `(Get-CimInstance Win32_Processor).Name`

The value is stored as `cpu_model` in the `RunnerSysStats-*.json` artifact (and printed in the step log), and `collect_ci_stats.py` forwards it to the CI-stats API as `runner_cpu_model`.

If no model can be determined, the value is `null`.

Known limitation (observed in this PR's CI run): on ARM64 hosts the value is `null` in containers whose util-linux is too old to decode the part id — Neoverse-N2 (`0xd49`) is missing from the `lscpu` table in ubuntu22, rockylinux8-vcpkg, and the emscripten images, while the ubuntu24 container decodes it fine. All other jobs (Windows, macOS, Linux x64) captured a real model. If those jobs matter, a follow-up can decode `CPU implementer`/`CPU part` from `/proc/cpuinfo` directly, like `GetCpuId()` in MRMesh does.

Note: if the `ci-stats/v2/log` backend validates the payload strictly, it needs to accept the new `runner_cpu_model` field (unknown-field-tolerant backends need no change; the `collect-stats` job is `continue-on-error` either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
