### PR TITLE
Strip the libraries in the deb package

### DIFF
--- a/scripts/distribution.sh
+++ b/scripts/distribution.sh
@@ -24,7 +24,7 @@ if [ -d "./distr/" ]; then
  rm -rf distr
 fi
 
-cmake --install ./build/Release --prefix "./distr/meshlib-dev/usr/local"
+cmake --install ./build/Release --prefix "./distr/meshlib-dev/usr/local" --strip
 
 MR_INSTALL_LIB_DIR="/usr/local/lib/MeshLib"
 MR_INSTALL_INCLUDE_DIR="/usr/local/include/MeshLib"
@@ -33,14 +33,16 @@ MR_INSTALL_RES_DIR="/usr/local/share/MeshLib"
 # Install the generated bindings, if needed.
 if [ ! -f "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib/mrmeshpy.so" ] && [ -f "build/Release/bin/meshlib/mrmeshpy.so" ]; then
   echo "Installing the generated bindings..."
-  install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/{mrmeshpy.so,mrmeshnumpy.so,__init__.py}
-  install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"         build/Release/bin/meshlib/{mrmeshpy.so,mrmeshnumpy.so,__init__.py}
+  install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/__init__.py
+  install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/{mrmeshpy.so,mrmeshnumpy.so}
+  install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"         build/Release/bin/meshlib/__init__.py
+  install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"        build/Release/bin/meshlib/{mrmeshpy.so,mrmeshnumpy.so}
   patchelf --set-rpath '' "distr/meshlib-dev$MR_INSTALL_LIB_DIR/"{,meshlib/}mrmeshpy.so
 
   if [ -f "build/Release/bin/meshlib/mrcudapy.so" ]; then
     echo "CUDA bindings found, installing with mrcudapy.so..."
-    install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/mrcudapy.so
-    install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"         build/Release/bin/meshlib/mrcudapy.so
+    install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/mrcudapy.so
+    install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"        build/Release/bin/meshlib/mrcudapy.so
     patchelf --set-rpath '' "distr/meshlib-dev$MR_INSTALL_LIB_DIR/"{,meshlib/}mrcudapy.so
   fi
 fi


### PR DESCRIPTION
Same treatment as #6556 gave the vcpkg package, for the Ubuntu `.deb`: `cmake --install` gains `--strip`, and the separately-installed Python bindings are copied with `install -s`. `.symtab`/`.strtab` are not `SEC_ALLOC`, are never loaded at runtime, and linking against the package needs only `.dynsym`, which `strip` keeps.

`install -s` matters for ordering, not brevity: it strips on copy, i.e. **before** the `patchelf --set-rpath` calls a few lines below. Stripping after patchelf is what corrupts load commands — the auditwheel `--strip` bug that made #6525 strip manually beforehand. `__init__.py` is split onto its own `install` line since `-s` would try to strip it.

### Sizes

Built both ways in one job on a throwaway branch — once as this PR does, once with the strip flags removed:

| `meshlib_ubuntu24-dev.deb` | unstripped | stripped | delta |
| --- | ---: | ---: | ---: |
| x64 | 105,193,088 | 74,806,296 | **−30,386,792 (−28.9%)** |

Far larger than the vcpkg package's −2.19% (#6556), because this package also carries the Python bindings, which nothing was stripping: `mrmeshpy.so` and friends dominate the archive and were shipping their full symbol tables.

### Testing

Ubuntu legs only; `scripts/distribution.sh` is not used by any other platform. In the measurement run `Create Deb` → `Extract Deb` → `Build C++ examples and samples` → `Build C examples` all passed against the stripped package, so headers, libraries and the CMake config still work for consumers.

The packaged *bindings* deserve their own check, because a strip/patchelf ordering mistake shows up only as an import failure, and the workflow that installs the `.deb` and runs pytest against it (`test-distribution.yml`) is release-triggered rather than PR-triggered. So the throwaway also imports the extracted, stripped, patchelf-ed `mrmeshpy.so` directly and constructs a `Vector3f` from it.
