### PR TITLE
Fix inspectVertNeighbourhood undercounting chains around a vertex

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -211,9 +211,21 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
                 {
                     assert( info.numChains > 0 );
                     --info.numChains;
-                    rInsertion.first->second = vEnd;
+                    // the right end of the chain grown from the current triangle: v2, or updated by the merge above
+                    const auto vRight = lInsertion.first->second;
+                    assert( vRight );
+                    if ( vRight != v2 )
+                    {
+                        // the current triangle merged two chains on both sides, so its both edges are inner
+                        lInsertion.first->second = VertId{};
+                        rInsertion.first->second = VertId{};
+                        assert( r_[vRight] == v1 );
+                        r_[vRight] = vEnd;
+                    }
+                    else
+                        rInsertion.first->second = vEnd;
                     assert( l_[vEnd] == v1 );
-                    l_[vEnd] = v2;
+                    l_[vEnd] = vRight;
                 }
             }
         }

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -1,4 +1,5 @@
 #include <MRMesh/MRMeshBuilder.h>
+#include <MRMesh/MRVertDuplication.h>
 #include <MRMesh/MRMeshBuilderTypes.h>
 #include <MRMesh/MRMeshLoad.h>
 #include <MRMesh/MRMeshComponents.h>
@@ -82,6 +83,30 @@ TEST( MRMesh, duplicateClosedPlusOpenChainVertex )
             ASSERT_EQ( t[i][0], 0_v );
         ASSERT_EQ( t[3_f][0], 6_v );
     }
+}
+
+// a vertex with two closed rings of triangles around it, from a real mesh
+TEST( MRMesh, inspectVertNeighbourhood )
+{
+    Triangulation t;
+    t.push_back( { 992_v, 991_v, 990_v } );     //0_f
+    t.push_back( { 992_v, 988_v, 1911_v } );    //1_f
+    t.push_back( { 992_v, 989_v, 988_v } );     //2_f
+    t.push_back( { 992_v, 1911_v, 989_v } );    //3_f
+    t.push_back( { 992_v, 1020_v, 1019_v } );   //4_f
+    t.push_back( { 992_v, 990_v, 1020_v } );    //5_f
+    t.push_back( { 992_v, 1019_v, 460079_v } ); //6_f
+    t.push_back( { 992_v, 1013_v, 991_v } );    //7_f
+    t.push_back( { 992_v, 460079_v, 1013_v } ); //8_f
+
+    std::vector<VertTri> recs;
+    for ( FaceId f = 0_f; f < t.size(); ++f )
+        recs.push_back( { 992_v, f } );
+
+    // 6-triangle closed ring (991,990,1020,1019,460079,1013) and 3-triangle closed ring (988,1911,989)
+    const auto info = inspectVertNeighbourhood( t, recs.data(), recs.data() + recs.size() );
+    EXPECT_EQ( info.numRepeatedVerts, 0 );
+    EXPECT_EQ( info.numChains, 2 );
 }
 
 static void testBuildWithDups( const char * objMesh, int numVerts, int numComps )

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -107,6 +107,12 @@ TEST( MRMesh, inspectVertNeighbourhood )
     const auto info = inspectVertNeighbourhood( t, recs.data(), recs.data() + recs.size() );
     EXPECT_EQ( info.numRepeatedVerts, 0 );
     EXPECT_EQ( info.numChains, 2 );
+
+    // the vertex is non-manifold, so one of its rings must get a duplicate
+    std::vector<VertDuplication> dups;
+    EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups ), 1 );
+    ASSERT_EQ( dups.size(), 1 );
+    EXPECT_EQ( dups[0].srcVert, 992_v );
 }
 
 static void testBuildWithDups( const char * objMesh, int numVerts, int numComps )


### PR DESCRIPTION
`inspectVertNeighbourhood` (and hence the skip-criterion of `duplicateNonManifoldVertices`) undercounted chains when one triangle merged two existing chains at both its edges: the `r_`-side merge assumed the right end of the current chain was still `v2`, ignoring that the `l_`-side merge in the same iteration had just extended it. The endpoint maps were left inconsistent, the closure of the final ring was not detected, and a non-manifold vertex could be skipped without duplication.

* New unit test with a vertex neighbourhood from a real mesh: 9 triangles around one vertex forming two closed rings (6 + 3 triangles). Before the fix it computed `numChains == 1` instead of 2, and `duplicateNonManifoldVertices` left the vertex non-manifold. The bug is face-order dependent, which the test order reproduces.
* The fix takes the actual right end of the grown chain (`lInsertion.first->second`, which the `l_`-merge keeps updated) for the `r_`-side merge, and invalidates both edge records of the current triangle since they become inner.

All 305 MRTest tests pass locally (Release, x64).
