### PR TITLE
generate.mk: dump the em++ probe output when the Emscripten sysroot can't be parsed

### DIFF
--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -138,7 +138,7 @@ else
 $(info Failed to parse the Emscripten sysroot out of the following probe, its output follows:)
 $(info $(EMSCRIPTEN_SYSROOT_PROBE))
 # `$(shell)` doesn't capture stderr, so sending stdout there too puts the whole output in our log, newlines intact.
-override EMSCRIPTEN_SYSROOT_PROBE_LOG := $(shell $(EMSCRIPTEN_SYSROOT_PROBE) 1>&2)
+$(call ,$(shell $(EMSCRIPTEN_SYSROOT_PROBE) 1>&2))
 $(error Unable to find Emscripten SDK, ensure you have `em++` in the PATH. In powershell run `emsdk/emsdk_env.ps1`; or in bash run `. emsdk/emsdk_env.sh`)
 endif
 endif

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -130,10 +130,15 @@ override IS_EMSCRIPTEN := 1
 # Must special-case Windows because there `em++` is actually `em++.py`, and Bash doesn't want to run it without the extension.
 # `MSYS2_ARG_CONV_EXCL=*` guards `/c`.
 # Note that we have to poke some libraries here too, to add them to the sysroot.
-EMSCRIPTEN_SYSROOT := $(shell echo |$(if $(IS_WINDOWS), MSYS2_ARG_CONV_EXCL=* cmd /c) em++ -fsyntax-only -v -xc++ - -sUSE_BOOST_HEADERS=1 2>&1 | grep -oP '(?<=^ ).*(?=/include/c\+\+/v1$$)')
+override EMSCRIPTEN_SYSROOT_PROBE := echo |$(if $(IS_WINDOWS), MSYS2_ARG_CONV_EXCL=* cmd /c) em++ -fsyntax-only -v -xc++ - -sUSE_BOOST_HEADERS=1
+EMSCRIPTEN_SYSROOT := $(shell $(EMSCRIPTEN_SYSROOT_PROBE) 2>&1 | grep -oP '(?<=^ ).*(?=/include/c\+\+/v1$$)')
 ifneq ($(EMSCRIPTEN_SYSROOT),)
 $(info Determined EMSCRIPTEN_SYSROOT = `$(EMSCRIPTEN_SYSROOT)`)
 else
+$(info Failed to parse the Emscripten sysroot out of the following probe, its output follows:)
+$(info $(EMSCRIPTEN_SYSROOT_PROBE))
+# `$(shell)` doesn't capture stderr, so sending stdout there too puts the whole output in our log, newlines intact.
+override EMSCRIPTEN_SYSROOT_PROBE_LOG := $(shell $(EMSCRIPTEN_SYSROOT_PROBE) 1>&2)
 $(error Unable to find Emscripten SDK, ensure you have `em++` in the PATH. In powershell run `emsdk/emsdk_env.ps1`; or in bash run `. emsdk/emsdk_env.sh`)
 endif
 endif


### PR DESCRIPTION
`generate-c-bindings` failed in [this run](https://github.com/MeshInspector/MeshLib/actions/runs/30809649035/job/91673309076) with nothing to go on:

```
scripts/mrbind/generate.mk:137: *** Unable to find Emscripten SDK, ensure you have `em++` in the PATH. ...
```

The image was byte-identical (same manifest digest) to the one that passed 10 minutes earlier in another PR, and `em++` was on the `PATH` (`EMSDK=/emsdk`), so the message was actively misleading. The sysroot probe took 0.3 s instead of the usual ~3 s, i.e. `em++` bailed out early — but `$(shell …)` only captures stdout, so whatever it said was thrown away.

This keeps the probe command in a variable and, on the failure path, re-runs it with stdout redirected to stderr. `$(shell)` doesn't capture stderr, so make passes it straight to the log with newlines intact.

Verified locally against a stub `em++` (GNU make 4.4):

- **missing** → `/bin/sh: line 1: em++: command not found`
- **erroring** → `em++: error: setting USE_BOOST_HEADERS is no longer supported`
- **working** → unchanged, `Determined EMSCRIPTEN_SYSROOT = /emsdk/upstream/emscripten/cache/sysroot`

In each failing case the echoed command line comes first, so the probe can be re-run by hand:

```
Failed to parse the Emscripten sysroot out of the following probe, its output follows:
echo | em++ -fsyntax-only -v -xc++ - -sUSE_BOOST_HEADERS=1
em++: error: setting USE_BOOST_HEADERS is no longer supported
scripts/mrbind/generate.mk:142: *** Unable to find Emscripten SDK, ...
```

The third case is the one this is really for: if a future emsdk changes the `-v` include-search-path format, the grep silently finds nothing and today's message blames the `PATH`. Now the full `-v` output lands in the log.

The changed lines only evaluate when `EM_USE_HOST_HEADERS=0`, which `generate-c-bindings` sets — and that job runs unconditionally, so the other build legs are disabled here.
