### PR TITLE
Match triangle orientation when duplicating non-manifold vertices

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -118,6 +118,7 @@ public:
                     if ( vi == vertDup.srcVert )
                     {
                         alreadyDuplicted = false;
+                        // make (v1,v2) the cyclic pair following srcVert in the triangle
                         if ( v1 && !v2 )
                             std::swap( v1, v2 );
                     }
@@ -132,7 +133,7 @@ public:
                 assert( v1 != v2 );
 
                 if ( ( triOrientation && v1 == path[i - 1] && v2 == path[i] ) ||
-                    ( !triOrientation && v2 == path[i - 1] && v1 == path[i] ) )
+                     ( !triOrientation && v2 == path[i - 1] && v1 == path[i] ) )
                 {
                     for ( VertId & vi : faceToVertices[it->f] )
                     {

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -97,7 +97,7 @@ public:
     }
 
     // duplicate the vertex around which the chain was found
-    void duplicateVertex( VertId v, std::vector<VertId>& path, VertId& lastUsedVertId,
+    void duplicateVertex( VertId v, const std::vector<VertId>& path, VertId& lastUsedVertId, bool triOrientation,
                           std::vector<VertDuplication>* dups = nullptr )
     {
         VertDuplication vertDup;
@@ -116,7 +116,11 @@ public:
                 for ( VertId vi : faceToVertices[it->f] )
                 {
                     if ( vi == vertDup.srcVert )
+                    {
                         alreadyDuplicted = false;
+                        if ( v1 && !v2 )
+                            std::swap( v1, v2 );
+                    }
                     else if ( !v1 )
                         v1 = vi;
                     else if ( !v2 )
@@ -127,8 +131,8 @@ public:
                 assert( v1 && v2 );
                 assert( v1 != v2 );
 
-                if ( ( v1 == path[i - 1] || v2 == path[i - 1] ) &&
-                     ( v1 == path[i] || v2 == path[i] ) )
+                if ( ( triOrientation && v1 == path[i - 1] && v2 == path[i] ) ||
+                    ( !triOrientation && v2 == path[i - 1] && v1 == path[i] ) )
                 {
                     for ( VertId & vi : faceToVertices[it->f] )
                     {
@@ -426,19 +430,20 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                     if ( triOrientation ) // try the opposite direction from firstVertex
                     {
                         triOrientation = false;
-                        nextVertex = pathMaker.getNextVertex( firstVertex, triOrientation );
+                        prevVertex = path[1];
+                        std::reverse( path.begin(), path.end() );
+                        nextVertex = pathMaker.getNextVertex( firstVertex, triOrientation, prevVertex );
                     }
                     if ( !nextVertex )
                     {
                         if ( foundChains )
                         {
-                            pathMaker.duplicateVertex( v, path, lastValidVert, dups );
+                            pathMaker.duplicateVertex( v, path, lastValidVert, triOrientation, dups );
                             ++duplicatedVerticesCnt;
                         }
                         ++foundChains;
                         break;
                     }
-                    std::reverse( path.begin(), path.end() );
                 }
 
                 // returned to already visited vertex
@@ -452,7 +457,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
 
                     if ( foundChains )
                     {
-                        pathMaker.duplicateVertex( v, closedPath, lastValidVert, dups );
+                        pathMaker.duplicateVertex( v, closedPath, lastValidVert, triOrientation, dups );
                         ++duplicatedVerticesCnt;
                     }
                     ++foundChains;

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -110,6 +110,35 @@ TEST( MRMesh, duplicateClosedPlusOpenChainVertex )
     }
 }
 
+// a closed ring around #0 plus one opposite-orientation triangle sharing the ring's rim pair (2,3):
+// the duplicated chain must take its own triangle 4_f, not the ring's 1_f with the same rim vertices
+TEST( MRMesh, duplicateVertexOppositeOrientedTri )
+{
+    Triangulation t;
+    t.push_back( { 0_v, 1_v, 2_v } ); //0_f closed ring 1-2-3-4-1
+    t.push_back( { 0_v, 2_v, 3_v } ); //1_f
+    t.push_back( { 0_v, 3_v, 4_v } ); //2_f
+    t.push_back( { 0_v, 4_v, 1_v } ); //3_f
+    t.push_back( { 0_v, 3_v, 2_v } ); //4_f reversed rim pair of 1_f
+
+    std::vector<VertDuplication> dups;
+    size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
+    EXPECT_EQ( duplicatedVerticesCnt, 1 );
+    ASSERT_EQ( dups.size(), 1 );
+    EXPECT_EQ( dups[0].srcVert, 0_v );
+    EXPECT_EQ( dups[0].dupVert, 5_v );
+
+    // the ring is intact and only the lone triangle got the duplicate
+    for ( FaceId i{ 0 }; i < 4; ++i )
+        EXPECT_EQ( t[i][0], 0_v );
+    EXPECT_EQ( t[4_f][0], 5_v );
+
+    // the result is manifold
+    dups.clear();
+    EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups ), 0 );
+    EXPECT_EQ( dups.size(), 0 );
+}
+
 // a vertex with three chains around it, where the walk enters the closed ring via shared rim vertex #3,
 // so the ring is extracted mid-walk as the first found chain, and both open chains get duplicates
 TEST( MRMesh, duplicateVertexWithThreeChains )


### PR DESCRIPTION
`PathAroundVertex::duplicateVertex` matched a path edge `(path[i-1], path[i])` against any triangle whose two other vertices equal that pair in either order. When two triangles around the same center share the same rim pair with opposite orientations (e.g. ring triangle `(v,2,3)` and a lone reversed triangle `(v,3,2)`), duplicating the lone chain could re-point the ring's triangle instead of its own: the fans are split incorrectly, the neighborhood of the center remains orientation-broken, and on a minimal 5-triangle reproducer the function performs 3 duplications instead of 1 because the mis-split fan also defeats the live recheck of neighbor vertices.

Changes:
- `duplicateVertex` normalizes `(v1,v2)` to the cyclic pair following the source vertex and matches the edge directionally according to `triOrientation`, so each path edge re-points exactly the triangle that produced it during the walk;
- the caller keeps the path consistent with the current orientation: on the direction flip the path is reversed before searching the continuation (also when no continuation is found), and `getNextVertex` now receives `path[1]` as the prefer-to-avoid hint;
- `path` is passed by const reference;
- new unit test `MRMesh.duplicateVertexOppositeOrientedTri`: a closed ring `1-2-3-4-1` around vertex 0 plus one opposite-orientation triangle `(0,3,2)` sharing the ring's rim pair. Before the fix it fails with 3 duplications and a stolen ring triangle; now the ring stays intact, only the lone triangle gets the duplicate, and a second pass confirms the result is manifold.
