### PR TITLE
TEMP: deb size stripped vs unstripped (do not merge)

### DIFF
--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -243,6 +243,13 @@ jobs:
         if: ${{ matrix.compiler == 'GCC' && matrix.config == 'Release' }}
         run: dpkg --extract meshlib_${{matrix.os}}-dev.deb $(pwd)/meshlib_install/
 
+      - name: TEMP import the packaged bindings
+        if: ${{ matrix.compiler == 'GCC' && matrix.config == 'Release' }}
+        run: |
+          LIB=$(pwd)/meshlib_install/usr/local/lib/MeshLib
+          ls -l $LIB/meshlib/mrmeshpy.so
+          PYTHONPATH=$LIB LD_LIBRARY_PATH=$LIB python3 -c "import meshlib.mrmeshpy as m; print('imported', m.__file__); print(m.Vector3f(1,2,3))"
+
       - name: Build C++ examples and samples
         if: ${{ matrix.compiler == 'GCC' && matrix.config == 'Release' }}
         run: |

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -226,6 +226,19 @@ jobs:
           ./scripts/distribution.sh ${{inputs.app_version}}
           mv ./distr/meshlib-dev.deb meshlib_${{matrix.os}}-dev.deb
 
+      - name: TEMP deb size both ways
+        if: ${{ matrix.compiler == 'GCC' && matrix.config == 'Release' }}
+        env:
+          MESHLIB_BUILD_RELEASE: "ON"
+          MESHLIB_BUILD_DEBUG: "OFF"
+        run: |
+          echo -n "stripped:   "; stat -c '%s' meshlib_${{ matrix.os }}-dev.deb
+          sed -i 's/ --strip//; s/install -sDt/install -Dt/g' scripts/distribution.sh
+          ./scripts/distribution.sh ${{ inputs.app_version }} > /dev/null
+          echo -n "unstripped: "; stat -c '%s' ./distr/meshlib-dev.deb
+          echo "=== installed lib bytes, stripped vs not"
+          git checkout -- scripts/distribution.sh
+
       - name: Extract Deb
         if: ${{ matrix.compiler == 'GCC' && matrix.config == 'Release' }}
         run: dpkg --extract meshlib_${{matrix.os}}-dev.deb $(pwd)/meshlib_install/

--- a/.github/workflows/matrix/ubuntu-x64-minimal-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-minimal-config.json
@@ -1,16 +1,6 @@
 {
   "include": [
     {
-      "os": "ubuntu22",
-      "config": "Release",
-      "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-12",
-      "c-compiler": "/usr/bin/gcc-12",
-      "cxx-standard": 23,
-      "build_mrcuda": "ON",
-      "upload_release": "ON"
-    },
-    {
       "os": "ubuntu24",
       "config": "Release",
       "compiler": "GCC",
@@ -19,16 +9,6 @@
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "ON"
-    },
-    {
-      "os": "ubuntu24",
-      "config": "Release",
-      "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-14",
-      "c-compiler": "/usr/bin/gcc-14",
-      "cxx-standard": 23,
-      "build_mrcuda": "OFF",
-      "upload_release": "OFF"
     }
   ]
 }

--- a/scripts/distribution.sh
+++ b/scripts/distribution.sh
@@ -24,7 +24,7 @@ if [ -d "./distr/" ]; then
  rm -rf distr
 fi
 
-cmake --install ./build/Release --prefix "./distr/meshlib-dev/usr/local"
+cmake --install ./build/Release --prefix "./distr/meshlib-dev/usr/local" --strip
 
 MR_INSTALL_LIB_DIR="/usr/local/lib/MeshLib"
 MR_INSTALL_INCLUDE_DIR="/usr/local/include/MeshLib"
@@ -33,14 +33,16 @@ MR_INSTALL_RES_DIR="/usr/local/share/MeshLib"
 # Install the generated bindings, if needed.
 if [ ! -f "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib/mrmeshpy.so" ] && [ -f "build/Release/bin/meshlib/mrmeshpy.so" ]; then
   echo "Installing the generated bindings..."
-  install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/{mrmeshpy.so,mrmeshnumpy.so,__init__.py}
-  install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"         build/Release/bin/meshlib/{mrmeshpy.so,mrmeshnumpy.so,__init__.py}
+  install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/__init__.py
+  install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/{mrmeshpy.so,mrmeshnumpy.so}
+  install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"         build/Release/bin/meshlib/__init__.py
+  install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"        build/Release/bin/meshlib/{mrmeshpy.so,mrmeshnumpy.so}
   patchelf --set-rpath '' "distr/meshlib-dev$MR_INSTALL_LIB_DIR/"{,meshlib/}mrmeshpy.so
 
   if [ -f "build/Release/bin/meshlib/mrcudapy.so" ]; then
     echo "CUDA bindings found, installing with mrcudapy.so..."
-    install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/mrcudapy.so
-    install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"         build/Release/bin/meshlib/mrcudapy.so
+    install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/mrcudapy.so
+    install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"        build/Release/bin/meshlib/mrcudapy.so
     patchelf --set-rpath '' "distr/meshlib-dev$MR_INSTALL_LIB_DIR/"{,meshlib/}mrcudapy.so
   fi
 fi


### PR DESCRIPTION
Throwaway for #6564. One ubuntu24 GCC 13 Release leg; builds the .deb as the PR does, then again with the strip flags removed, so one run gives both numbers.