### PR TITLE
Filter out redundant neighbours in alpha-shape search

### DIFF
--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -79,13 +79,11 @@ void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, const Alpha
     // a neighbor p makes a farther neighbor x redundant if p is strictly inside every ball of the given
     // radius through #v having x inside or on it: then x can neither make a triangle with #v (p blocks
     // both its balls) nor be the only point blocking a triangle of others; see the PR for the derivation
-    auto makesRedundant = [rSq4 = 4 * Int128( data.intRadiusSq )]( const Vector3i64 & p, const Vector3i64 & x )
+    auto makesRedundant = [rSq4 = 4 * Int128( data.intRadiusSq )]( const Vector3i64 & p, const Int128 & pp, const Vector3i64 & x, const Int128 & xx )
     {
-        const auto pp = dot( Vector3i128{ p }, Vector3i128{ p } );
         const auto px = dot( Vector3i128{ p }, Vector3i128{ x } );
         if ( px <= pp )
             return false; // x is not behind the plane through p orthogonal to #v-p
-        const auto xx = dot( Vector3i128{ x }, Vector3i128{ x } );
         const auto crossSq = Int256( xx ) * Int256( pp ) - sqr( Int256( px ) ); // |cross(p,x)|^2
         const auto d = Int256( rSq4 - pp );
         if ( 4 * crossSq >= Int256( pp ) * d )
@@ -93,14 +91,29 @@ void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, const Alpha
         // x is strictly outside every ball of the given radius through #v and p
         return Int256( pp ) * sqr( Int256( xx - px ) ) > d * crossSq;
     };
+    // exact squared distances from #v of the sorted neis, each serving as pp and as xx above;
+    // thread_local to avoid allocations on every call
+    thread_local std::vector<Int128> pps;
+    pps.resize( neis.size() );
+    for ( size_t i = 0; i < neis.size(); ++i )
+    {
+        const Vector3i64 p{ neis[i].pt - p0.pt };
+        pps[i] = dot( Vector3i128{ p }, Vector3i128{ p } );
+    }
     size_t goodSize = neis.size();
     for ( size_t i = 0; i < goodSize; ++i )
     {
         const Vector3i64 p{ neis[i].pt - p0.pt };
         size_t good = i + 1;
         for ( size_t j = i + 1; j < goodSize; ++j )
-            if ( !makesRedundant( p, Vector3i64{ neis[j].pt - p0.pt } ) )
-                neis[good++] = neis[j];
+        {
+            if ( !makesRedundant( p, pps[i], Vector3i64{ neis[j].pt - p0.pt }, pps[j] ) )
+            {
+                neis[good] = neis[j];
+                pps[good] = pps[j];
+                ++good;
+            }
+        }
         goodSize = good;
     }
     neis.resize( goodSize );

--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -76,6 +76,35 @@ void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, const Alpha
         return distSqFromV( a ) < distSqFromV( b );
     } );
 
+    // a neighbor p makes a farther neighbor x redundant if p is strictly inside every ball of the given
+    // radius through #v having x inside or on it: then x can neither make a triangle with #v (p blocks
+    // both its balls) nor be the only point blocking a triangle of others; see the PR for the derivation
+    auto makesRedundant = [rSq4 = 4 * Int128( data.intRadiusSq )]( const Vector3i64 & p, const Vector3i64 & x )
+    {
+        const auto pp = dot( Vector3i128{ p }, Vector3i128{ p } );
+        const auto px = dot( Vector3i128{ p }, Vector3i128{ x } );
+        if ( px <= pp )
+            return false; // x is not behind the plane through p orthogonal to #v-p
+        const auto xx = dot( Vector3i128{ x }, Vector3i128{ x } );
+        const auto crossSq = Int256( xx ) * Int256( pp ) - sqr( Int256( px ) ); // |cross(p,x)|^2
+        const auto d = Int256( rSq4 - pp );
+        if ( 4 * crossSq >= Int256( pp ) * d )
+            return false; // x is not closer to line #v-p than the centers of the balls through #v and p
+        // x is strictly outside every ball of the given radius through #v and p
+        return Int256( pp ) * sqr( Int256( xx - px ) ) > d * crossSq;
+    };
+    size_t goodSize = neis.size();
+    for ( size_t i = 0; i < goodSize; ++i )
+    {
+        const Vector3i64 p{ neis[i].pt - p0.pt };
+        size_t good = i + 1;
+        for ( size_t j = i + 1; j < goodSize; ++j )
+            if ( !makesRedundant( p, Vector3i64{ neis[j].pt - p0.pt } ) )
+                neis[good++] = neis[j];
+        goodSize = good;
+    }
+    neis.resize( goodSize );
+
     InSphereTesterSoS tester;
     AlphaShapeStats myStats; // local to keep the counters out of the caller's memory in the loops below
     // the tester must be already reset on the ball in question, and a, b are the ids of its points

--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -49,31 +49,27 @@ AlphaShapeData getAlphaShapeData( const PointCloud & cloud, float radius, bool a
 }
 
 void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, const AlphaShapeData & data,
-    Triangulation & appendTris, std::vector<PreciseVertCoords> & neis, bool onlyLargerVids, AlphaShapeStats * stats )
+    Triangulation & appendTris, std::vector<AlphaShapeNei> & neis, bool onlyLargerVids, AlphaShapeStats * stats )
 {
+    const auto p0 = data.coords( cloud, v );
     neis.clear();
     findPointsInBall( cloud, { cloud.points[v], sqr( data.searchRadius ) },
         [&]( const PointsProjectionResult & found, const Vector3f&, Ball3f & )
         {
             if ( v != found.vId )
-                neis.push_back( data.coords( cloud, found.vId ) );
+            {
+                const auto c = data.coords( cloud, found.vId );
+                const Vector3i64 d{ c.pt - p0.pt };
+                neis.push_back( { c, dot( Vector3i128{ d }, Vector3i128{ d } ) } );
+            }
             return Processing::Continue;
         } );
 
-    const auto p0 = data.coords( cloud, v );
-    // the ball emptiness test below stops on the first point inside the ball, and the points closest
-    // to #v have the best chance to be there; the integer coordinates of neis are taken as they are
-    // already here, and squared in double because their squares can overflow std::int64_t
-    auto distSqFromV = [&p0]( const PreciseVertCoords & c )
+    // the ball emptiness test below stops on the first point inside the ball,
+    // and the points closest to #v have the best chance to be there
+    std::sort( neis.begin(), neis.end(), []( const AlphaShapeNei & a, const AlphaShapeNei & b )
     {
-        const double dx = double( c.pt.x ) - p0.pt.x;
-        const double dy = double( c.pt.y ) - p0.pt.y;
-        const double dz = double( c.pt.z ) - p0.pt.z;
-        return dx * dx + dy * dy + dz * dz;
-    };
-    std::sort( neis.begin(), neis.end(), [&distSqFromV]( const PreciseVertCoords & a, const PreciseVertCoords & b )
-    {
-        return distSqFromV( a ) < distSqFromV( b );
+        return a.distSq < b.distSq;
     } );
 
     // a neighbor p makes a farther neighbor x redundant if p is strictly inside every ball of the given
@@ -91,28 +87,15 @@ void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, const Alpha
         // x is strictly outside every ball of the given radius through #v and p
         return Int256( pp ) * sqr( Int256( xx - px ) ) > d * crossSq;
     };
-    // exact squared distances from #v of the sorted neis, each serving as pp and as xx above;
-    // thread_local to avoid allocations on every call
-    thread_local std::vector<Int128> pps;
-    pps.resize( neis.size() );
-    for ( size_t i = 0; i < neis.size(); ++i )
-    {
-        const Vector3i64 p{ neis[i].pt - p0.pt };
-        pps[i] = dot( Vector3i128{ p }, Vector3i128{ p } );
-    }
     size_t goodSize = neis.size();
     for ( size_t i = 0; i < goodSize; ++i )
     {
-        const Vector3i64 p{ neis[i].pt - p0.pt };
+        const Vector3i64 p{ neis[i].coords.pt - p0.pt };
         size_t good = i + 1;
         for ( size_t j = i + 1; j < goodSize; ++j )
         {
-            if ( !makesRedundant( p, pps[i], Vector3i64{ neis[j].pt - p0.pt }, pps[j] ) )
-            {
-                neis[good] = neis[j];
-                pps[good] = pps[j];
-                ++good;
-            }
+            if ( !makesRedundant( p, neis[i].distSq, Vector3i64{ neis[j].coords.pt - p0.pt }, neis[j].distSq ) )
+                neis[good++] = neis[j];
         }
         goodSize = good;
     }
@@ -125,22 +108,22 @@ void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, const Alpha
     {
         for ( const auto & pn : neis )
         {
-            if ( pn.id == a || pn.id == b )
+            if ( pn.coords.id == a || pn.coords.id == b )
                 continue;
             ++myStats.inBallTests;
-            if ( tester( pn ) == InSphereResult::Inside )
+            if ( tester( pn.coords ) == InSphereResult::Inside )
                 return false;
         }
         return true;
     };
     for ( size_t i = 0; i + 1 < neis.size(); ++i )
     {
-        const auto & pi = neis[i];
+        const auto & pi = neis[i].coords;
         if ( onlyLargerVids && pi.id < v )
             continue;
         for ( size_t j = i + 1; j < neis.size(); ++j )
         {
-            const auto & pj = neis[j];
+            const auto & pj = neis[j].coords;
             if ( onlyLargerVids && pj.id < v )
                 continue;
             // the two balls touching all three points differ only by the side of the triangle,
@@ -175,7 +158,7 @@ std::optional<Triangulation> findAlphaShapeAllTriangles( const PointCloud & clou
     struct ThreadData
     {
         Triangulation tris;
-        std::vector<PreciseVertCoords> neis;
+        std::vector<AlphaShapeNei> neis;
         AlphaShapeStats stats;
     };
 

--- a/source/MRMesh/MRAlphaShape.h
+++ b/source/MRMesh/MRAlphaShape.h
@@ -2,7 +2,9 @@
 
 #include "MRMeshFwd.h"
 #include "MRPrecisePredicates3.h"
+#include "MRHighPrecision.h"
 #include "MRVector.h"
+#include "MRPch/MRBindingMacros.h"
 #include <cstddef>
 #include <optional>
 
@@ -70,12 +72,22 @@ struct AlphaShapeStats
     }
 };
 
+/// a neighbour of the point #v in the search of alpha-shape triangles around it
+struct AlphaShapeNei
+{
+    /// the neighbour's id together with its integer coordinates
+    PreciseVertCoords coords;
+
+    /// the exact squared distance from #v in the units of the same integer grid
+    MR_BIND_IGNORE Int128 distSq;
+};
+
 /// finds all triangles of alpha-shape with negative alpha = -1/radius,
 /// where each triangle contains point #v and two other points
 MRMESH_API void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v,
     const AlphaShapeData & data, ///< prepared by getAlphaShapeData for the same cloud and the same radius
     Triangulation & appendTris,  ///< found triangles will be appended here
-    std::vector<PreciseVertCoords> & neis, ///< temporary storage to avoid memory allocations, it will be filled with all neighbours of point #v within data.searchRadius
+    std::vector<AlphaShapeNei> & neis, ///< temporary storage to avoid memory allocations, it will be filled with the neighbours of point #v within data.searchRadius sorted by distance, except the ones redundant for the search
     bool onlyLargerVids,         ///< if true then two other points must have larger ids (to avoid finding same triangles several times)
     AlphaShapeStats * stats = nullptr ); ///< optional statistics of the work done, which is increased here
 

--- a/source/MRTest/MRAlphaShapeTests.cpp
+++ b/source/MRTest/MRAlphaShapeTests.cpp
@@ -18,7 +18,7 @@ TEST( MRMesh, AlphaShape )
     cloud.validPoints.autoResizeSet( 2_v, 3, true );
 
     Triangulation tris;
-    std::vector<PreciseVertCoords> neis;
+    std::vector<AlphaShapeNei> neis;
     AlphaShapeStats stats;
 
     auto data = getAlphaShapeData( cloud, 3, false );


### PR DESCRIPTION
In `findAlphaShapeNeiTriangles`, right after sorting the neighbours by distance from #v, a neighbour x is now dropped if some preceding (closer) neighbour p satisfies all three conditions (with #v taken as the origin):

1. `dot(p,x) > dot(p,p)` — x is behind the plane through p orthogonal to the segment #v-p;
2. x is strictly outside every ball of the given radius passing via #v and p;
3. x is closer to the line #v-p than the centers of all such balls.

Together they guarantee that p is *strictly inside* every ball of the given radius via #v that has x inside or on its boundary. (The minimum of the linear function `dot(c,p)` over the centers c of such balls is attained on the balls via both #v and x, where the claim reduces to conditions 2–3 by the meridian-plane decomposition; also verified numerically on 200k random configurations.) Hence x is redundant:

* x cannot make an alpha-shape triangle with #v — p is strictly inside both balls of any such triangle;
* x cannot be the only point blocking a triangle of others — every ball where x is `Inside` contains p strictly, so p blocks it too;
* the simulation-of-simplicity ties are preserved: an `Inside` verdict for x on a tie means x is exactly on the ball, and p being *strictly* inside is immune to the symbolic perturbation.

The conditions are evaluated exactly in integer arithmetic (128/256 bits, no divisions or square roots), reusing the derivation notation `pp = dot(p,p)`, `px = dot(p,x)`, `xx = dot(x,x)`, `crossSq = xx*pp - px*px = |cross(p,x)|^2`:

2. `pp * sqr(xx - px) > (4*rSq - pp) * crossSq`
3. `4 * crossSq < pp * (4*rSq - pp)`

Strictness in condition 2 matters: at exact equality the tangent ball passes via #v, p and x simultaneously, and the triangle (#v, p, x) can legitimately be in the output. Condition 3 also implies `pp < 4*rSq`, so no separate existence check is needed, and a duplicate of #v (`pp == 0`) never filters anything.

`neis` becomes a vector of `AlphaShapeNei { PreciseVertCoords coords; Int128 distSq; }`: the exact squared distance from #v is computed once when a neighbour is collected, serves as the key of the distance sort (previously approximated in double, which was harmless but is now free to be exact), and in the filter each entry serves both as `pp` for the pairs where the point filters and as `xx` for the pairs where it is filtered, saving two 128-bit dot products per tested pair (~10% of the total time). The `distSq` field is `MR_BIND_IGNORE`d to keep boost's `Int128` out of the bindings, same as the Eigen field in `BestFitPolynomial`.

The found triangles are identical on all benchmark clouds (equal triangle-list hashes), while both quadratic stages shrink; the filtering pass cost is included in the timings (Ryzen 9 3900X, Windows x64 Release, MSVC 19.51):

| cloud | master, ms | PR, ms | consideredTris | touchableTris | inBallTests |
|---|---|---|---|---|---|
| sphere 20k | 205 | 85 | 1622300 → 265028 | 847608 → 230891 | 5115228 → 1578670 |
| sphere 50k | 510 | 215 | 4070916 → 674971 | 2129348 → 587324 | 12792094 → 4003102 |
| crossing grids 61x61 | 255 | 100 | 2133796 → 260811 | 1076522 → 228532 | 5675019 → 1378089 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
