### PR TITLE
Skip unnecessary duplication of a vertex with two open chains and no closed ones

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -361,10 +361,13 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     size_t duplicatedVerticesCnt = 0;
     for ( auto v = 0_v; v + 1 < all.vert2firstRec.size(); ++v )
     {
-        // skip a vertex, for which the sequential walk via PathAroundVertex finds nothing to duplicate;
-        // also skip a vertex with exactly two open chains and no closed ones, MeshBuilder has no issue with such configuration
         const auto vertInfo = all.vertInfos[v];
-        if ( !vertInfo.hasRepeatedVerts() && ( vertInfo.numOpenChains() + vertInfo.numClosedChains() <= 1 || ( vertInfo.numOpenChains() == 2 && vertInfo.numClosedChains() == 0 ) ) )
+        // a vertex with exactly two open chains of triangles and no closed ones is not duplicated,
+        // because MeshBuilder has no issue with such configuration
+        const bool twoOpenChainsOnly = !vertInfo.hasRepeatedVerts() && vertInfo.numOpenChains() == 2 && vertInfo.numClosedChains() == 0;
+
+        // performance optimization only: skip a vertex, for which the sequential walk below finds nothing to duplicate
+        if ( twoOpenChainsOnly || ( !vertInfo.hasRepeatedVerts() && vertInfo.numOpenChains() + vertInfo.numClosedChains() <= 1 ) )
             continue;
         const auto posBegin = all.vert2firstRec[v];
         const auto posEnd = all.vert2firstRec[v + 1];
@@ -413,7 +416,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                     }
                     if ( !nextVertex )
                     {
-                        if ( foundChains )
+                        if ( foundChains && !twoOpenChainsOnly )
                         {
                             pathMaker.duplicateVertex( path, lastValidVert, dups );
                             ++duplicatedVerticesCnt;
@@ -433,7 +436,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                     for( const auto& vi : closedPath)
                         visitedVertices.reset(vi);
 
-                    if ( foundChains )
+                    if ( foundChains && !twoOpenChainsOnly )
                     {
                         pathMaker.duplicateVertex( closedPath, lastValidVert, dups );
                         ++duplicatedVerticesCnt;

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -338,6 +338,15 @@ void extractClosedPath( std::vector<VertId>& path, std::vector<VertId>& closedPa
     }
 }
 
+/// returns true if the vertex with such neighborhood does not require duplication:
+/// a single chain of triangles (or no triangles at all), or two open chains, which MeshBuilder has no issue with
+static bool noDuplicationNeeded( const VertInfo & vertInfo )
+{
+    return !vertInfo.hasRepeatedVerts() &&
+        ( vertInfo.numOpenChains() + vertInfo.numClosedChains() <= 1
+        || ( vertInfo.numOpenChains() == 2 && vertInfo.numClosedChains() == 0 ) );
+}
+
 // for all vertices get over all incident vertices to find connected sequences
 size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std::vector<VertDuplication>* dups, VertId lastValidVert )
 {
@@ -355,22 +364,25 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     all.computeVertSpans();
     all.computeVertInfos( t );
 
+    VertNeighbourhoodInspector inspector;
     std::vector<VertId> path;
     std::vector<VertId> closedPath;
     VertBitSet visitedVertices( all.recs.back().v ); // explicitly not `lastValidVert` but last vert used in triangulation
     size_t duplicatedVerticesCnt = 0;
     for ( auto v = 0_v; v + 1 < all.vert2firstRec.size(); ++v )
     {
-        const auto vertInfo = all.vertInfos[v];
-        // a vertex with exactly two open chains of triangles and no closed ones is not duplicated,
-        // because MeshBuilder has no issue with such configuration
-        const bool twoOpenChainsOnly = !vertInfo.hasRepeatedVerts() && vertInfo.numOpenChains() == 2 && vertInfo.numClosedChains() == 0;
-
-        // performance optimization only: skip a vertex, for which the sequential walk below finds nothing to duplicate
-        if ( twoOpenChainsOnly || ( !vertInfo.hasRepeatedVerts() && vertInfo.numOpenChains() + vertInfo.numClosedChains() <= 1 ) )
+        // performance optimization only: skip a vertex based on the neighborhood in the original triangulation;
+        // it is safe, because a vertex not requiring duplication cannot start requiring it after duplication of its neighbors
+        if ( noDuplicationNeeded( all.vertInfos[v] ) )
             continue;
         const auto posBegin = all.vert2firstRec[v];
         const auto posEnd = all.vert2firstRec[v + 1];
+        // duplication of one vertex can resolve non-manifoldness in its neighbor vertex,
+        // so after the first duplication the decision is made on the neighborhood in the current triangulation
+        const auto vertInfo = duplicatedVerticesCnt == 0 ? all.vertInfos[v]
+            : inspector.run( t, all.recs.data() + posBegin, all.recs.data() + posEnd );
+        if ( noDuplicationNeeded( vertInfo ) )
+            continue;
         PathAroundVertex pathMaker( t, all.recs, posBegin, posEnd );
 
         // first chain of vertices around the center does not require duplication
@@ -416,7 +428,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                     }
                     if ( !nextVertex )
                     {
-                        if ( foundChains && !twoOpenChainsOnly )
+                        if ( foundChains )
                         {
                             pathMaker.duplicateVertex( path, lastValidVert, dups );
                             ++duplicatedVerticesCnt;
@@ -436,7 +448,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                     for( const auto& vi : closedPath)
                         visitedVertices.reset(vi);
 
-                    if ( foundChains && !twoOpenChainsOnly )
+                    if ( foundChains )
                     {
                         pathMaker.duplicateVertex( closedPath, lastValidVert, dups );
                         ++duplicatedVerticesCnt;

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -371,17 +371,15 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     size_t duplicatedVerticesCnt = 0;
     for ( auto v = 0_v; v + 1 < all.vert2firstRec.size(); ++v )
     {
-        // performance optimization only: skip a vertex based on the neighborhood in the original triangulation;
-        // it is safe, because a vertex not requiring duplication cannot start requiring it after duplication of its neighbors
+        // skip a vertex based on the neighborhood in the original triangulation;
+        // a vertex not requiring duplication cannot start requiring it after duplication of its neighbors
         if ( noDuplicationNeeded( all.vertInfos[v] ) )
             continue;
         const auto posBegin = all.vert2firstRec[v];
         const auto posEnd = all.vert2firstRec[v + 1];
         // duplication of one vertex can resolve non-manifoldness in its neighbor vertex,
-        // so after the first duplication the decision is made on the neighborhood in the current triangulation
-        const auto vertInfo = duplicatedVerticesCnt == 0 ? all.vertInfos[v]
-            : inspector.run( t, all.recs.data() + posBegin, all.recs.data() + posEnd );
-        if ( noDuplicationNeeded( vertInfo ) )
+        // so after the first duplication recheck the neighborhood in the current triangulation
+        if ( duplicatedVerticesCnt > 0 && noDuplicationNeeded( inspector.run( t, all.recs.data() + posBegin, all.recs.data() + posEnd ) ) )
             continue;
         PathAroundVertex pathMaker( t, all.recs, posBegin, posEnd );
 

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -361,11 +361,11 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     size_t duplicatedVerticesCnt = 0;
     for ( auto v = 0_v; v + 1 < all.vert2firstRec.size(); ++v )
     {
-        // this skip-criterion must remain equivalent to
-        // "the sequential walk via PathAroundVertex finds nothing to duplicate for this vertex"
+        // skip a vertex, for which the sequential walk via PathAroundVertex finds nothing to duplicate;
+        // also skip a vertex with exactly two open chains and no closed ones, MeshBuilder has no issue with such configuration
         const auto vertInfo = all.vertInfos[v];
-        if ( !vertInfo.hasRepeatedVerts() && vertInfo.numOpenChains() + vertInfo.numClosedChains() <= 1 )
-            continue; // single chain of triangles or no triangles at all, nothing to duplicate
+        if ( !vertInfo.hasRepeatedVerts() && ( vertInfo.numOpenChains() + vertInfo.numClosedChains() <= 1 || ( vertInfo.numOpenChains() == 2 && vertInfo.numClosedChains() == 0 ) ) )
+            continue;
         const auto posBegin = all.vert2firstRec[v];
         const auto posEnd = all.vert2firstRec[v + 1];
         PathAroundVertex pathMaker( t, all.recs, posBegin, posEnd );

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -59,6 +59,28 @@ TEST( MRMesh, duplicateDoubleHoleVertex )
     EXPECT_EQ( topology.numValidFaces(), 2 );
 }
 
+// duplication of one vertex can resolve non-manifoldness in its neighbor vertex, which shall not be duplicated then
+TEST( MRMesh, duplicateResolvedNeighborVertex )
+{
+    Triangulation t;
+    t.push_back( { 1_v, 2_v, 3_v } ); //0_f
+    t.push_back( { 2_v, 1_v, 4_v } ); //1_f
+    t.push_back( { 1_v, 2_v, 5_v } ); //2_f
+    // the edge (1,2) is shared by three triangles, so both vertices 1 and 2 have repeated neighbor vertices;
+    // duplication of vertex 1 in one of the triangles resolves vertex 2 into two open chains requiring nothing
+
+    std::vector<VertDuplication> dups;
+    size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
+    EXPECT_EQ( duplicatedVerticesCnt, 1 );
+    ASSERT_EQ( dups.size(), 1 );
+    EXPECT_EQ( dups[0].srcVert, 1_v );
+    EXPECT_EQ( dups[0].dupVert, 6_v );
+
+    const auto topology = fromTrianglesDuplicatingNonManifoldVertices( t );
+    EXPECT_EQ( topology.numValidVerts(), 6 );
+    EXPECT_EQ( topology.numValidFaces(), 3 );
+}
+
 // check a vertex with both a closed ring of triangles and a separate chain around it
 TEST( MRMesh, duplicateClosedPlusOpenChainVertex )
 {

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -44,16 +44,19 @@ TEST( MRMesh, duplicateDoubleHoleVertex )
     Triangulation t;
     t.push_back( { 0_v, 1_v, 2_v } ); //0_f
     t.push_back( { 0_v, 3_v, 4_v } ); //1_f
-    // there are four edges with origin at vertex #0 having hole on one side (two with no left(e) and two with no right(e))
+    // there are four edges with origin at vertex #0 having hole on one side (two with no left(e) and two with no right(e));
+    // it is two open chains around vertex #0, and MeshBuilder has no issue with such configuration, so no duplication shall be done
 
     std::vector<VertDuplication> dups;
     size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
-    ASSERT_EQ( duplicatedVerticesCnt, 1 );
-    ASSERT_EQ( dups.size(), 1 );
-    ASSERT_EQ( dups[0].srcVert, 0_v );
-    ASSERT_EQ( dups[0].dupVert, 5_v );
+    ASSERT_EQ( duplicatedVerticesCnt, 0 );
+    ASSERT_EQ( dups.size(), 0 );
     ASSERT_EQ( t[0_f], ( ThreeVertIds{ 0_v, 1_v, 2_v } ) );
-    ASSERT_EQ( t[1_f], ( ThreeVertIds{ 5_v, 3_v, 4_v } ) );
+    ASSERT_EQ( t[1_f], ( ThreeVertIds{ 0_v, 3_v, 4_v } ) );
+
+    const auto topology = fromTrianglesDuplicatingNonManifoldVertices( t );
+    EXPECT_EQ( topology.numValidVerts(), 5 );
+    EXPECT_EQ( topology.numValidFaces(), 2 );
 }
 
 // check a vertex with both a closed ring of triangles and a separate chain around it


### PR DESCRIPTION
`duplicateNonManifoldVertices` no longer duplicates a vertex with exactly two open chains of triangles and no closed ones: MeshBuilder has no issue building topology for such a vertex, so its duplication was unnecessary.

The whole "does this vertex require duplication" decision is expressed by one predicate `noDuplicationNeeded( VertInfo )`: no repeated neighbor vertices, and either at most one chain or exactly two open chains. It is applied twice:

* to `all.vertInfos` precomputed in parallel on the original triangulation — safe, because a vertex not requiring duplication cannot start requiring it after duplication of its neighbors;
* since duplication of one vertex can resolve non-manifoldness in its neighbor vertex, after the first performed duplication the neighborhood of a not-skipped vertex is re-inspected on the current triangulation (a reused `VertNeighbourhoodInspector`), and the vertex can still be skipped. Before the first duplication the current triangulation is the original one, so the first check covers both purposes.

Tests:

* `duplicateDoubleHoleVertex` is updated: no duplication is expected anymore, and it additionally verifies that `fromTrianglesDuplicatingNonManifoldVertices` builds this configuration intact (5 vertices, 2 faces).
* New `duplicateResolvedNeighborVertex`: an edge shared by three triangles makes both its ends non-manifold; duplication of the first vertex resolves the second one into two open chains, and the recheck prevents its unnecessary duplication (1 duplication in total, valid topology of 6 vertices and 3 faces).

All 308 MRTest tests pass locally (Release, x64).
