### PR TITLE
CI: use GH_TOKEN env var instead of gh auth login in test-distribution

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -67,8 +67,9 @@ jobs:
           fi
 
       - name: Download Ubuntu x86-64 Release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token
           gh release download ${{ inputs.release_tag }} --pattern "*${{matrix.name}}-dev.deb" --repo ${{ github.repository }}
 
       - name: Install Ubuntu x86-64 Release
@@ -161,8 +162,9 @@ jobs:
           apt-get install -y gh
 
       - name: Download Ubuntu arm64 Release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token
           gh release download ${{ inputs.release_tag }} --pattern "*${{matrix.name}}-arm64-dev.deb" --repo ${{ github.repository }}
 
       - name: Install Ubuntu arm64 Release
@@ -249,17 +251,12 @@ jobs:
           ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Download Distributive
-        # `gh auth login --with-token` validates the token by calling the
-        # GraphQL `viewer` query, which intermittently returns HTTP 401
-        # ("Bad credentials") even for a perfectly valid token -- a known
-        # transient on GitHub's side. See community discussion #101661;
-        # GitHub's official guidance is to retry after a short delay.
-        # Auth and download are wrapped in independent retry loops so a
-        # flake in one does not force the other to re-run. `--clobber`
-        # lets a download retry overwrite a partial file from a previous
-        # attempt.
+        # GH_TOKEN instead of `gh auth login`: the login stores the token in
+        # the macOS keychain, which is locked in self-hosted runner sessions
+        # ("failed to move active token in keyring: exit status 36").
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          scripts/retry.sh -- bash -c 'echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token'
           scripts/retry.sh -- gh release download ${{ inputs.release_tag }} --pattern "${{ matrix.pkg_pattern }}" --repo ${{ github.repository }} --clobber
 
       # Self-hosted runners have no passwordless sudo, so they install into
@@ -342,8 +339,9 @@ jobs:
           ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Download Distributive
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token
           gh release download ${{ inputs.release_tag }} --pattern "${{ matrix.dist_pattern }}" --repo ${{ github.repository }}
 
       - name: Unpack Distributive

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -21,6 +21,23 @@ on:
     secrets:
       GH_TOKEN:
         required: true
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+      test_ubuntu_x64:
+        type: boolean
+        default: false
+      test_ubuntu_arm64:
+        type: boolean
+        default: false
+      test_macos:
+        type: boolean
+        default: false
+      test_windows:
+        type: boolean
+        default: false
 
 jobs:
   linux-x64-test:

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Download Ubuntu x86-64 Release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         run: |
           gh release download ${{ inputs.release_tag }} --pattern "*${{matrix.name}}-dev.deb" --repo ${{ github.repository }}
 
@@ -180,7 +180,7 @@ jobs:
 
       - name: Download Ubuntu arm64 Release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         run: |
           gh release download ${{ inputs.release_tag }} --pattern "*${{matrix.name}}-arm64-dev.deb" --repo ${{ github.repository }}
 
@@ -272,7 +272,7 @@ jobs:
         # the macOS keychain, which is locked in self-hosted runner sessions
         # ("failed to move active token in keyring: exit status 36").
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         run: |
           scripts/retry.sh -- gh release download ${{ inputs.release_tag }} --pattern "${{ matrix.pkg_pattern }}" --repo ${{ github.repository }} --clobber
 
@@ -357,7 +357,7 @@ jobs:
 
       - name: Download Distributive
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         run: |
           gh release download ${{ inputs.release_tag }} --pattern "${{ matrix.dist_pattern }}" --repo ${{ github.repository }}
 


### PR DESCRIPTION
## Problem

`test-distribution / macos-test` fails on the self-hosted `macos-12-intel` runner ([example run](https://github.com/MeshInspector/MeshLib/actions/runs/29087622434/job/86358382660)):

```
failed to move active token in keyring: exit status 36
```

Since v2.40, `gh auth login` stores the token in the OS keyring — on macOS that means writing to the login keychain via `/usr/bin/security`. In a self-hosted runner service session the keychain is locked (no GUI login), so the write fails deterministically with keychain error 36 ("user interaction is not allowed"); the retry wrapper cannot help.

## Fix

Drop `gh auth login` entirely and pass the token as a step-level `GH_TOKEN` env var at all four download sites in `test-distribution.yml`. `gh` reads `GH_TOKEN` directly, never touching the keyring. This also removes the flaky GraphQL `viewer` validation call that `gh auth login` performs (the reason the retry wrapper was added in the first place), so the stale comment about it is replaced.

The token also no longer appears in a `run:` command line (`echo <token> | ...`), which is a minor hardening bonus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Verification

Since `test-distribution` only runs via `workflow_call` from the release pipeline (and is skipped on PR CI), this PR also adds a `workflow_dispatch` trigger so the distribution tests can be run standalone against an existing release. Dispatch runs have no caller to pass the `GH_TOKEN` secret, so the env var falls back to the built-in `github.token`, which can read the repository's own releases.

Verified by dispatching a macOS-only run on this branch against `v3.1.3.322`: [run 29093527010](https://github.com/MeshInspector/MeshLib/actions/runs/29093527010) — all 7 macOS jobs green, including `macos-12-intel` where the keyring failure occurred; the download step completed in ~10 s with no keychain access.
