### PR TITLE
Ship third-party license notices in cmake-install and Windows packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,14 @@ install(
   DESTINATION ${MR_CONFIG_DIR}
 )
 
+# Bundle the upstream license notices of the third-party components shipped in
+# the SDK (see docs/third_party_licenses.md). Required to satisfy each upstream
+# license's redistribution/attribution clause.
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/licenses/
+  DESTINATION ${MR_RESOURCES_DIR}/third_party_licenses
+)
+
 IF(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(CPACK_GENERATOR "DRAGNDROP")
   include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,9 +362,6 @@ install(
   DESTINATION ${MR_CONFIG_DIR}
 )
 
-# Bundle the upstream license notices of the third-party components shipped in
-# the SDK (see docs/third_party_licenses.md). Required to satisfy each upstream
-# license's redistribution/attribution clause.
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/licenses/
   DESTINATION ${MR_RESOURCES_DIR}/third_party_licenses

--- a/scripts/install_tools.py
+++ b/scripts/install_tools.py
@@ -79,6 +79,8 @@ def copy_app():
 	print('Not implemented')
 def copy_lib():
 	print('Not implemented')
+def copy_licenses():
+	print('Not implemented')
 
 def main():
 	if (not check_python_version()):
@@ -94,6 +96,7 @@ def main():
 	copy_includes()
 	copy_app()
 	copy_lib()
+	copy_licenses()
 	version = "0.0.0.0"
 	if len(sys.argv) > 1:
 		version = sys.argv[1][1:]

--- a/scripts/make_install_folder.py
+++ b/scripts/make_install_folder.py
@@ -108,6 +108,6 @@ it.prepare_includes_list = prepare_includes_list
 it.copy_includes = copy_includes
 it.copy_app = copy_app
 it.copy_lib = copy_lib
+it.copy_licenses = copy_licenses
 
 it.main()
-copy_licenses()

--- a/scripts/make_install_folder.py
+++ b/scripts/make_install_folder.py
@@ -98,9 +98,16 @@ def copy_lib():
 	for f in glob.glob(os.path.join(it.path_to_app, "*/*pybind11nonlimitedapi_meshlib_*")):
 		os.remove(f)
 
+def copy_licenses():
+	# Bundle the upstream third-party license notices (see docs/third_party_licenses.md).
+	src = os.path.join(it.base_path, 'thirdparty', 'licenses')
+	dst = os.path.join(it.path_to_install_folder, 'third_party_licenses')
+	shutil.copytree(src, dst, dirs_exist_ok=True)
+
 it.prepare_includes_list = prepare_includes_list
 it.copy_includes = copy_includes
 it.copy_app = copy_app
 it.copy_lib = copy_lib
 
 it.main()
+copy_licenses()


### PR DESCRIPTION
## Why

Follow-up to #6415, which added the curated `thirdparty/licenses/` notices folder and its drift-check but deliberately left the packaging wiring out. This PR makes the notices actually **ship** in the SDK packages, satisfying each upstream license's redistribution/attribution clause at the point of download.

## What

- **`CMakeLists.txt`** — `install(DIRECTORY thirdparty/licenses/ DESTINATION ${MR_RESOURCES_DIR}/third_party_licenses)`. One rule ships the notices in every package assembled via `cmake --install`: the **deb** (`distribution.sh`), **macOS pkg** (`distribution_apple.sh`), and **generic/vcpkg** installs (`distribution_vcpkg.sh`). Lands at `share/MeshLib/third_party_licenses/`.
- **`scripts/make_install_folder.py`** — copies `thirdparty/licenses/` into the Windows `install/` folder as `install/third_party_licenses/`, mirroring the shipped-name from the CMake side.

## Scope / follow-up

NuGet (`generate_nuget_spec.py`) and the Python wheel (`build_wheel.py`) are assembled by their own scripts and get wired in a separate PR.

## Test plan

- Standalone `cmake --install` of the new rule to a temp prefix → all 41 component dirs + `manifest.json` land at `share/MeshLib/third_party_licenses/` (e.g. `Boost/LICENSE_1_0.txt`); the maintenance README (now in `docs/`) does not leak in.
- Dry-run of `copy_licenses()` → the same 41 dirs + manifest + the FreeType/OpenCASCADE `NOTE.txt` files copy into `install/third_party_licenses/`; script compiles.