### PR TITLE
Report GUI login session state in macos-diagnostics

### DIFF
--- a/.github/actions/macos-diagnostics/action.yml
+++ b/.github/actions/macos-diagnostics/action.yml
@@ -1,7 +1,8 @@
 name: macOS Diagnostics
 description: >
-  Print the runner's power source, Low Power Mode, thermal throttle state and
-  background load, then sample them every 10s until the end of the job; the
+  Print the runner's GUI login session state, power source, Low Power Mode,
+  thermal throttle state and background load, then sample them every 10s
+  until the end of the job; the
   automatic post step dumps the samples. Helps explain speed differences
   between self-hosted machines. macOS only.
 

--- a/.github/actions/macos-diagnostics/snapshot.sh
+++ b/.github/actions/macos-diagnostics/snapshot.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+echo "--- launchctl managername: Aqua = GUI login session, else user-domain XPC services are unavailable ---"
+launchctl managername
+launchctl print "gui/$(id -u)" >/dev/null 2>&1 && echo "gui/$(id -u) launchd domain: present" || echo "gui/$(id -u) launchd domain: MISSING (no GUI login session)"
 echo "--- pmset -g: active power settings (see lowpowermode) ---"
 pmset -g
 echo "--- pmset -g batt: power source & battery ---"

--- a/.github/actions/macos-diagnostics/snapshot.sh
+++ b/.github/actions/macos-diagnostics/snapshot.sh
@@ -2,6 +2,9 @@
 echo "--- launchctl managername: Aqua = GUI login session, else user-domain XPC services are unavailable ---"
 launchctl managername
 launchctl print "gui/$(id -u)" >/dev/null 2>&1 && echo "gui/$(id -u) launchd domain: present" || echo "gui/$(id -u) launchd domain: MISSING (no GUI login session)"
+echo "--- runner IP addresses: local IPv4 & public egress ---"
+ifconfig -a | awk '/inet /{print $2}' | grep -v '^127\.' || true
+curl -fsS --max-time 5 https://checkip.amazonaws.com || echo "public IP lookup failed"
 echo "--- pmset -g: active power settings (see lowpowermode) ---"
 pmset -g
 echo "--- pmset -g batt: power source & battery ---"

--- a/.github/actions/macos-diagnostics/snapshot.sh
+++ b/.github/actions/macos-diagnostics/snapshot.sh
@@ -2,6 +2,15 @@
 echo "--- launchctl managername: Aqua = GUI login session, else user-domain XPC services are unavailable ---"
 launchctl managername
 launchctl print "gui/$(id -u)" >/dev/null 2>&1 && echo "gui/$(id -u) launchd domain: present" || echo "gui/$(id -u) launchd domain: MISSING (no GUI login session)"
+echo "--- console owner / autoLoginUser / FileVault (does auto-login restore the GUI session after reboot) ---"
+stat -f 'console owner: %Su' /dev/console || true
+echo "autoLoginUser: $(defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser 2>/dev/null || echo '<not set>')"
+fdesetup status || true
+echo "--- runner service plists: a LaunchDaemon starts the runner outside the GUI session, a LaunchAgent inside ---"
+ls -l /Library/LaunchDaemons/actions.runner.*.plist "$HOME"/Library/LaunchAgents/actions.runner.*.plist 2>/dev/null || echo "no actions.runner service plists"
+echo "--- process ancestry up to launchd: which service actually runs this job ---"
+pid=$$
+while [ -n "$pid" ] && [ "$pid" -gt 1 ]; do ps -o pid=,ppid=,user=,comm= -p "$pid"; pid=$(ps -o ppid= -p "$pid" | tr -d ' '); done
 echo "--- runner IP addresses: local IPv4 & public egress ---"
 ifconfig -a | awk '/inet /{print $2}' | grep -v '^127\.' || true
 curl -fsS --max-time 5 https://checkip.amazonaws.com || echo "public IP lookup failed"

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -267,6 +267,9 @@ jobs:
         with:
           ref: ${{needs.setup.outputs.version_tag}}
 
+      - name: macOS Diagnostics
+        uses: ./.github/actions/macos-diagnostics
+
       - name: Download Distributive
         # GH_TOKEN instead of `gh auth login`: the login stores the token in
         # the macOS keychain, which is locked in self-hosted runner sessions


### PR DESCRIPTION
## Why

Since a reboot of the macos-12-intel runner on 2026-07-15 06:54 (local), every `installer -pkg ... -target CurrentUserHomeDirectory` on it failed in under a second with nothing but:

```
installer: Upgrading at base path /Users/githubrunner
installer: The upgrade failed..
```

The real cause (visible only with `installer -dumplog`) was:

```
PackageKit: XPC error ... "The connection to service named com.apple.installd.user was invalidated:
failed at lookup with error 3 - No such process."
Couldn't instantiate install client: Error Domain=PKInstallErrorDomain Code=201
```

The runner listener was started by a stale root LaunchDaemon left from an old registration, so it ran in the launchd **system** domain even though a GUI session existed — and per-user XPC services (`com.apple.installd.user`, `com.apple.fonts`, ...) are only reachable from the Aqua session. User-domain package installs need the runner to be started by a LaunchAgent inside the GUI login session. Nothing in the job log pointed at any of that; finding it required several rounds of throwaway diagnostics workflows.

## What

Add every probe that located the issue to the one-shot snapshot printed at the start of each job using `macos-diagnostics`:

- `launchctl managername` (`Aqua` = GUI session) and presence of the `gui/<uid>` launchd domain, with an explicit `MISSING (no GUI login session)` marker;
- console owner, `autoLoginUser`, and FileVault state — whether auto-login can restore the GUI session after an unattended reboot;
- `actions.runner.*` service plists in `/Library/LaunchDaemons` (starts the runner **outside** the GUI session) vs `~/Library/LaunchAgents` (inside);
- the job's process ancestry up to `launchd` — which of those services actually runs the job;
- runner IP addresses: local IPv4s and public egress IP (`checkip.amazonaws.com`, 5 s timeout, non-fatal) — same info the Windows runners log, useful with multi-WAN office egress.

Next time a self-hosted Mac comes back from a reboot in a broken state, the first lines of the diagnostics output will say so directly.

Verified in this PR's CI (healthy runner): prints `Aqua`, `gui/502 launchd domain: present`, the LaunchAgent plist, an ancestry ending in the agent-run listener, and the local + egress IPs.
