### PR TITLE
PlanarTriangulation: reusable ISweepLineCache for the sweep-line triangulation

### DIFF
--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -299,25 +299,22 @@ struct SweepLineParams
     Vector<int, FaceId>* outFaceWinding{ nullptr };
 };
 
-// the sweep-line triangulator and the only implementation of ISweepLineCache: an instance handed out
-// by makeSweepLineCache() is a queue whose internal buffers survive between runs
-class SweepLineQueue final : public ISweepLineCache
+// the sweep-line triangulator
+class SweepLineQueue
 {
 public:
-    // an instance is reusable: init() prepares it for the next run keeping the buffers of the previous one
-    SweepLineQueue() = default;
+    struct Cache; // all the buffers reused between runs, defined below
 
-    // resets the state of the previous run, if any (all internal buffers keep their capacity),
+    // the queue works on the given cache, reusing the capacity of the buffers left there by previous runs
+    explicit SweepLineQueue( Cache& cache ) : cache_( cache ) {}
+
+    // resets the state of the previous run, if any (all cache buffers keep their capacity),
     // and makes initial mesh which simply contain input contours as edges
     // if params.holesVertId is null - merge all vertices with same coordinates
     // otherwise only merge the ones with same initial vertId
     void init( SweepLinePredicates predicates, std::vector<int> contourSizes, const SweepLineParams& params );
 
-    // storage for the projected points of the predicates built for this queue's runs;
-    // kept here only so that a cached queue reuses the buffer's capacity across runs
-    const std::shared_ptr<Vector<Vector2i, VertId>>& pts2Buffer() { return pts2Buffer_; }
-
-    size_t vertSize() const { return tp_.vertSize(); }
+    size_t vertSize() const { return cache_.tp.vertSize(); }
     std::optional<Mesh> run( IntersectionsMap* interMap = nullptr );
 
     // same as run(), but does not create a Mesh: the result connectivity stays in the internal
@@ -330,11 +327,7 @@ public:
     void makeMonotone();
     void triangulate();
 private:
-    MeshTopology tp_;
-    VertCoords pointsCache_; // scratch positions of tp_'s vertices for the Delone flips in triangulate()
     SweepLinePredicates predicates_;
-    std::shared_ptr<Vector<Vector2i, VertId>> pts2Buffer_ = std::make_shared<Vector<Vector2i, VertId>>();
-
     SweepLineParams params_;
 
 // INITIALIZATION CLASS BLOCK
@@ -376,11 +369,8 @@ private:
 
         EdgeWindingInfo() {} // Make `Vector` notice register the default constructor. :/
     };
-    Vector<EdgeWindingInfo, UndirectedEdgeId> windingInfo_;
-
     void calculateWinding_();
 
-    std::vector<int> reflexChainCache_;
     void triangulateMonotoneBlock_( EdgeId holeEdgeId );
 
 // INTERSECTION CLASS BLOCK
@@ -390,20 +380,10 @@ private:
         EdgeId upper;
         VertId vId;
     };
-    std::vector<Intersection> intersections_;
-
     void setupStartVertices_();
-    // scratch bitset of setupStartVertices_()
-    VertBitSet startVerticesCache_;
-    // sorted vertices with no left-going edges
-    std::vector<VertId> startVerts_;
-    std::vector<EdgeId> startVertLowestRight_;
-    // index of next `startVerts_`
+    // index of next `startVerts`
     int startVertIndex_{ 0 };
-
-    // sorted vertices
-    std::vector<VertId> sortedVerts_;
-    // index of next `startVerts_`
+    // index of next `sortedVerts`
     int sortedVertIndex_{ 0 };
 
     struct SweepEdgeInfo
@@ -417,36 +397,29 @@ private:
         Info lowerInfo;
         Info upperInfo;
     };
-    // edges that are intersected by sweep line ordered by position
-    std::vector<SweepEdgeInfo> activeSweepEdges_;
-
     enum class EventType
     {
-        Start, // item from `startVerts_`
-        Destination, // one of the `activeSweepEdges_` destination vertices
-        Intersection // intersection of two edges from `activeSweepEdges_`
+        Start, // item from `cache_.startVerts`
+        Destination, // one of the `cache_.activeSweepEdges` destination vertices
+        Intersection // intersection of two edges from `cache_.activeSweepEdges`
     };
     struct Event
     {
         // type of event
         EventType type{ EventType::Start };
         // EventType::Start - position to inject start edges
-        // EventType::Destination - id of lowest edge (with this destenation) in `activeSweepEdges_`
-        // EventType::Intersection - id of lowest edge (with this intersection) in `activeSweepEdges_`
+        // EventType::Destination - id of lowest edge (with this destenation) in `cache_.activeSweepEdges`
+        // EventType::Intersection - id of lowest edge (with this intersection) in `cache_.activeSweepEdges`
         int index{ -1 }; // -1 means that we finished queue
         // return true if event is valid
         operator bool() const { return index != -1; }
     };
-    // ordered events after intersection stage
-    std::vector<Event> events_;
     // get next queue element
     Event getNext_();
 
     void invalidateIntersection_( int indexLower );
     bool isIntersectionValid_( int indexLower );
 
-    std::vector<SweepEdgeInfo> rightGoingCache_;
-    std::vector<EdgeId> findClosestCache_;
     int findStartIndex_();
     void updateStartRightGoingCache_();
     void processStartEvent_( int index );
@@ -460,18 +433,48 @@ private:
         operator bool() const { return vId.valid(); }
     };
     using IntersectionMap = HashMap<EdgePair, IntersectionInfo>;
-    IntersectionMap intersectionsMap_; // needed to prevent recreation of same vertices multiple times
     // whether segments (aOrg,aDest) and (bOrg,bDest) properly intersect, via the injected ccw
     bool doSegmentSegmentIntersect_( VertId aOrg, VertId aDest, VertId bOrg, VertId bDest ) const;
     void checkIntersection_( int index, bool lower );
     void checkIntersection_( int indexLower );
+
+public:
+    // all the buffers the sweep-line triangulation reuses between runs sharing the cache;
+    // the only implementation of ISweepLineCache
+    struct Cache final : public ISweepLineCache
+    {
+        MeshTopology tp;
+        VertCoords pointsCache; // scratch positions of tp's vertices for the Delone flips in triangulate()
+        // storage for the projected points of the predicates built for the runs on this cache
+        std::shared_ptr<Vector<Vector2i, VertId>> pts2Buffer = std::make_shared<Vector<Vector2i, VertId>>();
+        Vector<EdgeWindingInfo, UndirectedEdgeId> windingInfo;
+        std::vector<int> reflexChainCache;
+        std::vector<Intersection> intersections;
+        // scratch bitset of setupStartVertices_()
+        VertBitSet startVerticesCache;
+        // sorted vertices with no left-going edges
+        std::vector<VertId> startVerts;
+        std::vector<EdgeId> startVertLowestRight;
+        // sorted vertices
+        std::vector<VertId> sortedVerts;
+        // edges that are intersected by sweep line ordered by position
+        std::vector<SweepEdgeInfo> activeSweepEdges;
+        // ordered events after intersection stage
+        std::vector<Event> events;
+        std::vector<SweepEdgeInfo> rightGoingCache;
+        std::vector<EdgeId> findClosestCache;
+        IntersectionMap intersectionsMap; // needed to prevent recreation of same vertices multiple times
+    };
+
+private:
+    Cache& cache_;
 };
 
 ISweepLineCache::~ISweepLineCache() = default;
 
 std::unique_ptr<ISweepLineCache> makeSweepLineCache()
 {
-    return std::make_unique<SweepLineQueue>();
+    return std::make_unique<SweepLineQueue::Cache>();
 }
 
 void SweepLineQueue::init( SweepLinePredicates predicates, std::vector<int> contourSizes, const SweepLineParams& params )
@@ -479,17 +482,17 @@ void SweepLineQueue::init( SweepLinePredicates predicates, std::vector<int> cont
     predicates_ = std::move( predicates );
     params_ = params;
     stage_ = Stage::Init;
-    tp_.clear(); // empty husk if the previous run() moved it out, filled if runTopology() kept it
-    windingInfo_.clear(); // stale winding modifiers would leak into this run through resize()
-    intersections_.clear();
-    intersectionsMap_.clear(); // keyed by the previous run's edge ids
-    startVerts_.clear();
-    startVertLowestRight_.clear();
+    cache_.tp.clear(); // empty husk if the previous run() moved it out, filled if runTopology() kept it
+    cache_.windingInfo.clear(); // stale winding modifiers would leak into this run through resize()
+    cache_.intersections.clear();
+    cache_.intersectionsMap.clear(); // keyed by the previous run's edge ids
+    cache_.startVerts.clear();
+    cache_.startVertLowestRight.clear();
     startVertIndex_ = 0;
-    sortedVerts_.clear(); // mergeSamePoints_() appends
+    cache_.sortedVerts.clear(); // mergeSamePoints_() appends
     sortedVertIndex_ = 0;
-    activeSweepEdges_.clear();
-    events_.clear();
+    cache_.activeSweepEdges.clear();
+    cache_.events.clear();
 
     initMeshByContours_( contourSizes );
     mergeSamePoints_( params.holesVertId );
@@ -502,8 +505,8 @@ std::optional<MR::Mesh> SweepLineQueue::run( IntersectionsMap* interMap )
         return {};
     // materialize the result, donating the cached buffers to it
     Mesh mesh;
-    mesh.topology = std::move( tp_ );
-    mesh.points = std::move( pointsCache_ );
+    mesh.topology = std::move( cache_.tp );
+    mesh.points = std::move( cache_.pointsCache );
     return mesh;
 }
 
@@ -515,15 +518,15 @@ MeshTopology* SweepLineQueue::runTopology( IntersectionsMap* interMap )
     injectIntersections( interMap );
     makeMonotone();
     triangulate();
-    return &tp_;
+    return &cache_.tp;
 }
 
 bool SweepLineQueue::findIntersections()
 {
     MR_TIMER;
     stage_ = Stage::Intersections;
-    events_.clear();
-    events_.reserve( tp_.numValidVerts() * 2 );
+    cache_.events.clear();
+    cache_.events.reserve( cache_.tp.numValidVerts() * 2 );
     while ( auto event = getNext_() )
     {
         if ( event.type == EventType::Start )
@@ -536,7 +539,7 @@ bool SweepLineQueue::findIntersections()
                 return false;
             processIntersectionEvent_( event.index );
         }
-        events_.push_back( event );
+        cache_.events.push_back( event );
     }
     return true;
 }
@@ -546,23 +549,23 @@ void SweepLineQueue::injectIntersections( IntersectionsMap* interMap )
     MR_TIMER;
 
     if ( interMap )
-        interMap->map.resize( intersections_.size() );
+        interMap->map.resize( cache_.intersections.size() );
 
-    windingInfo_.resize( windingInfo_.size() + intersections_.size() * 2 );
-    Vector<EdgeId, UndirectedEdgeId> oldToFirstNewEdgeMap( tp_.undirectedEdgeSize() );
+    cache_.windingInfo.resize( cache_.windingInfo.size() + cache_.intersections.size() * 2 );
+    Vector<EdgeId, UndirectedEdgeId> oldToFirstNewEdgeMap( cache_.tp.undirectedEdgeSize() );
 
     if ( interMap )
     {
         // create mapping if needed
-        for ( const auto& inter : intersections_ )
+        for ( const auto& inter : cache_.intersections )
         {
             auto ind = size_t( inter.vId ) - interMap->shift;
             assert( ind < interMap->map.size() );
             auto& mapVal = interMap->map[ind];
-            mapVal.lOrg = tp_.org( inter.lower );
-            mapVal.lDest = tp_.dest( inter.lower );
-            mapVal.uOrg = tp_.org( inter.upper );
-            mapVal.uDest = tp_.dest( inter.upper );
+            mapVal.lOrg = cache_.tp.org( inter.lower );
+            mapVal.lDest = cache_.tp.dest( inter.lower );
+            mapVal.uOrg = cache_.tp.org( inter.upper );
+            mapVal.uDest = cache_.tp.dest( inter.upper );
 
             auto iP = predicates_.point( inter.vId );
             auto lO = predicates_.point( mapVal.lOrg );
@@ -585,40 +588,40 @@ void SweepLineQueue::injectIntersections( IntersectionsMap* interMap )
         }
     }
 
-    for ( const auto& inter : intersections_ )
+    for ( const auto& inter : cache_.intersections )
     {
         // split edges
         // set new edge ids to the left and save old to the right
         // because of intersections order
 
         // prev lower
-        auto pl = tp_.prev( inter.lower );
+        auto pl = cache_.tp.prev( inter.lower );
         // lower left
-        auto ll = tp_.makeEdge();
+        auto ll = cache_.tp.makeEdge();
         if ( inter.lower.odd() )
             ll = ll.sym(); // oddity should stay the same (for winding number)
-        tp_.splice( pl, inter.lower );
-        tp_.splice( pl, ll );
-        tp_.splice( inter.lower, ll.sym() );
+        cache_.tp.splice( pl, inter.lower );
+        cache_.tp.splice( pl, ll );
+        cache_.tp.splice( inter.lower, ll.sym() );
 
         // prev upper
-        auto pu = tp_.prev( inter.upper );
+        auto pu = cache_.tp.prev( inter.upper );
         // upper left
-        auto ul = tp_.makeEdge();
+        auto ul = cache_.tp.makeEdge();
         if ( inter.upper.odd() )
             ul = ul.sym(); // oddity should stay the same (for winding number)
 
-        tp_.splice( pu, inter.upper );
-        tp_.splice( pu, ul );
+        cache_.tp.splice( pu, inter.upper );
+        cache_.tp.splice( pu, ul );
 
-        tp_.splice( inter.lower, ul.sym() );
-        tp_.splice( ll.sym(), inter.upper );
+        cache_.tp.splice( inter.lower, ul.sym() );
+        cache_.tp.splice( ll.sym(), inter.upper );
 
-        tp_.setOrg( inter.upper, inter.vId );
+        cache_.tp.setOrg( inter.upper, inter.vId );
 
         // winding modifiers of new parts should be same as old parts
-        windingInfo_[ll.undirected()].windingModifier = windingInfo_[inter.lower.undirected()].windingModifier;
-        windingInfo_[ul.undirected()].windingModifier = windingInfo_[inter.upper.undirected()].windingModifier;
+        cache_.windingInfo[ll.undirected()].windingModifier = cache_.windingInfo[inter.lower.undirected()].windingModifier;
+        cache_.windingInfo[ul.undirected()].windingModifier = cache_.windingInfo[inter.upper.undirected()].windingModifier;
 
         auto& otfnL = oldToFirstNewEdgeMap[inter.lower.undirected()];
         if ( !otfnL )
@@ -627,7 +630,7 @@ void SweepLineQueue::injectIntersections( IntersectionsMap* interMap )
         if ( !otfnU )
             otfnU = ul;
     }
-    for ( auto& e : startVertLowestRight_ )
+    for ( auto& e : cache_.startVertLowestRight )
         if ( auto newE = oldToFirstNewEdgeMap[e.undirected()] )
             e = newE;
 }
@@ -638,7 +641,7 @@ void SweepLineQueue::makeMonotone()
     stage_ = Stage::Monotonation;
     startVertIndex_ = 0;
     sortedVertIndex_ = 0;
-    for ( auto event : events_ )
+    for ( auto event : cache_.events )
     {
         if ( event.type == EventType::Start )
             processStartEvent_( event.index );
@@ -653,57 +656,57 @@ void SweepLineQueue::triangulate()
     MR_TIMER;
     stage_ = Stage::Triangulation;
     if ( !params_.needOutline )
-        reflexChainCache_.reserve( 256 ); // reserve once to have less allocations later
-    for ( auto e : undirectedEdges( tp_ ) )
+        cache_.reflexChainCache.reserve( 256 ); // reserve once to have less allocations later
+    for ( auto e : undirectedEdges( cache_.tp ) )
     {
-        if ( e >= windingInfo_.size() )
+        if ( e >= cache_.windingInfo.size() )
             continue;
-        const auto& windInfo = windingInfo_[e];
+        const auto& windInfo = cache_.windingInfo[e];
         if ( !windInfo.inside( params_.windingMode ) )
             continue;
         auto dirE = EdgeId( e << 1 );
         if ( !windInfo.rightGoing )
             dirE = dirE.sym();
-        if ( tp_.left( dirE ) )
+        if ( cache_.tp.left( dirE ) )
             continue;
 
-        const auto firstBlockFace = FaceId( tp_.faceSize() );
+        const auto firstBlockFace = FaceId( cache_.tp.faceSize() );
         if ( !params_.needOutline )
             triangulateMonotoneBlock_( dirE ); // triangulate
         else
-            tp_.setLeft( dirE, tp_.addFaceId() ); // mark present
+            cache_.tp.setLeft( dirE, cache_.tp.addFaceId() ); // mark present
         if ( params_.outFaceWinding ) // all faces of one monotone block are in the region with same winding number
-            params_.outFaceWinding->autoResizeSet( firstBlockFace, tp_.faceSize() - firstBlockFace, windInfo.winding );
+            params_.outFaceWinding->autoResizeSet( firstBlockFace, cache_.tp.faceSize() - firstBlockFace, windInfo.winding );
     }
-    pointsCache_.resize( tp_.vertSize() );
-    BitSetParallelFor( tp_.getValidVerts(), [&] ( VertId v )
+    cache_.pointsCache.resize( cache_.tp.vertSize() );
+    BitSetParallelFor( cache_.tp.getValidVerts(), [&] ( VertId v )
     {
-        pointsCache_[v] = predicates_.point( v );
+        cache_.pointsCache[v] = predicates_.point( v );
     } );
     // Delone flips could cross a contour edge between two inside regions and smear the face winding map
     if ( !params_.needOutline && !params_.outFaceWinding )
     {
         // borrow the cached topology and points into a temporary mesh for the flips (moves, no copies)
         Mesh mesh;
-        mesh.topology = std::move( tp_ );
-        mesh.points = std::move( pointsCache_ );
+        mesh.topology = std::move( cache_.tp );
+        mesh.points = std::move( cache_.pointsCache );
         makeDeloneEdgeFlips( mesh, {}, 300 );
-        tp_ = std::move( mesh.topology );
-        pointsCache_ = std::move( mesh.points );
+        cache_.tp = std::move( mesh.topology );
+        cache_.pointsCache = std::move( mesh.points );
     }
 }
 
 void SweepLineQueue::setupStartVertices_()
 {
-    auto& startVertices = startVerticesCache_;
+    auto& startVertices = cache_.startVerticesCache;
     startVertices.clear();
-    startVertices.resize( tp_.vertSize() );
-    BitSetParallelFor( tp_.getValidVerts(), [&] ( VertId v )
+    startVertices.resize( cache_.tp.vertSize() );
+    BitSetParallelFor( cache_.tp.getValidVerts(), [&] ( VertId v )
     {
         bool startVert = true;
-        for ( auto e : orgRing( tp_, v ) )
+        for ( auto e : orgRing( cache_.tp, v ) )
         {
-            if ( predicates_.less( tp_.dest( e ), v ) )
+            if ( predicates_.less( cache_.tp.dest( e ), v ) )
             {
                 startVert = false;
                 break;
@@ -712,13 +715,13 @@ void SweepLineQueue::setupStartVertices_()
         if ( startVert )
             startVertices.set( v );
     } );
-    startVerts_.resize( startVertices.count() );
-    startVertLowestRight_.resize( startVerts_.size() );
+    cache_.startVerts.resize( startVertices.count() );
+    cache_.startVertLowestRight.resize( cache_.startVerts.size() );
     int i = 0;
     for ( auto v : startVertices )
-        startVerts_[i++] = v;
+        cache_.startVerts[i++] = v;
 
-    std::sort( startVerts_.begin(), startVerts_.end(), [&] ( VertId l, VertId r )
+    std::sort( cache_.startVerts.begin(), cache_.startVerts.end(), [&] ( VertId l, VertId r )
     {
         return predicates_.less( l, r );
     } );
@@ -730,10 +733,10 @@ SweepLineQueue::Event SweepLineQueue::getNext_()
     int minInterIndex = -1;
 
     VertId nextVertId;
-    for ( ; sortedVertIndex_ < sortedVerts_.size();)
+    for ( ; sortedVertIndex_ < cache_.sortedVerts.size();)
     {
-        nextVertId = sortedVerts_[sortedVertIndex_];
-        if ( tp_.hasVert( nextVertId ) )
+        nextVertId = cache_.sortedVerts[sortedVertIndex_];
+        if ( cache_.tp.hasVert( nextVertId ) )
             break;
         else
         {
@@ -747,10 +750,10 @@ SweepLineQueue::Event SweepLineQueue::getNext_()
 
     VertId minInter;
     VertId minDestId;
-    for ( int i = 0; i < activeSweepEdges_.size(); ++i )
+    for ( int i = 0; i < cache_.activeSweepEdges.size(); ++i )
     {
-        const auto& activeSweep = activeSweepEdges_[i];
-        VertId destId = tp_.dest( activeSweep.edgeId );
+        const auto& activeSweep = cache_.activeSweepEdges[i];
+        VertId destId = cache_.tp.dest( activeSweep.edgeId );
         if ( !minDestId && destId == nextVertId )
         {
             minDestId = destId; // we need first
@@ -768,8 +771,8 @@ SweepLineQueue::Event SweepLineQueue::getNext_()
 
     if ( minInter )
     {
-        if ( tp_.dest( activeSweepEdges_[minInterIndex].edgeId ) == nextVertId ||
-            tp_.dest( activeSweepEdges_[minInterIndex + 1].edgeId ) == nextVertId ||
+        if ( cache_.tp.dest( cache_.activeSweepEdges[minInterIndex].edgeId ) == nextVertId ||
+            cache_.tp.dest( cache_.activeSweepEdges[minInterIndex + 1].edgeId ) == nextVertId ||
             predicates_.less( minInter, nextVertId ) )
         {
             outEvent.type = EventType::Intersection;
@@ -778,9 +781,9 @@ SweepLineQueue::Event SweepLineQueue::getNext_()
         }
     }
 
-    if ( startVertIndex_ < startVerts_.size() )
+    if ( startVertIndex_ < cache_.startVerts.size() )
     {
-        if ( nextVertId == startVerts_[startVertIndex_] )
+        if ( nextVertId == cache_.startVerts[startVertIndex_] )
         {
             outEvent.type = EventType::Start;
             outEvent.index = findStartIndex_();
@@ -792,64 +795,64 @@ SweepLineQueue::Event SweepLineQueue::getNext_()
 
 void SweepLineQueue::invalidateIntersection_( int indexLower )
 {
-    if ( indexLower >= 0 && indexLower < activeSweepEdges_.size() )
-        activeSweepEdges_[indexLower].upperInfo.interVertId = {};
-    if ( indexLower + 1 >= 0 && indexLower + 1 < activeSweepEdges_.size() )
-        activeSweepEdges_[indexLower + 1].lowerInfo.interVertId = {};
+    if ( indexLower >= 0 && indexLower < cache_.activeSweepEdges.size() )
+        cache_.activeSweepEdges[indexLower].upperInfo.interVertId = {};
+    if ( indexLower + 1 >= 0 && indexLower + 1 < cache_.activeSweepEdges.size() )
+        cache_.activeSweepEdges[indexLower + 1].lowerInfo.interVertId = {};
 }
 
 bool SweepLineQueue::isIntersectionValid_( int indexLower )
 {
-    if ( indexLower < 0 || indexLower + 1 >= activeSweepEdges_.size() )
+    if ( indexLower < 0 || indexLower + 1 >= cache_.activeSweepEdges.size() )
         return false;
-    if ( !activeSweepEdges_[indexLower].upperInfo.interVertId )
+    if ( !cache_.activeSweepEdges[indexLower].upperInfo.interVertId )
         return false;
-    return activeSweepEdges_[indexLower].upperInfo.interVertId == activeSweepEdges_[indexLower + 1].lowerInfo.interVertId;
+    return cache_.activeSweepEdges[indexLower].upperInfo.interVertId == cache_.activeSweepEdges[indexLower + 1].lowerInfo.interVertId;
 }
 
 int SweepLineQueue::findStartIndex_()
 {
     int activeVPosition{ INT_MAX };// index of first edge, under activeV (INT_MAX - all edges are lower, -1 - all edges are upper)
-    const VertId activeV = startVerts_[startVertIndex_];
-    for ( int i = 0; i < activeSweepEdges_.size(); ++i )
+    const VertId activeV = cache_.startVerts[startVertIndex_];
+    for ( int i = 0; i < cache_.activeSweepEdges.size(); ++i )
     {
-        const VertId org = tp_.org( activeSweepEdges_[i].edgeId );
-        const VertId dest = tp_.dest( activeSweepEdges_[i].edgeId );
+        const VertId org = cache_.tp.org( cache_.activeSweepEdges[i].edgeId );
+        const VertId dest = cache_.tp.dest( cache_.activeSweepEdges[i].edgeId );
 
         if ( activeVPosition == INT_MAX && predicates_.ccw( org, activeV, dest ) )
             activeVPosition = i - 1;
     }
 
-    return activeVPosition == INT_MAX ? int( activeSweepEdges_.size() ) : activeVPosition + 1;
+    return activeVPosition == INT_MAX ? int( cache_.activeSweepEdges.size() ) : activeVPosition + 1;
 }
 
 void SweepLineQueue::updateStartRightGoingCache_()
 {
-    rightGoingCache_.clear();
+    cache_.rightGoingCache.clear();
     if ( stage_ == Stage::Intersections )
     {
-        findClosestCache_.clear();
-        findClosestCache_.emplace_back( EdgeId{} );
+        cache_.findClosestCache.clear();
+        cache_.findClosestCache.emplace_back( EdgeId{} );
     }
-    for ( auto e : orgRing( tp_, startVerts_[startVertIndex_] ) )
+    for ( auto e : orgRing( cache_.tp, cache_.startVerts[startVertIndex_] ) )
     {
-        rightGoingCache_.emplace_back( SweepEdgeInfo{ .edgeId = e } );
+        cache_.rightGoingCache.emplace_back( SweepEdgeInfo{ .edgeId = e } );
         if ( stage_ == Stage::Intersections )
-            findClosestCache_.push_back( e );
+            cache_.findClosestCache.push_back( e );
     }
 
     int pos = -1;
     if ( stage_ == Stage::Intersections )
     {
-        pos = findClosestToFront( tp_, predicates_, findClosestCache_, true ) - 1;
+        pos = findClosestToFront( cache_.tp, predicates_, cache_.findClosestCache, true ) - 1;
         assert( pos > -1 );
-        startVertLowestRight_[startVertIndex_] = rightGoingCache_[pos].edgeId;
+        cache_.startVertLowestRight[startVertIndex_] = cache_.rightGoingCache[pos].edgeId;
     }
     else
     {
-        for ( int i = 0; i < rightGoingCache_.size(); ++i )
+        for ( int i = 0; i < cache_.rightGoingCache.size(); ++i )
         {
-            if ( rightGoingCache_[i].edgeId != startVertLowestRight_[startVertIndex_] )
+            if ( cache_.rightGoingCache[i].edgeId != cache_.startVertLowestRight[startVertIndex_] )
                 continue;
             pos = i;
             break;
@@ -857,7 +860,7 @@ void SweepLineQueue::updateStartRightGoingCache_()
         assert( pos > -1 );
     }
 
-    std::rotate( rightGoingCache_.begin(), rightGoingCache_.begin() + pos, rightGoingCache_.end() );
+    std::rotate( cache_.rightGoingCache.begin(), cache_.rightGoingCache.begin() + pos, cache_.rightGoingCache.end() );
 }
 
 void SweepLineQueue::processStartEvent_( int index )
@@ -869,15 +872,15 @@ void SweepLineQueue::processStartEvent_( int index )
         invalidateIntersection_( index - 1 );
     }
 
-    if ( stage_ == Stage::Monotonation && index > 0 && index < activeSweepEdges_.size() &&
-        windingInfo_[activeSweepEdges_[index - 1].edgeId.undirected()].inside( params_.windingMode ) )
+    if ( stage_ == Stage::Monotonation && index > 0 && index < cache_.activeSweepEdges.size() &&
+        cache_.windingInfo[cache_.activeSweepEdges[index - 1].edgeId.undirected()].inside( params_.windingMode ) )
     {
         // find helper:
         // id of rightmost left vertex (it's lower edge) closest to active vertex
         // close to `helper` described here : https://www.cs.umd.edu/class/spring2020/cmsc754/Lects/lect05-triangulate.pdf
         EdgeId helperId;
-        auto& lowerLone = activeSweepEdges_[index - 1].upperInfo.loneEdgeId;
-        auto& upperLone = activeSweepEdges_[index].lowerInfo.loneEdgeId;
+        auto& lowerLone = cache_.activeSweepEdges[index - 1].upperInfo.loneEdgeId;
+        auto& upperLone = cache_.activeSweepEdges[index].lowerInfo.loneEdgeId;
         assert( lowerLone == upperLone );
         if ( lowerLone )
         {
@@ -886,25 +889,25 @@ void SweepLineQueue::processStartEvent_( int index )
         }
         else
         {
-            auto lowerOrg = tp_.org( activeSweepEdges_[index - 1].edgeId );
-            auto upperOrg = tp_.org( activeSweepEdges_[index].edgeId );
+            auto lowerOrg = cache_.tp.org( cache_.activeSweepEdges[index - 1].edgeId );
+            auto upperOrg = cache_.tp.org( cache_.activeSweepEdges[index].edgeId );
             if ( predicates_.less( lowerOrg, upperOrg ) )
-                helperId = tp_.prev( activeSweepEdges_[index].edgeId );
+                helperId = cache_.tp.prev( cache_.activeSweepEdges[index].edgeId );
             else
-                helperId = activeSweepEdges_[index - 1].edgeId;
+                helperId = cache_.activeSweepEdges[index - 1].edgeId;
         }
         assert( helperId );
 
-        auto newEdge = tp_.makeEdge();
-        if ( activeSweepEdges_[index - 1].edgeId.odd() )
+        auto newEdge = cache_.tp.makeEdge();
+        if ( cache_.activeSweepEdges[index - 1].edgeId.odd() )
             newEdge = newEdge.sym();
-        tp_.splice( helperId, newEdge );
-        tp_.splice( rightGoingCache_.back().edgeId, newEdge.sym() );
+        cache_.tp.splice( helperId, newEdge );
+        cache_.tp.splice( cache_.rightGoingCache.back().edgeId, newEdge.sym() );
 
-        windingInfo_.autoResizeSet( newEdge.undirected(), windingInfo_[activeSweepEdges_[index - 1].edgeId.undirected()] );
+        cache_.windingInfo.autoResizeSet( newEdge.undirected(), cache_.windingInfo[cache_.activeSweepEdges[index - 1].edgeId.undirected()] );
     }
 
-    activeSweepEdges_.insert( activeSweepEdges_.begin() + index, rightGoingCache_.begin(), rightGoingCache_.end() );
+    cache_.activeSweepEdges.insert( cache_.activeSweepEdges.begin() + index, cache_.rightGoingCache.begin(), cache_.rightGoingCache.end() );
 
     if ( stage_ == Stage::Intersections )
     {
@@ -920,61 +923,61 @@ void SweepLineQueue::processDestenationEvent_( int index )
 {
     int minIndex = index;
     int maxIndex = index;
-    for ( int i = minIndex + 1; i < activeSweepEdges_.size(); ++i )
+    for ( int i = minIndex + 1; i < cache_.activeSweepEdges.size(); ++i )
     {
-        if ( tp_.dest( activeSweepEdges_[index].edgeId ) != tp_.dest( activeSweepEdges_[i].edgeId ) )
+        if ( cache_.tp.dest( cache_.activeSweepEdges[index].edgeId ) != cache_.tp.dest( cache_.activeSweepEdges[i].edgeId ) )
             break;
         maxIndex = i;
     }
-    rightGoingCache_.clear();
-    for ( auto e : orgRing0( tp_, activeSweepEdges_[minIndex].edgeId.sym() ) )
+    cache_.rightGoingCache.clear();
+    for ( auto e : orgRing0( cache_.tp, cache_.activeSweepEdges[minIndex].edgeId.sym() ) )
     {
-        if ( e == activeSweepEdges_[maxIndex].edgeId.sym() )
+        if ( e == cache_.activeSweepEdges[maxIndex].edgeId.sym() )
             break;
-        rightGoingCache_.emplace_back( SweepEdgeInfo{ .edgeId = e } );
+        cache_.rightGoingCache.emplace_back( SweepEdgeInfo{ .edgeId = e } );
     }
     int numLeft = maxIndex - minIndex + 1;
-    int numRight = int( rightGoingCache_.size() );
-    EdgeId lowestLeft = activeSweepEdges_[minIndex].edgeId;
+    int numRight = int( cache_.rightGoingCache.size() );
+    EdgeId lowestLeft = cache_.activeSweepEdges[minIndex].edgeId;
     if ( stage_ == Stage::Monotonation )
     {
         // connect with prev lone if needed
-        for ( int i = std::max( 0, minIndex - 1 ); i < std::min( maxIndex + 1, int( activeSweepEdges_.size() ) - 1 ); ++i )
+        for ( int i = std::max( 0, minIndex - 1 ); i < std::min( maxIndex + 1, int( cache_.activeSweepEdges.size() ) - 1 ); ++i )
         {
-            auto& lowerLone = activeSweepEdges_[i].upperInfo.loneEdgeId;
-            auto& upperLone = activeSweepEdges_[i + 1].lowerInfo.loneEdgeId;
+            auto& lowerLone = cache_.activeSweepEdges[i].upperInfo.loneEdgeId;
+            auto& upperLone = cache_.activeSweepEdges[i + 1].lowerInfo.loneEdgeId;
             assert( lowerLone == upperLone );
             if ( !lowerLone )
                 continue;
 
             EdgeId connectorEdgeId;
             if ( i < maxIndex )
-                connectorEdgeId = activeSweepEdges_[i + 1].edgeId.sym();
+                connectorEdgeId = cache_.activeSweepEdges[i + 1].edgeId.sym();
             else
-                connectorEdgeId = tp_.prev( activeSweepEdges_[i].edgeId.sym() );
+                connectorEdgeId = cache_.tp.prev( cache_.activeSweepEdges[i].edgeId.sym() );
 
-            auto newEdge = tp_.makeEdge();
-            if ( activeSweepEdges_[i].edgeId.odd() )
+            auto newEdge = cache_.tp.makeEdge();
+            if ( cache_.activeSweepEdges[i].edgeId.odd() )
                 newEdge = newEdge.sym();
-            tp_.splice( lowerLone, newEdge );
-            tp_.splice( connectorEdgeId, newEdge.sym() );
+            cache_.tp.splice( lowerLone, newEdge );
+            cache_.tp.splice( connectorEdgeId, newEdge.sym() );
 
             lowerLone = upperLone = {};
 
-            windingInfo_.autoResizeSet( newEdge.undirected(), windingInfo_[activeSweepEdges_[i].edgeId.undirected()] );
+            cache_.windingInfo.autoResizeSet( newEdge.undirected(), cache_.windingInfo[cache_.activeSweepEdges[i].edgeId.undirected()] );
             if ( i == minIndex - 1 )
                 lowestLeft = newEdge;
         }
     }
     if ( numRight == 0 )
     {
-        if ( stage_ == Stage::Monotonation && minIndex > 0 && maxIndex + 1 < activeSweepEdges_.size() &&
-            windingInfo_[activeSweepEdges_[minIndex - 1].edgeId.undirected()].inside( params_.windingMode ) )
+        if ( stage_ == Stage::Monotonation && minIndex > 0 && maxIndex + 1 < cache_.activeSweepEdges.size() &&
+            cache_.windingInfo[cache_.activeSweepEdges[minIndex - 1].edgeId.undirected()].inside( params_.windingMode ) )
         {
-            activeSweepEdges_[minIndex - 1].upperInfo.loneEdgeId = lowestLeft.sym();
-            activeSweepEdges_[maxIndex + 1].lowerInfo.loneEdgeId = lowestLeft.sym();
+            cache_.activeSweepEdges[minIndex - 1].upperInfo.loneEdgeId = lowestLeft.sym();
+            cache_.activeSweepEdges[maxIndex + 1].lowerInfo.loneEdgeId = lowestLeft.sym();
         }
-        activeSweepEdges_.erase( activeSweepEdges_.begin() + minIndex, activeSweepEdges_.begin() + maxIndex + 1 );
+        cache_.activeSweepEdges.erase( cache_.activeSweepEdges.begin() + minIndex, cache_.activeSweepEdges.begin() + maxIndex + 1 );
         if ( stage_ == Stage::Intersections )
         {
             checkIntersection_( minIndex - 1, false );
@@ -984,13 +987,13 @@ void SweepLineQueue::processDestenationEvent_( int index )
     {
         for ( int i = minIndex; i < minIndex + std::min( numLeft, numRight ); ++i )
         {
-            assert( i < activeSweepEdges_.size() );
-            activeSweepEdges_[i] = rightGoingCache_[i - minIndex];
+            assert( i < cache_.activeSweepEdges.size() );
+            cache_.activeSweepEdges[i] = cache_.rightGoingCache[i - minIndex];
         }
         if ( numLeft > numRight )
-            activeSweepEdges_.erase( activeSweepEdges_.begin() + minIndex + numRight, activeSweepEdges_.begin() + maxIndex + 1 );
+            cache_.activeSweepEdges.erase( cache_.activeSweepEdges.begin() + minIndex + numRight, cache_.activeSweepEdges.begin() + maxIndex + 1 );
         else if ( numLeft < numRight )
-            activeSweepEdges_.insert( activeSweepEdges_.begin() + maxIndex + 1, rightGoingCache_.begin() + numLeft, rightGoingCache_.end() );
+            cache_.activeSweepEdges.insert( cache_.activeSweepEdges.begin() + maxIndex + 1, cache_.rightGoingCache.begin() + numLeft, cache_.rightGoingCache.end() );
 
         if ( stage_ == Stage::Intersections )
         {
@@ -1006,26 +1009,26 @@ void SweepLineQueue::processIntersectionEvent_( int index )
     bool isValid = isIntersectionValid_( index );
     if ( isValid )
     {
-        intersections_.emplace_back( Intersection{
-            .lower = activeSweepEdges_[index].edgeId,
-            .upper = activeSweepEdges_[index + 1].edgeId } );
+        cache_.intersections.emplace_back( Intersection{
+            .lower = cache_.activeSweepEdges[index].edgeId,
+            .upper = cache_.activeSweepEdges[index + 1].edgeId } );
     }
     invalidateIntersection_( index );
     if ( !isValid )
         return;
 
-    auto minEdgeId = std::min( activeSweepEdges_[index].edgeId, activeSweepEdges_[index + 1].edgeId );
-    auto maxEdgeId = std::max( activeSweepEdges_[index].edgeId, activeSweepEdges_[index + 1].edgeId );
+    auto minEdgeId = std::min( cache_.activeSweepEdges[index].edgeId, cache_.activeSweepEdges[index + 1].edgeId );
+    auto maxEdgeId = std::max( cache_.activeSweepEdges[index].edgeId, cache_.activeSweepEdges[index + 1].edgeId );
 
-    auto& interInfo = intersectionsMap_.at( { minEdgeId,maxEdgeId } );
+    auto& interInfo = cache_.intersectionsMap.at( { minEdgeId,maxEdgeId } );
     assert( !interInfo.processed );
     interInfo.processed = true;
-    intersections_.back().vId = interInfo.vId;
+    cache_.intersections.back().vId = interInfo.vId;
 
     invalidateIntersection_( index - 1 );
     invalidateIntersection_( index + 1 );
 
-    std::swap( activeSweepEdges_[index], activeSweepEdges_[index + 1] );
+    std::swap( cache_.activeSweepEdges[index], cache_.activeSweepEdges[index + 1] );
 
     checkIntersection_( index, true );
     checkIntersection_( index + 1, false );
@@ -1033,15 +1036,15 @@ void SweepLineQueue::processIntersectionEvent_( int index )
 
 void SweepLineQueue::checkIntersection_( int index, bool lower )
 {
-    if ( index < 0 || index >= activeSweepEdges_.size() )
+    if ( index < 0 || index >= cache_.activeSweepEdges.size() )
         return;
     if ( lower && index == 0 )
         return;
-    if ( !lower && index + 1 == activeSweepEdges_.size() )
+    if ( !lower && index + 1 == cache_.activeSweepEdges.size() )
         return;
     if ( lower && index >= 1 )
         return checkIntersection_( index - 1 );
-    if ( !lower && index + 1 < activeSweepEdges_.size() )
+    if ( !lower && index + 1 < cache_.activeSweepEdges.size() )
         return checkIntersection_( index );
 }
 
@@ -1060,12 +1063,12 @@ bool SweepLineQueue::doSegmentSegmentIntersect_( VertId aOrg, VertId aDest, Vert
 
 void SweepLineQueue::checkIntersection_( int i )
 {
-    assert( i >= 0 && i + 1 < activeSweepEdges_.size() );
+    assert( i >= 0 && i + 1 < cache_.activeSweepEdges.size() );
 
-    const VertId org1 = tp_.org( activeSweepEdges_[i].edgeId );
-    const VertId dest1 = tp_.dest( activeSweepEdges_[i].edgeId );
-    const VertId org2 = tp_.org( activeSweepEdges_[i + 1].edgeId );
-    const VertId dest2 = tp_.dest( activeSweepEdges_[i + 1].edgeId );
+    const VertId org1 = cache_.tp.org( cache_.activeSweepEdges[i].edgeId );
+    const VertId dest1 = cache_.tp.dest( cache_.activeSweepEdges[i].edgeId );
+    const VertId org2 = cache_.tp.org( cache_.activeSweepEdges[i + 1].edgeId );
+    const VertId dest2 = cache_.tp.dest( cache_.activeSweepEdges[i + 1].edgeId );
     bool canIntersect = org1 != org2 && dest1 != dest2;
     if ( !canIntersect || !org1 || !org2 || !dest1 || !dest2 )
         return;
@@ -1073,19 +1076,19 @@ void SweepLineQueue::checkIntersection_( int i )
     if ( !doSegmentSegmentIntersect_( org1, dest1, org2, dest2 ) )
         return;
 
-    auto minEdgeId = std::min( activeSweepEdges_[i].edgeId, activeSweepEdges_[i + 1].edgeId );
-    auto maxEdgeId = std::max( activeSweepEdges_[i].edgeId, activeSweepEdges_[i + 1].edgeId );
-    auto& interInfo = intersectionsMap_[{minEdgeId, maxEdgeId}];
+    auto minEdgeId = std::min( cache_.activeSweepEdges[i].edgeId, cache_.activeSweepEdges[i + 1].edgeId );
+    auto maxEdgeId = std::max( cache_.activeSweepEdges[i].edgeId, cache_.activeSweepEdges[i + 1].edgeId );
+    auto& interInfo = cache_.intersectionsMap[{minEdgeId, maxEdgeId}];
     if ( !interInfo )
     {
-        interInfo.vId = tp_.addVertId();
+        interInfo.vId = cache_.tp.addVertId();
         predicates_.addIntersectionPoint( interInfo.vId, org1, dest1, org2, dest2 );
     }
     else if ( interInfo.processed )
         return;
 
-    activeSweepEdges_[i].upperInfo.interVertId = interInfo.vId;
-    activeSweepEdges_[i + 1].lowerInfo.interVertId = interInfo.vId;
+    cache_.activeSweepEdges[i].upperInfo.interVertId = interInfo.vId;
+    cache_.activeSweepEdges[i + 1].lowerInfo.interVertId = interInfo.vId;
 }
 
 void SweepLineQueue::initMeshByContours_( const std::vector<int>& contourSizes )
@@ -1097,7 +1100,7 @@ void SweepLineQueue::initMeshByContours_( const std::vector<int>& contourSizes )
         {
             for ( int pointId = 0; pointId + 1 < contourSizes[contourId]; ++pointId )
             {
-                VertId v = tp_.addVertId();
+                VertId v = cache_.tp.addVertId();
                 predicates_.addInputPoint( v, contourId, pointId );
             }
         }
@@ -1121,14 +1124,14 @@ void SweepLineQueue::initMeshByContours_( const std::vector<int>& contourSizes )
 
         for ( int i = 0; i < size; ++i )
         {
-            auto newEdgeId = tp_.makeEdge();
-            tp_.setOrg( newEdgeId, VertId( firstVert + i ) );
+            auto newEdgeId = cache_.tp.makeEdge();
+            cache_.tp.setOrg( newEdgeId, VertId( firstVert + i ) );
             if ( params_.outBoundaries )
                 ( *params_.outBoundaries )[boundId][i] = newEdgeId;
         }
-        const auto& edgePerVert = tp_.edgePerVertex();
+        const auto& edgePerVert = cache_.tp.edgePerVertex();
         for ( int i = 0; i < size; ++i )
-            tp_.splice( edgePerVert[VertId( firstVert + i )], edgePerVert[VertId( firstVert + ( ( i + int( size ) - 1 ) % size ) )].sym() );
+            cache_.tp.splice( edgePerVert[VertId( firstVert + i )], edgePerVert[VertId( firstVert + ( ( i + int( size ) - 1 ) % size ) )].sym() );
         firstVert += size;
     }
 }
@@ -1146,14 +1149,14 @@ void SweepLineQueue::mergeSamePoints_( const HolesVertIds* holesVertId )
         }
         return ( *holesVertId )[holeId][patchId];
     };
-    sortedVerts_.reserve( tp_.vertSize() );
-    for ( int i = 0; i < tp_.vertSize(); ++i )
-        sortedVerts_.emplace_back( VertId( i ) );
+    cache_.sortedVerts.reserve( cache_.tp.vertSize() );
+    for ( int i = 0; i < cache_.tp.vertSize(); ++i )
+        cache_.sortedVerts.emplace_back( VertId( i ) );
     if ( !holesVertId )
-        tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r ) { return predicates_.less( l, r ); } );
+        tbb::parallel_sort( cache_.sortedVerts.begin(), cache_.sortedVerts.end(), [&] ( VertId l, VertId r ) { return predicates_.less( l, r ); } );
     else
     {
-        tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r )
+        tbb::parallel_sort( cache_.sortedVerts.begin(), cache_.sortedVerts.end(), [&] ( VertId l, VertId r )
         {
             if ( predicates_.less2d( l, r ) )
                 return true;
@@ -1165,28 +1168,28 @@ void SweepLineQueue::mergeSamePoints_( const HolesVertIds* holesVertId )
 
     if ( !params_.allowMerge )
     {
-        windingInfo_.resize( tp_.undirectedEdgeSize() );
+        cache_.windingInfo.resize( cache_.tp.undirectedEdgeSize() );
         return;
     }
 
     int prevUnique = 0;
-    for ( int i = 1; i < sortedVerts_.size(); ++i )
+    for ( int i = 1; i < cache_.sortedVerts.size(); ++i )
     {
-        bool sameIntCoord = predicates_.samePos( sortedVerts_[i], sortedVerts_[prevUnique] );
+        bool sameIntCoord = predicates_.samePos( cache_.sortedVerts[i], cache_.sortedVerts[prevUnique] );
         if ( !sameIntCoord )
         {
             prevUnique = i;
             continue;
         }
         // if same coords
-        if ( !holesVertId || findRealVertId( sortedVerts_[prevUnique] ) == findRealVertId( sortedVerts_[i] ) )
-            mergeSinglePare_( sortedVerts_[prevUnique], sortedVerts_[i] );
+        if ( !holesVertId || findRealVertId( cache_.sortedVerts[prevUnique] ) == findRealVertId( cache_.sortedVerts[i] ) )
+            mergeSinglePare_( cache_.sortedVerts[prevUnique], cache_.sortedVerts[i] );
     }
 
     if ( holesVertId ) // sort with correct indices in case of other way sort before
-        tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r ) { return predicates_.less( l, r ); } );
+        tbb::parallel_sort( cache_.sortedVerts.begin(), cache_.sortedVerts.end(), [&] ( VertId l, VertId r ) { return predicates_.less( l, r ); } );
 
-    windingInfo_.resize( tp_.undirectedEdgeSize() );
+    cache_.windingInfo.resize( cache_.tp.undirectedEdgeSize() );
     if ( !params_.abortWhenIntersect || !holesVertId )
         removeMultipleAfterMerge_();
 }
@@ -1196,10 +1199,10 @@ void SweepLineQueue::mergeSinglePare_( VertId unique, VertId same )
     std::vector<EdgeId> sameEdges;
     int sameToUniqueEdgeIndex{ -1 };
     int i = 0;
-    for ( auto eSame : orgRing( tp_, same ) )
+    for ( auto eSame : orgRing( cache_.tp, same ) )
     {
         sameEdges.push_back( eSame );
-        if ( tp_.dest( eSame ) == unique )
+        if ( cache_.tp.dest( eSame ) == unique )
         {
             assert( sameToUniqueEdgeIndex == -1 );
             sameToUniqueEdgeIndex = i;
@@ -1212,47 +1215,47 @@ void SweepLineQueue::mergeSinglePare_( VertId unique, VertId same )
         // if part of same contour
         // disconnect before merge
         auto e = sameEdges[sameToUniqueEdgeIndex];
-        tp_.splice( tp_.prev( e ), e );
-        tp_.splice( tp_.prev( e.sym() ), e.sym() );
+        cache_.tp.splice( cache_.tp.prev( e ), e );
+        cache_.tp.splice( cache_.tp.prev( e.sym() ), e.sym() );
         sameEdges.erase( sameEdges.begin() + sameToUniqueEdgeIndex );
         if ( sameEdges.empty() )
         {
-            tp_.setOrg( e, VertId{} ); // the "same" becomes invalid after removing of its only edge
-            tp_.setOrg( e.sym(), VertId{}); // the "same" becomes invalid after removing of its only edge
+            cache_.tp.setOrg( e, VertId{} ); // the "same" becomes invalid after removing of its only edge
+            cache_.tp.setOrg( e.sym(), VertId{}); // the "same" becomes invalid after removing of its only edge
         }
     }
 
     for ( auto eSame : sameEdges )
     {
-        findClosestCache_.clear();
-        findClosestCache_.push_back( eSame );
-        for ( auto eUnique : orgRing( tp_, unique ) )
+        cache_.findClosestCache.clear();
+        cache_.findClosestCache.push_back( eSame );
+        for ( auto eUnique : orgRing( cache_.tp, unique ) )
         {
-            findClosestCache_.emplace_back( eUnique );
+            cache_.findClosestCache.emplace_back( eUnique );
         }
-        auto minEUnique = findClosestCache_[findClosestToFront( tp_, predicates_, findClosestCache_, false )];
-        auto prev = tp_.prev( eSame );
+        auto minEUnique = cache_.findClosestCache[findClosestToFront( cache_.tp, predicates_, cache_.findClosestCache, false )];
+        auto prev = cache_.tp.prev( eSame );
         if ( prev != eSame )
-            tp_.splice( prev, eSame );
+            cache_.tp.splice( prev, eSame );
         else
-            tp_.setOrg( eSame, VertId{} );
-        tp_.splice( minEUnique, eSame );
-        if ( tp_.dest( minEUnique ) == tp_.dest( eSame ) )
+            cache_.tp.setOrg( eSame, VertId{} );
+        cache_.tp.splice( minEUnique, eSame );
+        if ( cache_.tp.dest( minEUnique ) == cache_.tp.dest( eSame ) )
         {
-            auto& edgeInfo = windingInfo_.autoResizeAt( minEUnique.undirected() );
+            auto& edgeInfo = cache_.windingInfo.autoResizeAt( minEUnique.undirected() );
             if ( edgeInfo.windingModifier == INT_MAX )
                 edgeInfo.windingModifier = 1;
             bool uniqueIsOdd = minEUnique.odd();
             bool sameIsOdd = eSame.odd();
             edgeInfo.windingModifier += ( ( uniqueIsOdd == sameIsOdd ) ? 1 : -1 );
-            tp_.splice( tp_.prev( eSame ), eSame );
-            tp_.splice( tp_.prev( eSame.sym() ), eSame.sym() );
-            if ( tp_.next( minEUnique ) == minEUnique )
+            cache_.tp.splice( cache_.tp.prev( eSame ), eSame );
+            cache_.tp.splice( cache_.tp.prev( eSame.sym() ), eSame.sym() );
+            if ( cache_.tp.next( minEUnique ) == minEUnique )
             {
                 // invalidate lone edge
-                tp_.splice( tp_.prev( minEUnique.sym() ), minEUnique.sym() );
-                tp_.setOrg( minEUnique, VertId{} );
-                tp_.setOrg( minEUnique.sym(), VertId{} );
+                cache_.tp.splice( cache_.tp.prev( minEUnique.sym() ), minEUnique.sym() );
+                cache_.tp.setOrg( minEUnique, VertId{} );
+                cache_.tp.setOrg( minEUnique.sym(), VertId{} );
             }
         }
     }
@@ -1261,13 +1264,13 @@ void SweepLineQueue::mergeSinglePare_( VertId unique, VertId same )
 void SweepLineQueue::removeMultipleAfterMerge_()
 {
     MR_TIMER;
-    auto multiples = findMultipleEdges( tp_ ).value();
+    auto multiples = findMultipleEdges( cache_.tp ).value();
     for ( const auto& multiple : multiples )
     {
         std::vector<EdgeId> multiplesFromThis;
-        for ( auto e : orgRing( tp_, multiple.first ) )
+        for ( auto e : orgRing( cache_.tp, multiple.first ) )
         {
-            if ( tp_.dest( e ) == multiple.second )
+            if ( cache_.tp.dest( e ) == multiple.second )
                 multiplesFromThis.push_back( e );
         }
         assert( multiplesFromThis.size() > 1 );
@@ -1297,7 +1300,7 @@ void SweepLineQueue::removeMultipleAfterMerge_()
             }
         }
 
-        auto& edgeInfo = windingInfo_[multiplesFromThis.front().undirected()];
+        auto& edgeInfo = cache_.windingInfo[multiplesFromThis.front().undirected()];
         edgeInfo.windingModifier = 1;
         bool uniqueIsOdd = int( multiplesFromThis.front() ) & 1;
         for ( int i = 1; i < multiplesFromThis.size(); ++i )
@@ -1305,9 +1308,9 @@ void SweepLineQueue::removeMultipleAfterMerge_()
             auto e = multiplesFromThis[i];
             bool isMEOdd = int( e ) & 1;
             edgeInfo.windingModifier += ( ( uniqueIsOdd == isMEOdd ) ? 1 : -1 );
-            tp_.splice( tp_.prev( e ), e );
-            tp_.splice( tp_.prev( e.sym() ), e.sym() );
-            assert( tp_.isLoneEdge( e ) );
+            cache_.tp.splice( cache_.tp.prev( e ), e );
+            cache_.tp.splice( cache_.tp.prev( e.sym() ), e.sym() );
+            assert( cache_.tp.isLoneEdge( e ) );
         }
     }
 }
@@ -1316,9 +1319,9 @@ void SweepLineQueue::calculateWinding_()
 {
     int windingLast = 0;
     // recalculate winding number for active edges
-    for ( const auto& e : activeSweepEdges_ )
+    for ( const auto& e : cache_.activeSweepEdges )
     {
-        auto& info = windingInfo_[e.edgeId.undirected()];
+        auto& info = cache_.windingInfo[e.edgeId.undirected()];
         info.rightGoing = e.edgeId.even();
         if ( info.windingModifier != INT_MAX )
             info.winding = windingLast + info.windingModifier;
@@ -1333,10 +1336,10 @@ void SweepLineQueue::calculateWinding_()
 void SweepLineQueue::triangulateMonotoneBlock_( EdgeId holeEdgeId )
 {
     MR_TIMER;
-    auto holeLoop = trackRightBoundaryLoop( tp_, holeEdgeId );
+    auto holeLoop = trackRightBoundaryLoop( cache_.tp, holeEdgeId );
     auto lessPred = [&] ( EdgeId l, EdgeId r )
     {
-        return predicates_.less( tp_.org( l ) , tp_.org( r ) );
+        return predicates_.less( cache_.tp.org( l ) , cache_.tp.org( r ) );
     };
     auto minMaxIt = std::minmax_element( holeLoop.begin(), holeLoop.end(), lessPred );
 
@@ -1348,12 +1351,12 @@ void SweepLineQueue::triangulateMonotoneBlock_( EdgeId holeEdgeId )
 
     auto isReflex = [&] ( int prev, int cur, int next, bool lowerChain )
     {
-        return predicates_.ccw( tp_.org( holeLoop[prev] ), tp_.org( holeLoop[next] ), tp_.org( holeLoop[cur] ) ) == lowerChain;
+        return predicates_.ccw( cache_.tp.org( holeLoop[prev] ), cache_.tp.org( holeLoop[next] ), cache_.tp.org( holeLoop[cur] ) ) == lowerChain;
     };
 
     auto addDiagonal = [&] ( int cur, int prev, bool lowerChain )->bool
     {
-        auto& tp = tp_;
+        auto& tp = cache_.tp;
         if ( tp.prev( holeLoop[cur].sym() ) == holeLoop[prev] ||
             tp.next( holeLoop[cur] ).sym() == holeLoop[prev] )
         {
@@ -1381,7 +1384,7 @@ void SweepLineQueue::triangulateMonotoneBlock_( EdgeId holeEdgeId )
     int curLower = minIndex;
     int curUpper = minIndex;
 
-    auto& reflexChain = reflexChainCache_;
+    auto& reflexChain = cache_.reflexChainCache;
     reflexChain.resize( 0 );
     reflexChain.push_back( curIndex );
     bool reflexChainLower{ false };
@@ -1477,8 +1480,9 @@ HolesVertIds findHoleVertIdsByHoleEdges( const MeshTopology& tp, const std::vect
 
 Mesh getOutlineMesh( const Contours2f& conts, IntersectionsMap* interMap /*= nullptr */, const BaseOutlineParameters& params )
 {
-    SweepLineQueue triangulator;
-    triangulator.init( precisePredicates( conts, triangulator.pts2Buffer() ), getContourSizes( conts ), { nullptr, false, params.innerType, true, params.allowMerge } );
+    SweepLineQueue::Cache cache;
+    SweepLineQueue triangulator( cache );
+    triangulator.init( precisePredicates( conts, cache.pts2Buffer ), getContourSizes( conts ), { nullptr, false, params.innerType, true, params.allowMerge } );
 
     if ( interMap )
         interMap->shift = triangulator.vertSize();
@@ -1549,8 +1553,9 @@ Mesh triangulateContours( const Contours2f& contours, const TriangulationParamet
 {
     if ( contours.empty() )
         return {};
-    SweepLineQueue triangulator;
-    triangulator.init( precisePredicates( contours, triangulator.pts2Buffer() ), getContourSizes( contours ),
+    SweepLineQueue::Cache cache;
+    SweepLineQueue triangulator( cache );
+    triangulator.init( precisePredicates( contours, cache.pts2Buffer ), getContourSizes( contours ),
         { params.holeVertsIds, false, WindingMode::NonZero, false, true, nullptr, params.outFaceWinding } );
     if ( params.outInterMap )
         params.outInterMap->shift = triangulator.vertSize();
@@ -1588,16 +1593,18 @@ std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours, con
 {
     if ( contours.empty() )
         return Mesh();
-    std::optional<SweepLineQueue> localQueue;
-    auto& triangulator = cache ? static_cast<SweepLineQueue&>( *cache ) : localQueue.emplace();
-    triangulator.init( precisePredicates( contours, triangulator.pts2Buffer() ), getContourSizes( contours ), { holeVertsIds, true, WindingMode::NonZero, false, true, outBoundaries } );
+    std::optional<SweepLineQueue::Cache> localCache;
+    auto& cacheImpl = cache ? static_cast<SweepLineQueue::Cache&>( *cache ) : localCache.emplace();
+    SweepLineQueue triangulator( cacheImpl );
+    triangulator.init( precisePredicates( contours, cacheImpl.pts2Buffer ), getContourSizes( contours ), { holeVertsIds, true, WindingMode::NonZero, false, true, outBoundaries } );
     return triangulator.run();
 }
 
 MeshTopology* triangulateDisjointContoursTopology( const Contours2f& contours, const HolesVertIds* holeVertsIds, std::vector<EdgePath>* outBoundaries, ISweepLineCache& cache )
 {
-    auto& triangulator = static_cast<SweepLineQueue&>( cache );
-    triangulator.init( precisePredicates( contours, triangulator.pts2Buffer() ), getContourSizes( contours ), { holeVertsIds, true, WindingMode::NonZero, false, true, outBoundaries } );
+    auto& cacheImpl = static_cast<SweepLineQueue::Cache&>( cache );
+    SweepLineQueue triangulator( cacheImpl );
+    triangulator.init( precisePredicates( contours, cacheImpl.pts2Buffer ), getContourSizes( contours ), { holeVertsIds, true, WindingMode::NonZero, false, true, outBoundaries } );
     return triangulator.runTopology();
 }
 
@@ -1611,8 +1618,9 @@ std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoo
     std::vector<int> sizes( loops.size() );
     for ( int i = 0; i < int( loops.size() ); ++i )
         sizes[i] = int( loops[i].size() ) + 1; // +1 matches the queue's closed-contour convention (it allocates size-1 verts)
-    SweepLineQueue triangulator;
-    triangulator.init( meshSpacePredicates( mesh, loops, normal, holeVertIds, triangulator.pts2Buffer() ), std::move( sizes ),
+    SweepLineQueue::Cache cache;
+    SweepLineQueue triangulator( cache );
+    triangulator.init( meshSpacePredicates( mesh, loops, normal, holeVertIds, cache.pts2Buffer ), std::move( sizes ),
         { &holeVertIds, true, WindingMode::NonZero, false, true, outBoundaries } );
     return triangulator.run();
 }

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -83,8 +83,9 @@ static void setPts2Predicates( SweepLinePredicates& p, std::shared_ptr<Vector<Ve
     };
 }
 
-// default predicates: exact integer arithmetic with simulation-of-simplicity (historical behavior)
-static SweepLinePredicates precisePredicates( const Contours2f& contours )
+// default predicates: exact integer arithmetic with simulation-of-simplicity (historical behavior);
+// `pts` is the storage for the projected points, cleared here; a cached buffer keeps its capacity
+static SweepLinePredicates precisePredicates( const Contours2f& contours, std::shared_ptr<Vector<Vector2i, VertId>> pts )
 {
     Box3f box;
     int pointsSize = 0;
@@ -99,7 +100,7 @@ static SweepLinePredicates precisePredicates( const Contours2f& contours )
         }
     }
 
-    auto pts = std::make_shared<Vector<Vector2i, VertId>>();
+    pts->clear();
     pts->reserve( pointsSize );
     auto toInt = [conv = getToIntConverter( Box3d( box ) )] ( const Vector2f& coord )
     {
@@ -158,7 +159,8 @@ static VertId holeSourceVertId( const HolesVertIds& holes, VertId v )
 // predicates via setPts2Predicates). point() restores each output vertex's exact original mesh position
 // through `holeVertIds` (no separate coordinate copy, no projection round-trip).
 // `mesh`, `loops` and `holeVertIds` only need to outlive the run.
-static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, const HolesVertIds& holeVertIds )
+static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, const HolesVertIds& holeVertIds,
+    std::shared_ptr<Vector<Vector2i, VertId>> pts2 ) // storage for the dominant-axis projection that drives every predicate
 {
     Box3f box;
     int pointsSize = 0;
@@ -181,7 +183,7 @@ static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoop
     if ( normal[dropAx] < 0 )
         std::swap( kx, ky );
 
-    auto pts2 = std::make_shared<Vector<Vector2i, VertId>>(); // dominant-axis projection, drives every predicate
+    pts2->clear();
     pts2->reserve( pointsSize );
     auto toInt = getToIntConverter( Box3d( box ) ); // Vector3f -> Vector3i
 
@@ -297,24 +299,41 @@ struct SweepLineParams
     Vector<int, FaceId>* outFaceWinding{ nullptr };
 };
 
-class SweepLineQueue
+// the sweep-line triangulator and the only implementation of ISweepLineCache: an instance handed out
+// by makeSweepLineCache() is a queue whose internal buffers survive between runs
+class SweepLineQueue final : public ISweepLineCache
 {
 public:
-    // constructor makes initial mesh which simply contain input contours as edges
-    // if holesVertId is null - merge all vertices with same coordinates
+    // an instance is reusable: init() prepares it for the next run keeping the buffers of the previous one
+    SweepLineQueue() = default;
+
+    // resets the state of the previous run, if any (all internal buffers keep their capacity),
+    // and makes initial mesh which simply contain input contours as edges
+    // if params.holesVertId is null - merge all vertices with same coordinates
     // otherwise only merge the ones with same initial vertId
-    SweepLineQueue( SweepLinePredicates predicates, std::vector<int> contourSizes, const SweepLineParams& params );
+    void init( SweepLinePredicates predicates, std::vector<int> contourSizes, const SweepLineParams& params );
+
+    // storage for the projected points of the predicates built for this queue's runs;
+    // kept here only so that a cached queue reuses the buffer's capacity across runs
+    const std::shared_ptr<Vector<Vector2i, VertId>>& pts2Buffer() { return pts2Buffer_; }
 
     size_t vertSize() const { return tp_.vertSize(); }
     std::optional<Mesh> run( IntersectionsMap* interMap = nullptr );
 
+    // same as run(), but does not create a Mesh: the result connectivity stays in the internal
+    // cached topology (so its buffers are reused by the next run) and a pointer to it is returned,
+    // valid until the next operation on this queue; nullptr if contours intersect while forbidden
+    MeshTopology* runTopology( IntersectionsMap* interMap = nullptr );
+
     bool findIntersections();
     void injectIntersections( IntersectionsMap* interMap );
     void makeMonotone();
-    Mesh triangulate();
+    void triangulate();
 private:
     MeshTopology tp_;
+    VertCoords pointsCache_; // scratch positions of tp_'s vertices for the Delone flips in triangulate()
     SweepLinePredicates predicates_;
+    std::shared_ptr<Vector<Vector2i, VertId>> pts2Buffer_ = std::make_shared<Vector<Vector2i, VertId>>();
 
     SweepLineParams params_;
 
@@ -374,6 +393,8 @@ private:
     std::vector<Intersection> intersections_;
 
     void setupStartVertices_();
+    // scratch bitset of setupStartVertices_()
+    VertBitSet startVerticesCache_;
     // sorted vertices with no left-going edges
     std::vector<VertId> startVerts_;
     std::vector<EdgeId> startVertLowestRight_;
@@ -446,10 +467,30 @@ private:
     void checkIntersection_( int indexLower );
 };
 
-SweepLineQueue::SweepLineQueue( SweepLinePredicates predicates, std::vector<int> contourSizes, const SweepLineParams& params ) :
-    predicates_{ std::move( predicates ) },
-    params_{ params }
+ISweepLineCache::~ISweepLineCache() = default;
+
+std::unique_ptr<ISweepLineCache> makeSweepLineCache()
 {
+    return std::make_unique<SweepLineQueue>();
+}
+
+void SweepLineQueue::init( SweepLinePredicates predicates, std::vector<int> contourSizes, const SweepLineParams& params )
+{
+    predicates_ = std::move( predicates );
+    params_ = params;
+    stage_ = Stage::Init;
+    tp_.clear(); // empty husk if the previous run() moved it out, filled if runTopology() kept it
+    windingInfo_.clear(); // stale winding modifiers would leak into this run through resize()
+    intersections_.clear();
+    intersectionsMap_.clear(); // keyed by the previous run's edge ids
+    startVerts_.clear();
+    startVertLowestRight_.clear();
+    startVertIndex_ = 0;
+    sortedVerts_.clear(); // mergeSamePoints_() appends
+    sortedVertIndex_ = 0;
+    activeSweepEdges_.clear();
+    events_.clear();
+
     initMeshByContours_( contourSizes );
     mergeSamePoints_( params.holesVertId );
     setupStartVertices_();
@@ -457,12 +498,24 @@ SweepLineQueue::SweepLineQueue( SweepLinePredicates predicates, std::vector<int>
 
 std::optional<MR::Mesh> SweepLineQueue::run( IntersectionsMap* interMap )
 {
+    if ( !runTopology( interMap ) )
+        return {};
+    // materialize the result, donating the cached buffers to it
+    Mesh mesh;
+    mesh.topology = std::move( tp_ );
+    mesh.points = std::move( pointsCache_ );
+    return mesh;
+}
+
+MeshTopology* SweepLineQueue::runTopology( IntersectionsMap* interMap )
+{
     MR_TIMER;
     if ( !findIntersections() )
-        return {};
+        return nullptr;
     injectIntersections( interMap );
     makeMonotone();
-    return triangulate();
+    triangulate();
+    return &tp_;
 }
 
 bool SweepLineQueue::findIntersections()
@@ -595,7 +648,7 @@ void SweepLineQueue::makeMonotone()
     }
 }
 
-Mesh SweepLineQueue::triangulate()
+void SweepLineQueue::triangulate()
 {
     MR_TIMER;
     stage_ = Stage::Triangulation;
@@ -622,24 +675,29 @@ Mesh SweepLineQueue::triangulate()
         if ( params_.outFaceWinding ) // all faces of one monotone block are in the region with same winding number
             params_.outFaceWinding->autoResizeSet( firstBlockFace, tp_.faceSize() - firstBlockFace, windInfo.winding );
     }
-    Mesh mesh;
-    mesh.topology = std::move( tp_ );
-    mesh.points.resize( mesh.topology.vertSize() );
-    BitSetParallelFor( mesh.topology.getValidVerts(), [&] ( VertId v )
+    pointsCache_.resize( tp_.vertSize() );
+    BitSetParallelFor( tp_.getValidVerts(), [&] ( VertId v )
     {
-        mesh.points[v] = predicates_.point( v );
+        pointsCache_[v] = predicates_.point( v );
     } );
     // Delone flips could cross a contour edge between two inside regions and smear the face winding map
     if ( !params_.needOutline && !params_.outFaceWinding )
     {
+        // borrow the cached topology and points into a temporary mesh for the flips (moves, no copies)
+        Mesh mesh;
+        mesh.topology = std::move( tp_ );
+        mesh.points = std::move( pointsCache_ );
         makeDeloneEdgeFlips( mesh, {}, 300 );
+        tp_ = std::move( mesh.topology );
+        pointsCache_ = std::move( mesh.points );
     }
-    return mesh;
 }
 
 void SweepLineQueue::setupStartVertices_()
 {
-    VertBitSet startVertices( tp_.vertSize() );
+    auto& startVertices = startVerticesCache_;
+    startVertices.clear();
+    startVertices.resize( tp_.vertSize() );
     BitSetParallelFor( tp_.getValidVerts(), [&] ( VertId v )
     {
         bool startVert = true;
@@ -1419,7 +1477,8 @@ HolesVertIds findHoleVertIdsByHoleEdges( const MeshTopology& tp, const std::vect
 
 Mesh getOutlineMesh( const Contours2f& conts, IntersectionsMap* interMap /*= nullptr */, const BaseOutlineParameters& params )
 {
-    SweepLineQueue triangulator( precisePredicates( conts ), getContourSizes( conts ), { nullptr, false, params.innerType, true, params.allowMerge } );
+    SweepLineQueue triangulator;
+    triangulator.init( precisePredicates( conts, triangulator.pts2Buffer() ), getContourSizes( conts ), { nullptr, false, params.innerType, true, params.allowMerge } );
 
     if ( interMap )
         interMap->shift = triangulator.vertSize();
@@ -1490,7 +1549,8 @@ Mesh triangulateContours( const Contours2f& contours, const TriangulationParamet
 {
     if ( contours.empty() )
         return {};
-    SweepLineQueue triangulator( precisePredicates( contours ), getContourSizes( contours ),
+    SweepLineQueue triangulator;
+    triangulator.init( precisePredicates( contours, triangulator.pts2Buffer() ), getContourSizes( contours ),
         { params.holeVertsIds, false, WindingMode::NonZero, false, true, nullptr, params.outFaceWinding } );
     if ( params.outInterMap )
         params.outInterMap->shift = triangulator.vertSize();
@@ -1518,18 +1578,27 @@ Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVe
     return triangulateContours( contours, { .holeVertsIds = holeVertsIds } );
 }
 
-std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours, const HolesVertIds* holeVertsIds /*= nullptr*/, std::vector<EdgePath>* outBoundaries /*= nullptr*/ )
+std::optional<Mesh> triangulateDisjointContours( const Contours2d& contours, const HolesVertIds* holeVertsIds /*= nullptr*/, std::vector<EdgePath>* outBoundaries /*= nullptr*/, ISweepLineCache* cache /*= nullptr*/ )
+{
+    const auto contsf = convertContours<Contours2f>( contours );
+    return triangulateDisjointContours( contsf, holeVertsIds, outBoundaries, cache );
+}
+
+std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours, const HolesVertIds* holeVertsIds /*= nullptr*/, std::vector<EdgePath>* outBoundaries /*= nullptr*/, ISweepLineCache* cache /*= nullptr*/ )
 {
     if ( contours.empty() )
         return Mesh();
-    SweepLineQueue triangulator( precisePredicates( contours ), getContourSizes( contours ), { holeVertsIds, true, WindingMode::NonZero, false, true, outBoundaries } );
+    std::optional<SweepLineQueue> localQueue;
+    auto& triangulator = cache ? static_cast<SweepLineQueue&>( *cache ) : localQueue.emplace();
+    triangulator.init( precisePredicates( contours, triangulator.pts2Buffer() ), getContourSizes( contours ), { holeVertsIds, true, WindingMode::NonZero, false, true, outBoundaries } );
     return triangulator.run();
 }
 
-std::optional<Mesh> triangulateDisjointContours( const Contours2d& contours, const HolesVertIds* holeVertsIds /*= nullptr*/, std::vector<EdgePath>* outBoundaries /*= nullptr*/ )
+MeshTopology* triangulateDisjointContoursTopology( const Contours2f& contours, const HolesVertIds* holeVertsIds, std::vector<EdgePath>* outBoundaries, ISweepLineCache& cache )
 {
-    const auto contsf = convertContours<Contours2f>( contours );
-    return triangulateDisjointContours( contsf, holeVertsIds, outBoundaries );
+    auto& triangulator = static_cast<SweepLineQueue&>( cache );
+    triangulator.init( precisePredicates( contours, triangulator.pts2Buffer() ), getContourSizes( contours ), { holeVertsIds, true, WindingMode::NonZero, false, true, outBoundaries } );
+    return triangulator.runTopology();
 }
 
 std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, std::vector<EdgePath>* outBoundaries /*= nullptr*/ )
@@ -1542,7 +1611,8 @@ std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoo
     std::vector<int> sizes( loops.size() );
     for ( int i = 0; i < int( loops.size() ); ++i )
         sizes[i] = int( loops[i].size() ) + 1; // +1 matches the queue's closed-contour convention (it allocates size-1 verts)
-    SweepLineQueue triangulator( meshSpacePredicates( mesh, loops, normal, holeVertIds ), std::move( sizes ),
+    SweepLineQueue triangulator;
+    triangulator.init( meshSpacePredicates( mesh, loops, normal, holeVertIds, triangulator.pts2Buffer() ), std::move( sizes ),
         { &holeVertIds, true, WindingMode::NonZero, false, true, outBoundaries } );
     return triangulator.run();
 }

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "MRMeshFwd.h"
 #include "MRId.h"
+#include <memory>
 #include <optional>
 
 namespace MR
@@ -103,15 +104,43 @@ MRMESH_API Mesh triangulateContours( const Contours2f& contours, const Triangula
 MR_BIND_IGNORE MRMESH_API Mesh triangulateContours( const Contours2d& contours, const HolesVertIds* holeVertsIds );
 MR_BIND_IGNORE MRMESH_API Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVertsIds );
 
+/// reusable internal state of the sweep-line triangulation;
+/// a caller making many triangulation calls one by one can pass the same cache into each of them
+/// to avoid re-allocating the internal buffers on every call;
+/// one cache serves one call at a time: never share an instance between concurrent calls
+class ISweepLineCache
+{
+public:
+    /// explicitly define ctors to avoid warning C5267: definition of implicit copy constructor is deprecated because it has a user-provided destructor
+    ISweepLineCache() = default;
+    ISweepLineCache( const ISweepLineCache & ) = default;
+    ISweepLineCache( ISweepLineCache && ) noexcept = default;
+
+    /// pure to make the class abstract: instances are created by makeSweepLineCache() only
+    MRMESH_API virtual ~ISweepLineCache() = 0;
+};
+
+/// creates a cache for the triangulation functions accepting it below
+MRMESH_API std::unique_ptr<ISweepLineCache> makeSweepLineCache();
+
 /**
  * @brief triangulate 2d contours
  * only closed contours are allowed (first point of each contour should be the same as last point of the contour)
  * @param holeVertsIds if set merge only points with same vertex id, otherwise merge all points with same coordinates
  * @param outBoundaries optional output EdgePaths that correspond to initial contours
+ * @param cache if not null, keeps the triangulation's internal buffers in it after the call,
+ * so that the next call with the same cache reuses them instead of allocating anew
  * @return std::optional<Mesh> : if some contours intersect return false, otherwise return created mesh
  */
-MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2d& contours, const HolesVertIds* holeVertsIds = nullptr, std::vector<EdgePath>* outBoundaries = nullptr );
-MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours, const HolesVertIds* holeVertsIds = nullptr, std::vector<EdgePath>* outBoundaries = nullptr );
+MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2d& contours, const HolesVertIds* holeVertsIds = nullptr, std::vector<EdgePath>* outBoundaries = nullptr, ISweepLineCache* cache = nullptr );
+MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours, const HolesVertIds* holeVertsIds = nullptr, std::vector<EdgePath>* outBoundaries = nullptr, ISweepLineCache* cache = nullptr );
+
+/// same as above, but does not create a Mesh at all: the triangulation connectivity is built inside
+/// \p cache (reusing even its topology buffers) and a pointer to it is returned, valid until the next
+/// operation with \p cache; returns nullptr if some contours intersect;
+/// use it when only the connectivity is needed, e.g. to build a HoleFillPlan;
+/// the cache is required here since it owns the returned topology
+MR_BIND_IGNORE MRMESH_API MeshTopology* triangulateDisjointContoursTopology( const Contours2f& contours, const HolesVertIds* holeVertsIds, std::vector<EdgePath>* outBoundaries, ISweepLineCache& cache );
 
 /**
  * @brief triangulate hole boundary loops of \p mesh in the mesh's own 3d space, orienting faces around \p normal

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -129,7 +129,41 @@ struct ProjectedFillMesh
     std::vector<EdgeLoop> paths;
 };
 
-Expected<ProjectedFillMesh> fillProjected( const MeshTopology& tp, const ProjectFillInput& input )
+// checks that the patch triangulation borders match the input hole loops and
+// fixes inverted degenerate holes right in the patch topology
+Expected<void> validateAndFixPatch( MeshTopology& patchTp, const std::vector<EdgeLoop>& inputPaths, std::vector<EdgeLoop>& patchPaths )
+{
+    if ( inputPaths.size() != patchPaths.size() )
+        return unexpected( "Patch surface borders size different from original mesh borders size" );
+
+    std::vector<EdgePath> invertedHoles;
+    invertedHoles.reserve( patchPaths.size() );
+    for ( int i = 0; i < patchPaths.size(); ++i )
+    {
+        if ( inputPaths[i].size() != patchPaths[i].size() )
+            return unexpected( "Patch surface borders size different from original mesh borders size" );
+
+        // degenerate holes might invert sometimes (it is expected as far as planar triangulation does not now about input topology)
+        if ( patchPaths[i].empty() || patchTp.right( patchPaths[i].front() ) )
+            if ( !patchPaths[i].empty() )
+                MR::reverse( invertedHoles.emplace_back( patchPaths[i] ) );
+    }
+    if ( !invertedHoles.empty() )
+    {
+        auto invertedParts = fillContourLeft( patchTp, invertedHoles );
+        auto invertedEdges = getIncidentEdges( patchTp, invertedParts );
+        patchTp.flipOrientation( &invertedEdges );
+
+        // validate one more time
+        for ( int i = 0; i < patchPaths.size(); ++i )
+            if ( patchPaths[i].empty() || patchTp.right( patchPaths[i].front() ) )
+                if ( !patchPaths[i].empty() )
+                    return unexpected( "Patch surface borders are incompatible with mesh borders" );
+    }
+    return {};
+}
+
+Expected<ProjectedFillMesh> fillProjected( const MeshTopology& tp, const ProjectFillInput& input, PlanarTriangulation::ISweepLineCache* cache )
 {
     MR_TIMER;
     ProjectedFillMesh res;
@@ -137,41 +171,15 @@ Expected<ProjectedFillMesh> fillProjected( const MeshTopology& tp, const Project
     auto holeVertIds = std::make_unique<PlanarTriangulation::HolesVertIds>(
         PlanarTriangulation::findHoleVertIdsByHoleEdges( tp, input.paths ) );
 
-    auto fillResult = PlanarTriangulation::triangulateDisjointContours( input.holes2d, holeVertIds.get(), &res.paths );
+    auto fillResult = PlanarTriangulation::triangulateDisjointContours( input.holes2d, holeVertIds.get(), &res.paths, cache );
     holeVertIds.reset();
     if ( !fillResult )
         return unexpected( "Cannot triangulate contours with self-intersections" );
 
     res.mesh = std::move( *fillResult );
 
-
-    if ( input.paths.size() != res.paths.size() )
-        return unexpected( "Patch surface borders size different from original mesh borders size" );
-
-    std::vector<EdgePath> invertedHoles;
-    invertedHoles.reserve( res.paths.size() );
-    for ( int i = 0; i < res.paths.size(); ++i )
-    {
-        if ( input.paths[i].size() != res.paths[i].size() )
-            return unexpected( "Patch surface borders size different from original mesh borders size" );
-
-        // degenerate holes might invert sometimes (it is expected as far as planar triangulation does not now about input topology)
-        if ( res.paths[i].empty() || res.mesh.topology.right( res.paths[i].front() ) )
-            if ( !res.paths[i].empty() )
-                MR::reverse( invertedHoles.emplace_back( res.paths[i] ) );
-    }
-    if ( !invertedHoles.empty() )
-    {
-        auto invertedParts = fillContourLeft( res.mesh.topology, invertedHoles );
-        auto invertedEdges = getIncidentEdges( res.mesh.topology, invertedParts );
-        res.mesh.topology.flipOrientation( &invertedEdges );
-
-        // validate one more time
-        for ( int i = 0; i < res.paths.size(); ++i )
-            if ( res.paths[i].empty() || res.mesh.topology.right( res.paths[i].front() ) )
-                if ( !res.paths[i].empty() )
-                    return unexpected( "Patch surface borders are incompatible with mesh borders" );
-    }
+    if ( auto v = validateAndFixPatch( res.mesh.topology, input.paths, res.paths ); !v )
+        return unexpected( std::move( v.error() ) );
     return res;
 }
 
@@ -183,7 +191,7 @@ Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepres
     if ( !projInput.has_value() )
         return unexpected( std::move( projInput.error() ) );
 
-    auto fillRes = fillProjected( mesh.topology, *projInput );
+    auto fillRes = fillProjected( mesh.topology, *projInput, nullptr );
     if ( !fillRes.has_value() )
         return unexpected( std::move( fillRes.error() ) );
 
@@ -205,21 +213,35 @@ Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepres
     return {};
 }
 
-Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
+Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId, PlanarTriangulation::ISweepLineCache* cache /*= nullptr*/ )
 {
     auto projInput = projectHoles( mesh, { holeEdgeId } );
     if ( !projInput.has_value() )
         return unexpected( std::move( projInput.error() ) );
 
-    auto fillRes = fillProjected( mesh.topology, *projInput );
-    if ( !fillRes.has_value() )
-        return unexpected( std::move( fillRes.error() ) );
+    // a plan needs only the patch connectivity: triangulate into the cache without creating a Mesh;
+    // the connectivity must live somewhere even if the caller gave no cache, hence the temporary one
+    std::unique_ptr<PlanarTriangulation::ISweepLineCache> tmpCache;
+    if ( !cache )
+        cache = ( tmpCache = PlanarTriangulation::makeSweepLineCache() ).get();
 
-    assert( fillRes->paths.size() == 1 ); // should be validated in fillProjected
+    auto holeVertIds = std::make_unique<PlanarTriangulation::HolesVertIds>(
+        PlanarTriangulation::findHoleVertIdsByHoleEdges( mesh.topology, projInput->paths ) );
 
-    const auto& pTp = fillRes->mesh.topology;
+    std::vector<EdgeLoop> patchPaths;
+    auto* patchTp = PlanarTriangulation::triangulateDisjointContoursTopology( projInput->holes2d, holeVertIds.get(), &patchPaths, *cache );
+    holeVertIds.reset();
+    if ( !patchTp )
+        return unexpected( "Cannot triangulate contours with self-intersections" );
+
+    if ( auto v = validateAndFixPatch( *patchTp, projInput->paths, patchPaths ); !v )
+        return unexpected( std::move( v.error() ) );
+
+    assert( patchPaths.size() == 1 ); // should be validated in validateAndFixPatch
+
+    const auto& pTp = *patchTp;
     const auto& ip = projInput->paths[0];
-    auto& np = fillRes->paths[0];
+    auto& np = patchPaths[0];
     HoleFillPlan res;
     res.numTris = pTp.numValidFaces();
     if ( res.numTris == 1 )

--- a/source/MRMesh/MRFillContours2D.h
+++ b/source/MRMesh/MRFillContours2D.h
@@ -6,6 +6,8 @@
 namespace MR
 {
 
+namespace PlanarTriangulation { class ISweepLineCache; }
+
 /**
  * @brief fill holes with border in same plane (i.e. after cut by plane)
  * @param mesh - mesh with holes
@@ -21,9 +23,11 @@ MRMESH_API Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>&
  * @param mesh - mesh with hole
  * @param holeEdgeId - the edge here represents a hole borders that should be filled
  * edge should have invalid left face (FaceId == -1)
+ * @param cache - if not null, keeps the triangulation's internal buffers in it after the call,
+ * so a caller preparing plans for many holes one by one avoids re-allocating them on every call
  * @return Expected with has_value()=true if hole plan is prepared, otherwise - string error
  */
-MRMESH_API Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId );
+MRMESH_API Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId, PlanarTriangulation::ISweepLineCache* cache = nullptr );
 
 /// computes the transformation that maps
 /// O into center mass of contours' points

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -9,11 +9,13 @@
 #include "MRMarkedContour.h"
 #include "MRParallelFor.h"
 #include "MRFillContours2D.h"
+#include "MR2DContoursTriangulation.h"
 #include "MRAABBTreePoints.h"
 #include "MRPointsProject.h"
 #include "MRClosestPointInTriangle.h"
 #include "MRphmap.h"
 #include "MRPch/MRSpdlog.h"
+#include <memory>
 #include <queue>
 #include <functional>
 
@@ -630,6 +632,7 @@ private:
     std::vector<EdgeId> edgeMap_;
     std::vector<std::vector<WeightedConn>> newEdgesMap_;
     tbb::enumerable_thread_specific<std::vector<unsigned>> optimalStepsCache_;
+    std::unique_ptr<PlanarTriangulation::ISweepLineCache> sweepCache_; ///< keeps swept-line triangulation buffers alive between runPlanar() runs
     MapPatch savedMapPatch_, cachedMapPatch_;
     std::queue<std::pair<WeightedConn, int>> newEdgesQueue_;
 };
@@ -821,7 +824,9 @@ HoleFillPlan HoleFillPlanner::runPlanar( const Mesh& mesh, EdgeId e, bool allowS
         if ( holeSize >= cMinSweptHoleSize )
         {
             // only use this for large holes
-            auto exRes = fillContours2DPlan( mesh, e );
+            if ( !sweepCache_ )
+                sweepCache_ = PlanarTriangulation::makeSweepLineCache();
+            auto exRes = fillContours2DPlan( mesh, e, sweepCache_.get() );
             if ( exRes.has_value() )
                 return *exRes;
         }

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -628,11 +628,11 @@ public:
     HoleFillPlan run( const Mesh& mesh, EdgeId e, const FillHoleParams& params = {} );
     HoleFillPlan runPlanar( const Mesh& mesh, EdgeId e, bool allowSweptLine = true );
     unsigned concurrentSmallHoleSize = 0; ///< if hole size is smaller than this value preffer concurrent processing, sometimes it better than isolated parallelism overhead
-    PlanarTriangulation::ISweepLineCache* sweepCache = nullptr; ///< if set, swept-line planning reuses this cache between runs instead of a temporary one per run
 private:
     std::vector<EdgeId> edgeMap_;
     std::vector<std::vector<WeightedConn>> newEdgesMap_;
     tbb::enumerable_thread_specific<std::vector<unsigned>> optimalStepsCache_;
+    std::unique_ptr<PlanarTriangulation::ISweepLineCache> sweepCache_; ///< keeps swept-line triangulation buffers alive between runPlanar() runs
     MapPatch savedMapPatch_, cachedMapPatch_;
     std::queue<std::pair<WeightedConn, int>> newEdgesQueue_;
 };
@@ -824,7 +824,9 @@ HoleFillPlan HoleFillPlanner::runPlanar( const Mesh& mesh, EdgeId e, bool allowS
         if ( holeSize >= cMinSweptHoleSize )
         {
             // only use this for large holes
-            auto exRes = fillContours2DPlan( mesh, e, sweepCache );
+            if ( !sweepCache_ )
+                sweepCache_ = PlanarTriangulation::makeSweepLineCache();
+            auto exRes = fillContours2DPlan( mesh, e, sweepCache_.get() );
             if ( exRes.has_value() )
                 return *exRes;
         }
@@ -872,18 +874,11 @@ std::vector<HoleFillPlan> getPlanarHoleFillPlans( const Mesh& mesh, const std::v
 {
     MR_TIMER;
     std::vector<HoleFillPlan> fillPlans( holeRepresentativeEdges.size() );
-    // per-worker sweep-line caches persisting across calls: they hold only hole-size-linear buffers,
-    // and constructing/freeing them per call would dominate here when there are few holes per thread
-    static tbb::enumerable_thread_specific<std::unique_ptr<PlanarTriangulation::ISweepLineCache>> staticSweepCaches;
     tbb::enumerable_thread_specific<HoleFillPlanner> threadData_;
     ParallelFor( holeRepresentativeEdges, threadData_, [&]( size_t i, HoleFillPlanner& planner )
     {
         // isolate keeps run()'s nested ParallelFor from stealing this thread onto another i-index
         planner.concurrentSmallHoleSize = cMinSweptHoleSize;
-        auto& threadSweepCache = staticSweepCaches.local();
-        if ( !threadSweepCache )
-            threadSweepCache = PlanarTriangulation::makeSweepLineCache();
-        planner.sweepCache = threadSweepCache.get();
         tbb::this_task_arena::isolate( [&]
         {
             fillPlans[i] = planner.runPlanar( mesh, holeRepresentativeEdges[i] );

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -9,11 +9,13 @@
 #include "MRMarkedContour.h"
 #include "MRParallelFor.h"
 #include "MRFillContours2D.h"
+#include "MR2DContoursTriangulation.h"
 #include "MRAABBTreePoints.h"
 #include "MRPointsProject.h"
 #include "MRClosestPointInTriangle.h"
 #include "MRphmap.h"
 #include "MRPch/MRSpdlog.h"
+#include <memory>
 #include <queue>
 #include <functional>
 
@@ -626,6 +628,7 @@ public:
     HoleFillPlan run( const Mesh& mesh, EdgeId e, const FillHoleParams& params = {} );
     HoleFillPlan runPlanar( const Mesh& mesh, EdgeId e, bool allowSweptLine = true );
     unsigned concurrentSmallHoleSize = 0; ///< if hole size is smaller than this value preffer concurrent processing, sometimes it better than isolated parallelism overhead
+    PlanarTriangulation::ISweepLineCache* sweepCache = nullptr; ///< if set, swept-line planning reuses this cache between runs instead of a temporary one per run
 private:
     std::vector<EdgeId> edgeMap_;
     std::vector<std::vector<WeightedConn>> newEdgesMap_;
@@ -821,7 +824,7 @@ HoleFillPlan HoleFillPlanner::runPlanar( const Mesh& mesh, EdgeId e, bool allowS
         if ( holeSize >= cMinSweptHoleSize )
         {
             // only use this for large holes
-            auto exRes = fillContours2DPlan( mesh, e );
+            auto exRes = fillContours2DPlan( mesh, e, sweepCache );
             if ( exRes.has_value() )
                 return *exRes;
         }
@@ -869,11 +872,18 @@ std::vector<HoleFillPlan> getPlanarHoleFillPlans( const Mesh& mesh, const std::v
 {
     MR_TIMER;
     std::vector<HoleFillPlan> fillPlans( holeRepresentativeEdges.size() );
+    // per-worker sweep-line caches persisting across calls: they hold only hole-size-linear buffers,
+    // and constructing/freeing them per call would dominate here when there are few holes per thread
+    static tbb::enumerable_thread_specific<std::unique_ptr<PlanarTriangulation::ISweepLineCache>> staticSweepCaches;
     tbb::enumerable_thread_specific<HoleFillPlanner> threadData_;
     ParallelFor( holeRepresentativeEdges, threadData_, [&]( size_t i, HoleFillPlanner& planner )
     {
         // isolate keeps run()'s nested ParallelFor from stealing this thread onto another i-index
         planner.concurrentSmallHoleSize = cMinSweptHoleSize;
+        auto& threadSweepCache = staticSweepCaches.local();
+        if ( !threadSweepCache )
+            threadSweepCache = PlanarTriangulation::makeSweepLineCache();
+        planner.sweepCache = threadSweepCache.get();
         tbb::this_task_arena::isolate( [&]
         {
             fillPlans[i] = planner.runPlanar( mesh, holeRepresentativeEdges[i] );

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -9,13 +9,11 @@
 #include "MRMarkedContour.h"
 #include "MRParallelFor.h"
 #include "MRFillContours2D.h"
-#include "MR2DContoursTriangulation.h"
 #include "MRAABBTreePoints.h"
 #include "MRPointsProject.h"
 #include "MRClosestPointInTriangle.h"
 #include "MRphmap.h"
 #include "MRPch/MRSpdlog.h"
-#include <memory>
 #include <queue>
 #include <functional>
 
@@ -632,7 +630,6 @@ private:
     std::vector<EdgeId> edgeMap_;
     std::vector<std::vector<WeightedConn>> newEdgesMap_;
     tbb::enumerable_thread_specific<std::vector<unsigned>> optimalStepsCache_;
-    std::unique_ptr<PlanarTriangulation::ISweepLineCache> sweepCache_; ///< keeps swept-line triangulation buffers alive between runPlanar() runs
     MapPatch savedMapPatch_, cachedMapPatch_;
     std::queue<std::pair<WeightedConn, int>> newEdgesQueue_;
 };
@@ -824,9 +821,7 @@ HoleFillPlan HoleFillPlanner::runPlanar( const Mesh& mesh, EdgeId e, bool allowS
         if ( holeSize >= cMinSweptHoleSize )
         {
             // only use this for large holes
-            if ( !sweepCache_ )
-                sweepCache_ = PlanarTriangulation::makeSweepLineCache();
-            auto exRes = fillContours2DPlan( mesh, e, sweepCache_.get() );
+            auto exRes = fillContours2DPlan( mesh, e );
             if ( exRes.has_value() )
                 return *exRes;
         }

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -884,6 +884,15 @@ std::vector<HoleFillPlan> getPlanarHoleFillPlans( const Mesh& mesh, const std::v
             fillPlans[i] = planner.runPlanar( mesh, holeRepresentativeEdges[i] );
         } );
     } );
+    // every worker's planner holds grown buffers (sweep-line cache, triangulation maps); freeing
+    // them all serially in the ETS destructor right here would dominate small batches
+    std::vector<HoleFillPlanner*> planners;
+    for ( auto& planner : threadData_ )
+        planners.push_back( &planner );
+    ParallelFor( size_t( 0 ), planners.size(), [&]( size_t i )
+    {
+        *planners[i] = HoleFillPlanner{};
+    } );
     return fillPlans;
 }
 

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -160,6 +160,18 @@ void MeshTopology::shrinkToFit()
     validFaces_.shrink_to_fit();
 }
 
+void MeshTopology::clear()
+{
+    edges_.clear();
+    edgePerVertex_.clear();
+    validVerts_.clear();
+    edgePerFace_.clear();
+    validFaces_.clear();
+    numValidVerts_ = 0;
+    numValidFaces_ = 0;
+    updateValids_ = true;
+}
+
 void MeshTopology::splice( EdgeId a, EdgeId b )
 {
     assert( a.valid() && b.valid() );

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -71,6 +71,9 @@ public:
     /// requests the removal of unused capacity
     MRMESH_API void shrinkToFit();
 
+    /// removes all vertices, edges and faces, keeping the buffers' capacity for reuse
+    MRMESH_API void clear();
+
 
     /// given two half edges do either of two:
     /// 1) if a and b were from distinct rings, puts them in one ring;


### PR DESCRIPTION
`SweepLineQueue` becomes reusable behind a new `ISweepLineCache` interface with a `makeSweepLineCache()` factory: `init()` resets a run while every internal buffer, including the topology (via new `MeshTopology::clear()`) and the projected points, keeps its capacity. The queue itself is now a cheap per-run object working on a `SweepLineQueue::Cache` (the only implementation of the interface) that holds all the reusable buffers.

- `triangulateDisjointContours` and `fillContours2DPlan` accept an optional cache as a defaulted last parameter (`ISweepLineCache* cache = nullptr`), so existing callers and bound signatures gain the parameter without new overloads. `ISweepLineCache` is abstract (pure virtual dtor): instances come only from the factory.
- New C++-only `triangulateDisjointContoursTopology` builds the patch connectivity for a `HoleFillPlan` inside the cache without materializing a `Mesh` at all.
- `HoleFillPlanner` owns a cache member created on the first swept run (like its `optimalStepsCache_`), so each worker of `getPlanarHoleFillPlans` reuses the buffers across all the holes it plans within a call; the per-worker planners are then released in a parallel pass, since freeing them serially in the ETS destructor dominates small batches.

Plans stay bit-identical (FNV hash over plan items, verified against master). Measured with `cMinSweptHoleSize` lowered to 3 so that every hole goes through the swept path: on MeshInspector's Boolean Benchmark workload (3366-vert spheres, DifferenceAB, ~9.7k per-face holes per cut, ~500 per worker) the whole boolean improves by 7-8% (median 19.5 -> 17.8 ms, interleaved rounds); on MRTest MeshBoolean (~30 holes per cut, 1-3 per worker, so nothing to amortize the cache against) it costs about 5% (38 vs 36 ms). At the shipping threshold both are at parity, and a serial 30-hole plan batch with a persistent cache goes 0.229 -> 0.184 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)