### PR TITLE
Improve sharpening offset

### DIFF
--- a/source/MRMesh/MRSharpenMarchingCubesMesh.cpp
+++ b/source/MRMesh/MRSharpenMarchingCubesMesh.cpp
@@ -6,6 +6,7 @@
 #include "MRParallelFor.h"
 #include "MRTriMath.h"
 #include "MRTimer.h"
+#include "MRReducePath.h"
 
 namespace MR
 {
@@ -67,6 +68,7 @@ void sharpenMarchingCubesMesh( const MeshPart & ref, Mesh & vox, Vector<VoxelId,
         e0 = e; // an edge with this voxel on the left and another voxel on the right
         Vector3f sumAC;
         float sumArea = 0;
+        Vector3f sumDirArea; // area-weighted normal sum of the voxel's faces
         PlaneAccumulator pacc;
         do
         {
@@ -81,9 +83,11 @@ void sharpenMarchingCubesMesh( const MeshPart & ref, Mesh & vox, Vector<VoxelId,
                     break;
                 if ( facesToProcess.test_set( l, false ) )
                 {
-                    auto a = vox.dblArea( l );
+                    const auto da = vox.dirDblArea( l ); // length = 2x face area
+                    const auto a = da.length();
                     sumArea += a;
                     sumAC += a * vox.triCenter( l );
+                    sumDirArea += da;
                 }
                 ei = vox.topology.next( ei );
             }
@@ -116,6 +120,12 @@ void sharpenMarchingCubesMesh( const MeshPart & ref, Mesh & vox, Vector<VoxelId,
         if ( rank == 3 && distSq > sqr( settings.maxNewRank3VertDev ) )
             continue; //new point is too from existing mesh triangles
 
+        // forbid in-plane shifts: the displacement to sharpPt must rise off the voxel's mean
+        // surface plane, not slide along it; an in-plane sharpPt is a phantom feature and a fold source
+        constexpr float minElevSin = 0.1f; // ~6 deg minimal angle between the displacement and the plane
+        const Vector3f d = sharpPt - avgPt;
+        if ( sqr( dot( d, sumDirArea ) ) < sqr( minElevSin ) * d.lengthSq() * sumDirArea.lengthSq() )
+            continue; //sharpPt shifts (nearly) within the surface plane
         auto v = vox.splitFace( f, sharpPt );
         assert( v == dirs.size() + firstNewVert );
         dirs.push_back( dir );
@@ -144,6 +154,8 @@ void sharpenMarchingCubesMesh( const MeshPart & ref, Mesh & vox, Vector<VoxelId,
             auto b = vox.topology.dest( vox.topology.prev( e ) );
             auto c = vox.topology.dest( e );
             auto d = vox.topology.dest( vox.topology.next( e ) );
+            if ( !isUnfoldQuadrangleConvex( vox.points[v], vox.points[b], vox.points[c], vox.points[d] ) )
+                return false;
             SymMatrix3f mat;
             mat += outerSquare( normals[b] );
             mat += outerSquare( normals[c] );

--- a/source/MRVoxels/MROffset.cpp
+++ b/source/MRVoxels/MROffset.cpp
@@ -293,6 +293,9 @@ Expected<Mesh> sharpOffsetMesh( const MeshPart& mp, float offset, const SharpOff
     if ( !reportProgress( params.callBack, 0.99f ) )
         return unexpectedOperationCanceled();
 
+    if ( params.outVoxelPerFace )
+        *params.outVoxelPerFace = std::move( map );
+
     return res;
 }
 

--- a/source/MRVoxels/MROffset.h
+++ b/source/MRVoxels/MROffset.h
@@ -61,6 +61,8 @@ struct SharpOffsetParameters : OffsetParameters
 {
     /// if non-null then created sharp edges will be saved here
     UndirectedEdgeBitSet* outSharpEdges = nullptr;
+    /// if non-null then for each output mesh face maps its voxel id
+    Vector<VoxelId, FaceId>* outVoxelPerFace = nullptr;
     /// minimal surface deviation to introduce new vertex in a voxel, measured in voxelSize
     float minNewVertDev = 1.0f / 25;
     /// maximal surface deviation to introduce new rank 2 vertex (on intersection of 2 planes), measured in voxelSize


### PR DESCRIPTION
## Fewer self-intersections in `sharpenMarchingCubesMesh`, by construction

Two contracts on vertex/flip creation — no new settings, no post-processing:

1. **Elevation gate on new sharp vertices.** A new vertex is created only if its displacement
   `sharpPt − avgPt` rises off the voxel's mean surface plane (area-weighted normal sum of the
   voxel's faces) by at least ~6° (`minElevSin = 0.1`). A displacement lying within the surface
   plane is a phantom feature — the plane intersection is ill-conditioned there — and such
   vertices were a major source of folds. The test is a pure direction test (voxel-size independent).
2. **Convex-unfold guard on old-vertex flips.** In the `flipEdgesOut` pass a flip is now also
   rejected when the unfolded quadrangle is non-convex (`isUnfoldQuadrangleConvex`) — a non-convex
   unfold means the flip folds the surface onto itself.

### Measurements

Fandisk, 3 rotations × 5 offsets (±R, ±R/2, 0; R = 4.5% of bbox diagonal) × 4 voxel sizes
(R … R/10), sharp offset mode. `selfPairs` = colliding face pairs (`findSelfCollidingTriangles`);
`creaseRec` = recovered sharp-edge length / input crease length (feature preservation; >1 means
over-generation).

Overall selfPairs: **8071 → 6149 (−24%)**; positive offsets **−80%** with all 12 fine-voxel
configs (voxel ≤ R/5) at exactly **0**; zero offset **−40%**; creaseRec within ±8% everywhere.

| rotation | offset | voxel | selfPairs | creaseRec |
|----------|--------|-------|-----------|-----------|
| id | +1.0R | R | 35 → 16 | 2.47 → 2.06 |
| id | +1.0R | R/2 | 7 → 3 | 3.46 → 3.27 |
| id | +1.0R | R/5 | 48 → **0** | 1.54 → 1.65 |
| id | +1.0R | R/10 | 0 → **0** | 0.20 → 0.18 |
| id | +0.5R | R | 33 → 9 | 1.79 → 1.61 |
| id | +0.5R | R/2 | 36 → 24 | 2.33 → 2.01 |
| id | +0.5R | R/5 | 12 → 3 | 3.28 → 3.22 |
| id | +0.5R | R/10 | 172 → **0** | 1.31 → 1.42 |
| id | 0 | R | 75 → 48 | 1.15 → 0.94 |
| id | 0 | R/2 | 70 → 33 | 1.19 → 1.07 |
| id | 0 | R/5 | 126 → 72 | 1.14 → 1.00 |
| id | 0 | R/10 | 177 → 81 | 1.19 → 1.05 |
| id | −0.5R | R | 60 → 36 | 0.91 → 0.82 |
| id | −0.5R | R/2 | 8 → 0 | 0.97 → 0.86 |
| id | −0.5R | R/5 | 73 → 46 | 1.29 → 1.23 |
| id | −0.5R | R/10 | 175 → 147 | 1.00 → 0.94 |
| id | −1.0R | R | 64 → 63 | 0.59 → 0.50 |
| id | −1.0R | R/2 | 324 → 270 | 0.76 → 0.68 |
| id | −1.0R | R/5 | 91 → 90 | 0.64 → 0.59 |
| id | −1.0R | R/10 | 600 → 321 | 0.59 → 0.51 |
| ax111-30 | +1.0R | R | 23 → 3 | 2.74 → 2.28 |
| ax111-30 | +1.0R | R/2 | 22 → 10 | 3.41 → 3.18 |
| ax111-30 | +1.0R | R/5 | 70 → **0** | 0.85 → 0.95 |
| ax111-30 | +1.0R | R/10 | 8 → **0** | 0.20 → 0.18 |
| ax111-30 | +0.5R | R | 74 → 45 | 2.10 → 1.69 |
| ax111-30 | +0.5R | R/2 | 17 → 21 | 2.46 → 2.14 |
| ax111-30 | +0.5R | R/5 | 43 → 3 | 3.12 → 3.07 |
| ax111-30 | +0.5R | R/10 | 160 → **0** | 0.59 → 0.72 |
| ax111-30 | 0 | R | 72 → 45 | 1.26 → 1.05 |
| ax111-30 | 0 | R/2 | 41 → 15 | 1.19 → 1.11 |
| ax111-30 | 0 | R/5 | 41 → 28 | 1.19 → 1.02 |
| ax111-30 | 0 | R/10 | 46 → 41 | 1.19 → 1.03 |
| ax111-30 | −0.5R | R | 65 → 52 | 0.95 → 0.80 |
| ax111-30 | −0.5R | R/2 | 126 → 101 | 1.10 → 1.00 |
| ax111-30 | −0.5R | R/5 | 497 → 428 | 1.33 → 1.24 |
| ax111-30 | −0.5R | R/10 | 829 → 917 | 0.96 → 0.89 |
| ax111-30 | −1.0R | R | 81 → 77 | 0.77 → 0.68 |
| ax111-30 | −1.0R | R/2 | 258 → 236 | 0.77 → 0.68 |
| ax111-30 | −1.0R | R/5 | 109 → 100 | 0.60 → 0.56 |
| ax111-30 | −1.0R | R/10 | 191 → 196 | 0.60 → 0.55 |
| eul30-20-10 | +1.0R | R | 72 → 52 | 2.82 → 2.35 |
| eul30-20-10 | +1.0R | R/2 | 24 → **0** | 3.46 → 3.25 |
| eul30-20-10 | +1.0R | R/5 | 103 → **0** | 0.87 → 1.03 |
| eul30-20-10 | +1.0R | R/10 | 0 → **0** | 0.20 → 0.18 |
| eul30-20-10 | +0.5R | R | 36 → 34 | 2.05 → 1.75 |
| eul30-20-10 | +0.5R | R/2 | 18 → 10 | 2.51 → 2.22 |
| eul30-20-10 | +0.5R | R/5 | 27 → 9 | 3.21 → 3.16 |
| eul30-20-10 | +0.5R | R/10 | 149 → **0** | 0.63 → 0.78 |
| eul30-20-10 | 0 | R | 104 → 107 | 1.25 → 1.18 |
| eul30-20-10 | 0 | R/2 | 29 → 3 | 1.23 → 1.09 |
| eul30-20-10 | 0 | R/5 | 28 → 21 | 1.20 → 1.02 |
| eul30-20-10 | 0 | R/10 | 41 → 18 | 1.20 → 1.03 |
| eul30-20-10 | −0.5R | R | 132 → 115 | 0.97 → 0.88 |
| eul30-20-10 | −0.5R | R/2 | 83 → 99 | 1.02 → 0.92 |
| eul30-20-10 | −0.5R | R/5 | 623 → 584 | 1.32 → 1.25 |
| eul30-20-10 | −0.5R | R/10 | 1163 → 1117 | 1.03 → 0.95 |
| eul30-20-10 | −1.0R | R | 159 → 130 | 0.70 → 0.67 |
| eul30-20-10 | −1.0R | R/2 | 134 → 103 | 0.81 → 0.68 |
| eul30-20-10 | −1.0R | R/5 | 102 → 92 | 0.62 → 0.59 |
| eul30-20-10 | −1.0R | R/10 | 85 → 75 | 0.59 → 0.53 |