### PR TITLE
Suppress MSVC warning noise in MRCuda CUDA compilation

### DIFF
--- a/cmake/Modules/ConfigureCuda.cmake
+++ b/cmake/Modules/ConfigureCuda.cmake
@@ -9,7 +9,8 @@ IF(NOT CUDAToolkit_FOUND AND NOT CUDA_FOUND)
       find_package(CUDAToolkit 11 REQUIRED)
 
       # For our VS2022 CI:
-      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH")
+      # 20011: VS2026's <cmath> calls the __host__-only __copysignf intrinsic from __host__ __device__ copysign
+      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler -diag-suppress 20011 -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH")
     ELSE()
       # https://cmake.org/cmake/help/latest/release/3.25.html#id2
       IF(CMAKE_VERSION VERSION_LESS 3.25.2)

--- a/source/MRCuda/MRCuda.vcxproj
+++ b/source/MRCuda/MRCuda.vcxproj
@@ -66,8 +66,9 @@
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
-      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalCompilerOptions>/wd4514 /wd4574 /wd4668 /wd5039</AdditionalCompilerOptions>
+      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler -diag-suppress 20011 %(AdditionalOptions)</AdditionalOptions>
+      <!-- the CUDA host compilation inherits /Wall from common.props but not DisableSpecificWarnings; mirror that list here as /wd flags (plus 4574) -->
+      <AdditionalCompilerOptions>/wd4061 /wd4250 /wd4324 /wd4365 /wd4371 /wd4388 /wd4435 /wd4514 /wd4574 /wd4582 /wd4583 /wd4599 /wd4605 /wd4623 /wd4625 /wd4626 /wd4651 /wd4668 /wd4686 /wd4710 /wd4711 /wd4820 /wd4865 /wd4866 /wd4868 /wd5026 /wd5027 /wd5031 /wd5039 /wd5045 /wd5104 /wd5105 /wd5219 /wd5243 /wd5246 /wd5262 /wd5264 /wd26451</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -92,8 +93,9 @@
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
-      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalCompilerOptions>/wd4514 /wd4574 /wd4668 /wd5039</AdditionalCompilerOptions>
+      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler -diag-suppress 20011 %(AdditionalOptions)</AdditionalOptions>
+      <!-- the CUDA host compilation inherits /Wall from common.props but not DisableSpecificWarnings; mirror that list here as /wd flags (plus 4574) -->
+      <AdditionalCompilerOptions>/wd4061 /wd4250 /wd4324 /wd4365 /wd4371 /wd4388 /wd4435 /wd4514 /wd4574 /wd4582 /wd4583 /wd4599 /wd4605 /wd4623 /wd4625 /wd4626 /wd4651 /wd4668 /wd4686 /wd4710 /wd4711 /wd4820 /wd4865 /wd4866 /wd4868 /wd5026 /wd5027 /wd5031 /wd5039 /wd5045 /wd5104 /wd5105 /wd5219 /wd5243 /wd5246 /wd5262 /wd5264 /wd26451</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/source/MRCuda/MRCuda.vcxproj
+++ b/source/MRCuda/MRCuda.vcxproj
@@ -66,9 +66,7 @@
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
-      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler -diag-suppress 20011 %(AdditionalOptions)</AdditionalOptions>
-      <!-- the CUDA host compilation inherits /Wall from common.props but not DisableSpecificWarnings; mirror that list here as /wd flags (plus 4574, 5247, 5248 from CUDA-generated stubs) -->
-      <AdditionalCompilerOptions>/wd4061 /wd4250 /wd4324 /wd4365 /wd4371 /wd4388 /wd4435 /wd4514 /wd4574 /wd4582 /wd4583 /wd4599 /wd4605 /wd4623 /wd4625 /wd4626 /wd4651 /wd4668 /wd4686 /wd4710 /wd4711 /wd4820 /wd4865 /wd4866 /wd4868 /wd5026 /wd5027 /wd5031 /wd5039 /wd5045 /wd5104 /wd5105 /wd5219 /wd5243 /wd5246 /wd5247 /wd5248 /wd5262 /wd5264 /wd26451</AdditionalCompilerOptions>
+      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler %(AdditionalOptions)</AdditionalOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -93,9 +91,7 @@
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
-      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler -diag-suppress 20011 %(AdditionalOptions)</AdditionalOptions>
-      <!-- the CUDA host compilation inherits /Wall from common.props but not DisableSpecificWarnings; mirror that list here as /wd flags (plus 4574, 5247, 5248 from CUDA-generated stubs) -->
-      <AdditionalCompilerOptions>/wd4061 /wd4250 /wd4324 /wd4365 /wd4371 /wd4388 /wd4435 /wd4514 /wd4574 /wd4582 /wd4583 /wd4599 /wd4605 /wd4623 /wd4625 /wd4626 /wd4651 /wd4668 /wd4686 /wd4710 /wd4711 /wd4820 /wd4865 /wd4866 /wd4868 /wd5026 /wd5027 /wd5031 /wd5039 /wd5045 /wd5104 /wd5105 /wd5219 /wd5243 /wd5246 /wd5247 /wd5248 /wd5262 /wd5264 /wd26451</AdditionalCompilerOptions>
+      <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler %(AdditionalOptions)</AdditionalOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/source/MRCuda/MRCuda.vcxproj
+++ b/source/MRCuda/MRCuda.vcxproj
@@ -67,8 +67,8 @@
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
       <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler -diag-suppress 20011 %(AdditionalOptions)</AdditionalOptions>
-      <!-- the CUDA host compilation inherits /Wall from common.props but not DisableSpecificWarnings; mirror that list here as /wd flags (plus 4574) -->
-      <AdditionalCompilerOptions>/wd4061 /wd4250 /wd4324 /wd4365 /wd4371 /wd4388 /wd4435 /wd4514 /wd4574 /wd4582 /wd4583 /wd4599 /wd4605 /wd4623 /wd4625 /wd4626 /wd4651 /wd4668 /wd4686 /wd4710 /wd4711 /wd4820 /wd4865 /wd4866 /wd4868 /wd5026 /wd5027 /wd5031 /wd5039 /wd5045 /wd5104 /wd5105 /wd5219 /wd5243 /wd5246 /wd5262 /wd5264 /wd26451</AdditionalCompilerOptions>
+      <!-- the CUDA host compilation inherits /Wall from common.props but not DisableSpecificWarnings; mirror that list here as /wd flags (plus 4574, 5247, 5248 from CUDA-generated stubs) -->
+      <AdditionalCompilerOptions>/wd4061 /wd4250 /wd4324 /wd4365 /wd4371 /wd4388 /wd4435 /wd4514 /wd4574 /wd4582 /wd4583 /wd4599 /wd4605 /wd4623 /wd4625 /wd4626 /wd4651 /wd4668 /wd4686 /wd4710 /wd4711 /wd4820 /wd4865 /wd4866 /wd4868 /wd5026 /wd5027 /wd5031 /wd5039 /wd5045 /wd5104 /wd5105 /wd5219 /wd5243 /wd5246 /wd5247 /wd5248 /wd5262 /wd5264 /wd26451</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -94,8 +94,8 @@
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH</Defines>
       <AdditionalOptions>-std=c++17 -Xcompiler "/std:c++17" -Xcudafe "--diag_suppress=field_without_dll_interface" -Xcudafe "--diag_suppress=base_class_has_different_dll_interface" -allow-unsupported-compiler -diag-suppress 20011 %(AdditionalOptions)</AdditionalOptions>
-      <!-- the CUDA host compilation inherits /Wall from common.props but not DisableSpecificWarnings; mirror that list here as /wd flags (plus 4574) -->
-      <AdditionalCompilerOptions>/wd4061 /wd4250 /wd4324 /wd4365 /wd4371 /wd4388 /wd4435 /wd4514 /wd4574 /wd4582 /wd4583 /wd4599 /wd4605 /wd4623 /wd4625 /wd4626 /wd4651 /wd4668 /wd4686 /wd4710 /wd4711 /wd4820 /wd4865 /wd4866 /wd4868 /wd5026 /wd5027 /wd5031 /wd5039 /wd5045 /wd5104 /wd5105 /wd5219 /wd5243 /wd5246 /wd5262 /wd5264 /wd26451</AdditionalCompilerOptions>
+      <!-- the CUDA host compilation inherits /Wall from common.props but not DisableSpecificWarnings; mirror that list here as /wd flags (plus 4574, 5247, 5248 from CUDA-generated stubs) -->
+      <AdditionalCompilerOptions>/wd4061 /wd4250 /wd4324 /wd4365 /wd4371 /wd4388 /wd4435 /wd4514 /wd4574 /wd4582 /wd4583 /wd4599 /wd4605 /wd4623 /wd4625 /wd4626 /wd4651 /wd4668 /wd4686 /wd4710 /wd4711 /wd4820 /wd4865 /wd4866 /wd4868 /wd5026 /wd5027 /wd5031 /wd5039 /wd5045 /wd5104 /wd5105 /wd5219 /wd5243 /wd5246 /wd5247 /wd5248 /wd5262 /wd5264 /wd26451</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/source/common.props
+++ b/source/common.props
@@ -74,7 +74,7 @@
       <!-- /external:W0, matching `/Wall /WX /external:W0` in CompilerOptions.cmake -->
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
       <!--
-        !! NOTE: Sync this list with `CompilerOptions.cmake` and the /wd flags in `MRCuda.vcxproj` (CudaCompile) !!
+        !! NOTE: Sync this list with `CompilerOptions.cmake` and the /wd flags in `platform.props` (CudaCompile) !!
            warning C4061: enumerator V in switch of enum E is not explicitly handled by a case label
            warning C4250: 'class1': inherits 'class2' via dominance
            warning C4324: structure was padded due to alignment specifier
@@ -113,7 +113,7 @@
            warning C5262: implicit fall-through occurs here; are you missing a break statement? Use [[fallthrough]] when a break statement is intentionally omitted between cases
            warning C5264: 'const' variable is not used
            warning C26451: Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2).
-        !! NOTE: Sync this list with `CompilerOptions.cmake` and the /wd flags in `MRCuda.vcxproj` (CudaCompile) !!
+        !! NOTE: Sync this list with `CompilerOptions.cmake` and the /wd flags in `platform.props` (CudaCompile) !!
       -->
       <DisableSpecificWarnings>4061;4250;4324;4365;4371;4388;4435;4514;4582;4583;4599;4605;4623;4625;4626;4651;4668;4686;4710;4711;4820;4865;4866;4868;5026;5027;5031;5039;5045;5104;5105;5219;5243;5246;5262;5264;26451;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>

--- a/source/common.props
+++ b/source/common.props
@@ -74,7 +74,7 @@
       <!-- /external:W0, matching `/Wall /WX /external:W0` in CompilerOptions.cmake -->
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
       <!--
-        !! NOTE: Sync this list with `CompilerOptions.cmake` !!
+        !! NOTE: Sync this list with `CompilerOptions.cmake` and the /wd flags in `MRCuda.vcxproj` (CudaCompile) !!
            warning C4061: enumerator V in switch of enum E is not explicitly handled by a case label
            warning C4250: 'class1': inherits 'class2' via dominance
            warning C4324: structure was padded due to alignment specifier
@@ -113,7 +113,7 @@
            warning C5262: implicit fall-through occurs here; are you missing a break statement? Use [[fallthrough]] when a break statement is intentionally omitted between cases
            warning C5264: 'const' variable is not used
            warning C26451: Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2).
-        !! NOTE: Sync this list with `CompilerOptions.cmake` !!
+        !! NOTE: Sync this list with `CompilerOptions.cmake` and the /wd flags in `MRCuda.vcxproj` (CudaCompile) !!
       -->
       <DisableSpecificWarnings>4061;4250;4324;4365;4371;4388;4435;4514;4582;4583;4599;4605;4623;4625;4626;4651;4668;4686;4710;4711;4820;4865;4866;4868;5026;5027;5031;5039;5045;5104;5105;5219;5243;5246;5262;5264;26451;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>

--- a/source/common.props
+++ b/source/common.props
@@ -74,7 +74,7 @@
       <!-- /external:W0, matching `/Wall /WX /external:W0` in CompilerOptions.cmake -->
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
       <!--
-        !! NOTE: Sync this list with `CompilerOptions.cmake` and the /wd flags in `platform.props` (CudaCompile) !!
+        !! NOTE: Sync this list with `CompilerOptions.cmake` and the CudaCompile /wd flags below !!
            warning C4061: enumerator V in switch of enum E is not explicitly handled by a case label
            warning C4250: 'class1': inherits 'class2' via dominance
            warning C4324: structure was padded due to alignment specifier
@@ -113,10 +113,16 @@
            warning C5262: implicit fall-through occurs here; are you missing a break statement? Use [[fallthrough]] when a break statement is intentionally omitted between cases
            warning C5264: 'const' variable is not used
            warning C26451: Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2).
-        !! NOTE: Sync this list with `CompilerOptions.cmake` and the /wd flags in `platform.props` (CudaCompile) !!
+        !! NOTE: Sync this list with `CompilerOptions.cmake` and the CudaCompile /wd flags below !!
       -->
       <DisableSpecificWarnings>4061;4250;4324;4365;4371;4388;4435;4514;4582;4583;4599;4605;4623;4625;4626;4651;4668;4686;4710;4711;4820;4865;4866;4868;5026;5027;5031;5039;5045;5104;5105;5219;5243;5246;5262;5264;26451;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
+    <CudaCompile>
+      <!-- the CUDA host compilation inherits /Wall from the ClCompile settings above but not DisableSpecificWarnings; mirror that list here as /wd flags (plus 4574, 5247, 5248 from CUDA-generated stubs) -->
+      <AdditionalCompilerOptions>/wd4061 /wd4250 /wd4324 /wd4365 /wd4371 /wd4388 /wd4435 /wd4514 /wd4574 /wd4582 /wd4583 /wd4599 /wd4605 /wd4623 /wd4625 /wd4626 /wd4651 /wd4668 /wd4686 /wd4710 /wd4711 /wd4820 /wd4865 /wd4866 /wd4868 /wd5026 /wd5027 /wd5031 /wd5039 /wd5045 /wd5104 /wd5105 /wd5219 /wd5243 /wd5246 /wd5247 /wd5248 /wd5262 /wd5264 /wd26451 %(AdditionalCompilerOptions)</AdditionalCompilerOptions>
+      <!-- 20011: VS2026's <cmath> calls the __host__-only __copysignf intrinsic from __host__ __device__ copysign -->
+      <AdditionalOptions>%(AdditionalOptions) -diag-suppress 20011</AdditionalOptions>
+    </CudaCompile>
     <Link>
       <AdditionalDependencies>$(PythonLibPath);%(AdditionalDependencies)</AdditionalDependencies>
       <!-- Needed to be able to see better stacktrace in deployed build with PDB files https://github.com/boostorg/stacktrace/blob/34e56c4e90f76e933d019b3ce824913957493f93/doc/stacktrace.qbk#L353-L360 -->

--- a/source/platform.props
+++ b/source/platform.props
@@ -37,14 +37,6 @@
     <MRCudaGencode Condition="'$(MRCudaGencode)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals($(MRCudaVersion), '12.0'))">-gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=[sm_89,compute_89]</MRCudaGencode>
     <MRCudaGencode Condition="'$(MRCudaGencode)' == ''">-gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=[sm_75,compute_75]</MRCudaGencode>
   </PropertyGroup>
-  <ItemDefinitionGroup>
-    <CudaCompile>
-      <!-- the CUDA host compilation inherits /Wall from common.props but not DisableSpecificWarnings; mirror that list here as /wd flags (plus 4574, 5247, 5248 from CUDA-generated stubs) -->
-      <AdditionalCompilerOptions>/wd4061 /wd4250 /wd4324 /wd4365 /wd4371 /wd4388 /wd4435 /wd4514 /wd4574 /wd4582 /wd4583 /wd4599 /wd4605 /wd4623 /wd4625 /wd4626 /wd4651 /wd4668 /wd4686 /wd4710 /wd4711 /wd4820 /wd4865 /wd4866 /wd4868 /wd5026 /wd5027 /wd5031 /wd5039 /wd5045 /wd5104 /wd5105 /wd5219 /wd5243 /wd5246 /wd5247 /wd5248 /wd5262 /wd5264 /wd26451 %(AdditionalCompilerOptions)</AdditionalCompilerOptions>
-      <!-- 20011: VS2026's <cmath> calls the __host__-only __copysignf intrinsic from __host__ __device__ copysign -->
-      <AdditionalOptions>%(AdditionalOptions) -diag-suppress 20011</AdditionalOptions>
-    </CudaCompile>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(MRCudaGencode)' != ''">
     <CudaCompile>
       <AdditionalOptions>%(AdditionalOptions) $(MRCudaGencode)</AdditionalOptions>

--- a/source/platform.props
+++ b/source/platform.props
@@ -37,6 +37,14 @@
     <MRCudaGencode Condition="'$(MRCudaGencode)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals($(MRCudaVersion), '12.0'))">-gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=[sm_89,compute_89]</MRCudaGencode>
     <MRCudaGencode Condition="'$(MRCudaGencode)' == ''">-gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=[sm_75,compute_75]</MRCudaGencode>
   </PropertyGroup>
+  <ItemDefinitionGroup>
+    <CudaCompile>
+      <!-- the CUDA host compilation inherits /Wall from common.props but not DisableSpecificWarnings; mirror that list here as /wd flags (plus 4574, 5247, 5248 from CUDA-generated stubs) -->
+      <AdditionalCompilerOptions>/wd4061 /wd4250 /wd4324 /wd4365 /wd4371 /wd4388 /wd4435 /wd4514 /wd4574 /wd4582 /wd4583 /wd4599 /wd4605 /wd4623 /wd4625 /wd4626 /wd4651 /wd4668 /wd4686 /wd4710 /wd4711 /wd4820 /wd4865 /wd4866 /wd4868 /wd5026 /wd5027 /wd5031 /wd5039 /wd5045 /wd5104 /wd5105 /wd5219 /wd5243 /wd5246 /wd5247 /wd5248 /wd5262 /wd5264 /wd26451 %(AdditionalCompilerOptions)</AdditionalCompilerOptions>
+      <!-- 20011: VS2026's <cmath> calls the __host__-only __copysignf intrinsic from __host__ __device__ copysign -->
+      <AdditionalOptions>%(AdditionalOptions) -diag-suppress 20011</AdditionalOptions>
+    </CudaCompile>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(MRCudaGencode)' != ''">
     <CudaCompile>
       <AdditionalOptions>%(AdditionalOptions) $(MRCudaGencode)</AdditionalOptions>


### PR DESCRIPTION
## Problem

The `windows-build-test (MSBuild)` job floods each CI run with ~200 warning annotations from `MRCuda.vcxproj` (e.g. [this run](https://github.com/MeshInspector/MeshLib/actions/runs/29109926680)): 120× C4711, 44× C4820, 32× C4365, plus C4625/C4626 — almost all in nvcc-generated stub files (`tmpxft_*.cudafe1.stub.c`) and CUDA's own headers.

Root cause: `common.props` compiles everything with `/Wall /WX` plus a `DisableSpecificWarnings` list, and all of these warning codes are already in that list. But the CUDA MSBuild integration inherits only `/Wall` into the nvcc host compilation — not `DisableSpecificWarnings` — and `MRCuda.vcxproj` forwarded just 4 of the codes (`/wd4514 /wd4574 /wd4668 /wd5039`). So every leaked warning is one the project has already decided to suppress.

Additionally, both msvc-2026 jobs emit 4× nvcc `#20011-D`: VS2026's (MSVC 14.51) `<cmath>` calls the `__host__`-only `__copysignf` intrinsic from the `__host__ __device__` `copysign`, which the CUDA frontend flags. Not our code; nvcc itself suggests `-diag-suppress`.

## Changes

- `common.props`: mirror the `DisableSpecificWarnings` list as `/wd` flags in a shared `CudaCompile` group right below it (keeping the CUDA-specific 4574, plus 5247/5248 emitted by CUDA 11.4 generated stub files), and add `-diag-suppress 20011` to the nvcc options — inherited by every CUDA project importing `common.props`, which is imported after the CUDA build customization props, and the options append via `%(...)`.
- `ConfigureCuda.cmake`: add `-diag-suppress 20011` to the Windows `CMAKE_CUDA_FLAGS` (nvcc has supported `--diag-suppress` since CUDA 11.2, and CI's oldest is 11.4.2).
- `common.props`: extend the existing sync notes to also point at the CudaCompile `/wd` mirror.

Only Windows builds are affected; other platforms are disabled via labels.
