### PR TITLE
Drop stale openvdb v9 entry from license-check exclusions

### DIFF
--- a/scripts/check_third_party_licenses.py
+++ b/scripts/check_third_party_licenses.py
@@ -42,7 +42,6 @@ NON_COMPONENT_ENTRIES = {"manifest.json"}
 EXCLUDED_SUBMODULES = {
     "thirdparty/googletest",          # unit-test framework, not shipped
     "thirdparty/mrbind",              # build-time binding generator, not shipped
-    "thirdparty/openvdb/v9/openvdb",  # legacy OpenVDB; only v10 ships (see OpenVDB entry)
     "test_data",                      # test assets
 }
 


### PR DESCRIPTION
## Why

#6417 removed the unused legacy OpenVDB v9 submodule (`thirdparty/openvdb/v9/openvdb`). The third-party license checker added in #6415 still lists that path in `EXCLUDED_SUBMODULES` (to suppress a coverage warning about it), so the entry is now dead — the submodule no longer exists in `.gitmodules`.

## What

Remove the one stale line from `EXCLUDED_SUBMODULES` in `scripts/check_third_party_licenses.py`.

Note: there is no v9 license *file* to remove — the bundled OpenVDB notice (`thirdparty/licenses/OpenVDB/LICENSE`) is v10's and stays; v10 still ships.

## Test plan

- `python scripts/check_third_party_licenses.py` → green, 41 components verified, no warning about `openvdb/v9`.