### PR TITLE
Restore macos-12-intel test legs now that the runner is back

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -766,11 +766,9 @@ jobs:
           - platform: "arm64"
             runner-tier: "github"
             instance: macos-26
-          # The macos-12-intel self-hosted runner is temporarily
-          # unavailable; restore this entry once it is back online.
-          # - platform: "x86"
-          #   runner-tier: "self-hosted"
-          #   instance: macos-12-intel
+          - platform: "x86"
+            runner-tier: "self-hosted"
+            instance: macos-12-intel
           - platform: "x86"
             runner-tier: "github"
             instance: macos-15-intel

--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -252,11 +252,9 @@ jobs:
           - arch: arm64
             runner: macos-26
             pkg_pattern: '*arm64.pkg'
-          # The macos-12-intel self-hosted runner is temporarily
-          # unavailable; restore this entry once it is back online.
-          # - arch: x64
-          #   runner: macos-12-intel
-          #   pkg_pattern: '*x64.pkg'
+          - arch: x64
+            runner: macos-12-intel
+            pkg_pattern: '*x64.pkg'
           - arch: x64
             runner: macos-15-intel
             pkg_pattern: '*x64.pkg'


### PR DESCRIPTION
The `macos-12-intel` self-hosted runner is available again, so this reverts #6495 (commit f3569def9) and puts both matrix entries back.

### Restored

| Workflow | Job | Entry |
|---|---|---|
| [pip-build.yml](.github/workflows/pip-build.yml) | `macos-pip-test` | `platform: x86` / `runner-tier: self-hosted` / `instance: macos-12-intel` |
| [test-distribution.yml](.github/workflows/test-distribution.yml) | `macos-test` | `arch: x64` / `runner: macos-12-intel` / `pkg_pattern: '*x64.pkg'` |

A plain `git revert` of f3569def9 applied cleanly — nothing else touched these two files in the meantime — so both files are now **byte-identical to their pre-#6495 state** (`git diff f3569def9^` over the two paths is empty). Both still parse under `yaml.safe_load`.

### Coverage regained

- The only Intel *self-hosted* wheel leg: the `runner-tier: self-hosted` + `x86` combination in `scripts/wheel/test_wheel_macos.sh`, i.e. the brew-install path that the `macos-15-intel` 3.11 skip deliberately avoids.
- The `-target CurrentUserHomeDirectory` pkg install path for x64 in `test-distribution.yml`.

### Validation

As with #6495, neither job runs on a plain PR — `test-pip-build` needs the `test-pip-build` label and `test-distribution` needs `upload_artifacts` — so PR CI cannot exercise this. The first real confirmation that the runner is genuinely back will be the next release or label-triggered pip-build run.

MIC companion: MeshInspector/MeshInspectorCode#7575.
