### PR TITLE
Support loading standalone slice stack .model files

### DIFF
--- a/source/MRIOExtras/MR3mf.cpp
+++ b/source/MRIOExtras/MR3mf.cpp
@@ -398,14 +398,30 @@ Expected<LoadedObject> ThreeMFLoader::load( const std::vector<std::filesystem::p
     if ( !reportProgress( callback, 0.8f ) )
         return unexpectedOperationCanceled();
 
-    if ( objectNodes_.empty() )
-        return unexpected( "No objects found" );
-
     std::shared_ptr<Object> objRes = std::make_shared<Object>();
     for ( auto& node : objectNodes_ )
     {
         objRes->addChild( std::move( node->obj_ ) );
     }
+
+    if ( objRes->children().empty() )
+    {
+        // no <build> items (e.g. standalone slice stack .model file): add slice stacks not owned by any object
+        for ( auto& [_, xmlDoc] : xmlDocuments_ )
+        {
+            if ( !xmlDoc.rootNode )
+                continue;
+            for ( auto& ssItem : xmlDoc.rootNode->slicestackNodes_ )
+            {
+                auto* ssNode = ssItem.second;
+                if ( ssNode && ssNode->obj_ && !ssNode->obj_->parent() )
+                    objRes->addChild( ssNode->obj_ );
+            }
+        }
+    }
+
+    if ( objRes->children().empty() )
+        return unexpected( "No objects found" );
 
     if ( !reportProgress( callback, 1.0f ) )
         return unexpectedOperationCanceled();
@@ -1140,7 +1156,7 @@ Expected<void> Node::loadSlicestack_( ThreeMFLoader& loader, const tinyxml2::XML
 
         auto verticesNode = sliceNode->FirstChildElement( "s:vertices" );
         if ( !verticesNode )
-            break;
+            continue; // a slice without polygons is valid (empty layer)
         Polyline3 localPoly;
 #if TINYXML2_MAJOR_VERSION > 10
         localPoly.points.reserve( verticesNode->ChildElementCount( "s:vertex" ) );


### PR DESCRIPTION
## Problem
Standalone slice stack `.model` files (e.g. `2D/*.model` parts of a slice stack package, as written by nesting export) failed to load with "No objects found": they contain only `<s:slicestack>` resources and an empty `<build/>`, while the loader assembles the scene only from `<build>` items, so the parsed slice stack was dropped.

Additionally, a slice without polygons (a valid empty layer) aborted parsing of all remaining slices in the stack.

## Fix
- If no `<build>` item produced any scene object, add parsed slice stacks that are not owned by any object to the scene. Fallback only: normal 3mf files with build items are unaffected, and their unreferenced slice stacks are still ignored.
- Skip empty slices (`continue` instead of `break`); z tracking stays correct since `zbtm` advances before the check.

## Verification
Standalone test exe against rebuilt Release MRIOExtras:
- real 18 MB standalone slice stack `.model`: now loads as `ObjectLines` — 183,489 points, 2,456 contours, 662 slices, z range [0.04, 52.92] consistent with its 0.08 mm step (errored before)
- synthetic stack with an empty middle slice: both remaining slices load at correct z (0.5, 2.5)
- synthetic file with a `<build>` item, one referenced + one unreferenced slice stack: scene unchanged — only the build object with its attached stack, orphan not added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
