### PR TITLE
Fix loading OBJ files with tab-indented lines

### DIFF
--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -58,22 +58,15 @@ enum class MtlElement
     DissolveTexture,
 };
 
-std::string_view skipSpaces( std::string_view line )
-{
-    while ( !line.empty() && ( line[0] == ' ' || line[0] == '\t' ) )
-        line.remove_prefix( 1 );
-    return line;
-}
-
 template <typename T>
 T parseToken( std::string_view line );
 
 template <>
 ObjElement parseToken<ObjElement>( std::string_view line )
 {
-    line = skipSpaces( line );
-
-    assert( !line.empty() );
+    line = trimLeft( line );
+    if ( line.empty() )
+        return ObjElement::Unknown;
     switch ( line[0] )
     {
     case 'v':
@@ -121,9 +114,9 @@ bool isSingleLineElement( T el )
 template <>
 MtlElement parseToken<MtlElement>( std::string_view line )
 {
-    line = skipSpaces( line );
-
-    assert( !line.empty() );
+    line = trimLeft( line );
+    if ( line.empty() )
+        return MtlElement::Unknown;
     switch ( line[0] )
     {
     case 'n':
@@ -478,7 +471,7 @@ Expected<MtlLibrary> loadMtlLibrary( const std::filesystem::path& path )
                 result.emplace( std::move( currentMaterialName ), std::move( currentMaterial ) );
                 currentMaterial = {};
             }
-            currentMaterialName = skipSpaces( line ).substr( strlen( "newmtl" ), std::string_view::npos );
+            currentMaterialName = trimLeft( line ).substr( strlen( "newmtl" ), std::string_view::npos );
             boost::trim( currentMaterialName );
         }
         break;
@@ -1026,7 +1019,7 @@ Expected<std::vector<MeshLoad::NamedMesh>> loadModelsFromObj(
         {
             std::string_view line( data + newlines[g.begin], newlines[g.end] - newlines[g.begin] );
             // TODO: support multiple files
-            std::string filename( skipSpaces( line ).substr( strlen( "mtllib" ), std::string_view::npos ) );
+            std::string filename( trimLeft( line ).substr( strlen( "mtllib" ), std::string_view::npos ) );
             boost::trim( filename );
             mtl = loadMtlLibrary( dir / filename );
             break;
@@ -1179,7 +1172,7 @@ Expected<std::vector<MeshLoad::NamedMesh>> loadModelsFromObj(
         {
             std::string_view line( data + newlines[g.begin], newlines[g.end] - newlines[g.begin] );
             auto& objData = oScopes.emplace_back();
-            objData.objName = skipSpaces( line ).substr( strlen( "o" ), std::string_view::npos );
+            objData.objName = trimLeft( line ).substr( strlen( "o" ), std::string_view::npos );
             objData.fId = faceInfos.size();
             boost::trim( objData.objName );
             break;
@@ -1191,7 +1184,7 @@ Expected<std::vector<MeshLoad::NamedMesh>> loadModelsFromObj(
         {
             std::string_view line( data + newlines[g.begin], newlines[g.end] - newlines[g.begin] );
             auto& mtlData = mScopes.emplace_back();
-            mtlData.mtName = skipSpaces( line ).substr( strlen( "usemtl" ), std::string_view::npos );
+            mtlData.mtName = trimLeft( line ).substr( strlen( "usemtl" ), std::string_view::npos );
             mtlData.fId = faceInfos.size();
             boost::trim( mtlData.mtName );
             break;

--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -58,14 +58,20 @@ enum class MtlElement
     DissolveTexture,
 };
 
+std::string_view skipSpaces( std::string_view line )
+{
+    while ( !line.empty() && ( line[0] == ' ' || line[0] == '\t' ) )
+        line.remove_prefix( 1 );
+    return line;
+}
+
 template <typename T>
 T parseToken( std::string_view line );
 
 template <>
 ObjElement parseToken<ObjElement>( std::string_view line )
 {
-    while ( !line.empty() && line[0] == ' ' )
-        line.remove_prefix( 1 );
+    line = skipSpaces( line );
 
     assert( !line.empty() );
     switch ( line[0] )
@@ -75,6 +81,7 @@ ObjElement parseToken<ObjElement>( std::string_view line )
         switch ( line[1] )
         {
         case ' ':
+        case '\t':
             return ObjElement::Vertex;
         case 't':
             return ObjElement::TextureVertex;
@@ -114,8 +121,7 @@ bool isSingleLineElement( T el )
 template <>
 MtlElement parseToken<MtlElement>( std::string_view line )
 {
-    while ( !line.empty() && line[0] == ' ' )
-        line.remove_prefix( 1 );
+    line = skipSpaces( line );
 
     assert( !line.empty() );
     switch ( line[0] )
@@ -472,7 +478,7 @@ Expected<MtlLibrary> loadMtlLibrary( const std::filesystem::path& path )
                 result.emplace( std::move( currentMaterialName ), std::move( currentMaterial ) );
                 currentMaterial = {};
             }
-            currentMaterialName = line.substr( 6, std::string_view::npos );
+            currentMaterialName = skipSpaces( line ).substr( strlen( "newmtl" ), std::string_view::npos );
             boost::trim( currentMaterialName );
         }
         break;
@@ -1020,7 +1026,7 @@ Expected<std::vector<MeshLoad::NamedMesh>> loadModelsFromObj(
         {
             std::string_view line( data + newlines[g.begin], newlines[g.end] - newlines[g.begin] );
             // TODO: support multiple files
-            std::string filename( line.substr( strlen( "mtllib" ), std::string_view::npos ) );
+            std::string filename( skipSpaces( line ).substr( strlen( "mtllib" ), std::string_view::npos ) );
             boost::trim( filename );
             mtl = loadMtlLibrary( dir / filename );
             break;
@@ -1173,7 +1179,7 @@ Expected<std::vector<MeshLoad::NamedMesh>> loadModelsFromObj(
         {
             std::string_view line( data + newlines[g.begin], newlines[g.end] - newlines[g.begin] );
             auto& objData = oScopes.emplace_back();
-            objData.objName = line.substr( strlen( "o" ), std::string_view::npos );
+            objData.objName = skipSpaces( line ).substr( strlen( "o" ), std::string_view::npos );
             objData.fId = faceInfos.size();
             boost::trim( objData.objName );
             break;
@@ -1185,7 +1191,7 @@ Expected<std::vector<MeshLoad::NamedMesh>> loadModelsFromObj(
         {
             std::string_view line( data + newlines[g.begin], newlines[g.end] - newlines[g.begin] );
             auto& mtlData = mScopes.emplace_back();
-            mtlData.mtName = line.substr( strlen( "usemtl" ), std::string_view::npos );
+            mtlData.mtName = skipSpaces( line ).substr( strlen( "usemtl" ), std::string_view::npos );
             mtlData.fId = faceInfos.size();
             boost::trim( mtlData.mtName );
             break;

--- a/source/MRTest/MRMeshLoadSaveTest.cpp
+++ b/source/MRTest/MRMeshLoadSaveTest.cpp
@@ -1,8 +1,11 @@
 #include <MRMesh/MRMeshLoad.h>
+#include <MRMesh/MRMeshLoadObj.h>
 #include <MRMesh/MRMeshSave.h>
 #include <MRMesh/MRMesh.h>
 #include <MRMesh/MRBox.h>
 #include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
 
 namespace MR
 {
@@ -74,6 +77,41 @@ TEST(MRMesh, LoadSave)
     EXPECT_EQ( loadRes->points.size(), 5 );
     EXPECT_EQ( loadRes->topology.numValidVerts(), 5 );
     EXPECT_EQ( loadRes->topology.numValidFaces(), 6 );
+}
+
+TEST(MRMesh, LoadObjTabIndented)
+{
+    // some exporters (e.g. 3ds Max guruware OBJ exporter) indent lines with tabs
+    const auto dir = std::filesystem::temp_directory_path();
+    const auto mtlPath = dir / "MRLoadObjTabIndented.mtl";
+    {
+        std::ofstream mtl( mtlPath, std::ios::binary );
+        mtl <<
+            "newmtl Mat1\n"
+            "\tKd 0.5880 0.5880 0.5880\n"
+            "\tmap_Kd tex1.jpg\n";
+    }
+
+    std::string file =
+        "mtllib MRLoadObjTabIndented.mtl\n"
+        "v 0 0 0\n"
+        "\tv 1 0 0\n"
+        "v 0 1 0\n"
+        "vt 0 0\n"
+        "vt 1 0\n"
+        "vt 0 1\n"
+        "\tusemtl Mat1\n"
+        "f 1/1 2/2 3/3\n";
+
+    auto res = MeshLoad::fromSceneObjFile( file.data(), file.size(), false, dir );
+    std::filesystem::remove( mtlPath );
+    ASSERT_TRUE( res.has_value() );
+    ASSERT_EQ( res->size(), 1 );
+    const auto& named = res->front();
+    EXPECT_EQ( named.mesh.topology.numValidFaces(), 1 );
+    ASSERT_EQ( named.textureFiles.size(), 1 );
+    EXPECT_EQ( named.textureFiles.front().filename(), "tex1.jpg" );
+    ASSERT_TRUE( named.diffuseColor.has_value() );
 }
 
 } //namespace MR


### PR DESCRIPTION
## Problem

OBJ models exported by tools that indent lines with tabs (e.g. the widespread guruware OBJ exporter for 3ds Max) load without textures and without diffuse colors. Such exporters write MTL files like:

```
newmtl Mat1
	Kd 0.5880 0.5880 0.5880
	map_Kd Mat1.jpg
```

`parseToken<MtlElement>` skips only leading spaces, so every tab-indented line is classified as `Unknown` and silently dropped: materials end up with no `Kd` and no `map_Kd`, and the mesh loads untextured (geometry and UVs are fine). `parseToken<ObjElement>` has the same limitation for tab-indented lines in the OBJ file itself.

## Fix

* new `skipSpaces` helper removes leading spaces **and tabs**; used by both `parseToken` specializations;
* `v<tab>` is now recognized as a vertex line, same as `v<space>`;
* keyword-suffix extractions (`newmtl`, `usemtl`, `mtllib`, `o`) skip leading whitespace before cutting off the keyword, so indented keyword lines produce correct names.

## Test

New `MRMesh.LoadObjTabIndented` unit test loads an OBJ with tab-indented `v`/`usemtl` lines and a tab-indented MTL, and checks that the texture file, diffuse color, and geometry all come through.

Verified on a real-world guruware-exported model (4 materials, 4 JPG textures): before the fix `getTextures()` returned 0 textures, after the fix all 4 textures load with `texturePerFace` fully populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
