### PR TITLE
CI: default arm64 apt to the Canonical mirror

### DIFF
--- a/docker/emscripten-build-c-bindingsDockerfile
+++ b/docker/emscripten-build-c-bindingsDockerfile
@@ -14,8 +14,8 @@ RUN <<EOF
     export DEBCONF_NONINTERACTIVE_SEEN=true
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections
     echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
-    # use more reliable mirror
-    sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
+    # uncomment in case of problems with the Canonical mirrors
+    # sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \

--- a/docker/emscripten-generate-c-bindingsDockerfile
+++ b/docker/emscripten-generate-c-bindingsDockerfile
@@ -13,8 +13,8 @@ COPY scripts/mrbind/clang_version.txt scripts/mrbind/clang_version.txt
 RUN <<EOF
     set -e
     export DEBIAN_FRONTEND=noninteractive
-    # use more reliable mirror
-    sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
+    # uncomment in case of problems with the Canonical mirrors
+    # sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
     # MRBind dependencies
     ./scripts/mrbind/install_deps_ubuntu.sh
     # clean downloaded files

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -11,8 +11,8 @@ RUN <<EOF
     export DEBCONF_NONINTERACTIVE_SEEN=true
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections
     echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
-    # use more reliable mirror
-    sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
+    # uncomment in case of problems with the Canonical mirrors
+    # sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -24,8 +24,8 @@ RUN <<EOF
     export DEBCONF_NONINTERACTIVE_SEEN=true
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections
     echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
-    # use more reliable mirror
-    sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
+    # uncomment in case of problems with the Canonical mirrors
+    # sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list
     # install prerequisites for additional repos
     apt update
     apt install -y software-properties-common curl

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -24,8 +24,8 @@ RUN <<EOF
     export DEBCONF_NONINTERACTIVE_SEEN=true
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections
     echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections
-    # use more reliable mirror
-    sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list.d/ubuntu.sources
+    # uncomment in case of problems with the Canonical mirrors
+    # sed -i 's http://ports.ubuntu.com/ubuntu-ports/ http://mirror.eu.ossplanet.net/ubuntu-ports/ ' /etc/apt/sources.list.d/ubuntu.sources
     # install prerequisites for additional repos
     apt update
     apt install -y software-properties-common curl


### PR DESCRIPTION
## What

Comments out the third-party `mirror.eu.ossplanet.net` ubuntu-ports override in all five Linux Dockerfiles, so arm64 image builds fetch from the official `ports.ubuntu.com`. The override is left in place — one uncomment away — behind a helper comment for when the Canonical mirrors misbehave.

## Why

The ossplanet mirror serves an index that's out of sync with its pool: it advertises package versions (e.g. `python3-httplib2 0.20.2-2ubuntu0.1`) whose `.deb` it has already pruned, so apt gets a hard **404** (not retryable — the file genuinely isn't there). This only hits **arm64** — the `sed` targets `ports.ubuntu.com`, while x64 uses `archive.ubuntu.com` and is untouched — and it breaks the Docker image build for any PR that touches `docker/**` or `thirdparty/**` (both force an image rebuild instead of reusing the cached `latest` image). The official ports archive is index/pool-consistent by construction, so it cannot produce this failure class.

## Verification

`full-ci` rebuilds the arm64 `ubuntu22` / `ubuntu24` images, exercising exactly the build that is currently failing on the official archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
