### PR TITLE
Test duplicateNonManifoldVertices on a vertex incident to two holes

### DIFF
--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -38,6 +38,22 @@ TEST( MRMesh, duplicateNonManifoldVertices )
         ASSERT_EQ( t[i][0], 7 );
 }
 
+TEST( MRMesh, duplicateDoubleHoleVertex )
+{
+    Triangulation t;
+    t.push_back( { 0_v, 1_v, 2_v } ); //0_f
+    t.push_back( { 0_v, 3_v, 4_v } ); //1_f
+    // there are four edges with origin at vertex #0 having hole on one side (two with no left(e) and two with no right(e))
+
+    std::vector<VertDuplication> dups;
+    size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
+    ASSERT_EQ( duplicatedVerticesCnt, 1 );
+    ASSERT_EQ( dups.size(), 1 );
+    ASSERT_EQ( dups[0].srcVert, 0_v );
+    ASSERT_EQ( dups[0].dupVert, 5_v );
+    ASSERT_EQ( t[1_f][0], 5_v );
+}
+
 static void testBuildWithDups( const char * objMesh, int numVerts, int numComps )
 {
     std::istringstream s( objMesh );

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -51,7 +51,8 @@ TEST( MRMesh, duplicateDoubleHoleVertex )
     ASSERT_EQ( dups.size(), 1 );
     ASSERT_EQ( dups[0].srcVert, 0_v );
     ASSERT_EQ( dups[0].dupVert, 5_v );
-    ASSERT_EQ( t[1_f][0], 5_v );
+    ASSERT_EQ( t[0_f], ( ThreeVertIds{ 0_v, 1_v, 2_v } ) );
+    ASSERT_EQ( t[1_f], ( ThreeVertIds{ 5_v, 3_v, 4_v } ) );
 }
 
 static void testBuildWithDups( const char * objMesh, int numVerts, int numComps )


### PR DESCRIPTION
Adds a regression test for `duplicateNonManifoldVertices` covering a non-manifold vertex that joins two *open* triangle fans: two triangles `{0,1,2}` and `{0,3,4}` sharing only vertex #0, so four edges with origin at that vertex have a hole on one side (two with no `left(e)` and two with no `right(e)`).

The existing `duplicateNonManifoldVertices` test covers only two closed fans around the shared vertex; this adds the complementary hole-adjacent case, exercising the code path recently refactored in #6355 and #6405.

The test verifies that exactly one duplication `#0 → #5` is reported, and checks both triangles in full afterwards: the first found fan keeps the original vertex (`{0,1,2}` unchanged) while the other one is rewritten to `{5,3,4}`.
