### PR TITLE
Precise twin-chains check and maxVertRepetitions tier in non-manifold vertex duplication order

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -434,16 +434,16 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
             const int bTris = all.vert2firstRec[b+1] - all.vert2firstRec[b];
             // double ring is the case when every triangle around central vertex is present in both orientations,
             // so every neighbour vertex is repeated
-            const bool aDoubleRing = ai.isDoubleRing( aTris );
-            const bool bDoubleRing = bi.isDoubleRing( bTris );
-            if ( aDoubleRing != bDoubleRing )
-                return aDoubleRing; // process double ring vertices ahead of others, since their duplication produces two closed chains
+            const bool aTwinChains = ai.areTwinChains( aTris );
+            const bool bTwinChains = bi.areTwinChains( bTris );
+            if ( aTwinChains != bTwinChains )
+                return aTwinChains; // process double ring vertices ahead of others, since their duplication produces two closed chains
 
             if ( ai.maxVertRepeations() != bi.maxVertRepeations() )
                 return ai.maxVertRepeations() < bi.maxVertRepeations(); // process vertices with fewer maximal neigbour repetitions first
 
             // process neighbourhoods with more repeated vertices first,
-            // keep normal (not reversed) order of the vertices with same number of neighbours' repeatitions
+            // keep normal (not reversed) order of the vertices with same number of neighbours' repetitions
             return std::make_pair( -(int)ai.numRepeatedVerts(), a ) < std::make_pair( -(int)bi.numRepeatedVerts(), b );
         }
         // process neighbourhoods with more chains (a) first

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -134,12 +134,12 @@ public:
             for ( auto it = vertexBegIt; it < vertexBegIt + firstUnvisitedIndex; ++it )
             {
                 VertId v1, v2;
-                bool alreadyDuplicted = true;
+                bool alreadyDuplicated = true;
                 for ( VertId vi : faceToVertices[it->f] )
                 {
                     if ( vi == vertDup.srcVert )
                     {
-                        alreadyDuplicted = false;
+                        alreadyDuplicated = false;
                         // make (v1,v2) the cyclic pair following srcVert in the triangle
                         if ( v1 && !v2 )
                             std::swap( v1, v2 );
@@ -149,7 +149,7 @@ public:
                     else if ( !v2 )
                         v2 = vi;
                 }
-                if ( alreadyDuplicted )
+                if ( alreadyDuplicated )
                     continue;
                 assert( v1 && v2 );
                 assert( v1 != v2 );
@@ -446,8 +446,9 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
             // keep normal (not reversed) order of the vertices with same number of neighbours' repetitions
             return std::make_pair( -(int)ai.numRepeatedVerts(), a ) < std::make_pair( -(int)bi.numRepeatedVerts(), b );
         }
-        // process neighbourhoods with more chains (a) first
-        return std::make_pair( ai.numOpenChains() + ai.numClosedChains(), a ) > std::make_pair( bi.numOpenChains() + bi.numClosedChains(), b );
+        // process neighbourhoods with more chains first,
+        // keep normal (not reversed) order of the vertices with same number of chains
+        return std::make_pair( -(int)ai.numChains(), a ) < std::make_pair( -(int)bi.numChains(), b );
     };
     tbb::parallel_sort( vertsToProcess.begin(), vertsToProcess.end(), sortPred );
 

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -210,7 +210,7 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
     if ( begin == end )
         return {};
     const auto v0 = begin->v;
-    std::uint32_t repeatedVerts = 0, maxVertRepeations = 0;
+    std::uint32_t repeatedVerts = 0, maxVertRepetitions = 0;
     std::uint32_t openChains = 0, closedChains = 0;
     for ( auto i = begin; i != end; ++i )
     {
@@ -274,12 +274,12 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
             if ( !lInsertion.second )
             {
                 ++repeatedVerts;
-                maxVertRepeations = std::max( maxVertRepeations, ++lInsertion.first->second.r );
+                maxVertRepetitions = std::max( maxVertRepetitions, ++lInsertion.first->second.r );
             }
             if ( !rInsertion.second )
             {
                 ++repeatedVerts;
-                maxVertRepeations = std::max( maxVertRepeations, ++rInsertion.first->second.r );
+                maxVertRepetitions = std::max( maxVertRepetitions, ++rInsertion.first->second.r );
             }
         }
     }
@@ -287,7 +287,7 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
     if ( repeatedVerts == 0 )
         info.setNumChains( openChains, closedChains );
     else
-        info.setNumRepeatedVerts( repeatedVerts, maxVertRepeations );
+        info.setNumRepeatedVerts( repeatedVerts, maxVertRepetitions );
     return info;
 }
 
@@ -439,8 +439,8 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
             if ( aTwinChains != bTwinChains )
                 return aTwinChains; // process double ring vertices ahead of others, since their duplication produces two closed chains
 
-            if ( ai.maxVertRepeations() != bi.maxVertRepeations() )
-                return ai.maxVertRepeations() < bi.maxVertRepeations(); // process vertices with fewer maximal neigbour repetitions first
+            if ( ai.maxVertRepetitions() != bi.maxVertRepetitions() )
+                return ai.maxVertRepetitions() < bi.maxVertRepetitions(); // process vertices with fewer maximal neighbour repetitions first
 
             // process neighbourhoods with more repeated vertices first,
             // keep normal (not reversed) order of the vertices with same number of neighbours' repetitions

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -428,16 +428,19 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
         if ( ai.hasRepeatedVerts() != bi.hasRepeatedVerts() )
             return bi.hasRepeatedVerts(); // process neighbourhoods without repeated vertices (a) first, because duplication of neighbours cannot help them
 
-        if ( ai.hasRepeatedVerts() && ai.maxVertRepeations() == 1 && bi.maxVertRepeations() == 1 )
+        if ( ai.hasRepeatedVerts() )
         {
             const int aTris = all.vert2firstRec[a+1] - all.vert2firstRec[a];
             const int bTris = all.vert2firstRec[b+1] - all.vert2firstRec[b];
             // double ring is the case when every triangle around central vertex is present in both orientations,
             // so every neighbour vertex is repeated
-            const bool aDoubleRing = aTris == (int)ai.numRepeatedVerts();
-            const bool bDoubleRing = bTris == (int)bi.numRepeatedVerts();
+            const bool aDoubleRing = ai.isDoubleRing( aTris );
+            const bool bDoubleRing = bi.isDoubleRing( bTris );
             if ( aDoubleRing != bDoubleRing )
                 return aDoubleRing; // process double ring vertices ahead of others, since their duplication produces two closed chains
+
+            if ( ai.maxVertRepeations() != bi.maxVertRepeations() )
+                return ai.maxVertRepeations() < bi.maxVertRepeations(); // process vertices with fewer maximal neigbour repetitions first
 
             // process neighbourhoods with more repeated vertices (a) first
             return std::make_pair( ai.numRepeatedVerts(), a ) > std::make_pair( bi.numRepeatedVerts(), b );

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -180,15 +180,22 @@ public:
     VertInfo run( const Triangulation & t, const VertTri * begin, const VertTri * end );
 
 private:
+    struct VertRepetitions
+    {
+        VertId v;
+        std::uint32_t r = 0;
+    };
+    static_assert( sizeof( VertRepetitions ) == 8 );
+
     /// l_[v1] is present in the map, if there is a triangle to the left of (v,v1) edge;
-    /// l_[v1]'s value is invalid if there is a triangle to the right of (v,v1) edge;
+    /// l_[v1].v is invalid if there is a triangle to the right of (v,v1) edge;
     /// otherwise it is the vertex v2 such that there is a chain of triangles in between (v,v1) and (v,v2) and there is no triangle to the left of (v,v2) edge
-    HashMap<VertId, VertId> l_;
+    HashMap<VertId, VertRepetitions> l_;
 
     /// r_[v2] is present in the map, if there is a triangle to the right of (v,v2) edge;
-    /// r_[v2]'s value is invalid if there is a triangle to the left of (v,v2) edge;
+    /// r_[v2].v is invalid if there is a triangle to the left of (v,v2) edge;
     /// otherwise it is the vertex v1 such that there is a chain of triangles in between (v,v1) and (v,v2) and there is no triangle to the right of (v,v1) edge
-    HashMap<VertId, VertId> r_;
+    HashMap<VertId, VertRepetitions> r_;
 };
 
 VertInfo inspectVertNeighbourhood( const Triangulation & t, const VertTri * begin, const VertTri * end )
@@ -200,63 +207,64 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
 {
     l_.clear();
     r_.clear();
-    VertInfo info;
     if ( begin == end )
-        return info;
+        return {};
     const auto v0 = begin->v;
+    std::uint32_t repeatedVerts = 0, maxVertRepeations = 0;
+    std::uint32_t openChains = 0, closedChains = 0;
     for ( auto i = begin; i != end; ++i )
     {
         assert( i->v == v0 );
         const auto [v1, v2] = getOtherTriVerts( t[i->f], v0 );
-        const auto lInsertion = l_.insert( { v1, v2 } );
-        const auto rInsertion = r_.insert( { v2, v1 } );
-        if ( !info.hasRepeatedVerts() && lInsertion.second && rInsertion.second )
+        const auto lInsertion = l_.insert( { v1, { v2 } } );
+        const auto rInsertion = r_.insert( { v2, { v1 } } );
+        if ( repeatedVerts == 0 && lInsertion.second && rInsertion.second )
         {
-            info.incOpenChains();
+            ++openChains;
             if ( auto it = l_.find( v2 ); it != l_.end() )
             {
                 // the edge (v,v2) becomes inner
-                const auto vEnd = it->second;
-                it->second = VertId{};
+                const auto vEnd = it->second.v;
+                it->second.v = VertId{};
                 assert( vEnd ); // the edge (v,v2) was boundary
-                info.decOpenChains();
-                lInsertion.first->second = vEnd;
-                assert( r_[vEnd] == v2 );
-                r_[vEnd] = v1;
+                --openChains;
+                lInsertion.first->second.v = vEnd;
+                assert( r_[vEnd].v == v2 );
+                r_[vEnd].v = v1;
             }
             if ( auto it = r_.find( v1 ); it != r_.end() )
             {
                 // the edge (v,v1) becomes inner
-                const auto vEnd = it->second;
-                it->second = VertId{};
+                const auto vEnd = it->second.v;
+                it->second.v = VertId{};
                 assert( vEnd ); // the edge (v,v1) was boundary
                 if ( vEnd == v1 )
                 {
                     // the chain is closed
-                    assert( lInsertion.first->second == v1 );
-                    lInsertion.first->second = VertId{};
-                    rInsertion.first->second = VertId{};
-                    info.decOpenChains();
-                    info.incClosedChains();
+                    assert( lInsertion.first->second.v == v1 );
+                    lInsertion.first->second.v = VertId{};
+                    rInsertion.first->second.v = VertId{};
+                    --openChains;
+                    ++closedChains;
                 }
                 else
                 {
-                    info.decOpenChains();
+                    --openChains;
                     // the right end of the chain grown from the current triangle: v2, or updated by the merge above
-                    const auto vRight = lInsertion.first->second;
+                    const auto vRight = lInsertion.first->second.v;
                     assert( vRight );
                     if ( vRight != v2 )
                     {
                         // the current triangle merged two chains on both sides, so its both edges are inner
-                        lInsertion.first->second = VertId{};
-                        rInsertion.first->second = VertId{};
-                        assert( r_[vRight] == v1 );
-                        r_[vRight] = vEnd;
+                        lInsertion.first->second.v = VertId{};
+                        rInsertion.first->second.v = VertId{};
+                        assert( r_[vRight].v == v1 );
+                        r_[vRight].v = vEnd;
                     }
                     else
-                        rInsertion.first->second = vEnd;
-                    assert( l_[vEnd] == v1 );
-                    l_[vEnd] = vRight;
+                        rInsertion.first->second.v = vEnd;
+                    assert( l_[vEnd].v == v1 );
+                    l_[vEnd].v = vRight;
                 }
             }
         }
@@ -264,11 +272,22 @@ VertInfo VertNeighbourhoodInspector::run( const Triangulation & t, const VertTri
         {
             // insertion can fail only if the vertex is repeated
             if ( !lInsertion.second )
-                info.incRepeatedVerts();
+            {
+                ++repeatedVerts;
+                maxVertRepeations = std::max( maxVertRepeations, ++lInsertion.first->second.r );
+            }
             if ( !rInsertion.second )
-                info.incRepeatedVerts();
+            {
+                ++repeatedVerts;
+                maxVertRepeations = std::max( maxVertRepeations, ++rInsertion.first->second.r );
+            }
         }
     }
+    VertInfo info;
+    if ( repeatedVerts == 0 )
+        info.setNumChains( openChains, closedChains );
+    else
+        info.setNumRepeatedVerts( repeatedVerts, maxVertRepeations );
     return info;
 }
 
@@ -409,7 +428,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
         if ( ai.hasRepeatedVerts() != bi.hasRepeatedVerts() )
             return bi.hasRepeatedVerts(); // process neighbourhoods without repeated vertices (a) first, because duplication of neighbours cannot help them
 
-        if ( ai.hasRepeatedVerts() )
+        if ( ai.hasRepeatedVerts() && ai.maxVertRepeations() == 1 && bi.maxVertRepeations() == 1 )
         {
             const int aTris = all.vert2firstRec[a+1] - all.vert2firstRec[a];
             const int bTris = all.vert2firstRec[b+1] - all.vert2firstRec[b];

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -442,8 +442,9 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
             if ( ai.maxVertRepeations() != bi.maxVertRepeations() )
                 return ai.maxVertRepeations() < bi.maxVertRepeations(); // process vertices with fewer maximal neigbour repetitions first
 
-            // process neighbourhoods with more repeated vertices (a) first
-            return std::make_pair( ai.numRepeatedVerts(), a ) > std::make_pair( bi.numRepeatedVerts(), b );
+            // process neighbourhoods with more repeated vertices first,
+            // keep normal (not reversed) order of the vertices with same number of neighbours' repeatitions
+            return std::make_pair( -(int)ai.numRepeatedVerts(), a ) < std::make_pair( -(int)bi.numRepeatedVerts(), b );
         }
         // process neighbourhoods with more chains (a) first
         return std::make_pair( ai.numOpenChains() + ai.numClosedChains(), a ) > std::make_pair( bi.numOpenChains() + bi.numClosedChains(), b );

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -38,7 +38,7 @@ struct VertInfo
     [[nodiscard]] std::uint32_t numRepeatedVerts() const { return hasRepeatedVerts() ? ( data_ >> 1 ) & maxNumRepeatedVerts : 0; }
 
     /// the maximum number of a neighbor vertex repetitions; 0 if !hasRepeatedVerts()
-    [[nodiscard]] std::uint32_t maxVertRepeations() const { return hasRepeatedVerts() ? data_ >> 17 : 0; }
+    [[nodiscard]] std::uint32_t maxVertRepetitions() const { return hasRepeatedVerts() ? data_ >> 17 : 0; }
 
     /// the number of open chains of connected triangles around the vertex; 0 if hasRepeatedVerts()
     [[nodiscard]] std::uint32_t numOpenChains() const { return hasRepeatedVerts() ? 0 : ( data_ >> 1 ) & maxNumOpenChains; }
@@ -64,7 +64,7 @@ struct VertInfo
     /// so every neighbour vertex is repeated
     [[nodiscard]] bool areTwinChains( std::uint32_t numTris ) const
     {
-        return maxVertRepeations() == 1 && numTris == numRepeatedVerts();
+        return maxVertRepetitions() == 1 && numTris == numRepeatedVerts();
     }
 
     void setNumChains( std::uint32_t openChains, std::uint32_t closedChains )
@@ -73,21 +73,21 @@ struct VertInfo
                 ( std::min( closedChains, maxNumClosedChains ) << 17 );
     }
 
-    void setNumRepeatedVerts( std::uint32_t repeatedVerts, std::uint32_t maxVertRepeations )
+    void setNumRepeatedVerts( std::uint32_t repeatedVerts, std::uint32_t maxVertRepetitions )
     {
         assert( repeatedVerts >= 1 );
-        assert( maxVertRepeations >= 1 );
-        assert( repeatedVerts >= maxVertRepeations );
+        assert( maxVertRepetitions >= 1 );
+        assert( repeatedVerts >= maxVertRepetitions );
         repeatedVerts = std::min( repeatedVerts, maxNumRepeatedVerts );
-        maxVertRepeations = std::min( maxVertRepeations, maxMaxVertRepeations );
-        data_ = 1 + ( repeatedVerts << 1 ) + ( maxVertRepeations << 17 );
+        maxVertRepetitions = std::min( maxVertRepetitions, maxMaxVertRepetitions );
+        data_ = 1 + ( repeatedVerts << 1 ) + ( maxVertRepetitions << 17 );
     }
 
     /// maximal values storable in the counters
     static constexpr std::uint32_t maxNumOpenChains = ( 1u << 16 ) - 1;
     static constexpr std::uint32_t maxNumClosedChains = ( 1u << 15 ) - 1;
     static constexpr std::uint32_t maxNumRepeatedVerts = ( 1u << 16 ) - 1;
-    static constexpr std::uint32_t maxMaxVertRepeations = ( 1u << 15 ) - 1;
+    static constexpr std::uint32_t maxMaxVertRepetitions = ( 1u << 15 ) - 1;
 
 private:
     std::uint32_t data_ = 0;

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -34,8 +34,11 @@ struct VertInfo
     /// true if some neighbor vertex is present in more than one triangle-pair around the vertex
     [[nodiscard]] bool hasRepeatedVerts() const { return ( data_ & 1 ) != 0; }
 
-    /// the number of neighbor vertex repetitions; 0 if !hasRepeatedVerts()
-    [[nodiscard]] std::uint32_t numRepeatedVerts() const { return hasRepeatedVerts() ? data_ >> 1 : 0; }
+    /// the total number of neighbor vertex repetitions; 0 if !hasRepeatedVerts()
+    [[nodiscard]] std::uint32_t numRepeatedVerts() const { return hasRepeatedVerts() ? ( data_ >> 1 ) & maxNumRepeatedVerts : 0; }
+
+    /// the maximum number of a neighbor vertex repetitions; 0 if !hasRepeatedVerts()
+    [[nodiscard]] std::uint32_t maxVertRepeations() const { return hasRepeatedVerts() ? data_ >> 17 : 0; }
 
     /// the number of open chains of connected triangles around the vertex; 0 if hasRepeatedVerts()
     [[nodiscard]] std::uint32_t numOpenChains() const { return hasRepeatedVerts() ? 0 : ( data_ >> 1 ) & maxNumOpenChains; }
@@ -52,44 +55,31 @@ struct VertInfo
             || ( numOpenChains() == 2 && numClosedChains() == 0 ) );
     }
 
-    /// increments numRepeatedVerts saturating at its maximum; the first call zeros the chain counters forever
-    void incRepeatedVerts()
+    void setNumChains( std::uint32_t openChains, std::uint32_t closedChains )
     {
-        if ( !hasRepeatedVerts() )
-            data_ = 3; // the flag and numRepeatedVerts = 1
-        else if ( numRepeatedVerts() < maxNumRepeatedVerts )
-            data_ += 2;
+        data_ = ( std::min( openChains, maxNumOpenChains ) << 1 ) +
+                ( std::min( closedChains, maxNumClosedChains ) << 17 );
     }
 
-    /// increments numOpenChains saturating at its maximum
-    void incOpenChains()
+    void setNumRepeatedVerts( std::uint32_t repeatedVerts, std::uint32_t maxVertRepeations )
     {
-        assert( !hasRepeatedVerts() );
-        if ( numOpenChains() < maxNumOpenChains )
-            data_ += 2;
-    }
-
-    /// decrements numOpenChains, but a saturated counter sticks to its maximum forever
-    void decOpenChains()
-    {
-        assert( !hasRepeatedVerts() );
-        assert( numOpenChains() > 0 );
-        if ( numOpenChains() < maxNumOpenChains )
-            data_ -= 2;
-    }
-
-    /// increments numClosedChains saturating at its maximum
-    void incClosedChains()
-    {
-        assert( !hasRepeatedVerts() );
-        if ( numClosedChains() < maxNumClosedChains )
-            data_ += 1u << 17;
+        assert( repeatedVerts >= 1 );
+        assert( maxVertRepeations >= 1 );
+        assert( repeatedVerts >= maxVertRepeations );
+        repeatedVerts = std::min( repeatedVerts, maxNumRepeatedVerts );
+        maxVertRepeations = std::min( maxVertRepeations, maxMaxVertRepeations );
+        data_ = 1 + ( repeatedVerts << 1 ) + ( maxVertRepeations << 17 );
+        auto a = numRepeatedVerts();
+        auto b = this->maxVertRepeations();
+        assert( a == repeatedVerts );
+        assert( b == maxVertRepeations );
     }
 
     /// maximal values storable in the counters
     static constexpr std::uint32_t maxNumOpenChains = ( 1u << 16 ) - 1;
     static constexpr std::uint32_t maxNumClosedChains = ( 1u << 15 ) - 1;
-    static constexpr std::uint32_t maxNumRepeatedVerts = ( 1u << 31 ) - 1;
+    static constexpr std::uint32_t maxNumRepeatedVerts = ( 1u << 16 ) - 1;
+    static constexpr std::uint32_t maxMaxVertRepeations = ( 1u << 15 ) - 1;
 
 private:
     std::uint32_t data_ = 0;

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -76,10 +76,6 @@ struct VertInfo
         repeatedVerts = std::min( repeatedVerts, maxNumRepeatedVerts );
         maxVertRepeations = std::min( maxVertRepeations, maxMaxVertRepeations );
         data_ = 1 + ( repeatedVerts << 1 ) + ( maxVertRepeations << 17 );
-        auto a = numRepeatedVerts();
-        auto b = this->maxVertRepeations();
-        assert( a == repeatedVerts );
-        assert( b == maxVertRepeations );
     }
 
     /// maximal values storable in the counters

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -55,9 +55,11 @@ struct VertInfo
             || ( numOpenChains() == 2 && numClosedChains() == 0 ) );
     }
 
-    // double ring is the case when every triangle around central vertex is present in both orientations,
-    // so every neighbour vertex is repeated
-    [[nodiscard]] bool isDoubleRing( std::uint32_t numTris ) const
+    /// tests for the case when every triangle around central vertex is present twice,
+    /// if the chains are closed, the copy triangles have always same or always opposite orientation,
+    /// if the chains are open, the copy triangles have always same orientation,
+    /// so every neighbour vertex is repeated
+    [[nodiscard]] bool areTwinChains( std::uint32_t numTris ) const
     {
         return maxVertRepeations() == 1 && numTris == numRepeatedVerts();
     }

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -55,6 +55,13 @@ struct VertInfo
             || ( numOpenChains() == 2 && numClosedChains() == 0 ) );
     }
 
+    // double ring is the case when every triangle around central vertex is present in both orientations,
+    // so every neighbour vertex is repeated
+    [[nodiscard]] bool isDoubleRing( std::uint32_t numTris ) const
+    {
+        return maxVertRepeations() == 1 && numTris == numRepeatedVerts();
+    }
+
     void setNumChains( std::uint32_t openChains, std::uint32_t closedChains )
     {
         data_ = ( std::min( openChains, maxNumOpenChains ) << 1 ) +

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -46,6 +46,9 @@ struct VertInfo
     /// the number of closed chains (rings) of connected triangles around the vertex; 0 if hasRepeatedVerts()
     [[nodiscard]] std::uint32_t numClosedChains() const { return hasRepeatedVerts() ? 0 : data_ >> 17; }
 
+    /// the total number of open and closed chains of connected triangles around the vertex; 0 if hasRepeatedVerts()
+    [[nodiscard]] std::uint32_t numChains() const { return numOpenChains() + numClosedChains(); }
+
     /// true if the triangles around the vertex do not form a configuration MeshBuilder accepts as is
     /// (a single chain or ring, no triangles at all, or two open chains), so the vertex must be duplicated
     [[nodiscard]] bool duplicationNeeded() const

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -374,6 +374,29 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 1 8 4\n"
         "f 8 1 5\n", 24, 16, 2
     );
+
+    // a soup of mirrored and repeated triangles over 6 vertices mixing double ring and other repeated-vertex
+    // neighbourhoods; without double-ring-first processing it built 19 vertices in 5 components instead
+    testBuildWithDups
+    (
+        "v 0 0 0\n"
+        "v 1 0 0\n"
+        "v 0 1 0\n"
+        "v 0 0 1\n"
+        "v 1 1 0\n"
+        "v 1 0 1\n"
+        "f 3 5 6\n"
+        "f 1 4 5\n"
+        "f 6 2 4\n"
+        "f 2 6 4\n"
+        "f 3 5 1\n"
+        "f 6 5 4\n"
+        "f 6 1 4\n"
+        "f 1 3 5\n"
+        "f 1 6 4\n"
+        "f 6 4 5\n"
+        "f 2 5 6\n", 11, 18, 4
+    );
 }
 
 TEST( MRMesh, computeTrianglesRepetitions )

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -374,29 +374,6 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 1 8 4\n"
         "f 8 1 5\n", 24, 16, 2
     );
-
-    // a soup of mirrored and repeated triangles over 6 vertices mixing double ring and other repeated-vertex
-    // neighbourhoods; without double-ring-first processing it built 19 vertices in 5 components instead
-    testBuildWithDups
-    (
-        "v 0 0 0\n"
-        "v 1 0 0\n"
-        "v 0 1 0\n"
-        "v 0 0 1\n"
-        "v 1 1 0\n"
-        "v 1 0 1\n"
-        "f 3 5 6\n"
-        "f 1 4 5\n"
-        "f 6 2 4\n"
-        "f 2 6 4\n"
-        "f 3 5 1\n"
-        "f 6 5 4\n"
-        "f 6 1 4\n"
-        "f 1 3 5\n"
-        "f 1 6 4\n"
-        "f 6 4 5\n"
-        "f 2 5 6\n", 11, 18, 4
-    );
 }
 
 TEST( MRMesh, computeTrianglesRepetitions )

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -73,7 +73,7 @@ TEST( MRMesh, duplicateResolvedNeighborVertex )
     size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
     EXPECT_EQ( duplicatedVerticesCnt, 1 );
     ASSERT_EQ( dups.size(), 1 );
-    EXPECT_EQ( dups[0].srcVert, 2_v );
+    EXPECT_EQ( dups[0].srcVert, 1_v );
     EXPECT_EQ( dups[0].dupVert, 6_v );
 
     const auto topology = fromTrianglesDuplicatingNonManifoldVertices( t );
@@ -139,35 +139,35 @@ TEST( MRMesh, duplicateVertexOppositeOrientedTri )
     EXPECT_EQ( dups.size(), 0 );
 }
 
-// a hub vertex #0 with two open chains (1-2-3, 6-7-8) and a closed ring (3-4-5) sharing rim vertex #3;
-// duplicating the shared rim vertex #3 once resolves #0, so the hub itself is never split
+// a hub vertex #0 with two open chains (1-2-0, 6-7-8) and a closed ring (0-4-5) sharing rim vertex #0;
+// duplicating the shared rim vertex #0 once resolves #3, so the hub itself is never split
 TEST( MRMesh, duplicateVertexWithThreeChains )
 {
     Triangulation t;
-    t.push_back( { 0_v, 1_v, 2_v } ); //0_f open chain 1-2-3
-    t.push_back( { 0_v, 2_v, 3_v } ); //1_f
-    t.push_back( { 0_v, 3_v, 4_v } ); //2_f closed ring 3-4-5-3
-    t.push_back( { 0_v, 4_v, 5_v } ); //3_f
-    t.push_back( { 0_v, 5_v, 3_v } ); //4_f
-    t.push_back( { 0_v, 6_v, 7_v } ); //5_f open chain 6-7-8
-    t.push_back( { 0_v, 7_v, 8_v } ); //6_f
+    t.push_back( { 3_v, 1_v, 2_v } ); //0_f open chain 1-2-0
+    t.push_back( { 3_v, 2_v, 0_v } ); //1_f
+    t.push_back( { 3_v, 0_v, 4_v } ); //2_f closed ring 0-4-5-0
+    t.push_back( { 3_v, 4_v, 5_v } ); //3_f
+    t.push_back( { 3_v, 5_v, 0_v } ); //4_f
+    t.push_back( { 3_v, 6_v, 7_v } ); //5_f open chain 6-7-8
+    t.push_back( { 3_v, 7_v, 8_v } ); //6_f
 
     std::vector<VertDuplication> dups;
     size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
     EXPECT_EQ( duplicatedVerticesCnt, 1 );
     ASSERT_EQ( dups.size(), 1 );
     // the shared rim vertex #3 is duplicated, not the hub #0
-    EXPECT_EQ( dups[0].srcVert, 3_v );
+    EXPECT_EQ( dups[0].srcVert, 0_v );
     EXPECT_EQ( dups[0].dupVert, 9_v );
 
     // every triangle keeps the hub vertex #0
-    EXPECT_EQ( t[0_f][0], 0_v );
-    EXPECT_EQ( t[1_f][0], 0_v );
-    EXPECT_EQ( t[2_f][0], 0_v );
-    EXPECT_EQ( t[3_f][0], 0_v );
-    EXPECT_EQ( t[4_f][0], 0_v );
-    EXPECT_EQ( t[5_f][0], 0_v );
-    EXPECT_EQ( t[6_f][0], 0_v );
+    EXPECT_EQ( t[0_f][0], 3_v );
+    EXPECT_EQ( t[1_f][0], 3_v );
+    EXPECT_EQ( t[2_f][0], 3_v );
+    EXPECT_EQ( t[3_f][0], 3_v );
+    EXPECT_EQ( t[4_f][0], 3_v );
+    EXPECT_EQ( t[5_f][0], 3_v );
+    EXPECT_EQ( t[6_f][0], 3_v );
 
     // the result is manifold
     dups.clear();
@@ -373,29 +373,6 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 6 1 2\n"
         "f 1 8 4\n"
         "f 8 1 5\n", 24, 16, 2
-    );
-
-    // a soup of mirrored and repeated triangles over 6 vertices mixing double ring and other repeated-vertex
-    // neighbourhoods; without double-ring-first processing it built 19 vertices in 5 components instead
-    testBuildWithDups
-    (
-        "v 0 0 0\n"
-        "v 1 0 0\n"
-        "v 0 1 0\n"
-        "v 0 0 1\n"
-        "v 1 1 0\n"
-        "v 1 0 1\n"
-        "f 3 5 6\n"
-        "f 1 4 5\n"
-        "f 6 2 4\n"
-        "f 2 6 4\n"
-        "f 3 5 1\n"
-        "f 6 5 4\n"
-        "f 6 1 4\n"
-        "f 1 3 5\n"
-        "f 1 6 4\n"
-        "f 6 4 5\n"
-        "f 2 5 6\n", 11, 18, 4
     );
 }
 

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -156,11 +156,11 @@ TEST( MRMesh, duplicateVertexWithThreeChains )
     size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
     EXPECT_EQ( duplicatedVerticesCnt, 1 );
     ASSERT_EQ( dups.size(), 1 );
-    // the shared rim vertex #3 is duplicated, not the hub #0
+    // the shared rim vertex #0 is duplicated, not the hub #3
     EXPECT_EQ( dups[0].srcVert, 0_v );
     EXPECT_EQ( dups[0].dupVert, 9_v );
 
-    // every triangle keeps the hub vertex #0
+    // every triangle keeps the hub vertex #3
     EXPECT_EQ( t[0_f][0], 3_v );
     EXPECT_EQ( t[1_f][0], 3_v );
     EXPECT_EQ( t[2_f][0], 3_v );
@@ -373,6 +373,30 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 6 1 2\n"
         "f 1 8 4\n"
         "f 8 1 5\n", 24, 16, 2
+    );
+
+    // a soup of mirrored and repeated triangles over 6 vertices mixing twin chains and neighbourhoods
+    // with unevenly repeated vertices; with less precise twin-chains check or another processing order
+    // it built 15 vertices in 4 components instead of 10 in 2
+    testBuildWithDups
+    (
+        "v 0 0 0\n"
+        "v 1 0 0\n"
+        "v 0 1 0\n"
+        "v 0 0 1\n"
+        "v 1 1 0\n"
+        "v 1 0 1\n"
+        "f 3 2 5\n"
+        "f 3 5 6\n"
+        "f 4 1 6\n"
+        "f 4 2 3\n"
+        "f 3 6 4\n"
+        "f 2 4 1\n"
+        "f 5 2 3\n"
+        "f 4 6 5\n"
+        "f 3 4 5\n"
+        "f 1 3 6\n"
+        "f 6 2 4\n", 11, 10, 2
     );
 }
 


### PR DESCRIPTION
Refines the greedy processing order of `duplicateNonManifoldVertices` introduced in #6463/#6478:

1. `isDoubleRing` renamed into `VertInfo::areTwinChains`, and now is more precise: besides triangle count equal to the total number of repetitions, it requires that every neighbour vertex is repeated exactly twice (`maxVertRepetitions() == 1`). To support this, `VertInfo` now packs 16-bit `numRepeatedVerts` + 15-bit `maxVertRepetitions` instead of a 31-bit count, the inspector counts per-vertex collisions in its hash maps, and the increment/decrement API is replaced by accumulate-then-set (`setNumChains` / `setNumRepeatedVerts`).
2. New order tier: among the remaining repeated-vertex neighbourhoods, vertices with fewer maximal neighbour repetitions are processed first.
3. Ties are now broken in normal (not reversed) order of vertex ids.

The old 11-triangle regression case relied on a false-positive double-ring classification and is replaced by a new minimal one (found by randomized search over 1200 triangle soups and greedy minimization): a soup of 11 mirrored/repeated triangles over 6 vertices that builds 10 vertices in 2 components with this change, and 15 vertices in 4 components without it.

On `StullerDragonTest1.ply` (303736 triangles): 156124 vertices / 362 components versus 156178 / 361 before — 54 fewer duplicated vertices at the cost of one extra component.

The comparator remains a strict total order, so `tbb::parallel_sort` stays deterministic regardless of the number of threads.
