### PR TITLE
Never continue a chain into the previous vertex or its duplicate, and try to duplicate all initially non-manifold vertices

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -56,7 +56,7 @@ public:
         return getOtherTriVerts( vs, first->v );
     }
 
-    // find incident unvisited vertex, in case of several option prefer finding the vertex not equal to preVertex
+    // find incident unvisited vertex except for prevVertex and its duplicates
     VertId getNextVertex( VertId center, bool triOrientation, VertId prevVertex, const std::vector<VertDuplication>& dups )
     {
         if ( empty() )
@@ -81,8 +81,6 @@ public:
         prevVertex = getOrgVertex( prevVertex );
         assert( prevVertex );
 
-        VertId prevOrPrevDup;
-        auto prevIt = vertexEndIt;
         for ( auto it = vertexBegIt + firstUnvisitedIndex; it < vertexEndIt; ++it )
         {
             VertId nextVertex;
@@ -92,28 +90,13 @@ public:
                 nextVertex = v12.second;
             else if ( !triOrientation && v12.second == center )
                 nextVertex = v12.first;
-            if ( nextVertex )
+            if ( nextVertex && getOrgVertex( nextVertex ) != prevVertex )
             {
-                if ( getOrgVertex( nextVertex ) != prevVertex )
-                {
-                    if ( it != vertexBegIt + firstUnvisitedIndex )
-                        std::iter_swap( it, vertexBegIt + firstUnvisitedIndex );
-                    ++firstUnvisitedIndex;
-                    return nextVertex;
-                }
-                // prevVertex (or its duplicate) is a possible continuation, store it, and search for other options
-                prevIt = it;
-                prevOrPrevDup = nextVertex;
+                if ( it != vertexBegIt + firstUnvisitedIndex )
+                    std::iter_swap( it, vertexBegIt + firstUnvisitedIndex );
+                ++firstUnvisitedIndex;
+                return nextVertex;
             }
-        }
-        if ( prevIt < vertexEndIt )
-        {
-            // the only option is return in prevVertex (or its duplicate)
-            if ( prevIt != vertexBegIt + firstUnvisitedIndex )
-                std::iter_swap( prevIt, vertexBegIt + firstUnvisitedIndex );
-            ++firstUnvisitedIndex;
-            assert( prevOrPrevDup );
-            return prevOrPrevDup;
         }
         return {};
     }
@@ -452,7 +435,6 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     };
     tbb::parallel_sort( vertsToProcess.begin(), vertsToProcess.end(), sortPred );
 
-    VertNeighbourhoodInspector inspector;
     std::vector<VertId> path;
     std::vector<VertId> closedPath;
     VertBitSet visitedVertices( all.recs.back().v ); // explicitly not `lastValidVert` but last vert used in triangulation
@@ -461,10 +443,11 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     {
         const auto posBegin = all.vert2firstRec[v];
         const auto posEnd = all.vert2firstRec[v + 1];
-        // duplication of one vertex can resolve non-manifoldness in its neighbor vertex,
-        // so after the first duplication recheck the neighborhood in the current triangulation
-        if ( duplicatedVerticesCnt > 0 && !inspector.run( t, all.recs.data() + posBegin, all.recs.data() + posEnd ).duplicationNeeded() )
-            continue;
+
+        // do not call inspector.run( t, all.recs.data() + posBegin, all.recs.data() + posEnd ).duplicationNeeded() to skip duplication,
+        // because formal non-manifoldness of this vertex can be resolved by a neighbour vertex duplication,
+        // but we still want to dupliate it to avoid neighbours with equal coordinates
+
         PathAroundVertex pathMaker( t, all.recs, posBegin, posEnd );
 
         // first chain of vertices around the center does not require duplication
@@ -502,6 +485,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                         prevVertex = path[1];
                         std::reverse( path.begin(), path.end() );
                         nextVertex = pathMaker.getNextVertex( firstVertex, triOrientation, prevVertex, myDups );
+                        prevVertex = firstVertex;
                     }
                     if ( !nextVertex )
                     {

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -59,25 +59,30 @@ TEST( MRMesh, duplicateDoubleHoleVertex )
     EXPECT_EQ( topology.numValidFaces(), 2 );
 }
 
-// duplication of one vertex can resolve non-manifoldness in its neighbor vertex, which shall not be duplicated then
-TEST( MRMesh, duplicateResolvedNeighborVertex )
+// the vertices of an edge shared by three triangles are both duplicated, fully detaching the third triangle
+TEST( MRMesh, duplicateTripleEdgeVertices )
 {
     Triangulation t;
     t.push_back( { 1_v, 2_v, 3_v } ); //0_f
     t.push_back( { 2_v, 1_v, 4_v } ); //1_f
     t.push_back( { 1_v, 2_v, 5_v } ); //2_f
-    // the edge (1,2) is shared by three triangles, so both vertices 1 and 2 have repeated neighbor vertices;
-    // duplication of vertex 2 in one of the triangles resolves vertex 1 into two open chains requiring nothing
+    // duplication of vertex 1 formally resolves vertex 2 into two open chains,
+    // but vertex 2 is still duplicated to avoid two neighbor vertices with equal coordinates
 
     std::vector<VertDuplication> dups;
     size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
-    EXPECT_EQ( duplicatedVerticesCnt, 1 );
-    ASSERT_EQ( dups.size(), 1 );
+    EXPECT_EQ( duplicatedVerticesCnt, 2 );
+    ASSERT_EQ( dups.size(), 2 );
     EXPECT_EQ( dups[0].srcVert, 1_v );
     EXPECT_EQ( dups[0].dupVert, 6_v );
+    EXPECT_EQ( dups[1].srcVert, 2_v );
+    EXPECT_EQ( dups[1].dupVert, 7_v );
+
+    // the last triangle is fully detached from the first two
+    EXPECT_EQ( t[2_f], ( ThreeVertIds{ 6_v, 7_v, 5_v } ) );
 
     const auto topology = fromTrianglesDuplicatingNonManifoldVertices( t );
-    EXPECT_EQ( topology.numValidVerts(), 6 );
+    EXPECT_EQ( topology.numValidVerts(), 7 );
     EXPECT_EQ( topology.numValidFaces(), 3 );
 }
 
@@ -111,7 +116,7 @@ TEST( MRMesh, duplicateClosedPlusOpenChainVertex )
 }
 
 // a closed ring around #0 plus one opposite-orientation triangle sharing the ring's rim pair (2,3):
-// the duplicated chain must take its own triangle 4_f, not the ring's 1_f with the same rim vertices
+// the lone triangle 4_f is fully detached: all its three vertices are duplicated
 TEST( MRMesh, duplicateVertexOppositeOrientedTri )
 {
     Triangulation t;
@@ -123,15 +128,19 @@ TEST( MRMesh, duplicateVertexOppositeOrientedTri )
 
     std::vector<VertDuplication> dups;
     size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
-    EXPECT_EQ( duplicatedVerticesCnt, 1 );
-    ASSERT_EQ( dups.size(), 1 );
+    EXPECT_EQ( duplicatedVerticesCnt, 3 );
+    ASSERT_EQ( dups.size(), 3 );
     EXPECT_EQ( dups[0].srcVert, 0_v );
     EXPECT_EQ( dups[0].dupVert, 5_v );
+    EXPECT_EQ( dups[1].srcVert, 2_v );
+    EXPECT_EQ( dups[1].dupVert, 6_v );
+    EXPECT_EQ( dups[2].srcVert, 3_v );
+    EXPECT_EQ( dups[2].dupVert, 7_v );
 
-    // the ring is intact and only the lone triangle got the duplicate
+    // the ring is intact and the lone triangle is fully detached
     for ( FaceId i{ 0 }; i < 4; ++i )
         EXPECT_EQ( t[i][0], 0_v );
-    EXPECT_EQ( t[4_f][0], 5_v );
+    EXPECT_EQ( t[4_f], ( ThreeVertIds{ 5_v, 7_v, 6_v } ) );
 
     // the result is manifold
     dups.clear();
@@ -139,8 +148,9 @@ TEST( MRMesh, duplicateVertexOppositeOrientedTri )
     EXPECT_EQ( dups.size(), 0 );
 }
 
-// a hub vertex #0 with two open chains (1-2-0, 6-7-8) and a closed ring (0-4-5) sharing rim vertex #0;
-// duplicating the shared rim vertex #0 once resolves #3, so the hub itself is never split
+// a hub vertex #3 with two open chains (1-2-0, 6-7-8) and a closed ring (0-4-5) sharing rim vertex #0;
+// duplicating #0 opens the ring into one long chain around the hub,
+// and the chain 6-7-8 is split off with its own duplicate of the hub
 TEST( MRMesh, duplicateVertexWithThreeChains )
 {
     Triangulation t;
@@ -154,20 +164,21 @@ TEST( MRMesh, duplicateVertexWithThreeChains )
 
     std::vector<VertDuplication> dups;
     size_t duplicatedVerticesCnt = duplicateNonManifoldVertices( t, nullptr, &dups );
-    EXPECT_EQ( duplicatedVerticesCnt, 1 );
-    ASSERT_EQ( dups.size(), 1 );
-    // the shared rim vertex #0 is duplicated, not the hub #3
+    EXPECT_EQ( duplicatedVerticesCnt, 2 );
+    ASSERT_EQ( dups.size(), 2 );
     EXPECT_EQ( dups[0].srcVert, 0_v );
     EXPECT_EQ( dups[0].dupVert, 9_v );
+    EXPECT_EQ( dups[1].srcVert, 3_v );
+    EXPECT_EQ( dups[1].dupVert, 10_v );
 
-    // every triangle keeps the hub vertex #3
+    // the first chain and the opened ring keep the hub vertex #3, the second chain gets its duplicate #10
     EXPECT_EQ( t[0_f][0], 3_v );
     EXPECT_EQ( t[1_f][0], 3_v );
     EXPECT_EQ( t[2_f][0], 3_v );
     EXPECT_EQ( t[3_f][0], 3_v );
-    EXPECT_EQ( t[4_f][0], 3_v );
-    EXPECT_EQ( t[5_f][0], 3_v );
-    EXPECT_EQ( t[6_f][0], 3_v );
+    EXPECT_EQ( t[4_f], ( ThreeVertIds{ 3_v, 5_v, 9_v } ) );
+    EXPECT_EQ( t[5_f][0], 10_v );
+    EXPECT_EQ( t[6_f][0], 10_v );
 
     // the result is manifold
     dups.clear();
@@ -278,7 +289,7 @@ TEST( MRMesh, MeshBuildWithDups )
     // first 4 triangles subdivide a square with center point,
     // following 4 triangles subdivide the opposite side of same triangle,
     // all 5 points are shared,
-    // expected that only center vetrex is duplicated and single connected component remains
+    // the two identical oppositely oriented sides are fully separated in two components
     testBuildWithDups
     (
         "v 0 0.5 0\n"
@@ -293,7 +304,7 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 3 5 1\n"
         "f 2 1 3\n"
         "f 3 1 5\n"
-        "f 1 4 5\n", 8, 6, 1
+        "f 1 4 5\n", 8, 10, 2
     );
 
     // same situation as above with the order of triangles changed
@@ -311,13 +322,13 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 1 4 2\n"
         "f 2 3 1\n"
         "f 1 5 4\n"
-        "f 3 5 1\n", 8, 6, 1
+        "f 3 5 1\n", 8, 10, 2
     );
 
     // first 4 triangles subdivide a square with center point,
     // following 4 triangles subdivide same square with center point,
     // 3 points on one diagonal are shared,
-    // it is divided properly on two components if the rings are computed from the smallest by id next triangle
+    // the two squares are fully separated in two components
     testBuildWithDups
     (
         "v -1 0 -1\n"
@@ -334,7 +345,7 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 5 7 2\n"
         "f 7 3 6\n"
         "f 2 7 6\n"
-        "f 7 5 3\n", 8, 8, 2
+        "f 7 5 3\n", 8, 10, 2
     );
 
     // two cubes with mirrored triangulations sharing all 8 vertices;
@@ -376,8 +387,7 @@ TEST( MRMesh, MeshBuildWithDups )
     );
 
     // a soup of mirrored and repeated triangles over 6 vertices mixing twin chains and neighbourhoods
-    // with unevenly repeated vertices; with less precise twin-chains check or another processing order
-    // it built 15 vertices in 4 components instead of 10 in 2
+    // with unevenly repeated vertices, sensitive to the processing order and chain construction rules
     testBuildWithDups
     (
         "v 0 0 0\n"
@@ -396,7 +406,7 @@ TEST( MRMesh, MeshBuildWithDups )
         "f 4 6 5\n"
         "f 3 4 5\n"
         "f 1 3 6\n"
-        "f 6 2 4\n", 11, 10, 2
+        "f 6 2 4\n", 11, 13, 2
     );
 }
 


### PR DESCRIPTION
1) Do not make chains containing a vertex and its duplicate: the "only option is return into prevVertex (or its duplicate)" fallback in `getNextVertex` is removed, so such continuations never happen and the walk prefers duplicating the vertex, separating the triangles on two one-triangle chains. This stops merging the boundaries of two identical but oppositely oriented open components: they are now fully separated (e.g. two oppositely oriented copies of a subdivided square sharing all 5 points now build 10 vertices in 2 components instead of 6 in 1).

2) The recheck that skipped a vertex whose non-manifoldness was formally resolved by a neighbour's duplication is removed: duplication is now attempted for every initially non-manifold vertex, to avoid neighbouring vertices with equal coordinates in the result (if `PathAroundVertex` finds only one chain, the vertex is still not duplicated). A vertex of an edge shared by three triangles is duplicated even after its neighbour's duplication detached the extra triangle, and the lone opposite-orientation triangle over a ring's rim pair is now fully detached with all three of its vertices duplicated.

3) Fix the stale `prevVertex` after the direction flip at a dead end: it is now set to `firstVertex`, from which the search actually continued.

Unit tests are updated to the new outcomes (every result verified manifold, second `duplicateNonManifoldVertices` pass returns 0); `duplicateResolvedNeighborVertex` is renamed into `duplicateTripleEdgeVertices` since its premise (the resolved neighbour shall not be duplicated) is exactly what this change removes.

On `StullerDragonTest1.ply` (303736 triangles): 156466 vertices / 361 components versus 156124 / 362 before — one component fewer at the cost of 342 more duplicated vertices from the no-skip policy. The two-mirrored-cubes case is unchanged (16 vertices, 2 components).
