### PR TITLE
Document sign detection modes supported by Smooth offset mode

### DIFF
--- a/source/MRMesh/MREnums.h
+++ b/source/MRMesh/MREnums.h
@@ -72,7 +72,7 @@ enum class OrientNormals
 
 enum class OffsetMode : int
 {
-    Smooth,     ///< create mesh using dual marching cubes from OpenVDB library
+    Smooth,     ///< create mesh using dual marching cubes from OpenVDB library (supports only Unsigned, OpenVDB and HoleWindingRule sign detection modes)
     Standard,   ///< create mesh using standard marching cubes implemented in MeshLib
     Sharpening  ///< create mesh using standard marching cubes with additional sharpening implemented in MeshLib
 };

--- a/source/MRVoxels/MROffset.h
+++ b/source/MRVoxels/MROffset.h
@@ -27,7 +27,8 @@ struct BaseShellParameters
 
 struct OffsetParameters : BaseShellParameters
 {
-    /// determines the method to compute distance sign
+    /// determines the method to compute distance sign;
+    /// \ref offsetMesh implementing OffsetMode::Smooth supports only Unsigned, OpenVDB and HoleWindingRule here
     SignDetectionMode signDetectionMode = SignDetectionMode::OpenVDB;
 
     /// whether to construct closed mesh in signMode = SignDetectionModeShort::HoleWindingNumber


### PR DESCRIPTION
## Summary

`offsetMesh()` implementing `OffsetMode::Smooth` supports only `Unsigned`, `OpenVDB` and `HoleWindingRule` sign detection (enforced by its assert); with `ProjectionNormal` a release build silently falls into the level-set branch, which yields a broken result on open meshes (see discussion #4520). State the restriction on `OffsetMode::Smooth` and `OffsetParameters::signDetectionMode`.

The viewer-side UI restriction lands separately.

## Test plan

Comment-only diff; a TU including both headers compiles with project flags.

Generated with [Claude Code](https://claude.com/claude-code)