### PR TITLE
Optional upper search limit in BitSet::find_next and other bit-searching methods

### DIFF
--- a/source/MRMesh/MRBitSet.cpp
+++ b/source/MRMesh/MRBitSet.cpp
@@ -283,37 +283,51 @@ bool BitSet::intersects( const BitSet& a ) const
     return false;
 }
 
-auto BitSet::findSetBitAfter_( IndexType n ) const -> IndexType
+auto BitSet::findSetBitAfter_( IndexType n, IndexType upTo ) const -> IndexType
 {
-    if ( n >= size() )
+    if ( n >= size() || n >= upTo )
         return npos;
 
+    const auto endBlock = std::min( blocks_.size(), blockIndex_( upTo - 1 ) + 1 );
     auto blockId = blockIndex_( n );
     const auto firstBit = bitIndex_( n );
     auto block0 = blocks_[blockId];
     block0 &= ~( ( block_type( 1 ) << firstBit ) - 1 ); // zero bits before firstBit
     if ( auto c = std::countr_zero( block0 ); c < bits_per_block )
-        return blockId * bits_per_block + c;
-    for ( ++blockId; blockId < blocks_.size(); ++blockId )
+    {
+        const auto res = blockId * bits_per_block + c;
+        return res < upTo ? res : npos;
+    }
+    for ( ++blockId; blockId < endBlock; ++blockId )
         if ( auto c = std::countr_zero( blocks_[blockId] ); c < bits_per_block )
-            return blockId * bits_per_block + c;
+        {
+            const auto res = blockId * bits_per_block + c;
+            return res < upTo ? res : npos;
+        }
     return npos;
 }
 
-auto BitSet::findNonSetBitAfter_( IndexType n ) const -> IndexType
+auto BitSet::findNonSetBitAfter_( IndexType n, IndexType upTo ) const -> IndexType
 {
-    if ( n >= size() )
+    if ( n >= size() || n >= upTo )
         return npos;
 
+    const auto endBlock = std::min( blocks_.size(), blockIndex_( upTo - 1 ) + 1 );
     auto blockId = blockIndex_( n );
     const auto firstBit = bitIndex_( n );
     auto block0 = blocks_[blockId];
     block0 |= ( ( block_type( 1 ) << firstBit ) - 1 ); // one bits before firstBit
     if ( auto c = std::countr_one( block0 ); c < bits_per_block )
-        return blockId * bits_per_block + c;
-    for ( ++blockId; blockId < blocks_.size(); ++blockId )
+    {
+        const auto res = blockId * bits_per_block + c;
+        return res < upTo ? res : npos;
+    }
+    for ( ++blockId; blockId < endBlock; ++blockId )
         if ( auto c = std::countr_one( blocks_[blockId] ); c < bits_per_block )
-            return blockId * bits_per_block + c;
+        {
+            const auto res = blockId * bits_per_block + c;
+            return res < upTo ? res : npos;
+        }
     return npos;
 }
 

--- a/source/MRMesh/MRBitSet.h
+++ b/source/MRMesh/MRBitSet.h
@@ -155,8 +155,8 @@ public:
     /// return the smallest index i such that bit i is set, or npos if *this has no on bits.
     [[nodiscard]] IndexType find_first() const { return findSetBitAfter_( 0 ); }
 
-    /// return the smallest index i>n such that bit i is set, or npos if *this has no on bits.
-    [[nodiscard]] IndexType find_next( IndexType n ) const { return findSetBitAfter_( n + 1 ); }
+    /// return the smallest index i such that n<i<upTo and bit i is set, or npos if there is no such bit
+    [[nodiscard]] IndexType find_next( IndexType n, IndexType upTo = npos ) const { return findSetBitAfter_( n + 1, upTo ); }
 
     /// return the highest index i such that bit i is set, or npos if *this has no on bits.
     [[nodiscard]] MRMESH_API IndexType find_last() const;
@@ -164,8 +164,8 @@ public:
     /// return the smallest index i such that bit i is NOT set, or npos if *this has no off bits.
     [[nodiscard]] IndexType find_first_not_set() const { return findNonSetBitAfter_( 0 ); }
 
-    /// return the smallest index i>n such that bit i is NOT set, or npos if *this has no off bits.
-    [[nodiscard]] IndexType find_next_not_set( IndexType n ) const { return findNonSetBitAfter_( n + 1 ); }
+    /// return the smallest index i such that n<i<upTo and bit i is NOT set, or npos if there is no such bit
+    [[nodiscard]] IndexType find_next_not_set( IndexType n, IndexType upTo = npos ) const { return findNonSetBitAfter_( n + 1, upTo ); }
 
     /// return the highest index i such that bit i is NOT set, or npos if *this has no off bits.
     [[nodiscard]] MRMESH_API IndexType find_last_not_set() const;
@@ -253,11 +253,11 @@ private:
     template<class FullBlock, class PartialBlock>
     BitSet & rangeOp_( IndexType n, size_type len, FullBlock&&, PartialBlock&& );
 
-    /// return the smallest index i>=n such that bit i is set, or npos if *this has no on bits.
-    MRMESH_API IndexType findSetBitAfter_( IndexType n ) const;
+    /// return the smallest index i such that n<=i<upTo and bit i is set, or npos if there is no such bit
+    MRMESH_API IndexType findSetBitAfter_( IndexType n, IndexType upTo = npos ) const;
 
-    /// return the smallest index i>=n such that bit i is not set, or npos if *this has no off bits.
-    MRMESH_API IndexType findNonSetBitAfter_( IndexType n ) const;
+    /// return the smallest index i such that n<=i<upTo and bit i is not set, or npos if there is no such bit
+    MRMESH_API IndexType findNonSetBitAfter_( IndexType n, IndexType upTo = npos ) const;
 
     MRMESH_API friend std::ostream& operator<<( std::ostream& s, const BitSet & bs );
     MRMESH_API friend std::istream& operator>>( std::istream& s, BitSet & bs );
@@ -300,10 +300,10 @@ public:
     [[nodiscard]] bool test_set( IndexType n, bool val = true ) { return base::test_set( n, val ); }
 
     [[nodiscard]] IndexType find_first() const { return IndexType( base::find_first() ); }
-    [[nodiscard]] IndexType find_next( IndexType pos ) const { return IndexType( base::find_next( pos ) ); }
+    [[nodiscard]] IndexType find_next( IndexType pos, IndexType upTo = IndexType( npos ) ) const { return IndexType( base::find_next( pos, upTo ) ); }
     [[nodiscard]] IndexType find_last() const { return IndexType( base::find_last() ); }
     [[nodiscard]] IndexType find_first_not_set() const { return IndexType( base::find_first_not_set() ); }
-    [[nodiscard]] IndexType find_next_not_set( IndexType pos ) const { return IndexType( base::find_next_not_set( pos ) ); }
+    [[nodiscard]] IndexType find_next_not_set( IndexType pos, IndexType upTo = IndexType( npos ) ) const { return IndexType( base::find_next_not_set( pos, upTo ) ); }
     [[nodiscard]] IndexType find_last_not_set() const { return IndexType( base::find_last_not_set() ); }
     /// returns the location of nth set bit (where the first bit corresponds to n=0) or IndexType(npos) if there are less bit set
     [[nodiscard]] IndexType nthSetBit( size_t n ) const { return IndexType( base::nthSetBit( n ) ); }

--- a/source/MRMesh/MRBitSet.h
+++ b/source/MRMesh/MRBitSet.h
@@ -156,7 +156,7 @@ public:
     [[nodiscard]] IndexType find_first() const { return findSetBitAfter_( 0 ); }
 
     /// return the smallest index i such that n<i<upTo and bit i is set, or npos if there is no such bit
-    [[nodiscard]] IndexType find_next( IndexType n, IndexType upTo = npos ) const { return findSetBitAfter_( n + 1, upTo ); }
+    [[nodiscard]] IndexType find_next( IndexType n, IndexType upTo = MR::BitSet::npos ) const { return findSetBitAfter_( n + 1, upTo ); } // the default argument is qualified to be copied in the bindings as is
 
     /// return the highest index i such that bit i is set, or npos if *this has no on bits.
     [[nodiscard]] MRMESH_API IndexType find_last() const;
@@ -165,7 +165,7 @@ public:
     [[nodiscard]] IndexType find_first_not_set() const { return findNonSetBitAfter_( 0 ); }
 
     /// return the smallest index i such that n<i<upTo and bit i is NOT set, or npos if there is no such bit
-    [[nodiscard]] IndexType find_next_not_set( IndexType n, IndexType upTo = npos ) const { return findNonSetBitAfter_( n + 1, upTo ); }
+    [[nodiscard]] IndexType find_next_not_set( IndexType n, IndexType upTo = MR::BitSet::npos ) const { return findNonSetBitAfter_( n + 1, upTo ); } // the default argument is qualified to be copied in the bindings as is
 
     /// return the highest index i such that bit i is NOT set, or npos if *this has no off bits.
     [[nodiscard]] MRMESH_API IndexType find_last_not_set() const;
@@ -300,10 +300,10 @@ public:
     [[nodiscard]] bool test_set( IndexType n, bool val = true ) { return base::test_set( n, val ); }
 
     [[nodiscard]] IndexType find_first() const { return IndexType( base::find_first() ); }
-    [[nodiscard]] IndexType find_next( IndexType pos, IndexType upTo = IndexType( npos ) ) const { return IndexType( base::find_next( pos, upTo ) ); }
+    [[nodiscard]] IndexType find_next( IndexType pos, IndexType upTo = IndexType( MR::BitSet::npos ) ) const { return IndexType( base::find_next( pos, upTo ) ); }
     [[nodiscard]] IndexType find_last() const { return IndexType( base::find_last() ); }
     [[nodiscard]] IndexType find_first_not_set() const { return IndexType( base::find_first_not_set() ); }
-    [[nodiscard]] IndexType find_next_not_set( IndexType pos, IndexType upTo = IndexType( npos ) ) const { return IndexType( base::find_next_not_set( pos, upTo ) ); }
+    [[nodiscard]] IndexType find_next_not_set( IndexType pos, IndexType upTo = IndexType( MR::BitSet::npos ) ) const { return IndexType( base::find_next_not_set( pos, upTo ) ); }
     [[nodiscard]] IndexType find_last_not_set() const { return IndexType( base::find_last_not_set() ); }
     /// returns the location of nth set bit (where the first bit corresponds to n=0) or IndexType(npos) if there are less bit set
     [[nodiscard]] IndexType nthSetBit( size_t n ) const { return IndexType( base::nthSetBit( n ) ); }

--- a/source/MRTest/MRBitSetTests.cpp
+++ b/source/MRTest/MRBitSetTests.cpp
@@ -57,6 +57,17 @@ TEST(MRMesh, BitSet)
     EXPECT_EQ( bs4.find_next_not_set( 0 ), 1 );
     EXPECT_EQ( bs4.find_last(), 161 );
     EXPECT_EQ( bs4.find_last_not_set(), 269 );
+
+    EXPECT_EQ( bs4.find_next( 42, 160 ), BitSet::npos );
+    EXPECT_EQ( bs4.find_next( 42, 161 ), 160 );
+    EXPECT_EQ( bs4.find_next( 160, 161 ), BitSet::npos );
+    EXPECT_EQ( bs4.find_next( 160, 162 ), 161 );
+    EXPECT_EQ( bs4.find_next( 160, 0 ), BitSet::npos );
+    EXPECT_EQ( bs4.find_next_not_set( 0, 1 ), BitSet::npos );
+    EXPECT_EQ( bs4.find_next_not_set( 0, 2 ), 1 );
+    EXPECT_EQ( bs4.find_next_not_set( 159, 162 ), BitSet::npos );
+    EXPECT_EQ( bs4.find_next_not_set( 159, 163 ), 162 );
+
     bs4.flip();
     EXPECT_EQ( bs4.find_first(), 0 );
     EXPECT_EQ( bs4.find_next( 0 ), 1 );
@@ -79,6 +90,12 @@ TEST(MRMesh, TaggedBitSet)
     EXPECT_EQ( bs1.nthSetBit( 0 ), 1_v );
     EXPECT_EQ( bs1.nthSetBit( 1 ), 2_v );
     EXPECT_EQ( bs1.nthSetBit( 2 ), VertId{} );
+
+    EXPECT_EQ( bs1.find_next( 1_v ), 2_v );
+    EXPECT_EQ( bs1.find_next( 1_v, 2_v ), VertId{} );
+    EXPECT_EQ( bs1.find_next( 1_v, 3_v ), 2_v );
+    EXPECT_EQ( bs1.find_next_not_set( 0_v, 3_v ), VertId{} );
+    EXPECT_EQ( bs1.find_next_not_set( 0_v ), 3_v );
 
     EXPECT_EQ( VertBitSet( bs0 & bs1 ).count(), 1 );
     EXPECT_EQ( VertBitSet( bs0 | bs1 ).count(), 3 );


### PR DESCRIPTION
`BitSet::find_next` and `BitSet::find_next_not_set` (and their `TypedBitSet` wrappers) get a second optional parameter `upTo`, limiting the search range from above: the returned index is always in `(n, upTo)`. The default value `npos` means no upper limit, keeping the current behavior of all existing calls.

The private helpers `findSetBitAfter_` / `findNonSetBitAfter_` implement the limit efficiently: block scanning stops at the block containing `upTo - 1`, so a bounded search never touches blocks past the limit.

Unit tests cover both bounded variants, including limits within the same block, across blocks, on a set bit, and degenerate `upTo <= n + 1` cases; plus `TypedBitSet` wrappers returning invalid id when nothing is found. Full local MRTest suite passes (326 tests).
