### PR TITLE
Simplify path start in duplicateNonManifoldVertices (getFirstTwoVertices)

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -46,7 +46,8 @@ public:
         return vertexBegIt + firstUnvisitedIndex >= vertexEndIt;
     }
 
-    // returns the first unvisited vertex, and the following one in the path
+    // takes the first unvisited triangle and returns its two other vertices in cyclic order
+    // to start a new path there, so the walk can continue with triOrientation = true
     std::pair<VertId, VertId> getFirstTwoVertices()
     {
         assert( !empty() );

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -46,14 +46,13 @@ public:
         return vertexBegIt + firstUnvisitedIndex >= vertexEndIt;
     }
 
-    // first unvisited vertex
-    VertId getFirstVertex() const
+    // returns the first unvisited vertex, and the following one in the path
+    std::pair<VertId, VertId> getFirstTwoVertices()
     {
         assert( !empty() );
-        const auto first = vertexBegIt + firstUnvisitedIndex;
-        // below selection ensures that getNextIncidentVertex( getFirstVertex(), true ) will find nextVertex in the very first triangle
+        const auto first = vertexBegIt + firstUnvisitedIndex++;
         const auto & vs = faceToVertices[first->f];
-        return getOtherTriVerts( vs, first->v ).first;
+        return getOtherTriVerts( vs, first->v );
     }
 
     // find incident unvisited vertex, in case of several option prefer finding the vertex not equal to preVertex
@@ -408,17 +407,10 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                 visitedVertices.reset(vi);
 
             bool triOrientation = true;
-            const VertId firstVertex = pathMaker.getFirstVertex();
+            auto [firstVertex, nextVertex] = pathMaker.getFirstTwoVertices();
             visitedVertices.autoResizeSet( firstVertex );
-            VertId prevVertex = firstVertex;
-            VertId nextVertex = pathMaker.getNextVertex( firstVertex, triOrientation );
-            if ( !nextVertex )
-            {
-                triOrientation = false;
-                nextVertex = pathMaker.getNextVertex( firstVertex, triOrientation );
-                assert( nextVertex.valid() );
-            }
             visitedVertices.autoResizeSet( nextVertex );
+            VertId prevVertex = firstVertex;
 
             // preserve allocated memory in path
             path.clear();


### PR DESCRIPTION
Simplification in `PathAroundVertex`: the walk start used a peek-then-rescan pair — `getFirstVertex()` returned the first rim vertex of the first unvisited triangle, chosen precisely so that the following `getNextVertex( firstVertex, true )` call would match that very triangle. That follow-up call could never fail: the triangle's cyclic pair `(v1,v2)` satisfies `v1 == firstVertex` under `triOrientation = true`, so the orientation-flip fallback at the walk start was unreachable dead code.

Changes:
- `getFirstVertex()` + first `getNextVertex()` call are merged into `getFirstTwoVertices()`, which consumes the first unvisited triangle and returns both of its other vertices in cyclic order, so the walk always starts with `triOrientation = true`;
- the unreachable `if ( !nextVertex )` fallback at the walk start is removed.

No behavior change: the same record is consumed and the same vertex pair is produced in all cases; all existing tests (including the exact-outcome duplication tests from #6461-#6463) pass unchanged.
