### PR TITLE
PlanarTriangulation: optional winding and intersection outputs in triangulateContours

### DIFF
--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -292,6 +292,9 @@ struct SweepLineParams
 
     /// optional out EdgePaths that corresponds to initial contours
     std::vector<EdgePath>* outBoundaries{ nullptr };
+
+    /// optional out per-face winding numbers
+    Vector<int, FaceId>* outFaceWinding{ nullptr };
 };
 
 class SweepLineQueue
@@ -611,10 +614,13 @@ Mesh SweepLineQueue::triangulate()
         if ( tp_.left( dirE ) )
             continue;
 
+        const auto firstBlockFace = FaceId( tp_.faceSize() );
         if ( !params_.needOutline )
             triangulateMonotoneBlock_( dirE ); // triangulate
         else
             tp_.setLeft( dirE, tp_.addFaceId() ); // mark present
+        if ( params_.outFaceWinding ) // all faces of one monotone block are in the region with same winding number
+            params_.outFaceWinding->autoResizeSet( firstBlockFace, tp_.faceSize() - firstBlockFace, windInfo.winding );
     }
     Mesh mesh;
     mesh.topology = std::move( tp_ );
@@ -623,7 +629,8 @@ Mesh SweepLineQueue::triangulate()
     {
         mesh.points[v] = predicates_.point( v );
     } );
-    if ( !params_.needOutline )
+    // Delone flips could cross a contour edge between two inside regions and smear the face winding map
+    if ( !params_.needOutline && !params_.outFaceWinding )
     {
         makeDeloneEdgeFlips( mesh, {}, 300 );
     }
@@ -1467,12 +1474,15 @@ Contours2f getOutline( const Contours2f& contours, const OutlineParameters& para
     return getOutline( contsd, params );
 }
 
-Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVertsIds /*= nullptr*/ )
+Mesh triangulateContours( const Contours2f& contours, const TriangulationParameters& params /*= {}*/ )
 {
     if ( contours.empty() )
         return {};
-    SweepLineQueue triangulator( precisePredicates( contours ), getContourSizes( contours ), { holeVertsIds, false, WindingMode::NonZero } );
-    auto res = triangulator.run();
+    SweepLineQueue triangulator( precisePredicates( contours ), getContourSizes( contours ),
+        { params.holeVertsIds, false, WindingMode::NonZero, false, true, nullptr, params.outFaceWinding } );
+    if ( params.outInterMap )
+        params.outInterMap->shift = triangulator.vertSize();
+    auto res = triangulator.run( params.outInterMap );
     assert( res );
     if ( res )
         return std::move( *res );
@@ -1480,10 +1490,20 @@ Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVe
         return Mesh();
 }
 
-Mesh triangulateContours( const Contours2d& contours, const HolesVertIds* holeVertsIds /*= nullptr*/ )
+Mesh triangulateContours( const Contours2d& contours, const TriangulationParameters& params /*= {}*/ )
 {
     const auto contsf = convertContours<Contours2f>( contours );
-    return triangulateContours( contsf, holeVertsIds );
+    return triangulateContours( contsf, params );
+}
+
+Mesh triangulateContours( const Contours2d& contours, const HolesVertIds* holeVertsIds )
+{
+    return triangulateContours( contours, { .holeVertsIds = holeVertsIds } );
+}
+
+Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVertsIds )
+{
+    return triangulateContours( contours, { .holeVertsIds = holeVertsIds } );
 }
 
 std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours, const HolesVertIds* holeVertsIds /*= nullptr*/, std::vector<EdgePath>* outBoundaries /*= nullptr*/ )

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -75,14 +75,32 @@ struct OutlineParameters
 MRMESH_API Contours2f getOutline( const Contours2f& contours, const OutlineParameters& params = {} );
 MRMESH_API Contours2f getOutline( const Contours2d& contours, const OutlineParameters& params = {} );
 
+struct TriangulationParameters
+{
+    /// if set merge only points with same vertex id, otherwise merge all points with same coordinates
+    const HolesVertIds* holeVertsIds{ nullptr };
+
+    /// optional output: winding number of the region each face belongs to;
+    /// when set, Delone flips after triangulation are skipped, so each face stays strictly inside one winding region
+    Vector<int, FaceId>* outFaceWinding{ nullptr };
+
+    /// optional output: maps each vertex created at contours intersection to the pair of intersected edges;
+    /// vertices with id less than `shift` are original contour vertices
+    IntersectionsMap* outInterMap{ nullptr };
+};
+
 /**
  * @brief triangulate 2d contours
  * only closed contours are allowed (first point of each contour should be the same as last point of the contour)
- * @param holeVertsIds if set merge only points with same vertex id, otherwise merge all points with same coordinates
  * @return return created mesh
  */
-MRMESH_API Mesh triangulateContours( const Contours2d& contours, const HolesVertIds* holeVertsIds = nullptr );
-MRMESH_API Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVertsIds = nullptr );
+MRMESH_API Mesh triangulateContours( const Contours2d& contours, const TriangulationParameters& params = {} );
+MRMESH_API Mesh triangulateContours( const Contours2f& contours, const TriangulationParameters& params = {} );
+
+/// triangulate 2d contours, overload for backward compatibility
+/// \param holeVertsIds if set merge only points with same vertex id, otherwise merge all points with same coordinates
+MRMESH_API Mesh triangulateContours( const Contours2d& contours, const HolesVertIds* holeVertsIds );
+MRMESH_API Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVertsIds );
 
 /**
  * @brief triangulate 2d contours

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -97,10 +97,11 @@ struct TriangulationParameters
 MRMESH_API Mesh triangulateContours( const Contours2d& contours, const TriangulationParameters& params = {} );
 MRMESH_API Mesh triangulateContours( const Contours2f& contours, const TriangulationParameters& params = {} );
 
-/// triangulate 2d contours, overload for backward compatibility
+/// triangulate 2d contours, C++-only overload for backward compatibility;
+/// hidden from generated bindings to keep their triangulateContours signatures unique
 /// \param holeVertsIds if set merge only points with same vertex id, otherwise merge all points with same coordinates
-MRMESH_API Mesh triangulateContours( const Contours2d& contours, const HolesVertIds* holeVertsIds );
-MRMESH_API Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVertsIds );
+MR_BIND_IGNORE MRMESH_API Mesh triangulateContours( const Contours2d& contours, const HolesVertIds* holeVertsIds );
+MR_BIND_IGNORE MRMESH_API Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVertsIds );
 
 /**
  * @brief triangulate 2d contours

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -8,6 +8,7 @@
 #include <MRMesh/MRExtractIsolines.h>
 #include <MRMesh/MRAffineXf3.h>
 #include <MRMesh/MRRegionBoundary.h>
+#include <MRMesh/MR2to3.h>
 #include <MRSymbolMesh/MRSymbolMesh.h>
 #include <gtest/gtest.h>
 #include <chrono>
@@ -37,6 +38,94 @@ TEST( MRMesh, PlanarTriangulation )
     // Must not contain degenerate faces
     EXPECT_TRUE( mesh.triangleAspectRatio( 0_f ) < 10.0f );
     EXPECT_TRUE( mesh.triangleAspectRatio( 1_f ) < 10.0f );
+}
+
+TEST( MRMesh, PlanarTriangulationWindingAndIntersections )
+{
+    // signed crossing number, independent of the sweep line internals
+    auto windingOracle = [] ( const Contours2f& conts, const Vector2f& p )
+    {
+        int w = 0;
+        for ( const auto& cont : conts )
+        {
+            for ( size_t i = 0; i + 1 < cont.size(); ++i )
+            {
+                const auto& a = cont[i];
+                const auto& b = cont[i + 1];
+                if ( a.y <= p.y && b.y > p.y && cross( b - a, p - a ) > 0 )
+                    ++w;
+                else if ( b.y <= p.y && a.y > p.y && cross( b - a, p - a ) < 0 )
+                    --w;
+            }
+        }
+        return w;
+    };
+
+    // checks each face's winding against the oracle at the face centroid (a mismatch means the face
+    // straddles two winding regions, e.g. if a Delone flip crossed a contour edge), then total areas per winding
+    auto checkWinding = [&] ( const Contours2f& conts, const Mesh& mesh, const Vector<int, FaceId>& faceWinding,
+        double expectedArea1, double expectedArea2 )
+    {
+        ASSERT_EQ( faceWinding.size(), mesh.topology.faceSize() );
+        double areaByWinding[3] = {};
+        for ( auto f : mesh.topology.getValidFaces() )
+        {
+            const int w = faceWinding[f];
+            EXPECT_EQ( w, windingOracle( conts, to2dim( mesh.triCenter( f ) ) ) );
+            ASSERT_TRUE( w == 1 || w == 2 );
+            areaByWinding[w] += mesh.area( f );
+        }
+        EXPECT_NEAR( areaByWinding[1], expectedArea1, 1e-4 );
+        EXPECT_NEAR( areaByWinding[2], expectedArea2, 1e-4 );
+    };
+
+    {
+        // two overlapping ccw squares [0,2]^2 and [1,3]^2: the [1,2]^2 overlap has winding number 2, the rest of the union 1
+        const Contours2f conts =
+        {
+            { { 0.f, 0.f }, { 2.f, 0.f }, { 2.f, 2.f }, { 0.f, 2.f }, { 0.f, 0.f } },
+            { { 1.f, 1.f }, { 3.f, 1.f }, { 3.f, 3.f }, { 1.f, 3.f }, { 1.f, 1.f } }
+        };
+
+        PlanarTriangulation::IntersectionsMap interMap;
+        Vector<int, FaceId> faceWinding;
+        const Mesh mesh = PlanarTriangulation::triangulateContours( conts,
+            { .outFaceWinding = &faceWinding, .outInterMap = &interMap } );
+
+        // squares' edges cross at (2,1) and (1,2); each crossing vertex interpolates both of its source edges
+        EXPECT_EQ( interMap.shift, size_t( 8 ) );
+        ASSERT_EQ( interMap.map.size(), size_t( 2 ) );
+        for ( size_t i = 0; i < interMap.map.size(); ++i )
+        {
+            const auto& info = interMap.map[i];
+            ASSERT_TRUE( info.isIntersection() );
+            const auto p = to2dim( mesh.points[VertId( interMap.shift + i )] );
+            const auto l = ( 1 - info.lRatio ) * to2dim( mesh.points[info.lOrg] ) + info.lRatio * to2dim( mesh.points[info.lDest] );
+            const auto u = ( 1 - info.uRatio ) * to2dim( mesh.points[info.uOrg] ) + info.uRatio * to2dim( mesh.points[info.uDest] );
+            EXPECT_LE( ( l - p ).length(), 1e-6f );
+            EXPECT_LE( ( u - p ).length(), 1e-6f );
+        }
+
+        checkWinding( conts, mesh, faceWinding, 6.0, 1.0 ); // union 7 = 6 + the [1,2]^2 overlap
+
+        // the holeVertsIds overload stays available and resolves without ambiguity
+        EXPECT_EQ( PlanarTriangulation::triangulateContours( conts, nullptr ).topology.numValidFaces(), mesh.topology.numValidFaces() );
+    }
+
+    {
+        // long thin overlap strip [0,10]x[0,0.3] (winding 2) with a far midpoint vertex below: if Delone flips
+        // ran here, they would cross the strip's long boundary edges and smear face winding
+        const Contours2f conts =
+        {
+            { { 0.f, -2.f }, { 5.f, -2.f }, { 10.f, -2.f }, { 10.f, 0.3f }, { 0.f, 0.3f }, { 0.f, -2.f } },
+            { { -1.f, 0.f }, { 11.f, 0.f }, { 11.f, 2.f }, { -1.f, 2.f }, { -1.f, 0.f } }
+        };
+
+        Vector<int, FaceId> faceWinding;
+        const Mesh mesh = PlanarTriangulation::triangulateContours( conts, { .outFaceWinding = &faceWinding } );
+
+        checkWinding( conts, mesh, faceWinding, 41.0, 3.0 ); // areas 23 + 24 with the strip counted once per winding
+    }
 }
 
 TEST( MRMesh, PlanarTriangulationMeshSpace )


### PR DESCRIPTION
## What

`triangulateContours` gains a `TriangulationParameters` struct with two optional outputs:
- `outFaceWinding` — winding number of the region each face belongs to (`Vector<int, FaceId>`)
- `outInterMap` — maps each vertex created at a contours intersection to its pair of intersected edges (the same `IntersectionsMap` that `getOutlineMesh` already fills)

The previous `( contours, const HolesVertIds* )` overloads remain as one-line delegates (without a default argument, so `triangulateContours( conts )` resolves unambiguously to the new form).

## How

No new machinery:
- the intersection map is passed through `SweepLineQueue::run()` exactly as `getOutlineMesh` does;
- faces are created only per monotone block in `triangulate()`, where the block's winding is already known — one `autoResizeSet` per block fills the face map;
- when `outFaceWinding` is requested, the final Delone flips are skipped: a flip can cross a contour edge between two inside regions (e.g. winding 1 vs 2) and produce faces straddling regions, making the map meaningless. Verified empirically: on a long-thin-overlap config, unrestricted flips yield 2 faces whose winding disagrees with an independent point-in-polygon oracle at the face centroid; without flips, 0.

When neither output is requested the code path is unchanged.

## Testing

New `MRMesh.PlanarTriangulationWindingAndIntersections`:
- two overlapping squares: `IntersectionsMap` shift/size, and each intersection vertex reproduces both source edges via `lRatio`/`uRatio` interpolation;
- per-face winding checked against an independent signed-crossing oracle at each face centroid (also proves no face straddles winding regions), plus exact area sums per winding value;
- a long thin overlap strip — the config where Delone flips would corrupt the map;
- the back-compat overload resolution (`nullptr` call form).

Existing `PlanarTriangulation` and `PlanarTriangulationMeshSpace` tests pass unchanged (default path A/B-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)