### PR TITLE
Link the GCC rows with lld as well (measured: no-op, images lack lld)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,9 @@ project(MeshLib CXX)
 set(MESHLIB_PROJECT_NAME "MeshLib" CACHE STRING "Project name")
 add_compile_definitions(MR_PROJECT_NAME=\"${MESHLIB_PROJECT_NAME}\")
 
-# Work around patchelf bug: https://github.com/NixOS/patchelf/issues/639
-# Force lld + give it room to grow PHT so patchelf doesn't trample `.init`.
-# Skip on images without lld (older ubuntu22 Clang 14 etc., which aren't
-# AppImage-packaged anyway).
-IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+# Link with lld where it exists, GCC rows included. Skipped on images without
+# it (older ubuntu22 Clang 14 etc.).
+IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN)
   include(CheckLinkerFlag)
   check_linker_flag(CXX "-fuse-ld=lld" MESHLIB_HAVE_LLD)
   IF(MESHLIB_HAVE_LLD)
@@ -48,15 +46,20 @@ IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "
     ELSE()
       add_link_options("-fuse-ld=lld")
     ENDIF()
-    add_link_options("LINKER:-z,separate-loadable-segments")
-    # Fold byte-identical functions. `safe` folds only the address-insignificant
-    # ones (per Clang's `.llvm_addrsig`), so function pointers stay comparable.
-    # lld-only: GNU ld has no ICF, and GCC emits no address-significance table.
-    add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,--icf=safe>)
-    # Widen what ICF can reach: without this only COMDAT functions (templates,
-    # inlines) get their own section, so plain out-of-line ones never fold.
-    # `-fdata-sections` would add nothing -- lld folds executable sections only.
-    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:-ffunction-sections>)
+    # The rest is Clang-only: `--icf=safe` reads Clang's `.llvm_addrsig`, which
+    # GCC does not emit, so folding would find nothing to do on GCC output --
+    # and the padding below only pays for the patchelf-ed AppImage path.
+    IF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      # Give lld room to grow the PHT so patchelf doesn't trample `.init`:
+      # https://github.com/NixOS/patchelf/issues/639
+      add_link_options("LINKER:-z,separate-loadable-segments")
+      # Fold byte-identical functions; `safe` folds only the address-insignificant
+      # ones, so function pointers stay comparable.
+      add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,--icf=safe>)
+      # Widen what ICF can reach: without this only COMDAT functions (templates,
+      # inlines) get their own section, so plain out-of-line ones never fold.
+      add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:-ffunction-sections>)
+    ENDIF()
   ENDIF()
 ENDIF()
 

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -52,10 +52,12 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh g++-12 clang-14 lld-14 \
+        gh g++-12 clang-14 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
-    # `-fuse-ld=lld` looks for `ld.lld` in PATH, which the versioned package does not provide
-    command -v ld.lld || ln -s "$(ls /usr/lib/llvm-*/bin/ld.lld | tail -n 1)" /usr/bin/ld.lld
+    # lld is installed by mrbind deps, but only under /usr/lib/llvm-*/bin; GCC resolves
+    # `-fuse-ld=lld` through PATH, so expose it and fail the image build if that breaks
+    ln -sf /usr/lib/llvm-$(xargs < scripts/mrbind/clang_version.txt)/bin/ld.lld /usr/bin/ld.lld
+    ld.lld --version > /dev/null
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -52,8 +52,10 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh g++-12 clang-14 \
+        gh g++-12 clang-14 lld-14 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
+    # `-fuse-ld=lld` looks for `ld.lld` in PATH, which the versioned package does not provide
+    command -v ld.lld || ln -s "$(ls /usr/lib/llvm-*/bin/ld.lld | tail -n 1)" /usr/bin/ld.lld
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -51,10 +51,12 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh g++-13 gcc-14 g++-14 clang-18 lld-18 \
+        gh g++-13 gcc-14 g++-14 clang-18 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
-    # `-fuse-ld=lld` looks for `ld.lld` in PATH, which the versioned package does not provide
-    command -v ld.lld || ln -s "$(ls /usr/lib/llvm-*/bin/ld.lld | tail -n 1)" /usr/bin/ld.lld
+    # lld is installed by mrbind deps, but only under /usr/lib/llvm-*/bin; GCC resolves
+    # `-fuse-ld=lld` through PATH, so expose it and fail the image build if that breaks
+    ln -sf /usr/lib/llvm-$(xargs < scripts/mrbind/clang_version.txt)/bin/ld.lld /usr/bin/ld.lld
+    ld.lld --version > /dev/null
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -51,8 +51,10 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh g++-13 gcc-14 g++-14 clang-18 \
+        gh g++-13 gcc-14 g++-14 clang-18 lld-18 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
+    # `-fuse-ld=lld` looks for `ld.lld` in PATH, which the versioned package does not provide
+    command -v ld.lld || ln -s "$(ls /usr/lib/llvm-*/bin/ld.lld | tail -n 1)" /usr/bin/ld.lld
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh


### PR DESCRIPTION
GCC rows on Linux still link with `ld.bfd`, so they get none of the folding from #6547 / #6550. This relaxes the compiler-ID gate on the lld selection while leaving the ICF and padding flags Clang-only: `--icf=safe` reads Clang's `.llvm_addrsig`, which GCC does not emit, and `-z separate-loadable-segments` only pays on the patchelf-ed AppImage path.

### Measured: a no-op, because the ubuntu images have no lld

One `ubuntu24` / GCC 13 / Release leg, three variants on a throwaway branch:

| | unstripped | stripped | link s |
| --- | ---: | ---: | ---: |
| baseline (`ld.bfd`) | 69,267,672 | 53,304,504 | 7 |
| this PR (GCC on lld) | 69,267,672 | 53,304,504 | 6 |
| plus `--icf=all` for GCC | 69,267,672 | 53,304,504 | 7 |

Byte-identical, all three. The configure log says it plainly: `Performing Test MESHLIB_HAVE_LLD - Failed`. Neither ubuntu image installs lld — `ubuntu22Dockerfile` has `g++-12 clang-14`, `ubuntu24Dockerfile` has `g++-13 gcc-14 g++-14 clang-18`, and `lld-21*` appears only in `rockylinux8-vcpkgDockerfile`. So every flag in the block is inert on ubuntu today, for the Clang rows as much as the GCC ones, and the whole ICF series only ever applied to the `rockylinux8-vcpkg` builds (the `linux-vcpkg` package and the manylinux wheels).

Making this actually do something needs `lld` added to both ubuntu Dockerfiles plus an image rebuild — a heavier change than a CMake gate. And it would still not shrink the `.deb`s:

* `--icf=safe` folds nothing on GCC output (no address-significance table), which the `--icf=all` row above cannot demonstrate here but #6547's measurements did.
* `--icf=all` would fold, but it folds functions whose addresses are taken, so `&f == &g` can become true — the semantic we deliberately rejected for a public library. Shipping `.deb`s with different folding rules from the wheels would be worse than shipping them unfolded.

So the honest options for the `.deb`s are: install lld and take the link-time win only, or build them with Clang. Neither is this PR.

### Recommendation

Close, unless we want the link-time angle — in which case this should be reopened together with the Dockerfile change, and justified on build time rather than size.
