### PR TITLE
Timer: do not allocate the name string when the timing is off

### DIFF
--- a/source/MRMesh/MRTimer.cpp
+++ b/source/MRMesh/MRTimer.cpp
@@ -188,6 +188,13 @@ void Timer::restart( std::string name )
     start( std::move( name ) );
 }
 
+void Timer::start( const char * name )
+{
+    if ( !currentRecord )
+        return; // the name will be thrown away, do not allocate a string for it
+    start( std::string( name ) );
+}
+
 void Timer::start( std::string name )
 {
     auto parent = currentRecord;

--- a/source/MRMesh/MRTimer.h
+++ b/source/MRMesh/MRTimer.h
@@ -17,10 +17,14 @@ class MR_BIND_IGNORE Timer
 {
 public:
     Timer( std::string name ) { start( std::move( name ) ); }
+    /// the name is converted in std::string only if the timing is enabled in this thread,
+    /// which is not the case in parallel worker threads, where MR_TIMER then costs nothing
+    Timer( const char * name ) { start( name ); }
     ~Timer() { finish(); }
 
     MRMESH_API void restart( std::string name );
     MRMESH_API void start( std::string name );
+    MRMESH_API void start( const char * name );
     MRMESH_API void finish();
 
     Timer( const Timer & ) = delete;


### PR DESCRIPTION
`MR_TIMER` expands to `MR::Timer _timer( __FUNCTION__ )`, and `Timer` took its name **by value as `std::string`**. MSVC's `__FUNCTION__` is the fully qualified name (`MR::PlanarTriangulation::SweepLineQueue::mergeSamePoints_` and friends are 40-60 characters), so it never fits the small-string buffer: every `MR_TIMER` hit did a malloc + memcpy + free.

That work is wasted whenever the timing is off, which is the case in **every thread except the one holding a `ThreadRootTimeRecord`** — i.e. in all TBB worker threads (`MRTimer.cpp` installs the root record for the main thread only). Code that runs a timer-instrumented function per item inside a parallel loop paid an allocation per timer per item.

This adds a `const char *` overload that checks `currentRecord` first and only then builds the string. `MR_TIMER` picks it up with no change to the macro, and callers passing a `std::string` are unaffected.

### Behaviour

Unchanged by construction: with timing on, `start( const char * )` delegates to the existing `start( std::string )`; with timing off, both return without touching anything. Checked empirically as well — dumping `printTimingTree` for the same workload before and after gives the same tree, same records, same names.

### Measurements

Release x64, one benchmark exe run against each `MRMesh.dll` in rotating order, 8-14 rounds, ten workloads. Because a change to a widely included header relinks the whole DLL and shifts code layout, the comparison includes two extra builds:

- **null control** — the identical code shape (new overload, same call graph) but still allocating, so it cannot be faster than master. It isolates layout noise from saved work, and it is the fair baseline to compare against.
- **no timers** — `MR_TIMER` redefined to `((void)0)`, i.e. the ceiling of what any work on the timers could ever buy. Not proposed, measured only.

Best-round medians, ms:

| workload | master | null control | **this PR** | no timers |
|---|---|---|---|---|
| hole-fill plans, 2000 × 16-vert holes (swept path) | 1.663 | 1.638 | **1.580** | 1.532 |
| hole-fill plans, 2000 × 8-vert holes (metric path) | 0.415 | 0.415 | 0.412 | 0.421 |
| boolean of two 3366-vert spheres | 13.693 | 13.587 | 13.620 | 13.618 |
| decimate 100k verts | 40.565 | 41.050 | 41.075 | 40.443 |
| subdivide 20k verts | 52.879 | 52.980 | 52.915 | 52.760 |
| relax 100k verts, 5 iterations | 1.587 | 1.519 | 1.543 | 1.514 |
| Delone flips, 100k verts | 1.717 | 1.647 | 1.678 | 1.716 |
| AABB tree rebuild, 200k verts | 17.301 | 17.427 | 17.401 | 17.345 |
| self-collision, 200k verts | 15.870 | 15.909 | 15.913 | 15.805 |

Only the first row moves. There it is **−3.5% against the null control** and −5.0% against master, while removing the timers altogether gives −6.5% — so this recovers a bit over half of the entire cost of the timer machinery on that workload. Everything else stays inside ±0.5%, and note the no-timer build does not beat the null control on those rows either: `MR_TIMER` is simply not a measurable tax in code that calls a handful of instrumented functions per operation. (A `fillHole`-in-a-loop workload was dropped from the table: on master it picks the planar path a varying number of times from run to run, so its timings are not comparable.)

The row that moves is the one with the timer density: ~13 `MR_TIMER` hits per hole, in worker threads, with little work per hole. The saving works out to ~58 ns per hit, which is what a malloc/memcpy/free pair costs here. The same measurement on a build where planar triangulation handles every hole (`cMinSweptHoleSize = 3`, not proposed here) shows −3.2% on the sphere boolean, consistent with that figure.

So: a narrow but real win, and — more usefully — it makes `MR_TIMER` cheap enough to leave in small functions that run inside parallel loops, which today is a trap. The remaining gap to the no-timer build is the cross-DLL call itself; closing it would mean inlining the "is timing on?" check into the header, which is a bigger change and not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
