### PR TITLE
Retry job ID lookup while the jobs API catches up

### DIFF
--- a/scripts/devops/fetch_job_id.py
+++ b/scripts/devops/fetch_job_id.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 import urllib.request
 
 GITHUB_HEADERS = {
@@ -19,26 +20,30 @@ def fetch_jobs(repo: str, run_id: str):
 def filter_job(job, job_name, runner_name):
     return job['status'] == "in_progress" and job_name in job['name'] and runner_name in [job['runner_name'], f"GitHub-Actions-{job['runner_id']}"]
 
-def get_job_id():
+def get_job_id(attempts=3, cooldown=10):
     job_name = os.environ.get("GITHUB_JOB")
     repo = os.environ.get("GITHUB_REPOSITORY")
     run_id = os.environ.get("GITHUB_RUN_ID")
     runner_name = os.environ.get("RUNNER_NAME")
 
-    resp = fetch_jobs(repo, run_id)
-    if int(resp['total_count']) > 100:
-        print("Total job count has exceeded 100; consider enabling the pagination support")
-    jobs = [
-        job
-        for job in resp['jobs']
-        if filter_job(job, job_name, runner_name)
-    ]
-    if len(jobs) == 0:
-        raise RuntimeError(f"No jobs found for {job_name}")
-    elif len(jobs) > 1:
-        raise RuntimeError(f"Multiple jobs found for {job_name}: {jobs}")
-    else:
-        return jobs[0]['id']
+    for attempt in range(1, attempts + 1):
+        resp = fetch_jobs(repo, run_id)
+        if int(resp['total_count']) > 100:
+            print("Total job count has exceeded 100; consider enabling the pagination support")
+        jobs = [
+            job
+            for job in resp['jobs']
+            if filter_job(job, job_name, runner_name)
+        ]
+        if len(jobs) > 1:
+            raise RuntimeError(f"Multiple jobs found for {job_name}: {jobs}")
+        elif len(jobs) == 1:
+            return jobs[0]['id']
+        # the jobs API is eventually consistent and may not list a just-started job yet
+        if attempt < attempts:
+            print(f"get_job_id: attempt {attempt}/{attempts} found no jobs for {job_name}; retrying in {cooldown}s...")
+            time.sleep(cooldown)
+    raise RuntimeError(f"No jobs found for {job_name}")
 
 if __name__ == "__main__":
     if os.environ.get('CI'):

--- a/scripts/devops/fetch_job_id.py
+++ b/scripts/devops/fetch_job_id.py
@@ -41,7 +41,7 @@ def get_job_id(attempts=3, cooldown=10):
             return jobs[0]['id']
         # the jobs API is eventually consistent and may not list a just-started job yet
         if attempt < attempts:
-            print(f"get_job_id: attempt {attempt}/{attempts} found no jobs for {job_name}; retrying in {cooldown}s...")
+            print(f"Attempt {attempt}/{attempts} failed, retrying...")
             time.sleep(cooldown)
     raise RuntimeError(f"No jobs found for {job_name}")
 


### PR DESCRIPTION
`fetch_job_id.py` (the first step of the `collect-runner-stats` action) occasionally fails with `RuntimeError: No jobs found for <job>` — seen on a MeshInspectorCode run where the step executed ~19 s after the job started, while the 11 sibling matrix jobs on the same runner all passed it. The jobs API is eventually consistent: shortly after a job starts it may still be listed as `queued` / without a runner assigned, so the `in_progress` + runner-name filter matches nothing.

Retry the lookup up to 3 times with a 10 s cooldown when no matching job is found, mirroring the in-script retry added to `collect_ci_stats.py` in #6311. The "multiple jobs found" case still fails immediately, as retrying cannot resolve a genuine ambiguity.

Verified with a mocked `fetch_jobs`: empty-then-found succeeds on the third attempt, always-empty still raises after 3 attempts, multiple matches raise without retrying.
