### PR TITLE
CI: Disable -fpch-codegen in the manual docs workflow

### DIFF
--- a/.github/workflows/update-docs-manual.yml
+++ b/.github/workflows/update-docs-manual.yml
@@ -85,7 +85,9 @@ jobs:
       - name: Generate and build MRBind bindings
         env:
           CXX: ${{ env.CXX-COMPILER }}
-        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{ env.CONFIG }}/bin
+        # PCH_CODEGEN=0: `-fpch-codegen` hits clang defect llvm/llvm-project#203691 on this image's
+        # libstdc++-12, same as the ubuntu22 opt-out in build-test-ubuntu-arm64.yml.
+        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{ env.CONFIG }}/bin PCH_CODEGEN=0
 
       - name: Create Python Stubs
         run: python3 ./scripts/wheel/create_stubs.py
@@ -100,7 +102,7 @@ jobs:
       - name: Generate C bindings
         env:
           CXX: ${{ env.CXX-COMPILER }}
-        run: make -f scripts/mrbind/generate.mk TARGET=c -B --trace
+        run: make -f scripts/mrbind/generate.mk TARGET=c -B --trace PCH_CODEGEN=0
 
       - name: Upload C bindings headers
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
The `create-stubs` job of `update-docs-manual.yml` runs in the ubuntu22-arm64 container, where `-fpch-codegen` hits clang defect llvm/llvm-project#203691 on libstdc++-12: `std::filesystem` internals are homed into the PCH object but never emitted, so the `mrmeshpy.so` post-link check fails ([failing run](https://github.com/MeshInspector/MeshLib/actions/runs/31115978884)).

`build-test-ubuntu-arm64.yml` got the `PCH_CODEGEN=0` opt-out when `-fpch-codegen` was introduced (#6255), but this workflow was missed — it had not run since February. Same opt-out applied to both bindings-build invocations here.

Validation: dispatch `update-docs-manual.yml` after merge (that run doubles as the pending docs refresh for the release-docs miss fixed by #6504).

🤖 Generated with [Claude Code](https://claude.com/claude-code)