### PR TITLE
Drop stale GCC/Clang warning suppressions around third-party headers

### DIFF
--- a/source/MRPch/MRJson.h
+++ b/source/MRPch/MRJson.h
@@ -1,12 +1,3 @@
 #pragma once
 
-#if defined(__APPLE__) && defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-volatile"
-#endif
-
 #include <json/json.h>
-
-#if defined(__APPLE__) && defined(__clang__)
-#pragma clang diagnostic pop
-#endif

--- a/source/MRPch/MRSpdlog.h
+++ b/source/MRPch/MRSpdlog.h
@@ -46,12 +46,6 @@ class __attribute__((visibility("default"))) ansicolor_stderr_sink;
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-#if __GNUC__ == 13
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif
-
 #pragma warning(push)
 #pragma warning(disable:4275) // non dll-interface class 'std::runtime_error' used as base for dll-interface class 'fmt::v10::format_error'
 #pragma warning(disable:4251)
@@ -66,10 +60,6 @@ class __attribute__((visibility("default"))) ansicolor_stderr_sink;
 #include <spdlog/sinks/msvc_sink.h>
 #endif
 #pragma warning(pop)
-
-#if __GNUC__ == 13
-#pragma GCC diagnostic pop
-#endif
 
 #if (defined(__APPLE__) && defined(__clang__)) || defined(__EMSCRIPTEN__)
 #pragma clang diagnostic pop

--- a/source/MRPch/MRTBB.h
+++ b/source/MRPch/MRTBB.h
@@ -2,13 +2,6 @@
 
 // this is to include all important for us Intel Threading Building Blocks (TBB) parts in a precompiled header and suppress warnings there
 
-#ifdef __EMSCRIPTEN__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-volatile"
-#pragma clang diagnostic ignored "-Wpedantic"
-#pragma clang diagnostic ignored "-W#warnings"
-#endif
-
 // otherwise precompiled header in CMake+MSVC cannot be used in TBB-free projects
 #define __TBB_NO_IMPLICIT_LINKAGE 1
 
@@ -39,7 +32,3 @@
 #include <tbb/global_control.h>
 #include <tbb/task_scheduler_observer.h>
 #pragma warning(pop)
-
-#ifdef __EMSCRIPTEN__
-#pragma clang diagnostic pop
-#endif


### PR DESCRIPTION
## Summary

Removes three GCC/Clang warning-suppression blocks around third-party headers whose reason to exist has since disappeared. All GCC/Clang lanes compile with `-Werror`, so CI on this PR is the proof: if any of these were still load-bearing, the corresponding lane fails.

- **`MRPch/MRSpdlog.h`** — the `__GNUC__ == 13` `-Warray-bounds` / `-Wstringop-overflow` push/pop (added with the fedora38/GCC 13 bring-up, #1590). `MRFmt.h`, included immediately above, carries the identical wrap (gated `>= 13`, extended to GCC 14/15 in #6248) around the fmt headers where these middle-end false positives actually originate; GCC records diagnostic-pragma state per source location, so the fmt lines stay covered in every TU. The `== 13` gate also means GCC 14/15 lanes have long been building with this block inactive.
- **`MRPch/MRJson.h`** — the Apple-clang `-Wdeprecated-volatile` wrap dates to 2021, when jsoncpp still used C++20-deprecated `volatile` operations. jsoncpp removed those in 1.9.5 (2021); vcpkg and Homebrew both ship 1.9.6.
- **`MRPch/MRTBB.h`** — the emscripten `-Wdeprecated-volatile` / `-Wpedantic` / `-W#warnings` block dates to the 2022 wasm bring-up (#35) against classic TBB 2020; `thirdparty/` builds oneTBB now.

## Deliberately kept

- `MRFmt.h`'s GCC ≥ 13 wrap — GCC's `-Warray-bounds`/`-Wstringop-overflow` are optimizer-stage diagnostics that leak through system-header suppression; this wrapper is the one that actually works.
- `MRSignal.h`'s Apple `-Wdeprecated-dynamic-exception-spec` — added only last month with the `-Wdeprecated` warning-level raise (#6201), so it demonstrably still fires.
- `MREigenSparseCore.h`'s `-Wunknown-warning-option` guard — still protects older Apple clang that predates `-Wunused-but-set-variable`.

Windows is label-disabled: every removed block is gated on `__GNUC__`, Apple clang, or `__EMSCRIPTEN__`, none of which apply to the MSVC lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
