### PR TITLE
Re-pin Eigen license notices after submodule bump

### DIFF
--- a/thirdparty/licenses/Eigen/COPYING.MPL2
+++ b/thirdparty/licenses/Eigen/COPYING.MPL2
@@ -357,7 +357,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE

--- a/thirdparty/licenses/Eigen/COPYING.README
+++ b/thirdparty/licenses/Eigen/COPYING.README
@@ -2,17 +2,5 @@ Eigen is primarily MPL2 licensed. See COPYING.MPL2 and these links:
   http://www.mozilla.org/MPL/2.0/
   http://www.mozilla.org/MPL/2.0/FAQ.html
 
-Some files contain third-party code under BSD or LGPL licenses, whence the other
-COPYING.* files here.
-
-All the LGPL code is either LGPL 2.1-only, or LGPL 2.1-or-later.
-For this reason, the COPYING.LGPL file contains the LGPL 2.1 text.
-
-If you want to guarantee that the Eigen code that you are #including is licensed
-under the MPL2 and possibly more permissive licenses (like BSD), #define this
-preprocessor symbol:
-  EIGEN_MPL2_ONLY
-For example, with most compilers, you could add this to your project CXXFLAGS:
-  -DEIGEN_MPL2_ONLY
-This will cause a compilation error to be generated if you #include any code that is
-LGPL licensed.
+Some files contain third-party code under BSD or other MPL2-compatible licenses,
+whence the other COPYING.* files here.

--- a/thirdparty/licenses/manifest.json
+++ b/thirdparty/licenses/manifest.json
@@ -55,7 +55,7 @@
         "type": "submodule",
         "path": "thirdparty/eigen"
       },
-      "version": "3147391d946bb4b6c68edd901f2add6ac1f31f8c",
+      "version": "bc3b39870ecb690a623a3f49149a358b95c5781d",
       "files": [
         "COPYING.MPL2",
         "COPYING.README"


### PR DESCRIPTION
Fixes the daily [Check third-party licenses failure](https://github.com/MeshInspector/MeshLib/actions/runs/29475766200): #6418 moved `thirdparty/eigen` from 3.4.0 (`3147391d`) to `bc3b3987` without re-pinning `thirdparty/licenses/`.

Upstream license texts at the new commit re-verified against `gitlab.com/libeigen/eigen` (stored copies are byte-identical to upstream):
- `COPYING.MPL2` — one character changed upstream (`http` → `https` in the Exhibit A notice); still verbatim MPL-2.0.
- `COPYING.README` — Eigen removed all LGPL-licensed code after 3.4, so the README dropped the LGPL/`EIGEN_MPL2_ONLY` paragraphs. Eigen's license remains MPL-2.0, so `ThirdpartyList.dox`/`MRAbout.h` need no change (MeshLib never defined `EIGEN_MPL2_ONLY`).

Verified locally: `python scripts/check_third_party_licenses.py` → `third-party license notices OK: 41 components verified.`

Label `update-doc-only`: nothing compiled changes; the license check itself re-runs on the daily schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)