### PR TITLE
Duplicate non-manifold vertices in a greedy order to reduce duplications

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -373,12 +373,30 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     all.computeVertSpans();
     all.computeVertInfos( t );
 
+    std::vector<VertId> voi;
+    for ( auto v = 0_v; v + 1 < all.vert2firstRec.size(); ++v )
+        if ( !noDuplicationNeeded( all.vertInfos[v] ) )
+            voi.push_back( v );
+
+    auto sortPred = [&]( VertId a, VertId b )
+    {
+        const auto ai = all.vertInfos[a];
+        const auto bi = all.vertInfos[b];
+        if ( ai.hasRepeatedVerts() != bi.hasRepeatedVerts() )
+            return bi.hasRepeatedVerts(); // process neighbourhoods without repeated vertices (a) first, because duplication of neighbours cannot help them
+        if ( ai.hasRepeatedVerts() ) // process neighbourhoods with more repeated vertices (a) first
+            return std::make_pair( ai.numRepeatedVerts(), a ) > std::make_pair( bi.numRepeatedVerts(), b );
+        // process neighbourhoods with more chains (a) first
+        return std::make_pair( ai.numOpenChains() + ai.numClosedChains(), a ) > std::make_pair( bi.numOpenChains() + bi.numClosedChains(), b );
+    };
+    tbb::parallel_sort( voi.begin(), voi.end(), sortPred );
+
     VertNeighbourhoodInspector inspector;
     std::vector<VertId> path;
     std::vector<VertId> closedPath;
     VertBitSet visitedVertices( all.recs.back().v ); // explicitly not `lastValidVert` but last vert used in triangulation
     size_t duplicatedVerticesCnt = 0;
-    for ( auto v = 0_v; v + 1 < all.vert2firstRec.size(); ++v )
+    for ( auto v : voi )
     {
         // skip a vertex based on the neighborhood in the original triangulation;
         // a vertex not requiring duplication cannot start requiring it after duplication of its neighbors

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -347,15 +347,6 @@ void extractClosedPath( std::vector<VertId>& path, std::vector<VertId>& closedPa
     }
 }
 
-/// returns true if the vertex with such neighborhood does not require duplication:
-/// a single chain of triangles (or no triangles at all), or two open chains, which MeshBuilder has no issue with
-static bool noDuplicationNeeded( const VertInfo & vertInfo )
-{
-    return !vertInfo.hasRepeatedVerts() &&
-        ( vertInfo.numOpenChains() + vertInfo.numClosedChains() <= 1
-        || ( vertInfo.numOpenChains() == 2 && vertInfo.numClosedChains() == 0 ) );
-}
-
 // for all vertices get over all incident vertices to find connected sequences
 size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std::vector<VertDuplication>* dups, VertId lastValidVert )
 {
@@ -373,10 +364,13 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     all.computeVertSpans();
     all.computeVertInfos( t );
 
-    std::vector<VertId> voi;
+    // collect the vertices requiring duplication in the original triangulation;
+    // a vertex not requiring duplication cannot start requiring it after duplication of its neighbors,
+    // so this set never has to grow later
+    std::vector<VertId> vertsToProcess;
     for ( auto v = 0_v; v + 1 < all.vert2firstRec.size(); ++v )
-        if ( !noDuplicationNeeded( all.vertInfos[v] ) )
-            voi.push_back( v );
+        if ( all.vertInfos[v].duplicationNeeded() )
+            vertsToProcess.push_back( v );
 
     auto sortPred = [&]( VertId a, VertId b )
     {
@@ -389,24 +383,20 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
         // process neighbourhoods with more chains (a) first
         return std::make_pair( ai.numOpenChains() + ai.numClosedChains(), a ) > std::make_pair( bi.numOpenChains() + bi.numClosedChains(), b );
     };
-    tbb::parallel_sort( voi.begin(), voi.end(), sortPred );
+    tbb::parallel_sort( vertsToProcess.begin(), vertsToProcess.end(), sortPred );
 
     VertNeighbourhoodInspector inspector;
     std::vector<VertId> path;
     std::vector<VertId> closedPath;
     VertBitSet visitedVertices( all.recs.back().v ); // explicitly not `lastValidVert` but last vert used in triangulation
     size_t duplicatedVerticesCnt = 0;
-    for ( auto v : voi )
+    for ( auto v : vertsToProcess )
     {
-        // skip a vertex based on the neighborhood in the original triangulation;
-        // a vertex not requiring duplication cannot start requiring it after duplication of its neighbors
-        if ( noDuplicationNeeded( all.vertInfos[v] ) )
-            continue;
         const auto posBegin = all.vert2firstRec[v];
         const auto posEnd = all.vert2firstRec[v + 1];
         // duplication of one vertex can resolve non-manifoldness in its neighbor vertex,
         // so after the first duplication recheck the neighborhood in the current triangulation
-        if ( duplicatedVerticesCnt > 0 && noDuplicationNeeded( inspector.run( t, all.recs.data() + posBegin, all.recs.data() + posEnd ) ) )
+        if ( duplicatedVerticesCnt > 0 && !inspector.run( t, all.recs.data() + posBegin, all.recs.data() + posEnd ).duplicationNeeded() )
             continue;
         PathAroundVertex pathMaker( t, all.recs, posBegin, posEnd );
 

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -42,6 +42,15 @@ struct VertInfo
     /// the number of closed chains (rings) of connected triangles around the vertex; 0 if hasRepeatedVerts()
     [[nodiscard]] std::uint32_t numClosedChains() const { return hasRepeatedVerts() ? 0 : data_ >> 17; }
 
+    /// true if the triangles around the vertex do not form a configuration MeshBuilder accepts as is
+    /// (a single chain or ring, no triangles at all, or two open chains), so the vertex must be duplicated
+    [[nodiscard]] bool duplicationNeeded() const
+    {
+        return hasRepeatedVerts() ||
+            !( numOpenChains() + numClosedChains() <= 1
+            || ( numOpenChains() == 2 && numClosedChains() == 0 ) );
+    }
+
     /// increments numRepeatedVerts saturating at its maximum; the first call zeros the chain counters forever
     void incRepeatedVerts()
     {

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -139,8 +139,8 @@ TEST( MRMesh, duplicateVertexOppositeOrientedTri )
     EXPECT_EQ( dups.size(), 0 );
 }
 
-// a vertex with three chains around it, where the walk enters the closed ring via shared rim vertex #3,
-// so the ring is extracted mid-walk as the first found chain, and both open chains get duplicates
+// a hub vertex #0 with two open chains (1-2-3, 6-7-8) and a closed ring (3-4-5) sharing rim vertex #3;
+// duplicating the shared rim vertex #3 once resolves #0, so the hub itself is never split
 TEST( MRMesh, duplicateVertexWithThreeChains )
 {
     Triangulation t;
@@ -156,11 +156,11 @@ TEST( MRMesh, duplicateVertexWithThreeChains )
     size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
     EXPECT_EQ( duplicatedVerticesCnt, 1 );
     ASSERT_EQ( dups.size(), 1 );
-    // both duplicates must originate from the true central vertex #0
+    // the shared rim vertex #3 is duplicated, not the hub #0
     EXPECT_EQ( dups[0].srcVert, 3_v );
     EXPECT_EQ( dups[0].dupVert, 9_v );
 
-    // the closed ring was found first and keeps #0, each open chain got its own duplicate
+    // every triangle keeps the hub vertex #0
     EXPECT_EQ( t[0_f][0], 0_v );
     EXPECT_EQ( t[1_f][0], 0_v );
     EXPECT_EQ( t[2_f][0], 0_v );

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -67,13 +67,13 @@ TEST( MRMesh, duplicateResolvedNeighborVertex )
     t.push_back( { 2_v, 1_v, 4_v } ); //1_f
     t.push_back( { 1_v, 2_v, 5_v } ); //2_f
     // the edge (1,2) is shared by three triangles, so both vertices 1 and 2 have repeated neighbor vertices;
-    // duplication of vertex 1 in one of the triangles resolves vertex 2 into two open chains requiring nothing
+    // duplication of vertex 2 in one of the triangles resolves vertex 1 into two open chains requiring nothing
 
     std::vector<VertDuplication> dups;
     size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
     EXPECT_EQ( duplicatedVerticesCnt, 1 );
     ASSERT_EQ( dups.size(), 1 );
-    EXPECT_EQ( dups[0].srcVert, 1_v );
+    EXPECT_EQ( dups[0].srcVert, 2_v );
     EXPECT_EQ( dups[0].dupVert, 6_v );
 
     const auto topology = fromTrianglesDuplicatingNonManifoldVertices( t );
@@ -154,22 +154,20 @@ TEST( MRMesh, duplicateVertexWithThreeChains )
 
     std::vector<VertDuplication> dups;
     size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
-    EXPECT_EQ( duplicatedVerticesCnt, 2 );
-    ASSERT_EQ( dups.size(), 2 );
+    EXPECT_EQ( duplicatedVerticesCnt, 1 );
+    ASSERT_EQ( dups.size(), 1 );
     // both duplicates must originate from the true central vertex #0
-    EXPECT_EQ( dups[0].srcVert, 0_v );
+    EXPECT_EQ( dups[0].srcVert, 3_v );
     EXPECT_EQ( dups[0].dupVert, 9_v );
-    EXPECT_EQ( dups[1].srcVert, 0_v );
-    EXPECT_EQ( dups[1].dupVert, 10_v );
 
     // the closed ring was found first and keeps #0, each open chain got its own duplicate
-    EXPECT_EQ( t[0_f][0], 9_v );
-    EXPECT_EQ( t[1_f][0], 9_v );
+    EXPECT_EQ( t[0_f][0], 0_v );
+    EXPECT_EQ( t[1_f][0], 0_v );
     EXPECT_EQ( t[2_f][0], 0_v );
     EXPECT_EQ( t[3_f][0], 0_v );
     EXPECT_EQ( t[4_f][0], 0_v );
-    EXPECT_EQ( t[5_f][0], 10_v );
-    EXPECT_EQ( t[6_f][0], 10_v );
+    EXPECT_EQ( t[5_f][0], 0_v );
+    EXPECT_EQ( t[6_f][0], 0_v );
 
     // the result is manifold
     dups.clear();
@@ -264,12 +262,13 @@ TEST( MRMesh, inspectVertNeighbourhoodSaturation )
     }
 }
 
-static void testBuildWithDups( const char * objMesh, int numVerts, int numComps )
+static void testBuildWithDups( const char * objMesh, int numFaces, int numVerts, int numComps )
 {
     std::istringstream s( objMesh );
     auto maybeMesh = MeshLoad::fromObj( s );
     EXPECT_TRUE( maybeMesh );
 
+    EXPECT_EQ( maybeMesh->topology.numValidFaces(), numFaces );
     EXPECT_EQ( maybeMesh->topology.numValidVerts(), numVerts );
     EXPECT_EQ( MeshComponents::getNumComponents( *maybeMesh ), numComps );
 }
@@ -294,7 +293,7 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 3 5 1\n"
         "f 2 1 3\n"
         "f 3 1 5\n"
-        "f 1 4 5\n", 6, 1
+        "f 1 4 5\n", 8, 6, 1
     );
 
     // same situation as above with the order of triangles changed
@@ -312,7 +311,7 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 1 4 2\n"
         "f 2 3 1\n"
         "f 1 5 4\n"
-        "f 3 5 1\n", 6, 1
+        "f 3 5 1\n", 8, 6, 1
     );
 
     // first 4 triangles subdivide a square with center point,
@@ -335,7 +334,7 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 5 7 2\n"
         "f 7 3 6\n"
         "f 2 7 6\n"
-        "f 7 5 3\n", 10, 2
+        "f 7 5 3\n", 8, 8, 2
     );
 }
 


### PR DESCRIPTION
`duplicateNonManifoldVertices` processed candidate vertices in ascending id order. Because duplicating one vertex can resolve the non-manifoldness of a neighbor (and the loop rechecks-and-skips vertices already resolved), the processing order determines how many duplications happen. This reduces the number of duplicated vertices and the number of resulting connected components, while still keeping all input triangles.

Changes:
- collect the vertices that need duplication in the original triangulation and sort them by a greedy priority before processing:
  1. neighbourhoods without repeated vertices first — their non-manifoldness (several disjoint chains) cannot be resolved by duplicating neighbors, so they must be duplicated regardless, and doing so may resolve neighbors that can be helped;
  2. among neighbourhoods with repeated vertices, more repetitions first;
  3. among the rest, more chains first.
  Ties are broken by vertex id, so the order is a strict total order and `tbb::parallel_sort` yields a deterministic result independent of the number of cores.
- `noDuplicationNeeded( const VertInfo& )` free function becomes the `VertInfo::duplicationNeeded()` method.
- the per-vertex skip inside the loop is dropped: the candidate set already excludes vertices not needing duplication, and that set never has to grow because a vertex not requiring duplication cannot start requiring it after its neighbors are duplicated.
- tests updated to the new outcomes: `duplicateResolvedNeighborVertex` and `duplicateVertexWithThreeChains` now duplicate the cheaper shared vertex (one duplication instead of two for the latter), and `MeshBuildWithDups` additionally asserts `numValidFaces` so the "all input triangles kept" guarantee is checked; comments updated accordingly.
