### PR TITLE
Process double ring vertices ahead of others when duplicating non-manifold vertices

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -408,8 +408,19 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
         const auto bi = all.vertInfos[b];
         if ( ai.hasRepeatedVerts() != bi.hasRepeatedVerts() )
             return bi.hasRepeatedVerts(); // process neighbourhoods without repeated vertices (a) first, because duplication of neighbours cannot help them
-        if ( ai.hasRepeatedVerts() ) // process neighbourhoods with more repeated vertices (a) first
+
+        if ( ai.hasRepeatedVerts() )
+        {
+            // double ring is the case when every triangle around central vertex is present in both orientations,
+            // so every neighbour vertex is repeated
+            const bool aDoubleRing = all.vert2firstRec[a+1] - all.vert2firstRec[a] == (int)ai.numRepeatedVerts();
+            const bool bDoubleRing = all.vert2firstRec[b+1] - all.vert2firstRec[b] == (int)bi.numRepeatedVerts();
+            if ( aDoubleRing != bDoubleRing )
+                return aDoubleRing; // process double ring vertices ahead of others, since their duplication produces two closed chains
+
+            // process neighbourhoods with more repeated vertices (a) first
             return std::make_pair( ai.numRepeatedVerts(), a ) > std::make_pair( bi.numRepeatedVerts(), b );
+        }
         // process neighbourhoods with more chains (a) first
         return std::make_pair( ai.numOpenChains() + ai.numClosedChains(), a ) > std::make_pair( bi.numOpenChains() + bi.numClosedChains(), b );
     };

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -411,10 +411,12 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
 
         if ( ai.hasRepeatedVerts() )
         {
+            const int aTris = all.vert2firstRec[a+1] - all.vert2firstRec[a];
+            const int bTris = all.vert2firstRec[b+1] - all.vert2firstRec[b];
             // double ring is the case when every triangle around central vertex is present in both orientations,
             // so every neighbour vertex is repeated
-            const bool aDoubleRing = all.vert2firstRec[a+1] - all.vert2firstRec[a] == (int)ai.numRepeatedVerts();
-            const bool bDoubleRing = all.vert2firstRec[b+1] - all.vert2firstRec[b] == (int)bi.numRepeatedVerts();
+            const bool aDoubleRing = aTris == (int)ai.numRepeatedVerts();
+            const bool bDoubleRing = bTris == (int)bi.numRepeatedVerts();
             if ( aDoubleRing != bDoubleRing )
                 return aDoubleRing; // process double ring vertices ahead of others, since their duplication produces two closed chains
 

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -374,6 +374,29 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 1 8 4\n"
         "f 8 1 5\n", 24, 16, 2
     );
+
+    // a soup of mirrored and repeated triangles over 6 vertices mixing double ring and other repeated-vertex
+    // neighbourhoods; without double-ring-first processing it built 19 vertices in 5 components instead
+    testBuildWithDups
+    (
+        "v 0 0 0\n"
+        "v 1 0 0\n"
+        "v 0 1 0\n"
+        "v 0 0 1\n"
+        "v 1 1 0\n"
+        "v 1 0 1\n"
+        "f 3 5 6\n"
+        "f 1 4 5\n"
+        "f 6 2 4\n"
+        "f 2 6 4\n"
+        "f 3 5 1\n"
+        "f 6 5 4\n"
+        "f 6 1 4\n"
+        "f 1 3 5\n"
+        "f 1 6 4\n"
+        "f 6 4 5\n"
+        "f 2 5 6\n", 11, 18, 4
+    );
 }
 
 TEST( MRMesh, computeTrianglesRepetitions )


### PR DESCRIPTION
Refines the greedy processing order of `duplicateNonManifoldVertices`: among the vertices with repeated neighbours, "double ring" vertices — those where every incident triangle is present in both orientations, detected by triangle count equal to `numRepeatedVerts` — are processed ahead of others. Duplication of such a vertex cleanly produces two closed chains, and it lowers the repetition counts of the neighbours, so many of them resolve without their own duplication.

Measured on `StullerDragonTest1.ply` (303736 triangles, too large to commit as a test):
- before: 160022 vertices, 2281 connected components;
- after: 156178 vertices (3844 fewer duplicates), 361 components (-84%);
- all input triangles kept, load time unchanged.

Also adds a minimal order-sensitive regression case to `MeshBuildWithDups`: a soup of 11 mirrored/repeated triangles over 6 vertices that mixes double ring and other repeated-vertex neighbourhoods. Without this change it builds 19 vertices in 5 components; with it, 18 vertices in 4 components (verified failing on the previous code).

The comparator remains a strict total order (the double-ring flag is a deterministic property of each vertex, ties still broken by id), so `tbb::parallel_sort` stays deterministic regardless of the number of threads.
