### PR TITLE
Comment out macos-12-intel test legs while the runner is unavailable

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -766,9 +766,11 @@ jobs:
           - platform: "arm64"
             runner-tier: "github"
             instance: macos-26
-          - platform: "x86"
-            runner-tier: "self-hosted"
-            instance: macos-12-intel
+          # The macos-12-intel self-hosted runner is temporarily
+          # unavailable; restore this entry once it is back online.
+          # - platform: "x86"
+          #   runner-tier: "self-hosted"
+          #   instance: macos-12-intel
           - platform: "x86"
             runner-tier: "github"
             instance: macos-15-intel

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -252,9 +252,11 @@ jobs:
           - arch: arm64
             runner: macos-26
             pkg_pattern: '*arm64.pkg'
-          - arch: x64
-            runner: macos-12-intel
-            pkg_pattern: '*x64.pkg'
+          # The macos-12-intel self-hosted runner is temporarily
+          # unavailable; restore this entry once it is back online.
+          # - arch: x64
+          #   runner: macos-12-intel
+          #   pkg_pattern: '*x64.pkg'
           - arch: x64
             runner: macos-15-intel
             pkg_pattern: '*x64.pkg'


### PR DESCRIPTION
The self-hosted `macos-12-intel` runner is temporarily unavailable. Every job targeting it just sits in the queue instead of failing fast, so both places that use it are commented out.

### Places changed

| Workflow | Job | Matrix entry |
|---|---|---|
| [pip-build.yml](.github/workflows/pip-build.yml) | `macos-pip-test` | `platform: x86` / `runner-tier: self-hosted` / `instance: macos-12-intel` |
| [test-distribution.yml](.github/workflows/test-distribution.yml) | `macos-test` | `arch: x64` / `runner: macos-12-intel` / `pkg_pattern: '*x64.pkg'` |

A `grep` for `macos-12` over `.github/` and `scripts/` confirms these were the only two usages (the remaining hit is a pre-existing comment in the `nlohmann-json` submodule, untouched).

### Why commented out rather than deleted

The entries are kept as comments with a short note, so bringing the runner back is a one-line uncomment in each file instead of a re-derivation of the matrix rows.

### Coverage impact

Intel macOS coverage is retained on the GitHub-hosted images that remain in both matrices — `macos-15-intel` and `macos-26-intel`. What is lost until the machine returns:

- the only Intel *self-hosted* leg, i.e. the `runner-tier: self-hosted` + `x86` combination in `test_wheel_macos.sh` (the brew-install path that the `macos-15-intel` 3.11 skip does *not* take);
- the `-target CurrentUserHomeDirectory` install path in `test-distribution.yml` for x64. That path is still exercised by the self-hosted arm64 `macos-13` leg, which is unchanged.

Both workflows still parse (`yaml.safe_load`), and neither job runs on a plain PR: `test-pip-build` needs the `test-pip-build` label, and `test-distribution` needs `upload_artifacts`. So this diff is validated by inspection rather than by CI.
