### PR TITLE
Post-mortem diagnostics for silent MSYS2 pacman install failures

### DIFF
--- a/.github/actions/install-msys2-mrbind/action.yml
+++ b/.github/actions/install-msys2-mrbind/action.yml
@@ -26,3 +26,18 @@ runs:
       shell: pwsh
       run: |
         C:\msys64\msys2_shell.cmd -no-start -defterm -here -c "set -e && bash scripts/mrbind/msys2_download_packages.sh _clang22 && bash scripts/mrbind/msys2_install_packages.sh _clang22"
+        $code = $LASTEXITCODE
+        if ($code -ne 0) {
+          # The msys2 shell occasionally dies without its console output
+          # reaching the runner; recover what hit the disk instead.
+          Write-Host "msys2_shell.cmd exited with code $code"
+          Write-Host '::group::scripts/mrbind/msys2_pacman_install.log'
+          $teeLog = 'scripts/mrbind/msys2_pacman_install.log'
+          if (Test-Path $teeLog) { Get-Content $teeLog } else { Write-Host 'absent — died before pacman produced output' }
+          Write-Host '::endgroup::'
+          Write-Host '::group::C:\msys64\var\log\pacman.log (last 200 lines)'
+          $pacLog = 'C:\msys64\var\log\pacman.log'
+          if (Test-Path $pacLog) { Get-Content $pacLog -Tail 200 } else { Write-Host 'absent — pacman never started a transaction' }
+          Write-Host '::endgroup::'
+          exit $code
+        }

--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,5 @@ compile_commands.json
 # ]
 /thirdparty/boost-libs/
 /scripts/mrbind/msys2_packages
+/scripts/mrbind/msys2_pacman_install.log
 /vcpkg_installed

--- a/scripts/mrbind/msys2_install_packages.sh
+++ b/scripts/mrbind/msys2_install_packages.sh
@@ -22,5 +22,11 @@ for ENTRY in "${ENTRIES[@]}"; do
     FILES+=("${ENTRY#*" *"}")
 done
 
-# Adding `|| true` because this is prone to crashing after install, if the core packages were touched. Though I haven't checked if the crash affects the exit code or not.
-pacman -U --noconfirm --needed "${FILES[@]}" || true
+# pacman sometimes dies here taking the whole msys2 shell (and any
+# not-yet-flushed console output) with it, so tee to a file the caller
+# can dump post-mortem. Its exit code is deliberately tolerated: it's
+# prone to crashing after install when the core packages were touched.
+echo "Installing ${#FILES[@]} packages with pacman -U..."
+RC=0
+pacman -U --noconfirm --needed "${FILES[@]}" 2>&1 | tee msys2_pacman_install.log || RC=$?
+echo "pacman exit status: ${RC}"


### PR DESCRIPTION
## Problem

The **Install MSYS2 for MRBind** step fails intermittently with no diagnosable error. Latest occurrence: [nightly 2026-07-20, msvc-2026 Release MSBuild leg](https://github.com/MeshInspector/MeshLib/actions/runs/29713915367/job/88263081866) — all 55 package checksums print `OK`, then ~5 seconds of silence, then `Process completed with exit code 1`. `pacman -U` produced zero visible output (in the 12 passing sibling jobs it starts printing `loading packages...` within 2 s of the last checksum), so pacman or the hosting msys2 bash crashed and its console output was lost with the crash. The `|| true` in `msys2_install_packages.sh` guards pacman's exit code but not a crash of the shell itself.

## Change

Diagnostics only — no behavior change on the happy path:

- `msys2_install_packages.sh`: tee pacman output to `msys2_pacman_install.log` (file writes survive the crash that eats the console pipe), print a marker line before pacman starts and its exit status after, keeping the existing tolerate-pacman-errors semantics.
- `install-msys2-mrbind` action: when `msys2_shell.cmd` exits nonzero, dump the tee'd log and the last 200 lines of `C:\msys64\var\log\pacman.log` (pacman writes it synchronously, so it shows exactly which package operation was in flight), then propagate the exit code.
- `.gitignore`: ignore the new log file.

Next time the flake hits, the job log will show whether pacman started, what it said, and where in the transaction it died.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
