### PR TITLE
Sharpening offset: exact zero-offset correction and optional voxel clamp

### DIFF
--- a/source/MRMesh/MRSharpenMarchingCubesMesh.cpp
+++ b/source/MRMesh/MRSharpenMarchingCubesMesh.cpp
@@ -7,26 +7,116 @@
 #include "MRTriMath.h"
 #include "MRTimer.h"
 #include "MRReducePath.h"
+#include "MRLineSegm.h"
+#include "MRVolumeIndexer.h"
+#include "MRBox.h"
+#include "MRMeshIntersect.h"
 
 namespace MR
 {
 
-void sharpenMarchingCubesMesh( const MeshPart & ref, Mesh & vox, Vector<VoxelId, FaceId> & face2voxel,
-    const SharpenMarchingCubesMeshSettings & settings )
+namespace
+{
+/// returns the two lattice nodes bounding the lattice edge, on which the vertex (v) of marching cubes mesh is located;
+/// valid for original marching cubes vertices only (all faces around a vertex introduced later are in one voxel);
+/// returns degenerate segment if the vertex is not surrounded by four voxels
+LineSegm3f findLatticeEdgeEnds( const MeshTopology& t, VertId v, const Vector<VoxelId, FaceId>& face2voxel,
+    const VolumeIndexer& vi, const AffineXf3f& gridToMeshXf )
+{
+    // every marching cubes vertex is located on a lattice edge, which is shared by exactly four voxels
+    VoxelId v0, v1, v2, v3;
+    for ( auto e : orgRing( t, v ) )
+    {
+        auto f = t.left( e );
+        assert( f );
+        auto vc = face2voxel[f];
+        if ( vc == v0 || vc == v1 || vc == v2 )
+            continue;
+        if ( !v0 ) v0 = vc;
+        else if ( !v1 ) v1 = vc;
+        else if ( !v2 ) v2 = vc;
+        else if ( !v3 )
+        {
+            v3 = vc;
+            break;
+        }
+    }
+    assert( v0 && v1 && v2 && v3 );
+    if ( !v3 )
+        return {};
+
+    // the origins of the four voxels are the corners of a unit square orthogonal to the lattice edge
+    Box3i box;
+    for ( VoxelId vc : { v0, v1, v2, v3 } )
+        box.include( vi.toPos( vc ) );
+
+    // the lattice edge is directed along the only axis, where all four voxels have equal coordinate
+    const auto sz = box.size();
+    int dir = -1, numEqualAxes = 0;
+    for ( int i = 0; i < 3; ++i )
+    {
+        if ( sz[i] != 0 )
+            continue;
+        dir = i;
+        ++numEqualAxes;
+    }
+    assert( numEqualAxes == 1 ); // otherwise the voxels do not share one lattice edge
+    if ( numEqualAxes != 1 )
+        return {};
+
+    // and it starts in the node with maximal coordinates among the voxels' origins
+    auto n1 = box.max;
+    ++n1[dir];
+    return { gridToMeshXf( Vector3f( box.max ) ), gridToMeshXf( Vector3f( n1 ) ) };
+}
+}
+
+void sharpenMarchingCubesMesh( const MeshPart& ref, Mesh& vox, Vector<VoxelId, FaceId>& face2voxel,
+    const SharpenMarchingCubesMeshSettings& settings )
 {
     MR_TIMER;
     assert( settings.minNewVertDev < settings.maxNewRank2VertDev );
     assert( settings.minNewVertDev < settings.maxNewRank3VertDev );
     VertNormals normals( vox.topology.vertSize() );
+    VolumeIndexer vi( settings.dims );
     // find normals and correct points
     ParallelFor( normals, [&] ( VertId v )
     {
         if ( !vox.topology.hasVert( v ) )
             return;
-        const auto proj = findProjection( vox.points[v], ref );
 
-        Vector3f n = ( vox.points[v] - proj.proj.point ).normalized();
-        Vector3f np = ref.mesh.pseudonormal( proj.mtp, ref.region );
+        MeshTriPoint rp;
+        Vector3f refPt;
+        // the vertex is located on the lattice edge, and its position there was found by linear interpolation
+        // of the values in the edge's ends; if the reference mesh crosses that edge, then the crossing
+        // is the exact point, which the interpolation approximates;
+        // this is valid for zero offset only, where the volume stores the distances to the reference mesh itself
+        if ( settings.offset == 0 )
+        {
+            const auto latticeSegm = findLatticeEdgeEnds( vox.topology, v, face2voxel, vi, settings.gridToMeshXf );
+            if ( latticeSegm.lengthSq() > 0 ) // otherwise no lattice edge was found for the vertex
+            {
+                const auto p = vox.points[v];
+                const auto d = latticeSegm.dir();
+                // the ray starts in the vertex and spans the edge in both directions,
+                // so the crossing closest to the vertex is found
+                const auto rayStart = dot( latticeSegm.a - p, d ) / d.lengthSq();
+                if ( const auto isect = rayMeshIntersect( ref, Line3f{ p, d }, rayStart, rayStart + 1 ) )
+                {
+                    rp = isect.mtp;
+                    refPt = ref.mesh.triPoint( rp );
+                }
+            }
+        }
+        if ( !rp.valid() )
+        {
+            const auto proj = findProjection( vox.points[v], ref );
+            rp = proj.mtp;
+            refPt = proj.proj.point;
+        }
+
+        Vector3f n = ( vox.points[v] - refPt ).normalized();
+        Vector3f np = ref.mesh.pseudonormal( rp, ref.region );
         if ( settings.offset == 0 || n.lengthSq() <= 0 )
             n = np;
         else if ( dot( n, np ) < 0 )
@@ -34,8 +124,12 @@ void sharpenMarchingCubesMesh( const MeshPart & ref, Mesh & vox, Vector<VoxelId,
 
         if ( settings.maxOldVertPosCorrection > 0 )
         {
-            const auto newPos = proj.proj.point + settings.offset * n;
-            if ( ( newPos - vox.points[v] ).lengthSq() <= sqr( settings.maxOldVertPosCorrection ) )
+            const auto newPos = refPt + settings.offset * n;
+            // at zero offset the reference point is the exact crossing of the vertex's lattice edge
+            // with the reference mesh, so a correction of any length is trustworthy there;
+            // for other offsets a large correction can be wrong and the limit is respected
+            if ( settings.offset == 0 ||
+                 ( newPos - vox.points[v] ).lengthSq() <= sqr( settings.maxOldVertPosCorrection ) )
                 vox.points[v] = newPos;
             else
                 n = Vector3f{}; //undefined
@@ -112,6 +206,28 @@ void sharpenMarchingCubesMesh( const MeshPart & ref, Mesh & vox, Vector<VoxelId,
         auto sharpPt = pacc.findBestCrossPoint( avgPt, tol, &rank, &dir );
         if ( rank <= 1 )
             continue; // the surface is planar within the voxel
+
+        if ( settings.voxelClamp )
+        {
+            // every marching cubes triangle is located within its own voxel, and the new vertex must not
+            // break that: shorten the displacement to sharpPt, keeping its direction, until the point
+            // is within the voxel's box, so the geometry of a voxel can never reach another one
+            const auto pos = vi.toPos( voxel );
+            Box3f voxBox;
+            voxBox.include( settings.gridToMeshXf( Vector3f( pos ) + Vector3f::diagonal( 1e-3f ) ) );
+            voxBox.include( settings.gridToMeshXf( Vector3f( pos ) + Vector3f::diagonal( 1.0f - 1e-3f ) ) );
+            const auto shift = sharpPt - avgPt;
+            float part = 1;
+            for ( int i = 0; i < 3; ++i )
+            {
+                if ( shift[i] > 0 )
+                    part = std::min( part, ( voxBox.max[i] - avgPt[i] ) / shift[i] );
+                else if ( shift[i] < 0 )
+                    part = std::min( part, ( voxBox.min[i] - avgPt[i] ) / shift[i] );
+            }
+            sharpPt = avgPt + std::max( 0.0f, part ) * shift;
+        }
+
         const auto distSq = ( avgPt - sharpPt ).lengthSq();
         if ( distSq < sqr( settings.minNewVertDev ) )
             continue; //too little deviation of new point to introduce a vertex in mesh
@@ -120,12 +236,16 @@ void sharpenMarchingCubesMesh( const MeshPart & ref, Mesh & vox, Vector<VoxelId,
         if ( rank == 3 && distSq > sqr( settings.maxNewRank3VertDev ) )
             continue; //new point is too from existing mesh triangles
 
-        // forbid in-plane shifts: the displacement to sharpPt must rise off the voxel's mean
-        // surface plane, not slide along it; an in-plane sharpPt is a phantom feature and a fold source
-        constexpr float minElevSin = 0.1f; // ~6 deg minimal angle between the displacement and the plane
-        const Vector3f d = sharpPt - avgPt;
-        if ( sqr( dot( d, sumDirArea ) ) < sqr( minElevSin ) * d.lengthSq() * sumDirArea.lengthSq() )
-            continue; //sharpPt shifts (nearly) within the surface plane
+        if ( !settings.voxelClamp )
+        {
+            // forbid in-plane shifts: the displacement to sharpPt must rise off the voxel's mean
+            // surface plane, not slide along it; an in-plane sharpPt is a phantom feature and a fold source
+            constexpr float minElevSin = 0.1f; // ~6 deg minimal angle between the displacement and the plane
+            const Vector3f d = sharpPt - avgPt;
+            if ( sqr( dot( d, sumDirArea ) ) < sqr( minElevSin ) * d.lengthSq() * sumDirArea.lengthSq() )
+                continue; //sharpPt shifts (nearly) within the surface plane
+        }
+
         auto v = vox.splitFace( f, sharpPt );
         assert( v == dirs.size() + firstNewVert );
         dirs.push_back( dir );

--- a/source/MRMesh/MRSharpenMarchingCubesMesh.h
+++ b/source/MRMesh/MRSharpenMarchingCubesMesh.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MRMeshFwd.h"
+#include "MRAffineXf3.h"
 
 namespace MR
 {
@@ -25,6 +26,15 @@ struct SharpenMarchingCubesMeshSettings
     /// the number of iterations to best select positions for new vertices,
     /// the probability of self-intersections and spikes are higher if posSelIters = 0
     int posSelIters = 3;
+    /// if true, the displacement of a new vertex from the average point is shortened to keep the vertex
+    /// within its voxel's box (so the geometry of a voxel can never reach another one),
+    /// and the in-plane elevation check is skipped; requires dims and gridToMeshXf to be set
+    bool voxelClamp = false;
+    /// Marching Cubes volume dimensions
+    Vector3i dims;
+    /// transform from integer Marching Cubes grid locations to the mesh reference frame:
+    /// the node with integer coordinates (i,j,k) is located in gridToMeshXf( Vector3f( i, j, k ) )
+    AffineXf3f gridToMeshXf;
     /// if non-null then created sharp edges will be saved here
     UndirectedEdgeBitSet * outSharpEdges = nullptr;
 };
@@ -33,7 +43,7 @@ struct SharpenMarchingCubesMeshSettings
 /// 1) correcting positions of all vertices to given offset relative to \param ref mesh (if correctOldVertPos == true);
 /// 2) introducing new vertices in the voxels where the normals change abruptly.
 /// \param face2voxel mapping from Face Id to Voxel Id where it is located
-MRMESH_API void sharpenMarchingCubesMesh( const MeshPart & ref, Mesh & vox, Vector<VoxelId, FaceId> & face2voxel,
-    const SharpenMarchingCubesMeshSettings & settings );
+MRMESH_API void sharpenMarchingCubesMesh( const MeshPart& ref, Mesh& vox, Vector<VoxelId, FaceId>& face2voxel,
+    const SharpenMarchingCubesMeshSettings& settings );
 
 } //namespace MR

--- a/source/MRVoxels/MRMarchingCubes.cpp
+++ b/source/MRVoxels/MRMarchingCubes.cpp
@@ -443,6 +443,20 @@ Expected<void> VolumeMesher::addPart( const V& part )
     const int layerCount = indexer_.dims().z;
 
     constexpr bool binary = std::is_same_v<V, SimpleBinaryVolume>;
+
+    if ( params_.outGridToMeshXf && partFirstZ == 0 ) // the first part starts in the grid's zero point
+    {
+        // the same shift as in addPartBlock_/addBinaryPartBlock_ below
+        const auto shift = [&]
+        {
+            if constexpr ( binary )
+                return Vector3f::diagonal( 0.5f );
+            else
+                return VoxelsVolumeAccessor<V>( part ).shift();
+        }();
+        *params_.outGridToMeshXf = { Matrix3f::scale( part.voxelSize ), params_.origin + mult( shift, part.voxelSize ) };
+    }
+
     if constexpr ( binary )
     {
         int fillFirstZ = partFirstZ;

--- a/source/MRVoxels/MRMarchingCubes.h
+++ b/source/MRVoxels/MRMarchingCubes.h
@@ -32,6 +32,11 @@ struct MarchingCubesParams
     /// optional output map FaceId->VoxelId
     Vector<VoxelId, FaceId>* outVoxelPerFaceMap{ nullptr };
 
+    /// optional output transform from integer grid locations to mesh reference frame:
+    /// the node with integer coordinates (i,j,k) is located in (*outGridToMeshXf)( Vector3f( i, j, k ) );
+    /// every vertex of output mesh is located on a grid edge
+    AffineXf3f* outGridToMeshXf{ nullptr };
+
     /// function to calculate position of result mesh points
     /// if the function isn't set, a linear positioner will be used
     /// note: this function is called in parallel from different threads

--- a/source/MRVoxels/MROffset.cpp
+++ b/source/MRVoxels/MROffset.cpp
@@ -115,7 +115,7 @@ Expected<Mesh> doubleOffsetMesh( const MeshPart& mp, float offsetA, float offset
 }
 
 Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
-    const OffsetParameters& params, Vector<VoxelId, FaceId> * outMap )
+    const OffsetParameters& params, const McOffsetMeshOutputs& outputs )
 {
     MR_TIMER;
 
@@ -140,12 +140,15 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
 
         VdbVolume volume = floatGridToVdbVolume( std::move( voxelRes ) );
         volume.voxelSize = Vector3f::diagonal( params.voxelSize );
+        if ( outputs.dims )
+            *outputs.dims = volume.dims;
 
         MarchingCubesParams vmParams;
         vmParams.iso = offsetInVoxels;
         vmParams.lessInside = true;
         vmParams.cb = subprogress( params.callBack, 0.4f, 1.0f );
-        vmParams.outVoxelPerFaceMap = outMap;
+        vmParams.outVoxelPerFaceMap = outputs.voxelPerFaceMap;
+        vmParams.outGridToMeshXf = outputs.gridToMeshXf;
         vmParams.freeVolume = [&volume]
         {
             Timer t( "~FloatGrid" );
@@ -160,6 +163,8 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
     const auto absOffset = std::abs( offset );
     const auto box = mp.mesh.computeBoundingBox( mp.region ).expanded( Vector3f::diagonal( absOffset ) );
     const auto [origin, dimensions] = calcOriginAndDimensions( box, params.voxelSize );
+    if ( outputs.dims )
+        *outputs.dims = dimensions;
 
     DistanceVolumeParams vol {
         .origin = origin,
@@ -182,7 +187,8 @@ Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
         .cb = subprogress( params.callBack, 0.4f, 1.0f ),
         .iso = offset,
         .lessInside = true,
-        .outVoxelPerFaceMap = outMap,
+        .outVoxelPerFaceMap = outputs.voxelPerFaceMap,
+        .outGridToMeshXf = outputs.gridToMeshXf,
     };
 
     if ( auto fwnByParts = std::dynamic_pointer_cast<IFastWindingNumberByParts>( params.fwn ); fwnByParts && isHoleWindingRule )
@@ -277,16 +283,20 @@ Expected<Mesh> sharpOffsetMesh( const MeshPart& mp, float offset, const SharpOff
     OffsetParameters mcParams = params;
     mcParams.callBack = subprogress( params.callBack, 0.0f, 0.7f );
     Vector<VoxelId, FaceId> map;
-    auto res = mcOffsetMesh( mp, offset, mcParams, &map );
+    SharpenMarchingCubesMeshSettings sharpenParams;
+    auto res = mcOffsetMesh( mp, offset, mcParams, {
+        .voxelPerFaceMap = &map,
+        .dims = &sharpenParams.dims,
+        .gridToMeshXf = &sharpenParams.gridToMeshXf } );
     if ( !res.has_value() )
         return res;
 
-    SharpenMarchingCubesMeshSettings sharpenParams;
     sharpenParams.minNewVertDev = params.voxelSize * params.minNewVertDev;
     sharpenParams.maxNewRank2VertDev = params.voxelSize * params.maxNewRank2VertDev;
     sharpenParams.maxNewRank3VertDev = params.voxelSize * params.maxNewRank3VertDev;
     sharpenParams.maxOldVertPosCorrection = params.voxelSize * params.maxOldVertPosCorrection;
     sharpenParams.offset = offset;
+    sharpenParams.voxelClamp = params.voxelClamp;
     sharpenParams.outSharpEdges = params.outSharpEdges;
 
     sharpenMarchingCubesMesh( mp, res.value(), map, sharpenParams );

--- a/source/MRVoxels/MROffset.h
+++ b/source/MRVoxels/MROffset.h
@@ -72,6 +72,8 @@ struct SharpOffsetParameters : OffsetParameters
     /// correct positions of the input vertices using reference mesh by not more than this distance, measured in voxelSize;
     /// big correction can be wrong and result from self-intersections in the reference mesh
     float maxOldVertPosCorrection = 0.5f;
+    /// see SharpenMarchingCubesMeshSettings::voxelClamp
+    bool voxelClamp = false;
 };
 
 /// Offsets mesh by converting it to distance field in voxels using OpenVDB library,
@@ -85,10 +87,25 @@ struct SharpOffsetParameters : OffsetParameters
 /// typically offsetA and offsetB have distinct signs
 [[nodiscard]] MRVOXELS_API Expected<Mesh> doubleOffsetMesh( const MeshPart& mp, float offsetA, float offsetB, const OffsetParameters& params = {} );
 
+/// optional outputs of mcOffsetMesh(...) describing the volume, from which the mesh was extracted
+struct McOffsetMeshOutputs
+{
+    /// optional output map FaceId->VoxelId
+    Vector<VoxelId, FaceId>* voxelPerFaceMap = nullptr;
+
+    /// optional output dimensions of the volume
+    Vector3i* dims = nullptr;
+
+    /// optional output transform from integer grid locations to mesh reference frame:
+    /// the node with integer coordinates (i,j,k) is located in (*gridToMeshXf)( Vector3f( i, j, k ) );
+    /// every vertex of output mesh is located on a grid edge
+    AffineXf3f* gridToMeshXf = nullptr;
+};
+
 /// Offsets mesh by converting it to distance field in voxels (using OpenVDB library if SignDetectionMode::OpenVDB or our implementation otherwise)
 /// and back using standard Marching Cubes, as opposed to Dual Marching Cubes in offsetMesh(...)
 [[nodiscard]] MRVOXELS_API Expected<Mesh> mcOffsetMesh( const MeshPart& mp, float offset,
-    const OffsetParameters& params = {}, Vector<VoxelId, FaceId>* outMap = nullptr );
+    const OffsetParameters& params = {}, const McOffsetMeshOutputs& outputs = {} );
 
 /// Constructs a shell around selected mesh region with the properties that every point on the shall must
 ///  1. be located not further than given distance from selected mesh part,

--- a/source/MRVoxels/MROffset.h
+++ b/source/MRVoxels/MROffset.h
@@ -72,7 +72,9 @@ struct SharpOffsetParameters : OffsetParameters
     /// correct positions of the input vertices using reference mesh by not more than this distance, measured in voxelSize;
     /// big correction can be wrong and result from self-intersections in the reference mesh
     float maxOldVertPosCorrection = 0.5f;
-    /// see SharpenMarchingCubesMeshSettings::voxelClamp
+    /// if true, the displacement of a new vertex from the average point is shortened to keep the vertex
+    /// within its voxel's box (so the geometry of a voxel can never reach another one),
+    /// and the in-plane elevation check is skipped
     bool voxelClamp = false;
 };
 


### PR DESCRIPTION
Two construction-level improvements to `sharpenMarchingCubesMesh`, plus the plumbing they need.

## Changes

1. **Exact zero-offset correction.** Every marching-cubes vertex lies on a lattice edge, positioned by linear interpolation of the edge-end values. At zero offset the volume stores distances to the reference mesh itself, so the exact surface point on that edge can be found by a ray cast along it; the correction now snaps the vertex to this crossing (falling back to closest-point projection when the edge is not recoverable), and the correction-length limit is not applied there since the point is exact by construction.
2. **`voxelClamp` (opt-in, default off).** `SharpenMarchingCubesMeshSettings::voxelClamp`, exposed as `SharpOffsetParameters::voxelClamp`: the displacement from the average point to the new sharp vertex is shortened so the vertex stays strictly inside its voxel's box (inset by 1e-3 of the voxel on each side, so vertices never land exactly on shared box faces). This bounds how far `findBestCrossPoint` solutions can travel, so one voxel's geometry can never reach another voxel; it replaces the in-plane elevation check when enabled.
3. `mcOffsetMesh` outputs are extended with the volume dimensions and grid-to-mesh transform (`McOffsetMeshOutputs`), which the sharpener needs to reconstruct lattice edges and voxel boxes.

## Measurements

Fandisk grid: 3 rotations x 5 offsets (+-R, +-R/2, 0; R = 4.5% of bbox diagonal) x 4 voxel sizes (R .. R/10), 60 configurations; strictly self-intersecting triangle pairs summed per offset; ProjectionNormal sign detection (the mode the viewer uses for Sharpening). featErr = mean deviation of recovered crease length from the expected value.

| | total | +1.0R | +0.5R | 0 | -0.5R | -1.0R | clean configs | featErr |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| master | 5540 | 90 | 135 | 360 | 3724 | 1231 | 10/60 | 0.786 |
| voxelClamp off | 5409 | 90 | 135 | 229 | 3724 | 1231 | 12/60 | 0.780 |
| voxelClamp on | 1303 | 20 | 20 | 51 | 633 | 579 | 26/60 | 0.892 |

With the clamp off the change is a strict improvement (nonzero offsets bit-identical to master, zero offset -36%). With the clamp on, self-intersections drop 76% overall and the identity-rotation zero-offset configurations become fully clean, at the cost of some crease over-generation (featErr 0.780 -> 0.892). Under OpenVDB sign detection the totals are 6149 (master) -> 1822 (clamp on).

Generated with [Claude Code](https://claude.com/claude-code)