### PR TITLE
Alpha-shape triangles of a point cloud

### DIFF
--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -79,14 +79,13 @@ void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, const Alpha
             const auto & pj = neis[j];
             if ( onlyLargerVids && pj.id < v )
                 continue;
-            // reset checks the existence of the ball, which does not depend on the order of pi and pj,
-            // and the two orders select the balls on the opposite sides of the triangle
+            // the two balls touching all three points differ only by the side of the triangle,
+            // so one reset is enough for the both
             if ( !tester.reset( p0, pi, pj, data.intRadiusSq ) )
                 continue;
             if ( ballEmpty( pi.id, pj.id ) )
                 appendTris.push_back( { v, pi.id, pj.id } );
-            [[maybe_unused]] const bool mirrorBallExists = tester.reset( p0, pj, pi, data.intRadiusSq );
-            assert( mirrorBallExists );
+            tester.flip();
             if ( ballEmpty( pj.id, pi.id ) )
                 appendTris.push_back( { v, pj.id, pi.id } );
         }

--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -1,0 +1,172 @@
+#include "MRAlphaShape.h"
+#include "MRPointCloud.h"
+#include "MRPointsInBall.h"
+#include "MRInSphere.h"
+#include "MRBox.h"
+#include "MRBitSetParallelFor.h"
+#include "MRMesh.h"
+#include "MRTimer.h"
+#include "MRProgressCallback.h"
+#include "MRPch/MRTBB.h"
+
+namespace MR
+{
+
+PreciseVertCoords AlphaShapeData::coords( const PointCloud & cloud, VertId v ) const
+{
+    return { v, intPoints.empty() ? toInt( cloud.points[v] ) : intPoints[v] };
+}
+
+AlphaShapeData getAlphaShapeData( const PointCloud & cloud, float radius, bool allPoints )
+{
+    MR_TIMER;
+    assert( radius > 0 );
+    AlphaShapeData res;
+    auto box = Box3d( cloud.getBoundingBox() );
+    if ( !box.valid() )
+        return res; // no valid points in the cloud
+
+    // getToIntConverter maps the largest box dimension onto the whole integer range, so the box is
+    // enlarged up to the radius here to keep the integer radius in the same range,
+    // where its square still fits in std::int64_t and the predicates below do not overflow
+    const auto boxCenter = box.center();
+    const auto halfRadius = Vector3d::diagonal( 0.5 * radius );
+    box.include( Box3d{ boxCenter - halfRadius, boxCenter + halfRadius } );
+    res.toInt = getToIntConverter( box );
+
+    if ( allPoints )
+        res.intPoints = computeIntCoords( res.toInt, cloud.points, &cloud.validPoints );
+
+    // rounding down to be sure that the integer ball is not larger than the given one
+    const auto intRadius = std::int64_t( double( radius ) * res.toInt.invRange );
+    res.intRadiusSq = sqr( intRadius );
+
+    // rounding of integer coordinates can move each of two points by half of the grid step,
+    // increasing their distance by one step; two steps are added for the sake of safety
+    res.searchRadius = 2 * radius + float( 2 / res.toInt.invRange );
+    return res;
+}
+
+void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, const AlphaShapeData & data,
+    Triangulation & appendTris, std::vector<PreciseVertCoords> & neis, bool onlyLargerVids )
+{
+    neis.clear();
+    findPointsInBall( cloud, { cloud.points[v], sqr( data.searchRadius ) },
+        [&]( const PointsProjectionResult & found, const Vector3f&, Ball3f & )
+        {
+            if ( v != found.vId )
+                neis.push_back( data.coords( cloud, found.vId ) );
+            return Processing::Continue;
+        } );
+
+    const auto p0 = data.coords( cloud, v );
+    InSphereTesterSoS tester;
+    // the tester must be already reset on the ball in question, and a, b are the ids of its points
+    auto ballEmpty = [&tester, &neis]( VertId a, VertId b )
+    {
+        for ( const auto & pn : neis )
+            if ( pn.id != a && pn.id != b && tester( pn ) == InSphereResult::Inside )
+                return false;
+        return true;
+    };
+    for ( size_t i = 0; i + 1 < neis.size(); ++i )
+    {
+        const auto & pi = neis[i];
+        if ( onlyLargerVids && pi.id < v )
+            continue;
+        for ( size_t j = i + 1; j < neis.size(); ++j )
+        {
+            const auto & pj = neis[j];
+            if ( onlyLargerVids && pj.id < v )
+                continue;
+            // reset checks the existence of the ball, which does not depend on the order of pi and pj,
+            // and the two orders select the balls on the opposite sides of the triangle
+            if ( !tester.reset( p0, pi, pj, data.intRadiusSq ) )
+                continue;
+            if ( ballEmpty( pi.id, pj.id ) )
+                appendTris.push_back( { v, pi.id, pj.id } );
+            [[maybe_unused]] const bool mirrorBallExists = tester.reset( p0, pj, pi, data.intRadiusSq );
+            assert( mirrorBallExists );
+            if ( ballEmpty( pj.id, pi.id ) )
+                appendTris.push_back( { v, pj.id, pi.id } );
+        }
+    }
+}
+
+std::optional<Triangulation> findAlphaShapeAllTriangles( const PointCloud & cloud, float radius, const ProgressCallback& cb )
+{
+    MR_TIMER;
+    struct ThreadData
+    {
+        Triangulation tris;
+        std::vector<PreciseVertCoords> neis;
+    };
+
+    tbb::enumerable_thread_specific<ThreadData> threadData;
+    cloud.getAABBTree(); // to avoid multiple calls to tree construction from parallel region,
+                         // which can result that two different vertices will start being processed by one thread
+
+    const auto data = getAlphaShapeData( cloud, radius, true );
+
+    if ( !BitSetParallelFor( cloud.validPoints, [&]( VertId v )
+    {
+        auto & tls = threadData.local();
+        findAlphaShapeNeiTriangles( cloud, v, data, tls.tris, tls.neis, true );
+    }, subprogress( cb, 0.0f, 0.9f ) ) )
+        return std::nullopt;
+
+    size_t numTris = 0;
+    for ( const auto & tls : threadData )
+        numTris += tls.tris.size();
+
+    Triangulation res;
+    res.reserve( numTris );
+    for ( const auto & tls : threadData )
+        res.vec_.insert( end( res ), begin( tls.tris ), end( tls.tris ) );
+
+    if ( !reportProgress( cb, 0.95f ) )
+        return std::nullopt;
+
+    /// to avoid dependency on work distribution among threads
+    tbb::parallel_sort( begin( res ), end( res ) );
+
+    if ( !reportProgress( cb, 1.0f ) )
+        return std::nullopt;
+
+    return res;
+}
+
+Triangulation findAlphaShapeAllTriangles( const PointCloud & cloud, float radius )
+{
+    auto maybe = findAlphaShapeAllTriangles( cloud, radius, ProgressCallback{} );
+    assert( maybe.has_value() );
+    Triangulation res;
+    if ( maybe.has_value() )
+        res = std::move( *maybe );
+    return res;
+}
+
+std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius, const ProgressCallback& cb )
+{
+    MR_TIMER;
+    auto maybeTris = findAlphaShapeAllTriangles( cloud, radius, subprogress( cb, 0.0f, 0.8f ) );
+    if ( !maybeTris )
+        return std::nullopt;
+
+    int skippedFaceCount = 0;
+    auto res = Mesh::fromTrianglesDuplicatingNonManifoldVertices( cloud.points, *maybeTris, nullptr, { .skippedFaceCount = &skippedFaceCount } );
+    assert( skippedFaceCount == 0 );
+    return res;
+}
+
+Mesh findAlphaShape( const PointCloud & cloud, float radius )
+{
+    auto maybe = findAlphaShape( cloud, radius, ProgressCallback{} );
+    assert( maybe.has_value() );
+    Mesh res;
+    if ( maybe.has_value() )
+        res = std::move( *maybe );
+    return res;
+}
+
+} //namespace MR

--- a/source/MRMesh/MRAlphaShape.h
+++ b/source/MRMesh/MRAlphaShape.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "MRMeshFwd.h"
+#include "MRPrecisePredicates3.h"
+#include "MRVector.h"
+#include <optional>
+
+namespace MR
+{
+
+// inspired by "On the Shape of a Set of Points in the Plane" by HERBERT EDELSBRUNNER, DAVID G. KIRKPATRICK, AND RAIMUND SEIDEL
+// https://www.cs.jhu.edu/~misha/Fall13b/Papers/Edelsbrunner93.pdf
+
+/// a point cloud and a ball radius prepared for the search of alpha-shape triangles;
+/// the emptiness of a ball is tested in integer coordinates with simulation-of-simplicity
+/// resolving the degeneracies, so both the cloud and the radius are needed in integer form as well
+struct AlphaShapeData
+{
+    /// converts cloud's points in integer coordinates
+    ConvertToIntVector toInt;
+
+    /// integer coordinates of all valid points of the cloud,
+    /// or empty if they have to be computed on the fly by toInt
+    Vector<Vector3i, VertId> intPoints;
+
+    /// squared ball radius in the units of toInt's integer grid, not larger than the squared
+    /// original radius (so that no point inside a ball can be farther than searchRadius
+    /// from the ball's points), and small enough for the predicates not to overflow
+    std::int64_t intRadiusSq = 0;
+
+    /// the radius of the neighbourhood of a point to consider;
+    /// a bit larger than the doubled ball radius to compensate the rounding of integer coordinates
+    float searchRadius = 0;
+
+    /// returns point #v of the cloud (which must be the cloud given to getAlphaShapeData)
+    /// together with its integer coordinates
+    [[nodiscard]] MRMESH_API PreciseVertCoords coords( const PointCloud & cloud, VertId v ) const;
+};
+
+/// prepares the data for the search of alpha-shape triangles with negative alpha = -1/radius in the cloud
+/// \param allPoints whether to convert all valid points of the cloud in integer coordinates in parallel,
+///                  which pays off if the triangles around many points will be searched
+[[nodiscard]] MRMESH_API AlphaShapeData getAlphaShapeData( const PointCloud & cloud, float radius, bool allPoints );
+
+/// finds all triangles of alpha-shape with negative alpha = -1/radius,
+/// where each triangle contains point #v and two other points
+MRMESH_API void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v,
+    const AlphaShapeData & data, ///< prepared by getAlphaShapeData for the same cloud and the same radius
+    Triangulation & appendTris,  ///< found triangles will be appended here
+    std::vector<PreciseVertCoords> & neis, ///< temporary storage to avoid memory allocations, it will be filled with all neighbours of point #v within data.searchRadius
+    bool onlyLargerVids );       ///< if true then two other points must have larger ids (to avoid finding same triangles several times)
+
+/// finds all triangles of alpha-shape with negative alpha = -1/radius
+[[nodiscard]] MRMESH_API std::optional<Triangulation> findAlphaShapeAllTriangles( const PointCloud & cloud, float radius, const ProgressCallback & cb );
+[[nodiscard]] MRMESH_API Triangulation findAlphaShapeAllTriangles( const PointCloud & cloud, float radius );
+
+/// builds alpha-shape mesh with negative alpha = -1/radius
+[[nodiscard]] MRMESH_API std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius, const ProgressCallback & cb );
+[[nodiscard]] MRMESH_API Mesh findAlphaShape( const PointCloud & cloud, float radius );
+
+} //namespace MR

--- a/source/MRMesh/MRInSphere.h
+++ b/source/MRMesh/MRInSphere.h
@@ -5,6 +5,7 @@
 #include "MRPch/MRBindingMacros.h"
 #include <cassert>
 #include <type_traits>
+#include <utility>
 
 namespace MR
 {
@@ -106,6 +107,17 @@ public:
         return E >= 0;
     }
 
+    /// swaps the points b and c, which selects the mirror sphere with the center on the other side
+    /// of plane abc, and gives exactly the state of reset( a, c, b, rSq ) without recomputing anything:
+    /// only the normal w changes there, and W, M, E are symmetric in b and c;
+    /// shall be called only after reset() returned true
+    void flip()
+    {
+        assert( E >= 0 ); // the last reset() must have returned true
+        std::swap( u, v );
+        w = -w;
+    }
+
     /// returns the position of the point d relative to the sphere (never NoSphere);
     /// shall be called only after reset() returned true
     [[nodiscard]] InSphereResult operator()( const Vector3<T> & d ) const
@@ -157,6 +169,17 @@ public:
     /// or rSq is less than the squared circumradius of triangle abc
     MRMESH_API bool reset( const Vector3i & a, const Vector3i & b, const Vector3i & c, std::int64_t rSq );
 
+    /// swaps the points b and c, which selects the mirror sphere with the center on the other side
+    /// of plane abc, and gives exactly the state of reset( a, c, b, rSq ) without recomputing anything:
+    /// only the normal w changes there, and W, M, E are symmetric in b and c;
+    /// shall be called only after reset() returned true
+    void flip()
+    {
+        assert( E >= 0 ); // the last reset() must have returned true
+        std::swap( u, v );
+        w = -w;
+    }
+
     /// returns the position of the point d relative to the sphere (never NoSphere);
     /// shall be called only after reset() returned true
     [[nodiscard]] MRMESH_API InSphereResult operator()( const Vector3i & d ) const;
@@ -187,6 +210,15 @@ public:
     /// or rSq is less than the squared circumradius of the triangle;
     /// this hides the id-less reset of the base class, which would leave stale ids
     MRMESH_API bool reset( const PreciseVertCoords & a, const PreciseVertCoords & b, const PreciseVertCoords & c, std::int64_t rSq );
+
+    /// swaps the points b and c together with their ids, which selects the mirror sphere as in the
+    /// base class, and gives exactly the state of reset( a, c, b, rSq );
+    /// this hides the id-less flip of the base class, which would leave stale ids
+    void flip()
+    {
+        InSphereTester<int>::flip();
+        std::swap( vb_, vc_ );
+    }
 
     /// returns the position of the point d.pt relative to the sphere, resolving "exactly on the
     /// sphere" ties into Inside or Outside by simulation-of-simplicity as described at the inSphere

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MRAlignContoursToMesh.h" />
+    <ClInclude Include="MRAlphaShape.h" />
     <ClInclude Include="MRBoxNesting.h" />
     <ClInclude Include="MRCurve.h" />
     <ClInclude Include="MRDivRound.h" />
@@ -472,6 +473,7 @@
       <ExcludedFromBuild Condition="'$(MR_PCH_USE_EXTRA_HEADERS)'!='ON'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="MRAlignContoursToMesh.cpp" />
+    <ClCompile Include="MRAlphaShape.cpp" />
     <ClCompile Include="MRBoxNesting.cpp" />
     <ClCompile Include="MRChangeMeshDataAction.cpp" />
     <ClCompile Include="MRDirMax.cpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -642,6 +642,9 @@
     <ClInclude Include="MRPointCloudTriangulation.h">
       <Filter>Source Files\Triangulation</Filter>
     </ClInclude>
+    <ClInclude Include="MRAlphaShape.h">
+      <Filter>Source Files\Triangulation</Filter>
+    </ClInclude>
     <ClInclude Include="MRPointCloudTriangulationHelpers.h">
       <Filter>Source Files\Triangulation</Filter>
     </ClInclude>
@@ -1800,6 +1803,9 @@
       <Filter>Source Files\Decimation</Filter>
     </ClCompile>
     <ClCompile Include="MRPointCloudTriangulation.cpp">
+      <Filter>Source Files\Triangulation</Filter>
+    </ClCompile>
+    <ClCompile Include="MRAlphaShape.cpp">
       <Filter>Source Files\Triangulation</Filter>
     </ClCompile>
     <ClCompile Include="MRPointCloudTriangulationHelpers.cpp">

--- a/source/MRTest/MRAlphaShapeTests.cpp
+++ b/source/MRTest/MRAlphaShapeTests.cpp
@@ -1,0 +1,73 @@
+#include <MRMesh/MRAlphaShape.h>
+#include <MRMesh/MRPointCloud.h>
+#include <MRMesh/MRMesh.h>
+#include <gtest/gtest.h>
+
+namespace MR
+{
+
+TEST( MRMesh, AlphaShape )
+{
+    PointCloud cloud;
+    cloud.points.push_back( { 0.5f, 0.5f, 0.1f } ); //0_v
+    cloud.points.push_back( { 0.5f, 0.5f, -.1f } ); //1_v
+    cloud.points.push_back( { 0,    0,    0 } );    //2_v
+    cloud.points.push_back( { 1,    0,    0 } );    //3_v
+    cloud.points.push_back( { 0,    1,    0 } );    //4_v
+    cloud.validPoints.autoResizeSet( 2_v, 3, true );
+
+    Triangulation tris;
+    std::vector<PreciseVertCoords> neis;
+
+    auto data = getAlphaShapeData( cloud, 3, false );
+    findAlphaShapeNeiTriangles( cloud, 3_v, data, tris, neis, true );
+    EXPECT_EQ( tris.size(), 0 );
+    findAlphaShapeNeiTriangles( cloud, 4_v, data, tris, neis, true );
+    EXPECT_EQ( tris.size(), 0 );
+    findAlphaShapeNeiTriangles( cloud, 2_v, data, tris, neis, true );
+    EXPECT_EQ( tris.size(), 2 ); // two balls touching all three points from the opposite sides are empty
+
+    cloud.validPoints.set( 1_v );
+    cloud.invalidateCaches();
+    tris.clear();
+    data = getAlphaShapeData( cloud, 3, false );
+    findAlphaShapeNeiTriangles( cloud, 2_v, data, tris, neis, true );
+    EXPECT_EQ( tris.size(), 1 ); // 1_v is inside one of the two balls
+
+    cloud.validPoints.set( 0_v );
+    cloud.invalidateCaches();
+    tris.clear();
+    data = getAlphaShapeData( cloud, 3, false );
+    findAlphaShapeNeiTriangles( cloud, 2_v, data, tris, neis, true );
+    EXPECT_EQ( tris.size(), 0 ); // 0_v and 1_v are inside the balls on the both sides
+
+    const auto allTris = findAlphaShapeAllTriangles( cloud, 3 );
+    EXPECT_EQ( allTris.size(), 6 );
+}
+
+// four points of a square are exactly on both balls passing via any three of them,
+// so every ball emptiness test here is a tie resolved by simulation-of-simplicity
+TEST( MRMesh, AlphaShapeSquare )
+{
+    PointCloud cloud;
+    cloud.points.push_back( { 0, 0, 0 } ); //0_v
+    cloud.points.push_back( { 1, 0, 0 } ); //1_v
+    cloud.points.push_back( { 1, 1, 0 } ); //2_v
+    cloud.points.push_back( { 0, 1, 0 } ); //3_v
+    cloud.validPoints.autoResizeSet( 0_v, 4, true );
+
+    const auto tris = findAlphaShapeAllTriangles( cloud, 0.8f );
+    // the square is covered by two triangles from each side, and the sides take different diagonals;
+    // in floating point all the four balls looked empty giving eight triangles
+    const std::vector<ThreeVertIds> expectedTris{
+        { 0_v, 1_v, 2_v }, { 0_v, 2_v, 3_v }, // the diagonal 0-2 from the positive side
+        { 0_v, 3_v, 1_v }, { 1_v, 3_v, 2_v }  // the diagonal 1-3 from the negative side
+    };
+    EXPECT_EQ( tris.vec_, expectedTris );
+
+    const auto mesh = findAlphaShape( cloud, 0.8f );
+    EXPECT_EQ( mesh.topology.numValidFaces(), 4 );
+    EXPECT_TRUE( mesh.topology.isClosed() );
+}
+
+} //namespace MR

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -345,6 +345,55 @@ TEST( MRMesh, inSphereTester )
     EXPECT_EQ( tester( b ), On );
 }
 
+TEST( MRMesh, inSphereTesterFlip )
+{
+    const Vector3i a{ 0, 0, 0 }, b{ 2, 0, 0 }, c{ 0, 2, 0 };
+    InSphereTesteri flipped, mirror;
+    ASSERT_TRUE( flipped.reset( a, b, c, 4 ) );
+    ASSERT_TRUE( mirror.reset( a, c, b, 4 ) );
+    flipped.flip();
+
+    // flip must give the answers of the tester reset with the swapped second and third points
+    for ( int z = -2; z <= 4; ++z )
+        for ( int y = -2; y <= 4; ++y )
+            for ( int x = -2; x <= 4; ++x )
+            {
+                const Vector3i d{ x, y, z };
+                EXPECT_EQ( flipped( d ), mirror( d ) );
+            }
+    flipped.flip();
+    EXPECT_EQ( flipped( Vector3i{ 1, 1, 2 } ), InSphereResult::Inside ); // the initial sphere is back
+
+    const Vector3d ad{ 0, 0, 0 }, bd{ 2, 0, 0 }, cd{ 0, 2, 0 };
+    InSphereTesterd flippedd, mirrord;
+    ASSERT_TRUE( flippedd.reset( ad, bd, cd, 4.0 ) );
+    ASSERT_TRUE( mirrord.reset( ad, cd, bd, 4.0 ) );
+    flippedd.flip();
+    EXPECT_EQ( flippedd( Vector3d{ 1, 1, -1 } ), mirrord( Vector3d{ 1, 1, -1 } ) );
+
+    // four concyclic points: every query point is exactly on the both spheres passing via three
+    // others, so the ties of all the arrangements are resolved by ids and must survive the flip
+    const PreciseVertCoords ps[4] = {
+        { 0_v, Vector3i{  5, 0, 0 } },
+        { 1_v, Vector3i{  0, 5, 0 } },
+        { 2_v, Vector3i{ -5, 0, 0 } },
+        { 3_v, Vector3i{  3, 4, 0 } }
+    };
+    InSphereTesterSoS flippedSos, mirrorSos;
+    for ( int i = 0; i < 4; ++i )
+        for ( int j = 0; j < 4; ++j )
+            for ( int k = 0; k < 4; ++k )
+            {
+                if ( i == j || j == k || i == k )
+                    continue;
+                ASSERT_TRUE( flippedSos.reset( ps[i], ps[j], ps[k], 169 ) );
+                ASSERT_TRUE( mirrorSos.reset( ps[i], ps[k], ps[j], 169 ) );
+                flippedSos.flip();
+                const auto & d = ps[6 - i - j - k];
+                EXPECT_EQ( flippedSos( d ), mirrorSos( d ) );
+            }
+}
+
 TEST( MRMesh, inSphereTesterFloat )
 {
     const auto In = InSphereResult::Inside;

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ClCompile Include="MRAABBTreeTests.cpp" />
     <ClCompile Include="MRAABBTreePointsTests.cpp" />
+    <ClCompile Include="MRAlphaShapeTests.cpp" />
     <ClCompile Include="MRBase64Tests.cpp" />
     <ClCompile Include="MRBestFitTests.cpp" />
     <ClCompile Include="MRBezierTests.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -175,6 +175,9 @@
     <ClCompile Include="MRAABBTreeTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRAlphaShapeTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="MRMeshMeshDistanceTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
Alpha-shape of a point cloud with negative alpha = -1/radius (Edelsbrunner-Kirkpatrick-Seidel): three points give a triangle if one of the two balls of the given radius touching all of them contains no other point of the cloud, oriented so that the empty ball is on the positive side of it. The two balls are tested independently, and a triple with the both of them empty gives the triangle twice, in the opposite orientations.

New in `MRMesh/MRAlphaShape.h`:
* `findAlphaShape( cloud, radius )` - the alpha-shape mesh,
* `findAlphaShapeAllTriangles( cloud, radius )` - its triangles,
* `findAlphaShapeNeiTriangles( cloud, v, data, ... )` - the triangles containing one given point,
* `getAlphaShapeData( cloud, radius, allPoints )` + `AlphaShapeData` - the data shared by the searches around individual points.

### The ball emptiness predicate

`InSphereTesterSoS` from #6517: the emptiness of a ball is decided exactly in integer coordinates, and a point exactly on the ball is resolved by simulation-of-simplicity. Such ties are not exotic - they are the regular grids and other symmetric configurations - and in floating point their outcome is the rounding noise of the circumball center. Four points of a square, for example, lie exactly on both balls passing via any three of them, so the floating-point emptiness test `distSq < rSq` fails for all the eight balls and reports all the eight triangles, a non-manifold soup; the new test `AlphaShapeSquare` pins what simulation-of-simplicity gives instead: two triangles from each side of the square (the two sides taking different diagonals), which is a closed mesh.

### Integer radius and the neighbourhood

`getAlphaShapeData` prepares the float-to-int converter, the integer coordinates of all valid points (in parallel, if the triangles around many points will be searched), the squared integer radius and the search radius together, so that no caller can compose an inconsistent set of them:
* the converter is built on the cloud's box enlarged up to the radius, because `getToIntConverter` maps the largest box dimension onto the whole integer range: without the enlargement `toInt.scaleOnly( radius )` overflows `int` already for a radius slightly above the largest box dimension (and its square overflows `int64` above ~1.43 of it), while the enlargement keeps the integer radius within the coordinate range, where the degree-16 products of the predicate are proven not to overflow. Incidentally this also fixes the infinite `invRange` of a cloud whose points all coincide;
* the squared radius is rounded down, and the search radius is two grid steps larger than the doubled ball radius, so that a point inside the integer ball is never missed by the neighbourhood search: the integer ball is not larger than the given one, and the rounding of the coordinates of its two points can increase their distance by one step.

### Per-point search

The neighbours are converted into integer coordinates once per point, and one `InSphereTesterSoS` is reset once per point pair - not twice, as the two balls touching the three points would suggest. The new `InSphereTester::flip()` turns the tester to the mirror ball by two swaps and a negation: swapping the sphere points b and c changes only the sign of the normal `w`, while `W`, `M` and `E` are symmetric in them (the two terms of `M` just add in the opposite order), so the resulting state is exactly the one of `reset( a, c, b, rSq )`, and `inSphereTesterFlip` asserts that on concyclic points, where every answer is a tie resolved by ids. `MR_TIMER` is not used in the per-point function.

### Tests

`AlphaShapeSquare` as described above, and `AlphaShape` checking the basic cases: a lone triple gives two triangles, a point inside one of the two balls leaves one, points inside the both leave none. Its radius 3 is thrice the largest box dimension, which the plain `scaleOnly` conversion could not survive.
