### PR TITLE
Add MeshBuilder::computeTrianglesRepetitions counting duplicate triangles in Triangulation

### DIFF
--- a/source/MRMesh/MRMeshBuilder.cpp
+++ b/source/MRMesh/MRMeshBuilder.cpp
@@ -671,9 +671,9 @@ std::vector<int> computeTrianglesRepetitions( const Triangulation & t )
     for ( const auto & [triplet, num] : map )
     {
         assert( num >= 1 );
-        while ( res.size() <= size_t( num ) )
+        while ( res.size() < size_t( num ) )
             res.push_back( 0 );
-        ++res[num];
+        ++res[num - 1];
     }
     return res;
 }

--- a/source/MRMesh/MRMeshBuilder.cpp
+++ b/source/MRMesh/MRMeshBuilder.cpp
@@ -671,8 +671,8 @@ std::vector<int> computeTrianglesRepetitions( const Triangulation & t )
     for ( const auto & [triplet, num] : map )
     {
         assert( num >= 1 );
-        if ( res.size() <= size_t( num ) )
-            res.resize( num + 1 );
+        while ( res.size() <= size_t( num ) )
+            res.push_back( 0 );
         ++res[num];
     }
     return res;

--- a/source/MRMesh/MRMeshBuilder.cpp
+++ b/source/MRMesh/MRMeshBuilder.cpp
@@ -3,6 +3,8 @@
 #include "MRRingIterator.h"
 #include "MRCloseVertices.h"
 #include "MRBuffer.h"
+#include "MRUnorientedTriangle.h"
+#include "MRphmap.h"
 #include "MRBitSetParallelFor.h"
 #include "MRParallelFor.h"
 #include "MRTimer.h"
@@ -645,6 +647,35 @@ int uniteCloseVertices( Mesh& mesh, const UniteCloseParams& params /*= {} */ )
         *params.optionalVertOldToNew = std::move( vertOldToNew );
 
     return numChanged;
+}
+
+std::vector<int> computeTrianglesRepetitions( const Triangulation & t )
+{
+    MR_TIMER;
+
+    ParallelHashMap<UnorientedTriangle, int> map;
+    ParallelFor( size_t( 0 ), map.subcnt(), [&]( size_t myPartId )
+    {
+        for ( const auto & vs : t )
+        {
+            const UnorientedTriangle triplet( vs );
+            const auto hashval = map.hash( triplet );
+            const auto idx = map.subidx( hashval );
+            if ( idx != myPartId )
+                continue;
+            ++map[triplet];
+        }
+    } );
+
+    std::vector<int> res;
+    for ( const auto & [triplet, num] : map )
+    {
+        assert( num >= 1 );
+        if ( res.size() <= size_t( num ) )
+            res.resize( num + 1 );
+        ++res[num];
+    }
+    return res;
 }
 
 } //namespace MeshBuilder

--- a/source/MRMesh/MRMeshBuilder.h
+++ b/source/MRMesh/MRMeshBuilder.h
@@ -79,6 +79,13 @@ MRMESH_API void addTriangles( MeshTopology & res, std::vector<VertId> & vertTrip
 MRMESH_API MeshTopology fromFaceSoup( const std::vector<VertId> & verts, const Vector<VertSpan, FaceId> & faces,
     const BuildSettings & settings = {}, ProgressCallback progressCb = {} );
 
+/// computes the histogram of triangle repetitions in given triangulation, ignoring vertex order in each triangle:
+/// res[0] is always zero,
+/// res[1] is the number of triangles without duplicates,
+/// res[2] is the number of distinct triangles present in two copies,
+/// res[3] is the number of distinct triangles present in three copies, etc.
+[[nodiscard]] MRMESH_API std::vector<int> computeTrianglesRepetitions( const Triangulation & t );
+
 struct UniteCloseParams
 {
     ///< vertices located closer to each other than \param closeDist will be united

--- a/source/MRMesh/MRMeshBuilder.h
+++ b/source/MRMesh/MRMeshBuilder.h
@@ -80,10 +80,9 @@ MRMESH_API MeshTopology fromFaceSoup( const std::vector<VertId> & verts, const V
     const BuildSettings & settings = {}, ProgressCallback progressCb = {} );
 
 /// computes the histogram of triangle repetitions in given triangulation, ignoring vertex order in each triangle:
-/// res[0] is always zero,
-/// res[1] is the number of triangles without duplicates,
-/// res[2] is the number of distinct triangles present in two copies,
-/// res[3] is the number of distinct triangles present in three copies, etc.
+/// res[0] is the number of triangles without duplicates,
+/// res[1] is the number of distinct triangles present in two copies,
+/// res[2] is the number of distinct triangles present in three copies, etc.
 [[nodiscard]] MRMESH_API std::vector<int> computeTrianglesRepetitions( const Triangulation & t );
 
 struct UniteCloseParams

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -272,6 +272,26 @@ TEST( MRMesh, MeshBuildWithDups )
     );
 }
 
+TEST( MRMesh, computeTrianglesRepetitions )
+{
+    Triangulation t;
+    EXPECT_TRUE( computeTrianglesRepetitions( t ).empty() );
+
+    t.push_back( { 0_v, 1_v, 2_v } ); //0_f
+    t.push_back( { 0_v, 2_v, 3_v } ); //1_f
+    t.push_back( { 2_v, 0_v, 3_v } ); //2_f same as 1_f with the opposite orientation
+    t.push_back( { 1_v, 2_v, 0_v } ); //3_f same as 0_f
+    t.push_back( { 2_v, 0_v, 1_v } ); //4_f same as 0_f
+    t.push_back( { 3_v, 4_v, 5_v } ); //5_f
+
+    const auto reps = computeTrianglesRepetitions( t );
+    ASSERT_EQ( reps.size(), 4 );
+    EXPECT_EQ( reps[0], 0 );
+    EXPECT_EQ( reps[1], 1 ); // {3,4,5}
+    EXPECT_EQ( reps[2], 1 ); // {0,2,3}
+    EXPECT_EQ( reps[3], 1 ); // {0,1,2}
+}
+
 } //namespace MeshBuilder
 
 } //namespace MR

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -285,11 +285,10 @@ TEST( MRMesh, computeTrianglesRepetitions )
     t.push_back( { 3_v, 4_v, 5_v } ); //5_f
 
     const auto reps = computeTrianglesRepetitions( t );
-    ASSERT_EQ( reps.size(), 4 );
-    EXPECT_EQ( reps[0], 0 );
-    EXPECT_EQ( reps[1], 1 ); // {3,4,5}
-    EXPECT_EQ( reps[2], 1 ); // {0,2,3}
-    EXPECT_EQ( reps[3], 1 ); // {0,1,2}
+    ASSERT_EQ( reps.size(), 3 );
+    EXPECT_EQ( reps[0], 1 ); // {3,4,5}
+    EXPECT_EQ( reps[1], 1 ); // {0,2,3}
+    EXPECT_EQ( reps[2], 1 ); // {0,1,2}
 }
 
 } //namespace MeshBuilder


### PR DESCRIPTION
New function `MeshBuilder::computeTrianglesRepetitions( const Triangulation & t )` counting duplicate triangles in a triangulation irrespective of vertex order in each triangle (`UnorientedTriangle`).

It returns a histogram of triangle repetitions:
- `res[0]` is the number of triangles without duplicates,
- `res[1]` is the number of distinct triangles present in two copies,
- `res[2]` is the number of distinct triangles present in three copies, etc.

The hash map construction is parallelized following the same pattern as `makeTriangleHashMap` in `MRLocalTriangulations.cpp`: each thread processes only the triangles hashed into its own `ParallelHashMap` submap.

Also adds a unit test.
