### PR TITLE
Pin CMake Python lookup to PYTHON_PREFIX on macOS

### DIFF
--- a/scripts/build_source.sh
+++ b/scripts/build_source.sh
@@ -94,7 +94,10 @@ if [[ $OSTYPE == 'darwin'* ]]; then
   PYTHON_LIBRARY=${PYTHON_PREFIX}/lib/libpython${PYTHON_VERSION}.dylib
   PYTHON_INCLUDE_DIR=${PYTHON_PREFIX}/include/python${PYTHON_VERSION}
 
+  # pin FindPython to this prefix: /usr/local/Frameworks (e.g. Rosetta Homebrew) must not shadow it
   MR_CMAKE_OPTIONS="${MR_CMAKE_OPTIONS} \
+    -D Python_ROOT_DIR=${PYTHON_PREFIX} \
+    -D Python_FIND_FRAMEWORK=LAST \
     -D PYTHON_LIBRARY=${PYTHON_LIBRARY} \
     -D PYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR} \
     -D PYTHON_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE} \


### PR DESCRIPTION
Since 2026-07-18 every `macos-build-test (arm64, Debug)` job on the MACBOOK-PRO-16-2021-TBI-2 runner fails: MRTest aborts at launch with

```
dyld[26064]: symbol not found in flat namespace '_PyExc_RuntimeError'
```

(e.g. the nightly [run 29713915367](https://github.com/MeshInspector/MeshLib/actions/runs/29713915367/job/88263081667) and several Dependabot PRs, while identical jobs pass on the other mac runner).

Root cause: an x86_64 (Rosetta) Homebrew was set up on that machine for producing cross-platform x64 builds, which linked an Intel `Python.framework` into `/usr/local/Frameworks`. `build_source.sh` only passes the legacy `PYTHON_LIBRARY`/`PYTHON_INCLUDE_DIR`/`PYTHON_EXECUTABLE` hints, which modern `find_package(Python)` ignores, and CMake's framework-first search order prefers `/usr/local/Frameworks` over the arm64 brew:

```
-- Found Python: /usr/local/Frameworks/Python.framework/Versions/3.10/bin/python3.10
ld: warning: ignoring file '/usr/local/opt/python@3.10/.../libpython3.10.dylib': found architecture 'x86_64', required architecture 'arm64'
```

MRPython is then linked with unresolved flat-namespace Python symbols and dyld aborts as soon as MRTest starts.

This PR pins the lookup: pass `Python_ROOT_DIR` (derived from `python${PYTHON_VERSION}-config --prefix`, i.e. the interpreter already selected by PATH) and `Python_FIND_FRAMEWORK=LAST`, so a foreign-arch framework in `/usr/local/Frameworks` can never shadow the intended Python — on CI runners or on developer macs that have both brews installed.

The Intel pythons still need to be unlinked on TBI-2 itself (`arch -x86_64 /usr/local/bin/brew unlink python@3.10 python@3.14`), but with this change the build no longer depends on that machine state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
