### PR TITLE
TEMP: section-level breakdown for #6550 (do not merge)

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -183,6 +183,18 @@ jobs:
             -DMRVIEWER_WITH_BUNDLED_CURL=ON
             -DCMAKE_CXX_FLAGS=${{ matrix.compiler == 'Clang 21' && format('--gcc-install-dir={0}', matrix.gcc-install-dir) || '' }}
 
+      - name: TEMP section breakdown
+        run: |
+          BIN=build/${{ matrix.config }}/bin
+          echo "=== file sizes"
+          find $BIN -maxdepth 1 -name '*.so' -exec stat -c '%s %n' {} + | sort -rn
+          echo "=== per-section sizes"
+          for f in $BIN/*.so ; do echo "## $(basename $f)"; size -A $f ; done
+          echo "=== section table libMeshLibC2.so"
+          readelf -SW $BIN/libMeshLibC2.so || true
+          echo "=== section table libMRMesh.so"
+          readelf -SW $BIN/libMRMesh.so || true
+
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | llvm-cxxfilt
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,10 @@ IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "
     # ones (per Clang's `.llvm_addrsig`), so function pointers stay comparable.
     # lld-only: GNU ld has no ICF, and GCC emits no address-significance table.
     add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,--icf=safe>)
+    # Widen what ICF can reach: without this only COMDAT functions (templates,
+    # inlines) get their own section, so plain out-of-line ones never fold.
+    # `-fdata-sections` would add nothing -- lld folds executable sections only.
+    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:-ffunction-sections>)
   ENDIF()
 ENDIF()
 


### PR DESCRIPTION
Throwaway. Run 1 = baseline at 186410a77 (also a variance control vs the earlier baseline run), run 2 = + -ffunction-sections. Per-section sizes for every .so.