### PR TITLE
Return error on ASCII STL facet with too few vertices

### DIFF
--- a/source/MRMesh/MRExpected.h
+++ b/source/MRMesh/MRExpected.h
@@ -17,7 +17,7 @@ template<class E = std::string>
 using Unexpected = std::unexpected<E>;
 
 template <class E>
-MR_BIND_IGNORE inline auto unexpected( E &&e )
+[[nodiscard]] MR_BIND_IGNORE inline auto unexpected( E &&e )
 {
     return std::unexpected( std::forward<E>( e ) );
 }
@@ -31,7 +31,7 @@ template<class E = std::string>
 using Unexpected = tl::unexpected<E>;
 
 template <class E>
-MR_BIND_IGNORE inline auto unexpected( E &&e )
+[[nodiscard]] MR_BIND_IGNORE inline auto unexpected( E &&e )
 {
     return tl::make_unexpected( std::forward<E>( e ) );
 }
@@ -45,7 +45,7 @@ MR_BIND_IGNORE inline std::string stringOperationCanceled()
 }
 
 /// returns Expected error with `stringOperationCanceled()`
-MR_BIND_IGNORE inline auto unexpectedOperationCanceled()
+[[nodiscard]] MR_BIND_IGNORE inline auto unexpectedOperationCanceled()
 {
     return MR::unexpected( stringOperationCanceled() );
 }
@@ -57,7 +57,7 @@ MR_BIND_IGNORE inline std::string stringUnsupportedFileExtension()
 }
 
 /// returns Expected error with `stringUnsupportedFileExtension()`
-MR_BIND_IGNORE inline auto unexpectedUnsupportedFileExtension()
+[[nodiscard]] MR_BIND_IGNORE inline auto unexpectedUnsupportedFileExtension()
 {
     return MR::unexpected( stringUnsupportedFileExtension() );
 }
@@ -69,7 +69,7 @@ MR_BIND_IGNORE inline std::string stringUnsupportedFileFormat()
 }
 
 /// returns Expected error with `stringUnsupportedFileFormat()`
-MR_BIND_IGNORE inline auto unexpectedUnsupportedFileFormat()
+[[nodiscard]] MR_BIND_IGNORE inline auto unexpectedUnsupportedFileFormat()
 {
     return MR::unexpected( stringUnsupportedFileFormat() );
 }

--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -594,7 +594,7 @@ Expected<Mesh> fromASCIIStl( std::istream& in, const MeshLoadSettings& settings 
                     return unexpected( parseRes.error() + " line: " + std::to_string( newlines[lineI] ) );
             }
             if ( triI != 3 )
-                unexpected( "Too few vertices for triangle, line: " + std::to_string( newlines[fLine] ) );
+                return unexpected( "Too few vertices for triangle, line: " + std::to_string( newlines[fLine] ) );
             chunk[i++] = std::move( tri );
         }
         if ( i == itemsInBuffer || fLine == lastFaceLine )

--- a/source/MRTest/MRMeshLoadSaveTest.cpp
+++ b/source/MRTest/MRMeshLoadSaveTest.cpp
@@ -179,6 +179,23 @@ TEST(MRMesh, LoadPlyPointCloud)
     EXPECT_EQ( loadRes->topology.numValidFaces(), 0 );
 }
 
+TEST(MRMesh, LoadAsciiStlTooFewVertices)
+{
+    std::string file =
+        "solid Name\n"
+        "facet normal 0 0 1\n"
+        "outer loop\n"
+        "vertex 0 0 0\n"
+        "vertex 1 0 0\n"
+        "endloop\n"
+        "endfacet\n"
+        "endsolid Name\n";
+
+    std::istringstream in( file );
+    auto loadRes = MeshLoad::fromASCIIStl( in );
+    EXPECT_FALSE( loadRes.has_value() );
+}
+
 TEST(MRMesh, LoadObjTabIndented)
 {
     // some exporters (e.g. 3ds Max guruware OBJ exporter) indent lines with tabs


### PR DESCRIPTION
In the ASCII STL loader, the `triI != 3` check constructed an `unexpected(...)` but did not return it, so the error was silently discarded and a triangle with fewer than 3 parsed vertices was added to the mesh with stale/default coordinates. Add the missing `return` and a unit test loading an ASCII STL facet with only 2 vertex lines, which now fails to load as expected.

Also mark `MR::unexpected` and the `unexpectedOperationCanceled` / `unexpectedUnsupportedFileExtension` / `unexpectedUnsupportedFileFormat` helpers `[[nodiscard]]`, so discarding a constructed error like this is a compiler warning from now on. No other violation exists in the codebase (clean MSVC build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
