### PR TITLE
InSphereTesterSoS: simulation-of-simplicity tester derived from InSphereTester<int>

### DIFF
--- a/source/MRMesh/MRInSphere.cpp
+++ b/source/MRMesh/MRInSphere.cpp
@@ -62,17 +62,15 @@ SqrtVec cross( const SqrtVec & u, const SqrtVec & v, const BigInt & ew )
 
 } // anonymous namespace
 
-bool InSphereTester<int>::reset( const PreciseVertCoords & va, const PreciseVertCoords & vb, const PreciseVertCoords & vc, std::int64_t sqRadius )
+bool InSphereTester<int>::reset( const Vector3i & va, const Vector3i & vb, const Vector3i & vc, std::int64_t sqRadius )
 {
     // no overflow anywhere below given that any difference of two points is within +-0.99*2^31
     // (as getToIntConverter guarantees) and rSq fits in int64
-    pa = va;
-    pb = vb;
-    pc = vc;
+    a = va;
     rSq = sqRadius;
     E = -1;
-    u = Vector3i64{ vb.pt - va.pt };
-    v = Vector3i64{ vc.pt - va.pt };
+    u = Vector3i64{ vb - va };
+    v = Vector3i64{ vc - va };
 
     // no sphere of radius sqrt(rSq) can pass via two points more than the diameter apart;
     // strictly greater: a side exactly equal to the diameter can lie on the sphere
@@ -106,7 +104,7 @@ bool InSphereTester<int>::reset( const PreciseVertCoords & va, const PreciseVert
 InSphereResult InSphereTester<int>::operator()( const Vector3i & d ) const
 {
     assert( E >= 0 ); // the last reset() must have returned true
-    const Vector3i64 q{ d - pa.pt };
+    const Vector3i64 q{ d - a };
 
     // d farther than the diameter from a point on the sphere is strictly outside
     const auto qq = dot( Vector3i128{ q }, Vector3i128{ q } );
@@ -134,12 +132,20 @@ InSphereResult InSphereTester<int>::operator()( const Vector3i & d ) const
 InSphereResult inSphere( const Vector3i & a, const Vector3i & b, const Vector3i & c, const Vector3i & d, std::int64_t rSq )
 {
     InSphereTesteri tester;
-    if ( !tester.reset( { {}, a }, { {}, b }, { {}, c }, rSq ) ) // the ids are unused without simulation-of-simplicity
+    if ( !tester.reset( a, b, c, rSq ) )
         return InSphereResult::NoSphere;
     return tester( d );
 }
 
-InSphereResult InSphereTester<int>::operator()( const PreciseVertCoords & d ) const
+bool InSphereTesterSoS::reset( const PreciseVertCoords & va, const PreciseVertCoords & vb, const PreciseVertCoords & vc, std::int64_t sqRadius )
+{
+    va_ = va.id;
+    vb_ = vb.id;
+    vc_ = vc.id;
+    return InSphereTester<int>::reset( va.pt, vb.pt, vc.pt, sqRadius );
+}
+
+InSphereResult InSphereTesterSoS::operator()( const PreciseVertCoords & d ) const
 {
     const auto res = ( *this )( d.pt );
     if ( res != InSphereResult::OnSphere )
@@ -147,7 +153,8 @@ InSphereResult InSphereTester<int>::operator()( const PreciseVertCoords & d ) co
     if ( E == 0 )
         return InSphereResult::Outside; // a perturbation of the triangle breaks the sphere's existence here
 
-    const PreciseVertCoords vs[4] = { pa, pb, pc, d };
+    // the sphere points with their ids; b and c are reconstructed exactly from the stored differences
+    const PreciseVertCoords vs[4] = { { va_, a }, { vb_, a + Vector3i( u ) }, { vc_, a + Vector3i( v ) }, d };
 #ifndef NDEBUG
     for ( int i = 0; i < 3; ++i )
         for ( int j = i + 1; j < 4; ++j )
@@ -162,7 +169,7 @@ InSphereResult InSphereTester<int>::operator()( const PreciseVertCoords & d ) co
     const BigInt ew = BigInt{ E } * bigW; // sqr( S ); the signs below are computed in Z[S]
 
     // ch[k] = 2 W^2 * ( vs[k].pt - sphereCenter ) = 2 W^2 ( vs[k].pt - vs[0].pt ) - W M - S w
-    const Vector3i64 rel[4] = { {}, u, v, Vector3i64{ d.pt - pa.pt } };
+    const Vector3i64 rel[4] = { {}, u, v, Vector3i64{ d.pt - a } };
     std::array<SqrtVec, 4> ch;
     for ( int k = 0; k < 4; ++k )
         for ( int i = 0; i < 3; ++i )
@@ -211,7 +218,7 @@ InSphereResult InSphereTester<int>::operator()( const PreciseVertCoords & d ) co
 
 InSphereResult inSphere( const std::array<PreciseVertCoords, 4> & vs, std::int64_t rSq )
 {
-    InSphereTesteri tester;
+    InSphereTesterSoS tester;
     if ( !tester.reset( vs[0], vs[1], vs[2], rSq ) )
         return InSphereResult::NoSphere;
     return tester( vs[3] );

--- a/source/MRMesh/MRInSphere.cpp
+++ b/source/MRMesh/MRInSphere.cpp
@@ -147,7 +147,7 @@ bool InSphereTesterSoS::reset( const PreciseVertCoords & va, const PreciseVertCo
 
 InSphereResult InSphereTesterSoS::operator()( const PreciseVertCoords & d ) const
 {
-    const auto res = ( *this )( d.pt );
+    const auto res = InSphereTester<int>::operator()( d.pt );
     if ( res != InSphereResult::OnSphere )
         return res;
     if ( E == 0 )

--- a/source/MRMesh/MRInSphere.cpp
+++ b/source/MRMesh/MRInSphere.cpp
@@ -62,15 +62,17 @@ SqrtVec cross( const SqrtVec & u, const SqrtVec & v, const BigInt & ew )
 
 } // anonymous namespace
 
-bool InSphereTester<int>::reset( const Vector3i & va, const Vector3i & vb, const Vector3i & vc, std::int64_t sqRadius )
+bool InSphereTester<int>::reset( const PreciseVertCoords & va, const PreciseVertCoords & vb, const PreciseVertCoords & vc, std::int64_t sqRadius )
 {
     // no overflow anywhere below given that any difference of two points is within +-0.99*2^31
     // (as getToIntConverter guarantees) and rSq fits in int64
-    a = va;
+    pa = va;
+    pb = vb;
+    pc = vc;
     rSq = sqRadius;
     E = -1;
-    u = Vector3i64{ vb - va };
-    v = Vector3i64{ vc - va };
+    u = Vector3i64{ vb.pt - va.pt };
+    v = Vector3i64{ vc.pt - va.pt };
 
     // no sphere of radius sqrt(rSq) can pass via two points more than the diameter apart;
     // strictly greater: a side exactly equal to the diameter can lie on the sphere
@@ -104,7 +106,7 @@ bool InSphereTester<int>::reset( const Vector3i & va, const Vector3i & vb, const
 InSphereResult InSphereTester<int>::operator()( const Vector3i & d ) const
 {
     assert( E >= 0 ); // the last reset() must have returned true
-    const Vector3i64 q{ d - a };
+    const Vector3i64 q{ d - pa.pt };
 
     // d farther than the diameter from a point on the sphere is strictly outside
     const auto qq = dot( Vector3i128{ q }, Vector3i128{ q } );
@@ -132,25 +134,25 @@ InSphereResult InSphereTester<int>::operator()( const Vector3i & d ) const
 InSphereResult inSphere( const Vector3i & a, const Vector3i & b, const Vector3i & c, const Vector3i & d, std::int64_t rSq )
 {
     InSphereTesteri tester;
-    if ( !tester.reset( a, b, c, rSq ) )
+    if ( !tester.reset( { {}, a }, { {}, b }, { {}, c }, rSq ) ) // the ids are unused without simulation-of-simplicity
         return InSphereResult::NoSphere;
     return tester( d );
 }
 
-InSphereResult InSphereTester<int>::operator()( const std::array<PreciseVertCoords, 4> & vs ) const
+InSphereResult InSphereTester<int>::operator()( const PreciseVertCoords & d ) const
 {
-    assert( E >= 0 ); // the last reset() must have returned true
-    assert( vs[0].pt == a && Vector3i64{ vs[1].pt - vs[0].pt } == u && Vector3i64{ vs[2].pt - vs[0].pt } == v );
+    const auto res = ( *this )( d.pt );
+    if ( res != InSphereResult::OnSphere )
+        return res;
+    if ( E == 0 )
+        return InSphereResult::Outside; // a perturbation of the triangle breaks the sphere's existence here
+
+    const PreciseVertCoords vs[4] = { pa, pb, pc, d };
 #ifndef NDEBUG
     for ( int i = 0; i < 3; ++i )
         for ( int j = i + 1; j < 4; ++j )
             assert( vs[i].id != vs[j].id );
 #endif
-    const auto res = ( *this )( vs[3].pt );
-    if ( res != InSphereResult::OnSphere )
-        return res;
-    if ( E == 0 )
-        return InSphereResult::Outside; // a perturbation of the triangle breaks the sphere's existence here
 
     // vs[3] is exactly on the sphere: perturb the points in the order of ascending ids, the first point
     // whose perturbation moves vs[3] off the sphere decides; when a triangle point is perturbed, the
@@ -160,7 +162,7 @@ InSphereResult InSphereTester<int>::operator()( const std::array<PreciseVertCoor
     const BigInt ew = BigInt{ E } * bigW; // sqr( S ); the signs below are computed in Z[S]
 
     // ch[k] = 2 W^2 * ( vs[k].pt - sphereCenter ) = 2 W^2 ( vs[k].pt - vs[0].pt ) - W M - S w
-    const Vector3i64 rel[4] = { {}, u, v, Vector3i64{ vs[3].pt - vs[0].pt } };
+    const Vector3i64 rel[4] = { {}, u, v, Vector3i64{ d.pt - pa.pt } };
     std::array<SqrtVec, 4> ch;
     for ( int k = 0; k < 4; ++k )
         for ( int i = 0; i < 3; ++i )
@@ -210,9 +212,9 @@ InSphereResult InSphereTester<int>::operator()( const std::array<PreciseVertCoor
 InSphereResult inSphere( const std::array<PreciseVertCoords, 4> & vs, std::int64_t rSq )
 {
     InSphereTesteri tester;
-    if ( !tester.reset( vs[0].pt, vs[1].pt, vs[2].pt, rSq ) )
+    if ( !tester.reset( vs[0], vs[1], vs[2], rSq ) )
         return InSphereResult::NoSphere;
-    return tester( vs );
+    return tester( vs[3] );
 }
 
 #if __GNUC__ >= 12

--- a/source/MRMesh/MRInSphere.h
+++ b/source/MRMesh/MRInSphere.h
@@ -150,26 +150,28 @@ template <>
 class InSphereTester<int>
 {
 public:
-    /// prepares the tester for the sphere of radius sqrt(rSq) passing via points a, b, c, with the
-    /// center located on the positive side of plane abc (in the half-space pointed at by
-    /// cross( b - a, c - a ) from the plane);
+    /// prepares the tester for the sphere of radius sqrt(rSq) passing via points a.pt, b.pt, c.pt,
+    /// with the center located on the positive side of their plane (in the half-space pointed at by
+    /// cross( b.pt - a.pt, c.pt - a.pt ) from the plane);
     /// returns false if no such sphere exists: the points are collinear or coincident,
-    /// or rSq is less than the squared circumradius of triangle abc
-    MRMESH_API bool reset( const Vector3i & a, const Vector3i & b, const Vector3i & c, std::int64_t rSq );
+    /// or rSq is less than the squared circumradius of the triangle;
+    /// rSq must be given in the same integer grid units as the point coordinates;
+    /// the ids are used only by the simulation-of-simplicity query below
+    MRMESH_API bool reset( const PreciseVertCoords & a, const PreciseVertCoords & b, const PreciseVertCoords & c, std::int64_t rSq );
 
     /// returns the position of the point d relative to the sphere (never NoSphere);
     /// shall be called only after reset() returned true
     [[nodiscard]] MRMESH_API InSphereResult operator()( const Vector3i & d ) const;
 
-    /// returns the position of the point vs[3] relative to the sphere, resolving "exactly on the
+    /// returns the position of the point d.pt relative to the sphere, resolving "exactly on the
     /// sphere" ties into Inside or Outside by simulation-of-simplicity as described at the inSphere
-    /// overload above (never returns OnSphere or NoSphere);
-    /// shall be called only after reset() returned true, and the points vs[0], vs[1], vs[2] must be
-    /// the same a, b, c as in that reset()
-    [[nodiscard]] MRMESH_API InSphereResult operator()( const std::array<PreciseVertCoords, 4> & vs ) const;
+    /// overload above, using the ids of d and of the points given in reset()
+    /// (never returns OnSphere or NoSphere);
+    /// shall be called only after reset() returned true, and all four ids must be distinct
+    [[nodiscard]] MRMESH_API InSphereResult operator()( const PreciseVertCoords & d ) const;
 
 private:
-    Vector3i a;           ///< the first sphere point
+    PreciseVertCoords pa, pb, pc; ///< the sphere points with their ids
     Vector3i64 u, v;      ///< b - a, c - a
     Vector3i64 w;         ///< doubled normal of triangle abc
     Int256 W;             ///< |w|^2

--- a/source/MRMesh/MRInSphere.h
+++ b/source/MRMesh/MRInSphere.h
@@ -150,28 +150,19 @@ template <>
 class InSphereTester<int>
 {
 public:
-    /// prepares the tester for the sphere of radius sqrt(rSq) passing via points a.pt, b.pt, c.pt,
-    /// with the center located on the positive side of their plane (in the half-space pointed at by
-    /// cross( b.pt - a.pt, c.pt - a.pt ) from the plane);
+    /// prepares the tester for the sphere of radius sqrt(rSq) passing via points a, b, c, with the
+    /// center located on the positive side of plane abc (in the half-space pointed at by
+    /// cross( b - a, c - a ) from the plane);
     /// returns false if no such sphere exists: the points are collinear or coincident,
-    /// or rSq is less than the squared circumradius of the triangle;
-    /// rSq must be given in the same integer grid units as the point coordinates;
-    /// the ids are used only by the simulation-of-simplicity query below
-    MRMESH_API bool reset( const PreciseVertCoords & a, const PreciseVertCoords & b, const PreciseVertCoords & c, std::int64_t rSq );
+    /// or rSq is less than the squared circumradius of triangle abc
+    MRMESH_API bool reset( const Vector3i & a, const Vector3i & b, const Vector3i & c, std::int64_t rSq );
 
     /// returns the position of the point d relative to the sphere (never NoSphere);
     /// shall be called only after reset() returned true
     [[nodiscard]] MRMESH_API InSphereResult operator()( const Vector3i & d ) const;
 
-    /// returns the position of the point d.pt relative to the sphere, resolving "exactly on the
-    /// sphere" ties into Inside or Outside by simulation-of-simplicity as described at the inSphere
-    /// overload above, using the ids of d and of the points given in reset()
-    /// (never returns OnSphere or NoSphere);
-    /// shall be called only after reset() returned true, and all four ids must be distinct
-    [[nodiscard]] MRMESH_API InSphereResult operator()( const PreciseVertCoords & d ) const;
-
-private:
-    PreciseVertCoords pa, pb, pc; ///< the sphere points with their ids
+protected:
+    Vector3i a;           ///< the first sphere point
     Vector3i64 u, v;      ///< b - a, c - a
     Vector3i64 w;         ///< doubled normal of triangle abc
     Int256 W;             ///< |w|^2
@@ -183,6 +174,33 @@ private:
 using InSphereTesterf = InSphereTester<float>;
 using InSphereTesterd = InSphereTester<double>;
 using InSphereTesteri = InSphereTester<int>;
+
+/// the precise tester with simulation-of-simplicity resolution of "exactly on the sphere" ties,
+/// which reuses all the geometric machinery of InSphereTester<int> and adds only the vertex ids
+class InSphereTesterSoS : public InSphereTester<int>
+{
+public:
+    /// prepares the tester for the sphere of radius sqrt(rSq) passing via points a.pt, b.pt, c.pt,
+    /// with the center located on the positive side of their plane (in the half-space pointed at by
+    /// cross( b.pt - a.pt, c.pt - a.pt ) from the plane), remembering the ids for the queries;
+    /// returns false if no such sphere exists: the points are collinear or coincident,
+    /// or rSq is less than the squared circumradius of the triangle;
+    /// this hides the id-less reset of the base class, which would leave stale ids
+    MRMESH_API bool reset( const PreciseVertCoords & a, const PreciseVertCoords & b, const PreciseVertCoords & c, std::int64_t rSq );
+
+    /// the plain query by coordinates only from the base class (may return OnSphere)
+    using InSphereTester<int>::operator();
+
+    /// returns the position of the point d.pt relative to the sphere, resolving "exactly on the
+    /// sphere" ties into Inside or Outside by simulation-of-simplicity as described at the inSphere
+    /// overload above, using the ids of d and of the points given in reset()
+    /// (never returns OnSphere or NoSphere);
+    /// shall be called only after reset() returned true, and all four ids must be distinct
+    [[nodiscard]] MRMESH_API InSphereResult operator()( const PreciseVertCoords & d ) const;
+
+private:
+    VertId va_, vb_, vc_; ///< the ids of the sphere points given in reset()
+};
 
 /// checks whether the point d is strictly inside the sphere of radius sqrt(rSq) passing via
 /// points a, b, c, whose center is located on the positive side of plane abc, in floating-point;

--- a/source/MRMesh/MRInSphere.h
+++ b/source/MRMesh/MRInSphere.h
@@ -188,9 +188,6 @@ public:
     /// this hides the id-less reset of the base class, which would leave stale ids
     MRMESH_API bool reset( const PreciseVertCoords & a, const PreciseVertCoords & b, const PreciseVertCoords & c, std::int64_t rSq );
 
-    /// the plain query by coordinates only from the base class (may return OnSphere)
-    using InSphereTester<int>::operator();
-
     /// returns the position of the point d.pt relative to the sphere, resolving "exactly on the
     /// sphere" ties into Inside or Outside by simulation-of-simplicity as described at the inSphere
     /// overload above, using the ids of d and of the points given in reset()

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -321,11 +321,11 @@ TEST( MRMesh, inSphereTester )
     const Vector3i c{ 0, 2, 0 };
 
     InSphereTesteri tester;
-    EXPECT_FALSE( tester.reset( a, b, c, 1 ) ); // rSq below the squared circumradius
-    EXPECT_FALSE( tester.reset( a, Vector3i{ 1, 1, 1 }, Vector3i{ 2, 2, 2 }, 9 ) ); // collinear
-    EXPECT_FALSE( tester.reset( a, Vector3i{ 10, 0, 0 }, c, 4 ) ); // a side beyond the diameter
+    EXPECT_FALSE( tester.reset( { 0_v, a }, { 1_v, b }, { 2_v, c }, 1 ) ); // rSq below the squared circumradius
+    EXPECT_FALSE( tester.reset( { 0_v, a }, { 1_v, Vector3i{ 1, 1, 1 } }, { 2_v, Vector3i{ 2, 2, 2 } }, 9 ) ); // collinear
+    EXPECT_FALSE( tester.reset( { 0_v, a }, { 1_v, Vector3i{ 10, 0, 0 } }, { 2_v, c }, 4 ) ); // a side beyond the diameter
 
-    ASSERT_TRUE( tester.reset( a, b, c, 4 ) ); // sphere center at ( 1, 1, sqrt(2) )
+    ASSERT_TRUE( tester.reset( { 0_v, a }, { 1_v, b }, { 2_v, c }, 4 ) ); // sphere center at ( 1, 1, sqrt(2) )
     EXPECT_EQ( tester( Vector3i{ 1, 1, 2 } ), In );
     EXPECT_EQ( tester( Vector3i{ 1, 1, -1 } ), Out );
     EXPECT_EQ( tester( Vector3i{ 30, 0, 0 } ), Out ); // farther than the diameter from A
@@ -340,7 +340,7 @@ TEST( MRMesh, inSphereTester )
             }
 
     // reuse of the same tester for another sphere
-    ASSERT_TRUE( tester.reset( a, b, c, 2 ) ); // the unique sphere centered at (1,1,0)
+    ASSERT_TRUE( tester.reset( { 0_v, a }, { 1_v, b }, { 2_v, c }, 2 ) ); // the unique sphere centered at (1,1,0)
     EXPECT_EQ( tester( Vector3i{ 1, 1, 1 } ), In );
     EXPECT_EQ( tester( b ), On );
 }
@@ -471,11 +471,12 @@ TEST( MRMesh, sosInSphere )
     EXPECT_EQ( inSphere( { vc( 0_v, 0,0,0 ), vc( 1_v, 2,0,0 ), vc( 2_v, 0,2,0 ), vc( 3_v, 1,1,1 ) }, 2 ), In );
     EXPECT_EQ( inSphere( { vc( 0_v, 0,0,0 ), vc( 1_v, 2,0,0 ), vc( 2_v, 0,2,0 ), vc( 3_v, 3,3,0 ) }, 2 ), Out );
 
-    // the same tie resolution via the tester method with one reset
+    // the same tie resolution via the tester: the triangle ids are given once in reset
     InSphereTesteri tester;
-    ASSERT_TRUE( tester.reset( Vector3i{ 3, 4, 0 }, Vector3i{ 4, 0, 3 }, Vector3i{ 0, 3, 4 }, 25 ) );
-    EXPECT_EQ( tester( { vc( 0_v, 3,4,0 ), vc( 1_v, 4,0,3 ), vc( 2_v, 0,3,4 ), vc( 3_v, 0,0,5 ) } ), Out );
-    EXPECT_EQ( tester( { vc( 2_v, 3,4,0 ), vc( 0_v, 4,0,3 ), vc( 3_v, 0,3,4 ), vc( 1_v, 0,0,5 ) } ), In );
+    ASSERT_TRUE( tester.reset( vc( 0_v, 3,4,0 ), vc( 1_v, 4,0,3 ), vc( 2_v, 0,3,4 ), 25 ) );
+    EXPECT_EQ( tester( vc( 3_v, 0,0,5 ) ), Out );
+    ASSERT_TRUE( tester.reset( vc( 2_v, 3,4,0 ), vc( 0_v, 4,0,3 ), vc( 3_v, 0,3,4 ), 25 ) );
+    EXPECT_EQ( tester( vc( 1_v, 0,0,5 ) ), In );
 }
 
 TEST( MRMesh, sosInSphereConcyclic )

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -321,11 +321,11 @@ TEST( MRMesh, inSphereTester )
     const Vector3i c{ 0, 2, 0 };
 
     InSphereTesteri tester;
-    EXPECT_FALSE( tester.reset( { 0_v, a }, { 1_v, b }, { 2_v, c }, 1 ) ); // rSq below the squared circumradius
-    EXPECT_FALSE( tester.reset( { 0_v, a }, { 1_v, Vector3i{ 1, 1, 1 } }, { 2_v, Vector3i{ 2, 2, 2 } }, 9 ) ); // collinear
-    EXPECT_FALSE( tester.reset( { 0_v, a }, { 1_v, Vector3i{ 10, 0, 0 } }, { 2_v, c }, 4 ) ); // a side beyond the diameter
+    EXPECT_FALSE( tester.reset( a, b, c, 1 ) ); // rSq below the squared circumradius
+    EXPECT_FALSE( tester.reset( a, Vector3i{ 1, 1, 1 }, Vector3i{ 2, 2, 2 }, 9 ) ); // collinear
+    EXPECT_FALSE( tester.reset( a, Vector3i{ 10, 0, 0 }, c, 4 ) ); // a side beyond the diameter
 
-    ASSERT_TRUE( tester.reset( { 0_v, a }, { 1_v, b }, { 2_v, c }, 4 ) ); // sphere center at ( 1, 1, sqrt(2) )
+    ASSERT_TRUE( tester.reset( a, b, c, 4 ) ); // sphere center at ( 1, 1, sqrt(2) )
     EXPECT_EQ( tester( Vector3i{ 1, 1, 2 } ), In );
     EXPECT_EQ( tester( Vector3i{ 1, 1, -1 } ), Out );
     EXPECT_EQ( tester( Vector3i{ 30, 0, 0 } ), Out ); // farther than the diameter from A
@@ -340,7 +340,7 @@ TEST( MRMesh, inSphereTester )
             }
 
     // reuse of the same tester for another sphere
-    ASSERT_TRUE( tester.reset( { 0_v, a }, { 1_v, b }, { 2_v, c }, 2 ) ); // the unique sphere centered at (1,1,0)
+    ASSERT_TRUE( tester.reset( a, b, c, 2 ) ); // the unique sphere centered at (1,1,0)
     EXPECT_EQ( tester( Vector3i{ 1, 1, 1 } ), In );
     EXPECT_EQ( tester( b ), On );
 }
@@ -471,10 +471,11 @@ TEST( MRMesh, sosInSphere )
     EXPECT_EQ( inSphere( { vc( 0_v, 0,0,0 ), vc( 1_v, 2,0,0 ), vc( 2_v, 0,2,0 ), vc( 3_v, 1,1,1 ) }, 2 ), In );
     EXPECT_EQ( inSphere( { vc( 0_v, 0,0,0 ), vc( 1_v, 2,0,0 ), vc( 2_v, 0,2,0 ), vc( 3_v, 3,3,0 ) }, 2 ), Out );
 
-    // the same tie resolution via the tester: the triangle ids are given once in reset
-    InSphereTesteri tester;
+    // the same tie resolution via InSphereTesterSoS: the triangle ids are given once in reset
+    InSphereTesterSoS tester;
     ASSERT_TRUE( tester.reset( vc( 0_v, 3,4,0 ), vc( 1_v, 4,0,3 ), vc( 2_v, 0,3,4 ), 25 ) );
     EXPECT_EQ( tester( vc( 3_v, 0,0,5 ) ), Out );
+    EXPECT_EQ( tester( Vector3i{ 0, 0, 5 } ), InSphereResult::OnSphere ); // the base plain query is also available
     ASSERT_TRUE( tester.reset( vc( 2_v, 3,4,0 ), vc( 0_v, 4,0,3 ), vc( 3_v, 0,3,4 ), 25 ) );
     EXPECT_EQ( tester( vc( 1_v, 0,0,5 ) ), In );
 }

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -475,7 +475,6 @@ TEST( MRMesh, sosInSphere )
     InSphereTesterSoS tester;
     ASSERT_TRUE( tester.reset( vc( 0_v, 3,4,0 ), vc( 1_v, 4,0,3 ), vc( 2_v, 0,3,4 ), 25 ) );
     EXPECT_EQ( tester( vc( 3_v, 0,0,5 ) ), Out );
-    EXPECT_EQ( tester( Vector3i{ 0, 0, 5 } ), InSphereResult::OnSphere ); // the base plain query is also available
     ASSERT_TRUE( tester.reset( vc( 2_v, 3,4,0 ), vc( 0_v, 4,0,3 ), vc( 3_v, 0,3,4 ), 25 ) );
     EXPECT_EQ( tester( vc( 1_v, 0,0,5 ) ), In );
 }


### PR DESCRIPTION
## Summary

Follow-up to #6491: the precise tester is split into two classes.

```cpp
template <> class InSphereTester<int> // plain integer tests, no simulation-of-simplicity
{
    bool reset( const Vector3i & a, const Vector3i & b, const Vector3i & c, std::int64_t rSq );
    InSphereResult operator()( const Vector3i & d ) const; // may return OnSphere
protected:
    ... // the geometric fields, reused by the derived class
};

class InSphereTesterSoS : public InSphereTester<int> // + simulation-of-simplicity, PreciseVertCoords everywhere
{
    bool reset( const PreciseVertCoords & a, const PreciseVertCoords & b, const PreciseVertCoords & c, std::int64_t rSq );
    InSphereResult operator()( const PreciseVertCoords & d ) const; // never OnSphere: ties resolved by the ids
};
```

- `InSphereTester<int>` now exactly mirrors the floating-point primary template (all methods take bare points), and the plain free `inSphere` no longer fabricates invalid ids.
- `InSphereTesterSoS` adds only three `VertId` fields: `reset()` remembers the ids, the geometry is reused from the base via protected fields, and b, c coordinates are reconstructed exactly from the stored integer differences. The query takes only the fourth point, so the former "the array must repeat the reset points" requirement is gone by construction.
- The derived `reset` intentionally hides the id-less base `reset`, which would leave stale ids for the following queries; the base plain query is hidden too (a `Vector3i` does not implicitly convert to `PreciseVertCoords`, so nothing resolves to it accidentally).
- The free simulation-of-simplicity `inSphere` is implemented via `InSphereTesterSoS`; the distinct-ids debug assert lives in the id-based query.

## Testing

Updated gtests: `MRMesh.sosInSphere` exercises `InSphereTesterSoS` directly (one reset per triangle-id assignment, query by the fourth point); `MRMesh.inSphereTester` continues to cover the plain class. All inSphere tests pass (327 total locally).
