### PR TITLE
Optional vertex coordinates in duplicateNonManifoldVertices to select the smoothest path continuation

### DIFF
--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -81,7 +81,7 @@ Mesh Mesh::fromTrianglesDuplicatingNonManifoldVertices(
     Mesh res;
     res.points = std::move( vertexCoordinates );
     std::vector<MeshBuilder::VertDuplication> localDups;
-    res.topology = MeshBuilder::fromTrianglesDuplicatingNonManifoldVertices( t, &localDups, settings );
+    res.topology = MeshBuilder::fromTrianglesDuplicatingNonManifoldVertices( t, &localDups, settings, &res.points );
     if ( res.points.size() < res.topology.vertSize() ) // never shrink
         res.points.resize( res.topology.vertSize() );
     for ( const auto & d : localDups )

--- a/source/MRMesh/MRMeshBuilder.cpp
+++ b/source/MRMesh/MRMeshBuilder.cpp
@@ -541,7 +541,7 @@ MeshTopology fromTriangles( const Triangulation & t, const BuildSettings & setti
 }
 
 MeshTopology fromTrianglesDuplicatingNonManifoldVertices( Triangulation & t,
-    std::vector<VertDuplication> * dups, const BuildSettings & settings )
+    std::vector<VertDuplication> * dups, const BuildSettings & settings, const VertCoords * points )
 {
     MR_TIMER;
     FaceBitSet localRegion = getLocalRegion( settings.region, t.size() );
@@ -560,7 +560,7 @@ MeshTopology fromTrianglesDuplicatingNonManifoldVertices( Triangulation & t,
     }
     // full path
     std::vector<VertDuplication> localDups;
-    MeshBuilder::duplicateNonManifoldVertices( t, settings.region, &localDups );
+    MeshBuilder::duplicateNonManifoldVertices( t, settings.region, &localDups, {}, points );
     const bool noDuplicates = localDups.empty();
     if ( dups )
         *dups = std::move( localDups );

--- a/source/MRMesh/MRMeshBuilder.h
+++ b/source/MRMesh/MRMeshBuilder.h
@@ -39,11 +39,13 @@ MRMESH_API MeshTopology fromTriangles( const Triangulation & t, const BuildSetti
 
 /// construct mesh topology from a set of triangles with given ids;
 /// unlike simple fromTriangles() it tries to resolve non-manifold vertices by creating duplicate vertices;
-/// triangulation is modified to introduce duplicates
+/// triangulation is modified to introduce duplicates;
+/// `points` (if given) provides the coordinates of the vertices for smoother vertex duplication
 MRMESH_API MeshTopology fromTrianglesDuplicatingNonManifoldVertices( 
     Triangulation & t,
     std::vector<VertDuplication> * dups = nullptr,
-    const BuildSettings & settings = {} );
+    const BuildSettings & settings = {},
+    const VertCoords * points = nullptr );
 
 /// construct mesh from point triples;
 /// all coinciding points are given the same VertId in the result

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -44,66 +44,66 @@ static VertId getOrgVertex( VertId v, const std::vector<VertDuplication>& dups )
 // to find connected sequences around central vertex, where a sequence does not repeat any neighbor vertex twice.
 class PathAroundVertex
 {
-    Triangulation& faceToVertices;
-    const std::vector<VertTri>& vertTris;
-    const VertCoords* points = nullptr; // optional vertex coordinates for smooth path continuation selection
-    // all elements in [vertexBegIndex, vertexEndIndex) of *vertTris have the same central vertex
-    size_t vertexBegIndex = 0, vertexEndIndex = 0;
-    size_t firstUnvisitedIndex = 0; // lazily advanced index of the first not yet visited element of the central vertex
-    VertId center; // the central vertex of the current neighborhood
+    Triangulation& faceToVertices_;
+    const std::vector<VertTri>& vertTris_;
+    const VertCoords* points_ = nullptr; // optional vertex coordinates for smooth path continuation selection
+    // all elements in [vertexBegIndex_, vertexEndIndex_) of *vertTris_ have the same central vertex
+    size_t vertexBegIndex_ = 0, vertexEndIndex_ = 0;
+    size_t firstUnvisitedIndex_ = 0; // lazily advanced index of the first not yet visited element of the central vertex
+    VertId center_; // the central vertex of the current neighborhood
 
     struct VertRec
     {
         VertId v;    // neighbor vertex
-        int rec = 0; // index of the element in [vertexBegIndex, vertexEndIndex) minus vertexBegIndex
+        int rec = 0; // index of the element in [vertexBegIndex_, vertexEndIndex_) minus vertexBegIndex_
         auto asPair() const { return std::make_pair( v, rec ); }
         friend bool operator <( const VertRec& l, const VertRec& r ) { return l.asPair() < r.asPair(); }
     };
-    // (vnext, rec): there is triangle #vertTris[vertexBegIndex+rec].f with the vertices (center, vnext, some-third-vert) up to rotation
-    std::vector<VertRec> vnextRecs;
-    // (vprev, rec): there is triangle #vertTris[vertexBegIndex+rec].f with the vertices (vprev, center, some-third-vert) up to rotation
-    std::vector<VertRec> vprevRecs;
-    // one bit per element in [vertexBegIndex, vertexEndIndex): set means the triangle was visited;
+    // (vnext, rec): there is triangle #vertTris_[vertexBegIndex_+rec].f with the vertices (center_, vnext, some-third-vert) up to rotation
+    std::vector<VertRec> vnextRecs_;
+    // (vprev, rec): there is triangle #vertTris_[vertexBegIndex_+rec].f with the vertices (vprev, center_, some-third-vert) up to rotation
+    std::vector<VertRec> vprevRecs_;
+    // one bit per element in [vertexBegIndex_, vertexEndIndex_): set means the triangle was visited;
     // a bit marks the element at once for the span cursor and for both sorted vectors above
-    BitSet visitedRecs;
-    FaceId firstTri; // the triangle visited first in the current path
-    FaceId refTri;   // the last visited triangle, its normal is the reference for smooth path continuation
-    std::optional<Vector3f> refNormal; // cached normal of refTri to avoid recomputing it for the same triangle
+    BitSet visitedRecs_;
+    FaceId firstTri_; // the triangle visited first in the current path
+    FaceId refTri_;   // the last visited triangle, its normal is the reference for smooth path continuation
+    std::optional<Vector3f> refNormal_; // cached normal of refTri_ to avoid recomputing it for the same triangle
 
 public:
     PathAroundVertex( Triangulation& triangleToVertices, const std::vector<VertTri>& tris, const VertCoords* pts )
-        : faceToVertices( triangleToVertices ), vertTris( tris ), points( pts ) {}
+        : faceToVertices_( triangleToVertices ), vertTris_( tris ), points_( pts ) {}
 
     // prepares the search around the central vertex of elements [beg, end), reusing the memory allocated for a previous vertex
     void init( size_t beg, size_t end )
     {
-        vertexBegIndex = beg;
-        vertexEndIndex = end;
-        firstUnvisitedIndex = beg;
+        vertexBegIndex_ = beg;
+        vertexEndIndex_ = end;
+        firstUnvisitedIndex_ = beg;
         assert( beg < end );
-        center = vertTris[beg].v;
+        center_ = vertTris_[beg].v;
 
-        vnextRecs.clear();
-        vprevRecs.clear();
-        vnextRecs.reserve( end - beg );
-        vprevRecs.reserve( end - beg );
-        visitedRecs.clear();
-        visitedRecs.resize( end - beg );
+        vnextRecs_.clear();
+        vprevRecs_.clear();
+        vnextRecs_.reserve( end - beg );
+        vprevRecs_.reserve( end - beg );
+        visitedRecs_.clear();
+        visitedRecs_.resize( end - beg );
         for ( auto i = beg; i < end; ++i )
         {
-            assert( vertTris[i].v == center );
-            const auto [v1, v2] = getOtherTriVerts( faceToVertices[vertTris[i].f], center );
-            vnextRecs.push_back( { v1, int( i - beg ) } );
-            vprevRecs.push_back( { v2, int( i - beg ) } );
+            assert( vertTris_[i].v == center_ );
+            const auto [v1, v2] = getOtherTriVerts( faceToVertices_[vertTris_[i].f], center_ );
+            vnextRecs_.push_back( { v1, int( i - beg ) } );
+            vprevRecs_.push_back( { v2, int( i - beg ) } );
         }
-        std::sort( vnextRecs.begin(), vnextRecs.end() );
-        std::sort( vprevRecs.begin(), vprevRecs.end() );
+        std::sort( vnextRecs_.begin(), vnextRecs_.end() );
+        std::sort( vprevRecs_.begin(), vprevRecs_.end() );
     }
 
     // true if all triangles around the central vertex are already visited
     bool empty() const
     {
-        return visitedRecs.all();
+        return visitedRecs_.all();
     }
 
     // takes the first not yet visited triangle and returns its two other vertices in cyclic order
@@ -111,22 +111,22 @@ public:
     std::pair<VertId, VertId> getFirstTwoVertices()
     {
         assert( !empty() );
-        while ( visitedRecs.test( firstUnvisitedIndex - vertexBegIndex ) )
-            ++firstUnvisitedIndex;
-        visitedRecs.set( firstUnvisitedIndex - vertexBegIndex );
-        const auto f = vertTris[firstUnvisitedIndex++].f;
-        firstTri = refTri = f;
-        refNormal.reset();
-        return getOtherTriVerts( faceToVertices[f], center );
+        while ( visitedRecs_.test( firstUnvisitedIndex_ - vertexBegIndex_ ) )
+            ++firstUnvisitedIndex_;
+        visitedRecs_.set( firstUnvisitedIndex_ - vertexBegIndex_ );
+        const auto f = vertTris_[firstUnvisitedIndex_++].f;
+        firstTri_ = refTri_ = f;
+        refNormal_.reset();
+        return getOtherTriVerts( faceToVertices_[f], center_ );
     }
 
     // the search from firstVertex continues over the edge of the first visited triangle, so its normal becomes the reference
     void restartFromFirstTriangle()
     {
-        if ( refTri != firstTri )
+        if ( refTri_ != firstTri_ )
         {
-            refTri = firstTri;
-            refNormal.reset();
+            refTri_ = firstTri_;
+            refNormal_.reset();
         }
     }
 
@@ -135,7 +135,7 @@ public:
     {
         Vector3f p[3];
         for ( int i = 0; i < 3; ++i )
-            p[i] = (*points)[ getOrgVertex( faceToVertices[f][i], dups ) ];
+            p[i] = (*points_)[ getOrgVertex( faceToVertices_[f][i], dups ) ];
         return cross( p[1] - p[0], p[2] - p[0] ).normalized();
     }
 
@@ -148,7 +148,7 @@ public:
         prevVertex = getOrgVertex( prevVertex, dups );
         assert( prevVertex );
 
-        const auto & vec = triOrientation ? vnextRecs : vprevRecs;
+        const auto & vec = triOrientation ? vnextRecs_ : vprevRecs_;
         const VertRec * best = nullptr;
         VertId bestNext;
         std::optional<Vector3f> bestNormal; // engaged only when several continuation options were compared
@@ -157,18 +157,18 @@ public:
         {
             if ( it == vec.end() || it->v != v )
                 break; // no more continuation options from v
-            if ( visitedRecs.test( it->rec ) )
+            if ( visitedRecs_.test( it->rec ) )
                 continue;
-            const auto f = vertTris[vertexBegIndex + it->rec].f;
-            const auto v12 = getOtherTriVerts( faceToVertices[f], center );
+            const auto f = vertTris_[vertexBegIndex_ + it->rec].f;
+            const auto v12 = getOtherTriVerts( faceToVertices_[f], center_ );
             assert( ( triOrientation ? v12.first : v12.second ) == v );
             const auto nextVertex = triOrientation ? v12.second : v12.first;
             if ( getOrgVertex( nextVertex, dups ) == prevVertex )
                 continue;
-            if ( !points )
+            if ( !points_ )
             {
                 // without coordinates, the first found continuation is taken
-                visitedRecs.set( it->rec );
+                visitedRecs_.set( it->rec );
                 return nextVertex;
             }
             if ( !best )
@@ -180,13 +180,13 @@ public:
             if ( !bestNormal )
             {
                 // the second continuation option is found, time to compute the normals
-                if ( !refNormal )
-                    refNormal = triNormal( refTri, dups );
-                bestNormal = triNormal( vertTris[vertexBegIndex + best->rec].f, dups );
-                bestDot = dot( *refNormal, *bestNormal );
+                if ( !refNormal_ )
+                    refNormal_ = triNormal( refTri_, dups );
+                bestNormal = triNormal( vertTris_[vertexBegIndex_ + best->rec].f, dups );
+                bestDot = dot( *refNormal_, *bestNormal );
             }
             const auto n = triNormal( f, dups );
-            if ( const auto d = dot( *refNormal, n ); d > bestDot )
+            if ( const auto d = dot( *refNormal_, n ); d > bestDot )
             {
                 best = &*it;
                 bestNext = nextVertex;
@@ -196,9 +196,9 @@ public:
         }
         if ( !best )
             return {};
-        visitedRecs.set( best->rec );
-        refTri = vertTris[vertexBegIndex + best->rec].f;
-        refNormal = bestNormal; // the normal of the winner (if it was computed) becomes the reference
+        visitedRecs_.set( best->rec );
+        refTri_ = vertTris_[vertexBegIndex_ + best->rec].f;
+        refNormal_ = bestNormal; // the normal of the winner (if it was computed) becomes the reference
         return bestNext;
     }
 
@@ -208,12 +208,12 @@ public:
     {
         VertDuplication vertDup;
         vertDup.dupVert = ++lastUsedVertId;
-        vertDup.srcVert = center;
+        vertDup.srcVert = center_;
         if ( dups )
             dups->push_back( vertDup );
 
         [[maybe_unused]] size_t changedTris = 0;
-        const auto & vec = triOrientation ? vnextRecs : vprevRecs;
+        const auto & vec = triOrientation ? vnextRecs_ : vprevRecs_;
         for ( size_t i = 1; i < path.size(); ++i )
         {
             // the triangle of this path step is (srcVert, path[i-1], path[i]) for triOrientation = true,
@@ -221,9 +221,9 @@ public:
             for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertRec{ path[i - 1], 0 } );
                   it != vec.end() && it->v == path[i - 1]; ++it )
             {
-                if ( !visitedRecs.test( it->rec ) )
+                if ( !visitedRecs_.test( it->rec ) )
                     continue; // only visited triangles can be in the path
-                auto & tri = faceToVertices[vertTris[vertexBegIndex + it->rec].f];
+                auto & tri = faceToVertices_[vertTris_[vertexBegIndex_ + it->rec].f];
                 if ( tri[0] != vertDup.srcVert && tri[1] != vertDup.srcVert && tri[2] != vertDup.srcVert )
                     continue; // this triangle has already been re-pointed to the duplicate
                 const auto v12 = getOtherTriVerts( tri, vertDup.srcVert );

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -3,6 +3,7 @@
 #include "MRParallelFor.h"
 #include "MRTimer.h"
 #include "MRVector.h"
+#include "MRVector3.h"
 #include "MRphmap.h"
 #include "MRPch/MRTBB.h"
 #include <algorithm>
@@ -24,11 +25,27 @@ static std::pair<VertId, VertId> getOtherTriVerts( const ThreeVertIds & vs, Vert
     return { vs[0], vs[1] };
 }
 
+/// if v is an original vertex, then returns it;
+/// if v is a duplicated vertex, then returns the id of the original vertex, which was duplicated to make v
+static VertId getOrgVertex( VertId v, const std::vector<VertDuplication>& dups )
+{
+    if ( dups.empty() || v < dups.front().dupVert )
+        return v;
+    const auto i = v - dups.front().dupVert;
+    assert( i < dups.size() );
+    if ( i >= dups.size() )
+        return v;
+    assert( dups[i].dupVert == v );
+    assert( dups[i].srcVert < dups.front().dupVert );
+    return dups[i].srcVert;
+}
+
 // to find connected sequences around central vertex, where a sequence does not repeat any neighbor vertex twice.
 class PathAroundVertex
 {
     Triangulation& faceToVertices;
     const std::vector<VertTri>& vertTris;
+    const VertCoords* points = nullptr; // optional vertex coordinates for smooth path continuation selection
     // all elements in [vertexBegIndex, vertexEndIndex) of *vertTris have the same central vertex
     size_t vertexBegIndex = 0, vertexEndIndex = 0;
     size_t firstUnvisitedIndex = 0; // lazily advanced index of the first not yet visited element of the central vertex
@@ -48,10 +65,12 @@ class PathAroundVertex
     // one bit per element in [vertexBegIndex, vertexEndIndex): set means the triangle was visited;
     // a bit marks the element at once for the span cursor and for both sorted vectors above
     BitSet visitedRecs;
+    FaceId firstTri; // the triangle visited first in the current path
+    FaceId refTri;   // the last visited triangle, its normal is the reference for smooth path continuation
 
 public:
-    PathAroundVertex( Triangulation& triangleToVertices, const std::vector<VertTri>& tris )
-        : faceToVertices( triangleToVertices ), vertTris( tris ) {}
+    PathAroundVertex( Triangulation& triangleToVertices, const std::vector<VertTri>& tris, const VertCoords* pts )
+        : faceToVertices( triangleToVertices ), vertTris( tris ), points( pts ) {}
 
     // prepares the search around the central vertex of elements [beg, end), reusing the memory allocated for a previous vertex
     void init( size_t beg, size_t end )
@@ -94,48 +113,83 @@ public:
             ++firstUnvisitedIndex;
         visitedRecs.set( firstUnvisitedIndex - vertexBegIndex );
         const auto f = vertTris[firstUnvisitedIndex++].f;
+        firstTri = refTri = f;
         return getOtherTriVerts( faceToVertices[f], center );
     }
 
-    // find incident vertex in a not yet visited triangle except for prevVertex and its duplicates
+    // the search from firstVertex continues over the edge of the first visited triangle, so its normal becomes the reference
+    void restartFromFirstTriangle()
+    {
+        refTri = firstTri;
+    }
+
+    // computes unit normal of the triangle #f using provided coordinates, mapping duplicated vertices on their originals
+    Vector3f triNormal( FaceId f, const std::vector<VertDuplication>& dups ) const
+    {
+        Vector3f p[3];
+        for ( int i = 0; i < 3; ++i )
+            p[i] = (*points)[ getOrgVertex( faceToVertices[f][i], dups ) ];
+        return cross( p[1] - p[0], p[2] - p[0] ).normalized();
+    }
+
+    // find incident vertex in a not yet visited triangle except for prevVertex and its duplicates;
+    // if the coordinates of the vertices are known and there are several continuation options,
+    // then the triangle with the maximal dot-product between its normal and the normal of the preceding triangle is selected
     VertId getNextVertex( VertId v, bool triOrientation, VertId prevVertex, const std::vector<VertDuplication>& dups )
     {
-        // if v is an original vertex, then return it;
-        // if v is a duplicated vertex, then return the id of the original vertex, which was duplicated to make v
-        auto getOrgVertex = [&dups]( VertId v )
-        {
-            if ( dups.empty() || v < dups.front().dupVert )
-                return v;
-            const auto i = v - dups.front().dupVert;
-            assert( i < dups.size() );
-            if ( i >= dups.size() )
-                return v;
-            assert( dups[i].dupVert == v );
-            assert( dups[i].srcVert < dups.front().dupVert );
-            return dups[i].srcVert;
-        };
-
         assert( prevVertex );
-        prevVertex = getOrgVertex( prevVertex );
+        prevVertex = getOrgVertex( prevVertex, dups );
         assert( prevVertex );
 
         const auto & vec = triOrientation ? vnextRecs : vprevRecs;
+        const VertRec * best = nullptr;
+        VertId bestNext;
+        float bestDot = 0;
+        Vector3f refNormal;
+        bool refNormalReady = false;
         for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertRec{ v, 0 } ); ; ++it )
         {
             if ( it == vec.end() || it->v != v )
-                return {}; // no unvisited continuation from v
+                break; // no more continuation options from v
             if ( visitedRecs.test( it->rec ) )
                 continue;
             const auto f = vertTris[vertexBegIndex + it->rec].f;
             const auto v12 = getOtherTriVerts( faceToVertices[f], center );
             assert( ( triOrientation ? v12.first : v12.second ) == v );
             const auto nextVertex = triOrientation ? v12.second : v12.first;
-            if ( getOrgVertex( nextVertex ) != prevVertex )
+            if ( getOrgVertex( nextVertex, dups ) == prevVertex )
+                continue;
+            if ( !points )
             {
+                // without coordinates, the first found continuation is taken
                 visitedRecs.set( it->rec );
                 return nextVertex;
             }
+            if ( !best )
+            {
+                best = &*it;
+                bestNext = nextVertex;
+                continue;
+            }
+            if ( !refNormalReady )
+            {
+                // the second continuation option is found, time to compute the normals
+                refNormal = triNormal( refTri, dups );
+                bestDot = dot( refNormal, triNormal( vertTris[vertexBegIndex + best->rec].f, dups ) );
+                refNormalReady = true;
+            }
+            if ( const auto d = dot( refNormal, triNormal( f, dups ) ); d > bestDot )
+            {
+                best = &*it;
+                bestNext = nextVertex;
+                bestDot = d;
+            }
         }
+        if ( !best )
+            return {};
+        visitedRecs.set( best->rec );
+        refTri = vertTris[vertexBegIndex + best->rec].f;
+        return bestNext;
     }
 
     // duplicate the vertex around which the chain was found
@@ -395,7 +449,7 @@ void extractClosedPath( std::vector<VertId>& path, std::vector<VertId>& closedPa
 }
 
 // for all vertices get over all incident vertices to find connected sequences
-size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std::vector<VertDuplication>* dups, VertId lastValidVert )
+size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std::vector<VertDuplication>* dups, VertId lastValidVert, const VertCoords * points )
 {
     MR_TIMER;
     if ( dups )
@@ -458,7 +512,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     };
     tbb::parallel_sort( vertsToProcess.begin(), vertsToProcess.end(), sortPred );
 
-    PathAroundVertex pathMaker( t, all.recs );
+    PathAroundVertex pathMaker( t, all.recs, points );
     std::vector<VertId> path;
     std::vector<VertId> closedPath;
     VertBitSet visitedVertices( all.recs.back().v ); // explicitly not `lastValidVert` but last vert used in triangulation
@@ -508,6 +562,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
                         triOrientation = false;
                         prevVertex = path[1];
                         std::reverse( path.begin(), path.end() );
+                        pathMaker.restartFromFirstTriangle();
                         nextVertex = pathMaker.getNextVertex( firstVertex, triOrientation, prevVertex, myDups );
                         prevVertex = firstVertex;
                     }

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -7,6 +7,7 @@
 #include "MRphmap.h"
 #include "MRPch/MRTBB.h"
 #include <algorithm>
+#include <optional>
 
 namespace MR
 {
@@ -67,6 +68,7 @@ class PathAroundVertex
     BitSet visitedRecs;
     FaceId firstTri; // the triangle visited first in the current path
     FaceId refTri;   // the last visited triangle, its normal is the reference for smooth path continuation
+    std::optional<Vector3f> refNormal; // cached normal of refTri to avoid recomputing it for the same triangle
 
 public:
     PathAroundVertex( Triangulation& triangleToVertices, const std::vector<VertTri>& tris, const VertCoords* pts )
@@ -114,13 +116,18 @@ public:
         visitedRecs.set( firstUnvisitedIndex - vertexBegIndex );
         const auto f = vertTris[firstUnvisitedIndex++].f;
         firstTri = refTri = f;
+        refNormal.reset();
         return getOtherTriVerts( faceToVertices[f], center );
     }
 
     // the search from firstVertex continues over the edge of the first visited triangle, so its normal becomes the reference
     void restartFromFirstTriangle()
     {
-        refTri = firstTri;
+        if ( refTri != firstTri )
+        {
+            refTri = firstTri;
+            refNormal.reset();
+        }
     }
 
     // computes unit normal of the triangle #f using provided coordinates, mapping duplicated vertices on their originals
@@ -144,9 +151,8 @@ public:
         const auto & vec = triOrientation ? vnextRecs : vprevRecs;
         const VertRec * best = nullptr;
         VertId bestNext;
+        std::optional<Vector3f> bestNormal; // engaged only when several continuation options were compared
         float bestDot = 0;
-        Vector3f refNormal;
-        bool refNormalReady = false;
         for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertRec{ v, 0 } ); ; ++it )
         {
             if ( it == vec.end() || it->v != v )
@@ -171,17 +177,20 @@ public:
                 bestNext = nextVertex;
                 continue;
             }
-            if ( !refNormalReady )
+            if ( !bestNormal )
             {
                 // the second continuation option is found, time to compute the normals
-                refNormal = triNormal( refTri, dups );
-                bestDot = dot( refNormal, triNormal( vertTris[vertexBegIndex + best->rec].f, dups ) );
-                refNormalReady = true;
+                if ( !refNormal )
+                    refNormal = triNormal( refTri, dups );
+                bestNormal = triNormal( vertTris[vertexBegIndex + best->rec].f, dups );
+                bestDot = dot( *refNormal, *bestNormal );
             }
-            if ( const auto d = dot( refNormal, triNormal( f, dups ) ); d > bestDot )
+            const auto n = triNormal( f, dups );
+            if ( const auto d = dot( *refNormal, n ); d > bestDot )
             {
                 best = &*it;
                 bestNext = nextVertex;
+                bestNormal = n;
                 bestDot = d;
             }
         }
@@ -189,6 +198,7 @@ public:
             return {};
         visitedRecs.set( best->rec );
         refTri = vertTris[vertexBegIndex + best->rec].f;
+        refNormal = bestNormal; // the normal of the winner (if it was computed) becomes the reference
         return bestNext;
     }
 

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -22,9 +22,11 @@ struct VertDuplication
 /// resolve non-manifold vertices by creating duplicate vertices in the triangulation (which is modified)
 /// `lastValidVert` is needed if `region` or `t` does not contain full mesh, then first duplicated vertex will have `lastValidVert+1` index
 /// `dups` (if given) contents will be ignored and overridden; it receives the duplications in creation order with consecutive dupVert ids starting from `lastValidVert+1`
+/// `points` (if given) provides the coordinates of the vertices, and among several possible path continuations
+/// the one with the maximal dot-product between its triangle's normal and the normal of the preceding triangle is selected
 /// return number of duplicated vertices
 MRMESH_API size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region = nullptr,
-    std::vector<VertDuplication>* dups = nullptr, VertId lastValidVert = {} );
+    std::vector<VertDuplication>* dups = nullptr, VertId lastValidVert = {}, const VertCoords * points = nullptr );
 
 /// classification of the triangles around one vertex, packed in 32 bits;
 /// it stores 1-bit flag (hasRepeatedVerts) and either 31-bit numRepeatedVerts (if the flag is on),

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -1,5 +1,6 @@
 #include <MRMesh/MRMeshBuilder.h>
 #include <MRMesh/MRVertDuplication.h>
+#include <MRMesh/MRVector3.h>
 #include <MRMesh/MRMeshBuilderTypes.h>
 #include <MRMesh/MRMeshLoad.h>
 #include <MRMesh/MRMeshComponents.h>
@@ -146,6 +147,50 @@ TEST( MRMesh, duplicateVertexOppositeOrientedTri )
     dups.clear();
     EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups ), 0 );
     EXPECT_EQ( dups.size(), 0 );
+}
+
+// a fan around #0 with two continuation options from the shared rim vertex #2:
+// folded triangle 1_f (normal opposite to 0_f) and flat triangle 2_f (normal equal to 0_f);
+// with given coordinates the walk prefers the flat continuation (maximal normals' dot-product),
+// so the folded triangle is fully detached; without coordinates the first option by face id wins instead
+TEST( MRMesh, duplicateVertexSmoothContinuation )
+{
+    Triangulation initT;
+    initT.push_back( { 0_v, 1_v, 2_v } ); //0_f
+    initT.push_back( { 0_v, 2_v, 3_v } ); //1_f folded
+    initT.push_back( { 0_v, 2_v, 4_v } ); //2_f flat
+
+    VertCoords points;
+    points.push_back( Vector3f( 0, 0, 0 ) );  //0
+    points.push_back( Vector3f( 1, 0, 0 ) );  //1
+    points.push_back( Vector3f( 0, 1, 0 ) );  //2
+    points.push_back( Vector3f( 1, 1, 0 ) );  //3
+    points.push_back( Vector3f( -1, 1, 0 ) ); //4
+
+    {
+        auto t = initT;
+        std::vector<VertDuplication> dups;
+        EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups, {}, &points ), 2 );
+        ASSERT_EQ( dups.size(), 2 );
+        EXPECT_EQ( dups[0].srcVert, 0_v );
+        EXPECT_EQ( dups[0].dupVert, 5_v );
+        EXPECT_EQ( dups[1].srcVert, 2_v );
+        EXPECT_EQ( dups[1].dupVert, 6_v );
+        EXPECT_EQ( t[0_f], ( ThreeVertIds{ 0_v, 1_v, 2_v } ) );
+        EXPECT_EQ( t[1_f], ( ThreeVertIds{ 5_v, 6_v, 3_v } ) );
+        EXPECT_EQ( t[2_f], ( ThreeVertIds{ 0_v, 2_v, 4_v } ) );
+
+        // the result is manifold
+        dups.clear();
+        EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups, {}, &points ), 0 );
+    }
+    {
+        auto t = initT;
+        std::vector<VertDuplication> dups;
+        EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups ), 2 );
+        EXPECT_EQ( t[1_f], ( ThreeVertIds{ 0_v, 2_v, 3_v } ) );
+        EXPECT_EQ( t[2_f], ( ThreeVertIds{ 5_v, 6_v, 4_v } ) );
+    }
 }
 
 // a hub vertex #3 with two open chains (1-2-0, 6-7-8) and a closed ring (0-4-5) sharing rim vertex #0;


### PR DESCRIPTION
`duplicateNonManifoldVertices` receives an optional pointer to constant `VertCoords` with the coordinates of the vertices (the last defaulted parameter, so the API is unchanged for existing callers).

When the coordinates are given and `PathAroundVertex::getNextVertex` finds several possible triangle-continuations of the path, it no longer takes the first encountered option: it selects the one with the maximal dot-product between its unit normal and the unit normal of the preceding triangle. The normals are computed from the provided coordinates, and a duplicated vertex in a triangle is mapped to its original vertex first (the `getOrgVertex` lambda is promoted into a file-scope function shared with the normal computation).

Details:
- the reference triangle is the last visited one; when the search continues in the opposite direction from `firstVertex` after a dead end, the caller calls the new `restartFromFirstTriangle()`, since that continuation goes over the edge of the very first visited triangle;
- the normals are computed lazily, only when the second continuation option of a step is discovered; with one option or without coordinates the behavior is exactly as before (the first acceptable option short-circuits);
- ties keep the previous face-id order; a degenerate triangle gets a zero normal and thus never wins over a valid one with a positive dot-product.

`Mesh::fromTrianglesDuplicatingNonManifoldVertices` passes its coordinates into `MeshBuilder::fromTrianglesDuplicatingNonManifoldVertices` (which received the same optional trailing parameter), so all mesh loading paths resolving non-manifold vertices now use the smooth selection. On `StullerDragonTest1.ply` this gives 156371 vertices / 354 components versus 156442 / 364 before (71 fewer duplicates and 10 fewer components), load time unchanged (~120 ms). All 326 old tests pass unchanged. The new unit test `duplicateVertexSmoothContinuation` covers the feature: a fan around vertex #0 with a folded and a flat continuation from the shared rim vertex — with coordinates the flat triangle stays in the first chain and the folded one is fully detached, without coordinates the choice is reversed; both results are manifold on the second pass.

Private members of `PathAroundVertex` received the `_` suffix.
