### PR TITLE
Download MRTest bundle via REST API path to support emscripten-test job reruns

### DIFF
--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -274,6 +274,8 @@ jobs:
         with:
           name: MRTest_${{ matrix.package_name }}
           path: mrtest-bundle
+          github-token: ${{ github.token }}
+          run-id: ${{ github.run_id }}
 
       - name: Unit Tests
         timeout-minutes: 5


### PR DESCRIPTION
## Problem

When only the `emscripten-test` jobs are rerun ("Re-run failed jobs"), they fail immediately at **Download MRTest bundle**:

```
Unable to download artifact(s): Failed to GetSignedArtifactURL: Received non-retryable error: Failed request: (404) Not Found: workflow run not found
```

Example: [run 29999605282, attempt 2](https://github.com/MeshInspector/MeshLib/actions/runs/29999605282/attempts/2) — only the `Multithreaded-64Bit` build was rerun, so its test leg downloaded a fresh same-attempt artifact and passed, while `singlethreaded` and `multithreaded` test legs had to fetch artifacts uploaded during attempt 1 and both failed with the identical 404.

## Cause

Without a `github-token` input, `actions/download-artifact` uses GitHub's internal artifact service (`GetSignedArtifactURL`), which resolves artifacts against the current *run attempt*. Artifacts uploaded in a previous attempt are not visible there, so rerunning just the test jobs cannot download the bundles their (not-rerun) build jobs uploaded earlier.

## Fix

Pass `github-token` + `run-id` to the download step. This switches the action to the public REST API path, where artifacts are scoped to the *run* rather than the attempt, so reruns of the test jobs alone work. The job already has the required `actions: read` permission.

The REST path costs a couple of API requests per job from the repo-scoped 1000/hour `GITHUB_TOKEN` pool — negligible for three test legs per run.
