### PR TITLE
Pin windows vcpkg triplets to CRLF checkout via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,2 @@
-# Windows vcpkg triplets are hashed byte-for-byte into vcpkg's triplet_abi,
-# which keys the S3 binary cache. Pin their checkout to CRLF (the effective
-# EOL on the runners that populate the cache) so every machine computes the
-# same key regardless of its core.autocrlf setting; an EOL mismatch silently
-# rebuilds all packages from source. Linux triplets are left untouched: their
-# cache namespace was populated from LF checkouts.
+# The triplet EOL feeds vcpkg's ABI hash; changing this invalidates the vcpkg binary cache on Windows.
 thirdparty/vcpkg/triplets/x64-windows-* text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Windows vcpkg triplets are hashed byte-for-byte into vcpkg's triplet_abi,
+# which keys the S3 binary cache. Pin their checkout to CRLF (the effective
+# EOL on the runners that populate the cache) so every machine computes the
+# same key regardless of its core.autocrlf setting; an EOL mismatch silently
+# rebuilds all packages from source. Linux triplets are left untouched: their
+# cache namespace was populated from LF checkouts.
+thirdparty/vcpkg/triplets/x64-windows-* text eol=crlf


### PR DESCRIPTION
## What

Adds a `.gitattributes` pinning the windows vcpkg triplets to a CRLF checkout:

```
thirdparty/vcpkg/triplets/x64-windows-* text eol=crlf
```

## Why

vcpkg hashes the triplet file byte-for-byte into `triplet_abi`, which is part of every package's ABI hash — i.e. the S3 binary-cache key (`s3://vcpkg-export/<tag>/<triplet>/<abi>.zip`). Without an attribute, the checked-out bytes depend on each machine's `core.autocrlf`: a CRLF checkout of `x64-windows-meshlib.cmake` hashes to `1c8ab474...`, an LF checkout to `9ec9b085...`. A machine on the minority ending finds zero matches in the cache and silently rebuilds all of vcpkg from source (~74 min), then uploads to keys nobody else reads — the cache splits into parallel namespaces per EOL setting.

The windows cache namespaces were populated from CRLF checkouts (`core.autocrlf=true`, the Git for Windows default on the runners that build them), so CRLF is pinned. **No existing cache key changes**; machines with `autocrlf` disabled join the shared namespace instead of building their own.

Scope notes:

- Linux triplets are deliberately not covered: the linux cache namespaces were populated from LF checkouts, and any EOL change there would invalidate them.
- Overlay ports (`thirdparty/vcpkg/ports/**`) also enter the ABI but are shared between windows and linux builds, so no single `eol=` choice is free there; they are out of scope for this PR.
- The attribute takes effect on fresh clones and re-smudged files. A persistent workspace that already holds an LF checkout keeps it until the file is re-checked-out (git does not rewrite files it considers clean on an attributes change).

Verified with a fresh `core.autocrlf=false` clone of this branch: the windows triplet now hashes to `1c8ab474...` (the existing cache key) and the linux triplets are byte-identical to master.
