### PR TITLE
Fix dangling ImFont* and locale subscription in the viewport corner controller

### DIFF
--- a/source/MRViewer/MRViewportCornerController.cpp
+++ b/source/MRViewer/MRViewportCornerController.cpp
@@ -16,6 +16,7 @@
 #include "MRMesh/MRImageLoad.h"
 #include "MRMesh/MR2DContoursTriangulation.h"
 #include "MRMesh/MR2to3.h"
+#include "MRMesh/MRFinally.h"
 #include "MRMesh/MRParallelFor.h"
 #include "MRMesh/MRStringConvert.h"
 #include "MRViewer/MRMouseController.h"
@@ -81,9 +82,12 @@ void flipVertically( Image& img )
 Expected<Image> renderControllerSideText( const Vector2i& resolution )
 {
     // TODO: disconnect from ImGui
-    static auto* font = loadControllerCubeFont( cControllerCubeFontSize );
+    // the font lives in the atlas only for this call: caching it is unsafe, since every
+    // ImFontAtlas::Clear() (font reload, display rescale) deletes all ImFont objects
+    auto* font = loadControllerCubeFont( cControllerCubeFontSize );
     if ( !font )
         return unexpected( "Could not load font" );
+    MR_FINALLY { ImGui::GetIO().Fonts->RemoveFont( font ); };
 
     auto* baked = font->GetFontBaked( cControllerCubeFontSize );
     if ( !baked )

--- a/source/MRViewer/MRViewportCornerController.cpp
+++ b/source/MRViewer/MRViewportCornerController.cpp
@@ -802,24 +802,25 @@ void CornerControllerObject::initDefault()
     } ) );
 
 #ifndef MRVIEWER_NO_LOCALE
-    [[maybe_unused]] static auto onLocaleChanged = Locale::onChanged( [hoverable = std::weak_ptr{ basisViewControllerHoverable }, nonhoverable = std::weak_ptr{ basisViewControllerNonHoverable }] ( const std::string& )
+    connections_.push_back( Locale::onChanged( [hoverable = std::weak_ptr{ basisViewControllerHoverable }, nonhoverable = std::weak_ptr{ basisViewControllerNonHoverable }] ( const std::string& )
     {
+        auto hoverableObj = hoverable.lock();
+        auto nonhoverableObj = nonhoverable.lock();
+        if ( !hoverableObj && !nonhoverableObj )
+            return; // loading textures is expensive, skip it if there is nothing to update
         const auto textures = loadCornerControllerTextures();
-        if ( auto obj = hoverable.lock() )
+        if ( hoverableObj )
         {
-            obj->setTextures( textures );
-            obj->setDirtyFlags( DIRTY_TEXTURE );
+            hoverableObj->setTextures( textures );
+            hoverableObj->setDirtyFlags( DIRTY_TEXTURE );
         }
-        if ( auto obj = nonhoverable.lock() )
+        if ( nonhoverableObj && !textures.empty() )
         {
-            if ( !textures.empty() )
-            {
-                obj->setTextures( { textures.front() } );
-                obj->setDirtyFlags( DIRTY_TEXTURE );
-            }
+            nonhoverableObj->setTextures( { textures.front() } );
+            nonhoverableObj->setDirtyFlags( DIRTY_TEXTURE );
         }
         getViewerInstance().setSceneDirty();
-    } );
+    } ) );
 #endif
 
     rootObj_ = std::make_shared<Object>();


### PR DESCRIPTION
## Problem

`renderControllerSideText()` cached its `ImFont*` in a function-local `static`:

```cpp
static auto* font = loadControllerCubeFont( cControllerCubeFontSize );
```

Every `ImFontAtlas::Clear()` runs `ClearFonts()` -> `Fonts.clear_delete()`, destroying all
`ImFont` objects and leaving that pointer dangling. There are three such call sites:
`ImGuiMenu::reloadFonts()`, `RibbonFontManager::updateFontsScaledOffset_()` and
`DefaultSplashWindow::reloadFont_()`.

Startup ordering guarantees it goes stale: `Viewer::init_()` calls
`initBasisViewControllerObject_()` (which fills the static) before `initPlugins_()` ->
`ImGuiMenu::init` -> `reloadFonts()`. The `Locale::onChanged` handler then dereferences the
freed object on the first locale change.

It is a use-after-free rather than a null dereference, so it is not reliably visible:
`Clear()` is immediately followed by `loadFonts()` allocating nine fresh `ImFont` objects, and
the freed block is usually reused by one of them. When that happens the stale pointer refers to
a live object and nothing appears wrong; it faults only when the block is used for something
else. Reported symptoms are an access violation on Windows and `memory access out of bounds`
under WASM, both with the same stack:

```
MR::Locale::set -> MR::loadCornerControllerTextures -> ImFont::GetFontBaked
  -> ImFontAtlasBakedGetOrAdd -> ImGuiStorage::GetVoidPtrRef
```

A second, independent defect sits in the same place. The `Locale::onChanged` connection was
also kept in a function-local `static`, so only the first `CornerControllerObject` ever
subscribed and the connection outlived it - recreating the object silently stopped the cube
from following language changes. The handler also called `loadCornerControllerTextures()`
before locking its weak pointers, so the full texture load ran even with no controller alive.

## Fix

Two commits, one per defect.

The font is only needed for the duration of the call: the glyph pixels are copied into a plain
`Image` and nothing downstream refers to the `ImFont` again. So it is loaded per call and
returned to the atlas on scope exit. `MR_FINALLY` covers the early `return unexpected` paths,
and is armed after the null check so it never removes a null font. This also avoids retaining
the ~20 MB of font data that a plain "drop the `static`" change would leak on every call, since
`AddFontFromFileTTF` adds to the atlas rather than looking anything up.

The locale connection moves into `connections_`, matching the three sibling connections in the
same function, so every instance subscribes and the connection dies with the object. Both weak
pointers are locked up front and the handler returns early when both are gone.

Adding and removing fonts outside a frame boundary is safe here: in 1.92 the atlas is only
locked when the backend lacks `ImGuiBackendFlags_RendererHasTextures`, which the OpenGL3
backend sets. `RemoveFont` also handles the atlas becoming empty, which it does at startup
before the ribbon fonts are loaded.

## Verification

An ASan harness compiling the vendored ImGui reproduces the defect and confirms the fix:

- pre-fix pattern: `heap-use-after-free`, `READ of size 8` in `ImFont::GetFontBaked`, freed by
  `ImFontAtlas::ClearFonts`, allocated by `loadControllerCubeFont` - matching the reported stack
- post-fix pattern: clean across one init, two atlas reloads and ten locale renders

The harness re-adds nine fonts after `Clear()` exactly as `loadFonts()` does, so it covers the
case where block reuse hides the bug under the normal allocator.

In the running application (Windows, Debug): cube labels render correctly at startup, 14
language switches across ten languages including CJK and Cyrillic, four UI-scale changes
(each an extra `reloadFonts()`), and language switches immediately after rescaling. No crash,
no log errors, and the final render is pixel-identical to the startup render, which also rules
out the silently-wrong-font case the old code could produce. Atlas font count stays constant
across renders, confirming no font is leaked.

Not covered: WASM, and the recreate-the-controller path for the second fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
