### PR TITLE
CI: detect ARM CPU model in runner's system stats

### DIFF
--- a/scripts/devops/collect_runner_sys_stats.py
+++ b/scripts/devops/collect_runner_sys_stats.py
@@ -21,18 +21,19 @@ def get_ram_amount():
     else:
         raise RuntimeError(f"Unknown system: {system}")
 
-# same tables as GetCpuId in source/MRMesh/MRSystem.cpp
+# decoding as in GetCpuId (source/MRMesh/MRSystem.cpp), but names must match
+# lscpu (util-linux sys-utils/lscpu-arm.c) so old and new stats rows agree
 ARM_CPU_NAMES = {
-    (0x41, 0xd03): "ARM Cortex-A53",    (0x41, 0xd05): "ARM Cortex-A55",
-    (0x41, 0xd07): "ARM Cortex-A57",    (0x41, 0xd08): "ARM Cortex-A72",
-    (0x41, 0xd09): "ARM Cortex-A73",    (0x41, 0xd0a): "ARM Cortex-A75",
-    (0x41, 0xd0b): "ARM Cortex-A76",    (0x41, 0xd0c): "ARM Neoverse-N1",
-    (0x41, 0xd0d): "ARM Cortex-A77",    (0x41, 0xd40): "ARM Neoverse-V1",
-    (0x41, 0xd41): "ARM Cortex-A78",    (0x41, 0xd44): "ARM Cortex-X1",
-    (0x41, 0xd49): "ARM Neoverse-N2",   (0x41, 0xd4f): "ARM Neoverse-V2",
-    (0xc0, 0xac3): "Ampere-1",          (0xc0, 0xac4): "Ampere-1a",
-    (0x43, 0x0af): "Marvell ThunderX2", (0x46, 0x001): "Fujitsu A64FX",
-    (0x51, 0xc01): "Qualcomm Kryo",
+    (0x41, 0xd03): "Cortex-A53",     (0x41, 0xd05): "Cortex-A55",
+    (0x41, 0xd07): "Cortex-A57",     (0x41, 0xd08): "Cortex-A72",
+    (0x41, 0xd09): "Cortex-A73",     (0x41, 0xd0a): "Cortex-A75",
+    (0x41, 0xd0b): "Cortex-A76",     (0x41, 0xd0c): "Neoverse-N1",
+    (0x41, 0xd0d): "Cortex-A77",     (0x41, 0xd40): "Neoverse-V1",
+    (0x41, 0xd41): "Cortex-A78",     (0x41, 0xd44): "Cortex-X1",
+    (0x41, 0xd49): "Neoverse-N2",    (0x41, 0xd4f): "Neoverse-V2",
+    (0xc0, 0xac3): "Ampere-1",       (0xc0, 0xac4): "Ampere-1a",
+    (0x43, 0x0af): "ThunderX2-99xx", (0x46, 0x001): "A64FX",
+    (0x51, 0xc01): "Saphira",
 }
 
 ARM_VENDORS = {

--- a/scripts/devops/collect_runner_sys_stats.py
+++ b/scripts/devops/collect_runner_sys_stats.py
@@ -21,6 +21,61 @@ def get_ram_amount():
     else:
         raise RuntimeError(f"Unknown system: {system}")
 
+# same tables as GetCpuId in source/MRMesh/MRSystem.cpp
+ARM_CPU_NAMES = {
+    (0x41, 0xd03): "ARM Cortex-A53",    (0x41, 0xd05): "ARM Cortex-A55",
+    (0x41, 0xd07): "ARM Cortex-A57",    (0x41, 0xd08): "ARM Cortex-A72",
+    (0x41, 0xd09): "ARM Cortex-A73",    (0x41, 0xd0a): "ARM Cortex-A75",
+    (0x41, 0xd0b): "ARM Cortex-A76",    (0x41, 0xd0c): "ARM Neoverse-N1",
+    (0x41, 0xd0d): "ARM Cortex-A77",    (0x41, 0xd40): "ARM Neoverse-V1",
+    (0x41, 0xd41): "ARM Cortex-A78",    (0x41, 0xd44): "ARM Cortex-X1",
+    (0x41, 0xd49): "ARM Neoverse-N2",   (0x41, 0xd4f): "ARM Neoverse-V2",
+    (0xc0, 0xac3): "Ampere-1",          (0xc0, 0xac4): "Ampere-1a",
+    (0x43, 0x0af): "Marvell ThunderX2", (0x46, 0x001): "Fujitsu A64FX",
+    (0x51, 0xc01): "Qualcomm Kryo",
+}
+
+ARM_VENDORS = {
+    0x41: "ARM",     0x42: "Broadcom",
+    0x43: "Cavium",  0x48: "HiSilicon",
+    0x4e: "NVIDIA",  0x51: "Qualcomm",
+    0x53: "Samsung", 0x56: "Marvell",
+    0x70: "Phytium", 0xc0: "Ampere",
+}
+
+def get_arm_cpu_model():
+    implementer, part = -1, -1
+    with open('/proc/cpuinfo') as f:
+        for line in f:
+            if line.startswith('CPU implementer'):
+                implementer = int(line.split(':', 1)[1], 0)
+            elif line.startswith('CPU part'):
+                part = int(line.split(':', 1)[1], 0)
+            if implementer >= 0 and part >= 0:
+                break
+
+    name = ARM_CPU_NAMES.get((implementer, part))
+    if name:
+        return name
+
+    vendor = ARM_VENDORS.get(implementer)
+    if vendor and part >= 0:
+        return f"{vendor} ARM CPU (part {part:#x})"
+
+    if implementer != -1 or part != -1:
+        return f"ARM CPU: {implementer:#x}, {part:#x}"
+
+    # single-board computers (Raspberry Pi etc.) expose a device-tree model name
+    try:
+        with open('/proc/device-tree/model') as f:
+            name = f.read().strip('\0').strip()
+            if name:
+                return name
+    except OSError:
+        pass
+
+    return "ARM CPU"
+
 def get_cpu_model():
     system = platform.system()
     if system == "Darwin":
@@ -30,7 +85,11 @@ def get_cpu_model():
         output = subprocess.check_output(['lscpu'], text=True)
         for line in output.splitlines():
             if line.startswith('Model name:'):
-                return line.split(':', 1)[1].strip()
+                model = line.split(':', 1)[1].strip()
+                if model and model != '-':
+                    return model
+        if platform.machine() in ('aarch64', 'arm64'):
+            return get_arm_cpu_model()
         return None
     elif system == "Windows":
         ps_command = "(Get-CimInstance Win32_Processor).Name"


### PR DESCRIPTION
## Problem

On ARM Linux runners the "Collect runner's system stat" step reports `"cpu_model": null`, while the C++ code in the same job correctly detects the CPU, e.g. in [this run](https://github.com/MeshInspector/MeshLib/actions/runs/29976097309/job/89108151970) "Unit Tests" prints `CPU: ARM Neoverse-N2` but the stats step emits `"cpu_model": null`.

The Python script relies on `lscpu`'s `Model name:` line, which is absent (or `-`) on ARM Linux because there is no CPUID-like brand string there.

## Solution

Copy the ARM CPU detection from `GetCpuId()` in `source/MRMesh/MRSystem.cpp` (#6300) into `collect_runner_sys_stats.py`:

* decode the `CPU implementer` / `CPU part` pair from `/proc/cpuinfo` and map it through the same core-name table (Neoverse, Cortex, Ampere, etc.);
* implementer-only vendor fallback, then raw `implementer, part` values;
* device-tree model name fallback for single-board computers.

Unlike the C++ table, the names here follow `lscpu` (util-linux [`sys-utils/lscpu-arm.c`](https://github.com/util-linux/util-linux/blob/master/sys-utils/lscpu-arm.c)) exactly — bare core names without vendor prefixes (`Neoverse-N2`, not `ARM Neoverse-N2`). Runners whose newer `lscpu` already decodes the model have been storing that spelling, so the fallback must produce identical strings to avoid splitting one CPU into two `cpu_model` values in the stats DB.

The new path is used only when `platform.machine()` is `aarch64`/`arm64` and `lscpu` gave no usable `Model name:` (empty or `-` values are now also treated as missing). x64, macOS and Windows behavior is unchanged.

Verified the parser against a simulated Neoverse-N2 `/proc/cpuinfo` (implementer `0x41`, part `0xd49`) and the fallback branches.
