### PR TITLE
CI: Restore the C bindings input for C# generation in manual docs

### DIFF
--- a/.github/workflows/update-docs-manual.yml
+++ b/.github/workflows/update-docs-manual.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
+      actions: read   # This is required for wait-for-job
 
     steps:
       - name: Work-around possible permission issues
@@ -98,6 +99,26 @@ jobs:
           name: PythonStubs
           path: ./scripts/wheel/meshlib/meshlib/*.pyi
           retention-days: 1
+
+      # `TARGET=csharp` only reads `source/MeshLibC2/temp/interop_desc.json`, which the C
+      # generator writes and the `CBindings` artifact carries, so the C bindings have to be
+      # unpacked here first. Same steps as build-test-ubuntu-arm64.yml and pip-build.yml.
+      - name: Wait for C bindings
+        uses: ./.github/actions/wait-for-job
+        with:
+          job-name: generate-c-bindings
+
+      - name: Download C bindings
+        uses: actions/download-artifact@v8
+        with:
+          name: CBindings
+          path: MeshLib/CbindingsTmp
+
+      - name: Prepare C bindings folders
+        run: |
+          rm -rf source/MeshLibC2 source/MeshLibC2Cuda
+          mv MeshLib/CbindingsTmp/MeshLibC2 source
+          mv MeshLib/CbindingsTmp/MeshLibC2Cuda source
 
       - name: Generate C# bindings # generate only sources
         run: make -f scripts/mrbind/generate.mk TARGET=csharp -B --trace generate


### PR DESCRIPTION
Fixes a regression from #6540. That PR moved C bindings generation out of `create-stubs`, but `TARGET=csharp` is not self-contained — its whole rule is:

```
mrbind_gen_csharp --input-json source/MeshLibC2/temp/interop_desc.json ...
```

and that JSON is written by the **C** generator (`MRBIND_GEN_C_FLAGS += --output-desc-json`, generate.mk:694), into a `TEMP_OUTPUT_DIR` shared by the `c` and `csharp` targets. The `generate` target is `.PHONY` with no prerequisites, so it cannot produce that file itself — and a separate job means a separate workspace, so no amount of ordering would help.

Confirmed by [run 31125723060](https://github.com/MeshInspector/MeshLib/actions/runs/31125723060/job/92695825587):

```
Unable to open file at: scripts/mrbind/../../source/MeshLibC2/temp/interop_desc.json
make: *** [scripts/mrbind/generate.mk:1129: generate] Aborted (core dumped)
```

`generate-c-bindings.yml` uploads the whole `source/MeshLibC2` directory, `temp/interop_desc.json` included, which is why `build-test-ubuntu-arm64.yml` and `pip-build.yml` unpack that artifact before their C# step. This does the same.

`wait-for-job` rather than `needs: generate-c-bindings` so the ~40-minute MeshLib build still overlaps with the C bindings job and only the dependent step blocks — the same reason build-test-ubuntu-arm64.yml uses it. It needs `actions: read`, added to the job's permissions.

Validation: dispatch `update-docs-manual.yml` after merge — that run doubles as the pending docs refresh for the release-docs miss fixed by #6504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)