### PR TITLE
CI: run the third-party license check inside Build Test Distribute

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -25,6 +25,9 @@ jobs:
     uses: ./.github/workflows/config.yml
     secrets: inherit
 
+  check-third-party-licenses:
+    uses: ./.github/workflows/check-third-party-licenses.yml
+
   debug-config:
     needs: config
     runs-on: ubuntu-latest

--- a/.github/workflows/check-third-party-licenses.yml
+++ b/.github/workflows/check-third-party-licenses.yml
@@ -1,17 +1,14 @@
 name: Check third-party licenses
 
 # The bundled notices in thirdparty/licenses/ are hand-curated and guarded by a
-# version tripwire (scripts/check_third_party_licenses.py). It gates every push and
-# PR: the check needs no build, no submodule checkout and no network, so the job costs
-# a runner slot and a few seconds, and catching a dependency bump on the PR that makes
-# it is far cheaper than rediscovering it at release. The daily run still covers drift
-# that lands without a version change, and release remains a hard gate.
-# Run manually any time via "Run workflow".
+# version tripwire (scripts/check_third_party_licenses.py). Build Test Distribute calls
+# this workflow on every push and PR, so a dependency bump is caught on the PR that makes
+# it, without a second workflow run per commit: the check needs no build, no submodule
+# checkout and no network, so it costs a runner slot and a few seconds. The daily run
+# still covers drift that lands without a version change, and release remains a hard
+# gate. Run manually any time via "Run workflow".
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_call:
   schedule:
     - cron: '23 5 * * *'   # daily, 05:23 UTC
   release:


### PR DESCRIPTION
### Problem

Every commit to `master` (and every PR) started **two** workflow runs: `Build Test Distribute` and `Check third-party licenses`. The second one existed as a separate workflow only because it repeated the same `push: [master]` / `pull_request: [master]` triggers.

### Change

- `check-third-party-licenses.yml`: `push` + `pull_request` → `workflow_call`. The `schedule` (daily 05:23 UTC), `release: published` and `workflow_dispatch` triggers stay, because `Build Test Distribute` has neither a `release` trigger nor that cron, so the release hard gate and the daily drift check must keep firing from this file.
- `build-test-distribute.yml`: call it as a job with no `needs:`, so it starts immediately in parallel with `config` and is not gated by any build leg.

Calling the reusable workflow rather than inlining the two steps keeps a single definition of the check for all four trigger paths.

### Effect

One workflow run per commit. The check itself is unchanged — same job, same script, same runner cost of a few seconds; on pushes and PRs it now reports as `check-third-party-licenses / check-licenses` inside the `Build Test Distribute` run.

Checked before writing this: `master` has no required status checks (neither in the `master` ruleset nor in classic branch protection), so the check name change gates nothing. `Build Test Distribute` has no `concurrency:` block, so cancellation behaviour is unchanged, and its `on:` has no `paths-ignore`, so the job runs on exactly the commits the standalone workflow ran on before. The called workflow's `contents: read` is more restrictive than the caller's permissions, as `workflow_call` requires.
