### PR TITLE
CI: Take C bindings from the shared workflow in manual docs

### DIFF
--- a/.github/workflows/update-docs-manual.yml
+++ b/.github/workflows/update-docs-manual.yml
@@ -99,20 +99,6 @@ jobs:
           path: ./scripts/wheel/meshlib/meshlib/*.pyi
           retention-days: 1
 
-      - name: Generate C bindings
-        env:
-          CXX: ${{ env.CXX-COMPILER }}
-        run: make -f scripts/mrbind/generate.mk TARGET=c -B --trace PCH_CODEGEN=0
-
-      - name: Upload C bindings headers
-        uses: actions/upload-artifact@v7
-        with:
-          name: CBindings
-          path: |
-            ./source/MeshLibC2/include
-            ./source/MeshLibC2Cuda/include
-          retention-days: 1
-
       - name: Generate C# bindings # generate only sources
         run: make -f scripts/mrbind/generate.mk TARGET=csharp -B --trace generate
 
@@ -130,8 +116,17 @@ jobs:
       upload_artifacts: false
       definitions_only: true
 
+  # The `CBindings` artifact comes from the shared workflow, same as in pip-build.yml and
+  # build-test-distribute.yml. Generating it inside `create-stubs` doesn't work: `TARGET=c`
+  # targets Emscripten, and host headers are only usable on Linux x64, so on this arm64 runner
+  # it needs an Emscripten SDK that the ubuntu22 image doesn't carry.
+  generate-c-bindings:
+    uses: ./.github/workflows/generate-c-bindings.yml
+    with:
+      docker_image_tag: latest
+
   update-dev-documentation:
-    needs: [ create-stubs, generate-wasm-definitions ]
+    needs: [ create-stubs, generate-wasm-definitions, generate-c-bindings ]
     uses: ./.github/workflows/update-docs.yml
     with:
       output_folder: ${{ inputs.output_folder }}


### PR DESCRIPTION
Follow-up to #6536, which unblocked the Python bindings in `update-docs-manual.yml`. The next step then failed ([run](https://github.com/MeshInspector/MeshLib/actions/runs/31122531743/job/92685972514)):

```
Pretending that the target platform is Emscripten? YES
Use host headers instead of the Emscripten ones? NO
scripts/mrbind/generate.mk:137: *** Unable to find Emscripten SDK, ensure you have `em++` in the PATH.
```

`TARGET=c` targets Emscripten, and `EM_USE_HOST_HEADERS` only defaults to 1 on Linux x86_64 (#6226). `create-stubs` runs on `ubuntu-24.04-arm`, so it falls through to needing a real Emscripten SDK, which the `meshlib-ubuntu22-arm64` image doesn't carry.

`generate-c-bindings.yml` already produces the `CBindings` artifact from an Emscripten-capable image, and `pip-build.yml`, `build-test-distribute.yml` and `distro-release.yml` all consume it that way. This does the same here instead of generating inline, so the manual path stops drifting from the one that publishes release docs — and it feeds `update-docs.yml` the same artifact shape release docs are already built from.

Both this and #6536 come from the same drift: this workflow duplicates build logic the shared workflows own, and hadn't run since February, so #6255 and #6226 rotted it silently in between.

Validation: dispatch `update-docs-manual.yml` after merge — that run doubles as the pending docs refresh for the release-docs miss fixed by #6504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)