### PR TITLE
MSBuild: mark vcpkg headers as external with /external:W0

### DIFF
--- a/source/common.props
+++ b/source/common.props
@@ -27,6 +27,8 @@
   </PropertyGroup>
   <PropertyGroup Label="Globals">
     <VcpkgCurrentInstalledDir>$(VcpkgRoot)\installed\$(VcpkgTriplet)</VcpkgCurrentInstalledDir>
+    <!-- Mark vcpkg headers as external (/external:I); with ExternalWarningLevel below this mutes their warnings like vcpkg's CMake toolchain does -->
+    <ExternalIncludePath>$(VcpkgCurrentInstalledDir)\include;$(ExternalIncludePath)</ExternalIncludePath>
   </PropertyGroup>
   <PropertyGroup Label="Globals" Condition="Exists('$(VcpkgCurrentInstalledDir)\include\python3.10')">
     <PythonVersion>310</PythonVersion>
@@ -69,6 +71,8 @@
       <UseStandardPreprocessor>true</UseStandardPreprocessor>
       <TreatWarningAsError>true</TreatWarningAsError>
       <WarningLevel>EnableAllWarnings</WarningLevel>
+      <!-- /external:W0, matching `/Wall /WX /external:W0` in CompilerOptions.cmake -->
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
       <!--
         !! NOTE: Sync this list with `CompilerOptions.cmake` !!
            warning C4061: enumerator V in switch of enum E is not explicitly handled by a case label


### PR DESCRIPTION
## Summary

Make the MSBuild build treat vcpkg headers the same way the CMake build already does: as external headers whose warnings are muted.

- `ExternalIncludePath` gets `$(VcpkgCurrentInstalledDir)\include` (prefix-matching also covers the `eigen3`, `suitesparse`, and `python3.x` subdirectory includes), which maps to `/external:I`.
- `ExternalWarningLevel` is set to `TurnOffAllWarnings` (`/external:W0`), mirroring the `/Wall /WX /external:W0` line in `CompilerOptions.cmake`. `MeshLibC2.vcxproj` already uses the same setting.

## Motivation

Today the MSBuild lane compiles vcpkg headers at full `/Wall /WX` (vcpkg's MSBuild integration passes its include as a plain `/I`), while the CMake lane compiles the identical headers at `/external:W0`. As a result, every vcpkg upgrade risks a build break that only the MSBuild lane sees — most recently `C4459` from fmt 12 `base.h` under VS2019 on #6382, and historically the reason for one-by-one suppressions like the `#pragma warning` wrappers in `MRPch/MRFmt.h` / `MRPch/MRSpdlog.h`.

## Notes

- `DisableSpecificWarnings` (the `/wd` list) is intentionally untouched: those warnings also fire in MeshLib's own sources, which stay at `/Wall /WX`.
- MeshLib's own headers and the in-tree `thirdparty/` includes (imgui, parallel-hashmap, mrbind-pybind11) are *not* marked external — only vcpkg-installed headers.
- Windows/MSBuild-only by construction (`.props` files are not read by CMake), so all other platforms are label-disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
