### PR TITLE
splitProgress splits a progress in consistent adjacent sub-progresses

### DIFF
--- a/source/MRMesh/MRMeshBoolean.cpp
+++ b/source/MRMesh/MRMeshBoolean.cpp
@@ -408,7 +408,7 @@ BooleanResult booleanImpl( Mesh&& meshA, Mesh&& meshB, BooleanOperation operatio
 
     converters = getVectorConverters( meshA, meshB, params.rigidB2A );
 
-    auto loneCb = subprogress( params.cb, 0.0f, 0.8f );
+    auto [loneCb, mainCb] = splitProgress( params.cb, 0.8f );
 
     FaceHashMap new2orgSubdivideMapA;
     FaceHashMap new2orgSubdivideMapB;
@@ -481,8 +481,6 @@ BooleanResult booleanImpl( Mesh&& meshA, Mesh&& meshB, BooleanOperation operatio
     // clear intersections
     intersections = {};
 
-
-    auto mainCb = subprogress( params.cb, 0.8f, 1.0f );
     if ( mainCb && !mainCb( 0.0f ) )
         return { .errorString = stringOperationCanceled() };
 

--- a/source/MRMesh/MRProgressCallback.h
+++ b/source/MRMesh/MRProgressCallback.h
@@ -50,7 +50,7 @@ inline ProgressCallback subprogress( ProgressCallback cb, float from, float to )
 {
     ProgressCallback res;
     if ( cb )
-        res = [cb, from, to]( float v ) { return cb( std::lerp( from, to, v ) ); };
+        res = [cb = std::move( cb ), from, to]( float v ) { return cb( std::lerp( from, to, v ) ); };
     return res;
 }
 
@@ -60,7 +60,7 @@ inline ProgressCallback subprogress( ProgressCallback cb, F && f )
 {
     ProgressCallback res;
     if ( cb )
-        res = [cb, f = std::forward<F>( f )]( float v ) { return cb( f( v ) ); };
+        res = [cb = std::move( cb ), f = std::forward<F>( f )]( float v ) { return cb( f( v ) ); };
     return res;
 }
 
@@ -69,9 +69,19 @@ inline ProgressCallback subprogress( ProgressCallback cb, size_t index, size_t c
 {
     assert( index < count );
     if ( cb )
-        return [cb, index, count] ( float v ) { return cb( ( (float)index + v ) / (float)count ); };
+        return [cb = std::move( cb ), index, count] ( float v ) { return cb( ( (float)index + v ) / (float)count ); };
     else
         return {};
+}
+
+/// splits the given progress on two sub-progresses: [0, threshold] and [threshold, 1]
+inline std::pair<ProgressCallback, ProgressCallback> splitProgress( const ProgressCallback& cb, float threshold )
+{
+    return
+    {
+        subprogress( cb, 0.0f, threshold ),
+        subprogress( cb, threshold, 1.0f )
+    };
 }
 
 } //namespace MR

--- a/source/MRMesh/MRProgressCallback.h
+++ b/source/MRMesh/MRProgressCallback.h
@@ -2,8 +2,11 @@
 
 #include "MRMeshFwd.h"
 
+#include <array>
 #include <cassert>
 #include <cmath>
+#include <tuple>
+#include <utility>
 
 namespace MR
 {
@@ -74,14 +77,20 @@ inline ProgressCallback subprogress( ProgressCallback cb, size_t index, size_t c
         return {};
 }
 
-/// splits the given progress on two sub-progresses: [0, threshold] and [threshold, 1]
-inline std::pair<ProgressCallback, ProgressCallback> splitProgress( const ProgressCallback& cb, float threshold )
+/// splits the given progress on (n+1) sub-progresses: [0,t1], [t1,t2], ... [tn,1],
+/// where n given thresholds must be sorted: 0 <= t1 <= ... <= tn <= 1;
+/// returns the sub-progresses in std::tuple with (n+1) elements
+template <typename ...Ts>
+auto splitProgress( const ProgressCallback& cb, Ts ... thresholds )
 {
-    return
+    constexpr size_t n = sizeof...( Ts );
+    static_assert( n > 0, "at least one threshold is required" );
+    const std::array<float, n + 2> bounds{ 0.0f, float( thresholds )..., 1.0f };
+    return [&]<size_t ...I>( std::index_sequence<I...> )
     {
-        subprogress( cb, 0.0f, threshold ),
-        subprogress( cb, threshold, 1.0f )
-    };
+        assert( ( ( bounds[I] <= bounds[I + 1] ) && ... ) );
+        return std::tuple{ subprogress( cb, bounds[I], bounds[I + 1] )... };
+    }( std::make_index_sequence<n + 1>{} );
 }
 
 } //namespace MR

--- a/source/MRMesh/MRProgressCallback.h
+++ b/source/MRMesh/MRProgressCallback.h
@@ -51,6 +51,7 @@ inline bool reportProgress( ProgressCallback cb, F && f, size_t counter, int div
 /// returns a callback that maps [0,1] linearly into [from,to] in the call to \param cb (which can be empty)
 inline ProgressCallback subprogress( ProgressCallback cb, float from, float to )
 {
+    assert( from <= to );
     ProgressCallback res;
     if ( cb )
         res = [cb = std::move( cb ), from, to]( float v ) { return cb( std::lerp( from, to, v ) ); };
@@ -88,7 +89,6 @@ auto splitProgress( const ProgressCallback& cb, Ts ... thresholds )
     const std::array<float, n + 2> bounds{ 0.0f, float( thresholds )..., 1.0f };
     return [&]<size_t ...I>( std::index_sequence<I...> )
     {
-        assert( ( ( bounds[I] <= bounds[I + 1] ) && ... ) );
         return std::tuple{ subprogress( cb, bounds[I], bounds[I + 1] )... };
     }( std::make_index_sequence<n + 1>{} );
 }

--- a/source/MRMesh/MRRegularGridMesh.cpp
+++ b/source/MRMesh/MRRegularGridMesh.cpp
@@ -25,6 +25,9 @@ Expected<Mesh> makeRegularGridMesh( size_t width, size_t height,
         .dim = Vector2i( (int)width - 1, (int)height - 1 )
     };
 
+    const auto [setValidVertsProgress, setPointsProgress, setFaceIdsProgress, setValidGridEdgesProgress,
+                buildGridMeshProgress, checkValidityProgress] = splitProgress( cb, 0.1f, 0.2f, 0.3f, 0.4f, 0.8f );
+
     BitSet validGridVerts( width * height );
     gs.vertIds.b.resize( width * height );
     auto result = BitSetParallelForAll( validGridVerts, [&]( size_t p )
@@ -35,7 +38,7 @@ Expected<Mesh> makeRegularGridMesh( size_t width, size_t height,
             validGridVerts.set( p );
         else
             gs.vertIds.b[p] = VertId{};
-    }, subprogress( cb, 0.0f, 0.1f ) );
+    }, setValidVertsProgress );
 
     if ( !result )
         return unexpectedOperationCanceled();
@@ -52,7 +55,7 @@ Expected<Mesh> makeRegularGridMesh( size_t width, size_t height,
         auto y = p / width;
         auto x = p - y * width;
         res.points[gs.vertIds.b[p]] = positioner( x, y );
-    }, subprogress( cb, 0.1f, 0.2f ) );
+    }, setPointsProgress );
 
     if ( !result )
         return unexpectedOperationCanceled();
@@ -140,7 +143,7 @@ Expected<Mesh> makeRegularGridMesh( size_t width, size_t height,
             gs.faceIds.b[2 * p + 1] = FaceId{};
             break;
         }
-    }, subprogress( cb, 0.2f, 0.3f ) );
+    }, setFaceIdsProgress );
 
     if ( !result )
         return unexpectedOperationCanceled();
@@ -215,7 +218,7 @@ Expected<Mesh> makeRegularGridMesh( size_t width, size_t height,
             validGridEdges.set( loc );
         else
             gs.uedgeIds.b[loc] = UndirectedEdgeId{};
-    }, subprogress( cb, 0.3f, 0.4f ) );
+    }, setValidGridEdgesProgress );
 
     if ( !result )
         return unexpectedOperationCanceled();
@@ -225,11 +228,11 @@ Expected<Mesh> makeRegularGridMesh( size_t width, size_t height,
         gs.uedgeIds.b[p] = nextUEdgeId++;
     gs.uedgeIds.tsize = size_t( nextUEdgeId );
 
-    result = res.topology.buildGridMesh( gs, subprogress( cb, 0.4f, 0.8f ) );
+    result = res.topology.buildGridMesh( gs, buildGridMeshProgress );
     if ( !result )
         return unexpectedOperationCanceled();
 
-    result = res.topology.checkValidity( subprogress( cb, 0.8f, 1.0f ) );
+    result = res.topology.checkValidity( checkValidityProgress );
     if ( !result )
         return unexpectedOperationCanceled();
 


### PR DESCRIPTION
### Problem

Sub-progresses were created one at a time:

```cpp
..., subprogress( cb, 0.3f, 0.4f ) );
...
result = res.topology.buildGridMesh( gs, subprogress( cb, 0.4f, 0.8f ) );
...
result = res.topology.checkValidity( subprogress( cb, 0.8f, 1.0f ) );
```

Every internal boundary is spelled twice, and nothing checks that the neighbouring ranges agree. A typo in one number, or an edit that adjusts one range and forgets its neighbour, silently leaves a gap or an overlap in the reported progress; the ranges may also fail to cover the whole `[0,1]`. Neither the compiler nor the tests can catch it.

### Solution

`splitProgress( cb, t1, ..., tn )` — a variadic function template that takes `n` sorted thresholds and subdivides the whole progress into the `(n+1)` sub-progresses on `[0,t1]`, `[t1,t2]`, ... `[tn,1]`, returned as `std::tuple`:

```cpp
const auto [setValidVertsProgress, setPointsProgress, setFaceIdsProgress, setValidGridEdgesProgress,
            buildGridMeshProgress, checkValidityProgress] = splitProgress( cb, 0.1f, 0.2f, 0.3f, 0.4f, 0.8f );
```

Each boundary is now written exactly once, so the sub-progresses are adjacent by construction and always cover `[0,1]` — the class of mistakes above becomes unrepresentable. All thresholds are visible together in one line, which also makes the split easy to review and rebalance.

Threshold ordering is checked by a new `assert( from <= to )` in `subprogress( ProgressCallback cb, float from, float to )`: every sub-progress is produced by it, so an unsorted threshold list is caught right there in debug builds — and the same check now also guards `subprogress` calls written by hand.

Converted call sites: `booleanImpl` in `MRMeshBoolean.cpp` (2 sub-progresses) and `makeRegularGridMesh` in `MRRegularGridMesh.cpp` (6 sub-progresses).

Additionally, `subprogress` now moves the passed callback into the returned lambda instead of copying it.
