### PR TITLE
TEMP: measure -ffunction-sections sizes (do not merge)

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -183,6 +183,17 @@ jobs:
             -DMRVIEWER_WITH_BUNDLED_CURL=ON
             -DCMAKE_CXX_FLAGS=${{ matrix.compiler == 'Clang 21' && format('--gcc-install-dir={0}', matrix.gcc-install-dir) || '' }}
 
+      - name: TEMP binary sizes
+        run: |
+          echo "=== bin sizes"
+          find build/${{ matrix.config }}/bin -maxdepth 1 -type f -exec stat -c '%s %n' {} + | sort -rn
+          echo "=== total .so bytes"
+          find build/${{ matrix.config }}/bin -maxdepth 1 -name '*.so' -exec stat -c '%s' {} + | awk '{s+=$1} END {print s}'
+          echo "=== .text sizes"
+          for f in libMRMesh.so libMRVoxels.so libMRViewer.so libMeshLibC2.so ; do echo -n "$f "; size -A build/${{ matrix.config }}/bin/$f | awk '$1 == ".text" {print $2}' ; done
+          echo "=== flags seen by the linker"
+          grep -oE "(ffunction-sections|icf=safe)" build/${{ matrix.config }}/link_timings.txt | sort | uniq -c || true
+
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | llvm-cxxfilt
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,10 @@ IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "
     # ones (per Clang's `.llvm_addrsig`), so function pointers stay comparable.
     # lld-only: GNU ld has no ICF, and GCC emits no address-significance table.
     add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,--icf=safe>)
+    # Widen what ICF can reach: without this only COMDAT functions (templates,
+    # inlines) get their own section, so plain out-of-line ones never fold.
+    # `-fdata-sections` would add nothing -- lld folds executable sections only.
+    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:-ffunction-sections>)
   ENDIF()
 ENDIF()
 


### PR DESCRIPTION
Throwaway measurement branch for the -ffunction-sections PR. Baseline commit first (master = --icf=safe only), then the change on top. Will be closed and deleted.