### PR TITLE
CI: paginate the jobs-API request in collect_ci_stats.py

### DIFF
--- a/scripts/devops/collect_ci_stats.py
+++ b/scripts/devops/collect_ci_stats.py
@@ -97,24 +97,32 @@ def parse_jobs(jobs: List[dict]):
         if job is not None
     ]
 
-def fetch_jobs(repo: str, run_id: str, attempts=3, cooldown=30):
-    url = f'https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs'
-    headers = {
-        'Accept': 'application/vnd.github.v3+json',
-        'Authorization': f'Bearer {os.environ.get("GITHUB_TOKEN")}',
-        'X-GitHub-Api-Version': '2022-11-28',
-    }
+def fetch_page(url, headers, attempts=3, cooldown=30):
     for attempt in range(1, attempts + 1):
         try:
             resp = requests.get(url, headers=headers)
         except requests.exceptions.RequestException as e:
             if attempt == attempts:
                 raise
-            print(f'fetch_jobs: attempt {attempt}/{attempts} failed ({e}); retrying in {cooldown}s...')
+            print(f'fetch_page: attempt {attempt}/{attempts} failed ({e}); retrying in {cooldown}s...')
             time.sleep(cooldown)
             continue
         resp.raise_for_status()
         return resp
+
+def fetch_jobs(repo: str, run_id: str):
+    url = f'https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100'
+    headers = {
+        'Accept': 'application/vnd.github.v3+json',
+        'Authorization': f'Bearer {os.environ.get("GITHUB_TOKEN")}',
+        'X-GitHub-Api-Version': '2022-11-28',
+    }
+    jobs = []
+    while url:
+        resp = fetch_page(url, headers)
+        jobs += resp.json()['jobs']
+        url = resp.links.get('next', {}).get('url')
+    return jobs
 
 def sign_api_request(url, method, headers, body, region, service):
     # Use the credentials from the assumed role
@@ -140,17 +148,19 @@ if __name__ == "__main__":
     ref = os.environ.get("GITHUB_REF")
     run_id = os.environ.get("GITHUB_RUN_ID")
 
-    resp = fetch_jobs(repo, run_id)
-
     result = {
         'id':          int(run_id),
         'git_commit':  commit,
         'git_branch':  branch,
         'github_ref':  ref,
         'github_repo': repo,
-        'jobs':        parse_jobs(resp.json()['jobs']),
+        'jobs':        parse_jobs(fetch_jobs(repo, run_id)),
     }
     pprint.pp(result, indent=2, width=150)
+
+    stats_file_count = len(list(Path('.').glob('RunnerSysStats-*.json')))
+    if stats_file_count != len(result['jobs']):
+        print(f"WARNING: found {stats_file_count} RunnerSysStats files but the payload has {len(result['jobs'])} jobs")
 
     headers = {
         'Content-Type': 'application/json',


### PR DESCRIPTION
Since ~07-17, scheduled runs' Windows jobs (and any other job past position 30 in the jobs listing) have been missing from the CI stats DB.

Root cause: `fetch_jobs()` issued a single unpaginated `GET /actions/runs/{run_id}/jobs`, which returns only the **first 30 jobs** (GitHub's default page size). `parse_job()` then silently skips every job it never saw. Scheduled full-config runs now have ~90 jobs, with `windows-build-test` at positions 42–55 — entirely past page 1. Evidence from run 29628186281: its collect-stats job downloaded 43 `RunnerSysStats-*` artifacts but the payload contained only 18 jobs, and was sent successfully — the ingestion side never received the rest.

Fix:
- `fetch_jobs()` requests `per_page=100` and follows the `Link: rel="next"` header until exhausted, returning the aggregated job list; the retry-with-cooldown behavior is kept per request (`fetch_page()`).
- After building the payload, print a warning when there are more `RunnerSysStats-*` files than payload jobs — the 43-vs-18 mismatch was visible in the log all along, this makes it explicit.

Verified locally against run 29628186281: the new `fetch_jobs()` returns all 90 jobs, including all 13 `windows-build-test` jobs (job 88036696490 among them).

Runs that already lost rows can be backfilled from their collect-stats job logs (the full payload is printed there) if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
