### PR TITLE
pip-build: pass --no-project to uv run when querying sysconfig

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -283,7 +283,7 @@ jobs:
           GET_SYSCONFIG_VAR=${PWD}/scripts/wheel/get_sysconfig_var.py
 
           for PYTHON_VER in ${PYTHON_VERSIONS} ; do
-            export PKG_CONFIG_PATH=$(uv run --python ${PYTHON_VER} ${GET_SYSCONFIG_VAR} LIBPC)
+            export PKG_CONFIG_PATH=$(uv run --no-project --python ${PYTHON_VER} ${GET_SYSCONFIG_VAR} LIBPC)
 
             make shims -f scripts/mrbind/generate.mk -B --trace \
               FOR_WHEEL=1 \
@@ -316,7 +316,7 @@ jobs:
 
           cd build/Release/bin
           for PYTHON_VER in ${PYTHON_VERSIONS} ; do
-            PYTHON_LIB_DIR=$(uv run --python ${PYTHON_VER} ${GET_SYSCONFIG_VAR} LIBDIR)
+            PYTHON_LIB_DIR=$(uv run --no-project --python ${PYTHON_VER} ${GET_SYSCONFIG_VAR} LIBDIR)
 
             LD_LIBRARY_PATH=${PYTHON_LIB_DIR} \
             uv run \


### PR DESCRIPTION
The `Build Python shim libs` step of `manylinux-pip-build` fails since uv 0.12 shipped ([aarch64 leg of the v3.1.3.429 release run](https://github.com/MeshInspector/MeshLib/actions/runs/30807701185/job/91666869908)):

```
× Failed to build `meshlib @ file:///__w/MeshLib/MeshLib/scripts/wheel`
├─▶ Failed to resolve requirements from `build-system.requires`
├─▶ No solution found when resolving: `setuptools>=77.0`
╰─▶ Because the current Python version (3.8.20) does not satisfy Python>=3.9 ...
...
Package 'python-3.8-embed', required by 'virtual:world', not found
scripts/mrbind/generate.mk:851: *** Command failed with exit code 1: `pkg-config --cflags python-3.8-embed`.  Stop.
```

uv 0.12.0 changed project discovery: it now starts from the directory of the script passed to `uv run` instead of the CWD (astral-sh/uv#20225). So `uv run --python 3.8 $PWD/scripts/wheel/get_sysconfig_var.py` no longer runs a bare interpreter from the repo root (which has no `pyproject.toml`) — it discovers `scripts/wheel` and tries to install the `meshlib` project there. Its `build-system.requires = ["setuptools >= 77.0"]` needs Python >= 3.9, so the 3.8 iteration of the loop is unsatisfiable.

`setup-uv` is not pinned, so this switched over as soon as 0.12.1 became latest: the last green run (2026-07-28) used uv 0.11.33, the failing one uses 0.12.1.

The failure was easy to misread because `export VAR=$(...)` hides the command's exit status from `sh -e`, so the step kept going with an empty `PKG_CONFIG_PATH` and only blew up later inside make.

Both call sites only need stdlib `sysconfig`, so `--no-project` is the right fix. The third `uv run` in `Python Tests` (which runs `python3`, not a script path) is unaffected — discovery there starts from `build/Release/bin` and finds no project.
