### PR TITLE
Make S3 vcpkg binary cache read-only without --write-s3

### DIFF
--- a/thirdparty/install.bat
+++ b/thirdparty/install.bat
@@ -86,7 +86,7 @@ if "!aws_cli_available!"=="true" (
         set "VCPKG_BINARY_SOURCES=clear;x-aws,s3://vcpkg-export/!VCPKG_TAG!/!VCPKG_DEFAULT_TRIPLET!/,readwrite;"
     ) else (
         echo "Mode: pull vcpkg binary cache. No AWS credentials are required."
-        set "VCPKG_BINARY_SOURCES=clear;x-aws-config,no-sign-request;x-aws,s3://vcpkg-export/!VCPKG_TAG!/!VCPKG_DEFAULT_TRIPLET!/,readwrite;"
+        set "VCPKG_BINARY_SOURCES=clear;x-aws-config,no-sign-request;x-aws,s3://vcpkg-export/!VCPKG_TAG!/!VCPKG_DEFAULT_TRIPLET!/,read;"
     )
 ) else (
     echo "Mode: build from source (no S3 binary cache)."


### PR DESCRIPTION
Without `--write-s3`, `thirdparty\install.bat` still configured the S3 binary cache as `readwrite` (with `x-aws-config,no-sign-request`). vcpkg's `x-aws` provider does not skip uploads in no-sign-request mode — it just appends `--no-sign-request` to `aws s3 cp` — so every cache-miss package triggered an anonymous upload to `s3://vcpkg-export/` that the bucket rejects with 403 AccessDenied. vcpkg treats push failures as warnings, so builds succeeded, but each locally-built package wasted time on a doomed upload and left a failed-upload warning in the log.

This changes the no-`--write-s3` mode to `read`, so vcpkg never attempts to push. The `--write-s3` path (signed, `readwrite`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
