### PR TITLE
pip-build: don't let `export` swallow the uv exit status

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -283,7 +283,9 @@ jobs:
           GET_SYSCONFIG_VAR=${PWD}/scripts/wheel/get_sysconfig_var.py
 
           for PYTHON_VER in ${PYTHON_VERSIONS} ; do
-            export PKG_CONFIG_PATH=$(uv run --no-project --python ${PYTHON_VER} ${GET_SYSCONFIG_VAR} LIBPC)
+            # Keep the assignment separate from `export`: the latter would mask a `uv` failure from `sh -e`.
+            PKG_CONFIG_PATH=$(uv run --no-project --python ${PYTHON_VER} ${GET_SYSCONFIG_VAR} LIBPC)
+            export PKG_CONFIG_PATH
 
             make shims -f scripts/mrbind/generate.mk -B --trace \
               FOR_WHEEL=1 \


### PR DESCRIPTION
Follow-up to #6513, which was merged before this commit made it in.

`export VAR=$(cmd)` keeps a non-zero status of the command substitution out of `$?`, so `sh -e` doesn't stop. That is why the uv 0.12 breakage fixed in #6513 surfaced ~1 s later as a confusing `pkg-config` error inside make, instead of at the `uv run` line:

```
Package 'python-3.8-embed', required by 'virtual:world', not found
scripts/mrbind/generate.mk:851: *** Command failed with exit code 1: `pkg-config --cflags python-3.8-embed`.  Stop.
```

A plain assignment does trip errexit, so splitting it from the `export` makes the step fail where it actually breaks. Verified with `sh -e` locally, right-hand side `$(sh -c 'echo out; exit 7')`:

| form | result |
|---|---|
| `export FOO=$(…)` | continues, status masked |
| `FOO=$(…)` | aborts, exit 7 |

This was the only `export VAR=$(…)` in `.github/workflows/`; the other uv call site in this file (`PYTHON_LIB_DIR=`, in *Python Tests*) is already a plain assignment.
