### PR TITLE
install.bat: fail on undetectable vcpkg tag; safe.directory for git describe

### DIFF
--- a/thirdparty/install.bat
+++ b/thirdparty/install.bat
@@ -38,13 +38,16 @@ if not defined vcpkg_path (
     REM S3 folder name = the checked-out vcpkg release tag (e.g. 2026.06.24).
     REM CI checks vcpkg out at a release tag before running this script, so
     REM `git describe --exact-match` yields that tag and keeps the binary-cache
-    REM producer (prepare-images) and consumer (build) in sync. Fall back to the
-    REM vcpkg-tool version date (YYYY-MM-DD) when vcpkg isn't on a tagged commit.
+    REM producer (prepare-images) and consumer (build) in sync. safe.directory
+    REM covers checkouts owned by another user (common on self-hosted runners).
+    REM A failed describe is fatal: silently falling back to another folder name
+    REM would split the binary cache between producers and consumers.
     set "VCPKG_TAG="
-    for /f "delims=" %%T in ('git -C "!vcpkg_path!." describe --tags --exact-match 2^>nul') do set VCPKG_TAG=%%T
+    for /f "delims=" %%T in ('git -c safe.directory^=* -C "!vcpkg_path!." describe --tags --exact-match 2^>nul') do set VCPKG_TAG=%%T
     if not defined VCPKG_TAG (
-        for /f "tokens=6" %%V in ('vcpkg version 2^>nul ^| findstr /R "vcpkg package management program version [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"') do set FULL_VCPKG_TAG=%%V
-        set VCPKG_TAG=!FULL_VCPKG_TAG:~0,10!
+        echo Error: could not determine the vcpkg release tag at "!vcpkg_path!":
+        git -c safe.directory=* -C "!vcpkg_path!." describe --tags --exact-match
+        exit /b 1
     )
 )
 

--- a/thirdparty/install.bat
+++ b/thirdparty/install.bat
@@ -40,14 +40,14 @@ if not defined vcpkg_path (
     REM `git describe --exact-match` yields that tag and keeps the binary-cache
     REM producer (prepare-images) and consumer (build) in sync. safe.directory
     REM covers checkouts owned by another user (common on self-hosted runners).
-    REM A failed describe is fatal: silently falling back to another folder name
-    REM would split the binary cache between producers and consumers.
+    REM A failed describe is fatal when the S3 cache is in use: silently falling
+    REM back to another folder name would split the cache between producers and
+    REM consumers. Without AWS CLI the cache is disabled and the tag irrelevant.
     set "VCPKG_TAG="
     for /f "delims=" %%T in ('git -c safe.directory^=* -C "!vcpkg_path!." describe --tags --exact-match 2^>nul') do set VCPKG_TAG=%%T
     if not defined VCPKG_TAG (
-        echo Error: could not determine the vcpkg release tag at "!vcpkg_path!":
-        git -c safe.directory=* -C "!vcpkg_path!." describe --tags --exact-match
-        exit /b 1
+        if "!aws_cli_available!"=="true" goto :tag_error
+        set VCPKG_TAG=no-tag
     )
 )
 
@@ -142,3 +142,9 @@ REM Error handling
 echo Failed with error #%errorlevel%.
 endlocal
 exit /b %errorlevel%
+
+:tag_error
+echo Error: could not determine the vcpkg release tag at "!vcpkg_path!":
+git -c safe.directory=* -C "!vcpkg_path!." describe --tags --exact-match
+endlocal
+exit /b 1


### PR DESCRIPTION
## What

Two changes to the `VCPKG_TAG` detection in `thirdparty/install.bat` (the tag names the S3 binary-cache folder, `s3://vcpkg-export/<VCPKG_TAG>/<TRIPLET>/`):

1. Run `git describe` with `-c safe.directory=*`, matching what `git` invocations in our other runner-facing scripts already do for vcpkg checkouts owned by a different user.
2. If `git describe --tags --exact-match` still fails **and the S3 binary cache is in use** (AWS CLI available), abort with the actual git error instead of silently falling back to the vcpkg-tool version date. Without AWS CLI the binary sources are `clear` and the tag is never used, so the script proceeds with `no-tag` as before.

The failure goes through a `:tag_error` label rather than an inline `exit /b` inside the nested block — cmd loses the exit code of a nested-parenthesized `exit /b` when the script is invoked directly (as CI does from pwsh); the label pattern matches the existing `:error` handler and propagates the code in both invocation styles.

## Why

On a self-hosted runner whose vcpkg checkout is owned by another user, git refuses to read the repo ("dubious ownership"). The describe output was redirected to `nul`, so the failure was invisible: `VCPKG_TAG` silently fell back to the tool date (e.g. `2026-05-27`) even though the checkout was at the correct release tag. All binary-cache reads and writes on that runner then targeted `s3://vcpkg-export/2026-05-27/...` — a folder no properly-tagged producer or consumer uses. Its uploads were wasted, and other runners rebuilt from source what it had already built (and vice versa).

The fallback exists to produce *some* folder name, but a wrong folder name is strictly worse than a hard error: it silently splits the cache between producer and consumer, and the cost shows up later as multi-minute full vcpkg rebuilds that are hard to trace back. Failing fast with the git error makes the misconfiguration visible in the job that has it.

Verified all three paths locally via direct pwsh invocation (how CI runs it): untagged checkout + AWS CLI prints `fatal: no tag exactly matches '...'` and exits 1; untagged checkout without AWS CLI proceeds with `no-tag`; checkout at a release tag resolves the tag as before.
