### PR TITLE
Never let MSBuild IncrementalClean delete DLLs from the shared output directory

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    All projects deploy into a shared $(OutDir), including ~150 vcpkg DLLs applocal-copied there.
+    vcpkg's AppLocalFromInstalled never registers these copies in @(FileWrites), so once they appear
+    in a project's FileListAbsolute.txt, the next relink makes IncrementalClean delete them as
+    "orphaned" outputs. No single project owns a DLL in a shared OutDir, so never clean them.
+  -->
+  <Target Name="MRProtectSharedDllsFromIncrementalClean" BeforeTargets="IncrementalClean">
+    <ItemGroup>
+      <_MRDllPriorFileWrites Include="@(_CleanPriorFileWrites)" Condition="'%(Extension)' == '.dll'" />
+      <_CleanPriorFileWrites Remove="@(_MRDllPriorFileWrites)" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
## Problem

On MSVC/MSBuild builds all projects share one output directory (`source\x64\<Config>`), where vcpkg applocal deployment copies ~150 runtime DLLs (tbb12, fmt, openvdb, python3, zlib1, ...). These DLLs intermittently disappear during ordinary incremental builds — with no build failure — and further incremental rebuilds do not restore them (applocal only runs when link actually executes). The result is `MRTest.exe`/apps failing with `0xC0000135` (DLL not found) and Visual Studio never-up-to-date rebuild loops, until the DLLs are manually re-copied from the vcpkg `bin` directory.

Reproduced deterministically with a detailed-verbosity build of `MRTest.vcxproj`: after touching one test source, the `Delete` task inside `IncrementalClean` removed 73 DLLs from `x64\Release` immediately after `AppLocalFromInstalled` had copied them (151 → 78 DLLs).

## Root cause (established after this PR was opened)

This is a vcpkg regression, since reported and fixed upstream:

- **Regression**: microsoft/vcpkg#50521 (in releases `2026.03.18` … `2026.06.01`) added `AppLocalFromInstalledPreserve`, which registers the deployed DLLs in `@(FileWrites)` only on **link-skipped** builds. That persists them into the project's `FileListAbsolute.txt` clean file, while the **real-link** path (`AppLocalFromInstalled`) still registers nothing — so the next build that actually relinks computes them as orphaned outputs (`_CleanPriorFileWrites` − `_CleanCurrentFileWrites`) and `IncrementalClean` deletes them all.
- **Report**: microsoft/vcpkg#51298 (closed completed).
- **Fix**: microsoft/vcpkg#52360 — registers the DLLs in `FileWrites` on the real-link path too; first shipped in release **`2026.06.24`**.

Our CI already uses vcpkg `2026.06.24` (#6382) and is unaffected. Developer machines pinned inside the broken window (common, since updating vcpkg invalidates triplet ABI hashes and forces port rebuilds) hit the wipe on every relink.

## Fix

Add a repo-root `Directory.Build.targets` (auto-imported by MSBuild into every project of the solution, including `thirdparty\pybind11nonlimitedapi*.vcxproj`) with a small target running before `IncrementalClean` that removes `.dll` entries from `_CleanPriorFileWrites`. In a shared output directory no single project owns a DLL, so per-project orphan cleanup of DLLs is always wrong.

Even with the upstream fix available, this guard is worth having:

1. **applocal-failure wipe**: upstream's `FileWrites` registration is conditional on applocal exit code 0. An intermittent applocal failure on a relink (e.g. a locked DLL during parallel builds, cf. #6404) is warning-only — and would again orphan-delete every DLL recorded in the clean file.
2. **Shrinking/renamed dependency sets**: when a project's deployed set changes (dropped dependency, version-suffixed DLL renames on a vcpkg update), the relinking project deletes the old names from the shared OutDir while sibling binaries may still need them. Per-project cleanup cannot know about shared ownership.
3. **Pinned vcpkg on dev machines**: any clone built with a broken-window vcpkg stays protected, with no coordination needed.

Notes:
- Full Clean/Rebuild still deletes the deployed DLLs via the tlog-based `CppClean`, so nothing accumulates across configuration changes.
- The stripped entries also stop being re-persisted, so already-poisoned `FileListAbsolute.txt` files heal on the first build.
- Only MSBuild builds are affected; CMake/other platforms don't read `Directory.Build.targets` (non-Windows CI disabled via labels).

Verified locally: with the fix, the same touch-and-rebuild scenario keeps all 151 DLLs (zero `Deleting file ... .dll` lines in the detailed log), and the full MRTest suite passes (324 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
