### PR TITLE
CI: capture free disk space in runner's system stats

### DIFF
--- a/scripts/devops/collect_ci_stats.py
+++ b/scripts/devops/collect_ci_stats.py
@@ -75,6 +75,7 @@ def parse_job(job: dict):
             'runner_cpu_count':  runner_stats['cpu_count'],
             'runner_cpu_model':  runner_stats.get('cpu_model'),
             'runner_ram_mb':     runner_stats['ram_mb'],
+            'runner_free_disk_mb': runner_stats.get('free_disk_mb'),
             'build_system':      runner_stats['build_system'],
             'aws_instance_type': runner_stats['aws_instance_type'],
             'artifact_size':     artifact_size,

--- a/scripts/devops/collect_runner_sys_stats.py
+++ b/scripts/devops/collect_runner_sys_stats.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os
 import platform
 import re
+import shutil
 import subprocess
 
 def get_ram_amount():
@@ -37,6 +38,9 @@ def get_cpu_model():
         return output.strip().splitlines()[0]
     else:
         raise RuntimeError(f"Unknown system: {system}")
+
+def get_free_disk_space():
+    return shutil.disk_usage(os.environ.get('GITHUB_WORKSPACE', os.getcwd())).free
 
 def get_compiler_id(compiler_path):
     # work-around for Windows runners
@@ -86,6 +90,7 @@ if __name__ == "__main__":
         aws_instance_type = os.environ.get('AWS_INSTANCE_TYPE', '').lower()
 
         cpu_model = get_cpu_model()
+        free_disk = math.floor(get_free_disk_space() / 1024 / 1024)
 
         results = {
             'target_os': os.environ.get('TARGET_OS'),
@@ -95,6 +100,7 @@ if __name__ == "__main__":
             'cpu_count': cpu_count,
             'cpu_model': cpu_model,
             'ram_mb': ram_amount,
+            'free_disk_mb': free_disk,
             'build_system': build_system,
             'aws_instance_type': aws_instance_type or None,
         }


### PR DESCRIPTION
The "Collect runner's system stats" step now captures free disk space on the runner — needed to monitor disk exhaustion, especially on the physical (self-hosted) runners.

- Measured with `shutil.disk_usage()` (stdlib, works on all three OSes) on `$GITHUB_WORKSPACE`, i.e. the volume builds actually run on; falls back to the current directory when unset.
- Stored as `free_disk_mb` in the `RunnerSysStats-*.json` artifact (and printed in the step log), matching the existing `ram_mb` unit convention.
- `collect_ci_stats.py` forwards it to the CI-stats API as `runner_free_disk_mb`.

Follow-up outside this repo: the stats backend needs a matching `runner_free_disk_mb` column and insert (same shape as `runner_ram_mb`); until then the new field is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
