### PR TITLE
TEMP: stripped-size measurement for #6550 (do not merge)

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -183,6 +183,19 @@ jobs:
             -DMRVIEWER_WITH_BUNDLED_CURL=ON
             -DCMAKE_CXX_FLAGS=${{ matrix.compiler == 'Clang 21' && format('--gcc-install-dir={0}', matrix.gcc-install-dir) || '' }}
 
+      - name: TEMP stripped vs unstripped sizes
+        run: |
+          BIN=build/${{ matrix.config }}/bin
+          rm -rf /tmp/st && mkdir -p /tmp/st && cp $BIN/*.so /tmp/st/
+          strip --strip-all /tmp/st/*.so
+          echo "=== unstripped"
+          for f in $BIN/*.so ; do stat -c '%s %n' $f ; done | sort -rn
+          echo "=== stripped"
+          for f in /tmp/st/*.so ; do stat -c '%s %n' $f ; done | sort -rn
+          echo "=== totals"
+          echo -n "unstripped: "; stat -c '%s' $BIN/*.so | awk '{s+=$1} END {print s}'
+          echo -n "stripped:   "; stat -c '%s' /tmp/st/*.so | awk '{s+=$1} END {print s}'
+
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | llvm-cxxfilt
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,10 @@ IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "
     # ones (per Clang's `.llvm_addrsig`), so function pointers stay comparable.
     # lld-only: GNU ld has no ICF, and GCC emits no address-significance table.
     add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,--icf=safe>)
+    # Widen what ICF can reach: without this only COMDAT functions (templates,
+    # inlines) get their own section, so plain out-of-line ones never fold.
+    # `-fdata-sections` would add nothing -- lld folds executable sections only.
+    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:-ffunction-sections>)
   ENDIF()
 ENDIF()
 


### PR DESCRIPTION
Throwaway. Baseline at 186410a77 first, then -ffunction-sections on top; each run reports both unstripped and stripped .so sizes.