### PR TITLE
Fix matrix-builder dist-rebuild smoke run

### DIFF
--- a/.github/workflows/matrix-builder-rebuild-dist.yml
+++ b/.github/workflows/matrix-builder-rebuild-dist.yml
@@ -37,8 +37,11 @@ jobs:
       - name: Test, including a smoke run of the rebuilt bundle
         run: |
           npm test
-          INPUT_MATRIX='{"os": ["a", "b"]}' GITHUB_OUTPUT=/tmp/smoke node dist/index.js
-          grep -q '"os":"a"' /tmp/smoke
+          # @actions/core appends outputs and errors out unless the file
+          # already exists (the runner normally pre-creates it).
+          touch "$RUNNER_TEMP/smoke"
+          INPUT_MATRIX='{"os": ["a", "b"]}' GITHUB_OUTPUT="$RUNNER_TEMP/smoke" node dist/index.js
+          grep -q '"os":"a"' "$RUNNER_TEMP/smoke"
 
       - name: Push dist if changed
         run: |
@@ -53,4 +56,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A .
           git commit -m "Rebuild matrix-builder dist"
-          git push
+          git push origin HEAD


### PR DESCRIPTION
The rebuild workflow's first real exercise on #6467 proved the pipeline (Dependabot opened its PR at the new path, rebuild + all 62 tests passed) but the smoke run failed: `Missing file at path: /tmp/smoke`. `@actions/core` appends outputs to `GITHUB_OUTPUT` and errors out unless the file already exists — the runner pre-creates it, the smoke harness didn't (the action's own `action.test.js` does `writeFileSync(outFile, '')` for the same reason). Pre-create it in `$RUNNER_TEMP` and verified the exact sequence locally.

Also made the final step push to `origin HEAD` explicitly — that step hasn't been exercised yet, and a bare `git push` depends on checkout's upstream setup.

After merge, re-triggering #6467 (e.g. close/reopen or `@dependabot rebase`) will run the fixed workflow from the new merge ref and push the rebuilt `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)