### PR TITLE
MRViewer: copy THIRD-PARTY-NOTICES.txt next to the executable in dev builds

### DIFF
--- a/source/MRViewer/CMakeLists.txt
+++ b/source/MRViewer/CMakeLists.txt
@@ -147,6 +147,9 @@ file(GLOB JSONS "*.json")
 file(GLOB AWESOME_FONTS "${MESHLIB_THIRDPARTY_DIR}/fontawesome-free/*.ttf")
 file(GLOB IMGUI_FONTS "${MESHLIB_THIRDPARTY_DIR}/imgui/misc/fonts/*.ttf")
 file(GLOB MAIN_FONTS "${MESHLIB_THIRDPARTY_DIR}/Noto_Sans/*.*")
+# desktop bundles the third-party notices next to the executable for the About dialog;
+# wasm links to them on GitHub instead, so they are not copied into the emscripten assets
+set(THIRD_PARTY_NOTICES "${MESHLIB_THIRDPARTY_DIR}/licenses/THIRD-PARTY-NOTICES.txt")
 IF(EMSCRIPTEN)
   file(
     COPY
@@ -168,6 +171,7 @@ ELSE()
       ${MAIN_FONTS}
       ${AWESOME_FONTS}
       ${IMGUI_FONTS}
+      ${THIRD_PARTY_NOTICES}
       "resource"
     DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
   )

--- a/source/MRViewer/MRViewer.vcxproj
+++ b/source/MRViewer/MRViewer.vcxproj
@@ -368,6 +368,9 @@
     <CopyFileToFolders Include="MRLightTheme.json">
       <FileType>Document</FileType>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="..\..\thirdparty\licenses\THIRD-PARTY-NOTICES.txt">
+      <FileType>Document</FileType>
+    </CopyFileToFolders>
     <None Include="MRFileDialogCocoa.mm">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>

--- a/source/MRViewer/MRViewer.vcxproj.filters
+++ b/source/MRViewer/MRViewer.vcxproj.filters
@@ -38,6 +38,9 @@
     <Filter Include="Fonts">
       <UniqueIdentifier>{44ab7180-8a0d-45cc-a894-2c7fc5419bd8}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Licenses">
+      <UniqueIdentifier>{b7e9c3a4-2f81-4d6e-9a05-3c1f7b2e8d40}</UniqueIdentifier>
+    </Filter>
     <Filter Include="History">
       <UniqueIdentifier>{3070cea7-b1d9-4627-9d06-476b27257614}</UniqueIdentifier>
     </Filter>
@@ -1149,6 +1152,9 @@
     </CopyFileToFolders>
     <CopyFileToFolders Include="MRLightTheme.json">
       <Filter>UIStyle</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="..\..\thirdparty\licenses\THIRD-PARTY-NOTICES.txt">
+      <Filter>Licenses</Filter>
     </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
`thirdparty/licenses/THIRD-PARTY-NOTICES.txt` is installed to the resources directory by the root `install(FILES …)` and ships in every package. Development builds, however, never copied it into the build output — so unlike the fonts, themes, and JSONs that `MRViewer` already copies to `CMAKE_RUNTIME_OUTPUT_DIRECTORY` (and to the MSBuild output dir), the notices file was absent next to the executable during development.

This adds the notices file to those same dev-build copy steps, so a viewer can open the bundled notices from the resources directory — the executable's own folder on Windows — in a plain development build, matching packaged builds.

- **CMake** (`source/MRViewer/CMakeLists.txt`): added to the non-Emscripten `file(COPY …)`. Emscripten is intentionally excluded — the wasm build links to the notices on GitHub rather than reading a local copy, so bundling ~300 KB into the assets would be dead weight.
- **MSBuild** (`MRViewer.vcxproj` + `.filters`): a `CopyFileToFolders` entry mirroring the existing font/theme entries.

Install rules are unchanged — the file already installs via the root `install(FILES …)`.

### Verification
- Incremental `Debug|x64` MSBuild (MeshInspector consuming this): `THIRD-PARTY-NOTICES.txt` (305 KB) now lands in the build output directory alongside `NotoSans-Regular.ttf` / `MRDarkTheme.json`; MRViewer compiles unchanged.
- The CMake addition mirrors the adjacent font/JSON `file(COPY … DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})` in the same block (not separately built here).
