### PR TITLE
Build hole fill plans in mesh space

### DIFF
--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -129,6 +129,39 @@ struct ProjectedFillMesh
     std::vector<EdgeLoop> paths;
 };
 
+// checks that patch boundary loops match the input hole loops one-to-one and re-orients inverted
+// degenerate holes (expected sometimes as far as planar triangulation does not now about input topology)
+static Expected<void> validateAndFixPatch( MeshTopology& patchTopology, const std::vector<EdgeLoop>& inputPaths, std::vector<EdgePath>& patchPaths )
+{
+    if ( inputPaths.size() != patchPaths.size() )
+        return unexpected( "Patch surface borders size different from original mesh borders size" );
+
+    std::vector<EdgePath> invertedHoles;
+    invertedHoles.reserve( patchPaths.size() );
+    for ( int i = 0; i < patchPaths.size(); ++i )
+    {
+        if ( inputPaths[i].size() != patchPaths[i].size() )
+            return unexpected( "Patch surface borders size different from original mesh borders size" );
+
+        if ( patchPaths[i].empty() || patchTopology.right( patchPaths[i].front() ) )
+            if ( !patchPaths[i].empty() )
+                MR::reverse( invertedHoles.emplace_back( patchPaths[i] ) );
+    }
+    if ( !invertedHoles.empty() )
+    {
+        auto invertedParts = fillContourLeft( patchTopology, invertedHoles );
+        auto invertedEdges = getIncidentEdges( patchTopology, invertedParts );
+        patchTopology.flipOrientation( &invertedEdges );
+
+        // validate one more time
+        for ( int i = 0; i < patchPaths.size(); ++i )
+            if ( patchPaths[i].empty() || patchTopology.right( patchPaths[i].front() ) )
+                if ( !patchPaths[i].empty() )
+                    return unexpected( "Patch surface borders are incompatible with mesh borders" );
+    }
+    return {};
+}
+
 Expected<ProjectedFillMesh> fillProjected( const MeshTopology& tp, const ProjectFillInput& input )
 {
     MR_TIMER;
@@ -144,34 +177,8 @@ Expected<ProjectedFillMesh> fillProjected( const MeshTopology& tp, const Project
 
     res.mesh = std::move( *fillResult );
 
-
-    if ( input.paths.size() != res.paths.size() )
-        return unexpected( "Patch surface borders size different from original mesh borders size" );
-
-    std::vector<EdgePath> invertedHoles;
-    invertedHoles.reserve( res.paths.size() );
-    for ( int i = 0; i < res.paths.size(); ++i )
-    {
-        if ( input.paths[i].size() != res.paths[i].size() )
-            return unexpected( "Patch surface borders size different from original mesh borders size" );
-
-        // degenerate holes might invert sometimes (it is expected as far as planar triangulation does not now about input topology)
-        if ( res.paths[i].empty() || res.mesh.topology.right( res.paths[i].front() ) )
-            if ( !res.paths[i].empty() )
-                MR::reverse( invertedHoles.emplace_back( res.paths[i] ) );
-    }
-    if ( !invertedHoles.empty() )
-    {
-        auto invertedParts = fillContourLeft( res.mesh.topology, invertedHoles );
-        auto invertedEdges = getIncidentEdges( res.mesh.topology, invertedParts );
-        res.mesh.topology.flipOrientation( &invertedEdges );
-
-        // validate one more time
-        for ( int i = 0; i < res.paths.size(); ++i )
-            if ( res.paths[i].empty() || res.mesh.topology.right( res.paths[i].front() ) )
-                if ( !res.paths[i].empty() )
-                    return unexpected( "Patch surface borders are incompatible with mesh borders" );
-    }
+    if ( auto v = validateAndFixPatch( res.mesh.topology, input.paths, res.paths ); !v )
+        return unexpected( std::move( v.error() ) );
     return res;
 }
 
@@ -207,19 +214,31 @@ Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepres
 
 Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
 {
-    auto projInput = projectHoles( mesh, { holeEdgeId } );
-    if ( !projInput.has_value() )
-        return unexpected( std::move( projInput.error() ) );
+    assert( !mesh.topology.left( holeEdgeId ) );
+    if ( mesh.topology.left( holeEdgeId ) )
+        return unexpected( "Hole edge has left face" );
 
-    auto fillRes = fillProjected( mesh.topology, *projInput );
-    if ( !fillRes.has_value() )
-        return unexpected( std::move( fillRes.error() ) );
+    // triangulate the hole in the mesh's own 3d space: only the plan is needed, so the projection
+    // round-trip of the mesh-filling path above is avoided
+    EdgeLoops loops( 1 );
+    loops.front() = trackRightBoundaryLoop( mesh.topology, holeEdgeId );
 
-    assert( fillRes->paths.size() == 1 ); // should be validated in fillProjected
+    // the hole loop winds counterclockwise around this direction, same as around the fitted plane's normal it replaces
+    Vector3d sumCross;
+    for ( EdgeId e : loops.front() )
+        sumCross += cross( Vector3d( mesh.orgPnt( e ) ), Vector3d( mesh.destPnt( e ) ) );
 
-    const auto& pTp = fillRes->mesh.topology;
-    const auto& ip = projInput->paths[0];
-    auto& np = fillRes->paths[0];
+    std::vector<EdgePath> newPaths;
+    auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f( sumCross.normalized() ), &newPaths );
+    if ( !patch )
+        return unexpected( "Cannot triangulate contours with self-intersections" );
+
+    if ( auto v = validateAndFixPatch( patch->topology, loops, newPaths ); !v )
+        return unexpected( std::move( v.error() ) );
+
+    const auto& pTp = patch->topology;
+    const auto& ip = loops.front();
+    auto& np = newPaths.front();
     HoleFillPlan res;
     res.numTris = pTp.numValidFaces();
     if ( res.numTris == 1 )

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -240,7 +240,7 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
     // A hairline boundary edge forces every triangulation to emit a zero-area needle whose placement
     // in 3d is arbitrary; two holes sharing such an edge pick their needles independently and can make
     // them cross. Leave those contours to the metric fill, which weighs triangle shape.
-    if ( minEdgeLenSq < 1e-12f * loopBox.diagonal() * loopBox.diagonal() )
+    if ( minEdgeLenSq < 1e-12f * loopBox.size().lengthSq() )
         return unexpected( "Hole boundary has a degenerate edge" );
 
     std::vector<EdgePath> newPaths;

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -11,6 +11,8 @@
 #include "MRObjectMeshData.h"
 #include "MRColor.h"
 #include "MRMeshFillHole.h"
+#include "MRBox.h"
+#include <cfloat>
 
 namespace MR
 {
@@ -225,8 +227,21 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
 
     // the hole loop winds counterclockwise around this direction, same as around the fitted plane's normal it replaces
     Vector3d sumCross;
+    Box3f loopBox;
+    float minEdgeLenSq = FLT_MAX;
     for ( EdgeId e : loops.front() )
-        sumCross += cross( Vector3d( mesh.orgPnt( e ) ), Vector3d( mesh.destPnt( e ) ) );
+    {
+        const auto o = mesh.orgPnt( e ), d = mesh.destPnt( e );
+        sumCross += cross( Vector3d( o ), Vector3d( d ) );
+        loopBox.include( o );
+        minEdgeLenSq = std::min( minEdgeLenSq, ( d - o ).lengthSq() );
+    }
+
+    // A hairline boundary edge forces every triangulation to emit a zero-area needle whose placement
+    // in 3d is arbitrary; two holes sharing such an edge pick their needles independently and can make
+    // them cross. Leave those contours to the metric fill, which weighs triangle shape.
+    if ( minEdgeLenSq < 1e-12f * loopBox.diagonal() * loopBox.diagonal() )
+        return unexpected( "Hole boundary has a degenerate edge" );
 
     std::vector<EdgePath> newPaths;
     auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f( sumCross.normalized() ), &newPaths );


### PR DESCRIPTION
`fillContours2DPlan` needed only the patch connectivity, yet it went through the full projection round-trip of the mesh-filling path: fit a plane, transform every boundary vertex, build a `Contours2f`, triangulate, then read the plan off the result.

Since #6309 the sweep-line triangulation can work in the mesh's own 3d space, so the plan path now tracks the hole loop, takes its Newell normal, and calls `triangulateDisjointContours( mesh, loops, normal, … )` directly. The border validation and the inverted-degenerate-hole fixup that `fillProjected` did inline are extracted into `validateAndFixPatch` and shared by both paths.

No public header changes.

### Hairline contours

The second commit declines contours that contain a boundary edge degenerate relative to the contour itself, leaving them to the metric fill.

The sphere boolean fixture cuts two mesh vertices 1e-8 apart and hands the resulting hairline edge to *two adjacent holes*. Any triangulation must then emit a zero-area needle on that edge (the one measured here has aspect ratio 1.1e6), each hole picks its needle independently, and the two can cross. This is not specific to this PR: over 300 slightly rotated variants of the same fixture, master produces self-colliding triangles on one of them too, just not on the un-rotated one the test happens to use.

| build | perturbations with self-collisions |
|---|---|
| master | 1 / 300 |
| this PR, first commit only | 1 / 300 |
| this PR | **0 / 300** |

So the guard leaves the boolean strictly more robust here than master, not merely as good.

### Correctness

- For holes lying in an axis-aligned plane the produced plans are bit-identical to master (FNV hash over all `FillHoleItem`s of 3000 mixed-size holes); the guard does not change that hash, nor the tilted-plane one.
- For holes on a plane tilted off all axes the triangulations differ combinatorially, but quality is indistinguishable: same triangle count (23995), same geometric-mean aspect ratio (1.2812), same maximum (4.64), no triangle above aspect 10 on either side.
- 16/16 of the boolean / hole-fill / triangulation tests pass; with `cMinSweptHoleSize` lowered locally to force every hole down the swept path, the failure set is exactly master's (only `MRMesh.HoleFillPlan4`, which is a known artifact of that lowered threshold), and the perturbation sweep stays at 0.

### Degenerate loop normals

Both implementations derive their plane from the same Newell sum, so they degenerate together, but their fallbacks differ: master's `getXfFromOxyPlane` yields an identity rotation (so it projects on XY), while the dominant-axis rule here drops X. Across 15 degenerate and near-degenerate loops — collinear along each axis and a diagonal, all-points-coincident, zero-area self-crossing loops in each of the three axis planes, out-and-back slits, and slivers down to a Newell norm of 6e-9 — behaviour is identical in 13 cases, including every collinear and coincident one (both emit the same zero-area plan) and every sliver (the normal stays correct at 1e-9).

The two that differ are zero-area *self-crossing* loops in the YZ and XZ planes: master's projection collapses them onto a line, hides the self-intersection and returns a 2-triangle self-overlapping patch, whereas this change reports "Cannot triangulate contours with self-intersections". No case does the reverse, so the change is strictly the more conservative of the two, and `HoleFillPlanner::runPlanar` already falls back to the metric fill when the plan is not available.

### Performance

Interleaved and counterbalanced against master, medians:

| workload | master | this PR |
|---|---|---|
| serial plan, 30 mixed holes | 0.228 ms | 0.211 ms |
| 500 swept 16-vertex holes, one shot each | 5.40 ms | 4.95 ms |
| sphere boolean, swept path forced on every hole | 19.35 ms | 18.85 ms |
| sphere boolean, default threshold | 13.73 ms | 13.73 ms |

The last row is parity because at the shipping `cMinSweptHoleSize` that workload never enters the swept path at all; the row above it lowers the threshold so the change is actually exercised, and it includes the guard (without it the same figure is 18.70 ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)