### PR TITLE
Fix binary stl loading race

### DIFF
--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -181,6 +181,8 @@ Expected<TriMesh> loadBinaryStlAsTriMesh( std::istream& in, const MeshLoadSettin
 
     while ( !buffer.empty() )
     {
+        auto preNumTris = vi.numTris();
+
         // decode previously read buffer in a worked thread
         tbb::task_group taskGroup;
         taskGroup.run( [&chunk, &vi, &buffer] ()
@@ -192,9 +194,9 @@ Expected<TriMesh> loadBinaryStlAsTriMesh( std::istream& in, const MeshLoadSettin
             vi.addTriangles( chunk );
         } );
 
-        if ( vi.numTris() + buffer.size() < numTris )
+        if ( preNumTris + buffer.size() < numTris )
         {
-            const auto itemsInNextChuck = std::min( numTris - (std::uint32_t)( vi.numTris() + buffer.size() ), itemsInBuffer );
+            const auto itemsInNextChuck = std::min( numTris - (std::uint32_t)( preNumTris + buffer.size() ), itemsInBuffer );
             nextBuffer.resize( itemsInNextChuck );
             const size_t size = sizeof( StlTriangle ) * nextBuffer.size();
             // read from stream in the current thread to be compatible with PythonIstreamBuf

--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -181,7 +181,7 @@ Expected<TriMesh> loadBinaryStlAsTriMesh( std::istream& in, const MeshLoadSettin
 
     while ( !buffer.empty() )
     {
-        auto preNumTris = vi.numTris();
+        auto preNumTris = vi.numTris(); // must be read before the task below starts adding more triangles in (vi)
 
         // decode previously read buffer in a worked thread
         tbb::task_group taskGroup;


### PR DESCRIPTION
`loadBinaryStlAsTriMesh` double-buffers the input: a TBB task decodes the current `buffer` and calls `vi.addTriangles()` while the main thread reads the next chunk from the stream. The main thread computed the number of remaining triangles from `vi.numTris()`, which the worker task concurrently increments (`numTris()` returns `t_.size()`, and the task is pushing into `t_`).

Besides being a data race on the vector, it had a concrete consequence: if the task finished decoding before the main thread evaluated the condition, `vi.numTris() + buffer.size()` counted the current chunk twice. The loop then treated the file as fully consumed one iteration early and cleared `nextBuffer`, silently dropping up to 32768 trailing triangles from the loaded mesh.

The fix reads `vi.numTris()` into `preNumTris` before spawning the task. At that point the previous iteration's `taskGroup.wait()` guarantees the value is stable and equals the count of all previously decoded chunks, so `preNumTris + buffer.size()` is exactly the number of triangles consumed from the stream after the current chunk.
