### PR TITLE
Re-pin OpenCTM license notices after submodule bump

### DIFF
--- a/thirdparty/licenses/manifest.json
+++ b/thirdparty/licenses/manifest.json
@@ -317,7 +317,7 @@
         "type": "submodule",
         "path": "thirdparty/OpenCTM-git"
       },
-      "version": "49cfd0eb5de37cfd1d1290dc58d2b934dce9d387"
+      "version": "2b444a4c70c432c1f4990fb32b0fcb11d0d81aad"
     },
     {
       "id": "LAZperf",


### PR DESCRIPTION
Fixes the "Check third-party licenses" failure on master introduced by #6527, which moved the OpenCTM pin `49cfd0eb` -> `2b444a4c`.

Verified: the new commit is one commit ahead of the old pin and touches only `CMakeLists.txt` (include-dirs fix); `LICENSE.txt` is unchanged and matches the OpenCTM section in `THIRD-PARTY-NOTICES.txt` verbatim, so only the manifest pin needs updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)