### PR TITLE
Fix Vector2i256 alias to point to Vector2 instead of Vector3

### DIFF
--- a/source/MRMesh/MRHighPrecision.h
+++ b/source/MRMesh/MRHighPrecision.h
@@ -34,7 +34,7 @@ using Vector2i128fast = Vector2<FastInt128>;
 using Vector3i128fast = Vector3<FastInt128>;
 #endif
 
-using Vector2i256 = Vector3<Int256>;
+using Vector2i256 = Vector2<Int256>;
 using Vector3i256 = Vector3<Int256>;
 
 


### PR DESCRIPTION
`Vector2i256` was aliased to `Vector3<Int256>` instead of `Vector2<Int256>` — apparently a copy-paste typo from the neighboring `Vector3i256` line.

Nothing in the repository uses `Vector2i256` yet (verified by grep), so no behavior changes; this just makes the alias usable as intended.

Built MRMesh + MRTest locally (Release x64) and ran the full suite: 318 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
