### PR TITLE
CI: pass MR_PCH_USE_EXTRA_HEADERS=ON to the C bindings MSBuild steps

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -224,7 +224,7 @@ jobs:
         env:
           VCPKG_ROOT: C:\vcpkg
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
-        run: msbuild -m source\MeshLibC2\MeshLibC2.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=x64 -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }}
+        run: msbuild -m source\MeshLibC2\MeshLibC2.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=x64 -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }};MR_PCH_USE_EXTRA_HEADERS=ON
 
       - name: Build C CUDA bindings with MSBuild
         if: ${{ inputs.mrbind_c && matrix.build_system == 'MSBuild' }}
@@ -232,7 +232,7 @@ jobs:
         env:
           VCPKG_ROOT: C:\vcpkg
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
-        run: msbuild -m source\MeshLibC2Cuda\MeshLibC2Cuda.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=x64 -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }}
+        run: msbuild -m source\MeshLibC2Cuda\MeshLibC2Cuda.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=x64 -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }};MR_PCH_USE_EXTRA_HEADERS=ON
 
       - name: Generate and build Python bindings
         if: ${{inputs.mrbind && matrix.vcpkg_triplet != 'x64-windows-meshlib-iterator-debug'}}


### PR DESCRIPTION
The main **Build** step builds `MeshLib.sln` with `-p:MR_PCH_USE_EXTRA_HEADERS=ON`, but **Build C bindings with MSBuild** and **Build C CUDA bindings with MSBuild** invoked msbuild without it.

That define is part of the tracked `CL.exe` command line, so MSBuild's up-to-date check failed for every file of every dependency project and rebuilt them from scratch — with a different PCH configuration, then relinking the DLLs over the ones the Build step had produced.

Measured on [job 91475426135](https://github.com/MeshInspector/MeshLib/actions/runs/30739571844/job/91475426135) (`msvc-2026, Release, MSBuild, x64-windows-meshlib`), where "Build C bindings with MSBuild" took **15m22s**:

| Interval | What it did |
| --- | --- |
| 08:56:46 → 08:57:14 | MRPch recompiled |
| 08:57:14 → 09:04:41 | MRMesh fully recompiled + MRMesh.dll relinked |
| 09:04:41 → 09:09:09 | MRSymbolMesh, MRIOExtras, MRVoxels fully recompiled + relinked |
| 09:09:10 → 09:12:07 | MeshLibC2's own 4 unity files + link |

354 of the 358 translation units compiled in that step had already been compiled in the Build step; only the 4 `unity_*.cpp` were new. Diffing the per-project `CL.exe` command lines between the two steps, the only difference for MRPch / MRMesh / MRIOExtras / MRSymbolMesh / MRVoxels / MRCuda is the `MR_PCH_USE_EXTRA_HEADERS` define, plus the knock-on `/Yc` + `/Fp TempOutput\MRMesh\...\MRPch.pch` to `/Yu` + `/Fp TempOutput\MRPch\...\MRPch.pch` switch in MRMesh.

The next step confirms the mechanism: "Build C CUDA bindings with MSBuild" passes the same property-less command line, finds those projects "All outputs are up-to-date" and finishes in 30s, rebuilding only MRCuda's 13 files.

Expected saving: roughly 12-13 minutes per Windows MSBuild job with C bindings enabled. As a side effect, the DLLs the tests run against are now the ones from the Build step rather than versions relinked against a different PCH.
