### PR TITLE
Pip: strip symbols in manylinux wheel repair

### DIFF
--- a/scripts/wheel/build_wheel.py
+++ b/scripts/wheel/build_wheel.py
@@ -125,6 +125,7 @@ def build_wheel():
                 sys.executable, "-m", "auditwheel",
                 "repair",
                 "--plat", f"manylinux_{manylinux_version}_{platform.machine()}",
+                "--strip",  # drop .symtab/.strtab (~9 MB unpacked); MR libs are built unstripped
                 wheel_file
             ]
         )

--- a/scripts/wheel/build_wheel.py
+++ b/scripts/wheel/build_wheel.py
@@ -107,6 +107,22 @@ def setup_workspace(version, modules, plat_name):
         config_file.write(config)
 
 
+def strip_libraries():
+    # Only MeshLib's own libs need this: the vcpkg-built third-party libs are already stripped.
+    # Must run before `auditwheel repair`, not after (e.g. via its --strip flag): auditwheel
+    # patchelf's the grafted libs, and stripping a patchelf'ed lib breaks its load command
+    # alignment, making it unloadable.
+    if SYSTEM != "Linux":
+        return
+    libs = [
+        *LIB_DIR.glob("libMR*.so"),
+        *LIB_DIR.glob("libpybind11nonlimitedapi_stubs.so"),
+        *WHEEL_SRC_DIR.glob("*.so"),
+    ]
+    for lib in libs:
+        subprocess.check_call(["strip", "--strip-all", lib])
+
+
 def build_wheel():
     os.chdir(WHEEL_ROOT_DIR)
     subprocess.check_call(
@@ -125,7 +141,6 @@ def build_wheel():
                 sys.executable, "-m", "auditwheel",
                 "repair",
                 "--plat", f"manylinux_{manylinux_version}_{platform.machine()}",
-                "--strip",  # drop .symtab/.strtab (~9 MB unpacked); MR libs are built unstripped
                 wheel_file
             ]
         )
@@ -180,6 +195,7 @@ if __name__ == "__main__":
         install_packages()
         setup_workspace(version=args.version, modules=args.modules, plat_name=args.plat_name)
         create_stubs.generate_stubs(modules=args.modules)
+        strip_libraries()
         build_wheel()
     except subprocess.CalledProcessError as e:
         sys.exit(e.returncode)


### PR DESCRIPTION
Strip symbols from MeshLib's own libraries (`libMR*.so`, the pybind stubs lib, and the module extensions) before building the manylinux wheels. The vcpkg-built third-party libraries and `mrmeshpy.so` itself are already stripped; our libs were the only unstripped ones — `.symtab` + `.strtab` are ~21% of `libMRMesh.so`.

`.dynsym` is untouched, so runtime symbol resolution is unaffected; the only cost is that native frames from our libs in user crash dumps lose names, same as the third-party libs today.

The stripping deliberately happens **before** `auditwheel repair` rather than via auditwheel's own `--strip` flag: auditwheel strips *after* patchelf-ing the grafted libs, and stripping a patchelf'ed library corrupts its ELF load command alignment. A first attempt with `--strip` built fine but the wheel failed to import on every distro with `ImportError: libTKernel-….so.7.9.1: ELF load command address/offset not page-aligned` ([run 31016844725](https://github.com/MeshInspector/MeshLib/actions/runs/31016844725)).

pip-build doesn't run on PRs, so this was verified with a dry `pip-build` dispatch from this branch, macOS/Windows legs disabled ([run 31020073470](https://github.com/MeshInspector/MeshLib/actions/runs/31020073470)): both manylinux builds green, and all 14 `manylinux-pip-test` jobs (Rocky 8, Debian 11, Ubuntu 22.04/25.10, Fedora 37/39/42 × x86_64/aarch64) installed the stripped wheel and passed the Python test suite.

Resulting x86_64 wheel from that run vs the published 3.1.3.429 wheel:

|  | published | stripped |
|---|---|---|
| wheel (download) | 78.4 MB | 77.5 MB |
| unpacked (installed) | 250.6 MB | 242.4 MB |
| `libMRMesh.so` | 10.6 MB | 8.4 MB |
| `libMRViewer.so` | 10.2 MB | 7.7 MB |
| `libMRVoxels.so` | 8.5 MB | 5.8 MB |

The download win is modest (symbol string tables compress ~7:1), the installed-size win is ~8 MB.

Windows is unaffected (PDBs are never packed), and delocate has no equivalent hook on macOS, so those wheels are unchanged for now.
