### PR TITLE
CI: checkout beta-patch script in sign-upload-nuget job

### DIFF
--- a/.github/workflows/sign-upload-nuget.yml
+++ b/.github/workflows/sign-upload-nuget.yml
@@ -43,6 +43,14 @@ jobs:
     needs: setup
     runs-on: [windows-x64-codesign]
     steps:
+      # Only the beta-patch script is needed here (used by "Make Beta").
+      # Must run before the download step: checkout cleans the workdir by default.
+      - name: Checkout beta-patch script
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: scripts/nuget_patch/nuget_make_beta.py
+          sparse-checkout-cone-mode: false
+
       - name: Remove old local NuGet packages
         run: Remove-Item "MeshLib_*.nupkg"
 


### PR DESCRIPTION
### Problem

The `sign-upload` job in `sign-upload-nuget.yml` runs the **Make Beta** step:

```
py -3 scripts\nuget_patch\nuget_make_beta.py "MeshLib_<ver>.nupkg"
```

…but the job never checks out the repository, so the script isn't present on the runner. Result — the step fails:

```
python.exe: can't open file '...\MeshLib\scripts\nuget_patch\nuget_make_beta.py': [Errno 2] No such file or directory
```

Seen in run [29335406821](https://github.com/MeshInspector/MeshLib/actions/runs/29335406821/job/87094539975). (The "Download NuGet package" step above it already succeeds — draft releases are resolved by `gh` via `tag_name`.)

### Fix

Add a checkout of **only** the one file that step needs, via sparse-checkout (non-cone mode). `scripts/nuget_patch/nuget_make_beta.py` is self-contained (Python stdlib only, operates solely on the `.nupkg` passed as `argv[1]`), so nothing else is required.

Placed as the **first** step of the job, before the download — `actions/checkout` cleans the workspace by default (`git clean -ffdx`), which would otherwise wipe the downloaded `.nupkg`.
