### PR TITLE
Mention repeated vertex ids in the skipped-triangles load warning

### DIFF
--- a/source/MRMesh/MRMeshLoadObj.cpp
+++ b/source/MRMesh/MRMeshLoadObj.cpp
@@ -1406,7 +1406,7 @@ Expected<LoadedObjects> loadObjectFromObj( const std::filesystem::path& file, co
         }
 
         if ( totalSkippedFaceCount )
-            res.warnings += fmt::format( "{} triangles were skipped as inconsistent with others.\n", totalSkippedFaceCount );
+            res.warnings += fmt::format( "{} triangles were skipped as having repeated vertex ids or being inconsistent with others.\n", totalSkippedFaceCount );
         if ( totalDuplicatedVertexCount )
             res.warnings += fmt::format( "{} vertices were duplicated to make them manifold.\n", totalDuplicatedVertexCount );
         if ( holesCount )

--- a/source/MRMesh/MRObjectLoad.cpp
+++ b/source/MRMesh/MRObjectLoad.cpp
@@ -137,7 +137,7 @@ static std::string makeWarningString( int skippedFaceCount, int duplicatedVertex
 {
     std::string res;
     if ( skippedFaceCount )
-        res = fmt::format( "{} triangles were skipped as inconsistent with others.\n", skippedFaceCount );
+        res = fmt::format( "{} triangles were skipped as having repeated vertex ids or being inconsistent with others.\n", skippedFaceCount );
     if ( duplicatedVertexCount )
         res += fmt::format( "{} vertices were duplicated to make them manifold.\n", duplicatedVertexCount );
     if ( holesCount )


### PR DESCRIPTION
Both places producing the load warning now say

> {} triangles were skipped as having repeated vertex ids or being inconsistent with others.

instead of only mentioning inconsistency. Motivated by `Hezrou.ply`: its report "4 triangles were skipped as inconsistent with others" was misleading, because all 4 skipped triangles were degenerate with a repeated vertex id (e.g. `351 353 351`), requiring a self-loop edge impossible in manifold topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
