### PR TITLE
Bump vcpkg to 2026.07.29

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -6,7 +6,7 @@ on:
       # manually defined values
       vcpkg_version:
         description: "vcpkg version"
-        value: "2026.06.24" # VCPKG-AUTO-UPDATE - refer 'vcpkg-auto-update.yml' for more info
+        value: "2026.07.29" # VCPKG-AUTO-UPDATE - refer 'vcpkg-auto-update.yml' for more info
       # automatically computed or tag-based values
       app_version:
         description: "Version without namespace: v1.2.3.4"
@@ -307,7 +307,7 @@ jobs:
           fi
 
           jq \
-            --arg vcpkg "2026.06.24" \
+            --arg vcpkg "2026.07.29" \
             '.include[] |= (. + {"vcpkg-version": $vcpkg})' \
             "$MATRIX_FILE" > tmp.json
 

--- a/.github/workflows/distro-release.yml
+++ b/.github/workflows/distro-release.yml
@@ -16,7 +16,7 @@ jobs:
   config:
     runs-on: ubuntu-latest
     env:
-      vcpkg_version: "2026.06.24"
+      vcpkg_version: "2026.07.29"
     outputs:
       app_version: ${{ steps.set.outputs.app_version }}
       release_tag: ${{ steps.set.outputs.release_tag }}

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -403,7 +403,7 @@ jobs:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
     env:
-      VCPKG-VERSION: '2026.06.24'
+      VCPKG-VERSION: '2026.07.29'
       CUDA-VERSION: '12.0.1'
       CUDA-MAJOR: '12'
       CUDA-MINOR: '0'

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG VCPKG_VERSION=2026.06.24
+ARG VCPKG_VERSION=2026.07.29
 ARG VCPKG_TRIPLET=x64-linux-meshlib
 
 

--- a/docker/rockylinux9-vcpkgDockerfile
+++ b/docker/rockylinux9-vcpkgDockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG VCPKG_VERSION=2026.06.24
+ARG VCPKG_VERSION=2026.07.29
 ARG VCPKG_TRIPLET=x64-linux-meshlib
 
 

--- a/doxygen/general_pages/CppSetupGuide.dox
+++ b/doxygen/general_pages/CppSetupGuide.dox
@@ -61,7 +61,7 @@ git clone https://github.com/microsoft/vcpkg.git
    4. **Navigate to the** `vcpkg` **directory**:
 \code{.cmd}
 cd vcpkg
-git checkout 2026.06.24
+git checkout 2026.07.29
 \endcode
    5. **Run the bootstrap script to build the** `vcpkg` **executable**:
 \code{.cmd}

--- a/source/MRMCPGateway/MRMCPGatewayBackend.cpp
+++ b/source/MRMCPGateway/MRMCPGatewayBackend.cpp
@@ -4,7 +4,7 @@
 #include "MRMCPGatewaySpawn.h"
 
 #pragma warning(push)
-#pragma warning(disable: 4127) //conditional expression is constant (vcpkg 2026.06.24 + vs2022)
+#pragma warning(disable: 4127) //conditional expression is constant (vcpkg 2026.07.29 + vs2022)
 #pragma warning(disable: 4800) //Implicit conversion from 'BrotliDecoderState *const ' to bool. Possible information loss (Visual Studio Build Tools 2019 16.11.32510.428)
 #include <httplib.h>
 #pragma warning(pop)

--- a/source/MRMCPGateway/MRMCPGatewayBackend.cpp
+++ b/source/MRMCPGateway/MRMCPGatewayBackend.cpp
@@ -4,7 +4,7 @@
 #include "MRMCPGatewaySpawn.h"
 
 #pragma warning(push)
-#pragma warning(disable: 4127) //conditional expression is constant (vcpkg 2026.07.29 + vs2022)
+#pragma warning(disable: 4127) //conditional expression is constant
 #pragma warning(disable: 4800) //Implicit conversion from 'BrotliDecoderState *const ' to bool. Possible information loss (Visual Studio Build Tools 2019 16.11.32510.428)
 #include <httplib.h>
 #pragma warning(pop)

--- a/source/MRMCPGateway/MRMCPGatewayMlTransport.h
+++ b/source/MRMCPGateway/MRMCPGatewayMlTransport.h
@@ -3,7 +3,7 @@
 #include "MRMcp/MRFastmcpp.h"
 
 #pragma warning(push)
-#pragma warning(disable: 4127) //conditional expression is constant (vcpkg 2026.07.29 + vs2022)
+#pragma warning(disable: 4127) //conditional expression is constant
 #pragma warning(disable: 4800) //Implicit conversion from 'BrotliDecoderState *const ' to bool. Possible information loss (Visual Studio Build Tools 2019 16.11.32510.428)
 #include <httplib.h>
 #pragma warning(pop)

--- a/source/MRMCPGateway/MRMCPGatewayMlTransport.h
+++ b/source/MRMCPGateway/MRMCPGatewayMlTransport.h
@@ -3,7 +3,7 @@
 #include "MRMcp/MRFastmcpp.h"
 
 #pragma warning(push)
-#pragma warning(disable: 4127) //conditional expression is constant (vcpkg 2026.06.24 + vs2022)
+#pragma warning(disable: 4127) //conditional expression is constant (vcpkg 2026.07.29 + vs2022)
 #pragma warning(disable: 4800) //Implicit conversion from 'BrotliDecoderState *const ' to bool. Possible information loss (Visual Studio Build Tools 2019 16.11.32510.428)
 #include <httplib.h>
 #pragma warning(pop)

--- a/source/MRMcp/MRFastmcpp.h
+++ b/source/MRMcp/MRFastmcpp.h
@@ -13,7 +13,7 @@
 #elif defined( _MSC_VER )
 #pragma warning( push )
 #pragma warning( disable: 4100 ) // unreferenced formal parameter
-#pragma warning( disable: 4127 ) // conditional expression is constant (vcpkg 2026.07.29 + vs2022)
+#pragma warning( disable: 4127 ) // conditional expression is constant
 #pragma warning( disable: 4355 ) // 'this': used in base member initializer list
 #pragma warning( disable: 4800 ) // Implicit conversion from 'BrotliDecoderState *const ' to bool. Possible information loss (Visual Studio Build Tools 2019 16.11.32510.428)
 #endif

--- a/source/MRMcp/MRFastmcpp.h
+++ b/source/MRMcp/MRFastmcpp.h
@@ -13,7 +13,7 @@
 #elif defined( _MSC_VER )
 #pragma warning( push )
 #pragma warning( disable: 4100 ) // unreferenced formal parameter
-#pragma warning( disable: 4127 ) // conditional expression is constant (vcpkg 2026.06.24 + vs2022)
+#pragma warning( disable: 4127 ) // conditional expression is constant (vcpkg 2026.07.29 + vs2022)
 #pragma warning( disable: 4355 ) // 'this': used in base member initializer list
 #pragma warning( disable: 4800 ) // Implicit conversion from 'BrotliDecoderState *const ' to bool. Possible information loss (Visual Studio Build Tools 2019 16.11.32510.428)
 #endif

--- a/thirdparty/install.bat
+++ b/thirdparty/install.bat
@@ -11,7 +11,7 @@ REM                                   May be passed multiple times. Lets downstr
 REM                                   onto the same vcpkg invocation, so all the env-var and overlay setup lives here.
 
 REM VCPKG_TAG is the S3 binary-cache folder, derived below from the checked-out
-REM vcpkg release tag (e.g. 2026.07.29); it may not always exist in S3.
+REM vcpkg release tag; it may not always exist in S3.
 REM use "aws s3 ls s3://vcpkg-export/" to list all available tags
 
 if not defined VCPKG_DEFAULT_TRIPLET set VCPKG_DEFAULT_TRIPLET=x64-windows-meshlib
@@ -35,7 +35,7 @@ if not defined vcpkg_path (
     echo vcpkg not found. Setting VCPKG_TAG to "no-tag".
     set VCPKG_TAG=no-tag
 ) else (
-    REM S3 folder name = the checked-out vcpkg release tag (e.g. 2026.07.29).
+    REM S3 folder name = the checked-out vcpkg release tag.
     REM CI checks vcpkg out at a release tag before running this script, so
     REM `git describe --exact-match` yields that tag and keeps the binary-cache
     REM producer (prepare-images) and consumer (build) in sync. safe.directory

--- a/thirdparty/install.bat
+++ b/thirdparty/install.bat
@@ -11,7 +11,7 @@ REM                                   May be passed multiple times. Lets downstr
 REM                                   onto the same vcpkg invocation, so all the env-var and overlay setup lives here.
 
 REM VCPKG_TAG is the S3 binary-cache folder, derived below from the checked-out
-REM vcpkg release tag (e.g. 2026.06.24); it may not always exist in S3.
+REM vcpkg release tag (e.g. 2026.07.29); it may not always exist in S3.
 REM use "aws s3 ls s3://vcpkg-export/" to list all available tags
 
 if not defined VCPKG_DEFAULT_TRIPLET set VCPKG_DEFAULT_TRIPLET=x64-windows-meshlib
@@ -35,7 +35,7 @@ if not defined vcpkg_path (
     echo vcpkg not found. Setting VCPKG_TAG to "no-tag".
     set VCPKG_TAG=no-tag
 ) else (
-    REM S3 folder name = the checked-out vcpkg release tag (e.g. 2026.06.24).
+    REM S3 folder name = the checked-out vcpkg release tag (e.g. 2026.07.29).
     REM CI checks vcpkg out at a release tag before running this script, so
     REM `git describe --exact-match` yields that tag and keeps the binary-cache
     REM producer (prepare-images) and consumer (build) in sync. safe.directory

--- a/thirdparty/vcpkg/ports/tinygltf/portfile.cmake
+++ b/thirdparty/vcpkg/ports/tinygltf/portfile.cmake
@@ -1,5 +1,6 @@
 # Overlay until upstream re-registers the hash: GitHub regenerated the v3.0.0 archive
-# (microsoft/vcpkg#53143). Extracted contents are unchanged; only the tarball encoding differs.
+# (microsoft/vcpkg#53143). The only content change is a dropped checked-in binary,
+# tools/windows/premake5.exe, which this port does not install.
 
 # Header-only library
 vcpkg_from_github(

--- a/thirdparty/vcpkg/ports/tinygltf/portfile.cmake
+++ b/thirdparty/vcpkg/ports/tinygltf/portfile.cmake
@@ -1,0 +1,22 @@
+# Overlay until upstream re-registers the hash: GitHub regenerated the v3.0.0 archive
+# (microsoft/vcpkg#53143). Extracted contents are unchanged; only the tarball encoding differs.
+
+# Header-only library
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO syoyo/tinygltf
+    REF "v${VERSION}"
+    SHA512 b9a689f25284206969f31ba382abd06cd4ed69ee6a118af3484aaa17b68aebefddc97a4e722e3bde8fa39b737677cb09cbd3d3e6f2a573ac4ba1fb718478b79a
+    HEAD_REF master
+)
+
+# Put the licence file where vcpkg expects it
+# Copy the tinygltf header files and fix the path to json
+vcpkg_replace_string("${SOURCE_PATH}/tiny_gltf.h" "#include \"json.hpp\"" "#include <nlohmann/json.hpp>")
+file(INSTALL
+        "${SOURCE_PATH}/tiny_gltf.h"
+        "${SOURCE_PATH}/tiny_gltf_v3.h"
+        "${SOURCE_PATH}/tinygltf_json.h"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/thirdparty/vcpkg/ports/tinygltf/vcpkg.json
+++ b/thirdparty/vcpkg/ports/tinygltf/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "tinygltf",
+  "version": "3.0.0",
+  "description": "A header only C++11 glTF 2.0 library.",
+  "homepage": "https://github.com/syoyo/tinygltf",
+  "dependencies": [
+    "nlohmann-json",
+    "stb"
+  ]
+}

--- a/thirdparty/vcpkg/vcpkg.json
+++ b/thirdparty/vcpkg/vcpkg.json
@@ -69,8 +69,8 @@
         "default-registry": {
             "kind": "git",
             "repository": "https://github.com/Microsoft/vcpkg",
-            "baseline": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3",
-            "$version-tag": "2026.06.24"
+            "baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
+            "$version-tag": "2026.07.29"
         },
         "overlay-ports": [
             "./ports"


### PR DESCRIPTION
Updates the vcpkg tag from 2026.06.24 to 2026.07.29.

## Why there is a second commit

The bump on its own cannot build. GitHub re-generated the archive for the syoyo/tinygltf
`v3.0.0` tag, so the SHA512 registered by vcpkg 2026.07.29 no longer matches what the URL
serves, and every from-scratch vcpkg build dies on the download:

```
Downloading https://github.com/syoyo/tinygltf/archive/v3.0.0.tar.gz -> syoyo-tinygltf-v3.0.0.tar.gz
error: download from https://github.com/syoyo/tinygltf/archive/v3.0.0.tar.gz had an unexpected hash
note: Expected: 3305c94aaa6f2b82ac2533bb17672b0ddd0239c413acc87b428be50dc0f9bcd4c300f6ed7f3077424ccc8237e4e75f1194d311d21f799809e0220eeb3f8900a4
note: Actual  : b9a689f25284206969f31ba382abd06cd4ed69ee6a118af3484aaa17b68aebefddc97a4e722e3bde8fa39b737677cb09cbd3d3e6f2a573ac4ba1fb718478b79a
error: building tinygltf:x64-windows-meshlib failed with: BUILD_FAILED
```

All four Windows and both Linux vcpkg image jobs failed this way, on every triplet, with an
identical `Actual` hash. Reported upstream as microsoft/vcpkg#53143, still open; the port has
not been touched since the 3.0.0 bump in March.

This is not specific to the new tag. The identical portfile and SHA512 ship in 2026.06.24 as
well, so master is exposed too and is green only because its S3 binary cache is fully
populated and no build ever fetches the source. Any ABI change would surface it there.

## The fix

`thirdparty/vcpkg/ports/tinygltf/` is upstream's port copied verbatim with only the SHA512
line changed. One overlay covers every job: Windows picks it up through
`install.bat --overlay-ports`, Linux through `"overlay-ports": ["./ports"]` in
`thirdparty/vcpkg/vcpkg.json`.

**Delete this overlay once upstream re-registers the hash.**

## Why the new hash is safe to adopt

The re-generated archive drops `tools/windows/premake5.exe`, a 1.2 MB checked-in Windows
binary that upstream has removed - the current tagged tree has no `tools/` directory at all.
That single file accounts for the entire 505 KB size difference between the two archives, and
the port installs none of it. The original archive was recovered locally, hashes to the old
`3305c94a...`, and diffing the two extracted trees shows that removed binary as the only
difference across 1355 files.

Everything the port actually installs is unchanged. Verified twice: against a vcpkg
installation made on 2026-06-02, two months before the regeneration, and again by installing
this overlay port with the binary and asset caches disabled so the source had to be fetched.

| installed file | pre-regeneration vs. new archive |
| --- | --- |
| `tiny_gltf.h` | byte-identical |
| `tiny_gltf_v3.h` | byte-identical |
| `tinygltf_json.h` | byte-identical |
| `copyright` / `LICENSE` | byte-identical |

## Result

The vcpkg image jobs now finish in roughly 10 minutes each, against the 2h10m-2h56m they
previously spent before failing, and the full matrix is green.
