### PR TITLE
TEMP: GCC-with-lld size and link-time measurement (do not merge)

### DIFF
--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -148,6 +148,18 @@ jobs:
       - name: PCH size (diagnostic)
         run: find ./build/${{ matrix.config }} -name 'cmake_pch.hxx.gch' -exec ls -lh {} +
 
+      - name: TEMP sizes and link time
+        run: |
+          BIN=build/${{ matrix.config }}/bin
+          echo "=== flags in use"
+          grep -oE "(-fuse-ld=[a-z]+|--icf=[a-z]+|ffunction-sections)" build/${{ matrix.config }}/link_timings.txt build/${{ matrix.config }}/compile_timings.txt 2>/dev/null | sed 's/.*://' | sort | uniq -c || true
+          echo "=== so sizes"
+          for f in $BIN/*.so ; do stat -c '%s %n' $f ; done | sort -rn
+          echo -n "total unstripped: "; stat -c '%s' $BIN/*.so | awk '{s+=$1} END {print s}'
+          rm -rf /tmp/st && mkdir -p /tmp/st && cp $BIN/*.so /tmp/st/ && strip --strip-all /tmp/st/*.so
+          echo -n "total stripped: "; stat -c '%s' /tmp/st/*.so | awk '{s+=$1} END {print s}'
+          echo -n "link seconds: "; awk -F, '{s+=$2+$3} END {print int(s+0.5)}' build/${{ matrix.config }}/link_timings.txt
+
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | c++filt
 

--- a/.github/workflows/matrix/ubuntu-x64-minimal-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-minimal-config.json
@@ -1,16 +1,6 @@
 {
   "include": [
     {
-      "os": "ubuntu22",
-      "config": "Release",
-      "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-12",
-      "c-compiler": "/usr/bin/gcc-12",
-      "cxx-standard": 23,
-      "build_mrcuda": "ON",
-      "upload_release": "ON"
-    },
-    {
       "os": "ubuntu24",
       "config": "Release",
       "compiler": "GCC",
@@ -19,16 +9,6 @@
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "ON"
-    },
-    {
-      "os": "ubuntu24",
-      "config": "Release",
-      "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-14",
-      "c-compiler": "/usr/bin/gcc-14",
-      "cxx-standard": 23,
-      "build_mrcuda": "OFF",
-      "upload_release": "OFF"
     }
   ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,11 @@ IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN)
     # The rest is Clang-only: `--icf=safe` reads Clang's `.llvm_addrsig`, which
     # GCC does not emit, so folding would find nothing to do on GCC output --
     # and the padding below only pays for the patchelf-ed AppImage path.
+    IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      # TEMP ceiling probe: GCC emits no .llvm_addrsig, so only `all` can fold.
+      add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,--icf=all>)
+      add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:-ffunction-sections>)
+    ENDIF()
     IF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
       # Give lld room to grow the PHT so patchelf doesn't trample `.init`:
       # https://github.com/NixOS/patchelf/issues/639

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,9 @@ project(MeshLib CXX)
 set(MESHLIB_PROJECT_NAME "MeshLib" CACHE STRING "Project name")
 add_compile_definitions(MR_PROJECT_NAME=\"${MESHLIB_PROJECT_NAME}\")
 
-# Work around patchelf bug: https://github.com/NixOS/patchelf/issues/639
-# Force lld + give it room to grow PHT so patchelf doesn't trample `.init`.
-# Skip on images without lld (older ubuntu22 Clang 14 etc., which aren't
-# AppImage-packaged anyway).
-IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+# Link with lld where it exists, GCC rows included. Skipped on images without
+# it (older ubuntu22 Clang 14 etc.).
+IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN)
   include(CheckLinkerFlag)
   check_linker_flag(CXX "-fuse-ld=lld" MESHLIB_HAVE_LLD)
   IF(MESHLIB_HAVE_LLD)
@@ -48,15 +46,20 @@ IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "
     ELSE()
       add_link_options("-fuse-ld=lld")
     ENDIF()
-    add_link_options("LINKER:-z,separate-loadable-segments")
-    # Fold byte-identical functions. `safe` folds only the address-insignificant
-    # ones (per Clang's `.llvm_addrsig`), so function pointers stay comparable.
-    # lld-only: GNU ld has no ICF, and GCC emits no address-significance table.
-    add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,--icf=safe>)
-    # Widen what ICF can reach: without this only COMDAT functions (templates,
-    # inlines) get their own section, so plain out-of-line ones never fold.
-    # `-fdata-sections` would add nothing -- lld folds executable sections only.
-    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:-ffunction-sections>)
+    # The rest is Clang-only: `--icf=safe` reads Clang's `.llvm_addrsig`, which
+    # GCC does not emit, so folding would find nothing to do on GCC output --
+    # and the padding below only pays for the patchelf-ed AppImage path.
+    IF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      # Give lld room to grow the PHT so patchelf doesn't trample `.init`:
+      # https://github.com/NixOS/patchelf/issues/639
+      add_link_options("LINKER:-z,separate-loadable-segments")
+      # Fold byte-identical functions; `safe` folds only the address-insignificant
+      # ones, so function pointers stay comparable.
+      add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,--icf=safe>)
+      # Widen what ICF can reach: without this only COMDAT functions (templates,
+      # inlines) get their own section, so plain out-of-line ones never fold.
+      add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:-ffunction-sections>)
+    ENDIF()
   ENDIF()
 ENDIF()
 


### PR DESCRIPTION
Throwaway for #6559-to-be. One ubuntu24 GCC 13 Release leg. Run 1 = baseline (ld.bfd), run 2 = GCC on lld, run 3 = GCC on lld with --icf=all as a ceiling data point.