### PR TITLE
Skip logging of benign EPT_S_NOT_REGISTERED Windows exception

### DIFF
--- a/source/MRMesh/MRLogWindowsExceptions.cpp
+++ b/source/MRMesh/MRLogWindowsExceptions.cpp
@@ -15,6 +15,7 @@ namespace
 constexpr auto EXCEPTION_CXX   = 0xE06D7363L; // c++ throw ...
 constexpr auto MS_VC_EXCEPTION = 0x406D1388L; // thread renaming
 constexpr auto RPC_UNAVAILABLE = 0x000006BAL; // thrown in file dialog
+constexpr auto EPT_NOT_REGISTERED = 0x000006D9L; // EPT_S_NOT_REGISTERED, raised and handled inside RPC runtime, e.g. when print spooler service is stopped
 
 // we limit the number of logged stacktraces since typically only the first exception is of any interest,
 // and the following ones are either repetitions or consequences of the first exception which only make the log huge
@@ -33,6 +34,7 @@ LONG WINAPI logWindowsException( LPEXCEPTION_POINTERS pExInfo )
     if ( pExceptionRecord->ExceptionCode == EXCEPTION_BREAKPOINT ||
          pExceptionRecord->ExceptionCode == EXCEPTION_SINGLE_STEP ||
          pExceptionRecord->ExceptionCode == RPC_UNAVAILABLE ||
+         pExceptionRecord->ExceptionCode == EPT_NOT_REGISTERED ||
          pExceptionRecord->ExceptionCode == EXCEPTION_CXX ||
          pExceptionRecord->ExceptionCode == MS_VC_EXCEPTION )
         return EXCEPTION_CONTINUE_SEARCH; //normal situation, handled otherwise


### PR DESCRIPTION
## Summary

Windows CI logs are flooded with:

```
[warning] Windows exception 0x000006d9
```

`0x6D9` is `EPT_S_NOT_REGISTERED` (win32 error 1753, "There are no more endpoints available from the endpoint mapper"). It is a first-chance exception raised and handled entirely inside the RPC runtime: the Intel OpenGL ICD calls `CreateDC` during pixel format selection in `glfwCreateWindow`, which probes the print spooler via `winspool!OpenPrinterW`; when the spooler service is stopped (typical on CI runners), the RPC runtime raises 1753 and catches it itself, once per probed pixel format.

This adds `0x6D9` to the skip list in `logWindowsException`, next to the analogous `RPC_S_SERVER_UNAVAILABLE` (`0x6BA`) that is already filtered.

## Test plan

- Windows CI build/tests pass; the repeated `Windows exception 0x000006d9` warnings and their stacktraces no longer appear in viewer startup logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
