### PR TITLE
Use fromTrianglesDuplicatingNonManifoldVertices in all mesh format loaders

### DIFF
--- a/source/MRIOExtras/MRCtm.cpp
+++ b/source/MRIOExtras/MRCtm.cpp
@@ -191,15 +191,8 @@ Expected<Mesh> fromCtm( std::istream& in, const MeshLoadSettings& settings /*= {
     for ( FaceId i{0}; i < (int)triCount; ++i )
         t.push_back( { VertId( (int)indices[3*i] ), VertId( (int)indices[3*i+1] ), VertId( (int)indices[3*i+2] ) } );
 
-    Mesh mesh;
-    if ( t.empty() ) // a CTM point cloud must not lose its points in mesh construction below
-    {
-        mesh.points = std::move( points );
-        return mesh;
-    }
-
     std::vector<MeshBuilder::VertDuplication> dups;
-    mesh = Mesh::fromTrianglesDuplicatingNonManifoldVertices( std::move( points ), t, &dups,
+    auto mesh = Mesh::fromTrianglesDuplicatingNonManifoldVertices( std::move( points ), t, &dups,
         { .skippedFaceCount = settings.skippedFaceCount } );
     if ( mesh.topology.lastValidVert() + 1 > vertCount + dups.size() )
         return unexpected( "vertex id is larger than total point coordinates" );

--- a/source/MRIOExtras/MRCtm.cpp
+++ b/source/MRIOExtras/MRCtm.cpp
@@ -182,19 +182,42 @@ Expected<Mesh> fromCtm( std::istream& in, const MeshLoadSettings& settings /*= {
             (*settings.normals)[i] = Vector3f( normals[3 * i], normals[3 * i + 1], normals[3 * i + 2] );
     }
 
-    Mesh mesh;
-    mesh.points.resize( vertCount );
+    VertCoords points( vertCount );
     for ( VertId i{0}; i < (int)vertCount; ++i )
-        mesh.points[i] = Vector3f( vertices[3*i], vertices[3*i+1], vertices[3*i+2] );
+        points[i] = Vector3f( vertices[3*i], vertices[3*i+1], vertices[3*i+2] );
 
     Triangulation t;
     t.reserve( triCount );
     for ( FaceId i{0}; i < (int)triCount; ++i )
         t.push_back( { VertId( (int)indices[3*i] ), VertId( (int)indices[3*i+1] ), VertId( (int)indices[3*i+2] ) } );
 
-    mesh.topology = MeshBuilder::fromTriangles( t, { .skippedFaceCount = settings.skippedFaceCount } );
-    if ( mesh.topology.lastValidVert() + 1 > mesh.points.size() )
+    Mesh mesh;
+    if ( t.empty() ) // a CTM point cloud must not lose its points in mesh construction below
+    {
+        mesh.points = std::move( points );
+        return mesh;
+    }
+
+    std::vector<MeshBuilder::VertDuplication> dups;
+    mesh = Mesh::fromTrianglesDuplicatingNonManifoldVertices( std::move( points ), t, &dups,
+        { .skippedFaceCount = settings.skippedFaceCount } );
+    if ( mesh.topology.lastValidVert() + 1 > vertCount + dups.size() )
         return unexpected( "vertex id is larger than total point coordinates" );
+    if ( settings.duplicatedVertexCount )
+        *settings.duplicatedVertexCount = int( dups.size() );
+    if ( !dups.empty() )
+    {
+        auto copyDupAttributes = [&dups, sz = mesh.points.size()] ( auto * attributes )
+        {
+            if ( !attributes || attributes->empty() )
+                return;
+            attributes->resize( sz );
+            for ( const auto & [src, dup] : dups )
+                (*attributes)[dup] = (*attributes)[src];
+        };
+        copyDupAttributes( settings.colors );
+        copyDupAttributes( settings.normals );
+    }
     return mesh;
 }
 

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -82,7 +82,8 @@ Mesh Mesh::fromTrianglesDuplicatingNonManifoldVertices(
     res.points = std::move( vertexCoordinates );
     std::vector<MeshBuilder::VertDuplication> localDups;
     res.topology = MeshBuilder::fromTrianglesDuplicatingNonManifoldVertices( t, &localDups, settings );
-    res.points.resize( res.topology.vertSize() );
+    if ( res.points.size() < res.topology.vertSize() ) // never shrink
+        res.points.resize( res.topology.vertSize() );
     for ( const auto & d : localDups )
         res.points[d.dupVert] = res.points[d.srcVert];
     if ( dups )

--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -660,7 +660,7 @@ static Expected<Mesh> fromPly( std::istream& in, const MeshLoadSettings& setting
     Mesh res;
     res.points = std::move( *maybePoints );
 
-    if ( tris && !tris->empty() ) // an empty PLY point cloud must not lose its points in mesh construction below
+    if ( tris )
     {
         int mySkippedFaceCount = 0;
         const auto numPoints = res.points.size();

--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -660,16 +660,33 @@ static Expected<Mesh> fromPly( std::istream& in, const MeshLoadSettings& setting
     Mesh res;
     res.points = std::move( *maybePoints );
 
-    if ( tris )
+    if ( tris && !tris->empty() ) // an empty PLY point cloud must not lose its points in mesh construction below
     {
         int mySkippedFaceCount = 0;
-        res.topology = MeshBuilder::fromTriangles( *tris,
-            { .skippedFaceCount = settings.skippedFaceCount ? &mySkippedFaceCount : nullptr },
-            subprogress( settings.callback, 0.9f, 1.0f ) );
-        if ( res.topology.lastValidVert() + 1 > res.points.size() )
+        const auto numPoints = res.points.size();
+        std::vector<MeshBuilder::VertDuplication> dups;
+        res = Mesh::fromTrianglesDuplicatingNonManifoldVertices( std::move( res.points ), *tris, &dups,
+            { .skippedFaceCount = settings.skippedFaceCount ? &mySkippedFaceCount : nullptr } );
+        if ( res.topology.lastValidVert() + 1 > numPoints + dups.size() )
             return unexpected( "vertex id is larger than total point coordinates" );
         if ( settings.skippedFaceCount )
             *settings.skippedFaceCount += mySkippedFaceCount;
+        if ( settings.duplicatedVertexCount )
+            *settings.duplicatedVertexCount = int( dups.size() );
+        if ( !dups.empty() )
+        {
+            auto copyDupAttributes = [&dups, sz = res.points.size()] ( auto * attributes )
+            {
+                if ( !attributes || attributes->empty() )
+                    return;
+                attributes->resize( sz );
+                for ( const auto & [src, dup] : dups )
+                    (*attributes)[dup] = (*attributes)[src];
+            };
+            copyDupAttributes( settings.colors );
+            copyDupAttributes( settings.uvCoords );
+            copyDupAttributes( settings.normals );
+        }
     }
 
     // try converting per-corner UVs into per-vertex UVs

--- a/source/MRTest/MRMeshLoadSaveTest.cpp
+++ b/source/MRTest/MRMeshLoadSaveTest.cpp
@@ -156,6 +156,29 @@ TEST(MRMesh, LoadPlyDuplicatingNonManifoldVertices)
     EXPECT_EQ( loadedColors[7_v], colors[0_v] );
 }
 
+TEST(MRMesh, LoadPlyPointCloud)
+{
+    // PLY point cloud with a face element having zero faces must keep all its points
+    std::string file =
+        "ply\n"
+        "format ascii 1.0\n"
+        "element vertex 2\n"
+        "property float x\n"
+        "property float y\n"
+        "property float z\n"
+        "element face 0\n"
+        "property list uchar int vertex_indices\n"
+        "end_header\n"
+        "0 0 0\n"
+        "1 0 0\n";
+
+    std::istringstream in( file );
+    auto loadRes = MeshLoad::fromPly( in );
+    ASSERT_TRUE( loadRes.has_value() );
+    EXPECT_EQ( loadRes->points.size(), 2 );
+    EXPECT_EQ( loadRes->topology.numValidFaces(), 0 );
+}
+
 TEST(MRMesh, LoadObjTabIndented)
 {
     // some exporters (e.g. 3ds Max guruware OBJ exporter) indent lines with tabs

--- a/source/MRTest/MRMeshLoadSaveTest.cpp
+++ b/source/MRTest/MRMeshLoadSaveTest.cpp
@@ -4,6 +4,7 @@
 #include <MRMesh/MRMesh.h>
 #include <MRMesh/MRTriMesh.h>
 #include <MRMesh/MRBox.h>
+#include <MRMesh/MRColor.h>
 #include <gtest/gtest.h>
 #include <filesystem>
 #include <fstream>
@@ -112,6 +113,47 @@ TEST(MRMesh, TriMeshSavePly)
     EXPECT_EQ( loadRes->points.size(), 5 );
     EXPECT_EQ( loadRes->topology.numValidVerts(), 5 );
     EXPECT_EQ( loadRes->topology.numValidFaces(), 6 );
+}
+
+TEST(MRMesh, LoadPlyDuplicatingNonManifoldVertices)
+{
+    // two closed triangle fans sharing only the central vertex #0
+    TriMesh triMesh;
+    triMesh.tris = Triangulation{
+        { 0_v, 1_v, 2_v },
+        { 0_v, 2_v, 3_v },
+        { 0_v, 3_v, 1_v },
+        { 0_v, 4_v, 5_v },
+        { 0_v, 5_v, 6_v },
+        { 0_v, 6_v, 4_v }
+    };
+    triMesh.points.emplace_back( 0.f, 0.f, 0.f );
+    triMesh.points.emplace_back( 1.f, 0.f, 0.f );
+    triMesh.points.emplace_back( 0.f, 1.f, 0.f );
+    triMesh.points.emplace_back( 0.f, 0.f, 1.f );
+    triMesh.points.emplace_back( -1.f, 0.f, 0.f );
+    triMesh.points.emplace_back( 0.f, -1.f, 0.f );
+    triMesh.points.emplace_back( 0.f, 0.f, -1.f );
+
+    VertColors colors;
+    for ( int i = 0; i < 7; ++i )
+        colors.push_back( Color( i, 0, 0 ) );
+
+    std::ostringstream out;
+    ASSERT_TRUE( MeshSave::toPly( triMesh, out, { .colors = &colors } ).has_value() );
+
+    VertColors loadedColors;
+    int dupCount = 0;
+    std::istringstream in( out.str() );
+    auto loadRes = MeshLoad::fromPly( in, { .colors = &loadedColors, .duplicatedVertexCount = &dupCount } );
+    ASSERT_TRUE( loadRes.has_value() );
+    EXPECT_EQ( dupCount, 1 );
+    EXPECT_EQ( loadRes->points.size(), 8 );
+    EXPECT_EQ( loadRes->topology.numValidVerts(), 8 );
+    EXPECT_EQ( loadRes->topology.numValidFaces(), 6 );
+    EXPECT_EQ( loadRes->points[7_v], triMesh.points[0_v] );
+    ASSERT_EQ( loadedColors.size(), 8 );
+    EXPECT_EQ( loadedColors[7_v], colors[0_v] );
 }
 
 TEST(MRMesh, LoadObjTabIndented)


### PR DESCRIPTION
## Summary

All mesh-format loaders (except `.mrmesh`) now resolve non-manifold vertices by duplication, as `fromBinaryStl`/`fromASCIIStl` already did:

- **PLY** (`MeshLoad::fromPly`) — used plain `MeshBuilder::fromTriangles`, so triangles at non-manifold vertices were silently skipped;
- **CTM** (`MeshLoad::fromCtm`) — same.

Both loaders now also report `MeshLoadSettings::duplicatedVertexCount` and extend loaded per-vertex attributes (colors, uv-coordinates, normals) onto the duplicated vertices, same as OBJ/glTF/3MF loaders do.

The remaining formats already resolved non-manifold vertices: OBJ, STL, 3MF, glTF (`fromTrianglesDuplicatingNonManifoldVertices`), DXF and STEP (`fromPointTriples( ..., true )`); OFF builds via `fromFaceSoup`.

## Point clouds in .ply/.ctm

`Mesh::fromTrianglesDuplicatingNonManifoldVertices` resized the point array to `topology.vertSize()`, which for an empty triangulation is zero. That would break point-cloud files opened as meshes: `fromCtm` explicitly supports points-only CTM files (a single degenerate `(i,i,i)` triangle is written as a placeholder and detected on load as `triCount = 0`), and `fromPly` engages its triangulation output whenever a `face` element is present in the header, even with zero faces. The resize is now grow-only ("never shrink"), so the loaders need no special handling for these files.

Duplicates are still numbered right after the last vertex id used in the triangulation, so in a file containing points not referenced by any triangle they can overwrite such points — of no practical interest. The "vertex id is larger than total point coordinates" corruption checks keep working: for a valid file `lastValidVert + 1 <= numPoints + dups.size()`, while out-of-range indices in the file violate that bound.

## Testing

New unit tests:
- `MRMesh.LoadPlyDuplicatingNonManifoldVertices`: a PLY with two closed triangle fans sharing only their central vertex loads with that vertex duplicated (`duplicatedVertexCount == 1`, 8 points out of 7) and with the per-vertex color copied onto the duplicate;
- `MRMesh.LoadPlyPointCloud`: a PLY with `element face 0` keeps all its points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
