### PR TITLE
CI: exclude thirdparty/licenses from docker image source checksums

### DIFF
--- a/scripts/devops/docker_image_source_checksum.sh
+++ b/scripts/devops/docker_image_source_checksum.sh
@@ -14,6 +14,10 @@ common=(
   ':(exclude)thirdparty/mrbind'
   ':(exclude)thirdparty/mrbind/**'
   ':(exclude)thirdparty/Noto_Sans/**'
+  # license texts shipped in packages, not an image input: including them would
+  # move the source-checksum-* tag on licenses-only commits and force a needless
+  # rebuild of every image (the registry-check finds nothing at the new tag).
+  ':(exclude)thirdparty/licenses/**'
 )
 
 ubuntu=(


### PR DESCRIPTION
Follow-up to #6436, reopening the change from the closed #6437 against the merged registry-check mechanism.

`thirdparty/licenses/**` — the curated `THIRD-PARTY-NOTICES.txt` and its `manifest.json` — is currently hashed into every image's `source-checksum-*` tag, yet none of it reaches the images: the license texts are copied into the distributed packages, not into the build environment. So a licenses-only commit moves the checksum tag, and under #6436 that tag then resolves to no image in the registry, forcing a full rebuild of every distro image for a change that alters nothing in them.

This excludes the directory from the hashed set, matching the existing exclusions for `Noto_Sans`, `mrbind`, and `vcpkg`.

### Effect
- The exclusion changes every checksum once, so this PR's own CI (and the first build after merge) rebuilds all images one time; stable thereafter.
- Editing the notices no longer churns the image cache.

### Verified locally
`ubuntu24`: `source-checksum-a600c4fdf24cd22e` → `source-checksum-22cb33e3f998330a`, and the only paths leaving the hashed set are `thirdparty/licenses/THIRD-PARTY-NOTICES.txt` and `thirdparty/licenses/manifest.json` — no collateral.
