### PR TITLE
ccwAroundLine: precise predicate for counter-clockwise order of 3 half-planes around a line

### DIFF
--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -177,11 +177,6 @@ bool orient3d( const PreciseVertCoords* vs )
     return odd != orient3d( vs[order[0]].pt, vs[order[1]].pt, vs[order[2]].pt, vs[order[3]].pt );
 }
 
-bool orient3d( const std::array<PreciseVertCoords, 4> & vs )
-{
-    return orient3d( vs.data() );
-}
-
 bool ccwAroundLine( const PreciseVertCoords* vs )
 {
     // orient3d( vs[0], vs[1], x, y ) is true iff the rotation around the line from the half-plane
@@ -193,11 +188,6 @@ bool ccwAroundLine( const PreciseVertCoords* vs )
         return l4; // the pairs (2,3) and (4,2) agree, and give the answer
 
     return orient3d( { vs[0], vs[1], vs[4], vs[3] } ); // they disagree, so the pair (3,4) decides
-}
-
-bool ccwAroundLine( const std::array<PreciseVertCoords, 5> & vs )
-{
-    return ccwAroundLine( vs.data() );
 }
 
 TriangleSegmentIntersectResult doTriangleSegmentIntersect( const std::array<PreciseVertCoords, 5> & vs )

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -28,28 +28,29 @@ struct PointDegree
 // if it is not enough then we will get assert violation inside poly.isPositive(), and increase the value
 constexpr int cMaxPolyD = 14'941'836;
 
-std::array<PointDegree, 8> getPointDegrees( const std::array<PreciseVertCoords, 8> & vs )
+template <std::size_t N>
+std::array<PointDegree, N> getPointDegrees( const std::array<PreciseVertCoords, N> & vs )
 {
     struct VertN
     {
         VertId v;
         int n = 0;
     };
-    std::array<VertN, 8> as;
-    for ( int i = 0; i < 8; ++i )
-        as[i] = { vs[i].id, i };
+    std::array<VertN, N> as;
+    for ( std::size_t i = 0; i < N; ++i )
+        as[i] = { vs[i].id, int( i ) };
     std::sort( begin( as ), end( as ), []( const auto & a, const auto & b ) { return a.v < b.v; } );
 
-    std::array<PointDegree, 8> res;
+    std::array<PointDegree, N> res;
     int d = 1;
     constexpr int maxD = INT_MAX / 9;
     static_assert( maxD > cMaxPolyD );
     constexpr int preMaxD = maxD / 27;
-    for ( int i = 0; i < 8; ++i )
+    for ( std::size_t i = 0; i < N; ++i )
     {
         const auto n = as[i].n;
         res[n] = { vs[n].pt, d };
-        if ( i < 7 && as[i].v < as[i+1].v ) // skip to support triangles with shared vertices
+        if ( i + 1 < N && as[i].v < as[i+1].v ) // skip to support triangles with shared vertices
         {
             if ( d <= preMaxD )
                 d *= 27; // normal power up
@@ -98,16 +99,18 @@ Poly orient3dPoly( const PointDegree & a, const PointDegree & b, const PointDegr
     return det;
 }
 
-Int128 volume( const Vector3i & a, const Vector3i & b, const Vector3i & c, const Vector3i & d )
+// signed volume of the parallelepiped given by three vectors, whose components must fit in 32 bits
+Int128 volume( const Vector3i64 & x, const Vector3i64 & y, const Vector3i64 & z )
 {
-    const Vector3i64 x( a - d );
-    const Vector3i64 y( b - d );
-    const Vector3i64 z( c - d );
-
     return
         x.x * Int128( y.y * z.z - y.z * z.y )
      -  x.y * Int128( y.x * z.z - y.z * z.x )
      +  x.z * Int128( y.x * z.y - y.y * z.x );
+}
+
+Int128 volume( const Vector3i & a, const Vector3i & b, const Vector3i & c, const Vector3i & d )
+{
+    return volume( Vector3i64( a - d ), Vector3i64( b - d ), Vector3i64( c - d ) );
 }
 
 } // anonymous namespace
@@ -180,6 +183,31 @@ bool orient3d( const PreciseVertCoords* vs )
 bool orient3d( const std::array<PreciseVertCoords, 4> & vs )
 {
     return orient3d( vs.data() );
+}
+
+bool ccw3d( const std::array<PreciseVertCoords, 5> & vs )
+{
+    const auto v = volume( Vector3i64( vs[1].pt - vs[0].pt ), Vector3i64( vs[3].pt - vs[2].pt ), Vector3i64( vs[4].pt - vs[2].pt ) );
+    if ( v != 0 )
+        return v > 0;
+
+    // the direction is exactly parallel to the plane of the three points, so resolve it by simulation-of-simplicity
+    // using det( q-p, b-a, c-a ) = det( q-a, b-a, c-a ) - det( p-a, b-a, c-a )
+#ifndef NDEBUG
+    for ( int i = 0; i < 5; ++i )
+        for ( int j = i + 1; j < 5; ++j )
+            assert( vs[i].id != vs[j].id );
+#endif
+    const auto ds = getPointDegrees( vs );
+    auto poly = orient3dPoly( ds[1], ds[3], ds[4], ds[2], 3 );
+    poly -= orient3dPoly( ds[0], ds[3], ds[4], ds[2], 3 );
+    assert( poly.get().find( 0 ) == poly.get().end() ); // zero degree coefficients are equal here and cancel one another
+    return poly.isPositive();
+}
+
+bool ccw3d( const PreciseVertCoords* vs )
+{
+    return ccw3d( std::array<PreciseVertCoords, 5>{ vs[0], vs[1], vs[2], vs[3], vs[4] } );
 }
 
 TriangleSegmentIntersectResult doTriangleSegmentIntersect( const std::array<PreciseVertCoords, 5> & vs )

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -28,29 +28,28 @@ struct PointDegree
 // if it is not enough then we will get assert violation inside poly.isPositive(), and increase the value
 constexpr int cMaxPolyD = 14'941'836;
 
-template <std::size_t N>
-std::array<PointDegree, N> getPointDegrees( const std::array<PreciseVertCoords, N> & vs )
+std::array<PointDegree, 8> getPointDegrees( const std::array<PreciseVertCoords, 8> & vs )
 {
     struct VertN
     {
         VertId v;
         int n = 0;
     };
-    std::array<VertN, N> as;
-    for ( std::size_t i = 0; i < N; ++i )
-        as[i] = { vs[i].id, int( i ) };
+    std::array<VertN, 8> as;
+    for ( int i = 0; i < 8; ++i )
+        as[i] = { vs[i].id, i };
     std::sort( begin( as ), end( as ), []( const auto & a, const auto & b ) { return a.v < b.v; } );
 
-    std::array<PointDegree, N> res;
+    std::array<PointDegree, 8> res;
     int d = 1;
     constexpr int maxD = INT_MAX / 9;
     static_assert( maxD > cMaxPolyD );
     constexpr int preMaxD = maxD / 27;
-    for ( std::size_t i = 0; i < N; ++i )
+    for ( int i = 0; i < 8; ++i )
     {
         const auto n = as[i].n;
         res[n] = { vs[n].pt, d };
-        if ( i + 1 < N && as[i].v < as[i+1].v ) // skip to support triangles with shared vertices
+        if ( i < 7 && as[i].v < as[i+1].v ) // skip to support triangles with shared vertices
         {
             if ( d <= preMaxD )
                 d *= 27; // normal power up
@@ -99,18 +98,16 @@ Poly orient3dPoly( const PointDegree & a, const PointDegree & b, const PointDegr
     return det;
 }
 
-// signed volume of the parallelepiped given by three vectors, whose components must fit in 32 bits
-Int128 volume( const Vector3i64 & x, const Vector3i64 & y, const Vector3i64 & z )
+Int128 volume( const Vector3i & a, const Vector3i & b, const Vector3i & c, const Vector3i & d )
 {
+    const Vector3i64 x( a - d );
+    const Vector3i64 y( b - d );
+    const Vector3i64 z( c - d );
+
     return
         x.x * Int128( y.y * z.z - y.z * z.y )
      -  x.y * Int128( y.x * z.z - y.z * z.x )
      +  x.z * Int128( y.x * z.y - y.y * z.x );
-}
-
-Int128 volume( const Vector3i & a, const Vector3i & b, const Vector3i & c, const Vector3i & d )
-{
-    return volume( Vector3i64( a - d ), Vector3i64( b - d ), Vector3i64( c - d ) );
 }
 
 } // anonymous namespace
@@ -185,29 +182,22 @@ bool orient3d( const std::array<PreciseVertCoords, 4> & vs )
     return orient3d( vs.data() );
 }
 
-bool ccw3d( const std::array<PreciseVertCoords, 5> & vs )
+bool ccwAroundLine( const PreciseVertCoords* vs )
 {
-    const auto v = volume( Vector3i64( vs[1].pt - vs[0].pt ), Vector3i64( vs[3].pt - vs[2].pt ), Vector3i64( vs[4].pt - vs[2].pt ) );
-    if ( v != 0 )
-        return v > 0;
+    // orient3d( vs[0], vs[1], x, y ) is true iff the rotation around the line from the half-plane
+    // via x to the half-plane via y is clockwise, and the three half-planes are counter-clockwise
+    // iff at least two of the pairs (2,3), (3,4), (4,2) are counter-clockwise
+    const bool l3 = orient3d( { vs[0], vs[1], vs[2], vs[3] } );
+    const bool l4 = orient3d( { vs[0], vs[1], vs[2], vs[4] } );
+    if ( l3 != l4 )
+        return l4; // the pairs (2,3) and (4,2) agree, and give the answer
 
-    // the direction is exactly parallel to the plane of the three points, so resolve it by simulation-of-simplicity
-    // using det( q-p, b-a, c-a ) = det( q-a, b-a, c-a ) - det( p-a, b-a, c-a )
-#ifndef NDEBUG
-    for ( int i = 0; i < 5; ++i )
-        for ( int j = i + 1; j < 5; ++j )
-            assert( vs[i].id != vs[j].id );
-#endif
-    const auto ds = getPointDegrees( vs );
-    auto poly = orient3dPoly( ds[1], ds[3], ds[4], ds[2], 3 );
-    poly -= orient3dPoly( ds[0], ds[3], ds[4], ds[2], 3 );
-    assert( poly.get().find( 0 ) == poly.get().end() ); // zero degree coefficients are equal here and cancel one another
-    return poly.isPositive();
+    return orient3d( { vs[0], vs[1], vs[4], vs[3] } ); // they disagree, so the pair (3,4) decides
 }
 
-bool ccw3d( const PreciseVertCoords* vs )
+bool ccwAroundLine( const std::array<PreciseVertCoords, 5> & vs )
 {
-    return ccw3d( std::array<PreciseVertCoords, 5>{ vs[0], vs[1], vs[2], vs[3], vs[4] } );
+    return ccwAroundLine( vs.data() );
 }
 
 TriangleSegmentIntersectResult doTriangleSegmentIntersect( const std::array<PreciseVertCoords, 5> & vs )

--- a/source/MRMesh/MRPrecisePredicates3.h
+++ b/source/MRMesh/MRPrecisePredicates3.h
@@ -44,14 +44,17 @@ struct PreciseVertCoords
 MRMESH_API bool orient3d( const std::array<PreciseVertCoords, 4> & vs );
 MRMESH_API bool orient3d( const PreciseVertCoords* vs );
 
-/// returns true if the points vs[2], vs[3], vs[4] are in counter-clockwise order on the plane
-/// orthogonal to the direction vs[1]-vs[0], as seen by the viewer this direction points at,
-/// i.e. if dot( vs[1]-vs[0], cross( vs[3]-vs[2], vs[4]-vs[2] ) ) is positive;
-/// uses simulation-of-simplicity (assuming larger perturbations of points with smaller id)
-/// to avoid "the direction is exactly parallel to the plane of the three points";
-/// all five ids must be distinct, while the coordinates of the points can coincide arbitrarily
-[[nodiscard]] MRMESH_API bool ccw3d( const std::array<PreciseVertCoords, 5> & vs );
-[[nodiscard]] MRMESH_API bool ccw3d( const PreciseVertCoords* vs );
+/// Precise predicate for the rotational order of three half-planes around a directed line.
+/// The line passes via vs[0] and vs[1] and is directed from vs[0] to vs[1]; the three half-planes
+/// are bounded by that line and pass via vs[2], vs[3], vs[4] respectively. Returns true iff the
+/// half-planes follow one another in counter-clockwise order around the line, as seen by the viewer
+/// the line's direction points at. Only the rotation of every point around the line matters, so
+/// cyclic permutations of vs[2], vs[3], vs[4] do not change the result, while a swap of two of them,
+/// as well as a swap of vs[0] and vs[1], inverts it. Implemented via orient3d and inherits its
+/// simulation-of-simplicity, so the predicate is never "undefined" even if some of the points
+/// coincide; all five ids must be distinct.
+[[nodiscard]] MRMESH_API bool ccwAroundLine( const std::array<PreciseVertCoords, 5> & vs );
+[[nodiscard]] MRMESH_API bool ccwAroundLine( const PreciseVertCoords* vs );
 
 struct TriangleSegmentIntersectResult
 {

--- a/source/MRMesh/MRPrecisePredicates3.h
+++ b/source/MRMesh/MRPrecisePredicates3.h
@@ -30,6 +30,15 @@ struct PreciseVertCoords
 MRMESH_API bool orient3d( const std::array<PreciseVertCoords, 4> & vs );
 MRMESH_API bool orient3d( const PreciseVertCoords* vs );
 
+/// returns true if the points vs[2], vs[3], vs[4] are in counter-clockwise order on the plane
+/// orthogonal to the direction vs[1]-vs[0], as seen by the viewer this direction points at,
+/// i.e. if dot( vs[1]-vs[0], cross( vs[3]-vs[2], vs[4]-vs[2] ) ) is positive;
+/// uses simulation-of-simplicity (assuming larger perturbations of points with smaller id)
+/// to avoid "the direction is exactly parallel to the plane of the three points";
+/// all five ids must be distinct, while the coordinates of the points can coincide arbitrarily
+[[nodiscard]] MRMESH_API bool ccw3d( const std::array<PreciseVertCoords, 5> & vs );
+[[nodiscard]] MRMESH_API bool ccw3d( const PreciseVertCoords* vs );
+
 struct TriangleSegmentIntersectResult
 {
     bool doIntersect = false;    ///< whether triangle and segment intersect

--- a/source/MRMesh/MRPrecisePredicates3.h
+++ b/source/MRMesh/MRPrecisePredicates3.h
@@ -18,7 +18,7 @@ namespace MR
 /// (equivalently, seen from the origin A->B->C winds clockwise).
 /// Simulation-of-simplicity resolves the degenerate case dot( a, cross( b, c ) ) == 0 (origin exactly
 /// on plane ABC) deterministically, so the predicate is never "undefined".
-MRMESH_API bool orient3d( const Vector3i & a, const Vector3i & b, const Vector3i & c );
+[[nodiscard]] MRMESH_API bool orient3d( const Vector3i & a, const Vector3i & b, const Vector3i & c );
 
 /// Precise orientation predicate for point D against the plane of triangle ABC
 /// (the general case of the 3-argument overload above, which tests the origin instead of D).
@@ -27,7 +27,7 @@ MRMESH_API bool orient3d( const Vector3i & a, const Vector3i & b, const Vector3i
 /// cross( b - a, c - a ) of triangle ABC points away from (equivalently, seen from D the vertices
 /// A->B->C wind clockwise). Simulation-of-simplicity resolves the degenerate case (D exactly on
 /// plane ABC) deterministically, so the predicate is never "undefined".
-inline bool orient3d( const Vector3i & a, const Vector3i & b, const Vector3i & c, const Vector3i & d )
+[[nodiscard]] inline bool orient3d( const Vector3i & a, const Vector3i & b, const Vector3i & c, const Vector3i & d )
     { return orient3d( a - d, b - d, c - d ); }
 
 struct PreciseVertCoords
@@ -41,8 +41,9 @@ struct PreciseVertCoords
 /// perturbation depends on vertex id, so sorting makes the result depend only on the set of four
 /// vertices and not on the order they are passed in: every call involving the same four vertices
 /// agrees, which keeps orientation decisions consistent mesh-wide.
-MRMESH_API bool orient3d( const std::array<PreciseVertCoords, 4> & vs );
-MRMESH_API bool orient3d( const PreciseVertCoords* vs );
+[[nodiscard]] MRMESH_API bool orient3d( const PreciseVertCoords* vs );
+[[nodiscard]] inline bool orient3d( const std::array<PreciseVertCoords, 4> & vs )
+    { return orient3d( vs.data() ); }
 
 /// Precise predicate for the rotational order of three half-planes around a directed line.
 /// The line passes via vs[0] and vs[1] and is directed from vs[0] to vs[1]; the three half-planes
@@ -53,8 +54,9 @@ MRMESH_API bool orient3d( const PreciseVertCoords* vs );
 /// as well as a swap of vs[0] and vs[1], inverts it. Implemented via orient3d and inherits its
 /// simulation-of-simplicity, so the predicate is never "undefined" even if some of the points
 /// coincide; all five ids must be distinct.
-[[nodiscard]] MRMESH_API bool ccwAroundLine( const std::array<PreciseVertCoords, 5> & vs );
 [[nodiscard]] MRMESH_API bool ccwAroundLine( const PreciseVertCoords* vs );
+[[nodiscard]] inline bool ccwAroundLine( const std::array<PreciseVertCoords, 5> & vs )
+    { return ccwAroundLine( vs.data() ); }
 
 struct TriangleSegmentIntersectResult
 {
@@ -132,9 +134,9 @@ struct CoordinateConverters
 };
 
 /// creates converter from Vector3f to Vector3i in Box range (int diapason is mapped to box range)
-MRMESH_API ConvertToIntVector getToIntConverter( const Box3d& box );
+[[nodiscard]] MRMESH_API ConvertToIntVector getToIntConverter( const Box3d& box );
 /// creates converter from Vector3i to Vector3f in Box range (int diapason is mapped to box range)
-MRMESH_API ConvertToFloatVector getToFloatConverter( const Box3d& box );
+[[nodiscard]] MRMESH_API ConvertToFloatVector getToFloatConverter( const Box3d& box );
 
 /// converts given points into integer coordinates in parallel
 /// \param valid if given then only valid points are converted, and the content of other elements in the returned vector is undefined

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -685,109 +685,80 @@ TEST( MRMesh, orientParaboloid3d )
     EXPECT_FALSE( orientParaboloid3d( a, b, b ) );
 }
 
-TEST( MRMesh, ccw3d )
+TEST( MRMesh, ccwAroundLine )
 {
     const std::array<PreciseVertCoords, 5> vs =
     {
-        PreciseVertCoords{ 0_v, Vector3i(  0,  0, -1 ) }, //p
-        PreciseVertCoords{ 1_v, Vector3i(  0,  0,  1 ) }, //q
+        PreciseVertCoords{ 0_v, Vector3i(  0,  0,  0 ) }, // the line is the z-axis directed up
+        PreciseVertCoords{ 1_v, Vector3i(  0,  0,  1 ) },
 
-        PreciseVertCoords{ 2_v, Vector3i(  2,  1,  0 ) }, //a
-        PreciseVertCoords{ 3_v, Vector3i( -2,  1,  0 ) }, //b
-        PreciseVertCoords{ 4_v, Vector3i(  0, -2,  0 ) }  //c
+        PreciseVertCoords{ 2_v, Vector3i(  2,  0,  7 ) }, // rotation 0 degrees
+        PreciseVertCoords{ 3_v, Vector3i( -1,  2, -3 ) }, // rotation ~117 degrees
+        PreciseVertCoords{ 4_v, Vector3i( -1, -2,  5 ) }  // rotation ~243 degrees
     };
 
-    // the triangle abc is counter-clockwise in the plane z=0 for the viewer the direction p->q points at
-    EXPECT_TRUE(  ccw3d( vs ) );
-    EXPECT_FALSE( ccw3d( { vs[1], vs[0], vs[2], vs[3], vs[4] } ) ); // the viewer on the other side of the plane
-    EXPECT_FALSE( ccw3d( { vs[0], vs[1], vs[2], vs[4], vs[3] } ) ); // clockwise triangle
-    EXPECT_TRUE(  ccw3d( { vs[0], vs[1], vs[3], vs[4], vs[2] } ) ); // cyclic permutation of the triangle changes nothing
+    EXPECT_TRUE(  ccwAroundLine( vs ) );
+    EXPECT_FALSE( ccwAroundLine( { vs[0], vs[1], vs[2], vs[4], vs[3] } ) ); // swapped half-planes
+    EXPECT_FALSE( ccwAroundLine( { vs[1], vs[0], vs[2], vs[3], vs[4] } ) ); // reversed line
+    EXPECT_TRUE(  ccwAroundLine( { vs[0], vs[1], vs[3], vs[4], vs[2] } ) ); // cyclic permutations
+    EXPECT_TRUE(  ccwAroundLine( { vs[0], vs[1], vs[4], vs[2], vs[3] } ) );
 
-    // both ends of the direction are on the same side of the triangle's plane
-    EXPECT_TRUE(  ccw3d( { PreciseVertCoords{ 0_v, Vector3i( 10, 10, 1 ) },
-                           PreciseVertCoords{ 1_v, Vector3i( 20, 30, 2 ) }, vs[2], vs[3], vs[4] } ) );
-    EXPECT_FALSE( ccw3d( { PreciseVertCoords{ 0_v, Vector3i( 10, 10, 2 ) },
-                           PreciseVertCoords{ 1_v, Vector3i( 20, 30, 1 ) }, vs[2], vs[3], vs[4] } ) );
+    // all three half-planes within one half-space: rotations 0, ~11 and ~22 degrees
+    const PreciseVertCoords a{ 2_v, Vector3i( 10, 0, 0 ) };
+    const PreciseVertCoords b{ 3_v, Vector3i( 10, 2, 0 ) };
+    const PreciseVertCoords c{ 4_v, Vector3i( 10, 4, 0 ) };
+    EXPECT_TRUE(  ccwAroundLine( { vs[0], vs[1], a, b, c } ) );
+    EXPECT_FALSE( ccwAroundLine( { vs[0], vs[1], a, c, b } ) );
 
-    // large coordinates requiring more than 64-bit arithmetic
-    constexpr int m = 1000000000;
-    EXPECT_TRUE( ccw3d( {
-        PreciseVertCoords{ 0_v, Vector3i( 0, 0,  0 ) },
-        PreciseVertCoords{ 1_v, Vector3i( 0, 0, 10 ) },
-        PreciseVertCoords{ 2_v, Vector3i( 0, 0,  0 ) },
-        PreciseVertCoords{ 3_v, Vector3i( m, 0,  0 ) },
-        PreciseVertCoords{ 4_v, Vector3i( 0, m,  0 ) } } ) );
-    EXPECT_FALSE( ccw3d( {
-        PreciseVertCoords{ 0_v, Vector3i( 0, 0,   0 ) },
-        PreciseVertCoords{ 1_v, Vector3i( 0, 0, -10 ) },
-        PreciseVertCoords{ 2_v, Vector3i( 0, 0,   0 ) },
-        PreciseVertCoords{ 3_v, Vector3i( m, 0,   0 ) },
-        PreciseVertCoords{ 4_v, Vector3i( 0, m,   0 ) } } ) );
+    // the same three half-planes around an oblique line
+    const PreciseVertCoords p{ 0_v, Vector3i( 1, 1, 1 ) };
+    const PreciseVertCoords q{ 1_v, Vector3i( 3, 3, 3 ) };
+    EXPECT_TRUE(  ccwAroundLine( { p, q, PreciseVertCoords{ 2_v, Vector3i(  1, -1,  0 ) },
+                                         PreciseVertCoords{ 3_v, Vector3i(  0,  1, -1 ) },
+                                         PreciseVertCoords{ 4_v, Vector3i( -1,  0,  1 ) } } ) );
+    EXPECT_FALSE( ccwAroundLine( { p, q, PreciseVertCoords{ 2_v, Vector3i(  1, -1,  0 ) },
+                                         PreciseVertCoords{ 4_v, Vector3i( -1,  0,  1 ) },
+                                         PreciseVertCoords{ 3_v, Vector3i(  0,  1, -1 ) } } ) );
 }
 
-TEST( MRMesh, ccw3dSmallGrid )
+TEST( MRMesh, ccwAroundLineCircle )
 {
-    const PreciseVertCoords a{ 2_v, Vector3i( 0, 0, 0 ) };
-    const PreciseVertCoords b{ 3_v, Vector3i( 2, 0, 0 ) };
-    const PreciseVertCoords c{ 4_v, Vector3i( 0, 2, 0 ) };
-    const auto n = cross( Vector3i64( b.pt - a.pt ), Vector3i64( c.pt - a.pt ) );
-
-    for ( int i = 0; i < 27; ++i )
+    // 16 directions with strictly increasing rotation around the z-axis
+    constexpr int cNum = 16;
+    const Vector2i dirs[cNum] =
     {
-        const PreciseVertCoords q{ 1_v, Vector3i( i % 3 - 1, ( i / 3 ) % 3 - 1, i / 9 - 1 ) };
+        { 1, 0 }, { 2, 1 }, { 1, 1 }, { 1, 2 }, { 0, 1 }, { -1, 2 }, { -1, 1 }, { -2, 1 },
+        { -1, 0 }, { -2, -1 }, { -1, -1 }, { -1, -2 }, { 0, -1 }, { 1, -2 }, { 1, -1 }, { 2, -1 }
+    };
+    std::array<PreciseVertCoords, cNum> ps;
+    for ( int i = 0; i < cNum; ++i )
+        ps[i] = { VertId( i + 2 ), Vector3i( dirs[i].x, dirs[i].y, i - cNum / 2 ) }; // z varies on purpose
 
-        // the direction starting exactly at the triangle's point a is equivalent to orient3d
-        const PreciseVertCoords p0{ 0_v, a.pt };
-        if ( dot( Vector3i64( q.pt - a.pt ), n ) != 0 )
-        {
-            EXPECT_EQ( ccw3d( { p0, q, a, b, c } ), !orient3d( { a, b, c, q } ) );
-        }
-
-        for ( int j = 0; j < 27; ++j )
-        {
-            const PreciseVertCoords p{ 0_v, Vector3i( j % 3 - 1, ( j / 3 ) % 3 - 1, j / 9 - 1 ) };
-            const auto v = dot( Vector3i64( q.pt - p.pt ), n );
-            if ( v != 0 )
+    const PreciseVertCoords p{ 0_v, Vector3i( 0, 0, -5 ) };
+    const PreciseVertCoords q{ 1_v, Vector3i( 0, 0,  7 ) };
+    for ( int i = 0; i < cNum; ++i )
+        for ( int j = i + 1; j < cNum; ++j )
+            for ( int k = j + 1; k < cNum; ++k )
             {
-                EXPECT_EQ( ccw3d( { p, q, a, b, c } ), v > 0 );
+                EXPECT_TRUE(  ccwAroundLine( { p, q, ps[i], ps[j], ps[k] } ) );
+                EXPECT_FALSE( ccwAroundLine( { p, q, ps[i], ps[k], ps[j] } ) );
             }
-        }
-    }
 }
 
-TEST( MRMesh, sosCcw3d )
-{
-    // the direction lies in the plane of the three points, and the triangle is degenerate as well,
-    // so the answer is given by simulation-of-simplicity only
-    const std::array<PreciseVertCoords, 5> vs =
-    {
-        PreciseVertCoords{ 0_v, Vector3i( 0, 0, 0 ) },
-        PreciseVertCoords{ 1_v, Vector3i( 1, 0, 0 ) },
-
-        PreciseVertCoords{ 2_v, Vector3i( 0, 0, 0 ) },
-        PreciseVertCoords{ 3_v, Vector3i( 1, 0, 0 ) },
-        PreciseVertCoords{ 4_v, Vector3i( 2, 0, 0 ) }
-    };
-
-    const bool res = ccw3d( vs );
-    EXPECT_NE( res, ccw3d( { vs[1], vs[0], vs[2], vs[3], vs[4] } ) );
-    EXPECT_NE( res, ccw3d( { vs[0], vs[1], vs[2], vs[4], vs[3] } ) );
-    EXPECT_EQ( res, ccw3d( { vs[0], vs[1], vs[3], vs[4], vs[2] } ) );
-}
-
-TEST( MRMesh, ccw3dFullDegen )
+TEST( MRMesh, sosCcwAroundLine )
 {
     std::array<PreciseVertCoords, 5> vs;
     for ( VertId i = 0_v; i < 5; ++i )
         vs[i].id = i; //and point coordinate is (0,0,0)
 
-    // test that maximum degree in ccw3d can cope with most degenerate situation possible
+    // simulation-of-simplicity must answer consistently in the most degenerate situation possible
     do
     {
-        const bool res = ccw3d( vs );
-        EXPECT_NE( res, ccw3d( { vs[1], vs[0], vs[2], vs[3], vs[4] } ) ); // swapped ends of the direction
-        EXPECT_NE( res, ccw3d( { vs[0], vs[1], vs[2], vs[4], vs[3] } ) ); // swapped points of the triangle
-        EXPECT_EQ( res, ccw3d( { vs[0], vs[1], vs[3], vs[4], vs[2] } ) ); // cyclic permutation of the triangle
+        const bool res = ccwAroundLine( vs );
+        EXPECT_NE( res, ccwAroundLine( { vs[0], vs[1], vs[2], vs[4], vs[3] } ) ); // swapped half-planes
+        EXPECT_NE( res, ccwAroundLine( { vs[1], vs[0], vs[2], vs[3], vs[4] } ) ); // reversed line
+        EXPECT_EQ( res, ccwAroundLine( { vs[0], vs[1], vs[3], vs[4], vs[2] } ) ); // cyclic permutations
+        EXPECT_EQ( res, ccwAroundLine( { vs[0], vs[1], vs[4], vs[2], vs[3] } ) );
     }
     while ( std::next_permutation( vs.begin(), vs.end(), []( const auto & l, const auto & r ) { return l.id < r.id; } ) );
 }

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -690,14 +690,18 @@ TEST( MRMesh, ccw3dSmallGrid )
         // the direction starting exactly at the triangle's point a is equivalent to orient3d
         const PreciseVertCoords p0{ 0_v, a.pt };
         if ( dot( Vector3i64( q.pt - a.pt ), n ) != 0 )
+        {
             EXPECT_EQ( ccw3d( { p0, q, a, b, c } ), !orient3d( { a, b, c, q } ) );
+        }
 
         for ( int j = 0; j < 27; ++j )
         {
             const PreciseVertCoords p{ 0_v, Vector3i( j % 3 - 1, ( j / 3 ) % 3 - 1, j / 9 - 1 ) };
             const auto v = dot( Vector3i64( q.pt - p.pt ), n );
             if ( v != 0 )
+            {
                 EXPECT_EQ( ccw3d( { p, q, a, b, c } ), v > 0 );
+            }
         }
     }
 }

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -636,6 +636,109 @@ TEST( MRMesh, orientParaboloid3d )
     EXPECT_FALSE( orientParaboloid3d( a, b, b ) );
 }
 
+TEST( MRMesh, ccw3d )
+{
+    const std::array<PreciseVertCoords, 5> vs =
+    {
+        PreciseVertCoords{ 0_v, Vector3i(  0,  0, -1 ) }, //p
+        PreciseVertCoords{ 1_v, Vector3i(  0,  0,  1 ) }, //q
+
+        PreciseVertCoords{ 2_v, Vector3i(  2,  1,  0 ) }, //a
+        PreciseVertCoords{ 3_v, Vector3i( -2,  1,  0 ) }, //b
+        PreciseVertCoords{ 4_v, Vector3i(  0, -2,  0 ) }  //c
+    };
+
+    // the triangle abc is counter-clockwise in the plane z=0 for the viewer the direction p->q points at
+    EXPECT_TRUE(  ccw3d( vs ) );
+    EXPECT_FALSE( ccw3d( { vs[1], vs[0], vs[2], vs[3], vs[4] } ) ); // the viewer on the other side of the plane
+    EXPECT_FALSE( ccw3d( { vs[0], vs[1], vs[2], vs[4], vs[3] } ) ); // clockwise triangle
+    EXPECT_TRUE(  ccw3d( { vs[0], vs[1], vs[3], vs[4], vs[2] } ) ); // cyclic permutation of the triangle changes nothing
+
+    // both ends of the direction are on the same side of the triangle's plane
+    EXPECT_TRUE(  ccw3d( { PreciseVertCoords{ 0_v, Vector3i( 10, 10, 1 ) },
+                           PreciseVertCoords{ 1_v, Vector3i( 20, 30, 2 ) }, vs[2], vs[3], vs[4] } ) );
+    EXPECT_FALSE( ccw3d( { PreciseVertCoords{ 0_v, Vector3i( 10, 10, 2 ) },
+                           PreciseVertCoords{ 1_v, Vector3i( 20, 30, 1 ) }, vs[2], vs[3], vs[4] } ) );
+
+    // large coordinates requiring more than 64-bit arithmetic
+    constexpr int m = 1000000000;
+    EXPECT_TRUE( ccw3d( {
+        PreciseVertCoords{ 0_v, Vector3i( 0, 0,  0 ) },
+        PreciseVertCoords{ 1_v, Vector3i( 0, 0, 10 ) },
+        PreciseVertCoords{ 2_v, Vector3i( 0, 0,  0 ) },
+        PreciseVertCoords{ 3_v, Vector3i( m, 0,  0 ) },
+        PreciseVertCoords{ 4_v, Vector3i( 0, m,  0 ) } } ) );
+    EXPECT_FALSE( ccw3d( {
+        PreciseVertCoords{ 0_v, Vector3i( 0, 0,   0 ) },
+        PreciseVertCoords{ 1_v, Vector3i( 0, 0, -10 ) },
+        PreciseVertCoords{ 2_v, Vector3i( 0, 0,   0 ) },
+        PreciseVertCoords{ 3_v, Vector3i( m, 0,   0 ) },
+        PreciseVertCoords{ 4_v, Vector3i( 0, m,   0 ) } } ) );
+}
+
+TEST( MRMesh, ccw3dSmallGrid )
+{
+    const PreciseVertCoords a{ 2_v, Vector3i( 0, 0, 0 ) };
+    const PreciseVertCoords b{ 3_v, Vector3i( 2, 0, 0 ) };
+    const PreciseVertCoords c{ 4_v, Vector3i( 0, 2, 0 ) };
+    const auto n = cross( Vector3i64( b.pt - a.pt ), Vector3i64( c.pt - a.pt ) );
+
+    for ( int i = 0; i < 27; ++i )
+    {
+        const PreciseVertCoords q{ 1_v, Vector3i( i % 3 - 1, ( i / 3 ) % 3 - 1, i / 9 - 1 ) };
+
+        // the direction starting exactly at the triangle's point a is equivalent to orient3d
+        const PreciseVertCoords p0{ 0_v, a.pt };
+        if ( dot( Vector3i64( q.pt - a.pt ), n ) != 0 )
+            EXPECT_EQ( ccw3d( { p0, q, a, b, c } ), !orient3d( { a, b, c, q } ) );
+
+        for ( int j = 0; j < 27; ++j )
+        {
+            const PreciseVertCoords p{ 0_v, Vector3i( j % 3 - 1, ( j / 3 ) % 3 - 1, j / 9 - 1 ) };
+            const auto v = dot( Vector3i64( q.pt - p.pt ), n );
+            if ( v != 0 )
+                EXPECT_EQ( ccw3d( { p, q, a, b, c } ), v > 0 );
+        }
+    }
+}
+
+TEST( MRMesh, sosCcw3d )
+{
+    // the direction lies in the plane of the three points, and the triangle is degenerate as well,
+    // so the answer is given by simulation-of-simplicity only
+    const std::array<PreciseVertCoords, 5> vs =
+    {
+        PreciseVertCoords{ 0_v, Vector3i( 0, 0, 0 ) },
+        PreciseVertCoords{ 1_v, Vector3i( 1, 0, 0 ) },
+
+        PreciseVertCoords{ 2_v, Vector3i( 0, 0, 0 ) },
+        PreciseVertCoords{ 3_v, Vector3i( 1, 0, 0 ) },
+        PreciseVertCoords{ 4_v, Vector3i( 2, 0, 0 ) }
+    };
+
+    const bool res = ccw3d( vs );
+    EXPECT_NE( res, ccw3d( { vs[1], vs[0], vs[2], vs[3], vs[4] } ) );
+    EXPECT_NE( res, ccw3d( { vs[0], vs[1], vs[2], vs[4], vs[3] } ) );
+    EXPECT_EQ( res, ccw3d( { vs[0], vs[1], vs[3], vs[4], vs[2] } ) );
+}
+
+TEST( MRMesh, ccw3dFullDegen )
+{
+    std::array<PreciseVertCoords, 5> vs;
+    for ( VertId i = 0_v; i < 5; ++i )
+        vs[i].id = i; //and point coordinate is (0,0,0)
+
+    // test that maximum degree in ccw3d can cope with most degenerate situation possible
+    do
+    {
+        const bool res = ccw3d( vs );
+        EXPECT_NE( res, ccw3d( { vs[1], vs[0], vs[2], vs[3], vs[4] } ) ); // swapped ends of the direction
+        EXPECT_NE( res, ccw3d( { vs[0], vs[1], vs[2], vs[4], vs[3] } ) ); // swapped points of the triangle
+        EXPECT_EQ( res, ccw3d( { vs[0], vs[1], vs[3], vs[4], vs[2] } ) ); // cyclic permutation of the triangle
+    }
+    while ( std::next_permutation( vs.begin(), vs.end(), []( const auto & l, const auto & r ) { return l.id < r.id; } ) );
+}
+
 TEST( MRMesh, doTriangleSegmentIntersect )
 {
     const std::array<PreciseVertCoords, 5> vs = 


### PR DESCRIPTION
Adds a precise predicate for the rotational order of three half-planes around a directed line:

```cpp
[[nodiscard]] MRMESH_API bool ccwAroundLine( const std::array<PreciseVertCoords, 5> & vs );
[[nodiscard]] MRMESH_API bool ccwAroundLine( const PreciseVertCoords* vs );
```

The line passes via `vs[0]` and `vs[1]` and is directed from `vs[0]` to `vs[1]`; the three half-planes are bounded by that line and pass via `vs[2]`, `vs[3]`, `vs[4]` respectively. The predicate returns whether these half-planes follow one another in counter-clockwise order around the line, as seen by the viewer the line's direction points at. Only the rotation of every point around the line matters, so shifting any of them along the line changes nothing; cyclic permutations of `vs[2]`, `vs[3]`, `vs[4]` do not change the answer, while a swap of two of them, as well as a swap of `vs[0]` and `vs[1]`, inverts it.

## Implementation

`orient3d( { vs[0], vs[1], x, y } )` is exactly "the rotation around the line from the half-plane via `x` to the half-plane via `y` is clockwise", so the three half-planes are counter-clockwise iff at least two of the pairs (2,3), (3,4), (4,2) are counter-clockwise. That majority is what these two or three calls compute:

```cpp
const bool l3 = orient3d( { vs[0], vs[1], vs[2], vs[3] } );
const bool l4 = orient3d( { vs[0], vs[1], vs[2], vs[4] } );
if ( l3 != l4 )
    return l4; // the pairs (2,3) and (4,2) agree, and give the answer

return orient3d( { vs[0], vs[1], vs[4], vs[3] } ); // they disagree, so the pair (3,4) decides
```

Nothing else is needed: every degenerate case (a point exactly on the line, two half-planes exactly equal or opposite, all five points coinciding) is resolved by the simulation-of-simplicity of `orient3d`, and because all the calls see the same symbolically perturbed points, the geometric reasoning above stays valid there. All five ids must be distinct, just as `orient3d` requires of its four.

## Tests

* `ccwAroundLine` — three half-planes 120 degrees apart around the z-axis, three within a 22-degree sector (the branch where the first two calls agree), and three around an oblique line; plus the reversed line, a swap and both cyclic permutations.
* `ccwAroundLineCircle` — 16 directions with strictly increasing rotation around the line: all 560 increasing triples must be counter-clockwise, and all 560 with the last two swapped clockwise. The points are placed at different positions along the line on purpose, so this also checks that the answer does not depend on them.
* `sosCcwAroundLine` — all five points coinciding, for all 120 orders of their ids: the answer must invert on a swap of two half-planes and on a reversal of the line, and must not change on cyclic permutations. This is what pins the mutual consistency of the three `orient3d` calls in the fully degenerate case.

MRTest passes locally (333 tests).
