### PR TITLE
Auto-rebuild matrix-builder dist on Dependabot PRs

### DIFF
--- a/.github/workflows/matrix-builder-rebuild-dist.yml
+++ b/.github/workflows/matrix-builder-rebuild-dist.yml
@@ -1,0 +1,53 @@
+name: Rebuild matrix-builder dist
+
+# The action runs from the committed ncc bundle (dist/index.js), but Dependabot
+# PRs only bump package.json/package-lock.json. Regenerate and push the bundle
+# on its PRs so the dependency update actually takes effect.
+on:
+  pull_request:
+    paths:
+      - scripts/actions/matrix-builder/package.json
+      - scripts/actions/matrix-builder/package-lock.json
+
+permissions: {}
+
+jobs:
+  rebuild-dist:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: scripts/actions/matrix-builder
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Rebuild dist
+        run: |
+          npm ci --ignore-scripts
+          npm run build
+
+      - name: Test, including a smoke run of the rebuilt bundle
+        run: |
+          npm test
+          INPUT_MATRIX='{"os": ["a", "b"]}' GITHUB_OUTPUT=/tmp/smoke node dist/index.js
+          grep -q '"os":"a"' /tmp/smoke
+
+      - name: Push dist if changed
+        run: |
+          if git diff --quiet; then
+            echo "dist unchanged"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A .
+          git commit -m "Rebuild matrix-builder dist"
+          git push

--- a/.github/workflows/matrix-builder-rebuild-dist.yml
+++ b/.github/workflows/matrix-builder-rebuild-dist.yml
@@ -46,6 +46,9 @@ jobs:
             echo "dist unchanged"
             exit 0
           fi
+          # <account-id>+<login>@users.noreply.github.com is GitHub's noreply
+          # format (41898282 = github-actions[bot]); it makes GitHub attribute
+          # the commit to the bot instead of an unlinked author.
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A .


### PR DESCRIPTION
Companion to #6464. Dependabot's PRs only bump `package.json`/`package-lock.json`, but the action executes the committed ncc bundle (`dist/index.js`) — without a rebuild, a security bump closes the alert while the vulnerable code keeps running.

This adds a workflow that triggers on PRs touching the action's manifests, and only for `dependabot[bot]` same-repo PRs: it reruns `npm ci --ignore-scripts && npm run build`, runs the action's tests plus a smoke run of the rebuilt bundle, and pushes the regenerated `dist/` back to the PR branch. Dependabot-triggered workflows get a read-only `GITHUB_TOKEN` by default; the job elevates it to `contents: write` via the `permissions` key, which is the [documented mechanism](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automate-dependabot-with-actions). The bot push does not re-trigger workflows (GITHUB_TOKEN pushes never do), so there is no recursion — and the `paths` filter wouldn't match a dist-only commit anyway.

The referenced path is the post-#6464 location, so this workflow is inert until that PR merges; merge this one right after it. If Dependabot's js-yaml PR appears in the gap between the two, a `@dependabot rebase` comment on it will re-trigger the rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)