### PR TITLE
Quote paths-filter outputs in Docker image tag selection

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Select Docker image tag
         id: select-docker-image-tag
         run: |
-          if [[ ${{ steps.linux-changes.outputs.src }} == 'true' ]] && [[ ${{ github.event_name }} != 'push' && ${{ github.event_name }} != 'schedule' ]]; then
+          if [[ "${{ steps.linux-changes.outputs.src }}" == 'true' ]] && [[ ${{ github.event_name }} != 'push' && ${{ github.event_name }} != 'schedule' ]]; then
             # https://stackoverflow.com/q/58033366/7325599
             IMAGE_TAG=$(echo "${{ github.head_ref || github.ref_name }}" | sed -r 's/[^a-zA-Z0-9._-]+/-/g')
           else
@@ -256,7 +256,7 @@ jobs:
       - name: Select vcpkg Docker image tag
         id: select-vcpkg-docker-image-tag
         run: |
-          if [[ ${{ steps.linux-vcpkg-changes.outputs.src }} == 'true' ]] && [[ ${{ github.event_name }} != 'push' && ${{ github.event_name }} != 'schedule' ]]; then
+          if [[ "${{ steps.linux-vcpkg-changes.outputs.src }}" == 'true' ]] && [[ ${{ github.event_name }} != 'push' && ${{ github.event_name }} != 'schedule' ]]; then
             # https://stackoverflow.com/q/58033366/7325599
             IMAGE_TAG=$(echo "${{ github.head_ref || github.ref_name }}" | sed -r 's/[^a-zA-Z0-9._-]+/-/g')
           else


### PR DESCRIPTION
## Problem

The nightly scheduled run failed in `config / prepare-config` ([run 29177750795](https://github.com/MeshInspector/MeshLib/actions/runs/29177750795/job/86609819882)):

```
line 1: conditional binary operator expected
Process completed with exit code 2.
```

Since #6403, the paths-filter steps are skipped on `schedule` runs, so `steps.linux-changes.outputs.src` expands to an empty string. Interpolated unquoted into the bash condition, the rendered script becomes `if [[  == 'true' ]] && ...`, which is a bash syntax error.

## Fix

Quote the filter-output expansions in both `Select Docker image tag` and `Select vcpkg Docker image tag` steps. With an empty output, the condition now evaluates to false and falls through to `IMAGE_TAG="latest"`, which is the correct tag for schedule runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
