### PR TITLE
Add MeshSave::toPly overloads for TriMesh

### DIFF
--- a/source/MRMesh/MRMeshSave.cpp
+++ b/source/MRMesh/MRMeshSave.cpp
@@ -1,6 +1,7 @@
 #include "MRMeshSave.h"
 #include "MRIOFormatsRegistry.h"
 #include "MRMesh.h"
+#include "MRTriMesh.h"
 #include "MRTimer.h"
 #include "MRColor.h"
 #include "MRStringConvert.h"
@@ -394,7 +395,50 @@ Expected<void> toAsciiStl( const Mesh& mesh, std::ostream& out, const SaveSettin
     return {};
 }
 
-Expected<void> toPly( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings )
+// helpers allowing to save Mesh and TriMesh by the same code;
+// all vertices and triangles of TriMesh are always valid
+
+static VertRenumber getVertRenumber( const Mesh & mesh, const SaveSettings & settings )
+{
+    return VertRenumber( mesh.topology.getValidVerts(), settings.onlyValidPoints );
+}
+
+/// identity vertex renumbering for TriMesh
+struct NoRenumber
+{
+    int numVerts = 0;
+    int sizeVerts() const { return numVerts; }
+    int operator()( VertId v ) const { assert( v ); return (int)v; }
+};
+
+static NoRenumber getVertRenumber( const TriMesh & mesh, const SaveSettings & )
+{
+    return { .numVerts = (int)mesh.points.size() };
+}
+
+static VertId lastValidVert( const Mesh & mesh ) { return mesh.topology.lastValidVert(); }
+static VertId lastValidVert( const TriMesh & mesh ) { return VertId( (int)mesh.points.size() - 1 ); }
+
+static bool hasVert( const Mesh & mesh, VertId v ) { return mesh.topology.hasVert( v ); }
+static bool hasVert( const TriMesh &, VertId ) { return true; }
+
+static FaceId lastValidFace( const Mesh & mesh ) { return mesh.topology.lastValidFace(); }
+static FaceId lastValidFace( const TriMesh & mesh ) { return FaceId( (int)mesh.tris.size() - 1 ); }
+
+static int numValidFaces( const Mesh & mesh ) { return mesh.topology.numValidFaces(); }
+static int numValidFaces( const TriMesh & mesh ) { return (int)mesh.tris.size(); }
+
+static bool hasFace( const Mesh & mesh, FaceId f ) { return mesh.topology.hasFace( f ); }
+static bool hasFace( const TriMesh &, FaceId ) { return true; }
+
+static ThreeVertIds getTriVerts( const Mesh & mesh, FaceId f ) { return mesh.topology.getTriVerts( f ); }
+static const ThreeVertIds & getTriVerts( const TriMesh & mesh, FaceId f ) { return mesh.tris[f]; }
+
+template<typename MeshType>
+static Expected<void> toPlyImpl( const MeshType & mesh, std::ostream & out, const SaveSettings & settings );
+
+template<typename MeshType>
+static Expected<void> toPlyImpl( const MeshType & mesh, const std::filesystem::path & file, const SaveSettings & settings )
 {
     std::ofstream out( file, std::ofstream::binary );
     if ( !out )
@@ -409,16 +453,17 @@ Expected<void> toPly( const Mesh & mesh, const std::filesystem::path & file, con
             (void)texSaver( *settings.texture, file.parent_path() / asU8String( settings.materialName + ".jpg" ) );
     }
 #endif
-    return toPly( mesh, out, settings );
+    return toPlyImpl( mesh, out, settings );
 }
 
-Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings & settings )
+template<typename MeshType>
+static Expected<void> toPlyImpl( const MeshType & mesh, std::ostream & out, const SaveSettings & settings )
 {
     MR_TIMER;
 
-    const VertRenumber vertRenumber( mesh.topology.getValidVerts(), settings.onlyValidPoints );
+    const auto vertRenumber = getVertRenumber( mesh, settings );
     const int numPoints = vertRenumber.sizeVerts();
-    const VertId lastVertId = mesh.topology.lastValidVert();
+    const VertId lastVertId = lastValidVert( mesh );
 
     bool saveTexture = settings.texture && !settings.texture->pixels.empty();
     bool saveUV = settings.uvMap && !settings.uvMap->empty();
@@ -434,8 +479,8 @@ Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings 
     if ( saveUV && !settings.saveTriCornerUVCoords )
         out << "property float texture_u\nproperty float texture_v\n";
 
-    const auto fLast = mesh.topology.lastValidFace();
-    const auto numSaveFaces = settings.packPrimitives ? mesh.topology.numValidFaces() : int( fLast + 1 );
+    const auto fLast = lastValidFace( mesh );
+    const auto numSaveFaces = settings.packPrimitives ? numValidFaces( mesh ) : int( fLast + 1 );
     out << "element face " << numSaveFaces << "\nproperty list uchar int vertex_indices\n";
     if ( saveFaceColors )
         out << "property uchar red\nproperty uchar green\nproperty uchar blue\n";
@@ -455,7 +500,7 @@ Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings 
     int numSaved = 0;
     for ( VertId i{ 0 }; i <= lastVertId; ++i )
     {
-        if ( settings.onlyValidPoints && !mesh.topology.hasVert( i ) )
+        if ( settings.onlyValidPoints && !hasVert( mesh, i ) )
             continue;
         const Vector3f p = applyFloat( settings.xf, mesh.points[i] );
         out.write( ( const char* )&p, 12 );
@@ -480,10 +525,10 @@ Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings 
     int savedFaces = 0;
     for ( FaceId f{0}; f <= fLast; ++f )
     {
-        VertId vs[3];
-        if ( mesh.topology.hasFace( f ) )
+        ThreeVertIds vs;
+        if ( hasFace( mesh, f ) )
         {
-            mesh.topology.getTriVerts( f, vs );
+            vs = getTriVerts( mesh, f );
             for ( int i = 0; i < 3; ++i )
                 tri[i] = vertRenumber( vs[i] );
         }
@@ -519,6 +564,26 @@ Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings 
 
     reportProgress( settings.progress, 1.f );
     return {};
+}
+
+Expected<void> toPly( const Mesh & mesh, const std::filesystem::path & file, const SaveSettings & settings )
+{
+    return toPlyImpl( mesh, file, settings );
+}
+
+Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings & settings )
+{
+    return toPlyImpl( mesh, out, settings );
+}
+
+Expected<void> toPly( const TriMesh & mesh, const std::filesystem::path & file, const SaveSettings & settings )
+{
+    return toPlyImpl( mesh, file, settings );
+}
+
+Expected<void> toPly( const TriMesh & mesh, std::ostream & out, const SaveSettings & settings )
+{
+    return toPlyImpl( mesh, out, settings );
 }
 
 Expected<void> toAnySupportedFormat( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings & settings )

--- a/source/MRMesh/MRMeshSave.h
+++ b/source/MRMesh/MRMeshSave.h
@@ -81,6 +81,11 @@ MRMESH_API Expected<void> toAsciiStl( const Mesh & mesh, std::ostream& out, cons
 MRMESH_API Expected<void> toPly( const Mesh & mesh, const std::filesystem::path& file, const SaveSettings & settings = {} );
 MRMESH_API Expected<void> toPly( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
 
+/// saves in .ply file; all vertices and triangles of TriMesh are always saved
+/// independently of SaveSettings::onlyValidPoints and SaveSettings::packPrimitives
+MRMESH_API Expected<void> toPly( const TriMesh & mesh, const std::filesystem::path& file, const SaveSettings & settings = {} );
+MRMESH_API Expected<void> toPly( const TriMesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
+
 /// saves in 3mf .model file
 MRMESH_API Expected<void> toModel3mf( const Mesh & mesh, const std::filesystem::path& file, const SaveSettings & settings = {} );
 MRMESH_API Expected<void> toModel3mf( const Mesh & mesh, std::ostream & out, const SaveSettings & settings = {} );

--- a/source/MRTest/MRMeshLoadSaveTest.cpp
+++ b/source/MRTest/MRMeshLoadSaveTest.cpp
@@ -2,6 +2,7 @@
 #include <MRMesh/MRMeshLoadObj.h>
 #include <MRMesh/MRMeshSave.h>
 #include <MRMesh/MRMesh.h>
+#include <MRMesh/MRTriMesh.h>
 #include <MRMesh/MRBox.h>
 #include <gtest/gtest.h>
 #include <filesystem>
@@ -74,6 +75,40 @@ TEST(MRMesh, LoadSave)
     loadRes = MeshLoad::fromBinaryStl( ss );
     EXPECT_TRUE( loadRes.has_value() );
 
+    EXPECT_EQ( loadRes->points.size(), 5 );
+    EXPECT_EQ( loadRes->topology.numValidVerts(), 5 );
+    EXPECT_EQ( loadRes->topology.numValidFaces(), 6 );
+}
+
+TEST(MRMesh, TriMeshSavePly)
+{
+    TriMesh triMesh;
+    triMesh.tris = Triangulation{
+        { 0_v, 1_v, 2_v },
+        { 0_v, 2_v, 3_v },
+        { 0_v, 3_v, 4_v },
+        { 0_v, 4_v, 1_v },
+        { 1_v, 3_v, 2_v },
+        { 1_v, 4_v, 3_v }
+    };
+    triMesh.points.emplace_back( 0.f, 0.f, 1.f );
+    triMesh.points.emplace_back( 1.f, 0.f, 0.f );
+    triMesh.points.emplace_back( 0.f, 1.f, 0.f );
+    triMesh.points.emplace_back( -1.f, 0.f, 0.f );
+    triMesh.points.emplace_back( 0.f, -1.f, 0.f );
+
+    std::ostringstream outTriMesh;
+    EXPECT_TRUE( MeshSave::toPly( triMesh, outTriMesh ).has_value() );
+
+    // the same bytes must be saved for TriMesh and for equivalent Mesh
+    const auto mesh = Mesh::fromTriMesh( TriMesh( triMesh ) );
+    std::ostringstream outMesh;
+    EXPECT_TRUE( MeshSave::toPly( mesh, outMesh ).has_value() );
+    EXPECT_EQ( outTriMesh.str(), outMesh.str() );
+
+    std::istringstream in( outTriMesh.str() );
+    auto loadRes = MeshLoad::fromPly( in );
+    ASSERT_TRUE( loadRes.has_value() );
     EXPECT_EQ( loadRes->points.size(), 5 );
     EXPECT_EQ( loadRes->topology.numValidVerts(), 5 );
     EXPECT_EQ( loadRes->topology.numValidFaces(), 6 );


### PR DESCRIPTION
Adds two new functions for saving `TriMesh` in .ply format:

```cpp
MRMESH_API Expected<void> toPly( const TriMesh & mesh, const std::filesystem::path& file, const SaveSettings & settings = {} );
MRMESH_API Expected<void> toPly( const TriMesh & mesh, std::ostream & out, const SaveSettings & settings = {} );
```

To avoid copy-paste and any conversion between `Mesh` and `TriMesh`, the existing `toPly` implementation is turned into the `toPlyImpl` function template, and the differences between the two representations are factored into small accessor helpers (`getVertRenumber`, `lastValidVert`, `hasVert`, `lastValidFace`, `numValidFaces`, `hasFace`, `getTriVerts`). All vertices and triangles of `TriMesh` are considered valid, so vertex renumbering for it is identity, and `SaveSettings::onlyValidPoints` / `SaveSettings::packPrimitives` have no effect on it.

The saved bytes for `Mesh` are exactly the same as before (only `mesh.topology.getTriVerts( f, vs )` call was replaced with the equivalent by-value overload).

New unit test `MRMesh.TriMeshSavePly` verifies that saving a `TriMesh` produces byte-identical .ply output to saving the equivalent `Mesh`, and that the output loads back correctly.

Local verification: MRTest Release x64 — all 306 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
