### PR TITLE
Pack VertInfo in 32 bits: 1-bit flag selecting repeated-verts counter or open/closed chain counters

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -143,6 +143,34 @@ public:
     }
 };
 
+// all changes of VertInfo counters below saturate at the field's maximum instead of overflowing,
+// and a saturated counter sticks to its maximum to keep the vertex suspicious for the sequential walk
+
+static void incOpenChains( VertInfo & info )
+{
+    if ( info.numOpenChains < VertInfo::maxNumOpenChains )
+        ++info.numOpenChains;
+}
+
+static void decOpenChains( VertInfo & info )
+{
+    assert( info.numOpenChains > 0 );
+    if ( info.numOpenChains < VertInfo::maxNumOpenChains )
+        --info.numOpenChains;
+}
+
+static void incClosedChains( VertInfo & info )
+{
+    if ( info.numClosedChains < VertInfo::maxNumClosedChains )
+        ++info.numClosedChains;
+}
+
+static void incRepeatedVerts( VertInfo & info )
+{
+    if ( info.numRepeatedVerts < VertInfo::maxNumRepeatedVerts )
+        ++info.numRepeatedVerts;
+}
+
 class VertNeighbourhoodInspector
 {
 public:
@@ -181,15 +209,14 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
         const auto rInsertion = r_.insert( { v2, v1 } );
         if ( info.numRepeatedVerts == 0 && lInsertion.second && rInsertion.second )
         {
-            ++info.numChains;
+            incOpenChains( info );
             if ( auto it = l_.find( v2 ); it != l_.end() )
             {
                 // the edge (v,v2) becomes inner
                 const auto vEnd = it->second;
                 it->second = VertId{};
                 assert( vEnd ); // the edge (v,v2) was boundary
-                assert( info.numChains > 0 );
-                --info.numChains;
+                decOpenChains( info );
                 lInsertion.first->second = vEnd;
                 assert( r_[vEnd] == v2 );
                 r_[vEnd] = v1;
@@ -206,11 +233,12 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
                     assert( lInsertion.first->second == v1 );
                     lInsertion.first->second = VertId{};
                     rInsertion.first->second = VertId{};
+                    decOpenChains( info );
+                    incClosedChains( info );
                 }
                 else
                 {
-                    assert( info.numChains > 0 );
-                    --info.numChains;
+                    decOpenChains( info );
                     // the right end of the chain grown from the current triangle: v2, or updated by the merge above
                     const auto vRight = lInsertion.first->second;
                     assert( vRight );
@@ -233,11 +261,12 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
         {
             // insertion can fail only if the vertex is repeated
             if ( !lInsertion.second )
-                ++info.numRepeatedVerts;
+                incRepeatedVerts( info );
             if ( !rInsertion.second )
-                ++info.numRepeatedVerts;
-            // numChains is not updated and not trustworthy after this
-            info.numChains = 0;
+                incRepeatedVerts( info );
+            // chain counters are not updated and not trustworthy after this
+            info.numOpenChains = 0;
+            info.numClosedChains = 0;
         }
     }
     return info;
@@ -365,7 +394,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     {
         // this skip-criterion must remain equivalent to
         // "the sequential walk via PathAroundVertex finds nothing to duplicate for this vertex"
-        if ( all.vertInfos[v].numRepeatedVerts == 0 && all.vertInfos[v].numChains <= 1 )
+        if ( all.vertInfos[v].numRepeatedVerts == 0 && all.vertInfos[v].numOpenChains + all.vertInfos[v].numClosedChains <= 1 )
             continue; // single chain of triangles or no triangles at all, nothing to duplicate
         const auto posBegin = all.vert2firstRec[v];
         const auto posEnd = all.vert2firstRec[v + 1];

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -143,34 +143,6 @@ public:
     }
 };
 
-// all changes of VertInfo counters below saturate at the field's maximum instead of overflowing,
-// and a saturated counter sticks to its maximum to keep the vertex suspicious for the sequential walk
-
-static void incOpenChains( VertInfo & info )
-{
-    if ( info.numOpenChains < VertInfo::maxNumOpenChains )
-        ++info.numOpenChains;
-}
-
-static void decOpenChains( VertInfo & info )
-{
-    assert( info.numOpenChains > 0 );
-    if ( info.numOpenChains < VertInfo::maxNumOpenChains )
-        --info.numOpenChains;
-}
-
-static void incClosedChains( VertInfo & info )
-{
-    if ( info.numClosedChains < VertInfo::maxNumClosedChains )
-        ++info.numClosedChains;
-}
-
-static void incRepeatedVerts( VertInfo & info )
-{
-    if ( info.numRepeatedVerts < VertInfo::maxNumRepeatedVerts )
-        ++info.numRepeatedVerts;
-}
-
 class VertNeighbourhoodInspector
 {
 public:
@@ -207,16 +179,16 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
         const auto [v1, v2] = getOtherTriVerts( t[i->f], v0 );
         const auto lInsertion = l_.insert( { v1, v2 } );
         const auto rInsertion = r_.insert( { v2, v1 } );
-        if ( info.numRepeatedVerts == 0 && lInsertion.second && rInsertion.second )
+        if ( !info.hasRepeatedVerts() && lInsertion.second && rInsertion.second )
         {
-            incOpenChains( info );
+            info.incOpenChains();
             if ( auto it = l_.find( v2 ); it != l_.end() )
             {
                 // the edge (v,v2) becomes inner
                 const auto vEnd = it->second;
                 it->second = VertId{};
                 assert( vEnd ); // the edge (v,v2) was boundary
-                decOpenChains( info );
+                info.decOpenChains();
                 lInsertion.first->second = vEnd;
                 assert( r_[vEnd] == v2 );
                 r_[vEnd] = v1;
@@ -233,12 +205,12 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
                     assert( lInsertion.first->second == v1 );
                     lInsertion.first->second = VertId{};
                     rInsertion.first->second = VertId{};
-                    decOpenChains( info );
-                    incClosedChains( info );
+                    info.decOpenChains();
+                    info.incClosedChains();
                 }
                 else
                 {
-                    decOpenChains( info );
+                    info.decOpenChains();
                     // the right end of the chain grown from the current triangle: v2, or updated by the merge above
                     const auto vRight = lInsertion.first->second;
                     assert( vRight );
@@ -261,12 +233,9 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
         {
             // insertion can fail only if the vertex is repeated
             if ( !lInsertion.second )
-                incRepeatedVerts( info );
+                info.incRepeatedVerts();
             if ( !rInsertion.second )
-                incRepeatedVerts( info );
-            // chain counters are not updated and not trustworthy after this
-            info.numOpenChains = 0;
-            info.numClosedChains = 0;
+                info.incRepeatedVerts();
         }
     }
     return info;
@@ -394,7 +363,8 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     {
         // this skip-criterion must remain equivalent to
         // "the sequential walk via PathAroundVertex finds nothing to duplicate for this vertex"
-        if ( all.vertInfos[v].numRepeatedVerts == 0 && all.vertInfos[v].numOpenChains + all.vertInfos[v].numClosedChains <= 1 )
+        const auto vertInfo = all.vertInfos[v];
+        if ( !vertInfo.hasRepeatedVerts() && vertInfo.numOpenChains() + vertInfo.numClosedChains() <= 1 )
             continue; // single chain of triangles or no triangles at all, nothing to duplicate
         const auto posBegin = all.vert2firstRec[v];
         const auto posEnd = all.vert2firstRec[v + 1];

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -2,6 +2,7 @@
 
 #include "MRId.h"
 #include "MRPch/MRBindingMacros.h"
+#include <cassert>
 #include <cstdint>
 #include <utility>
 #include <vector>
@@ -25,24 +26,63 @@ MRMESH_API size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * 
     std::vector<VertDuplication>* dups = nullptr, VertId lastValidVert = {} );
 
 /// classification of the triangles around one vertex, packed in 32 bits;
-/// each counter saturates at its maximum value instead of overflowing
+/// it stores 1-bit flag (hasRepeatedVerts) and either 31-bit numRepeatedVerts (if the flag is on),
+/// or 16-bit numOpenChains and 15-bit numClosedChains (if the flag is off)
 struct VertInfo
 {
-    /// the number of open chains of connected triangles around the vertex;
-    /// set to 0 if numRepeatedVerts > 0
-    std::uint32_t numOpenChains : 10 = 0;
+    /// true if some neighbor vertex is present in more than one triangle-pair around the vertex
+    [[nodiscard]] bool hasRepeatedVerts() const { return ( data_ & 1 ) != 0; }
 
-    /// the number of closed chains (rings) of connected triangles around the vertex;
-    /// set to 0 if numRepeatedVerts > 0
-    std::uint32_t numClosedChains : 10 = 0;
+    /// the number of neighbor vertex repetitions; 0 if !hasRepeatedVerts()
+    [[nodiscard]] std::uint32_t numRepeatedVerts() const { return hasRepeatedVerts() ? data_ >> 1 : 0; }
 
-    /// the number of vertices, which are passed more than once
-    std::uint32_t numRepeatedVerts : 12 = 0;
+    /// the number of open chains of connected triangles around the vertex; 0 if hasRepeatedVerts()
+    [[nodiscard]] std::uint32_t numOpenChains() const { return hasRepeatedVerts() ? 0 : ( data_ >> 1 ) & maxNumOpenChains; }
 
-    /// maximal values storable in the bit-fields above
-    static constexpr std::uint32_t maxNumOpenChains = 1023;
-    static constexpr std::uint32_t maxNumClosedChains = 1023;
-    static constexpr std::uint32_t maxNumRepeatedVerts = 4095;
+    /// the number of closed chains (rings) of connected triangles around the vertex; 0 if hasRepeatedVerts()
+    [[nodiscard]] std::uint32_t numClosedChains() const { return hasRepeatedVerts() ? 0 : data_ >> 17; }
+
+    /// increments numRepeatedVerts saturating at its maximum; the first call zeros the chain counters forever
+    void incRepeatedVerts()
+    {
+        if ( !hasRepeatedVerts() )
+            data_ = 3; // the flag and numRepeatedVerts = 1
+        else if ( numRepeatedVerts() < maxNumRepeatedVerts )
+            data_ += 2;
+    }
+
+    /// increments numOpenChains saturating at its maximum
+    void incOpenChains()
+    {
+        assert( !hasRepeatedVerts() );
+        if ( numOpenChains() < maxNumOpenChains )
+            data_ += 2;
+    }
+
+    /// decrements numOpenChains, but a saturated counter sticks to its maximum forever
+    void decOpenChains()
+    {
+        assert( !hasRepeatedVerts() );
+        assert( numOpenChains() > 0 );
+        if ( numOpenChains() < maxNumOpenChains )
+            data_ -= 2;
+    }
+
+    /// increments numClosedChains saturating at its maximum
+    void incClosedChains()
+    {
+        assert( !hasRepeatedVerts() );
+        if ( numClosedChains() < maxNumClosedChains )
+            data_ += 1u << 17;
+    }
+
+    /// maximal values storable in the counters
+    static constexpr std::uint32_t maxNumOpenChains = ( 1u << 16 ) - 1;
+    static constexpr std::uint32_t maxNumClosedChains = ( 1u << 15 ) - 1;
+    static constexpr std::uint32_t maxNumRepeatedVerts = ( 1u << 31 ) - 1;
+
+private:
+    std::uint32_t data_ = 0;
 };
 static_assert( sizeof( VertInfo ) == 4 );
 

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -2,6 +2,7 @@
 
 #include "MRId.h"
 #include "MRPch/MRBindingMacros.h"
+#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -23,16 +24,27 @@ struct VertDuplication
 MRMESH_API size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region = nullptr,
     std::vector<VertDuplication>* dups = nullptr, VertId lastValidVert = {} );
 
-/// classification of the triangles around one vertex
+/// classification of the triangles around one vertex, packed in 32 bits;
+/// each counter saturates at its maximum value instead of overflowing
 struct VertInfo
 {
-    /// the number of chains of connected triangles around the vertex;
-    /// numChains is set to 0 if numRepeatedVerts > 0
-    int numChains = 0;
+    /// the number of open chains of connected triangles around the vertex;
+    /// set to 0 if numRepeatedVerts > 0
+    std::uint32_t numOpenChains : 10 = 0;
+
+    /// the number of closed chains (rings) of connected triangles around the vertex;
+    /// set to 0 if numRepeatedVerts > 0
+    std::uint32_t numClosedChains : 10 = 0;
 
     /// the number of vertices, which are passed more than once
-    int numRepeatedVerts = 0;
+    std::uint32_t numRepeatedVerts : 12 = 0;
+
+    /// maximal values storable in the bit-fields above
+    static constexpr std::uint32_t maxNumOpenChains = 1023;
+    static constexpr std::uint32_t maxNumClosedChains = 1023;
+    static constexpr std::uint32_t maxNumRepeatedVerts = 4095;
 };
+static_assert( sizeof( VertInfo ) == 4 );
 
 /// describes a vertex and one of triangles incident to it
 struct VertTri

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -106,13 +106,69 @@ TEST( MRMesh, inspectVertNeighbourhood )
     // 6-triangle closed ring (991,990,1020,1019,460079,1013) and 3-triangle closed ring (988,1911,989)
     const auto info = inspectVertNeighbourhood( t, recs.data(), recs.data() + recs.size() );
     EXPECT_EQ( info.numRepeatedVerts, 0 );
-    EXPECT_EQ( info.numChains, 2 );
+    EXPECT_EQ( info.numOpenChains, 0 );
+    EXPECT_EQ( info.numClosedChains, 2 );
 
     // the vertex is non-manifold, so one of its rings must get a duplicate
     std::vector<VertDuplication> dups;
     EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups ), 1 );
     ASSERT_EQ( dups.size(), 1 );
     EXPECT_EQ( dups[0].srcVert, 992_v );
+}
+
+// check that VertInfo counters saturate at their maximum values instead of overflowing
+TEST( MRMesh, inspectVertNeighbourhoodSaturation )
+{
+    // more disjoint triangles around one vertex than numOpenChains can store
+    {
+        Triangulation t;
+        std::vector<VertTri> recs;
+        const int n = (int)VertInfo::maxNumOpenChains + 100;
+        for ( int i = 0; i < n; ++i )
+        {
+            t.push_back( { 0_v, VertId( 1 + 2 * i ), VertId( 2 + 2 * i ) } );
+            recs.push_back( { 0_v, FaceId( i ) } );
+        }
+        const auto info = inspectVertNeighbourhood( t, recs.data(), recs.data() + recs.size() );
+        EXPECT_EQ( info.numRepeatedVerts, 0 );
+        EXPECT_EQ( info.numOpenChains, VertInfo::maxNumOpenChains );
+        EXPECT_EQ( info.numClosedChains, 0 );
+    }
+
+    // more closed rings around one vertex than numClosedChains can store
+    {
+        Triangulation t;
+        std::vector<VertTri> recs;
+        const int n = (int)VertInfo::maxNumClosedChains + 100;
+        for ( int i = 0; i < n; ++i )
+        {
+            const VertId a( 1 + 2 * i ), b( 2 + 2 * i );
+            t.push_back( { 0_v, a, b } );
+            t.push_back( { 0_v, b, a } );
+            recs.push_back( { 0_v, FaceId( 2 * i ) } );
+            recs.push_back( { 0_v, FaceId( 2 * i + 1 ) } );
+        }
+        const auto info = inspectVertNeighbourhood( t, recs.data(), recs.data() + recs.size() );
+        EXPECT_EQ( info.numRepeatedVerts, 0 );
+        EXPECT_EQ( info.numOpenChains, 0 );
+        EXPECT_EQ( info.numClosedChains, VertInfo::maxNumClosedChains );
+    }
+
+    // the same triangle repeated more times than numRepeatedVerts can store (each repetition adds 2)
+    {
+        Triangulation t;
+        std::vector<VertTri> recs;
+        const int n = (int)VertInfo::maxNumRepeatedVerts;
+        for ( int i = 0; i < n; ++i )
+        {
+            t.push_back( { 0_v, 1_v, 2_v } );
+            recs.push_back( { 0_v, FaceId( i ) } );
+        }
+        const auto info = inspectVertNeighbourhood( t, recs.data(), recs.data() + recs.size() );
+        EXPECT_EQ( info.numRepeatedVerts, VertInfo::maxNumRepeatedVerts );
+        EXPECT_EQ( info.numOpenChains, 0 );
+        EXPECT_EQ( info.numClosedChains, 0 );
+    }
 }
 
 static void testBuildWithDups( const char * objMesh, int numVerts, int numComps )

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -105,9 +105,9 @@ TEST( MRMesh, inspectVertNeighbourhood )
 
     // 6-triangle closed ring (991,990,1020,1019,460079,1013) and 3-triangle closed ring (988,1911,989)
     const auto info = inspectVertNeighbourhood( t, recs.data(), recs.data() + recs.size() );
-    EXPECT_EQ( info.numRepeatedVerts, 0 );
-    EXPECT_EQ( info.numOpenChains, 0 );
-    EXPECT_EQ( info.numClosedChains, 2 );
+    EXPECT_FALSE( info.hasRepeatedVerts() );
+    EXPECT_EQ( info.numOpenChains(), 0 );
+    EXPECT_EQ( info.numClosedChains(), 2 );
 
     // the vertex is non-manifold, so one of its rings must get a duplicate
     std::vector<VertDuplication> dups;
@@ -123,23 +123,23 @@ TEST( MRMesh, inspectVertNeighbourhoodSaturation )
     {
         Triangulation t;
         std::vector<VertTri> recs;
-        const int n = (int)VertInfo::maxNumOpenChains + 100;
+        const int n = int( VertInfo::maxNumOpenChains ) + 100;
         for ( int i = 0; i < n; ++i )
         {
             t.push_back( { 0_v, VertId( 1 + 2 * i ), VertId( 2 + 2 * i ) } );
             recs.push_back( { 0_v, FaceId( i ) } );
         }
         const auto info = inspectVertNeighbourhood( t, recs.data(), recs.data() + recs.size() );
-        EXPECT_EQ( info.numRepeatedVerts, 0 );
-        EXPECT_EQ( info.numOpenChains, VertInfo::maxNumOpenChains );
-        EXPECT_EQ( info.numClosedChains, 0 );
+        EXPECT_FALSE( info.hasRepeatedVerts() );
+        EXPECT_EQ( info.numOpenChains(), VertInfo::maxNumOpenChains );
+        EXPECT_EQ( info.numClosedChains(), 0 );
     }
 
     // more closed rings around one vertex than numClosedChains can store
     {
         Triangulation t;
         std::vector<VertTri> recs;
-        const int n = (int)VertInfo::maxNumClosedChains + 100;
+        const int n = int( VertInfo::maxNumClosedChains ) + 100;
         for ( int i = 0; i < n; ++i )
         {
             const VertId a( 1 + 2 * i ), b( 2 + 2 * i );
@@ -149,25 +149,26 @@ TEST( MRMesh, inspectVertNeighbourhoodSaturation )
             recs.push_back( { 0_v, FaceId( 2 * i + 1 ) } );
         }
         const auto info = inspectVertNeighbourhood( t, recs.data(), recs.data() + recs.size() );
-        EXPECT_EQ( info.numRepeatedVerts, 0 );
-        EXPECT_EQ( info.numOpenChains, 0 );
-        EXPECT_EQ( info.numClosedChains, VertInfo::maxNumClosedChains );
+        EXPECT_FALSE( info.hasRepeatedVerts() );
+        EXPECT_EQ( info.numOpenChains(), 0 );
+        EXPECT_EQ( info.numClosedChains(), VertInfo::maxNumClosedChains );
     }
 
-    // the same triangle repeated more times than numRepeatedVerts can store (each repetition adds 2)
+    // the same triangle repeated many times: repetitions are counted, chain counters read as zero
     {
         Triangulation t;
         std::vector<VertTri> recs;
-        const int n = (int)VertInfo::maxNumRepeatedVerts;
+        const int n = 100;
         for ( int i = 0; i < n; ++i )
         {
             t.push_back( { 0_v, 1_v, 2_v } );
             recs.push_back( { 0_v, FaceId( i ) } );
         }
         const auto info = inspectVertNeighbourhood( t, recs.data(), recs.data() + recs.size() );
-        EXPECT_EQ( info.numRepeatedVerts, VertInfo::maxNumRepeatedVerts );
-        EXPECT_EQ( info.numOpenChains, 0 );
-        EXPECT_EQ( info.numClosedChains, 0 );
+        EXPECT_TRUE( info.hasRepeatedVerts() );
+        EXPECT_EQ( info.numRepeatedVerts(), 2u * ( n - 1 ) );
+        EXPECT_EQ( info.numOpenChains(), 0 );
+        EXPECT_EQ( info.numClosedChains(), 0 );
     }
 }
 


### PR DESCRIPTION
`MeshBuilder::VertInfo` is packed in 32 bits (`static_assert( sizeof( VertInfo ) == 4 )`) with a 1-bit discriminating flag:

* if `hasRepeatedVerts()` is on, the remaining 31 bits store `numRepeatedVerts`;
* if it is off, they store `numOpenChains` (16 bits) and `numClosedChains` (15 bits) — the former single `numChains` counter split in two; the skip-criterion of `duplicateNonManifoldVertices` uses their sum, so its behavior is unchanged.

All access goes through member functions. Getters of the branch not selected by the flag return 0. Incrementing/decrementing setters saturate at each counter's maximum instead of overflowing, and a saturated counter sticks to its maximum (it is not decremented), so a vertex whose true counts exceed the limits always stays classified as suspicious and is passed to the sequential walk, never wrongly skipped. The first `incRepeatedVerts()` switches the layout, which structurally enforces the old rule "chain counters are zeroed if there are repeated vertices".

New unit test `inspectVertNeighbourhoodSaturation` checks saturation of both chain counters and the counting of repeated vertices; the existing `inspectVertNeighbourhood` test is updated for the split fields (2 closed rings, 0 open chains).

Note: mrbind binds the accessor member functions normally; `inspectVertNeighbourhood` itself remains hidden from Python.

All 307 MRTest tests pass locally (Release, x64).
