### PR TITLE
retry.sh: add --timeout so a hung command is retried instead of eating the job budget

### DIFF
--- a/.github/actions/python-regression-tests/action.yml
+++ b/.github/actions/python-regression-tests/action.yml
@@ -55,7 +55,7 @@ runs:
           export HOME="${RUNNER_TEMP}"
           git config --global --add safe.directory '*'
         fi
-        bash scripts/retry.sh -- git submodule update --init --checkout --depth 1 test_data
+        bash scripts/retry.sh --timeout 300 -- git submodule update --init --checkout --depth 1 test_data
 
     - name: Python Regression Tests
       if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/build-test-emscripten-c-bindings.yml
+++ b/.github/workflows/build-test-emscripten-c-bindings.yml
@@ -75,7 +75,7 @@ jobs:
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           # Retried via retry.sh: submodule endpoints occasionally 500.
-          bash scripts/retry.sh -- scripts/clone_submodules_emscripten.sh --skip-prebuilt-thirdparty
+          bash scripts/retry.sh --timeout 300 -- scripts/clone_submodules_emscripten.sh --skip-prebuilt-thirdparty
 
       - name: Install thirdparty libs
         run: |

--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -81,7 +81,7 @@ jobs:
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           # Retried via retry.sh: submodule endpoints occasionally 500.
-          bash scripts/retry.sh -- scripts/clone_submodules_emscripten.sh --skip-prebuilt-thirdparty
+          bash scripts/retry.sh --timeout 300 -- scripts/clone_submodules_emscripten.sh --skip-prebuilt-thirdparty
 
       - name: Install thirdparty libs
         run: |
@@ -186,7 +186,7 @@ jobs:
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           # Retried via retry.sh: submodule endpoints occasionally 500.
-          bash scripts/retry.sh -- scripts/clone_submodules_emscripten.sh --skip-prebuilt-thirdparty
+          bash scripts/retry.sh --timeout 300 -- scripts/clone_submodules_emscripten.sh --skip-prebuilt-thirdparty
 
       - name: Install thirdparty libs
         run: |

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -84,7 +84,7 @@ jobs:
           # Selective init -- parent Checkout drops submodules:true.
           # https://github.com/actions/checkout/issues/1779
           # Retried via retry.sh: submodule endpoints occasionally 500.
-          bash scripts/retry.sh -- scripts/clone_submodules_linux.sh --skip-prebuilt-thirdparty
+          bash scripts/retry.sh --timeout 300 -- scripts/clone_submodules_linux.sh --skip-prebuilt-thirdparty
 
       - name: Install thirdparty libs
         id: thirdparty

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Checkout third-party submodules
         shell: bash
         run: |
-          bash scripts/retry.sh -- powershell scripts/clone_submodules_windows.ps1 --skip-prebuilt-thirdparty
+          bash scripts/retry.sh --timeout 300 -- powershell scripts/clone_submodules_windows.ps1 --skip-prebuilt-thirdparty
 
       - name: Get AWS instance type
         uses: ./.github/actions/get-aws-instance-type

--- a/.github/workflows/generate-c-bindings.yml
+++ b/.github/workflows/generate-c-bindings.yml
@@ -33,7 +33,7 @@ jobs:
           export HOME=${RUNNER_TEMP}
           git config --global --add safe.directory '*'
           # Retried via retry.sh: submodule endpoints occasionally 500.
-          bash scripts/retry.sh -- scripts/clone_submodules_emscripten_bindings.sh
+          bash scripts/retry.sh --timeout 300 -- scripts/clone_submodules_emscripten_bindings.sh
 
       - name: Install MRBind
         uses: ./.github/actions/build-mrbind

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -232,7 +232,7 @@ jobs:
           git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/mrbind
           git config --global --add safe.directory ${GITHUB_WORKSPACE}/thirdparty/mrbind/deps/cppdecl
           # Retried via retry.sh: submodule endpoints occasionally 500.
-          bash scripts/retry.sh -- scripts/clone_submodules_emscripten.sh --skip-prebuilt-thirdparty
+          bash scripts/retry.sh --timeout 300 -- scripts/clone_submodules_emscripten.sh --skip-prebuilt-thirdparty
 
       - name: Install mrbind
         uses: ./.github/actions/build-mrbind

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -40,6 +40,8 @@ fi
 
 run_attempt() {
     if [ -n "$timeout_bin" ]; then
+        # SIGTERM once the limit is up (exit 124), then --kill-after SIGKILL for
+        # commands that ignore it (exit 137).
         "$timeout_bin" --kill-after "${kill_after}s" "${timeout}s" "$@"
     else
         "$@"

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -3,9 +3,10 @@ set -eu
 
 times=3
 cooldown=30
+timeout=0
 
 usage() {
-    echo "Usage: $0 [--times N] [--cooldown S] -- COMMAND [ARGS...]" >&2
+    echo "Usage: $0 [--times N] [--cooldown S] [--timeout S] -- COMMAND [ARGS...]" >&2
     exit 2
 }
 
@@ -13,6 +14,7 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --times)    times="${2:?--times requires a value}"; shift 2 ;;
         --cooldown) cooldown="${2:?--cooldown requires a value}"; shift 2 ;;
+        --timeout)  timeout="${2:?--timeout requires a value}"; shift 2 ;;
         --)         shift; break ;;
         *)          echo "Unknown argument: $1" >&2; usage ;;
     esac
@@ -20,18 +22,44 @@ done
 
 [[ "$times"    =~ ^[1-9][0-9]*$ ]] || { echo "--times must be a positive integer"         >&2; exit 2; }
 [[ "$cooldown" =~ ^[0-9]+$       ]] || { echo "--cooldown must be a non-negative integer" >&2; exit 2; }
+[[ "$timeout"  =~ ^[0-9]+$       ]] || { echo "--timeout must be a non-negative integer"  >&2; exit 2; }
 [ $# -ge 1 ] || { echo "Missing command after --" >&2; usage; }
+
+# Insist on GNU timeout: macOS calls it gtimeout, Windows has an unrelated System32\timeout.exe.
+timeout_bin=
+if [ "$timeout" -gt 0 ]; then
+    for candidate in timeout gtimeout; do
+        if "$candidate" --version 2>/dev/null | grep -q coreutils; then
+            timeout_bin="$candidate"
+            break
+        fi
+    done
+    [ -n "$timeout_bin" ] || echo "$(basename "$0"): GNU timeout not found; running without a time limit" >&2
+fi
+
+run_attempt() {
+    if [ -n "$timeout_bin" ]; then
+        "$timeout_bin" --kill-after 10s "${timeout}s" "$@"
+    else
+        "$@"
+    fi
+}
 
 rc=0
 for attempt in $(seq 1 "$times"); do
     rc=0
     # `|| rc=$?` captures the exit code without tripping `set -e`.
-    "$@" || rc=$?
+    run_attempt "$@" || rc=$?
     if [ "$rc" -eq 0 ]; then
         exit 0
     fi
     if [ "$attempt" -lt "$times" ]; then
-        echo "$(basename "$0"): attempt $attempt/$times failed (exit $rc); retrying in ${cooldown}s..." >&2
+        if [ "$rc" -eq 124 ] && [ -n "$timeout_bin" ]; then
+            reason="timed out after ${timeout}s"
+        else
+            reason="failed (exit $rc)"
+        fi
+        echo "$(basename "$0"): attempt $attempt/$times $reason; retrying in ${cooldown}s..." >&2
         sleep "$cooldown"
     fi
 done

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -4,6 +4,7 @@ set -eu
 times=3
 cooldown=30
 timeout=0
+kill_after=10
 
 usage() {
     echo "Usage: $0 [--times N] [--cooldown S] [--timeout S] -- COMMAND [ARGS...]" >&2
@@ -39,7 +40,7 @@ fi
 
 run_attempt() {
     if [ -n "$timeout_bin" ]; then
-        "$timeout_bin" --kill-after 10s "${timeout}s" "$@"
+        "$timeout_bin" --kill-after "${kill_after}s" "${timeout}s" "$@"
     else
         "$@"
     fi
@@ -54,10 +55,13 @@ for attempt in $(seq 1 "$times"); do
         exit 0
     fi
     if [ "$attempt" -lt "$times" ]; then
-        if [ "$rc" -eq 124 ] && [ -n "$timeout_bin" ]; then
-            reason="timed out after ${timeout}s"
-        else
-            reason="failed (exit $rc)"
+        reason="failed (exit $rc)"
+        if [ -n "$timeout_bin" ]; then
+            case "$rc" in
+                # 137 is our SIGKILL escalation: timed out, then ignored SIGTERM.
+                124) reason="timed out after ${timeout}s" ;;
+                137) reason="timed out after ${timeout}s, SIGKILLed ${kill_after}s later" ;;
+            esac
         fi
         echo "$(basename "$0"): attempt $attempt/$times $reason; retrying in ${cooldown}s..." >&2
         sleep "$cooldown"


### PR DESCRIPTION
`scripts/retry.sh` only retried commands that **exited non-zero**. A network operation that *hangs* instead of failing was never retried — it just ate the whole job budget.

That happened in [run 30808982047](https://github.com/MeshInspector/MeshLib/actions/runs/30808982047/job/91671075707): the `emscripten-build-c-bindings (Multithreaded, 3.1.38)` leg sat in `Checkout third-party submodules` for 44 minutes and was killed by `timeout-minutes: 40`, while its three sibling legs completed the identical step in seconds. The retry wrapper was in place and never fired.

### `--timeout S`

```
retry.sh [--times N] [--cooldown S] [--timeout S] -- COMMAND [ARGS...]
```

Each attempt runs under `timeout --kill-after 10s "${timeout}s"`, so a hang ends the attempt with exit 124 and the next attempt starts instead of the job dying.

* GNU-only, by probe: tries `timeout`, then `gtimeout` (that is the GNU one on macOS), requiring `--version` to report coreutils. The probe also rejects Windows' unrelated `System32\timeout.exe`. If neither is GNU, it warns and runs without a limit — the option can't break a step by being unavailable.
* Both timeout exit codes are reported as timeouts: 124 when SIGTERM ended the command, 137 when it ignored SIGTERM and needed the `--kill-after` SIGKILL 10s later. A bare 137 with no `--timeout` in effect stays a plain failure.
* Default is `--timeout 0`, i.e. current behavior byte-for-byte. Only the retry message changes, from `failed (exit 124)` to `timed out after Ns`.

### Callers

`--timeout 300` on every submodule-clone call site (emscripten ×3, emscripten-c-bindings, generate-c-bindings, pip-build, macos, windows, and the `git submodule update test_data` in the python-regression-tests action). Worst case is 3 × 300s + 2 × 30s cooldown ≈ 16 min, well inside the 40-min cap that killed the job above.

Untouched on purpose: the `dnf` calls in the rockylinux Dockerfiles (legitimately slow) and `gh release download` in test-distribution.

### Tested

In Git Bash (`bash -n` clean, LF preserved):

| case | result |
| --- | --- |
| `--times 3 --timeout 2 -- sleep 60` | 3 attempts, exit 124, ~6s total |
| hang on attempt 1, succeed on attempt 2 | recovers, exit 0 |
| command traps SIGTERM, needs SIGKILL | retried, reported as a timeout, exit 137 |
| `kill -9 $$` with no `--timeout` | stays `failed (exit 137)` |
| `-- false` (no `--timeout`) | unchanged message and exit code |
| `--timeout x`, missing command | exit 2 + usage |
| PATH with only `gtimeout` | protected, no warning |
| PATH with neither | warning, runs unlimited, exit 0 |

### Caveat

On the Windows leg the wrapped command is `powershell scripts/clone_submodules_windows.ps1`, and msys `timeout` killing a *native* Windows process group is less reliable than on Linux — a hung `git.exe` grandchild may survive TERM/KILL. Worst case there is the same job-level timeout we already have, so it is not a regression, but it is not a guarantee either.
