### PR TITLE
Replace VertCoords in duplicateNonManifoldVertices with an optional 5-vertex continuation predicate

### DIFF
--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -94,6 +94,11 @@ void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, const Alpha
 
 std::optional<Triangulation> findAlphaShapeAllTriangles( const PointCloud & cloud, float radius, const ProgressCallback& cb )
 {
+    return findAlphaShapeAllTriangles( cloud, getAlphaShapeData( cloud, radius, true ), cb );
+}
+
+std::optional<Triangulation> findAlphaShapeAllTriangles( const PointCloud & cloud, const AlphaShapeData & data, const ProgressCallback& cb )
+{
     MR_TIMER;
     struct ThreadData
     {
@@ -104,8 +109,6 @@ std::optional<Triangulation> findAlphaShapeAllTriangles( const PointCloud & clou
     tbb::enumerable_thread_specific<ThreadData> threadData;
     cloud.getAABBTree(); // to avoid multiple calls to tree construction from parallel region,
                          // which can result that two different vertices will start being processed by one thread
-
-    const auto data = getAlphaShapeData( cloud, radius, true );
 
     if ( !BitSetParallelFor( cloud.validPoints, [&]( VertId v )
     {
@@ -148,11 +151,11 @@ Triangulation findAlphaShapeAllTriangles( const PointCloud & cloud, float radius
 std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius, const ProgressCallback& cb )
 {
     MR_TIMER;
-    auto maybeTris = findAlphaShapeAllTriangles( cloud, radius, subprogress( cb, 0.0f, 0.8f ) );
+    const auto sd = getAlphaShapeData( cloud, radius, true );
+    auto maybeTris = findAlphaShapeAllTriangles( cloud, sd, subprogress( cb, 0.0f, 0.8f ) );
     if ( !maybeTris )
         return std::nullopt;
 
-    const auto sd = getAlphaShapeData( cloud, radius, true );
     // the best triangle-continuation during vertex duplication is the first one rotating counter-clockwise
     // from the reference triangle around the shared edge directed from the neighbor vertex (e1) to the center (e0)
     auto betterCont = [&sd, &cloud]( VertId e0, VertId e1, VertId vRef, VertId vCand, VertId vBest )

--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -156,14 +156,14 @@ std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius, cons
     if ( !maybeTris )
         return std::nullopt;
 
-    // the best triangle-continuation during vertex duplication is the first one rotating counter-clockwise
-    // from the reference triangle around the shared edge directed from the neighbor vertex (e1) to the center (e0)
+    // the best triangle-continuation during vertex duplication is the first one rotating
+    // counter-clockwise from the reference triangle around the directed shared edge (e0, e1)
     auto betterCont = [&sd, &cloud]( VertId e0, VertId e1, VertId vRef, VertId vCand, VertId vBest )
     {
         if ( vCand == vBest )
             return false; // two remaining vertices can be equal as originals if two triangles over the shared edge
                           // had equal third vertices before duplication; ccwAroundLine requires all distinct points
-        return ccwAroundLine( { sd.coords( cloud, e1 ), sd.coords( cloud, e0 ),
+        return ccwAroundLine( { sd.coords( cloud, e0 ), sd.coords( cloud, e1 ),
             sd.coords( cloud, vRef ), sd.coords( cloud, vCand ), sd.coords( cloud, vBest ) } );
     };
 

--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -160,8 +160,9 @@ std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius, cons
     // from the reference triangle around the shared edge directed from the neighbor vertex (e1) to the center (e0)
     auto betterCont = [&sd, &cloud]( VertId e0, VertId e1, VertId vRef, VertId vCand, VertId vBest )
     {
-        if ( vRef == vCand || vRef == vBest || vCand == vBest )
-            return false; // ccwAroundLine requires all distinct points, keep the current best otherwise
+        if ( vCand == vBest )
+            return false; // two remaining vertices can be equal as originals if two triangles over the shared edge
+                          // had equal third vertices before duplication; ccwAroundLine requires all distinct points
         return ccwAroundLine( { sd.coords( cloud, e1 ), sd.coords( cloud, e0 ),
             sd.coords( cloud, vRef ), sd.coords( cloud, vCand ), sd.coords( cloud, vBest ) } );
     };

--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -152,8 +152,20 @@ std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius, cons
     if ( !maybeTris )
         return std::nullopt;
 
+    const auto sd = getAlphaShapeData( cloud, radius, true );
+    // the best triangle-continuation during vertex duplication is the first one rotating counter-clockwise
+    // from the reference triangle around the shared edge directed from the neighbor vertex (e1) to the center (e0)
+    auto betterCont = [&sd, &cloud]( VertId e0, VertId e1, VertId vRef, VertId vCand, VertId vBest )
+    {
+        if ( vRef == vCand || vRef == vBest || vCand == vBest )
+            return false; // ccwAroundLine requires all distinct points, keep the current best otherwise
+        return ccwAroundLine( { sd.coords( cloud, e1 ), sd.coords( cloud, e0 ),
+            sd.coords( cloud, vRef ), sd.coords( cloud, vCand ), sd.coords( cloud, vBest ) } );
+    };
+
     int skippedFaceCount = 0;
-    auto res = Mesh::fromTrianglesDuplicatingNonManifoldVertices( cloud.points, *maybeTris, nullptr, { .skippedFaceCount = &skippedFaceCount } );
+    auto res = Mesh::fromTrianglesDuplicatingNonManifoldVertices( cloud.points, *maybeTris, nullptr,
+        { .skippedFaceCount = &skippedFaceCount }, betterCont );
     assert( skippedFaceCount == 0 );
     return res;
 }

--- a/source/MRMesh/MRAlphaShape.h
+++ b/source/MRMesh/MRAlphaShape.h
@@ -52,12 +52,12 @@ MRMESH_API void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v,
 
 /// finds all triangles of alpha-shape with negative alpha = -1/radius
 [[nodiscard]] MRMESH_API std::optional<Triangulation> findAlphaShapeAllTriangles( const PointCloud & cloud, float radius, const ProgressCallback & cb );
+[[nodiscard]] MRMESH_API Triangulation findAlphaShapeAllTriangles( const PointCloud & cloud, float radius );
 
 /// finds all triangles of alpha-shape given the data prepared by getAlphaShapeData for the same cloud
 /// (preferably with allPoints=true, since the triangles around all points will be searched)
 [[nodiscard]] MRMESH_API std::optional<Triangulation> findAlphaShapeAllTriangles( const PointCloud & cloud,
     const AlphaShapeData & data, const ProgressCallback & cb );
-[[nodiscard]] MRMESH_API Triangulation findAlphaShapeAllTriangles( const PointCloud & cloud, float radius );
 
 /// builds alpha-shape mesh with negative alpha = -1/radius
 [[nodiscard]] MRMESH_API std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius, const ProgressCallback & cb );

--- a/source/MRMesh/MRAlphaShape.h
+++ b/source/MRMesh/MRAlphaShape.h
@@ -52,6 +52,11 @@ MRMESH_API void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v,
 
 /// finds all triangles of alpha-shape with negative alpha = -1/radius
 [[nodiscard]] MRMESH_API std::optional<Triangulation> findAlphaShapeAllTriangles( const PointCloud & cloud, float radius, const ProgressCallback & cb );
+
+/// finds all triangles of alpha-shape given the data prepared by getAlphaShapeData for the same cloud
+/// (preferably with allPoints=true, since the triangles around all points will be searched)
+[[nodiscard]] MRMESH_API std::optional<Triangulation> findAlphaShapeAllTriangles( const PointCloud & cloud,
+    const AlphaShapeData & data, const ProgressCallback & cb );
 [[nodiscard]] MRMESH_API Triangulation findAlphaShapeAllTriangles( const PointCloud & cloud, float radius );
 
 /// builds alpha-shape mesh with negative alpha = -1/radius

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -81,7 +81,7 @@ Mesh Mesh::fromTrianglesDuplicatingNonManifoldVertices(
     Mesh res;
     res.points = std::move( vertexCoordinates );
     std::vector<MeshBuilder::VertDuplication> localDups;
-    res.topology = MeshBuilder::fromTrianglesDuplicatingNonManifoldVertices( t, &localDups, settings, &res.points );
+    res.topology = MeshBuilder::fromTrianglesDuplicatingNonManifoldVertices( t, &localDups, settings );
     if ( res.points.size() < res.topology.vertSize() ) // never shrink
         res.points.resize( res.topology.vertSize() );
     for ( const auto & d : localDups )

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -75,13 +75,14 @@ Mesh Mesh::fromTrianglesDuplicatingNonManifoldVertices(
     VertCoords vertexCoordinates,
     Triangulation & t,
     std::vector<MeshBuilder::VertDuplication> * dups,
-    const MeshBuilder::BuildSettings & settings )
+    const MeshBuilder::BuildSettings & settings,
+    const MeshBuilder::BetterDupContinuation & betterCont )
 {
     MR_TIMER;
     Mesh res;
     res.points = std::move( vertexCoordinates );
     std::vector<MeshBuilder::VertDuplication> localDups;
-    res.topology = MeshBuilder::fromTrianglesDuplicatingNonManifoldVertices( t, &localDups, settings );
+    res.topology = MeshBuilder::fromTrianglesDuplicatingNonManifoldVertices( t, &localDups, settings, betterCont );
     if ( res.points.size() < res.topology.vertSize() ) // never shrink
         res.points.resize( res.topology.vertSize() );
     for ( const auto & d : localDups )

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -3,6 +3,7 @@
 #include "MRPch/MRBindingMacros.h"
 #include "MRMeshMath.h"
 #include "MRMeshBuilderTypes.h"
+#include "MRVertDuplication.h"
 #include "MRMeshProject.h"
 #include "MREdgePoint.h"
 #include "MRSharedThreadSafeOwner.h"
@@ -35,12 +36,14 @@ struct [[nodiscard]] Mesh
         const MeshBuilder::BuildSettings& settings = {}, ProgressCallback cb = {} );
 
     /// construct mesh from vertex coordinates and a set of triangles with given ids;
-    /// unlike simple fromTriangles() it tries to resolve non-manifold vertices by creating duplicate vertices
+    /// unlike simple fromTriangles() it tries to resolve non-manifold vertices by creating duplicate vertices;
+    /// `betterCont` (if given) selects the best triangle among several possible continuations during the duplication
     [[nodiscard]] MRMESH_API static Mesh fromTrianglesDuplicatingNonManifoldVertices(
         VertCoords vertexCoordinates,
         Triangulation & t,
         std::vector<MeshBuilder::VertDuplication> * dups = nullptr,
-        const MeshBuilder::BuildSettings & settings = {} );
+        const MeshBuilder::BuildSettings & settings = {},
+        const MeshBuilder::BetterDupContinuation & betterCont = {} );
 
     /// construct mesh from vertex coordinates and construct mesh topology from face soup,
     /// where each face can have arbitrary degree (not only triangles);

--- a/source/MRMesh/MRMeshBuilder.cpp
+++ b/source/MRMesh/MRMeshBuilder.cpp
@@ -541,7 +541,7 @@ MeshTopology fromTriangles( const Triangulation & t, const BuildSettings & setti
 }
 
 MeshTopology fromTrianglesDuplicatingNonManifoldVertices( Triangulation & t,
-    std::vector<VertDuplication> * dups, const BuildSettings & settings, const VertCoords * points )
+    std::vector<VertDuplication> * dups, const BuildSettings & settings )
 {
     MR_TIMER;
     FaceBitSet localRegion = getLocalRegion( settings.region, t.size() );
@@ -560,7 +560,7 @@ MeshTopology fromTrianglesDuplicatingNonManifoldVertices( Triangulation & t,
     }
     // full path
     std::vector<VertDuplication> localDups;
-    MeshBuilder::duplicateNonManifoldVertices( t, settings.region, &localDups, {}, points );
+    MeshBuilder::duplicateNonManifoldVertices( t, settings.region, &localDups );
     const bool noDuplicates = localDups.empty();
     if ( dups )
         *dups = std::move( localDups );

--- a/source/MRMesh/MRMeshBuilder.cpp
+++ b/source/MRMesh/MRMeshBuilder.cpp
@@ -541,7 +541,7 @@ MeshTopology fromTriangles( const Triangulation & t, const BuildSettings & setti
 }
 
 MeshTopology fromTrianglesDuplicatingNonManifoldVertices( Triangulation & t,
-    std::vector<VertDuplication> * dups, const BuildSettings & settings )
+    std::vector<VertDuplication> * dups, const BuildSettings & settings, const BetterDupContinuation & betterCont )
 {
     MR_TIMER;
     FaceBitSet localRegion = getLocalRegion( settings.region, t.size() );
@@ -560,7 +560,7 @@ MeshTopology fromTrianglesDuplicatingNonManifoldVertices( Triangulation & t,
     }
     // full path
     std::vector<VertDuplication> localDups;
-    MeshBuilder::duplicateNonManifoldVertices( t, settings.region, &localDups );
+    MeshBuilder::duplicateNonManifoldVertices( t, settings.region, &localDups, {}, betterCont );
     const bool noDuplicates = localDups.empty();
     if ( dups )
         *dups = std::move( localDups );

--- a/source/MRMesh/MRMeshBuilder.h
+++ b/source/MRMesh/MRMeshBuilder.h
@@ -39,11 +39,13 @@ MRMESH_API MeshTopology fromTriangles( const Triangulation & t, const BuildSetti
 
 /// construct mesh topology from a set of triangles with given ids;
 /// unlike simple fromTriangles() it tries to resolve non-manifold vertices by creating duplicate vertices;
-/// triangulation is modified to introduce duplicates
+/// triangulation is modified to introduce duplicates;
+/// `betterCont` (if given) selects the best triangle among several possible continuations during the duplication
 MRMESH_API MeshTopology fromTrianglesDuplicatingNonManifoldVertices( 
     Triangulation & t,
     std::vector<VertDuplication> * dups = nullptr,
-    const BuildSettings & settings = {} );
+    const BuildSettings & settings = {},
+    const BetterDupContinuation & betterCont = {} );
 
 /// construct mesh from point triples;
 /// all coinciding points are given the same VertId in the result

--- a/source/MRMesh/MRMeshBuilder.h
+++ b/source/MRMesh/MRMeshBuilder.h
@@ -39,13 +39,11 @@ MRMESH_API MeshTopology fromTriangles( const Triangulation & t, const BuildSetti
 
 /// construct mesh topology from a set of triangles with given ids;
 /// unlike simple fromTriangles() it tries to resolve non-manifold vertices by creating duplicate vertices;
-/// triangulation is modified to introduce duplicates;
-/// `points` (if given) provides the coordinates of the vertices for smoother vertex duplication
+/// triangulation is modified to introduce duplicates
 MRMESH_API MeshTopology fromTrianglesDuplicatingNonManifoldVertices( 
     Triangulation & t,
     std::vector<VertDuplication> * dups = nullptr,
-    const BuildSettings & settings = {},
-    const VertCoords * points = nullptr );
+    const BuildSettings & settings = {} );
 
 /// construct mesh from point triples;
 /// all coinciding points are given the same VertId in the result

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -3,11 +3,9 @@
 #include "MRParallelFor.h"
 #include "MRTimer.h"
 #include "MRVector.h"
-#include "MRVector3.h"
 #include "MRphmap.h"
 #include "MRPch/MRTBB.h"
 #include <algorithm>
-#include <optional>
 
 namespace MR
 {
@@ -46,7 +44,7 @@ class PathAroundVertex
 {
     Triangulation& faceToVertices_;
     const std::vector<VertTri>& vertTris_;
-    const VertCoords* points_ = nullptr; // optional vertex coordinates for smooth path continuation selection
+    const BetterDupContinuation& betterCont_; // optional selector of the best triangle among several path continuations
     // all elements in [vertexBegIndex_, vertexEndIndex_) of *vertTris_ have the same central vertex
     size_t vertexBegIndex_ = 0, vertexEndIndex_ = 0;
     size_t firstUnvisitedIndex_ = 0; // lazily advanced index of the first not yet visited element of the central vertex
@@ -67,12 +65,11 @@ class PathAroundVertex
     // a bit marks the element at once for the span cursor and for both sorted vectors above
     BitSet visitedRecs_;
     FaceId firstTri_; // the triangle visited first in the current path
-    FaceId refTri_;   // the last visited triangle, its normal is the reference for smooth path continuation
-    std::optional<Vector3f> refNormal_; // cached normal of refTri_ to avoid recomputing it for the same triangle
+    FaceId refTri_;   // the last visited triangle, the reference for the continuation selection
 
 public:
-    PathAroundVertex( Triangulation& triangleToVertices, const std::vector<VertTri>& tris, const VertCoords* pts )
-        : faceToVertices_( triangleToVertices ), vertTris_( tris ), points_( pts ) {}
+    PathAroundVertex( Triangulation& triangleToVertices, const std::vector<VertTri>& tris, const BetterDupContinuation & betterCont )
+        : faceToVertices_( triangleToVertices ), vertTris_( tris ), betterCont_( betterCont ) {}
 
     // prepares the search around the central vertex of elements [beg, end), reusing the memory allocated for a previous vertex
     void init( size_t beg, size_t end )
@@ -116,32 +113,17 @@ public:
         visitedRecs_.set( firstUnvisitedIndex_ - vertexBegIndex_ );
         const auto f = vertTris_[firstUnvisitedIndex_++].f;
         firstTri_ = refTri_ = f;
-        refNormal_.reset();
         return getOtherTriVerts( faceToVertices_[f], center_ );
     }
 
-    // the search from firstVertex continues over the edge of the first visited triangle, so its normal becomes the reference
+    // the search from firstVertex continues over the edge of the first visited triangle, so it becomes the reference
     void restartFromFirstTriangle()
     {
-        if ( refTri_ != firstTri_ )
-        {
-            refTri_ = firstTri_;
-            refNormal_.reset();
-        }
-    }
-
-    // computes unit normal of the triangle #f using provided coordinates, mapping duplicated vertices on their originals
-    Vector3f triNormal( FaceId f, const std::vector<VertDuplication>& dups ) const
-    {
-        Vector3f p[3];
-        for ( int i = 0; i < 3; ++i )
-            p[i] = (*points_)[ getOrgVertex( faceToVertices_[f][i], dups ) ];
-        return cross( p[1] - p[0], p[2] - p[0] ).normalized();
+        refTri_ = firstTri_;
     }
 
     // find incident vertex in a not yet visited triangle except for prevVertex and its duplicates;
-    // if the coordinates of the vertices are known and there are several continuation options,
-    // then the triangle with the maximal dot-product between its normal and the normal of the preceding triangle is selected
+    // if the predicate is given and there are several continuation options, the best triangle by the predicate is selected
     VertId getNextVertex( VertId v, bool triOrientation, VertId prevVertex, const std::vector<VertDuplication>& dups )
     {
         assert( prevVertex );
@@ -150,9 +132,8 @@ public:
 
         const auto & vec = triOrientation ? vnextRecs_ : vprevRecs_;
         const VertRec * best = nullptr;
-        VertId bestNext;
-        std::optional<Vector3f> bestNormal; // engaged only when several continuation options were compared
-        float bestDot = 0;
+        VertId bestNext, bestNextOrg;
+        VertId vOrg, refThird; // prepared only when several continuation options were found
         for ( auto it = std::lower_bound( vec.begin(), vec.end(), VertRec{ v, 0 } ); ; ++it )
         {
             if ( it == vec.end() || it->v != v )
@@ -163,11 +144,12 @@ public:
             const auto v12 = getOtherTriVerts( faceToVertices_[f], center_ );
             assert( ( triOrientation ? v12.first : v12.second ) == v );
             const auto nextVertex = triOrientation ? v12.second : v12.first;
-            if ( getOrgVertex( nextVertex, dups ) == prevVertex )
+            const auto nextOrg = getOrgVertex( nextVertex, dups );
+            if ( nextOrg == prevVertex )
                 continue;
-            if ( !points_ )
+            if ( !betterCont_ )
             {
-                // without coordinates, the first found continuation is taken
+                // without the predicate, the first found continuation is taken
                 visitedRecs_.set( it->rec );
                 return nextVertex;
             }
@@ -175,30 +157,35 @@ public:
             {
                 best = &*it;
                 bestNext = nextVertex;
+                bestNextOrg = nextOrg;
                 continue;
             }
-            if ( !bestNormal )
+            if ( !vOrg )
             {
-                // the second continuation option is found, time to compute the normals
-                if ( !refNormal_ )
-                    refNormal_ = triNormal( refTri_, dups );
-                bestNormal = triNormal( vertTris_[vertexBegIndex_ + best->rec].f, dups );
-                bestDot = dot( *refNormal_, *bestNormal );
+                // the second continuation option is found, time to prepare the predicate arguments
+                vOrg = getOrgVertex( v, dups );
+                for ( VertId tv : faceToVertices_[refTri_] )
+                {
+                    const auto tvOrg = getOrgVertex( tv, dups );
+                    if ( tvOrg != center_ && tvOrg != vOrg )
+                    {
+                        refThird = tvOrg;
+                        break;
+                    }
+                }
+                assert( refThird );
             }
-            const auto n = triNormal( f, dups );
-            if ( const auto d = dot( *refNormal_, n ); d > bestDot )
+            if ( refThird && betterCont_( center_, vOrg, refThird, nextOrg, bestNextOrg ) )
             {
                 best = &*it;
                 bestNext = nextVertex;
-                bestNormal = n;
-                bestDot = d;
+                bestNextOrg = nextOrg;
             }
         }
         if ( !best )
             return {};
         visitedRecs_.set( best->rec );
         refTri_ = vertTris_[vertexBegIndex_ + best->rec].f;
-        refNormal_ = bestNormal; // the normal of the winner (if it was computed) becomes the reference
         return bestNext;
     }
 
@@ -459,7 +446,7 @@ void extractClosedPath( std::vector<VertId>& path, std::vector<VertId>& closedPa
 }
 
 // for all vertices get over all incident vertices to find connected sequences
-size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std::vector<VertDuplication>* dups, VertId lastValidVert, const VertCoords * points )
+size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std::vector<VertDuplication>* dups, VertId lastValidVert, const BetterDupContinuation & betterCont )
 {
     MR_TIMER;
     if ( dups )
@@ -522,7 +509,7 @@ size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region, std
     };
     tbb::parallel_sort( vertsToProcess.begin(), vertsToProcess.end(), sortPred );
 
-    PathAroundVertex pathMaker( t, all.recs, points );
+    PathAroundVertex pathMaker( t, all.recs, betterCont );
     std::vector<VertId> path;
     std::vector<VertId> closedPath;
     VertBitSet visitedVertices( all.recs.back().v ); // explicitly not `lastValidVert` but last vert used in triangulation

--- a/source/MRMesh/MRVertDuplication.cpp
+++ b/source/MRMesh/MRVertDuplication.cpp
@@ -175,7 +175,10 @@ public:
                 }
                 assert( refThird );
             }
-            if ( refThird && betterCont_( center_, vOrg, refThird, nextOrg, bestNextOrg ) )
+            // the shared edge (e0, e1) is oriented so that the reference triangle is (e0, e1, refThird)
+            // and the continuation candidates are (e1, e0, cand-remaining-vertex) up to rotation
+            if ( refThird && betterCont_( triOrientation ? vOrg : center_, triOrientation ? center_ : vOrg,
+                refThird, nextOrg, bestNextOrg ) )
             {
                 best = &*it;
                 bestNext = nextVertex;

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -3,6 +3,7 @@
 #include "MRId.h"
 #include "MRPch/MRBindingMacros.h"
 #include <cassert>
+#include <functional>
 #include <cstdint>
 #include <utility>
 #include <vector>
@@ -19,14 +20,22 @@ struct VertDuplication
     VertId dupVert; ///< new vertex after duplication
 };
 
+/// decides which of the two continuation triangles is better during a walk around a non-manifold vertex;
+/// all 5 arguments are original vertices (before duplication):
+/// e0, e1 - the vertices of the shared edge between the reference triangle and both continuation candidates (e0 is the central vertex),
+/// vRef - the remaining vertex of the reference triangle,
+/// vCand - the remaining vertex of the candidate triangle,
+/// vBest - the remaining vertex of the currently best continuation triangle;
+/// returns true if the candidate triangle shall replace the currently best continuation triangle
+using BetterDupContinuation = std::function<bool( VertId e0, VertId e1, VertId vRef, VertId vCand, VertId vBest )>;
+
 /// resolve non-manifold vertices by creating duplicate vertices in the triangulation (which is modified)
 /// `lastValidVert` is needed if `region` or `t` does not contain full mesh, then first duplicated vertex will have `lastValidVert+1` index
 /// `dups` (if given) contents will be ignored and overridden; it receives the duplications in creation order with consecutive dupVert ids starting from `lastValidVert+1`
-/// `points` (if given) provides the coordinates of the vertices, and among several possible path continuations
-/// the one with the maximal dot-product between its triangle's normal and the normal of the preceding triangle is selected
+/// `betterCont` (if given) selects the best triangle among several possible path continuations
 /// return number of duplicated vertices
 MRMESH_API size_t duplicateNonManifoldVertices( Triangulation & t, FaceBitSet * region = nullptr,
-    std::vector<VertDuplication>* dups = nullptr, VertId lastValidVert = {}, const VertCoords * points = nullptr );
+    std::vector<VertDuplication>* dups = nullptr, VertId lastValidVert = {}, const BetterDupContinuation & betterCont = {} );
 
 /// classification of the triangles around one vertex, packed in 32 bits;
 /// it stores 1-bit flag (hasRepeatedVerts) and either 31-bit numRepeatedVerts (if the flag is on),

--- a/source/MRMesh/MRVertDuplication.h
+++ b/source/MRMesh/MRVertDuplication.h
@@ -21,8 +21,10 @@ struct VertDuplication
 };
 
 /// decides which of the two continuation triangles is better during a walk around a non-manifold vertex;
-/// all 5 arguments are original vertices (before duplication):
-/// e0, e1 - the vertices of the shared edge between the reference triangle and both continuation candidates (e0 is the central vertex),
+/// all 5 arguments are original vertices (before duplication), and one of e0, e1 is the central vertex:
+/// e0, e1 - the vertices of the shared edge between the reference triangle and both continuation candidates,
+/// oriented so that the reference triangle has the vertices (e0, e1, vRef) up to rotation,
+/// while the candidate triangles have the vertices (e1, e0, vCand) and (e1, e0, vBest) up to rotation;
 /// vRef - the remaining vertex of the reference triangle,
 /// vCand - the remaining vertex of the candidate triangle,
 /// vBest - the remaining vertex of the currently best continuation triangle;

--- a/source/MRTest/MRAlphaShapeTests.cpp
+++ b/source/MRTest/MRAlphaShapeTests.cpp
@@ -1,6 +1,7 @@
 #include <MRMesh/MRAlphaShape.h>
 #include <MRMesh/MRPointCloud.h>
 #include <MRMesh/MRMesh.h>
+#include <MRMesh/MRMeshComponents.h>
 #include <gtest/gtest.h>
 
 namespace MR
@@ -68,6 +69,27 @@ TEST( MRMesh, AlphaShapeSquare )
     const auto mesh = findAlphaShape( cloud, 0.8f );
     EXPECT_EQ( mesh.topology.numValidFaces(), 4 );
     EXPECT_TRUE( mesh.topology.isClosed() );
+}
+
+// two grids crossing along a line: many junction fans where several continuation triangles exist;
+// the ccwAroundLine-based selection of the best continuation gives 676 vertices in 68 components here,
+// while taking the first found continuation gave 725 vertices in 98 components
+TEST( MRMesh, AlphaShapeCrossingGrids )
+{
+    PointCloud cloud;
+    for ( int i = 0; i <= 10; ++i )
+        for ( int j = 0; j <= 10; ++j )
+            cloud.points.push_back( { i * 0.05f, j * 0.05f, 0 } );
+    for ( int i = 0; i <= 10; ++i )
+        for ( int k = 0; k <= 10; ++k )
+            if ( k != 5 )
+                cloud.points.push_back( { i * 0.05f, 0.25f, k * 0.05f - 0.25f } );
+    cloud.validPoints.autoResizeSet( 0_v, (int)cloud.points.size(), true );
+
+    const auto mesh = findAlphaShape( cloud, 0.08f );
+    EXPECT_EQ( mesh.topology.numValidFaces(), 904 );
+    EXPECT_EQ( mesh.topology.numValidVerts(), 676 );
+    EXPECT_EQ( MeshComponents::getNumComponents( mesh ), 68 );
 }
 
 } //namespace MR

--- a/source/MRTest/MRAlphaShapeTests.cpp
+++ b/source/MRTest/MRAlphaShapeTests.cpp
@@ -72,8 +72,8 @@ TEST( MRMesh, AlphaShapeSquare )
 }
 
 // two grids crossing along a line: many junction fans where several continuation triangles exist;
-// the ccwAroundLine-based selection of the best continuation gives 676 vertices in 68 components here,
-// while taking the first found continuation gave 725 vertices in 98 components
+// the ccwAroundLine-based selection of the best continuation gives one connected component here,
+// while taking the first found continuation gave 468 vertices in 65 components
 TEST( MRMesh, AlphaShapeCrossingGrids )
 {
     PointCloud cloud;
@@ -86,10 +86,10 @@ TEST( MRMesh, AlphaShapeCrossingGrids )
                 cloud.points.push_back( { i * 0.05f, 0.25f, k * 0.05f - 0.25f } );
     cloud.validPoints.autoResizeSet( 0_v, (int)cloud.points.size(), true );
 
-    const auto mesh = findAlphaShape( cloud, 0.08f );
-    EXPECT_EQ( mesh.topology.numValidFaces(), 904 );
-    EXPECT_EQ( mesh.topology.numValidVerts(), 676 );
-    EXPECT_EQ( MeshComponents::getNumComponents( mesh ), 68 );
+    const auto mesh = findAlphaShape( cloud, 0.1f );
+    EXPECT_EQ( mesh.topology.numValidFaces(), 584 );
+    EXPECT_EQ( mesh.topology.numValidVerts(), 322 );
+    EXPECT_EQ( MeshComponents::getNumComponents( mesh ), 1 );
 }
 
 } //namespace MR

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -162,10 +162,11 @@ TEST( MRMesh, duplicateVertexPreferredContinuation )
         auto t = initT;
         auto prefer4 = []( VertId e0, VertId e1, VertId vRef, VertId vCand, VertId vBest )
         {
-            if ( e0 == 0_v )
+            if ( e1 == 0_v )
             {
-                // the branching during the walk around #0
-                EXPECT_EQ( e1, 2_v );
+                // the branching during the walk around #0: the reference triangle is (2, 0, 1) = 0_f up to rotation,
+                // and the candidates are (0, 2, 3) = 1_f and (0, 2, 4) = 2_f
+                EXPECT_EQ( e0, 2_v );
                 EXPECT_EQ( vRef, 1_v );
                 EXPECT_EQ( vBest, 3_v );
             }

--- a/source/MRTest/MRMeshBuilderTests.cpp
+++ b/source/MRTest/MRMeshBuilderTests.cpp
@@ -1,6 +1,5 @@
 #include <MRMesh/MRMeshBuilder.h>
 #include <MRMesh/MRVertDuplication.h>
-#include <MRMesh/MRVector3.h>
 #include <MRMesh/MRMeshBuilderTypes.h>
 #include <MRMesh/MRMeshLoad.h>
 #include <MRMesh/MRMeshComponents.h>
@@ -149,28 +148,31 @@ TEST( MRMesh, duplicateVertexOppositeOrientedTri )
     EXPECT_EQ( dups.size(), 0 );
 }
 
-// a fan around #0 with two continuation options from the shared rim vertex #2:
-// folded triangle 1_f (normal opposite to 0_f) and flat triangle 2_f (normal equal to 0_f);
-// with given coordinates the walk prefers the flat continuation (maximal normals' dot-product),
-// so the folded triangle is fully detached; without coordinates the first option by face id wins instead
-TEST( MRMesh, duplicateVertexSmoothContinuation )
+// a fan around #0 with two continuation options from the shared rim vertex #2;
+// the given predicate prefers the triangle with the remaining vertex #4,
+// so the other continuation 1_f is fully detached; without the predicate the first option by face id wins instead
+TEST( MRMesh, duplicateVertexPreferredContinuation )
 {
     Triangulation initT;
     initT.push_back( { 0_v, 1_v, 2_v } ); //0_f
-    initT.push_back( { 0_v, 2_v, 3_v } ); //1_f folded
-    initT.push_back( { 0_v, 2_v, 4_v } ); //2_f flat
-
-    VertCoords points;
-    points.push_back( Vector3f( 0, 0, 0 ) );  //0
-    points.push_back( Vector3f( 1, 0, 0 ) );  //1
-    points.push_back( Vector3f( 0, 1, 0 ) );  //2
-    points.push_back( Vector3f( 1, 1, 0 ) );  //3
-    points.push_back( Vector3f( -1, 1, 0 ) ); //4
+    initT.push_back( { 0_v, 2_v, 3_v } ); //1_f
+    initT.push_back( { 0_v, 2_v, 4_v } ); //2_f
 
     {
         auto t = initT;
+        auto prefer4 = []( VertId e0, VertId e1, VertId vRef, VertId vCand, VertId vBest )
+        {
+            if ( e0 == 0_v )
+            {
+                // the branching during the walk around #0
+                EXPECT_EQ( e1, 2_v );
+                EXPECT_EQ( vRef, 1_v );
+                EXPECT_EQ( vBest, 3_v );
+            }
+            return vCand == 4_v;
+        };
         std::vector<VertDuplication> dups;
-        EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups, {}, &points ), 2 );
+        EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups, {}, prefer4 ), 2 );
         ASSERT_EQ( dups.size(), 2 );
         EXPECT_EQ( dups[0].srcVert, 0_v );
         EXPECT_EQ( dups[0].dupVert, 5_v );
@@ -182,7 +184,7 @@ TEST( MRMesh, duplicateVertexSmoothContinuation )
 
         // the result is manifold
         dups.clear();
-        EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups, {}, &points ), 0 );
+        EXPECT_EQ( duplicateNonManifoldVertices( t, nullptr, &dups, {}, prefer4 ), 0 );
     }
     {
         auto t = initT;


### PR DESCRIPTION
Reverts most of #6512: `duplicateNonManifoldVertices` does not take `VertCoords` on input anymore, the normal computation and its caching are gone, and `MeshBuilder::fromTrianglesDuplicatingNonManifoldVertices` / `Mesh::fromTrianglesDuplicatingNonManifoldVertices` return to their previous signatures (mesh loading behaves as before #6512, verified on `StullerDragonTest1.ply`: 156442 vertices / 364 components again).

Instead, the duplication takes an optional predicate

```cpp
using BetterDupContinuation = std::function<bool( VertId e0, VertId e1, VertId vRef, VertId vCand, VertId vBest )>;
```

receiving 5 original vertex ids (before duplication), where one of `e0`, `e1` is the central vertex:
- `e0`, `e1` - the vertices of the shared edge between the reference triangle and the candidate triangles, oriented so that the reference triangle has the vertices `(e0, e1, vRef)` up to rotation, while the candidate triangles have `(e1, e0, vCand)` and `(e1, e0, vBest)` up to rotation;
- `vRef` - the remaining vertex of the reference triangle;
- `vCand` - the remaining vertex of the candidate continuation triangle;
- `vBest` - the remaining vertex of the currently best continuation triangle.

If the predicate returns true, then the candidate triangle replaces the currently best continuation triangle. Without the predicate (or with only one continuation option) the first found option is taken exactly as before. The reference-triangle tracking from #6512 (`refTri_`, `restartFromFirstTriangle()` at the direction flip) is kept, as is the mapping of duplicated vertices to their originals before any id reaches the predicate.

The predicate is passed through `Mesh::fromTrianglesDuplicatingNonManifoldVertices` and `MeshBuilder::fromTrianglesDuplicatingNonManifoldVertices` (both received the same optional trailing parameter), and `findAlphaShape` implements it via `ccwAroundLine` from #6519 on the integer coordinates from `AlphaShapeData::intPoints`: the best continuation is the first triangle rotating counter-clockwise from the reference triangle around the directed shared edge `(e0, e1)`. Since the edge order encodes the orientation relation of the triangles, this one fixed formula is correct for both walk directions. The rotation sense was verified empirically on two grids crossing along a line (many junction fans): with the ball radius 0.1 (grid step 0.05) it assembles the whole cloud into a single connected component of 322 vertices, while taking the first found continuation gives 468 vertices in 65 components, and the inverted sense is no better than that; with a tighter radius 0.08 the chosen sense gives 534 vertices in 6 components versus 725 in 98 without the predicate. The new test `AlphaShapeCrossingGrids` pins the single-component outcome, and `AlphaShapeSquare` still produces the closed mesh.

The unit test `duplicateVertexSmoothContinuation` is replaced by `duplicateVertexPreferredContinuation`: the same fan with two continuation options, a predicate preferring the triangle with the remaining vertex #4 (also validating all 5 arguments at the branching), and the reversed outcome without the predicate.
