### PR TITLE
Strip the libraries in the vcpkg package

### DIFF
--- a/scripts/distribution_vcpkg.sh
+++ b/scripts/distribution_vcpkg.sh
@@ -32,8 +32,6 @@ mkdir ${DISTR_DIR}
 VCPKG_INSTALLED_DIR=${VCPKG_INSTALLED_DIR:=${VCPKG_ROOT}/installed}
 cp -a ${VCPKG_INSTALLED_DIR}/${VCPKG_TRIPLET}/* ${DISTR_DIR}/
 # install MeshLib files
-# --strip drops .symtab/.strtab: linking needs only .dynsym, and the wheels
-# and the AppImage have always shipped stripped.
 cmake --install ./build/Release --prefix ${DISTR_DIR} --strip
 # create tar.xz file
 tar --create --use-compress-program='xz -9 -T0' --file=meshlib_linux-vcpkg.tar.xz --directory=${DISTR_DIR} .

--- a/scripts/distribution_vcpkg.sh
+++ b/scripts/distribution_vcpkg.sh
@@ -32,7 +32,9 @@ mkdir ${DISTR_DIR}
 VCPKG_INSTALLED_DIR=${VCPKG_INSTALLED_DIR:=${VCPKG_ROOT}/installed}
 cp -a ${VCPKG_INSTALLED_DIR}/${VCPKG_TRIPLET}/* ${DISTR_DIR}/
 # install MeshLib files
-cmake --install ./build/Release --prefix ${DISTR_DIR}
+# --strip drops .symtab/.strtab: linking needs only .dynsym, and the wheels
+# and the AppImage have always shipped stripped.
+cmake --install ./build/Release --prefix ${DISTR_DIR} --strip
 # create tar.xz file
 tar --create --use-compress-program='xz -9 -T0' --file=meshlib_linux-vcpkg.tar.xz --directory=${DISTR_DIR} .
 


### PR DESCRIPTION
The `linux-vcpkg` `tar.xz` is the last artifact that ships unstripped libraries: `cmake --install` is called without `--strip`, while the wheels (#6525) and the AppImage (linuxdeploy strips unless `NO_STRIP` is set) have always been stripped. Measured on the `Release` / `Clang 21` legs, the MeshLib shared libraries alone carry **16.3 MB** (x64) and **17.6 MB** (arm64) of `.symtab`/`.strtab`:

| all `.so` in `build/Release/bin` | unstripped | stripped |
| --- | ---: | ---: |
| x64 | 62,285,048 | 46,020,984 |
| arm64 | 65,737,856 | 45,443,384 |

Those sections are not `SEC_ALLOC` — never loaded at runtime — and linking against the package needs only `.dynsym`, which `strip` keeps. This also removes the wart that #6550 left behind: `-ffunction-sections` grows `.symtab` (per-function section symbols), which is invisible everywhere except in this one artifact.

Trade-off worth stating: backtraces taken inside the shipped libraries lose the names of non-exported functions, since MeshLib builds with `-fvisibility=hidden`. That is already true of every wheel and AppImage we publish, so this only makes the vcpkg package consistent with them.

Third-party libraries copied from vcpkg are left alone: blanket-stripping that tree would hit `.a` archives, where it breaks linking.

### Sizes

Packaged twice in one job on a throwaway branch — once as this PR does, once with `--strip` removed:

| `meshlib_linux-vcpkg.tar.xz` | unstripped | stripped | delta |
| --- | ---: | ---: | ---: |
| x64 | 68,676,728 | 67,172,652 | **−1,504,076 (−2.19%)** |
| arm64 | 65,309,252 | 63,177,912 | **−2,131,340 (−3.26%)** |

16.3 MB (x64) / 17.6 MB (arm64) of raw symbol tables compress down to a 1.5 MB / 2.1 MB saving in the shipped archive — they compress about 9:1, but the absolute win is still real, and the uncompressed install shrinks by the full amount.

This also closes the one caveat left by #6550: `-ffunction-sections` inflates `.symtab`, and this package was the only artifact that carried it.

### Testing

`linux-vcpkg` only; the script is not used by any other platform. The `Create Package` → `Extract Package` → `Build C++/C examples` steps in that job build the examples against the stripped package, which is the check that matters here.
