### PR TITLE
Untap aws/tap in install_brew_requirements.sh

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -290,6 +290,8 @@ jobs:
             installer -pkg meshlib_*.pkg -target CurrentUserHomeDirectory
             MESHLIB_FW="${HOME}/Library/Frameworks/MeshLib.framework/Versions/Current"
           fi
+          # aws/tap ships untrusted in GH images and warns on every brew command
+          brew untap aws/tap 2>/dev/null || true
           xargs brew install --quiet < "${MESHLIB_FW}/requirements/macos.txt"
           echo "MESHLIB_FW=${MESHLIB_FW}" >> "${GITHUB_ENV}"
           echo "${MESHLIB_FW}/bin" >> "${GITHUB_PATH}"

--- a/scripts/install_brew_requirements.sh
+++ b/scripts/install_brew_requirements.sh
@@ -17,6 +17,9 @@ if [ -n "$MESHLIB_EXTRA_BREW_REQUIREMENTS" ] ; then
 fi
 
 
+# GitHub-hosted macOS images ship the untrusted aws/tap, which makes every brew command emit a warning
+brew untap aws/tap 2>/dev/null || true
+
 brew install --quiet $(echo "$MESHLIB_BREW_REQUIREMENTS" | tr '\n' ' ')
 # FIXME: build w/o pybind11
 brew install --quiet pybind11


### PR DESCRIPTION
GitHub-hosted macOS runner images ship the third-party `aws/tap` (for the preinstalled AWS SAM CLI). Newer Homebrew introduced tap trust: it ignores formulae from untrusted taps and emits a warning on every `brew` invocation, which shows up as `##[warning]` annotations in CI runs (e.g. several per macOS job in run 29302636582).

MeshLib installs nothing from `aws/tap`, so untap it before installing requirements to silence the noise. `2>/dev/null || true` keeps `set -e` happy on runners where the tap is absent (self-hosted machines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
