### PR TITLE
Scope emsdk chmod to the emscripten cache dir

### DIFF
--- a/docker/emscripten-build-c-bindingsDockerfile
+++ b/docker/emscripten-build-c-bindingsDockerfile
@@ -75,7 +75,9 @@ FROM base
 COPY --from=builder /opt/meshlib-thirdparty/emscripten        /usr/local/lib/emscripten
 COPY --from=builder /opt/meshlib-thirdparty/emscripten-single /usr/local/lib/emscripten-single
 
-RUN chmod -R 777 /emsdk/upstream/emscripten/
+# Only cache/ needs to be writable (emcc regenerates system libs there); a
+# whole-tree chmod copies up every file on containerd-overlayfs docker hosts.
+RUN chmod -R 777 /emsdk/upstream/emscripten/cache
 
 RUN useradd -u 8877 -m aws-user
 RUN useradd -u 1001 -m github-user

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -86,7 +86,9 @@ COPY --from=builder /opt/meshlib-thirdparty/emscripten        /usr/local/lib/ems
 COPY --from=builder /opt/meshlib-thirdparty/emscripten-single /usr/local/lib/emscripten-single
 COPY --from=builder /opt/meshlib-thirdparty/emscripten-wasm64 /usr/local/lib/emscripten-wasm64
 
-RUN chmod -R 777 /emsdk/upstream/emscripten/
+# Only cache/ needs to be writable (emcc regenerates system libs there); a
+# whole-tree chmod copies up every file on containerd-overlayfs docker hosts.
+RUN chmod -R 777 /emsdk/upstream/emscripten/cache
 
 RUN useradd -u 8877 -m aws-user
 RUN useradd -u 1001 -m github-user


### PR DESCRIPTION
`chmod -R 777` of the whole `/emsdk/upstream/emscripten` tree only exists to make the emscripten cache writable for the non-root CI users — emcc regenerates system libs, the sanity marker, and ports under `cache/`, and writes nowhere else in the emsdk tree. Scoping the chmod to `cache/` keeps that behavior while avoiding a full overlayfs copy-up of the tree (15k files, ~600 MB): on docker hosts using the containerd overlayfs snapshotter (no metacopy), a metadata-only change copies up every file's content, turning this layer into a ~23-minute step that looks like a hung build. Measured on such a host: whole-tree chmod ~23 min, cache-only ~3.5 min.

Same change in both `emscriptenDockerfile` and `emscripten-build-c-bindingsDockerfile` (the mirror note at the top of the former); `emscripten-generate-c-bindingsDockerfile` has no chmod.

Test plan: the Dockerfile changes move the emscripten image source checksums, so CI on this PR rebuilds the images and builds all emscripten configs in them, verifying cache-only write access is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
