### PR TITLE
Fix source vertex in duplicateNonManifoldVertices when several chains are duplicated around one vertex

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -106,7 +106,7 @@ public:
         if ( dups )
             dups->push_back( vertDup );
 
-        [[maybe_unused]] int changedTris = 0;
+        [[maybe_unused]] size_t changedTris = 0;
         for ( size_t i = 1; i < path.size(); ++i )
         {
             for ( auto it = vertexBegIt; it < vertexBegIt + firstUnvisitedIndex; ++it )

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -97,15 +97,16 @@ public:
     }
 
     // duplicate the vertex around which the chain was found
-    void duplicateVertex( std::vector<VertId>& path, VertId& lastUsedVertId,
+    void duplicateVertex( VertId v, std::vector<VertId>& path, VertId& lastUsedVertId,
                           std::vector<VertDuplication>* dups = nullptr )
     {
         VertDuplication vertDup;
         vertDup.dupVert = ++lastUsedVertId;
-        vertDup.srcVert = vertexBegIt->v;
+        vertDup.srcVert = v;
         if ( dups )
             dups->push_back( vertDup );
 
+        [[maybe_unused]] int changedTris = 0;
         for ( size_t i = 1; i < path.size(); ++i )
         {
             for ( auto it = vertexBegIt; it < vertexBegIt + firstUnvisitedIndex; ++it )
@@ -124,6 +125,7 @@ public:
                 if ( alreadyDuplicted )
                     continue;
                 assert( v1 && v2 );
+                assert( v1 != v2 );
 
                 if ( ( v1 == path[i - 1] || v2 == path[i - 1] ) &&
                      ( v1 == path[i] || v2 == path[i] ) )
@@ -135,11 +137,13 @@ public:
                         vi = vertDup.dupVert;
                         break;
                     }
+                    ++changedTris;
                     it->v = vertDup.dupVert;
                     break;
                 }
             }
         }
+        assert( changedTris + 1 == path.size() );
     }
 };
 
@@ -428,7 +432,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                     {
                         if ( foundChains )
                         {
-                            pathMaker.duplicateVertex( path, lastValidVert, dups );
+                            pathMaker.duplicateVertex( v, path, lastValidVert, dups );
                             ++duplicatedVerticesCnt;
                         }
                         ++foundChains;
@@ -448,7 +452,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
 
                     if ( foundChains )
                     {
-                        pathMaker.duplicateVertex( closedPath, lastValidVert, dups );
+                        pathMaker.duplicateVertex( v, closedPath, lastValidVert, dups );
                         ++duplicatedVerticesCnt;
                     }
                     ++foundChains;

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -110,6 +110,44 @@ TEST( MRMesh, duplicateClosedPlusOpenChainVertex )
     }
 }
 
+// a vertex with three chains around it, where the walk enters the closed ring via shared rim vertex #3,
+// so the ring is extracted mid-walk as the first found chain, and both open chains get duplicates
+TEST( MRMesh, duplicateVertexWithThreeChains )
+{
+    Triangulation t;
+    t.push_back( { 0_v, 1_v, 2_v } ); //0_f open chain 1-2-3
+    t.push_back( { 0_v, 2_v, 3_v } ); //1_f
+    t.push_back( { 0_v, 3_v, 4_v } ); //2_f closed ring 3-4-5-3
+    t.push_back( { 0_v, 4_v, 5_v } ); //3_f
+    t.push_back( { 0_v, 5_v, 3_v } ); //4_f
+    t.push_back( { 0_v, 6_v, 7_v } ); //5_f open chain 6-7-8
+    t.push_back( { 0_v, 7_v, 8_v } ); //6_f
+
+    std::vector<VertDuplication> dups;
+    size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
+    EXPECT_EQ( duplicatedVerticesCnt, 2 );
+    ASSERT_EQ( dups.size(), 2 );
+    // both duplicates must originate from the true central vertex #0
+    EXPECT_EQ( dups[0].srcVert, 0_v );
+    EXPECT_EQ( dups[0].dupVert, 9_v );
+    EXPECT_EQ( dups[1].srcVert, 0_v );
+    EXPECT_EQ( dups[1].dupVert, 10_v );
+
+    // the closed ring was found first and keeps #0, each open chain got its own duplicate
+    EXPECT_EQ( t[0_f][0], 9_v );
+    EXPECT_EQ( t[1_f][0], 9_v );
+    EXPECT_EQ( t[2_f][0], 0_v );
+    EXPECT_EQ( t[3_f][0], 0_v );
+    EXPECT_EQ( t[4_f][0], 0_v );
+    EXPECT_EQ( t[5_f][0], 10_v );
+    EXPECT_EQ( t[6_f][0], 10_v );
+
+    // the result is manifold
+    dups.clear();
+    EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups ), 0 );
+    EXPECT_EQ( dups.size(), 0 );
+}
+
 // a vertex with two closed rings of triangles around it, from a real mesh
 TEST( MRMesh, inspectVertNeighbourhood )
 {


### PR DESCRIPTION
`PathAroundVertex::duplicateVertex` took the source vertex from `vertexBegIt->v`, but that record is rewritten to the just-created duplicate when the chain owning it is duplicated. This happens when the walk enters a closed ring through a shared rim vertex: the ring is extracted by `extractClosedPath` and counted as the first found chain, so the chain containing the very first record is duplicated after it. Every following `duplicateVertex` call for the same center then received a previously created duplicate as the source: no triangle contains it, so the loop silently changed nothing, leaving the vertex non-manifold, while still reporting a bogus `VertDuplication` record and incrementing the returned counter.

Changes:
- pass the central vertex into `duplicateVertex` explicitly instead of reading it from `vertexBegIt->v`;
- new debug assertions: `v1 != v2`, and every path edge must re-point exactly one triangle (`changedTris + 1 == path.size()`), which catches exactly the silent no-op above;
- new unit test `MRMesh.duplicateVertexWithThreeChains` reproducing the scenario: two open chains and a closed ring entered mid-walk around one vertex. Before the fix it fails: the second open chain keeps the original vertex, and `dups[1].srcVert` refers to the first duplicate instead of the original vertex.
