### PR TITLE
TEMP: measure --icf=safe binary sizes (do not merge)

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -189,8 +189,8 @@ jobs:
           grep -i "MESHLIB_HAVE_ICF\|icf" build/${{ matrix.config }}/*.log build/${{ matrix.config }}/CMakeCache.txt || true
           echo "=== bin sizes"
           find build/${{ matrix.config }}/bin -maxdepth 1 -type f -printf '%10s %f\n' | sort -rn
-          echo "=== total bytes"
-          find build/${{ matrix.config }}/bin -maxdepth 1 -type f -printf '%s\n' | paste -sd+ | bc
+          echo "=== total bytes of .so"
+          find build/${{ matrix.config }}/bin -maxdepth 1 -name '*.so' -printf '%s\n' | awk '{s+=$1} END {print s}'
           echo "=== link timings"
           find build/${{ matrix.config }} -maxdepth 1 -name link_timings.txt -exec cat {} + || true
 

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -183,6 +183,17 @@ jobs:
             -DMRVIEWER_WITH_BUNDLED_CURL=ON
             -DCMAKE_CXX_FLAGS=${{ matrix.compiler == 'Clang 21' && format('--gcc-install-dir={0}', matrix.gcc-install-dir) || '' }}
 
+      - name: TEMP binary sizes
+        run: |
+          echo "=== ICF check"
+          grep -i "MESHLIB_HAVE_ICF\|icf" build/${{ matrix.config }}/*.log build/${{ matrix.config }}/CMakeCache.txt || true
+          echo "=== bin sizes"
+          find build/${{ matrix.config }}/bin -maxdepth 1 -type f -printf '%10s %f\n' | sort -rn
+          echo "=== total bytes"
+          find build/${{ matrix.config }}/bin -maxdepth 1 -type f -printf '%s\n' | paste -sd+ | bc
+          echo "=== link timings"
+          find build/${{ matrix.config }} -maxdepth 1 -name link_timings.txt -exec cat {} + || true
+
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | llvm-cxxfilt
 

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -268,6 +268,12 @@ jobs:
           ./scripts/distribution_vcpkg.sh ${{ inputs.app_version }}
           mv meshlib_linux-vcpkg.tar.xz meshlib_linux-vcpkg-${{ matrix.arch }}.tar.xz
 
+      - name: TEMP package size
+        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
+        run: |
+          ls -l meshlib_linux-vcpkg-${{ matrix.arch }}.tar.xz
+          tar -tvf meshlib_linux-vcpkg-${{ matrix.arch }}.tar.xz | grep -E '/lib(MR|meshlib)' || true
+
       - name: Extract Package
         if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,20 +49,10 @@ IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "
       add_link_options("-fuse-ld=lld")
     ENDIF()
     add_link_options("LINKER:-z,separate-loadable-segments")
-    set(MESHLIB_LINKER_OPTIONS "-fuse-ld=lld")
-  ENDIF()
-ENDIF()
-
-# Fold byte-identical functions at link time. Supported by lld, gold and mold;
-# GNU ld (bfd) has no ICF, so the check just fails there. `safe` folds only
-# address-insignificant functions, keeping function pointers comparable.
-IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN)
-  include(CheckLinkerFlag)
-  set(CMAKE_REQUIRED_LINK_OPTIONS ${MESHLIB_LINKER_OPTIONS})
-  check_linker_flag(CXX "-Wl,--icf=safe" MESHLIB_HAVE_ICF)
-  unset(CMAKE_REQUIRED_LINK_OPTIONS)
-  IF(MESHLIB_HAVE_ICF)
-    add_link_options($<$<NOT:$<CONFIG:Debug>>:LINKER:--icf=safe>)
+    # Fold byte-identical functions. `safe` folds only the address-insignificant
+    # ones (per Clang's `.llvm_addrsig`), so function pointers stay comparable.
+    # lld-only: GNU ld has no ICF, and GCC emits no address-significance table.
+    add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,--icf=safe>)
   ENDIF()
 ENDIF()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,20 @@ IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "
       add_link_options("-fuse-ld=lld")
     ENDIF()
     add_link_options("LINKER:-z,separate-loadable-segments")
+    set(MESHLIB_LINKER_OPTIONS "-fuse-ld=lld")
+  ENDIF()
+ENDIF()
+
+# Fold byte-identical functions at link time. Supported by lld, gold and mold;
+# GNU ld (bfd) has no ICF, so the check just fails there. `safe` folds only
+# address-insignificant functions, keeping function pointers comparable.
+IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN)
+  include(CheckLinkerFlag)
+  set(CMAKE_REQUIRED_LINK_OPTIONS ${MESHLIB_LINKER_OPTIONS})
+  check_linker_flag(CXX "-Wl,--icf=safe" MESHLIB_HAVE_ICF)
+  unset(CMAKE_REQUIRED_LINK_OPTIONS)
+  IF(MESHLIB_HAVE_ICF)
+    add_link_options($<$<NOT:$<CONFIG:Debug>>:LINKER:--icf=safe>)
   ENDIF()
 ENDIF()
 


### PR DESCRIPTION
Throwaway measurement branch for #6547 — prints per-binary sizes from the Clang 21 / lld legs. Not for merge; will be closed and deleted.