### PR TITLE
Disable ImGui multi-viewport when the main window is hidden

### DIFF
--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -636,7 +636,10 @@ int Viewer::launch( const LaunchParams& params )
     experimentalFeatures = params.developerFeatures;
 
     bool defaultMultiViewport = Config::instance().getBool( cDefaultMultiViewportKey, true );
-    launchParams_.multiViewport = defaultMultiViewport && params.multiViewport;
+    // tool windows detached from a never-shown main window become visible OS windows of their own
+    const bool hiddenWindow = params.windowMode == LaunchParams::Hide || params.windowMode == LaunchParams::TryHidden
+                           || params.windowMode == LaunchParams::NoWindow;
+    launchParams_.multiViewport = defaultMultiViewport && params.multiViewport && !hiddenWindow;
 
     auto res = launchInit_( params );
     if ( res != EXIT_SUCCESS )


### PR DESCRIPTION
## Problem

`-hidden` (and `-tryHidden` / `-noWindow`) only hides the **main** window — `multiViewport` was computed without consulting `windowMode`, so ImGui kept `ImGuiConfigFlags_ViewportsEnable` on. Two things then compound:

1. An ImGui window not fully inside the main window rect gets its own **real OS window**, created visible. A hidden main window does not suppress it.
2. With multi-viewport on, the dialog auto-placer uses the **whole monitor work area** as its bounds (`MRUIRectAllocator.cpp`, `findLocation` branch) instead of the app window — so it actively places dialogs outside the hidden window once a few are open.

Result: a "hidden" viewer paints stray tool windows onto the user's desktop. Those windows are also outside the main framebuffer, so `viewer.captureScreenshot` cannot see them — automated UI verification silently loses whatever they contain.

## Fix

Gate `multiViewport` on the window actually being shown, at the one place the effective per-launch value is computed. `ImGuiMenu::init` is its only reader; the "Enable multi-windows" settings checkbox only writes a config key applied on the next restart, so there is no bypass. `Show` and `HideInit` are unaffected.

## Verification

Windows, Debug x64. Hidden launch, then four dialogs opened over MCP (Create Simple Objects, Camera, History Explorer, Object Info); top-level windows of the process enumerated via `EnumWindows`.

| | detached `GLFW30` windows | visible on desktop |
|---|---|---|
| before | 2 — `Object Info` at y=86, `History Explorer` at y=142 | yes, both above the hidden main window's top edge at y=195 |
| after | 0 | none |

All four dialogs now render inside the main framebuffer and appear in `viewer.captureScreenshot` output, which was not the case for the two that had escaped.
