### PR TITLE
Deploy vcpkg DLLs in one serial pass after Windows CMake build

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -206,12 +206,20 @@ jobs:
         # `|| exit /b 1` is used instead of `if errorlevel 1 exit 1`
         # because the latter can miss exit codes inside parenthesized IF
         # blocks in cmd.exe (e.g. it failed to catch a ninja build failure).
+        # The z-applocal loop uses `exit 1` (no /b): cmd.exe drops the errorlevel
+        # of `exit /b` from a for-loop body nested in the parenthesized IF block.
         run: |
           if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
             call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=x86 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
             cmake --version || exit /b 1
-            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} -DMR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
+            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DVCPKG_APPLOCAL_DEPS=OFF -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} -DMR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
             cmake --build source\TempOutput -j || exit /b 1
+            rem Deploy vcpkg DLLs in one serial pass here: with VCPKG_APPLOCAL_DEPS=ON (default)
+            rem every parallel Ninja link edge runs its own z-applocal into the shared bin dir,
+            rem and concurrent copies of the same DLL intermittently fail with ERROR_SHARING_VIOLATION.
+            for %%b in (source\TempOutput\bin\*.exe source\TempOutput\bin\*.dll) do (
+              %VCPKG_ROOT%\vcpkg.exe z-applocal --target-binary="%%b" --installed-bin-dir="%VCPKG_ROOT%\installed\%VCPKG_TARGET_TRIPLET%${{ matrix.config == 'Debug' && '\debug' || '' }}\bin" >nul || exit 1
+            )
             if not exist source\x64 mkdir source\x64 || exit /b 1
             xcopy source\TempOutput\bin\* source\x64\${{matrix.config}}\* /s /e /i /Y || exit /b 1
           ) else (


### PR DESCRIPTION
## Problem

An internal nightly Windows CMake (Ninja) build intermittently fails at a link step:

```
FAILED: bin/<module>.dll bin/<module>.lib
The process cannot access the file because it is being used by another process.
ninja: build stopped: subcommand failed.
```

With `VCPKG_APPLOCAL_DEPS=ON` (the vcpkg toolchain default on Windows), every DLL/EXE link edge ends with its own `vcpkg z-applocal` run that copies dependency DLLs into the shared `TempOutput\bin`. Ninja links several targets concurrently, so multiple `z-applocal` instances copy the same DLLs (tbb, fmt, spdlog, ...) into the same directory at once; `z-applocal` takes no lock, and any overlap is a sharing violation that fails the whole build.

## Fix

- Configure with `-DVCPKG_APPLOCAL_DEPS=OFF`, so link edges are pure `link.exe` again and stay fully parallel.
- After `cmake --build`, run the same `vcpkg z-applocal` once per built binary in a single serial pass. The deployed DLL set — and therefore `source\x64\<config>` and the `MREDist_*` artifact contents — is unchanged (a blanket copy of `installed\<triplet>\bin\*.dll` was rejected because it would add ~67 unrelated DLLs / ~31 MB, incl. gtest and unused OpenCASCADE modules, to the distributed archive).

Side benefit: several thousand `deploying dependencies` / `skipped, up to date` lines disappear from the build log.

## Notes

- Inside the deployment loop, `exit 1` (without `/b`) is used deliberately: cmd.exe drops the errorlevel of `exit /b` from a `for`-loop body nested in the parenthesized `IF` block (verified locally — with `exit /b 1` the step would pass despite a failed deployment; with `exit 1` it fails with code 1).
- The `%VCPKG_ROOT%`/`%VCPKG_TARGET_TRIPLET%`-style expansions inside the block are parse-time, matching the existing configure line, so the `VsDevCmd.bat` override of `VCPKG_ROOT` does not affect them.
- Loop semantics, the success path (2 seed binaries → 23 dependency DLLs deployed), and failure propagation were all verified locally against a real vcpkg install with the `x64-windows-meshlib` triplet.

The MSBuild leg is untouched; its applocal deployment goes through vcpkg's MSBuild integration.
