### PR TITLE
sqr and distanceSq: deduce the return type instead of forcing it back to T

### DIFF
--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -765,9 +765,9 @@ constexpr inline int sgn( T x ) noexcept { return x > 0 ? 1 : ( x < 0 ? -1 : 0 )
 template <typename T>
 constexpr inline T distance( T x, T y ) noexcept { return x >= y ? x - y : y - x; }
 
-/// squared difference between two value
+/// squared difference between two value; the result type is the type of sqr( x - y )
 template <typename T>
-constexpr inline T distanceSq( T x, T y ) noexcept { return sqr( x - y ); }
+constexpr inline auto distanceSq( T x, T y ) noexcept -> decltype( sqr( x - y ) ) { return sqr( x - y ); }
 
 /// Linear interpolation: returns v0 when t==0 and v1 when t==1
 template <typename V, typename T>

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -755,7 +755,7 @@ struct TransparencyMode;
 
 /// squared value; the result type is the type of x*x, which is int for small integer types (char, short)
 template <typename T>
-constexpr inline auto sqr( T x ) noexcept { return x * x; }
+constexpr inline auto sqr( T x ) noexcept -> decltype( x * x ) { return x * x; }
 
 /// sign of given value in { -1, 0, 1 }
 template <typename T>

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -753,9 +753,9 @@ enum class Reorder : char;
 
 struct TransparencyMode;
 
-/// squared value
+/// squared value; the result type is the type of x*x, which is int for small integer types (char, short)
 template <typename T>
-constexpr inline T sqr( T x ) noexcept { return x * x; }
+constexpr inline auto sqr( T x ) noexcept { return x * x; }
 
 /// sign of given value in { -1, 0, 1 }
 template <typename T>

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -765,9 +765,10 @@ constexpr inline int sgn( T x ) noexcept { return x > 0 ? 1 : ( x < 0 ? -1 : 0 )
 template <typename T>
 constexpr inline T distance( T x, T y ) noexcept { return x >= y ? x - y : y - x; }
 
-/// squared difference between two value; the result type is the type of sqr( x - y )
+/// squared difference between two value; the result type is the type of the product
+/// (spelled via * and not via sqr, so that vector types with their own distanceSq do not match here)
 template <typename T>
-constexpr inline auto distanceSq( T x, T y ) noexcept -> decltype( sqr( x - y ) ) { return sqr( x - y ); }
+constexpr inline auto distanceSq( T x, T y ) noexcept -> decltype( ( x - y ) * ( x - y ) ) { return sqr( x - y ); }
 
 /// Linear interpolation: returns v0 when t==0 and v1 when t==1
 template <typename V, typename T>


### PR DESCRIPTION
`sqr` evaluated `x * x` and then converted the result back to `T`:

```cpp
template <typename T>
constexpr inline T sqr( T x ) noexcept { return x * x; }
```

For every type MeshLib instantiates it with — `float`, `double`, `int`, `unsigned`, `size_t`, `int64_t`, `Int128`…`Int1024` — that conversion is the identity, so this PR does not change the signature or the generated code there at all.

For integer types narrower than `int` it is not the identity. `x * x` is evaluated after integral promotion, in `int`, and the old return type silently truncated the product back:

```cpp
sqr( uint8_t( 16 ) );   // was 0,     now 256
sqr( int16_t( 300 ) );  // was 24464, now 90000
```

The new signature returns whatever `x * x` actually produced:

```cpp
template <typename T>
constexpr inline auto sqr( T x ) noexcept -> decltype( x * x ) { return x * x; }
```

### Why the return type is spelled out instead of a plain `auto`

A plain deduced return type does not work here, and the first commit of this PR shows it failing: `scripts/mrbind/extra_headers/instantiate_templates.h` explicitly instantiates the *other* `sqr`,

```cpp
template T sqr( const Vector3<T> & a );
```

and matching that declaration against this primary template deduces `T = const Vector3f &`. With `auto`, the compiler has to instantiate the body to find out the return type, and `x * x` on a `Vector3f` is a hard error — the C bindings generator died on all six `Vector2`/`Vector3` instantiations. With the return type written as `decltype( x * x )` the same substitution fails in the immediate context, so the candidate is quietly discarded and the `Vector3` overload is selected, as before. As a bonus `sqr` is now SFINAE-friendly for any type without `operator*`.

### Checked

* No existing call site changes meaning: all 183 uses of `sqr` in `source/` pass `float`, `double`, `int`, `int64_t` or one of the fixed-width boost integers.
* The fixed-width `boost::multiprecision` types used by the precise predicates have expression templates off (`expression_template_default<cpp_int_backend<…, void>>` is `et_off`), so `x * x` returns the number itself and not an expression node referring to the by-value parameter: `decltype( sqr( Int128 ) )` is still `Int128`, likewise `Int256`/`Int512`/`Int1024`. Verified with `static_assert`s against the vcpkg boost headers.

### `distanceSq`

`distanceSq( T x, T y ) { return sqr( x - y ); }` had the very same truncation and gets the very same treatment:

```cpp
template <typename T>
constexpr inline auto distanceSq( T x, T y ) noexcept -> decltype( ( x - y ) * ( x - y ) ) { return sqr( x - y ); }
```

The return type is spelled with `*` rather than as `decltype( sqr( x - y ) )` on purpose. `instantiate_templates.h` explicitly instantiates `distanceSq( const Vector3<T> &, const Vector3<T> & )` too, and for `T = const Vector3f &` the `sqr` spelling *is* valid — `x - y` is a `Vector3f` and `sqr` of it resolves through ADL to the `Vector3` overload returning `float` — so the primary template stayed a viable match. It loses partial ordering to the dedicated overload, but the specialization still lands in the AST, and the bindings generator dutifully emitted

```cpp
float MR_distanceSq_const_MR_Vector3f_ref( const MR_Vector3f *x, const MR_Vector3f *y )
{ return ::MR::distanceSq<const MR::Vector3f &>( ... ); }
```

for all six `Vector2`/`Vector3` instantiations, which of course does not compile. Spelling the return type with `*` makes the substitution fail for vector types exactly as it does in `sqr`, so the primary template is never a candidate there.

Verified locally with `-Xclang -ast-dump -Xclang -ast-dump-filter=distanceSq` over the real headers plus that instantiation list: with the `sqr` spelling the AST contains `distanceSq<const MR::Vector2d &>`, `<const MR::Vector2f &>`, `<const MR::Vector2i &>`, `<const MR::Vector3d &>`, `<const MR::Vector3f &>`, `<const MR::Vector3i &>`; with the `*` spelling the only template arguments left are `float`, `double` and `int`, i.e. the generated C API is unchanged.

### Deliberately not changed

* `distance( T x, T y ) { return x >= y ? x - y : y - x; }` truncates for narrow types too, but it is not a squaring operation and its result genuinely fits in `T` for every `T`, so it is left alone. Say the word if you want it converted as well.
* `MR::Cuda::sqr` in `MRCudaMath.cuh` is a separate device-side function and is left alone.
