### PR TITLE
Plan the filling of several coplanar holes at once

### DIFF
--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -13,6 +13,7 @@
 #include "MRMeshFillHole.h"
 #include "MRBox.h"
 #include <cfloat>
+#include <climits>
 
 namespace MR
 {
@@ -224,92 +225,84 @@ static Expected<HoleFillPlan> patchToPlan( const MeshTopology& pTp, const std::v
 {
     assert( meshLoops.size() == patchBds.size() ); // validated in validateAndFixPatch
 
-    // peeling state per boundary point; each current polygon ring is implicit in succ
-    int n = 0;
+    int n = 0; // boundary positions, i.e. edge sides the patch borders take
     for ( const auto& loop : meshLoops )
         n += int( loop.size() );
-    std::vector<EdgeId> cur;  // current polygon edge in the patch, invalid = consumed position
-    std::vector<int> refCode; // plan code of cur: not-negative absolute EdgeId in the mesh, negative - plan edge
-    std::vector<int> succ;    // next position around the polygon
-    cur.reserve( n + patchBds.size() ); // joining two rings adds a position
-    refCode.reserve( n + patchBds.size() );
-    succ.reserve( n + patchBds.size() );
-    Vector<EdgeId, UndirectedEdgeId> bd2mesh( n ); // patch boundary edge (even direction) -> mesh edge
+
+    // the polygon being peeled: the patch edge currently at each boundary position, and the position
+    // following it - so a ring is a cycle of `next` and rings can be joined and split in place
+    struct Pos
+    {
+        EdgeId cur; // invalid once the position is consumed
+        int next = 0;
+    };
+    std::vector<Pos> pos;
+    pos.reserve( n + patchBds.size() ); // joining two rings adds a position
+
+    // how the plan can name each patch edge: not-negative absolute mesh edge (given for its even
+    // direction) on the hole borders, negative plan edge once a chord for it is planned
+    constexpr int cUnnameable = INT_MAX;
+    Vector<int, UndirectedEdgeId> codes( pTp.undirectedEdgeSize(), cUnnameable );
     for ( int j = 0, base = 0; j < int( patchBds.size() ); base += int( patchBds[j].size() ), ++j )
     {
         for ( int i = 0; i < int( patchBds[j].size() ); ++i )
         {
-            const EdgeId b = patchBds[j][i];
+            const EdgeId b = patchBds[j][i], m = meshLoops[j][i];
             if ( !pTp.left( b ) )
                 return unexpected( "Patch surface borders are incompatible with mesh borders" );
-            cur.push_back( b );
-            refCode.push_back( int( meshLoops[j][i] ) );
-            succ.push_back( i + 1 < int( patchBds[j].size() ) ? int( cur.size() ) : base );
-            bd2mesh.autoResizeSet( b.undirected(), b.even() ? meshLoops[j][i] : meshLoops[j][i].sym() );
+            codes[b.undirected()] = int( b.even() ? m : m.sym() );
+            pos.push_back( { b, i + 1 < int( patchBds[j].size() ) ? int( pos.size() ) + 1 : base } );
         }
     }
-    auto meshEdge = [&] ( EdgeId patchBd )
+    // a plan edge can only be named in the direction it is created in, so a chord already planned from
+    // the other side is off limits; a mesh edge can be named either way
+    auto planned = [&] ( EdgeId e ) { return codes[e.undirected()] < 0; };
+    auto nameable = [&] ( EdgeId e ) { return codes[e.undirected()] != cUnnameable; };
+    auto codeOf = [&] ( EdgeId e )
     {
-        return patchBd.even() ? bd2mesh[patchBd.undirected()] : bd2mesh[patchBd.undirected()].sym();
+        const int c = codes[e.undirected()];
+        assert( c != cUnnameable );
+        return c < 0 ? c : int( e.even() ? EdgeId( c ) : EdgeId( c ).sym() );
     };
 
-    UndirectedEdgeBitSet bdEdges( pTp.undirectedEdgeSize() );
-    for ( auto e : cur )
-        bdEdges.set( e.undirected() );
-
-    // the plan has to create every interior edge of the patch, and every filled face must be adjacent
-    // to one of them (or belong to a hole filled with a single face, see below)
-    int numChords = 0;
-    FaceBitSet chordFaces( pTp.faceSize() );
-    for ( UndirectedEdgeId ue{ 0 }; ue < pTp.undirectedEdgeSize(); ++ue )
-    {
-        if ( bdEdges.test( ue ) )
-            continue;
-        const auto l = pTp.left( ue ), r = pTp.right( EdgeId( ue ) );
-        if ( !l && !r )
-            continue; // lone edge
-        if ( !l || !r )
-            return unexpected( "Incorrect filling" );
-        ++numChords;
-        chordFaces.set( l );
-        chordFaces.set( r );
-    }
+    // the plan has to create every interior edge of the patch: each of the numFaces faces has three
+    // edge sides, and the boundary takes n of them, so the rest are the two sides of every chord
+    const int numFaces = pTp.numValidFaces();
+    if ( 3 * numFaces < n || ( 3 * numFaces - n ) % 2 != 0 )
+        return unexpected( "Incorrect filling" );
+    const int numChords = ( 3 * numFaces - n ) / 2;
 
     HoleFillPlan res;
     res.items.reserve( numChords );
-    UndirectedEdgeBitSet emitted( pTp.undirectedEdgeSize() ); // patch edges already present in the plan
-    auto clip = [&] ( int p0, EdgeId ne, int code )
+    auto clip = [&] ( int p0, EdgeId ne )
     {
-        const int p1 = succ[p0];
-        cur[p1] = {};
-        cur[p0] = ne;
-        refCode[p0] = code;
-        succ[p0] = succ[p1];
+        const int p1 = pos[p0].next;
+        pos[p1].cur = {};
+        pos[p0].cur = ne;
+        pos[p0].next = pos[p1].next;
     };
     while ( int( res.items.size() ) < numChords )
     {
         bool progress = false;
-        for ( int p0 = 0; p0 < int( cur.size() ) && int( res.items.size() ) < numChords; ++p0 )
+        for ( int p0 = 0; p0 < int( pos.size() ) && int( res.items.size() ) < numChords; ++p0 )
         {
-            if ( !cur[p0] )
+            if ( !pos[p0].cur )
                 continue;
-            const int p1 = succ[p0];
-            const int p2 = succ[p1];
-            if ( succ[p2] == p0 )
+            const int p1 = pos[p0].next;
+            const int p2 = pos[p1].next;
+            if ( pos[p2].next == p0 )
                 continue; // triangle ring: its last face needs no new edge
-            const EdgeId ne = pTp.next( cur[p0] );
-            if ( pTp.dest( ne ) != pTp.dest( cur[p1] ) )
+            const EdgeId ne = pTp.next( pos[p0].cur );
+            if ( pTp.dest( ne ) != pTp.dest( pos[p1].cur ) )
                 continue; // left face of cur[p0] is not an ear here
-            if ( emitted.test( ne.undirected() ) )
+            if ( planned( ne ) )
                 continue; // this face is clipped from the position holding ne as its polygon edge
-            if ( bdEdges.test( ne.undirected() ) )
-                clip( p0, ne, int( meshEdge( ne ) ) ); // pinched ring: the closing edge exists in the mesh
-            else
+            if ( !nameable( ne ) ) // an interior edge: the plan has to create it
             {
-                res.items.push_back( { refCode[p0], refCode[p2] } );
-                emitted.set( ne.undirected() );
-                clip( p0, ne, -int( res.items.size() ) );
-            }
+                res.items.push_back( { codeOf( pos[p0].cur ), codeOf( pos[p2].cur ) } );
+                codes[ne.undirected()] = -int( res.items.size() );
+            } // otherwise a pinched ring closing on an edge that already exists in the mesh
+            clip( p0, ne );
             progress = true;
         }
         if ( progress || int( res.items.size() ) >= numChords )
@@ -320,46 +313,41 @@ static Expected<HoleFillPlan> patchToPlan( const MeshTopology& pTp, const std::v
         // when the face left of its reversed direction is clipped before it: that clip lands right after
         // the bridge in the shared vertex ring, so it has to be created earlier (see anchoring above)
         bool joined = false;
-        for ( int s = 0; s < int( cur.size() ) && !joined; ++s )
+        for ( int s = 0; s < int( pos.size() ) && !joined; ++s )
         {
-            if ( !cur[s] )
+            if ( !pos[s].cur )
                 continue;
-            const EdgeId m = pTp.next( cur[s] );
-            if ( bdEdges.test( m.undirected() ) || emitted.test( m.undirected() ) )
+            const EdgeId m = pTp.next( pos[s].cur );
+            if ( nameable( m ) )
                 continue;
             int q = -1;
-            for ( int c = 0; c < int( cur.size() ) && q < 0; ++c )
-                if ( cur[c] && c != s && pTp.next( cur[c] ) == m.sym() )
+            for ( int c = 0; c < int( pos.size() ) && q < 0; ++c )
+                if ( pos[c].cur && c != s && pTp.next( pos[c].cur ) == m.sym() )
                     q = c;
-            if ( q < 0 || q == succ[s] || succ[q] == s )
+            if ( q < 0 || q == pos[s].next || pos[q].next == s )
                 continue;
             const EdgeId x = pTp.next( m.sym() ); // closes the face left of m.sym() together with cur[s]
-            assert( pTp.dest( x ) == pTp.dest( cur[s] ) );
-            int codeX;
-            if ( bdEdges.test( x.undirected() ) )
-                codeX = int( meshEdge( x ) );
-            else
+            assert( pTp.dest( x ) == pTp.dest( pos[s].cur ) );
+            if ( planned( x ) )
+                continue; // its plan edge is named in the other direction, which nothing can reference
+            if ( !nameable( x ) )
             {
-                res.items.push_back( { refCode[q], refCode[succ[s]] } );
-                emitted.set( x.undirected() );
-                codeX = -int( res.items.size() );
+                res.items.push_back( { codeOf( pos[q].cur ), codeOf( pos[pos[s].next].cur ) } );
+                codes[x.undirected()] = -int( res.items.size() );
             }
-            res.items.push_back( { refCode[s], refCode[q] } );
-            emitted.set( m.undirected() );
-            // join the rings: ... -> s( cur = m ) -> q -> ... -> q's old predecessor -> t( cur = x ) -> old succ[s] -> ...
-            const int t = int( cur.size() );
-            cur.push_back( x );
-            refCode.push_back( codeX );
-            succ.push_back( succ[s] );
+            res.items.push_back( { codeOf( pos[s].cur ), codeOf( pos[q].cur ) } );
+            codes[m.undirected()] = -int( res.items.size() );
+            // join the rings: ... -> s( cur = m ) -> q -> ... -> q's old predecessor -> t( cur = x ) -> old next of s -> ...
+            const int t = int( pos.size() );
+            pos.push_back( { x, pos[s].next } );
             for ( int c = 0; c < t; ++c )
-                if ( cur[c] && succ[c] == q )
+                if ( pos[c].cur && pos[c].next == q )
                 {
-                    succ[c] = t;
+                    pos[c].next = t;
                     break;
                 }
-            cur[s] = m;
-            refCode[s] = -int( res.items.size() );
-            succ[s] = q;
+            pos[s].cur = m;
+            pos[s].next = q;
             joined = true;
         }
         if ( !joined )
@@ -371,19 +359,23 @@ static Expected<HoleFillPlan> patchToPlan( const MeshTopology& pTp, const std::v
     int numSingleFaceHoles = 0;
     for ( int j = 0, base = 0; j < int( patchBds.size() ); base += int( patchBds[j].size() ), ++j )
     {
-        if ( patchBds[j].size() != 3 || !cur[base] || !cur[base + 1] || !cur[base + 2] ||
-            succ[base] != base + 1 || succ[base + 1] != base + 2 || succ[base + 2] != base )
+        if ( patchBds[j].size() != 3 || !pos[base].cur || !pos[base + 1].cur || !pos[base + 2].cur ||
+            pos[base].next != base + 1 || pos[base + 1].next != base + 2 || pos[base + 2].next != base )
             continue;
-        if ( !pTp.isLeftTri( cur[base] ) )
+        if ( !pTp.isLeftTri( pos[base].cur ) )
             return unexpected( "Incorrect filling" );
         ++numSingleFaceHoles;
         if ( !outSingleFaceHoles )
             return unexpected( "Hole needs no new edges to be filled" );
         outSingleFaceHoles->push_back( meshLoops[j].front() );
     }
-    if ( int( chordFaces.count() ) + numSingleFaceHoles != pTp.numValidFaces() )
-        return unexpected( "Incorrect filling" );
-    res.numTris = pTp.numValidFaces() - numSingleFaceHoles;
+
+    // every chord is planned once, so with all of them planned each ring must be down to one triangle;
+    // then the faces the plan reaches are all of them but the single-face holes
+    for ( int p = 0; p < int( pos.size() ); ++p )
+        if ( pos[p].cur && pos[pos[pos[p].next].next].next != p )
+            return unexpected( "Incorrect filling" );
+    res.numTris = numFaces - numSingleFaceHoles;
     return res;
 }
 

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -214,28 +214,209 @@ Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepres
     return {};
 }
 
-Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
+// converts a triangulated patch into a plan of new edges for executeHoleFillPlan.
+// The patch is peeled ear by ear, each ear recording its closing edge as a chord between the polygon
+// edges currently at its ends. executeHoleFillPlan re-creates such a chord by splicing it right after
+// those edges in their vertex rings, and every later chord at the same vertex lands closer to the
+// anchor - which is exactly the patch's angular order, also where several holes meet in one vertex.
+static Expected<HoleFillPlan> patchToPlan( const MeshTopology& pTp, const std::vector<EdgeLoop>& meshLoops,
+    const std::vector<EdgePath>& patchBds, std::vector<EdgeId>* outSingleFaceHoles )
 {
-    assert( !mesh.topology.left( holeEdgeId ) );
-    if ( mesh.topology.left( holeEdgeId ) )
-        return unexpected( "Hole edge has left face" );
+    assert( meshLoops.size() == patchBds.size() ); // validated in validateAndFixPatch
 
-    // triangulate the hole in the mesh's own 3d space: only the plan is needed, so the projection
+    // peeling state per boundary point; each current polygon ring is implicit in succ
+    int n = 0;
+    for ( const auto& loop : meshLoops )
+        n += int( loop.size() );
+    std::vector<EdgeId> cur;  // current polygon edge in the patch, invalid = consumed position
+    std::vector<int> refCode; // plan code of cur: not-negative absolute EdgeId in the mesh, negative - plan edge
+    std::vector<int> succ;    // next position around the polygon
+    cur.reserve( n + patchBds.size() ); // joining two rings adds a position
+    refCode.reserve( n + patchBds.size() );
+    succ.reserve( n + patchBds.size() );
+    Vector<EdgeId, UndirectedEdgeId> bd2mesh( n ); // patch boundary edge (even direction) -> mesh edge
+    for ( int j = 0, base = 0; j < int( patchBds.size() ); base += int( patchBds[j].size() ), ++j )
+    {
+        for ( int i = 0; i < int( patchBds[j].size() ); ++i )
+        {
+            const EdgeId b = patchBds[j][i];
+            if ( !pTp.left( b ) )
+                return unexpected( "Patch surface borders are incompatible with mesh borders" );
+            cur.push_back( b );
+            refCode.push_back( int( meshLoops[j][i] ) );
+            succ.push_back( i + 1 < int( patchBds[j].size() ) ? int( cur.size() ) : base );
+            bd2mesh.autoResizeSet( b.undirected(), b.even() ? meshLoops[j][i] : meshLoops[j][i].sym() );
+        }
+    }
+    auto meshEdge = [&] ( EdgeId patchBd )
+    {
+        return patchBd.even() ? bd2mesh[patchBd.undirected()] : bd2mesh[patchBd.undirected()].sym();
+    };
+
+    UndirectedEdgeBitSet bdEdges( pTp.undirectedEdgeSize() );
+    for ( auto e : cur )
+        bdEdges.set( e.undirected() );
+
+    // the plan has to create every interior edge of the patch, and every filled face must be adjacent
+    // to one of them (or belong to a hole filled with a single face, see below)
+    int numChords = 0;
+    FaceBitSet chordFaces( pTp.faceSize() );
+    for ( UndirectedEdgeId ue{ 0 }; ue < pTp.undirectedEdgeSize(); ++ue )
+    {
+        if ( bdEdges.test( ue ) )
+            continue;
+        const auto l = pTp.left( ue ), r = pTp.right( EdgeId( ue ) );
+        if ( !l && !r )
+            continue; // lone edge
+        if ( !l || !r )
+            return unexpected( "Incorrect filling" );
+        ++numChords;
+        chordFaces.set( l );
+        chordFaces.set( r );
+    }
+
+    HoleFillPlan res;
+    res.items.reserve( numChords );
+    UndirectedEdgeBitSet emitted( pTp.undirectedEdgeSize() ); // patch edges already present in the plan
+    auto clip = [&] ( int p0, EdgeId ne, int code )
+    {
+        const int p1 = succ[p0];
+        cur[p1] = {};
+        cur[p0] = ne;
+        refCode[p0] = code;
+        succ[p0] = succ[p1];
+    };
+    while ( int( res.items.size() ) < numChords )
+    {
+        bool progress = false;
+        for ( int p0 = 0; p0 < int( cur.size() ) && int( res.items.size() ) < numChords; ++p0 )
+        {
+            if ( !cur[p0] )
+                continue;
+            const int p1 = succ[p0];
+            const int p2 = succ[p1];
+            if ( succ[p2] == p0 )
+                continue; // triangle ring: its last face needs no new edge
+            const EdgeId ne = pTp.next( cur[p0] );
+            if ( pTp.dest( ne ) != pTp.dest( cur[p1] ) )
+                continue; // left face of cur[p0] is not an ear here
+            if ( emitted.test( ne.undirected() ) )
+                continue; // this face is clipped from the position holding ne as its polygon edge
+            if ( bdEdges.test( ne.undirected() ) )
+                clip( p0, ne, int( meshEdge( ne ) ) ); // pinched ring: the closing edge exists in the mesh
+            else
+            {
+                res.items.push_back( { refCode[p0], refCode[p2] } );
+                emitted.set( ne.undirected() );
+                clip( p0, ne, -int( res.items.size() ) );
+            }
+            progress = true;
+        }
+        if ( progress || int( res.items.size() ) >= numChords )
+            continue;
+
+        // no ears left: the rings have to be joined through a bridge edge first. A bridge is expressible
+        // only if it is the first new edge after the current polygon edge at both of its ends, and only
+        // when the face left of its reversed direction is clipped before it: that clip lands right after
+        // the bridge in the shared vertex ring, so it has to be created earlier (see anchoring above)
+        bool joined = false;
+        for ( int s = 0; s < int( cur.size() ) && !joined; ++s )
+        {
+            if ( !cur[s] )
+                continue;
+            const EdgeId m = pTp.next( cur[s] );
+            if ( bdEdges.test( m.undirected() ) || emitted.test( m.undirected() ) )
+                continue;
+            int q = -1;
+            for ( int c = 0; c < int( cur.size() ) && q < 0; ++c )
+                if ( cur[c] && c != s && pTp.next( cur[c] ) == m.sym() )
+                    q = c;
+            if ( q < 0 || q == succ[s] || succ[q] == s )
+                continue;
+            const EdgeId x = pTp.next( m.sym() ); // closes the face left of m.sym() together with cur[s]
+            assert( pTp.dest( x ) == pTp.dest( cur[s] ) );
+            int codeX;
+            if ( bdEdges.test( x.undirected() ) )
+                codeX = int( meshEdge( x ) );
+            else
+            {
+                res.items.push_back( { refCode[q], refCode[succ[s]] } );
+                emitted.set( x.undirected() );
+                codeX = -int( res.items.size() );
+            }
+            res.items.push_back( { refCode[s], refCode[q] } );
+            emitted.set( m.undirected() );
+            // join the rings: ... -> s( cur = m ) -> q -> ... -> q's old predecessor -> t( cur = x ) -> old succ[s] -> ...
+            const int t = int( cur.size() );
+            cur.push_back( x );
+            refCode.push_back( codeX );
+            succ.push_back( succ[s] );
+            for ( int c = 0; c < t; ++c )
+                if ( cur[c] && succ[c] == q )
+                {
+                    succ[c] = t;
+                    break;
+                }
+            cur[s] = m;
+            refCode[s] = -int( res.items.size() );
+            succ[s] = q;
+            joined = true;
+        }
+        if ( !joined )
+            return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
+    }
+
+    // an untouched triangle ring got no new edges, so executeHoleFillPlan cannot reach its face:
+    // such a hole is reported to be filled with one face separately
+    int numSingleFaceHoles = 0;
+    for ( int j = 0, base = 0; j < int( patchBds.size() ); base += int( patchBds[j].size() ), ++j )
+    {
+        if ( patchBds[j].size() != 3 || !cur[base] || !cur[base + 1] || !cur[base + 2] ||
+            succ[base] != base + 1 || succ[base + 1] != base + 2 || succ[base + 2] != base )
+            continue;
+        if ( !pTp.isLeftTri( cur[base] ) )
+            return unexpected( "Incorrect filling" );
+        ++numSingleFaceHoles;
+        if ( !outSingleFaceHoles )
+            return unexpected( "Hole needs no new edges to be filled" );
+        outSingleFaceHoles->push_back( meshLoops[j].front() );
+    }
+    if ( int( chordFaces.count() ) + numSingleFaceHoles != pTp.numValidFaces() )
+        return unexpected( "Incorrect filling" );
+    res.numTris = pTp.numValidFaces() - numSingleFaceHoles;
+    return res;
+}
+
+Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges,
+    std::vector<EdgeId>* outSingleFaceHoles )
+{
+    assert( !holeRepresentativeEdges.empty() );
+    if ( holeRepresentativeEdges.empty() )
+        return unexpected( "No hole edges are given" );
+
+    // triangulate the holes in the mesh's own 3d space: only the plan is needed, so the projection
     // round-trip of the mesh-filling path above is avoided
-    EdgeLoops loops( 1 );
-    loops.front() = trackRightBoundaryLoop( mesh.topology, holeEdgeId );
+    EdgeLoops loops( holeRepresentativeEdges.size() );
+    for ( int i = 0; i < int( holeRepresentativeEdges.size() ); ++i )
+    {
+        assert( !mesh.topology.left( holeRepresentativeEdges[i] ) );
+        if ( mesh.topology.left( holeRepresentativeEdges[i] ) )
+            return unexpected( "Hole edge has left face" );
+        loops[i] = trackRightBoundaryLoop( mesh.topology, holeRepresentativeEdges[i] );
+    }
 
-    // the hole loop winds counterclockwise around this direction, same as around the fitted plane's normal it replaces
+    // the hole loops wind counterclockwise around this direction, same as around the fitted plane's normal it replaces
     Vector3d sumCross;
     Box3f loopBox;
     float minEdgeLenSq = FLT_MAX;
-    for ( EdgeId e : loops.front() )
-    {
-        const auto o = mesh.orgPnt( e ), d = mesh.destPnt( e );
-        sumCross += cross( Vector3d( o ), Vector3d( d ) );
-        loopBox.include( o );
-        minEdgeLenSq = std::min( minEdgeLenSq, ( d - o ).lengthSq() );
-    }
+    for ( const auto& loop : loops )
+        for ( EdgeId e : loop )
+        {
+            const auto o = mesh.orgPnt( e ), d = mesh.destPnt( e );
+            sumCross += cross( Vector3d( o ), Vector3d( d ) );
+            loopBox.include( o );
+            minEdgeLenSq = std::min( minEdgeLenSq, ( d - o ).lengthSq() );
+        }
 
     // A hairline boundary edge forces every triangulation to emit a zero-area needle whose placement
     // in 3d is arbitrary; two holes sharing such an edge pick their needles independently and can make
@@ -251,50 +432,16 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
     if ( auto v = validateAndFixPatch( patch->topology, loops, newPaths ); !v )
         return unexpected( std::move( v.error() ) );
 
-    const auto& pTp = patch->topology;
-    const auto& ip = loops.front();
-    auto& np = newPaths.front();
-    HoleFillPlan res;
-    res.numTris = pTp.numValidFaces();
-    if ( res.numTris == 1 )
-        return res;
-    auto size = int( np.size() );
-    assert( size > 3 );
-    res.items.reserve( size - 3 );
+    return patchToPlan( patch->topology, loops, newPaths, outSingleFaceHoles );
+}
 
-    for ( ;;)
-    {
-        for ( int i0 = 0; i0 < np.size(); ++i0 )
-        {
-            auto e0 = np[i0];
-            if ( !e0 )
-                continue; // skip unused/encoded 
-            auto i1 = int( pTp.dest( np[i0] ) );
-            if ( i1 < 0 )
-                return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
-            auto e1 = np[i1];
-            if ( !e1 )
-                return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
-            auto ne = pTp.next( e0 );
-            auto dest = pTp.dest( ne );
-            if ( dest != pTp.dest( e1 ) )
-                continue;
-            FillHoleItem fhi;
-            int i01 = ( i0 + 1 ) % size;
-            fhi.edgeCode1 = i1 == i01 ? ip[i0] : int( np[i01] );
-            i1 = dest;
-            e1 = np[i1];
-            if ( !e1 )
-                return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
-            int i11 = ( i1 + 1 ) % size;
-            fhi.edgeCode2 = ( pTp.dest( e1 ) == i11 ) ? ip[i1] : int( np[i11] );
-            res.items.push_back( std::move( fhi ) );
-            if ( res.items.size() == size - 3 )
-                return res;
-            np[i0] = ne;
-            np[i01] = EdgeId( -int( res.items.size() ) ); // encode newly created plan edge in free slot
-        }
-    }
+Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
+{
+    std::vector<EdgeId> singleFaceHoles;
+    auto res = fillContours2DPlan( mesh, std::vector<EdgeId>{ holeEdgeId }, &singleFaceHoles );
+    if ( res && !singleFaceHoles.empty() )
+        res->numTris = 1; // the only hole is a triangle, executeHoleFillPlan fills it by the empty plan
+    return res;
 }
 
 Expected<void> fillPlanarHole( ObjectMeshData& data, std::vector<EdgeLoop>& holeContours )

--- a/source/MRMesh/MRFillContours2D.h
+++ b/source/MRMesh/MRFillContours2D.h
@@ -25,6 +25,21 @@ MRMESH_API Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>&
  */
 MRMESH_API Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId );
 
+/**
+ * @brief prepare one filling plan for several holes with borders in same plane (i.e. after cut by plane),
+ * the holes are triangulated together, so the filling may connect different holes (e.g. it can fill the
+ * region between two nested borders); execute it by executeHoleFillPlan with any hole edge
+ * except the ones reported in outSingleFaceHoles
+ * @param mesh - mesh with holes
+ * @param holeRepresentativeEdges - each edge here represents a hole borders that should be filled
+ * should be not empty, edges should have invalid left face (FaceId == -1)
+ * @param outSingleFaceHoles - receives an edge of every hole that the plan does not cover because its
+ * filling needs no new edges (a triangular hole); each of them is to be filled with one face separately
+ * @return Expected with has_value()=true if the plan is prepared, otherwise - string error
+ */
+MRMESH_API Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges,
+    std::vector<EdgeId>* outSingleFaceHoles = nullptr );
+
 /// computes the transformation that maps
 /// O into center mass of contours' points
 /// OXY into best plane containing the points

--- a/source/MRTest/MRFillContours2DTests.cpp
+++ b/source/MRTest/MRFillContours2DTests.cpp
@@ -2,6 +2,7 @@
 #include <MRMesh/MRMesh.h>
 #include <MRMesh/MRVector3.h>
 #include <MRMesh/MRMakeSphereMesh.h>
+#include <MRMesh/MRMeshFillHole.h>
 #include <MRMesh/MRMeshTrimWithPlane.h>
 #include <MRMesh/MRPlane3.h>
 #include <gtest/gtest.h>
@@ -57,6 +58,37 @@ TEST( MRMesh, fillContours2DTiltedPlane )
     // the current fill emits slivers, and the exact triangulation is not a stable invariant to guard.
     for ( FaceId f = firstNewFace; f <= mesh.topology.lastValidFace(); ++f )
         EXPECT_GT( dot( mesh.normal( f ), -normal ), 0.99f );
+}
+
+// Plans the filling of several coplanar holes at once: trimming a hollow sphere leaves an outer and an
+// inner border, and the ring between them cannot be triangulated hole by hole, so the plan has to
+// connect the two borders - the case the single-hole overload cannot express.
+TEST( MRMesh, fillContours2DPlanMultipleHoles )
+{
+    Mesh mesh = makeUVSphere( 1.0f, 32, 32 );
+    Mesh sphereSmall = makeUVSphere( 0.7f, 16, 16 );
+    sphereSmall.topology.flipOrientation();
+    mesh.addMesh( sphereSmall );
+    trimWithPlane( mesh, TrimWithPlaneParams{ .plane = Plane3f::fromDirAndPt( Vector3f::plusZ(), Vector3f() ) } );
+    mesh.pack();
+
+    const auto holes = mesh.topology.findHoleRepresentiveEdges();
+    ASSERT_EQ( holes.size(), size_t( 2 ) );
+
+    auto plan = fillContours2DPlan( mesh, holes );
+    ASSERT_TRUE( plan.has_value() ) << plan.error();
+
+    const int vertsBefore = mesh.topology.numValidVerts();
+    const int facesBefore = mesh.topology.numValidFaces();
+    const FaceId firstNewFace = mesh.topology.lastValidFace() + 1;
+    executeHoleFillPlan( mesh, holes[0], *plan );
+
+    // both holes are closed by the planned filling alone, reusing the border vertices in place
+    EXPECT_TRUE( mesh.topology.findHoleRepresentiveEdges().empty() );
+    EXPECT_EQ( mesh.topology.numValidVerts(), vertsBefore );
+    EXPECT_EQ( mesh.topology.numValidFaces() - facesBefore, plan->numTris );
+    for ( FaceId f = firstNewFace; f <= mesh.topology.lastValidFace(); ++f )
+        EXPECT_GT( dot( mesh.normal( f ), Vector3f::minusZ() ), 0.99f );
 }
 
 }


### PR DESCRIPTION
`fillContours2DPlan` plans one hole at a time, so a caller holding several holes that lie in one plane can only plan and execute them one by one. That cannot express a filling whose triangles connect two different holes — the ring between two nested borders being the obvious case — and it is exactly what a caller filling the cut faces of a boolean needs, since one original face can be left with several holes at once.

This adds an overload taking all the hole edges of one plane. They are tracked into loops, triangulated together by the same mesh-space `triangulateDisjointContours` the single-hole path uses since #6555 (one sweep for the whole group, sharing the Newell normal and the hairline-edge guard), and the resulting patch is converted into a single `HoleFillPlan`. The single-hole overload becomes a wrapper over it, so there is one patch-to-plan conversion instead of two.

### Why the conversion had to be generalized

`executeHoleFillPlan` resolves a negative edge code to *the forward direction* of an earlier plan edge (`EdgeId( plan.items[-(code+1)].edgeCode1 )`); nothing can name its `sym`. A plan therefore cannot just replay the order in which the sweep spliced its own edges, because the sweep anchors on syms (`holeLoop[prev] = newE.sym()`).

The existing conversion sidesteps that by peeling ears off the boundary ring and addressing positions by patch vertex id (`i1 = int( pTp.dest( np[i0] ) )`), which holds only while vertex ids coincide with positions around a single loop. With several loops in one patch, and vertices shared between them, it no longer does.

The generalized conversion keeps the same ear discipline but tracks the polygon explicitly: for each boundary position, the patch edge currently sitting there, its plan code, and the ring successor. Rings are then plain successor cycles, so several coexist and a vertex shared by two loops is unambiguous. Each ear records its closing edge as a chord between the polygon edges at its two ends — precisely what `makeNewEdge` splices right after them — and every later chord at the same vertex lands closer to its anchor, which reproduces the patch's angular order.

The peeling state is two buffers (second commit): one entry per boundary position holding its current patch edge and its ring successor, and one code per patch edge saying how the plan can name it — an absolute mesh edge on the borders, a plan edge once a chord for it is planned, nothing while it cannot be named yet. That single code subsumes what would otherwise be a boundary map plus two masks, and the number of chords to plan follows from `3F = n + 2C` rather than a scan over every patch edge.

Two rings are joined by a bridge chord. A bridge is expressible only when it is the first new edge after the current polygon edge at both of its ends, and the face left of its reverse must be clipped *before* it, so that the bridge's `sym` ends up between the anchor and that clip. Whatever the encoding cannot express is refused rather than mis-encoded.

### Holes that need no new edges

A triangular hole is filled by one face and no chord, and `executeHoleFillPlan` only creates faces adjacent to edges the plan creates, so such a hole cannot ride inside a shared plan. They are reported through `outSingleFaceHoles` for the caller to fill one by one; passing no output makes such a group an error rather than a silently unfilled hole.

### Verification

- MRTest: 335/335.
- New `MRMesh.fillContours2DPlanMultipleHoles` covers the case the single-hole overload cannot express: trimming a hollow sphere leaves an outer and an inner coplanar border, and one plan executed from a single edge closes both, reuses every border vertex in place, adds exactly `numTris` faces, and produces no degenerate ones.
- Single-hole plans are unchanged. Over a corpus of 539 holes — spheres at 11 resolutions, each trimmed by 7 differently oriented planes at 7 offsets — master and this branch produce identical plans: the same 511 successes and 28 declines (the hairline guard), the same 50365 items and 50876 triangles, and the same FNV hash over every `FillHoleItem`. So for one hole the shared conversion reproduces the old one exactly; only the multi-hole entry point is new behaviour.

| corpus of 539 holes | master | this PR |
|---|---|---|
| plans produced / declined | 511 / 28 | 511 / 28 |
| total items / triangles | 50365 / 50876 | 50365 / 50876 |
| FNV hash of all items | 16595764369074226670 | 16595764369074226670 |

  The same corpus also pins the second commit: the hash is unchanged by it, so shrinking the peeling state is not a behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
