### PR TITLE
Exclude thirdparty/licenses from the docker image source checksums

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -203,7 +203,6 @@ jobs:
       - name: Check for errors
         run: uvx --python 3.12 pre-commit run --all-files --hook-stage manual
 
-      # Keep in sync with scripts/devops/docker_image_source_checksum.sh (see the note there).
       - name: Filter Linux paths
         if: ${{ github.event_name != 'schedule' }}
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -217,7 +216,6 @@ jobs:
               - 'scripts/install_apt_requirements.sh'
               - 'scripts/mrbind/install_deps_ubuntu.sh'
               - 'scripts/mrbind/clang_version.txt'
-              - 'scripts/devops/docker_image_source_checksum.sh'
               - 'thirdparty/!(install.bat|vcpkg/**|mrbind|mrbind/**|Noto_Sans/**|licenses/**)'
 
       - name: Filter Linux vcpkg paths
@@ -228,7 +226,6 @@ jobs:
           filters: |
             src:
               - 'docker/(rockylinux8|rockylinux9)-vcpkgDockerfile'
-              - 'scripts/devops/docker_image_source_checksum.sh'
               - 'thirdparty/vcpkg/**'
 
       - name: Filter Windows paths

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -203,6 +203,7 @@ jobs:
       - name: Check for errors
         run: uvx --python 3.12 pre-commit run --all-files --hook-stage manual
 
+      # Keep in sync with scripts/devops/docker_image_source_checksum.sh (see the note there).
       - name: Filter Linux paths
         if: ${{ github.event_name != 'schedule' }}
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -216,6 +217,7 @@ jobs:
               - 'scripts/install_apt_requirements.sh'
               - 'scripts/mrbind/install_deps_ubuntu.sh'
               - 'scripts/mrbind/clang_version.txt'
+              - 'scripts/devops/docker_image_source_checksum.sh'
               - 'thirdparty/!(install.bat|vcpkg/**|mrbind|mrbind/**|Noto_Sans/**|licenses/**)'
 
       - name: Filter Linux vcpkg paths
@@ -226,6 +228,7 @@ jobs:
           filters: |
             src:
               - 'docker/(rockylinux8|rockylinux9)-vcpkgDockerfile'
+              - 'scripts/devops/docker_image_source_checksum.sh'
               - 'thirdparty/vcpkg/**'
 
       - name: Filter Windows paths

--- a/scripts/devops/docker_image_source_checksum.sh
+++ b/scripts/devops/docker_image_source_checksum.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # Usage: docker_image_source_checksum.sh <distro>
+# The path sets must stay in sync with the image-rebuild filters in
+# .github/workflows/config.yml: a path hashed here but absent from the filter
+# moves the expected tag without triggering the rebuild that would push it.
 set -euo pipefail
 
 distro=$1
@@ -14,6 +17,7 @@ common=(
   ':(exclude)thirdparty/mrbind'
   ':(exclude)thirdparty/mrbind/**'
   ':(exclude)thirdparty/Noto_Sans/**'
+  ':(exclude)thirdparty/licenses/**'
 )
 
 ubuntu=(

--- a/scripts/devops/docker_image_source_checksum.sh
+++ b/scripts/devops/docker_image_source_checksum.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Usage: docker_image_source_checksum.sh <distro>
-# The path sets must stay in sync with the image-rebuild filters in
-# .github/workflows/config.yml: a path hashed here but absent from the filter
-# moves the expected tag without triggering the rebuild that would push it.
+# Hash only paths that affect image content: hashing anything else moves the
+# expected source-checksum-* tag on commits that build no new image, breaking
+# consumers that pull strictly by that tag (thirdparty/licenses/** is license
+# texts shipped in packages, not image inputs).
 set -euo pipefail
 
 distro=$1


### PR DESCRIPTION
Rescoped per review to the checksum-input change only; the rebuild/selection mechanism is #6436's registry check, with which this composes under either merge order.

**Problem**: `docker_image_source_checksum.sh` hashed `thirdparty/licenses/**`, so licenses-only commits (#6429, #6422, #6434) moved every Linux image's expected `source-checksum-*` tag on commits that build no new image. Under the old paths-filter world that meant tags that were never pushed (`manifest unknown` for consumers pinning them); under #6436 it would mean a pointless full image-rebuild cycle and tag churn on every license-text edit.

**Fix**: exclude `thirdparty/licenses/**` from the hashed set -- license texts ship in packages and are not image inputs. The script comment now states the invariant: hash only paths that affect image content.

**Transition note** (applies regardless of mechanism): redefining the hash invalidates all previously pushed `source-checksum-*` tags. This PR's earlier full-matrix run already minted and pushed new-definition tags for current master content (e.g. emscripten `source-checksum-aa94f48bb1837b1d`); consumers pinned to older commits compute old-definition tags that will never exist, and unblock only by moving their pin past this merge.

## Test plan

- `bash -n`; checksum computed for all six distro cases (ubuntu22/24, emscripten x3, rockylinux8-vcpkg).
- With the exclusion, recomputing across the licenses-era commits yields identical tags -- license edits no longer move them.
