### PR TITLE
Run the third-party license check on every push and PR, and actualize the notices

### DIFF
--- a/.github/workflows/check-third-party-licenses.yml
+++ b/.github/workflows/check-third-party-licenses.yml
@@ -1,11 +1,17 @@
 name: Check third-party licenses
 
 # The bundled notices in thirdparty/licenses/ are hand-curated and guarded by a
-# version tripwire (scripts/check_third_party_licenses.py). Running it daily and
-# at release keeps the notices current without gating every PR: a dependency bump
-# merges freely, and this flags within a day (and hard-fails at release) if a
-# notice needs updating. Run manually any time via "Run workflow".
+# version tripwire (scripts/check_third_party_licenses.py). It gates every push and
+# PR: the check needs no build and no submodule checkout, so the job costs a runner
+# slot and a few seconds, and catching a dependency bump on the PR that makes it is
+# far cheaper than rediscovering it at release. The daily run still covers drift that
+# lands without a version change, and release remains a hard gate.
+# Run manually any time via "Run workflow".
 on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
   schedule:
     - cron: '23 5 * * *'   # daily, 05:23 UTC
   release:

--- a/.github/workflows/check-third-party-licenses.yml
+++ b/.github/workflows/check-third-party-licenses.yml
@@ -2,10 +2,10 @@ name: Check third-party licenses
 
 # The bundled notices in thirdparty/licenses/ are hand-curated and guarded by a
 # version tripwire (scripts/check_third_party_licenses.py). It gates every push and
-# PR: the check needs no build and no submodule checkout, so the job costs a runner
-# slot and a few seconds, and catching a dependency bump on the PR that makes it is
-# far cheaper than rediscovering it at release. The daily run still covers drift that
-# lands without a version change, and release remains a hard gate.
+# PR: the check needs no build, no submodule checkout and no network, so the job costs
+# a runner slot and a few seconds, and catching a dependency bump on the PR that makes
+# it is far cheaper than rediscovering it at release. The daily run still covers drift
+# that lands without a version change, and release remains a hard gate.
 # Run manually any time via "Run workflow".
 on:
   push:

--- a/docs/third_party_licenses.md
+++ b/docs/third_party_licenses.md
@@ -46,30 +46,46 @@ hand -- and guarded by a drift tripwire.
 `scripts/check_third_party_licenses.py` verifies every manifest component has a matching
 non-empty section and that each dependency's version has **not moved** since its text was
 curated. It runs **on every push and pull request, daily, and on release**
-(`.github/workflows/check-third-party-licenses.yml`): the check needs no build and no
-submodule checkout, so gating a PR costs only a runner slot and a few seconds, and catching
-a bump on the PR that makes it beats rediscovering it at release. The daily run still covers
-drift that lands without a version change. Run it locally any time:
+(`.github/workflows/check-third-party-licenses.yml`): checking needs no build, no submodule
+checkout and no network, so gating a PR costs only a runner slot and a few seconds, and
+catching a bump on the PR that makes it beats rediscovering it at release. The daily run
+still covers drift that lands without a version change. Run it locally any time:
 `python scripts/check_third_party_licenses.py`.
-
-When it reports drift:
-
-1. `"<id>: version changed A -> B"`.
-2. Re-check the upstream license for the new version; if it changed, update the component's
-   section in `THIRD-PARTY-NOTICES.txt` (and the manifest `license` field if needed).
-3. Re-pin: `python scripts/check_third_party_licenses.py --update-versions`, and commit the
-   updated `manifest.json`.
 
 Version is tracked per source (see `manifest.json` `_comment`): git submodule SHA, vcpkg
 overlay-port version, the baseline version of each registry port the component covers (sound
 because `vcpkg.json` has no per-port overrides), or a sha256 of tracked in-tree files (vendored
 code, fonts, Python zips).
 
-Registry ports are tracked **per port**, not by the registry baseline commit: that commit moves
-on every routine vcpkg bump, so using it flagged all nine vcpkg components at once even when
-their own libraries were untouched -- and blanket re-pinning that noise is how a genuine license
-change gets waved through. Reading the ports' own baseline versions is the one signal that needs
-the network (a single `versions/baseline.json` fetch from the registry, shared across components).
+### Fixing drift
+
+**A component's own version moved** -- `"<id>: version changed A -> B"`:
+
+1. Re-check the upstream license at the new version; if the text changed, update that
+   component's section in `THIRD-PARTY-NOTICES.txt` (and the manifest `license` field if the
+   license itself changed).
+2. Re-pin: `python scripts/check_third_party_licenses.py --update-versions`.
+3. Commit the updated `manifest.json` together with any notice edits.
+
+**The vcpkg baseline moved** -- `"vcpkg registry baseline moved A -> B"`, which is what a
+routine vcpkg bump produces:
+
+1. Run `python scripts/check_third_party_licenses.py --update-versions`. This is the only
+   step that reads the vcpkg registry over the network, and it prints exactly which ports
+   moved -- usually none or one or two, not all nine components.
+2. For each port it names, re-check that component's upstream license and update its section
+   if the text changed. Ports it does not name have not moved; nothing to re-verify.
+3. Commit the updated `manifest.json` (its per-port `version` diff is the review record of
+   what actually changed) together with any notice edits.
+
+Registry ports are recorded **per port**, not by the registry baseline commit, because that
+commit moves on every routine vcpkg bump: tracking it directly flagged all nine vcpkg
+components at once even when their own libraries were untouched, and blanket re-pinning that
+noise is how a genuine license change gets waved through. `manifest.json`'s
+`vcpkg_registry_baseline` records the commit those port versions were resolved at. A port's
+version is a pure function of that commit, so while it still matches `vcpkg.json` no registry
+port can have moved -- which is why the check stays offline and only `--update-versions`
+reaches the network.
 
 ## Adding a new dependency
 

--- a/docs/third_party_licenses.md
+++ b/docs/third_party_licenses.md
@@ -45,9 +45,11 @@ hand -- and guarded by a drift tripwire.
 
 `scripts/check_third_party_licenses.py` verifies every manifest component has a matching
 non-empty section and that each dependency's version has **not moved** since its text was
-curated. It runs **daily and on release** (`.github/workflows/check-third-party-licenses.yml`)
--- deliberately not on every PR, so a routine dependency bump merges freely and this flags
-within a day (and hard-fails at release) if a notice needs updating. Run it locally any time:
+curated. It runs **on every push and pull request, daily, and on release**
+(`.github/workflows/check-third-party-licenses.yml`): the check needs no build and no
+submodule checkout, so gating a PR costs only a runner slot and a few seconds, and catching
+a bump on the PR that makes it beats rediscovering it at release. The daily run still covers
+drift that lands without a version change. Run it locally any time:
 `python scripts/check_third_party_licenses.py`.
 
 When it reports drift:
@@ -59,8 +61,15 @@ When it reports drift:
    updated `manifest.json`.
 
 Version is tracked per source (see `manifest.json` `_comment`): git submodule SHA, vcpkg
-overlay-port version, the vcpkg registry baseline (sound because `vcpkg.json` has no per-port
-overrides), or a sha256 of tracked in-tree files (vendored code, fonts, Python zips).
+overlay-port version, the baseline version of each registry port the component covers (sound
+because `vcpkg.json` has no per-port overrides), or a sha256 of tracked in-tree files (vendored
+code, fonts, Python zips).
+
+Registry ports are tracked **per port**, not by the registry baseline commit: that commit moves
+on every routine vcpkg bump, so using it flagged all nine vcpkg components at once even when
+their own libraries were untouched -- and blanket re-pinning that noise is how a genuine license
+change gets waved through. Reading the ports' own baseline versions is the one signal that needs
+the network (a single `versions/baseline.json` fetch from the registry, shared across components).
 
 ## Adding a new dependency
 

--- a/scripts/check_third_party_licenses.py
+++ b/scripts/check_third_party_licenses.py
@@ -15,14 +15,13 @@ the drift tripwire for that file. For each component in `manifest.json` it:
   3. warns about git submodules that look shippable but are absent from the manifest.
 
 Run `--update-versions` to re-pin the manifest to current versions after you have
-verified the texts are still correct.
+verified the texts are still correct. That is the only mode that reads the vcpkg registry
+(over the network) to resolve per-port versions; see docs/third_party_licenses.md.
 
 Runs on every push and pull request, daily, and on release
 (.github/workflows/check-third-party-licenses.yml); run it locally any time with
-`python scripts/check_third_party_licenses.py`. It needs no build and no submodule
-checkout: every version signal is read from the git tree and in-tree files, except
-`vcpkg-registry` components, whose per-port versions live in the registry repository
-and so cost one HTTPS fetch (see vcpkg_baseline_versions).
+`python scripts/check_third_party_licenses.py`. Checking needs no build, no submodule
+checkout and no network -- every signal is read from the git tree and in-tree files.
 """
 import argparse
 import hashlib
@@ -80,20 +79,15 @@ def vcpkg_default_registry():
     return reg["repository"], reg["baseline"]
 
 
-_BASELINE_VERSIONS = None  # memoized: the port map on success, the ValueError on failure
+_BASELINE_VERSIONS = None  # memoized: the registry is read at most once per run
 
 
 def vcpkg_baseline_versions():
     """port -> baseline version map of the default registry, at the pinned baseline commit.
 
-    The registry is not vendored in-tree, so this is the one signal that needs the network:
-    it fetches versions/baseline.json from the registry repository at the pinned baseline.
-    Resolved once per run and shared by every vcpkg-registry component -- the failure is
-    memoized too, so an outage costs one attempt, not one per component.
-
-    Keep this per-port: the baseline SHA moves on every routine registry bump, so tracking
-    it flagged all nine vcpkg components at once even when their own libraries were
-    untouched -- and blanket re-pinning that noise is how a real license change slips by.
+    Only --update-versions reaches here. The registry is not vendored in-tree, so this is
+    the one signal that reads the network; `check` never does, because the pinned
+    `vcpkg_registry_baseline` already tells it whether these versions can have moved.
     """
     global _BASELINE_VERSIONS
     if _BASELINE_VERSIONS is None:
@@ -104,10 +98,7 @@ def vcpkg_baseline_versions():
             with urllib.request.urlopen(url, timeout=30) as resp:
                 _BASELINE_VERSIONS = json.loads(resp.read().decode("utf-8"))["default"]
         except (OSError, ValueError, KeyError) as e:
-            _BASELINE_VERSIONS = ValueError(
-                f"cannot read vcpkg baseline versions from {url} ({e})")
-    if isinstance(_BASELINE_VERSIONS, ValueError):
-        raise _BASELINE_VERSIONS
+            raise ValueError(f"cannot read vcpkg baseline versions from {url} ({e})")
     return _BASELINE_VERSIONS
 
 
@@ -148,20 +139,49 @@ def files_hash(track):
     return hashlib.sha256(",".join(oids).encode()).hexdigest()[:16]
 
 
-def current_version(source):
-    """Recompute a component's version from its source, or None for manual entries."""
+def current_version(source, resolve_registry=False):
+    """Recompute a component's version from its source, or None when it cannot be.
+
+    'manual' entries have no computable version. 'vcpkg-registry' ones do, but resolving
+    them reads the registry over the network, so only --update-versions asks for it
+    (resolve_registry=True); `check` covers them with one offline comparison instead --
+    see check_vcpkg_baseline.
+    """
     t = source["type"]
     if t == "submodule":
         return submodule_sha(source["path"])
     if t == "vcpkg-overlay":
         return vcpkg_overlay_version(source["port"])
     if t == "vcpkg-registry":
-        return vcpkg_registry_versions(source["ports"])
+        return vcpkg_registry_versions(source["ports"]) if resolve_registry else None
     if t == "hash":
         return files_hash(source["track"])
     if t == "manual":
         return None
     raise ValueError(f"unknown source type '{t}'")
+
+
+def check_vcpkg_baseline(data):
+    """The whole vcpkg-registry tripwire, as one offline comparison. Returns errors.
+
+    A port's baseline version is a pure function of the registry commit, and
+    versions/baseline.json at a given commit is immutable -- so a baseline that has not
+    moved proves no registry port has moved, without reading the registry at all. When it
+    does move, --update-versions re-resolves the per-port versions and names the ones that
+    actually changed, which is the only moment the detail is worth fetching.
+    """
+    pinned = data.get("vcpkg_registry_baseline", "")
+    _, current = vcpkg_default_registry()
+    if not pinned:
+        return [f"vcpkg_registry_baseline not pinned -- run "
+                f"'scripts/check_third_party_licenses.py --update-versions'"]
+    if pinned != current:
+        return [f"vcpkg registry baseline moved {pinned[:12]} -> {current[:12]} -- run "
+                f"'scripts/check_third_party_licenses.py --update-versions' to see which "
+                f"ports moved, re-verify the upstream LICENSE text of each, update their "
+                f"sections in {REL}/{NOTICES.name}, then commit the re-pinned manifest "
+                f"(docs/third_party_licenses.md)"]
+    return []
 
 
 def describe_change(pinned, current):
@@ -206,8 +226,8 @@ def parse_sections(text):
 
 
 def check():
-    _, components = load_components()
-    errors, warnings = [], []
+    data, components = load_components()
+    errors, warnings = check_vcpkg_baseline(data), []
     seen_ids = set()
 
     notices_rel = f"{REL}/{NOTICES.name}"
@@ -308,7 +328,7 @@ def update_versions():
     changed = 0
     for comp in components:
         try:
-            cur = current_version(comp["source"])
+            cur = current_version(comp["source"], resolve_registry=True)
         except (ValueError, subprocess.CalledProcessError) as e:
             print(f"ERROR: {comp['id']}: cannot compute version ({e})", file=sys.stderr)
             return False
@@ -316,6 +336,9 @@ def update_versions():
             print(f"  {comp['id']}: {describe_change(comp.get('version', ''), cur)}")
             comp["version"] = cur
             changed += 1
+    # Re-pin the baseline those registry versions were resolved at; `check` compares it
+    # against thirdparty/vcpkg/vcpkg.json to stay offline.
+    data["vcpkg_registry_baseline"] = vcpkg_default_registry()[1]
     # Write explicit LF bytes: Path.write_text would translate to CRLF on Windows,
     # producing spurious end-of-line churn when a Windows dev re-pins.
     MANIFEST.write_bytes((json.dumps(data, indent=2, ensure_ascii=False) + "\n").encode("utf-8"))

--- a/scripts/check_third_party_licenses.py
+++ b/scripts/check_third_party_licenses.py
@@ -9,23 +9,28 @@ the drift tripwire for that file. For each component in `manifest.json` it:
   1. checks the file has a matching non-empty section (id, license, upstream), with
      no orphan or misordered sections;
   2. recomputes the component's current version from its source (git submodule SHA,
-     vcpkg overlay-port version, vcpkg baseline, or a hash of tracked in-tree files)
-     and fails if it differs from the pinned `version` in the manifest -- forcing a
-     human to re-check the upstream license text and re-pin;
+     vcpkg overlay-port version, vcpkg registry baseline versions, or a hash of tracked
+     in-tree files) and fails if it differs from the pinned `version` in the manifest --
+     forcing a human to re-check the upstream license text and re-pin;
   3. warns about git submodules that look shippable but are absent from the manifest.
 
 Run `--update-versions` to re-pin the manifest to current versions after you have
 verified the texts are still correct.
 
-Runs daily and on release (.github/workflows/check-third-party-licenses.yml); run it
-locally any time with `python scripts/check_third_party_licenses.py`. Every version signal
-is read from the git tree and in-tree files, so it needs no build and no submodule checkout.
+Runs on every push and pull request, daily, and on release
+(.github/workflows/check-third-party-licenses.yml); run it locally any time with
+`python scripts/check_third_party_licenses.py`. It needs no build and no submodule
+checkout: every version signal is read from the git tree and in-tree files, except
+`vcpkg-registry` components, whose per-port versions live in the registry repository
+and so cost one HTTPS fetch (see vcpkg_baseline_versions).
 """
 import argparse
 import hashlib
 import json
 import subprocess
 import sys
+import urllib.parse
+import urllib.request
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -69,9 +74,53 @@ def submodule_sha(path):
     return sha
 
 
-def vcpkg_baseline():
+def vcpkg_default_registry():
     data = json.loads(VCPKG_JSON.read_text(encoding="utf-8"))
-    return data["configuration"]["default-registry"]["baseline"]
+    reg = data["configuration"]["default-registry"]
+    return reg["repository"], reg["baseline"]
+
+
+_BASELINE_VERSIONS = None  # memoized: the port map on success, the ValueError on failure
+
+
+def vcpkg_baseline_versions():
+    """port -> baseline version map of the default registry, at the pinned baseline commit.
+
+    The registry is not vendored in-tree, so this is the one signal that needs the network:
+    it fetches versions/baseline.json from the registry repository at the pinned baseline.
+    Resolved once per run and shared by every vcpkg-registry component -- the failure is
+    memoized too, so an outage costs one attempt, not one per component.
+
+    Keep this per-port: the baseline SHA moves on every routine registry bump, so tracking
+    it flagged all nine vcpkg components at once even when their own libraries were
+    untouched -- and blanket re-pinning that noise is how a real license change slips by.
+    """
+    global _BASELINE_VERSIONS
+    if _BASELINE_VERSIONS is None:
+        repo, baseline = vcpkg_default_registry()
+        slug = urllib.parse.urlparse(repo).path.strip("/").removesuffix(".git")
+        url = f"https://raw.githubusercontent.com/{slug}/{baseline}/versions/baseline.json"
+        try:
+            with urllib.request.urlopen(url, timeout=30) as resp:
+                _BASELINE_VERSIONS = json.loads(resp.read().decode("utf-8"))["default"]
+        except (OSError, ValueError, KeyError) as e:
+            _BASELINE_VERSIONS = ValueError(
+                f"cannot read vcpkg baseline versions from {url} ({e})")
+    if isinstance(_BASELINE_VERSIONS, ValueError):
+        raise _BASELINE_VERSIONS
+    return _BASELINE_VERSIONS
+
+
+def vcpkg_registry_versions(ports):
+    """Baseline version of each of a component's registry ports."""
+    baseline = vcpkg_baseline_versions()
+    versions = {}
+    for port in ports:
+        entry = baseline.get(port)
+        if entry is None:
+            raise ValueError(f"port '{port}' is not in the vcpkg registry baseline")
+        versions[port] = f"{entry['baseline']}#{entry.get('port-version', 0)}"
+    return versions
 
 
 def vcpkg_overlay_version(port):
@@ -107,12 +156,26 @@ def current_version(source):
     if t == "vcpkg-overlay":
         return vcpkg_overlay_version(source["port"])
     if t == "vcpkg-registry":
-        return vcpkg_baseline()
+        return vcpkg_registry_versions(source["ports"])
     if t == "hash":
         return files_hash(source["track"])
     if t == "manual":
         return None
     raise ValueError(f"unknown source type '{t}'")
+
+
+def describe_change(pinned, current):
+    """'old -> new' for a version change, naming only the ports that actually moved.
+
+    Multi-port components carry a port -> version mapping, so spelling out the whole
+    mapping would bury the one port that moved (Boost alone has 13).
+    """
+    if isinstance(current, dict):
+        was = pinned if isinstance(pinned, dict) else {}
+        ports = sorted(set(was) | set(current))
+        return ", ".join(f"{p} {was.get(p, '(unpinned)')} -> {current.get(p, '(dropped)')}"
+                         for p in ports if was.get(p) != current.get(p))
+    return f"{pinned} -> {current}"
 
 
 def load_components():
@@ -194,9 +257,9 @@ def check():
             errors.append(f"{cid}: version not pinned -- run "
                           f"'scripts/check_third_party_licenses.py --update-versions'")
         elif pinned != cur:
-            errors.append(f"{cid}: version changed {pinned} -> {cur} -- re-verify the "
-                          f"upstream LICENSE text, update its section in {notices_rel}, "
-                          f"then re-pin with --update-versions")
+            errors.append(f"{cid}: version changed {describe_change(pinned, cur)} -- "
+                          f"re-verify the upstream LICENSE text, update its section in "
+                          f"{notices_rel}, then re-pin with --update-versions")
 
     # 3a. orphan or misordered sections, stray files in the folder
     for cid, *_ in sections:
@@ -250,7 +313,7 @@ def update_versions():
             print(f"ERROR: {comp['id']}: cannot compute version ({e})", file=sys.stderr)
             return False
         if cur is not None and comp.get("version", "") != cur:
-            print(f"  {comp['id']}: {comp.get('version', '') or '(unpinned)'} -> {cur}")
+            print(f"  {comp['id']}: {describe_change(comp.get('version', ''), cur)}")
             comp["version"] = cur
             changed += 1
     # Write explicit LF bytes: Path.write_text would translate to CRLF on Windows,

--- a/thirdparty/licenses/THIRD-PARTY-NOTICES.txt
+++ b/thirdparty/licenses/THIRD-PARTY-NOTICES.txt
@@ -523,6 +523,32 @@ WHETHER OR NOT ADVISED OF THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF
 LIABILITY, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE 
 OF THIS SOFTWARE.
 
+# Lempel-Ziv & Welch Compression (tif_lzw.c) license
+The code of tif_lzw.c is derived from the compress program whose code is
+derived from software contributed to Berkeley by James A. Woods,
+derived from original work by Spencer Thomas and Joseph Orost.
+
+The original Berkeley copyright notice appears below in its entirety:
+
+Copyright (c) 1985, 1986 The Regents of the University of California.
+All rights reserved.
+
+This code is derived from software contributed to Berkeley by
+James A. Woods, derived from original work by Spencer Thomas
+and Joseph Orost.
+
+Redistribution and use in source and binary forms are permitted
+provided that the above copyright notice and this paragraph are
+duplicated in all such forms and that any documentation,
+advertising materials, and other materials related to such
+distribution and use acknowledge that the software was developed
+by the University of California, Berkeley.  The name of the
+University may not be used to endorse or promote products derived
+from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
 
 ################################################################################
 jsoncpp -- MIT

--- a/thirdparty/licenses/manifest.json
+++ b/thirdparty/licenses/manifest.json
@@ -12,7 +12,9 @@
     "doxygen/general_pages/ThirdpartyList.dox, reconciled against .gitmodules and",
     "thirdparty/vcpkg/vcpkg.json.",
     "source.type: submodule=gitlink SHA | vcpkg-overlay=port version+port-version |",
-    "vcpkg-registry=vcpkg baseline (sound: vcpkg.json has no per-port overrides) |",
+    "vcpkg-registry=baseline version of each listed port, read from the registry at the",
+    "pinned baseline (sound: vcpkg.json has no per-port overrides), so a registry bump",
+    "only trips the components whose own ports moved |",
     "hash=sha256 of tracked in-tree files | manual=stable/link-only, presence-checked only."
   ],
   "components": [
@@ -42,7 +44,21 @@
           "boost-url"
         ]
       },
-      "version": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
+      "version": {
+        "boost-algorithm": "1.91.0#0",
+        "boost-dynamic-bitset": "1.91.0#0",
+        "boost-functional": "1.91.0#0",
+        "boost-integer": "1.91.0#0",
+        "boost-locale": "1.91.0#0",
+        "boost-move": "1.91.0#0",
+        "boost-multiprecision": "1.91.0#0",
+        "boost-program-options": "1.91.0#0",
+        "boost-range": "1.91.0#0",
+        "boost-serialization": "1.91.0#0",
+        "boost-signals2": "1.91.0#0",
+        "boost-stacktrace": "1.91.0#0",
+        "boost-url": "1.91.0#0"
+      }
     },
     {
       "id": "Eigen",
@@ -97,7 +113,9 @@
           "tiff"
         ]
       },
-      "version": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
+      "version": {
+        "tiff": "4.7.2#0"
+      }
     },
     {
       "id": "jsoncpp",
@@ -221,7 +239,9 @@
           "libharu"
         ]
       },
-      "version": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
+      "version": {
+        "libharu": "2.4.6#0"
+      }
     },
     {
       "id": "libjpeg-turbo",
@@ -250,7 +270,9 @@
           "libpng"
         ]
       },
-      "version": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
+      "version": {
+        "libpng": "1.6.58#0"
+      }
     },
     {
       "id": "OpenCASCADE",
@@ -360,7 +382,9 @@
           "freetype"
         ]
       },
-      "version": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
+      "version": {
+        "freetype": "2.14.3#0"
+      }
     },
     {
       "id": "Python",
@@ -470,7 +494,9 @@
           "glfw3"
         ]
       },
-      "version": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
+      "version": {
+        "glfw3": "3.4#1"
+      }
     },
     {
       "id": "DearImGui",
@@ -538,7 +564,9 @@
           "hidapi"
         ]
       },
-      "version": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
+      "version": {
+        "hidapi": "0.15.0#1"
+      }
     },
     {
       "id": "dbus",
@@ -554,7 +582,9 @@
           "dbus"
         ]
       },
-      "version": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
+      "version": {
+        "dbus": "1.16.2#5"
+      }
     },
     {
       "id": "FontAwesome",
@@ -633,7 +663,9 @@
           "mimalloc"
         ]
       },
-      "version": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
+      "version": {
+        "mimalloc": "3.4.3#0"
+      }
     }
   ]
 }

--- a/thirdparty/licenses/manifest.json
+++ b/thirdparty/licenses/manifest.json
@@ -12,11 +12,16 @@
     "doxygen/general_pages/ThirdpartyList.dox, reconciled against .gitmodules and",
     "thirdparty/vcpkg/vcpkg.json.",
     "source.type: submodule=gitlink SHA | vcpkg-overlay=port version+port-version |",
-    "vcpkg-registry=baseline version of each listed port, read from the registry at the",
-    "pinned baseline (sound: vcpkg.json has no per-port overrides), so a registry bump",
-    "only trips the components whose own ports moved |",
-    "hash=sha256 of tracked in-tree files | manual=stable/link-only, presence-checked only."
+    "vcpkg-registry=baseline version of each listed port (sound: vcpkg.json has no",
+    "per-port overrides), so a registry bump only implicates the components whose own",
+    "ports moved |",
+    "hash=sha256 of tracked in-tree files | manual=stable/link-only, presence-checked only.",
+    "vcpkg_registry_baseline is the vcpkg.json baseline those port versions were resolved",
+    "at. Port versions are a pure function of that commit, so while it matches vcpkg.json",
+    "no registry port can have moved and the check needs no network; when it differs,",
+    "--update-versions re-resolves them and names the ports that actually changed."
   ],
+  "vcpkg_registry_baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
   "components": [
     {
       "id": "Boost",


### PR DESCRIPTION
## What

The third-party license check now runs on every push and PR, not just daily and at release. It is cheap enough to gate a build -- the script step measures well under a second, with no build, no submodule checkout and no network -- and catching a dependency bump on the PR that makes it beats rediscovering it at release.

Master's daily run is currently red, so this also actualizes the manifest and the notices.

## Why it was red

The 2026.07.29 vcpkg bump (#6509) moved the registry baseline. `vcpkg-registry` components tracked that registry-wide commit SHA as their version, so all nine were flagged at once -- but only two libraries had actually moved:

- libtiff 4.7.1 -> 4.7.2
- mimalloc 3.3.2 -> 3.4.3

Blanket re-pinning that noise is how a genuine license change gets waved through, so the signal had to become precise before it could gate a PR.

## Changes

**Per-port version tracking.** `vcpkg-registry` components now record the baseline version of each port they cover (`"tiff": "4.7.2#0"`) rather than the registry commit SHA. `manifest.json` gains `vcpkg_registry_baseline`: the commit those versions were resolved at.

**Checking stays offline.** A port's version is a pure function of the baseline commit, and `versions/baseline.json` at a given commit is immutable -- so while the pinned baseline still matches `vcpkg.json`, no registry port can have moved. Only `--update-versions` reads the registry. A future vcpkg bump therefore reports one actionable error instead of nine, and `--update-versions` names the ports that actually moved, so only those components need re-verifying.

**libtiff notice completed.** Added libtiff's second upstream section -- the Lempel-Ziv & Welch (`tif_lzw.c`) Berkeley notice -- missing since the notices file was created. A version tripwire compares versions, never texts, so it could not catch this. The bundled text is now byte-identical to upstream v4.7.2.

**Re-pinned after verifying, not stamping.** mimalloc 3.4.3's text is byte-identical to what is bundled; libtiff's text is unchanged between 4.7.1 and 4.7.2; the other seven never changed version at all.

## Verification

- `check()` passes with `urlopen` and `socket.socket` both replaced by hard failures, confirming it touches no network.
- Replaying the 2026.07.29 bump offline reports a single error naming the command to run.
- `--update-versions` on that bump prints exactly `libtiff: tiff 4.7.1#0 -> 4.7.2#0` and `mimalloc: mimalloc 3.3.2#0 -> 3.4.3#0`.
- The libtiff section diffed byte-for-byte against upstream v4.7.2.

## Notes for reviewers

The next vcpkg bump PR will go red by design, with one message pointing at `--update-versions`. Procedures for both drift cases are in `docs/third_party_licenses.md`.

Platform builds are disabled by label: the diff touches only the license workflow, its script, docs, and the shipped notices text, none of which affect any platform build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
