### PR TITLE
computeIntCoords/computeFloatCoords convert all coordinates in parallel

### DIFF
--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -1,4 +1,8 @@
 #include "MRPrecisePredicates3.h"
+#include "MRBitSetParallelFor.h"
+#include "MRParallelFor.h"
+#include "MRTimer.h"
+#include "MRVector.h"
 #include "MRHighPrecision.h"
 #include "MRVector2.h"
 #include "MRBox.h"
@@ -397,6 +401,29 @@ ConvertToFloatVector getToFloatConverter( const Box3d& box )
     {
         return Vector3f( Vector3d{ v }*range + center );
     };
+}
+
+Vector<Vector3i, VertId> computeIntCoords( const ConvertToIntVector& conv,
+    const VertCoords& points, const VertBitSet* valid )
+{
+    MR_TIMER;
+    Vector<Vector3i, VertId> res;
+    res.resizeNoInit( points.size() );
+    if ( valid )
+    {
+        BitSetParallelFor( *valid, [&]( VertId v )
+        {
+            res[v] = conv( points[v] );
+        } );
+    }
+    else
+    {
+        ParallelFor( res, [&]( VertId v )
+        {
+            res[v] = conv( points[v] );
+        } );
+    }
+    return res;
 }
 
 std::optional<Vector3i> findTwoSegmentsIntersection( const Vector3i& ai, const Vector3i& bi, const Vector3i& ci, const Vector3i& di )

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -426,6 +426,29 @@ Vector<Vector3i, VertId> computeIntCoords( const ConvertToIntVector& conv,
     return res;
 }
 
+VertCoords computeFloatCoords( const ConvertToFloatVector& conv,
+    const Vector<Vector3i, VertId>& intCoords, const VertBitSet* valid )
+{
+    MR_TIMER;
+    VertCoords res;
+    res.resizeNoInit( intCoords.size() );
+    if ( valid )
+    {
+        BitSetParallelFor( *valid, [&]( VertId v )
+        {
+            res[v] = conv( intCoords[v] );
+        } );
+    }
+    else
+    {
+        ParallelFor( res, [&]( VertId v )
+        {
+            res[v] = conv( intCoords[v] );
+        } );
+    }
+    return res;
+}
+
 std::optional<Vector3i> findTwoSegmentsIntersection( const Vector3i& ai, const Vector3i& bi, const Vector3i& ci, const Vector3i& di )
 {
     const auto ab = Vector3i64{ bi - ai };

--- a/source/MRMesh/MRPrecisePredicates3.h
+++ b/source/MRMesh/MRPrecisePredicates3.h
@@ -65,6 +65,11 @@ MRMESH_API ConvertToIntVector getToIntConverter( const Box3d& box );
 /// creates converter from Vector3i to Vector3f in Box range (int diapason is mapped to box range)
 MRMESH_API ConvertToFloatVector getToFloatConverter( const Box3d& box );
 
+/// converts given points into integer coordinates in parallel
+/// \param valid if given then only valid points are converted, and the content of other elements in the returned vector is undefined
+[[nodiscard]] MRMESH_API Vector<Vector3i, VertId> computeIntCoords( const ConvertToIntVector& conv,
+    const VertCoords& points, const VertBitSet* valid = nullptr );
+
 /// given two line segments AB and CD located in one plane,
 /// finds whether they intersect and if yes, computes their common point using integer-only arithmetic
 [[nodiscard]] MRMESH_API std::optional<Vector3i> findTwoSegmentsIntersection( const Vector3i& ai, const Vector3i& bi, const Vector3i& ci, const Vector3i& di );

--- a/source/MRMesh/MRPrecisePredicates3.h
+++ b/source/MRMesh/MRPrecisePredicates3.h
@@ -70,6 +70,11 @@ MRMESH_API ConvertToFloatVector getToFloatConverter( const Box3d& box );
 [[nodiscard]] MRMESH_API Vector<Vector3i, VertId> computeIntCoords( const ConvertToIntVector& conv,
     const VertCoords& points, const VertBitSet* valid = nullptr );
 
+/// converts given integer coordinates into float points in parallel
+/// \param valid if given then only valid coordinates are converted, and the content of other elements in the returned vector is undefined
+[[nodiscard]] MRMESH_API VertCoords computeFloatCoords( const ConvertToFloatVector& conv,
+    const Vector<Vector3i, VertId>& intCoords, const VertBitSet* valid = nullptr );
+
 /// given two line segments AB and CD located in one plane,
 /// finds whether they intersect and if yes, computes their common point using integer-only arithmetic
 [[nodiscard]] MRMESH_API std::optional<Vector3i> findTwoSegmentsIntersection( const Vector3i& ai, const Vector3i& bi, const Vector3i& ci, const Vector3i& di );


### PR DESCRIPTION
Adds two functions for parallel conversion of all vertex coordinates at once:
* `computeIntCoords` converts given `VertCoords` into `Vector<Vector3i, VertId>` using given `ConvertToIntVector` converter;
* `computeFloatCoords` converts given `Vector<Vector3i, VertId>` back into `VertCoords` using given `ConvertToFloatVector` converter.

If optional `valid` bitset is provided, then only valid elements are converted, and the content of other elements in the returned vector is undefined.
