### PR TITLE
Avoid returning into a duplicate of the previous vertex when walking around a non-manifold vertex

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -57,11 +57,26 @@ public:
     }
 
     // find incident unvisited vertex, in case of several option prefer finding the vertex not equal to preVertex
-    VertId getNextVertex( VertId v, bool triOrientation, VertId prevVertex = {} )
+    VertId getNextVertex( VertId v, bool triOrientation, VertId prevVertex, std::vector<VertDuplication>& dups )
     {
         if ( empty() )
             return VertId( -1 );
 
+        auto isPrevOrPrevDup = [prevVertex, &dups]( VertId nextVertex )
+        {
+            if ( prevVertex == nextVertex )
+                return true;
+            if ( dups.empty() || nextVertex < dups.front().dupVert )
+                return false;
+            const auto i = nextVertex - dups.front().dupVert;
+            assert( i < dups.size() );
+            if ( i >= dups.size() )
+                return false;
+            assert( dups[i].dupVert == nextVertex );
+            return dups[i].srcVert == prevVertex;
+        };
+
+        VertId prevOrPrevDup;
         auto prevIt = vertexEndIt;
         for ( auto it = vertexBegIt + firstUnvisitedIndex; it < vertexEndIt; ++it )
         {
@@ -74,7 +89,7 @@ public:
                 nextVertex = v12.first;
             if ( nextVertex )
             {
-                if ( nextVertex != prevVertex )
+                if ( !isPrevOrPrevDup( nextVertex ) )
                 {
                     if ( it != vertexBegIt + firstUnvisitedIndex )
                         std::iter_swap( it, vertexBegIt + firstUnvisitedIndex );
@@ -83,6 +98,7 @@ public:
                 }
                 // prevVertex is a possible continuation, store it, and search for other options
                 prevIt = it;
+                prevOrPrevDup = nextVertex;
             }
         }
         if ( prevIt < vertexEndIt )
@@ -91,7 +107,8 @@ public:
             if ( prevIt != vertexBegIt + firstUnvisitedIndex )
                 std::iter_swap( prevIt, vertexBegIt + firstUnvisitedIndex );
             ++firstUnvisitedIndex;
-            return prevVertex;
+            assert( prevOrPrevDup );
+            return prevOrPrevDup;
         }
         return {};
     }
@@ -354,6 +371,10 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     if ( t.empty() )
         return 0; // input triangulation is empty
 
+    std::vector<VertDuplication> myDups;
+    if ( dups )
+        myDups = std::move( *dups );
+
     AllVertTris all( t, region );
     if ( all.recs.empty() )
         return 0; // input triangulation contains only degenerate triangles, e.g. with repeating vertex (v v u)
@@ -423,7 +444,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                 {
                     // prefer finding nextVertex not equal to prevVertex to maximize neighbour ring sizes
                     auto currVertex = nextVertex;
-                    nextVertex = pathMaker.getNextVertex( currVertex, triOrientation, prevVertex );
+                    nextVertex = pathMaker.getNextVertex( currVertex, triOrientation, prevVertex, myDups );
                     prevVertex = currVertex;
                 }
 
@@ -434,13 +455,13 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                         triOrientation = false;
                         prevVertex = path[1];
                         std::reverse( path.begin(), path.end() );
-                        nextVertex = pathMaker.getNextVertex( firstVertex, triOrientation, prevVertex );
+                        nextVertex = pathMaker.getNextVertex( firstVertex, triOrientation, prevVertex, myDups );
                     }
                     if ( !nextVertex )
                     {
                         if ( foundChains )
                         {
-                            pathMaker.duplicateVertex( v, path, lastValidVert, triOrientation, dups );
+                            pathMaker.duplicateVertex( v, path, lastValidVert, triOrientation, &myDups );
                             ++duplicatedVerticesCnt;
                         }
                         ++foundChains;
@@ -459,7 +480,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
 
                     if ( foundChains )
                     {
-                        pathMaker.duplicateVertex( v, closedPath, lastValidVert, triOrientation, dups );
+                        pathMaker.duplicateVertex( v, closedPath, lastValidVert, triOrientation, &myDups );
                         ++duplicatedVerticesCnt;
                     }
                     ++foundChains;
@@ -471,6 +492,10 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
             }
         }
     }
+
+    if ( dups )
+        *dups = std::move( myDups );
+
     return duplicatedVerticesCnt;
 }
 

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -57,24 +57,29 @@ public:
     }
 
     // find incident unvisited vertex, in case of several option prefer finding the vertex not equal to preVertex
-    VertId getNextVertex( VertId v, bool triOrientation, VertId prevVertex, std::vector<VertDuplication>& dups )
+    VertId getNextVertex( VertId center, bool triOrientation, VertId prevVertex, std::vector<VertDuplication>& dups )
     {
         if ( empty() )
             return VertId( -1 );
 
-        auto isPrevOrPrevDup = [prevVertex, &dups]( VertId nextVertex )
+        // if v is an original vertex, then return it;
+        // if v is a duplicated vertex, then return the id of the original vertex, which was duplicated to make v
+        auto getOrgVertex = [&dups]( VertId v )
         {
-            if ( prevVertex == nextVertex )
-                return true;
-            if ( dups.empty() || nextVertex < dups.front().dupVert )
-                return false;
-            const auto i = nextVertex - dups.front().dupVert;
+            if ( dups.empty() || v < dups.front().dupVert )
+                return v;
+            const auto i = v - dups.front().dupVert;
             assert( i < dups.size() );
             if ( i >= dups.size() )
-                return false;
-            assert( dups[i].dupVert == nextVertex );
-            return dups[i].srcVert == prevVertex;
+                return v;
+            assert( dups[i].dupVert == v );
+            assert( dups[i].srcVert < dups.front().dupVert );
+            return dups[i].srcVert;
         };
+
+        assert( prevVertex );
+        prevVertex = getOrgVertex( prevVertex );
+        assert( prevVertex );
 
         VertId prevOrPrevDup;
         auto prevIt = vertexEndIt;
@@ -83,27 +88,27 @@ public:
             VertId nextVertex;
             const auto & vs = faceToVertices[it->f];
             const auto v12 = getOtherTriVerts( vs, it->v );
-            if ( triOrientation && v12.first == v )
+            if ( triOrientation && v12.first == center )
                 nextVertex = v12.second;
-            else if ( !triOrientation && v12.second == v )
+            else if ( !triOrientation && v12.second == center )
                 nextVertex = v12.first;
             if ( nextVertex )
             {
-                if ( !isPrevOrPrevDup( nextVertex ) )
+                if ( getOrgVertex( nextVertex ) != prevVertex )
                 {
                     if ( it != vertexBegIt + firstUnvisitedIndex )
                         std::iter_swap( it, vertexBegIt + firstUnvisitedIndex );
                     ++firstUnvisitedIndex;
                     return nextVertex;
                 }
-                // prevVertex is a possible continuation, store it, and search for other options
+                // prevVertex (or its duplicate) is a possible continuation, store it, and search for other options
                 prevIt = it;
                 prevOrPrevDup = nextVertex;
             }
         }
         if ( prevIt < vertexEndIt )
         {
-            // the only option is return in prevVertex
+            // the only option is return in prevVertex (or its duplicate)
             if ( prevIt != vertexBegIt + firstUnvisitedIndex )
                 std::iter_swap( prevIt, vertexBegIt + firstUnvisitedIndex );
             ++firstUnvisitedIndex;

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -57,7 +57,7 @@ public:
     }
 
     // find incident unvisited vertex, in case of several option prefer finding the vertex not equal to preVertex
-    VertId getNextVertex( VertId center, bool triOrientation, VertId prevVertex, std::vector<VertDuplication>& dups )
+    VertId getNextVertex( VertId center, bool triOrientation, VertId prevVertex, const std::vector<VertDuplication>& dups )
     {
         if ( empty() )
             return VertId( -1 );

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -376,13 +376,14 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     if ( t.empty() )
         return 0; // input triangulation is empty
 
-    std::vector<VertDuplication> myDups;
-    if ( dups )
-        myDups = std::move( *dups );
-
     AllVertTris all( t, region );
     if ( all.recs.empty() )
         return 0; // input triangulation contains only degenerate triangles, e.g. with repeating vertex (v v u)
+
+    // maintain the duplications even if the caller did not ask for them, they are necessary for getOrgVertex
+    std::vector<VertDuplication> myDups;
+    if ( dups )
+        myDups = std::move( *dups );
 
     if ( !lastValidVert )
         lastValidVert = all.recs.back().v;

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -373,6 +373,8 @@ void extractClosedPath( std::vector<VertId>& path, std::vector<VertId>& closedPa
 size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std::vector<VertDuplication>* dups, VertId lastValidVert )
 {
     MR_TIMER;
+    if ( dups )
+        dups->clear(); // input contents are ignored
     if ( t.empty() )
         return 0; // input triangulation is empty
 
@@ -380,7 +382,8 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     if ( all.recs.empty() )
         return 0; // input triangulation contains only degenerate triangles, e.g. with repeating vertex (v v u)
 
-    // maintain the duplications even if the caller did not ask for them, they are necessary for getOrgVertex
+    // maintain the duplications even if the caller did not ask for them, they are necessary for getOrgVertex;
+    // the caller's vector was cleared above, moving it in just reuses its buffer
     std::vector<VertDuplication> myDups;
     if ( dups )
         myDups = std::move( *dups );

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -21,7 +21,7 @@ struct VertDuplication
 
 /// resolve non-manifold vertices by creating duplicate vertices in the triangulation (which is modified)
 /// `lastValidVert` is needed if `region` or `t` does not contain full mesh, then first duplicated vertex will have `lastValidVert+1` index
-/// `dups` (if given) shall be empty on input; it receives the duplications in creation order with consecutive dupVert ids starting from `lastValidVert+1`
+/// `dups` (if given) contents will be ignored and overridden; it receives the duplications in creation order with consecutive dupVert ids starting from `lastValidVert+1`
 /// return number of duplicated vertices
 MRMESH_API size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region = nullptr,
     std::vector<VertDuplication>* dups = nullptr, VertId lastValidVert = {} );

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -21,6 +21,7 @@ struct VertDuplication
 
 /// resolve non-manifold vertices by creating duplicate vertices in the triangulation (which is modified)
 /// `lastValidVert` is needed if `region` or `t` does not contain full mesh, then first duplicated vertex will have `lastValidVert+1` index
+/// `dups` (if given) shall be empty on input; it receives the duplications in creation order with consecutive dupVert ids starting from `lastValidVert+1`
 /// return number of duplicated vertices
 MRMESH_API size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region = nullptr,
     std::vector<VertDuplication>* dups = nullptr, VertId lastValidVert = {} );

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -336,6 +336,44 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 2 7 6\n"
         "f 7 5 3\n", 8, 8, 2
     );
+
+    // two cubes with mirrored triangulations sharing all 8 vertices;
+    // every vertex must be duplicated exactly once giving two separate cube components
+    testBuildWithDups
+    (
+        "v -0.5 -0.5 -0.5\n"
+        "v -0.5 0.5 -0.5\n"
+        "v 0.5 0.5 -0.5\n"
+        "v 0.5 -0.5 -0.5\n"
+        "v -0.5 -0.5 0.5\n"
+        "v -0.5 0.5 0.5\n"
+        "v 0.5 0.5 0.5\n"
+        "v 0.5 -0.5 0.5\n"
+        "f 7 5 6\n"
+        "f 5 7 8\n"
+        "f 2 7 6\n"
+        "f 7 2 3\n"
+        "f 7 4 8\n"
+        "f 4 7 3\n"
+        "f 1 2 3\n"
+        "f 3 4 1\n"
+        "f 1 5 6\n"
+        "f 6 2 1\n"
+        "f 1 4 8\n"
+        "f 8 5 1\n"
+        "f 7 6 5\n"
+        "f 5 8 7\n"
+        "f 2 6 7\n"
+        "f 7 3 2\n"
+        "f 7 8 4\n"
+        "f 4 3 7\n"
+        "f 1 3 2\n"
+        "f 3 1 4\n"
+        "f 1 6 5\n"
+        "f 6 1 2\n"
+        "f 1 8 4\n"
+        "f 8 1 5\n", 24, 16, 2
+    );
 }
 
 TEST( MRMesh, computeTrianglesRepetitions )


### PR DESCRIPTION
When building a path around a non-manifold vertex, prefer not returning not only into the previous path vertex, but also into a duplicate of the previous path vertex.

Before this change, a walk could immediately return through a duplicate created while processing a neighbor vertex, welding together triangle fans that belong to separate surface sheets. Symptom: two cubes with mirrored triangulations sharing all 8 vertices loaded as a single connected component with only 6 of 8 vertices duplicated; now every vertex is duplicated exactly once and the mesh properly decomposes into two cube components, keeping all input triangles.

Changes:
- `getNextVertex` receives the list of duplications made so far and maps every candidate (and `prevVertex`) to its original vertex via `getOrgVertex` before the comparison; duplicate ids are consecutive starting from `lastValidVert+1`, so the lookup is O(1);
- when returning into the previous vertex is the only option, the actual vertex found in the triangle (possibly the duplicate id) is returned instead of `prevVertex`, so the path stays consistent with the orientation-aware triangle matching in `duplicateVertex`;
- the function now maintains the duplication list internally even when the caller passes no `dups` output; a caller-provided vector is cleared up front (its buffer is reused) and overridden with this call's duplications on return;
- the `dups` contract is documented in the header (input contents are ignored and overridden; receives duplications in creation order with consecutive ids);
- new regression case in `MeshBuildWithDups`: the two-mirror-cubes mesh above, expecting 24 faces, 16 vertices and 2 components (fails before the fix with 14 vertices and 1 component).
