### PR TITLE
TEMP: GCC/Clang on lld with lld in the image (do not merge)

### DIFF
--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -148,6 +148,18 @@ jobs:
       - name: PCH size (diagnostic)
         run: find ./build/${{ matrix.config }} -name 'cmake_pch.hxx.gch' -exec ls -lh {} +
 
+      - name: TEMP sizes and link time
+        run: |
+          BIN=build/${{ matrix.config }}/bin
+          echo "=== ld.lld present"; command -v ld.lld || echo "NO ld.lld"
+          echo "=== flags in use"
+          grep -oE "(-fuse-ld=[a-z]+|--icf=[a-z]+|ffunction-sections)" build/${{ matrix.config }}/link_timings.txt build/${{ matrix.config }}/compile_timings.txt 2>/dev/null | sed 's/.*://' | sort | uniq -c || true
+          echo -n "total unstripped: "; stat -c '%s' $BIN/*.so | awk '{s+=$1} END {print s}'
+          rm -rf /tmp/st && mkdir -p /tmp/st && cp $BIN/*.so /tmp/st/ && strip --strip-all /tmp/st/*.so
+          echo -n "total stripped: "; stat -c '%s' /tmp/st/*.so | awk '{s+=$1} END {print s}'
+          echo -n "link count: "; grep -c "" build/${{ matrix.config }}/link_timings.txt
+          echo -n "link seconds: "; awk -F, '{s+=$2+$3} END {printf "%.2f", s; print ""}' build/${{ matrix.config }}/link_timings.txt
+
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | c++filt
 

--- a/.github/workflows/matrix/ubuntu-x64-minimal-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-minimal-config.json
@@ -1,14 +1,14 @@
 {
   "include": [
     {
-      "os": "ubuntu22",
+      "os": "ubuntu24",
       "config": "Release",
-      "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-12",
-      "c-compiler": "/usr/bin/gcc-12",
+      "compiler": "Clang",
+      "cxx-compiler": "/usr/bin/clang++-18",
+      "c-compiler": "/usr/bin/clang-18",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
-      "upload_release": "ON"
+      "upload_release": "OFF"
     },
     {
       "os": "ubuntu24",
@@ -19,16 +19,6 @@
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "ON"
-    },
-    {
-      "os": "ubuntu24",
-      "config": "Release",
-      "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-14",
-      "c-compiler": "/usr/bin/gcc-14",
-      "cxx-standard": 23,
-      "build_mrcuda": "OFF",
-      "upload_release": "OFF"
     }
   ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,9 @@ project(MeshLib CXX)
 set(MESHLIB_PROJECT_NAME "MeshLib" CACHE STRING "Project name")
 add_compile_definitions(MR_PROJECT_NAME=\"${MESHLIB_PROJECT_NAME}\")
 
-# Work around patchelf bug: https://github.com/NixOS/patchelf/issues/639
-# Force lld + give it room to grow PHT so patchelf doesn't trample `.init`.
-# Skip on images without lld (older ubuntu22 Clang 14 etc., which aren't
-# AppImage-packaged anyway).
-IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+# Link with lld where it exists, GCC rows included. Skipped on images without
+# it (older ubuntu22 Clang 14 etc.).
+IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN)
   include(CheckLinkerFlag)
   check_linker_flag(CXX "-fuse-ld=lld" MESHLIB_HAVE_LLD)
   IF(MESHLIB_HAVE_LLD)
@@ -48,15 +46,20 @@ IF(UNIX AND NOT APPLE AND NOT MR_EMSCRIPTEN AND CMAKE_CXX_COMPILER_ID STREQUAL "
     ELSE()
       add_link_options("-fuse-ld=lld")
     ENDIF()
-    add_link_options("LINKER:-z,separate-loadable-segments")
-    # Fold byte-identical functions. `safe` folds only the address-insignificant
-    # ones (per Clang's `.llvm_addrsig`), so function pointers stay comparable.
-    # lld-only: GNU ld has no ICF, and GCC emits no address-significance table.
-    add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,--icf=safe>)
-    # Widen what ICF can reach: without this only COMDAT functions (templates,
-    # inlines) get their own section, so plain out-of-line ones never fold.
-    # `-fdata-sections` would add nothing -- lld folds executable sections only.
-    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:-ffunction-sections>)
+    # The rest is Clang-only: `--icf=safe` reads Clang's `.llvm_addrsig`, which
+    # GCC does not emit, so folding would find nothing to do on GCC output --
+    # and the padding below only pays for the patchelf-ed AppImage path.
+    IF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      # Give lld room to grow the PHT so patchelf doesn't trample `.init`:
+      # https://github.com/NixOS/patchelf/issues/639
+      add_link_options("LINKER:-z,separate-loadable-segments")
+      # Fold byte-identical functions; `safe` folds only the address-insignificant
+      # ones, so function pointers stay comparable.
+      add_link_options($<$<NOT:$<CONFIG:Debug>>:-Wl,--icf=safe>)
+      # Widen what ICF can reach: without this only COMDAT functions (templates,
+      # inlines) get their own section, so plain out-of-line ones never fold.
+      add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:-ffunction-sections>)
+    ENDIF()
   ENDIF()
 ENDIF()
 

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -52,8 +52,10 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh g++-12 clang-14 \
+        gh g++-12 clang-14 lld-14 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
+    # `-fuse-ld=lld` looks for `ld.lld` in PATH, which the versioned package does not provide
+    command -v ld.lld || ln -s "$(ls /usr/lib/llvm-*/bin/ld.lld | tail -n 1)" /usr/bin/ld.lld
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -51,8 +51,10 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh g++-13 gcc-14 g++-14 clang-18 \
+        gh g++-13 gcc-14 g++-14 clang-18 lld-18 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
+    # `-fuse-ld=lld` looks for `ld.lld` in PATH, which the versioned package does not provide
+    command -v ld.lld || ln -s "$(ls /usr/lib/llvm-*/bin/ld.lld | tail -n 1)" /usr/bin/ld.lld
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh


### PR DESCRIPTION
Throwaway for #6562. Two ubuntu24 Release legs (GCC 13, Clang 18). Run 1 = baseline on the current image; run 2 = lld installed in the image plus the gate relaxation, so the image is rebuilt.