### PR TITLE
PathAroundVertex: reusable init, sorted neighbor vectors with binary search, visited faces in a hash set

### DIFF
--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -34,11 +34,21 @@ class PathAroundVertex
     size_t firstUnvisitedIndex = 0; // lazily advanced index of the first not yet visited element of the central vertex
     VertId center; // the central vertex of the current neighborhood
 
-    // (vnext, f): there is triangle #f with the vertices (center, vnext, some-third-vert) up to rotation
-    std::vector<VertTri> vnextFaces;
-    // (vprev, f): there is triangle #f with the vertices (vprev, center, some-third-vert) up to rotation
-    std::vector<VertTri> vprevFaces;
-    HashSet<FaceId> visitedFaces;
+    struct VertRec
+    {
+        VertId v;    // neighbor vertex
+        int rec = 0; // index of the element in [vertexBegIndex, vertexEndIndex) minus vertexBegIndex
+        auto asPair() const { return std::make_pair( v, rec ); }
+        friend bool operator <( const VertRec& l, const VertRec& r ) { return l.asPair() < r.asPair(); }
+    };
+    // (vnext, rec): there is triangle #vertTris[vertexBegIndex+rec].f with the vertices (center, vnext, some-third-vert) up to rotation
+    std::vector<VertRec> vnextRecs;
+    // (vprev, rec): there is triangle #vertTris[vertexBegIndex+rec].f with the vertices (vprev, center, some-third-vert) up to rotation
+    std::vector<VertRec> vprevRecs;
+    // one bit per element in [vertexBegIndex, vertexEndIndex): set means the triangle was visited;
+    // a bit marks the element at once for the span cursor and for both sorted vectors above
+    BitSet visitedRecs;
+    size_t numVisited = 0;
 
 public:
     PathAroundVertex( Triangulation& triangleToVertices, const std::vector<VertTri>& tris )
@@ -53,27 +63,28 @@ public:
         assert( beg < end );
         center = vertTris[beg].v;
 
-        vnextFaces.clear();
-        vprevFaces.clear();
-        visitedFaces.clear();
-        vnextFaces.reserve( end - beg );
-        vprevFaces.reserve( end - beg );
+        vnextRecs.clear();
+        vprevRecs.clear();
+        vnextRecs.reserve( end - beg );
+        vprevRecs.reserve( end - beg );
+        visitedRecs.clear();
+        visitedRecs.resize( end - beg );
+        numVisited = 0;
         for ( auto i = beg; i < end; ++i )
         {
             assert( vertTris[i].v == center );
-            const auto f = vertTris[i].f;
-            const auto [v1, v2] = getOtherTriVerts( faceToVertices[f], center );
-            vnextFaces.push_back( { v1, f } );
-            vprevFaces.push_back( { v2, f } );
+            const auto [v1, v2] = getOtherTriVerts( faceToVertices[vertTris[i].f], center );
+            vnextRecs.push_back( { v1, int( i - beg ) } );
+            vprevRecs.push_back( { v2, int( i - beg ) } );
         }
-        std::sort( vnextFaces.begin(), vnextFaces.end() );
-        std::sort( vprevFaces.begin(), vprevFaces.end() );
+        std::sort( vnextRecs.begin(), vnextRecs.end() );
+        std::sort( vprevRecs.begin(), vprevRecs.end() );
     }
 
     // true if all triangles around the central vertex are already visited
     bool empty() const
     {
-        return visitedFaces.size() == vertexEndIndex - vertexBegIndex;
+        return numVisited == vertexEndIndex - vertexBegIndex;
     }
 
     // takes the first not yet visited triangle and returns its two other vertices in cyclic order
@@ -81,10 +92,11 @@ public:
     std::pair<VertId, VertId> getFirstTwoVertices()
     {
         assert( !empty() );
-        while ( visitedFaces.contains( vertTris[firstUnvisitedIndex].f ) )
+        while ( visitedRecs.test( firstUnvisitedIndex - vertexBegIndex ) )
             ++firstUnvisitedIndex;
+        visitedRecs.set( firstUnvisitedIndex - vertexBegIndex );
+        ++numVisited;
         const auto f = vertTris[firstUnvisitedIndex++].f;
-        visitedFaces.insert( f );
         return getOtherTriVerts( faceToVertices[f], center );
     }
 
@@ -110,20 +122,21 @@ public:
         prevVertex = getOrgVertex( prevVertex );
         assert( prevVertex );
 
-        const auto & vec = triOrientation ? vnextFaces : vprevFaces;
-        for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertTri{ v, FaceId{} } ); ; ++it )
+        const auto & vec = triOrientation ? vnextRecs : vprevRecs;
+        for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertRec{ v, 0 } ); ; ++it )
         {
             if ( it == vec.end() || it->v != v )
                 return {}; // no unvisited continuation from v
-            const auto f = it->f;
-            if ( visitedFaces.contains( f ) )
+            if ( visitedRecs.test( it->rec ) )
                 continue;
+            const auto f = vertTris[vertexBegIndex + it->rec].f;
             const auto v12 = getOtherTriVerts( faceToVertices[f], center );
             assert( ( triOrientation ? v12.first : v12.second ) == v );
             const auto nextVertex = triOrientation ? v12.second : v12.first;
             if ( getOrgVertex( nextVertex ) != prevVertex )
             {
-                visitedFaces.insert( f );
+                visitedRecs.set( it->rec );
+                ++numVisited;
                 return nextVertex;
             }
         }
@@ -142,18 +155,17 @@ public:
             dups->push_back( vertDup );
 
         [[maybe_unused]] size_t changedTris = 0;
-        const auto & vec = triOrientation ? vnextFaces : vprevFaces;
+        const auto & vec = triOrientation ? vnextRecs : vprevRecs;
         for ( size_t i = 1; i < path.size(); ++i )
         {
             // the triangle of this path step is (srcVert, path[i-1], path[i]) for triOrientation = true,
             // and (srcVert, path[i], path[i-1]) otherwise, up to rotation
-            for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertTri{ path[i - 1], FaceId{} } );
+            for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertRec{ path[i - 1], 0 } );
                   it != vec.end() && it->v == path[i - 1]; ++it )
             {
-                const auto f = it->f;
-                if ( !visitedFaces.contains( f ) )
+                if ( !visitedRecs.test( it->rec ) )
                     continue; // only visited triangles can be in the path
-                auto & tri = faceToVertices[f];
+                auto & tri = faceToVertices[vertTris[vertexBegIndex + it->rec].f];
                 if ( tri[0] != vertDup.srcVert && tri[1] != vertDup.srcVert && tri[2] != vertDup.srcVert )
                     continue; // this triangle has already been re-pointed to the duplicate
                 const auto v12 = getOtherTriVerts( tri, vertDup.srcVert );

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -31,7 +31,7 @@ class PathAroundVertex
     const std::vector<VertTri>& vertTris;
     // all elements in [vertexBegIndex, vertexEndIndex) of *vertTris have the same central vertex
     size_t vertexBegIndex = 0, vertexEndIndex = 0;
-    size_t firstUnvisitedIndex = 0; // lazily advanced index of the first element with not yet visited face
+    size_t firstUnvisitedIndex = 0; // lazily advanced index of the first not yet visited element of the central vertex
     VertId center; // the central vertex of the current neighborhood
 
     // (vnext, f): there is triangle #f with the vertices (center, vnext, some-third-vert) up to rotation
@@ -70,9 +70,9 @@ public:
         std::sort( vprevFaces.begin(), vprevFaces.end() );
     }
 
-    // takes the first triangle with not yet visited face and returns its two other vertices in cyclic order
+    // takes the first not yet visited triangle and returns its two other vertices in cyclic order
     // to start a new path there, so the walk can continue with triOrientation = true;
-    // returns a pair of invalid ids if all faces around the central vertex are already visited
+    // returns a pair of invalid ids if all triangles around the central vertex are already visited
     std::pair<VertId, VertId> getFirstTwoVertices()
     {
         while ( firstUnvisitedIndex < vertexEndIndex && visitedFaces.contains( vertTris[firstUnvisitedIndex].f ) )
@@ -84,7 +84,7 @@ public:
         return getOtherTriVerts( faceToVertices[f], center );
     }
 
-    // find incident vertex in a not yet visited face except for prevVertex and its duplicates
+    // find incident vertex in a not yet visited triangle except for prevVertex and its duplicates
     VertId getNextVertex( VertId v, bool triOrientation, VertId prevVertex, const std::vector<VertDuplication>& dups )
     {
         // if v is an original vertex, then return it;
@@ -474,7 +474,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
             bool triOrientation = true;
             auto [firstVertex, nextVertex] = pathMaker.getFirstTwoVertices();
             if ( !firstVertex )
-                break; // all faces around the central vertex are already visited
+                break; // all triangles around the central vertex are already visited
             visitedVertices.autoResizeSet( firstVertex );
             visitedVertices.autoResizeSet( nextVertex );
             VertId prevVertex = firstVertex;

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -35,9 +35,9 @@ class PathAroundVertex
     VertId center; // the central vertex of the current neighborhood
 
     // (vnext, f): there is triangle #f with the vertices (center, vnext, some-third-vert) up to rotation
-    std::vector<std::pair<VertId, FaceId>> vnextFaces;
+    std::vector<VertTri> vnextFaces;
     // (vprev, f): there is triangle #f with the vertices (vprev, center, some-third-vert) up to rotation
-    std::vector<std::pair<VertId, FaceId>> vprevFaces;
+    std::vector<VertTri> vprevFaces;
     HashSet<FaceId> visitedFaces;
 
 public:
@@ -62,8 +62,8 @@ public:
             assert( tris[i].v == center );
             const auto f = tris[i].f;
             const auto [v1, v2] = getOtherTriVerts( triangleToVertices[f], center );
-            vnextFaces.emplace_back( v1, f );
-            vprevFaces.emplace_back( v2, f );
+            vnextFaces.push_back( { v1, f } );
+            vprevFaces.push_back( { v2, f } );
         }
         std::sort( vnextFaces.begin(), vnextFaces.end() );
         std::sort( vprevFaces.begin(), vprevFaces.end() );
@@ -111,10 +111,10 @@ public:
         assert( prevVertex );
 
         const auto & vec = triOrientation ? vnextFaces : vprevFaces;
-        for ( auto it = std::lower_bound( vec.begin(), vec.end(), std::make_pair( v, FaceId{} ) );
-              it != vec.end() && it->first == v; ++it )
+        for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertTri{ v, FaceId{} } );
+              it != vec.end() && it->v == v; ++it )
         {
-            const auto f = it->second;
+            const auto f = it->f;
             if ( visitedFaces.contains( f ) )
                 continue;
             const auto v12 = getOtherTriVerts( (*faceToVertices)[f], center );
@@ -146,10 +146,10 @@ public:
         {
             // the triangle of this path step is (srcVert, path[i-1], path[i]) for triOrientation = true,
             // and (srcVert, path[i], path[i-1]) otherwise, up to rotation
-            for ( auto it = std::lower_bound( vec.begin(), vec.end(), std::make_pair( path[i - 1], FaceId{} ) );
-                  it != vec.end() && it->first == path[i - 1]; ++it )
+            for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertTri{ path[i - 1], FaceId{} } );
+                  it != vec.end() && it->v == path[i - 1]; ++it )
             {
-                const auto f = it->second;
+                const auto f = it->f;
                 if ( !visitedFaces.contains( f ) )
                     continue; // only visited triangles can be in the path
                 auto & tri = (*faceToVertices)[f];

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -27,7 +27,7 @@ static std::pair<VertId, VertId> getOtherTriVerts( const ThreeVertIds & vs, Vert
 // to find connected sequences around central vertex, where a sequence does not repeat any neighbor vertex twice.
 class PathAroundVertex
 {
-    Triangulation* faceToVertices = nullptr;
+    Triangulation& faceToVertices;
     const std::vector<VertTri>* vertTris = nullptr;
     // all elements in [vertexBegIndex, vertexEndIndex) of *vertTris have the same central vertex
     size_t vertexBegIndex = 0, vertexEndIndex = 0;
@@ -41,10 +41,11 @@ class PathAroundVertex
     HashSet<FaceId> visitedFaces;
 
 public:
+    explicit PathAroundVertex( Triangulation& triangleToVertices ) : faceToVertices( triangleToVertices ) {}
+
     // prepares the search around the central vertex of elements [beg, end), reusing the memory allocated for a previous vertex
-    void init( Triangulation& triangleToVertices, const std::vector<VertTri>& tris, size_t beg, size_t end )
+    void init( const std::vector<VertTri>& tris, size_t beg, size_t end )
     {
-        faceToVertices = &triangleToVertices;
         vertTris = &tris;
         vertexBegIndex = beg;
         vertexEndIndex = end;
@@ -61,7 +62,7 @@ public:
         {
             assert( tris[i].v == center );
             const auto f = tris[i].f;
-            const auto [v1, v2] = getOtherTriVerts( triangleToVertices[f], center );
+            const auto [v1, v2] = getOtherTriVerts( faceToVertices[f], center );
             vnextFaces.push_back( { v1, f } );
             vprevFaces.push_back( { v2, f } );
         }
@@ -69,23 +70,18 @@ public:
         std::sort( vprevFaces.begin(), vprevFaces.end() );
     }
 
-    // false if there are some elements with not yet visited faces; advances firstUnvisitedIndex
-    bool empty()
+    // takes the first triangle with not yet visited face and returns its two other vertices in cyclic order
+    // to start a new path there, so the walk can continue with triOrientation = true;
+    // returns a pair of invalid ids if all faces around the central vertex are already visited
+    std::pair<VertId, VertId> getFirstTwoVertices()
     {
         while ( firstUnvisitedIndex < vertexEndIndex && visitedFaces.contains( (*vertTris)[firstUnvisitedIndex].f ) )
             ++firstUnvisitedIndex;
-        return firstUnvisitedIndex >= vertexEndIndex;
-    }
-
-    // takes the first triangle with not yet visited face and returns its two other vertices in cyclic order
-    // to start a new path there, so the walk can continue with triOrientation = true
-    std::pair<VertId, VertId> getFirstTwoVertices()
-    {
-        [[maybe_unused]] const bool noRecs = empty(); // also advances firstUnvisitedIndex
-        assert( !noRecs );
+        if ( firstUnvisitedIndex >= vertexEndIndex )
+            return {};
         const auto f = (*vertTris)[firstUnvisitedIndex].f;
         visitedFaces.insert( f );
-        return getOtherTriVerts( (*faceToVertices)[f], center );
+        return getOtherTriVerts( faceToVertices[f], center );
     }
 
     // find incident vertex in a not yet visited face except for prevVertex and its duplicates
@@ -111,13 +107,14 @@ public:
         assert( prevVertex );
 
         const auto & vec = triOrientation ? vnextFaces : vprevFaces;
-        for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertTri{ v, FaceId{} } );
-              it != vec.end() && it->v == v; ++it )
+        for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertTri{ v, FaceId{} } ); ; ++it )
         {
+            if ( it == vec.end() || it->v != v )
+                return {}; // no unvisited continuation from v
             const auto f = it->f;
             if ( visitedFaces.contains( f ) )
                 continue;
-            const auto v12 = getOtherTriVerts( (*faceToVertices)[f], center );
+            const auto v12 = getOtherTriVerts( faceToVertices[f], center );
             assert( ( triOrientation ? v12.first : v12.second ) == v );
             const auto nextVertex = triOrientation ? v12.second : v12.first;
             if ( getOrgVertex( nextVertex ) != prevVertex )
@@ -126,17 +123,17 @@ public:
                 return nextVertex;
             }
         }
+        assert( false );
         return {};
     }
 
     // duplicate the vertex around which the chain was found
-    void duplicateVertex( VertId v, const std::vector<VertId>& path, VertId& lastUsedVertId, bool triOrientation,
+    void duplicateVertex( const std::vector<VertId>& path, VertId& lastUsedVertId, bool triOrientation,
                           std::vector<VertDuplication>* dups = nullptr )
     {
-        assert( v == center );
         VertDuplication vertDup;
         vertDup.dupVert = ++lastUsedVertId;
-        vertDup.srcVert = v;
+        vertDup.srcVert = center;
         if ( dups )
             dups->push_back( vertDup );
 
@@ -152,7 +149,7 @@ public:
                 const auto f = it->f;
                 if ( !visitedFaces.contains( f ) )
                     continue; // only visited triangles can be in the path
-                auto & tri = (*faceToVertices)[f];
+                auto & tri = faceToVertices[f];
                 if ( tri[0] != vertDup.srcVert && tri[1] != vertDup.srcVert && tri[2] != vertDup.srcVert )
                     continue; // this triangle has already been re-pointed to the duplicate
                 const auto v12 = getOtherTriVerts( tri, vertDup.srcVert );
@@ -451,7 +448,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     };
     tbb::parallel_sort( vertsToProcess.begin(), vertsToProcess.end(), sortPred );
 
-    PathAroundVertex pathMaker;
+    PathAroundVertex pathMaker( t );
     std::vector<VertId> path;
     std::vector<VertId> closedPath;
     VertBitSet visitedVertices( all.recs.back().v ); // explicitly not `lastValidVert` but last vert used in triangulation
@@ -465,17 +462,19 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
         // because formal non-manifoldness of this vertex can be resolved by a neighbour vertex duplication,
         // but we still want to dupliate it to avoid neighbours with equal coordinates
 
-        pathMaker.init( t, all.recs, posBegin, posEnd );
+        pathMaker.init( all.recs, posBegin, posEnd );
 
         // first chain of vertices around the center does not require duplication
         int foundChains = 0;
-        while ( !pathMaker.empty() )
+        for ( ;; )
         {
             for(const auto& vi : path)
                 visitedVertices.reset(vi);
 
             bool triOrientation = true;
             auto [firstVertex, nextVertex] = pathMaker.getFirstTwoVertices();
+            if ( !firstVertex )
+                break; // all faces around the central vertex are already visited
             visitedVertices.autoResizeSet( firstVertex );
             visitedVertices.autoResizeSet( nextVertex );
             VertId prevVertex = firstVertex;
@@ -508,7 +507,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                     {
                         if ( foundChains )
                         {
-                            pathMaker.duplicateVertex( v, path, lastValidVert, triOrientation, &myDups );
+                            pathMaker.duplicateVertex( path, lastValidVert, triOrientation, &myDups );
                             ++duplicatedVerticesCnt;
                         }
                         ++foundChains;
@@ -527,7 +526,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
 
                     if ( foundChains )
                     {
-                        pathMaker.duplicateVertex( v, closedPath, lastValidVert, triOrientation, &myDups );
+                        pathMaker.duplicateVertex( closedPath, lastValidVert, triOrientation, &myDups );
                         ++duplicatedVerticesCnt;
                     }
                     ++foundChains;

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -48,7 +48,6 @@ class PathAroundVertex
     // one bit per element in [vertexBegIndex, vertexEndIndex): set means the triangle was visited;
     // a bit marks the element at once for the span cursor and for both sorted vectors above
     BitSet visitedRecs;
-    size_t numVisited = 0;
 
 public:
     PathAroundVertex( Triangulation& triangleToVertices, const std::vector<VertTri>& tris )
@@ -69,7 +68,6 @@ public:
         vprevRecs.reserve( end - beg );
         visitedRecs.clear();
         visitedRecs.resize( end - beg );
-        numVisited = 0;
         for ( auto i = beg; i < end; ++i )
         {
             assert( vertTris[i].v == center );
@@ -84,7 +82,7 @@ public:
     // true if all triangles around the central vertex are already visited
     bool empty() const
     {
-        return numVisited == vertexEndIndex - vertexBegIndex;
+        return visitedRecs.all();
     }
 
     // takes the first not yet visited triangle and returns its two other vertices in cyclic order
@@ -95,7 +93,6 @@ public:
         while ( visitedRecs.test( firstUnvisitedIndex - vertexBegIndex ) )
             ++firstUnvisitedIndex;
         visitedRecs.set( firstUnvisitedIndex - vertexBegIndex );
-        ++numVisited;
         const auto f = vertTris[firstUnvisitedIndex++].f;
         return getOtherTriVerts( faceToVertices[f], center );
     }
@@ -136,12 +133,9 @@ public:
             if ( getOrgVertex( nextVertex ) != prevVertex )
             {
                 visitedRecs.set( it->rec );
-                ++numVisited;
                 return nextVertex;
             }
         }
-        assert( false );
-        return {};
     }
 
     // duplicate the vertex around which the chain was found

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -79,7 +79,7 @@ public:
             ++firstUnvisitedIndex;
         if ( firstUnvisitedIndex >= vertexEndIndex )
             return {};
-        const auto f = vertTris[firstUnvisitedIndex].f;
+        const auto f = vertTris[firstUnvisitedIndex++].f;
         visitedFaces.insert( f );
         return getOtherTriVerts( faceToVertices[f], center );
     }

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -91,9 +91,6 @@ public:
     // find incident vertex in a not yet visited face except for prevVertex and its duplicates
     VertId getNextVertex( VertId v, bool triOrientation, VertId prevVertex, const std::vector<VertDuplication>& dups )
     {
-        if ( empty() )
-            return {};
-
         // if v is an original vertex, then return it;
         // if v is a duplicated vertex, then return the id of the original vertex, which was duplicated to make v
         auto getOrgVertex = [&dups]( VertId v )

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -27,40 +27,72 @@ static std::pair<VertId, VertId> getOtherTriVerts( const ThreeVertIds & vs, Vert
 // to find connected sequences around central vertex, where a sequence does not repeat any neighbor vertex twice.
 class PathAroundVertex
 {
-    Triangulation& faceToVertices;
-    // all iterators in [vertexBegIt, vertexEndIt) must have the same central vertex
-    std::vector<VertTri>::iterator vertexBegIt, vertexEndIt;
-    size_t firstUnvisitedIndex = 0; // pivot index. [vertexBegIt + firstUnvistedIndex, vertexBegIt) - unvisited vertices
+    Triangulation* faceToVertices = nullptr;
+    const std::vector<VertTri>* vertTris = nullptr;
+    // all elements in [vertexBegIndex, vertexEndIndex) of *vertTris have the same central vertex
+    size_t vertexBegIndex = 0, vertexEndIndex = 0;
+    size_t firstUnvisitedIndex = 0; // lazily advanced index of the first element with not yet visited face
+    VertId center; // the central vertex of the current neighborhood
+
+    // (vnext, f): there is triangle #f with the vertices (center, vnext, some-third-vert) up to rotation
+    std::vector<std::pair<VertId, FaceId>> vnextFaces;
+    // (vprev, f): there is triangle #f with the vertices (vprev, center, some-third-vert) up to rotation
+    std::vector<std::pair<VertId, FaceId>> vprevFaces;
+    HashSet<FaceId> visitedFaces;
 
 public:
-    PathAroundVertex( Triangulation& triangleToVertices,
-                std::vector<VertTri>& vertTris, size_t beg, size_t end )
-        : faceToVertices( triangleToVertices )
-        , vertexBegIt( vertTris.begin() + beg )
-        , vertexEndIt( vertTris.begin() + end )
-    {}
-
-    // false if there are some unvisited vertices
-    bool empty() const
+    // prepares the search around the central vertex of elements [beg, end), reusing the memory allocated for a previous vertex
+    void init( Triangulation& triangleToVertices, const std::vector<VertTri>& tris, size_t beg, size_t end )
     {
-        return vertexBegIt + firstUnvisitedIndex >= vertexEndIt;
+        faceToVertices = &triangleToVertices;
+        vertTris = &tris;
+        vertexBegIndex = beg;
+        vertexEndIndex = end;
+        firstUnvisitedIndex = beg;
+        assert( beg < end );
+        center = tris[beg].v;
+
+        vnextFaces.clear();
+        vprevFaces.clear();
+        visitedFaces.clear();
+        vnextFaces.reserve( end - beg );
+        vprevFaces.reserve( end - beg );
+        for ( auto i = beg; i < end; ++i )
+        {
+            assert( tris[i].v == center );
+            const auto f = tris[i].f;
+            const auto [v1, v2] = getOtherTriVerts( triangleToVertices[f], center );
+            vnextFaces.emplace_back( v1, f );
+            vprevFaces.emplace_back( v2, f );
+        }
+        std::sort( vnextFaces.begin(), vnextFaces.end() );
+        std::sort( vprevFaces.begin(), vprevFaces.end() );
     }
 
-    // takes the first unvisited triangle and returns its two other vertices in cyclic order
+    // false if there are some elements with not yet visited faces; advances firstUnvisitedIndex
+    bool empty()
+    {
+        while ( firstUnvisitedIndex < vertexEndIndex && visitedFaces.contains( (*vertTris)[firstUnvisitedIndex].f ) )
+            ++firstUnvisitedIndex;
+        return firstUnvisitedIndex >= vertexEndIndex;
+    }
+
+    // takes the first triangle with not yet visited face and returns its two other vertices in cyclic order
     // to start a new path there, so the walk can continue with triOrientation = true
     std::pair<VertId, VertId> getFirstTwoVertices()
     {
-        assert( !empty() );
-        const auto first = vertexBegIt + firstUnvisitedIndex++;
-        const auto & vs = faceToVertices[first->f];
-        return getOtherTriVerts( vs, first->v );
+        [[maybe_unused]] const bool noRecs = empty(); // also advances firstUnvisitedIndex
+        assert( !noRecs );
+        const auto f = (*vertTris)[firstUnvisitedIndex].f;
+        visitedFaces.insert( f );
+        return getOtherTriVerts( (*faceToVertices)[f], center );
     }
 
-    // find incident unvisited vertex except for prevVertex and its duplicates
-    VertId getNextVertex( VertId center, bool triOrientation, VertId prevVertex, const std::vector<VertDuplication>& dups )
+    // find incident vertex in a not yet visited face except for prevVertex and its duplicates
+    VertId getNextVertex( VertId v, bool triOrientation, VertId prevVertex, const std::vector<VertDuplication>& dups )
     {
         if ( empty() )
-            return VertId( -1 );
+            return {};
 
         // if v is an original vertex, then return it;
         // if v is a duplicated vertex, then return the id of the original vertex, which was duplicated to make v
@@ -81,20 +113,19 @@ public:
         prevVertex = getOrgVertex( prevVertex );
         assert( prevVertex );
 
-        for ( auto it = vertexBegIt + firstUnvisitedIndex; it < vertexEndIt; ++it )
+        const auto & vec = triOrientation ? vnextFaces : vprevFaces;
+        for ( auto it = std::lower_bound( vec.begin(), vec.end(), std::make_pair( v, FaceId{} ) );
+              it != vec.end() && it->first == v; ++it )
         {
-            VertId nextVertex;
-            const auto & vs = faceToVertices[it->f];
-            const auto v12 = getOtherTriVerts( vs, it->v );
-            if ( triOrientation && v12.first == center )
-                nextVertex = v12.second;
-            else if ( !triOrientation && v12.second == center )
-                nextVertex = v12.first;
-            if ( nextVertex && getOrgVertex( nextVertex ) != prevVertex )
+            const auto f = it->second;
+            if ( visitedFaces.contains( f ) )
+                continue;
+            const auto v12 = getOtherTriVerts( (*faceToVertices)[f], center );
+            assert( ( triOrientation ? v12.first : v12.second ) == v );
+            const auto nextVertex = triOrientation ? v12.second : v12.first;
+            if ( getOrgVertex( nextVertex ) != prevVertex )
             {
-                if ( it != vertexBegIt + firstUnvisitedIndex )
-                    std::iter_swap( it, vertexBegIt + firstUnvisitedIndex );
-                ++firstUnvisitedIndex;
+                visitedFaces.insert( f );
                 return nextVertex;
             }
         }
@@ -105,6 +136,7 @@ public:
     void duplicateVertex( VertId v, const std::vector<VertId>& path, VertId& lastUsedVertId, bool triOrientation,
                           std::vector<VertDuplication>* dups = nullptr )
     {
+        assert( v == center );
         VertDuplication vertDup;
         vertDup.dupVert = ++lastUsedVertId;
         vertDup.srcVert = v;
@@ -112,45 +144,32 @@ public:
             dups->push_back( vertDup );
 
         [[maybe_unused]] size_t changedTris = 0;
+        const auto & vec = triOrientation ? vnextFaces : vprevFaces;
         for ( size_t i = 1; i < path.size(); ++i )
         {
-            for ( auto it = vertexBegIt; it < vertexBegIt + firstUnvisitedIndex; ++it )
+            // the triangle of this path step is (srcVert, path[i-1], path[i]) for triOrientation = true,
+            // and (srcVert, path[i], path[i-1]) otherwise, up to rotation
+            for ( auto it = std::lower_bound( vec.begin(), vec.end(), std::make_pair( path[i - 1], FaceId{} ) );
+                  it != vec.end() && it->first == path[i - 1]; ++it )
             {
-                VertId v1, v2;
-                bool alreadyDuplicated = true;
-                for ( VertId vi : faceToVertices[it->f] )
-                {
-                    if ( vi == vertDup.srcVert )
-                    {
-                        alreadyDuplicated = false;
-                        // make (v1,v2) the cyclic pair following srcVert in the triangle
-                        if ( v1 && !v2 )
-                            std::swap( v1, v2 );
-                    }
-                    else if ( !v1 )
-                        v1 = vi;
-                    else if ( !v2 )
-                        v2 = vi;
-                }
-                if ( alreadyDuplicated )
+                const auto f = it->second;
+                if ( !visitedFaces.contains( f ) )
+                    continue; // only visited triangles can be in the path
+                auto & tri = (*faceToVertices)[f];
+                if ( tri[0] != vertDup.srcVert && tri[1] != vertDup.srcVert && tri[2] != vertDup.srcVert )
+                    continue; // this triangle has already been re-pointed to the duplicate
+                const auto v12 = getOtherTriVerts( tri, vertDup.srcVert );
+                if ( ( triOrientation ? v12.second : v12.first ) != path[i] )
                     continue;
-                assert( v1 && v2 );
-                assert( v1 != v2 );
-
-                if ( ( triOrientation && v1 == path[i - 1] && v2 == path[i] ) ||
-                     ( !triOrientation && v2 == path[i - 1] && v1 == path[i] ) )
+                for ( VertId & vi : tri )
                 {
-                    for ( VertId & vi : faceToVertices[it->f] )
-                    {
-                        if ( vi != vertDup.srcVert )
-                            continue;
-                        vi = vertDup.dupVert;
-                        break;
-                    }
-                    ++changedTris;
-                    it->v = vertDup.dupVert;
+                    if ( vi != vertDup.srcVert )
+                        continue;
+                    vi = vertDup.dupVert;
                     break;
                 }
+                ++changedTris;
+                break;
             }
         }
         assert( changedTris + 1 == path.size() );
@@ -435,6 +454,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     };
     tbb::parallel_sort( vertsToProcess.begin(), vertsToProcess.end(), sortPred );
 
+    PathAroundVertex pathMaker;
     std::vector<VertId> path;
     std::vector<VertId> closedPath;
     VertBitSet visitedVertices( all.recs.back().v ); // explicitly not `lastValidVert` but last vert used in triangulation
@@ -448,7 +468,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
         // because formal non-manifoldness of this vertex can be resolved by a neighbour vertex duplication,
         // but we still want to dupliate it to avoid neighbours with equal coordinates
 
-        PathAroundVertex pathMaker( t, all.recs, posBegin, posEnd );
+        pathMaker.init( t, all.recs, posBegin, posEnd );
 
         // first chain of vertices around the center does not require duplication
         int foundChains = 0;

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -28,7 +28,7 @@ static std::pair<VertId, VertId> getOtherTriVerts( const ThreeVertIds & vs, Vert
 class PathAroundVertex
 {
     Triangulation& faceToVertices;
-    const std::vector<VertTri>* vertTris = nullptr;
+    const std::vector<VertTri>& vertTris;
     // all elements in [vertexBegIndex, vertexEndIndex) of *vertTris have the same central vertex
     size_t vertexBegIndex = 0, vertexEndIndex = 0;
     size_t firstUnvisitedIndex = 0; // lazily advanced index of the first element with not yet visited face
@@ -41,17 +41,17 @@ class PathAroundVertex
     HashSet<FaceId> visitedFaces;
 
 public:
-    explicit PathAroundVertex( Triangulation& triangleToVertices ) : faceToVertices( triangleToVertices ) {}
+    PathAroundVertex( Triangulation& triangleToVertices, const std::vector<VertTri>& tris )
+        : faceToVertices( triangleToVertices ), vertTris( tris ) {}
 
     // prepares the search around the central vertex of elements [beg, end), reusing the memory allocated for a previous vertex
-    void init( const std::vector<VertTri>& tris, size_t beg, size_t end )
+    void init( size_t beg, size_t end )
     {
-        vertTris = &tris;
         vertexBegIndex = beg;
         vertexEndIndex = end;
         firstUnvisitedIndex = beg;
         assert( beg < end );
-        center = tris[beg].v;
+        center = vertTris[beg].v;
 
         vnextFaces.clear();
         vprevFaces.clear();
@@ -60,8 +60,8 @@ public:
         vprevFaces.reserve( end - beg );
         for ( auto i = beg; i < end; ++i )
         {
-            assert( tris[i].v == center );
-            const auto f = tris[i].f;
+            assert( vertTris[i].v == center );
+            const auto f = vertTris[i].f;
             const auto [v1, v2] = getOtherTriVerts( faceToVertices[f], center );
             vnextFaces.push_back( { v1, f } );
             vprevFaces.push_back( { v2, f } );
@@ -75,11 +75,11 @@ public:
     // returns a pair of invalid ids if all faces around the central vertex are already visited
     std::pair<VertId, VertId> getFirstTwoVertices()
     {
-        while ( firstUnvisitedIndex < vertexEndIndex && visitedFaces.contains( (*vertTris)[firstUnvisitedIndex].f ) )
+        while ( firstUnvisitedIndex < vertexEndIndex && visitedFaces.contains( vertTris[firstUnvisitedIndex].f ) )
             ++firstUnvisitedIndex;
         if ( firstUnvisitedIndex >= vertexEndIndex )
             return {};
-        const auto f = (*vertTris)[firstUnvisitedIndex].f;
+        const auto f = vertTris[firstUnvisitedIndex].f;
         visitedFaces.insert( f );
         return getOtherTriVerts( faceToVertices[f], center );
     }
@@ -448,7 +448,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     };
     tbb::parallel_sort( vertsToProcess.begin(), vertsToProcess.end(), sortPred );
 
-    PathAroundVertex pathMaker( t );
+    PathAroundVertex pathMaker( t, all.recs );
     std::vector<VertId> path;
     std::vector<VertId> closedPath;
     VertBitSet visitedVertices( all.recs.back().v ); // explicitly not `lastValidVert` but last vert used in triangulation
@@ -462,7 +462,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
         // because formal non-manifoldness of this vertex can be resolved by a neighbour vertex duplication,
         // but we still want to dupliate it to avoid neighbours with equal coordinates
 
-        pathMaker.init( all.recs, posBegin, posEnd );
+        pathMaker.init( posBegin, posEnd );
 
         // first chain of vertices around the center does not require duplication
         int foundChains = 0;

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -70,15 +70,19 @@ public:
         std::sort( vprevFaces.begin(), vprevFaces.end() );
     }
 
+    // true if all triangles around the central vertex are already visited
+    bool empty() const
+    {
+        return visitedFaces.size() == vertexEndIndex - vertexBegIndex;
+    }
+
     // takes the first not yet visited triangle and returns its two other vertices in cyclic order
-    // to start a new path there, so the walk can continue with triOrientation = true;
-    // returns a pair of invalid ids if all triangles around the central vertex are already visited
+    // to start a new path there, so the walk can continue with triOrientation = true
     std::pair<VertId, VertId> getFirstTwoVertices()
     {
-        while ( firstUnvisitedIndex < vertexEndIndex && visitedFaces.contains( vertTris[firstUnvisitedIndex].f ) )
+        assert( !empty() );
+        while ( visitedFaces.contains( vertTris[firstUnvisitedIndex].f ) )
             ++firstUnvisitedIndex;
-        if ( firstUnvisitedIndex >= vertexEndIndex )
-            return {};
         const auto f = vertTris[firstUnvisitedIndex++].f;
         visitedFaces.insert( f );
         return getOtherTriVerts( faceToVertices[f], center );
@@ -466,15 +470,13 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
 
         // first chain of vertices around the center does not require duplication
         int foundChains = 0;
-        for ( ;; )
+        while ( !pathMaker.empty() )
         {
             for(const auto& vi : path)
                 visitedVertices.reset(vi);
 
             bool triOrientation = true;
             auto [firstVertex, nextVertex] = pathMaker.getFirstTwoVertices();
-            if ( !firstVertex )
-                break; // all triangles around the central vertex are already visited
             visitedVertices.autoResizeSet( firstVertex );
             visitedVertices.autoResizeSet( nextVertex );
             VertId prevVertex = firstVertex;


### PR DESCRIPTION
Rework of `PathAroundVertex` in `duplicateNonManifoldVertices`:

1. `pathMaker` is moved outside of the per-vertex loop, and the constructor becomes the `init` function, so the memory allocated for one vertex (the two vectors and the bitmap below) is reused for all following vertices.

2. `init` constructs two lexicographically sorted member vectors, each with one record per face incident to the center vertex:
   - `vnextRecs` of `(vnext, rec)`: there is triangle `vertTris[beg+rec].f` with the vertices `(center, vnext, some-third-vert)` up to rotation;
   - `vprevRecs` of `(vprev, rec)`: there is triangle `vertTris[beg+rec].f` with the vertices `(vprev, center, some-third-vert)` up to rotation.

3. Visited triangles are tracked in a per-vertex `BitSet` over the span elements plus an O(1) counter for `empty()`; the sorted vectors store the element index, so one bit marks a triangle visited at once for the span cursor and for both sorted vectors, with no hashing at all (a `HashSet<FaceId>` was used here initially and was replaced during the review).

4. The linear searches in `getNextVertex` and `duplicateVertex` are replaced with binary search (`std::lower_bound`) in `vnextRecs` for `triOrientation == true` and in `vprevRecs` otherwise, followed by the scan of only the faces incident to the sought vertex. The input `std::vector<VertTri>` is never modified (held by const reference; the former `std::iter_swap` compaction and the `rec.v = dupVert` write are gone).

Since visited elements are no longer compacted to the front, candidates are scanned in the canonical (face id) order rather than in an order perturbed by earlier swaps. All 326 unit tests pass unchanged, including every exact-outcome duplication fixture. On `StullerDragonTest1.ply` the result is 156442 vertices / 364 components versus 156466 / 361 on master (the same values as in #6506, which changes the scan order in the same way), load time unchanged (~120 ms).
