### PR TITLE
TEMP: package size stripped vs unstripped (do not merge)

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -257,6 +257,15 @@ jobs:
           ./scripts/distribution_vcpkg.sh ${{ inputs.app_version }}
           mv meshlib_linux-vcpkg.tar.xz meshlib_linux-vcpkg-${{ matrix.arch }}.tar.xz
 
+      - name: TEMP package size both ways
+        if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
+        run: |
+          echo -n "stripped:   "; stat -c '%s' meshlib_linux-vcpkg-${{ matrix.arch }}.tar.xz
+          sed -i 's/ --strip//' scripts/distribution_vcpkg.sh
+          ./scripts/distribution_vcpkg.sh 0.0.0.0 > /dev/null
+          echo -n "unstripped: "; stat -c '%s' meshlib_linux-vcpkg.tar.xz
+          git checkout -- scripts/distribution_vcpkg.sh
+
       - name: Extract Package
         if: ${{ matrix.config == 'Release' && matrix.compiler == 'Clang 21' }}
         run: |

--- a/scripts/distribution_vcpkg.sh
+++ b/scripts/distribution_vcpkg.sh
@@ -32,7 +32,9 @@ mkdir ${DISTR_DIR}
 VCPKG_INSTALLED_DIR=${VCPKG_INSTALLED_DIR:=${VCPKG_ROOT}/installed}
 cp -a ${VCPKG_INSTALLED_DIR}/${VCPKG_TRIPLET}/* ${DISTR_DIR}/
 # install MeshLib files
-cmake --install ./build/Release --prefix ${DISTR_DIR}
+# --strip drops .symtab/.strtab: linking needs only .dynsym, and the wheels
+# and the AppImage have always shipped stripped.
+cmake --install ./build/Release --prefix ${DISTR_DIR} --strip
 # create tar.xz file
 tar --create --use-compress-program='xz -9 -T0' --file=meshlib_linux-vcpkg.tar.xz --directory=${DISTR_DIR} .
 


### PR DESCRIPTION
Throwaway for #6556. Packages twice in one job: once as the PR does (stripped), once with --strip removed.