### PR TITLE
Skip paths-filter steps on scheduled runs

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -204,6 +204,7 @@ jobs:
         run: uvx --python 3.12 pre-commit run --all-files --hook-stage manual
 
       - name: Filter Linux paths
+        if: ${{ github.event_name != 'schedule' }}
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: linux-changes
         with:
@@ -218,6 +219,7 @@ jobs:
               - 'thirdparty/!(install.bat|vcpkg/**|mrbind|mrbind/**|Noto_Sans/**)'
 
       - name: Filter Linux vcpkg paths
+        if: ${{ github.event_name != 'schedule' }}
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: linux-vcpkg-changes
         with:
@@ -227,6 +229,7 @@ jobs:
               - 'thirdparty/vcpkg/**'
 
       - name: Filter Windows paths
+        if: ${{ github.event_name != 'schedule' }}
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: windows-changes
         with:


### PR DESCRIPTION
Every nightly `Build Test Distribute` run emits a warning annotation from each of the three `dorny/paths-filter` steps in `prepare-config`:

> 'before' field is missing in event payload - changes will be detected from last commit

(e.g. https://github.com/MeshInspector/MeshLib/actions/runs/29137433957). The action warns because a `schedule` event payload has no `before`/`after` SHAs, and then falls back to diffing the last commit only.

On scheduled runs the results of these steps are already discarded everywhere:
- the `need_*_image_rebuild` workflow outputs are gated with `github.event_name != 'schedule'`;
- the `Select (vcpkg) Docker image tag` steps force `latest` on `push`/`schedule`.

So skip the three steps entirely on `schedule`. A skipped step yields empty outputs, and every consumer compares against `'true'`, so behavior is unchanged; the warnings disappear. `push`/`pull_request` runs are unaffected (`push` payloads carry `before`, PRs diff against the merge base — neither warns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
