### PR TITLE
Coordinate converters as structs instead of std::function

### DIFF
--- a/examples/c-examples/CollisionPrecise.dox.c
+++ b/examples/c-examples/CollisionPrecise.dox.c
@@ -29,7 +29,7 @@ int main( void )
     MR_CoordinateConverters* converters = MR_getVectorConverters_3( mpA, mpB, NULL );
     // find each intersecting edge/triangle pair
     MR_std_vector_MR_VarEdgeTri* collidingFaceEdges = MR_findCollidingEdgeTrisPrecise_5(
-        mpA, mpB, MR_PassBy_Copy, MR_CoordinateConverters_GetMutable_toInt( converters ), NULL, NULL );
+        mpA, mpB, MR_CoordinateConverters_Get_toInt( converters ), NULL, NULL );
 
     // print pairs of edges triangles
     for ( size_t i = 0; i < MR_std_vector_MR_VarEdgeTri_size( collidingFaceEdges ); ++i )

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -378,13 +378,7 @@ ConvertToIntVector getToIntConverter( const Box3d& box )
     // so the difference of any two points will be within [-max; +max] range
     double invRange = cRangeIntMax / maxDim;
 
-    return [invRange, center] ( const Vector3f& v )
-    {
-        // perform intermediate operations in double for better precision
-        const auto d = ( Vector3d{ v } - center ) * invRange;
-        // and round to the nearest integer instead of truncating to zero
-        return Vector3i( (int)std::round( d.x ), (int)std::round( d.y ), (int)std::round( d.z ) );
-    };
+    return ConvertToIntVector{ center, invRange };
 }
 
 ConvertToFloatVector getToFloatConverter( const Box3d& box )
@@ -397,10 +391,7 @@ ConvertToFloatVector getToFloatConverter( const Box3d& box )
     // so the difference of any two points will be within [-max; +max] range
     double range = maxDim / cRangeIntMax;
 
-    return [range, center] ( const Vector3i& v )
-    {
-        return Vector3f( Vector3d{ v }*range + center );
-    };
+    return ConvertToFloatVector{ range, center };
 }
 
 Vector<Vector3i, VertId> computeIntCoords( const ConvertToIntVector& conv,

--- a/source/MRMesh/MRPrecisePredicates3.h
+++ b/source/MRMesh/MRPrecisePredicates3.h
@@ -49,15 +49,51 @@ struct TriangleSegmentIntersectResult
 /// triangles ta and tb can have at most two shared points, all other points must be unique
 [[nodiscard]] MRMESH_API bool segmentIntersectionOrder( const std::array<PreciseVertCoords, 8> & vs );
 
-/// float-to-int coordinate converter
-using ConvertToIntVector = std::function<Vector3i( const Vector3f& )>;
-/// int-to-float coordinate converter
-using ConvertToFloatVector = std::function<Vector3f( const Vector3i& )>;
+/// translate then scale float-to-int coordinate converter
+struct ConvertToIntVector
+{
+    Vector3d center;
+    double invRange = 0;
+
+    [[nodiscard]] int scaleOnly( double v ) const
+    {
+        return (int)std::round( v * invRange );
+    }
+
+    [[nodiscard]] Vector3i operator()( const Vector3d& p ) const
+    {
+        const auto d = p - center;
+        return { scaleOnly( d.x ), scaleOnly( d.y ), scaleOnly( d.z ) };
+    }
+
+    [[nodiscard]] Vector3i operator()( const Vector3f& p ) const
+    {
+        return operator()( Vector3d{ p } );
+    }
+};
+
+/// scale then translate int-to-float coordinate converter
+struct ConvertToFloatVector
+{
+    double range = 0;
+    Vector3d center;
+
+    [[nodiscard]] Vector3d convert( const Vector3i& v ) const
+    {
+        return Vector3d{ v } * range + center;
+    }
+
+    [[nodiscard]] Vector3f operator()( const Vector3i& v ) const
+    {
+        return Vector3f( convert( v ) );
+    }
+};
+
 /// this struct contains coordinate converters float-int-float
 struct CoordinateConverters
 {
-    ConvertToIntVector toInt{};
-    ConvertToFloatVector toFloat{};
+    ConvertToIntVector toInt;
+    ConvertToFloatVector toFloat;
 };
 
 /// creates converter from Vector3f to Vector3i in Box range (int diapason is mapped to box range)

--- a/source/MRMesh/MRPrecisePredicates3.h
+++ b/source/MRMesh/MRPrecisePredicates3.h
@@ -53,19 +53,22 @@ struct TriangleSegmentIntersectResult
 struct ConvertToIntVector
 {
     Vector3d center;
-    double invRange = 0;
+    double invRange = 1;
 
+    /// applies scaling only (without translation) with the following rounding to the nearest int
     [[nodiscard]] int scaleOnly( double v ) const
     {
         return (int)std::round( v * invRange );
     }
 
+    /// double-to-int coordinates converter
     [[nodiscard]] Vector3i operator()( const Vector3d& p ) const
     {
         const auto d = p - center;
         return { scaleOnly( d.x ), scaleOnly( d.y ), scaleOnly( d.z ) };
     }
 
+    /// float-to-int coordinates converter
     [[nodiscard]] Vector3i operator()( const Vector3f& p ) const
     {
         return operator()( Vector3d{ p } );
@@ -75,14 +78,16 @@ struct ConvertToIntVector
 /// scale then translate int-to-float coordinate converter
 struct ConvertToFloatVector
 {
-    double range = 0;
+    double range = 1;
     Vector3d center;
 
+    /// int-to-double coordinates converter
     [[nodiscard]] Vector3d convert( const Vector3i& v ) const
     {
         return Vector3d{ v } * range + center;
     }
 
+    /// int-to-float coordinates converter
     [[nodiscard]] Vector3f operator()( const Vector3i& v ) const
     {
         return Vector3f( convert( v ) );

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -814,8 +814,8 @@ TEST( MRMesh, segmentIntersectionOrder3b )
 TEST( MRMesh, getToIntConverter )
 {
     auto toInt = getToIntConverter( Box3d( {0,0,-1.0}, {0,0,1.0} ) );
-    auto i0 = toInt( { 0,0,-1.f } );
-    auto i1 = toInt( { 0,0, 1.f } );
+    auto i0 = toInt( Vector3f{ 0,0,-1.f } );
+    auto i1 = toInt( Vector3f{ 0,0, 1.f } );
     // check that sum and difference of any two points can be computed in integer without overflow
     EXPECT_LE( -i0.z, INT_MAX / 2 );
     EXPECT_LE(  i1.z, INT_MAX / 2 );

--- a/source/MRTestC2/MRMeshCollidePrecise.c
+++ b/source/MRTestC2/MRMeshCollidePrecise.c
@@ -37,7 +37,7 @@ void testMeshCollidePrecise( void )
     MR_MeshPart* meshBPart = MR_MeshPart_Construct( meshB, NULL );
     MR_CoordinateConverters* conv = MR_getVectorConverters_3( meshAPart, meshBPart, NULL );
 
-    MR_std_vector_MR_VarEdgeTri* intersections = MR_findCollidingEdgeTrisPrecise_5( meshAPart, meshBPart, MR_PassBy_Copy, MR_CoordinateConverters_GetMutable_toInt( conv ), NULL, false );
+    MR_std_vector_MR_VarEdgeTri* intersections = MR_findCollidingEdgeTrisPrecise_5( meshAPart, meshBPart, MR_CoordinateConverters_Get_toInt( conv ), NULL, NULL );
 
     MR_MeshPart_Destroy( meshAPart );
     MR_MeshPart_Destroy( meshBPart );


### PR DESCRIPTION
Replaces the type-erased `std::function` aliases `ConvertToIntVector` / `ConvertToFloatVector` with concrete structs holding the conversion parameters (`center`, `invRange` / `range`). The conversion math is unchanged, so precise predicates produce bit-identical results.

Motivation:
* Converters are called per vertex in hot paths (`computeIntCoords`, precise collision detection, boolean). A concrete struct removes `std::function`'s indirect call and potential heap allocation, and enables inlining; passing a converter by value becomes a trivial 32-byte copy.
* New `scaleOnly( double )` applies scaling without translation, which is needed to convert scalar distances (e.g. sphere radius) into integer coordinates for precise predicates.
* New `operator()( const Vector3d& )` overload converts double points without a lossy roundtrip via float, and `convert( const Vector3i& )` returns the double point before narrowing to float.

Other notes:
* Default-constructed converters now perform identity scaling (`invRange`/`range` = 1) instead of holding an empty `std::function` that would throw on call.
* C bindings signature changed: the converter is now passed as `const MR_ConvertToIntVector *` without `MR_PassBy` — the C test and example are updated accordingly.
* A test call site was updated because a braced-init argument became ambiguous between the `Vector3f` and `Vector3d` overloads.
