### PR TITLE
Int64Mul128: 64-bit integer with exact 128-bit product

### DIFF
--- a/scripts/mrbind/extra_headers/instantiate_templates.h
+++ b/scripts/mrbind/extra_headers/instantiate_templates.h
@@ -27,7 +27,7 @@ namespace MR
     template Vector3<T> cross( const Vector3<T> & a, const Vector3<T> & b ); \
     template T dot( const Vector3<T> & a, const Vector3<T> & b ); \
     template T sqr( const Vector3<T> & a ); \
-    template T mixed( const Vector3<T> & a, const Vector3<T> & b, const Vector3<T> & c ); \
+    template T mixed<T, T>( const Vector3<T> & a, const Vector3<T> & b, const Vector3<T> & c ); \
     template Vector3<T> mult( const Vector3<T>& a, const Vector3<T>& b ); \
     template Vector3<T> div( const Vector3<T>& a, const Vector3<T>& b ); \
     template T angle( const Vector3<T> & a, const Vector3<T> & b ); \

--- a/source/MRMesh/MRInt64Mul128.h
+++ b/source/MRMesh/MRInt64Mul128.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "MRMeshFwd.h"
+#include "MRFastInt128.h"
+#include <MRPch/MRBindingMacros.h>
+#include <cstdint>
+
+#if defined _MSC_VER && !defined __clang__
+#include <intrin.h>
+#endif
+
+namespace MR
+{
+
+/// \addtogroup HighPrecisionGroup
+/// \{
+
+/// a 64-bit integer, which product with another one is an exact 128-bit integer
+/// obtained by a single widening machine multiplication;
+/// addition and subtraction stay 64-bit and can overflow just like std::int64_t
+class MR_BIND_IGNORE Int64Mul128
+{
+public:
+    Int64Mul128() noexcept = default;
+    constexpr Int64Mul128( std::int64_t v ) noexcept : v_( v ) { }
+    [[nodiscard]] constexpr explicit operator std::int64_t() const noexcept { return v_; }
+
+    [[nodiscard]] friend constexpr std::int64_t operator +( Int64Mul128 a ) noexcept { return a.v_; }
+    [[nodiscard]] friend constexpr std::int64_t operator -( Int64Mul128 a ) noexcept { return -a.v_; }
+
+    [[nodiscard]] friend constexpr std::int64_t operator +( Int64Mul128 a, Int64Mul128 b ) noexcept { return a.v_ + b.v_; }
+    [[nodiscard]] friend constexpr std::int64_t operator -( Int64Mul128 a, Int64Mul128 b ) noexcept { return a.v_ - b.v_; }
+    [[nodiscard]] friend constexpr std::int64_t operator /( Int64Mul128 a, Int64Mul128 b ) noexcept { return a.v_ / b.v_; }
+
+    [[nodiscard]] friend FastInt128 operator *( Int64Mul128 a, Int64Mul128 b ) noexcept
+    {
+#if defined _MSC_VER && !defined __clang__ && defined _M_X64
+        std::int64_t hi = 0;
+        const auto lo = _mul128( a.v_, b.v_, &hi );
+        return FastInt128( std::uint64_t( lo ), std::uint64_t( hi ) );
+#elif defined _MSC_VER && !defined __clang__ && defined _M_ARM64
+        const auto hi = __mulh( a.v_, b.v_ );
+        return FastInt128( std::uint64_t( a.v_ ) * std::uint64_t( b.v_ ), std::uint64_t( hi ) );
+#else
+        // both arguments are extensions of 64-bit values, which the compiler recognizes
+        return FastInt128( a.v_ ) * b.v_;
+#endif
+    }
+
+    [[nodiscard]] friend constexpr bool operator ==( Int64Mul128 a, Int64Mul128 b ) noexcept { return a.v_ == b.v_; }
+    [[nodiscard]] friend constexpr auto operator <=>( Int64Mul128 a, Int64Mul128 b ) noexcept { return a.v_ <=> b.v_; }
+
+private:
+    std::int64_t v_;
+};
+
+// no bindings for the same reason as for Vector3i128fast
+#if !defined MR_PARSING_FOR_ANY_BINDINGS && !defined MR_COMPILING_ANY_BINDINGS
+using Vector2i64mul = Vector2<Int64Mul128>;
+using Vector3i64mul = Vector3<Int64Mul128>;
+#endif
+
+/// \}
+
+} // namespace MR

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -19,6 +19,7 @@
     <ClInclude Include="MRFastInt128.h" />
     <ClInclude Include="MRHoleFillPlan.h" />
     <ClInclude Include="MRImageTransform.h" />
+    <ClInclude Include="MRInt64Mul128.h" />
     <ClInclude Include="MRLinesLoadSettings.h" />
     <ClInclude Include="MRLoadedMeshData.h" />
     <ClInclude Include="MRMapOrHashMap.h" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1335,6 +1335,9 @@
     <ClInclude Include="MRFastInt128.h">
       <Filter>Source Files\Math</Filter>
     </ClInclude>
+    <ClInclude Include="MRInt64Mul128.h">
+      <Filter>Source Files\Math</Filter>
+    </ClInclude>
     <ClInclude Include="MREndMill.h">
       <Filter>Source Files\Gcode</Filter>
     </ClInclude>

--- a/source/MRMesh/MRPrecisePredicates2.cpp
+++ b/source/MRMesh/MRPrecisePredicates2.cpp
@@ -131,7 +131,7 @@ bool orientParaboloid3d( const Vector2i & a0, const Vector2i & b0, const Vector2
     const Vector3i64 c( c0.x, c0.y, sqr( std::int64_t( c0.x ) ) + sqr( std::int64_t( c0.y ) ) );
 
     //e**0
-    if ( auto v = dot( Vector3i128fast( a ), cross( Vector3i64mul( b ), Vector3i64mul( c ) ) ) )
+    if ( auto v = mixed( Vector3i128fast( a ), Vector3i64mul( b ), Vector3i64mul( c ) ) )
         return v > 0;
 
     // e**1

--- a/source/MRMesh/MRPrecisePredicates2.cpp
+++ b/source/MRMesh/MRPrecisePredicates2.cpp
@@ -1,5 +1,6 @@
 #include "MRPrecisePredicates2.h"
 #include "MRHighPrecision.h"
+#include "MRInt64Mul128.h"
 #include "MRPrecisePredicates3.h"
 #include "MRSparsePolynomial.h"
 #include "MRDivRound.h"
@@ -135,7 +136,7 @@ bool orientParaboloid3d( const Vector2i & a0, const Vector2i & b0, const Vector2
 
     // e**1
     const auto bxy_cxy = cross( Vector2i64{ b.x, b.y }, Vector2i64{ c.x, c.y } );
-    if ( auto v = -cross( Vector2i128fast{ b.x, b.z }, Vector2i128fast{ c.x, c.z } ) + 2 * a.y * FastInt128( bxy_cxy ) )
+    if ( auto v = -cross( Vector2i128fast{ b.x, b.z }, Vector2i128fast{ c.x, c.z } ) + Int64Mul128( 2 * a.y ) * Int64Mul128( bxy_cxy ) )
         return v > 0;
 
     // e**2
@@ -151,7 +152,7 @@ bool orientParaboloid3d( const Vector2i & a0, const Vector2i & b0, const Vector2
 
     // e**9
     const auto axy_cxy = cross( Vector2i64{ a.x, a.y }, Vector2i64{ c.x, c.y } );
-    if ( auto v = cross( Vector2i128fast{ a.x, a.z }, Vector2i128fast{ c.x, c.z } ) - 2 * b.y * FastInt128( axy_cxy ) )
+    if ( auto v = cross( Vector2i128fast{ a.x, a.z }, Vector2i128fast{ c.x, c.z } ) - Int64Mul128( 2 * b.y ) * Int64Mul128( axy_cxy ) )
         return v > 0;
 
     // e**10
@@ -177,7 +178,7 @@ bool orientParaboloid3d( const Vector2i & a0, const Vector2i & b0, const Vector2
     assert( c.x == 0 && c.y == 0 && c.z == 0 );
 
     // e**81
-    if ( auto v = b.x * FastInt128( a.z ) - a.x * FastInt128( b.z ) )
+    if ( auto v = Int64Mul128( b.x ) * Int64Mul128( a.z ) - Int64Mul128( a.x ) * Int64Mul128( b.z ) )
         return v > 0;
 
     // e**82
@@ -342,7 +343,7 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords2, 6> & vs )
     const auto areaSbDest = area( vs[4].pt, vs[5].pt, vs[1].pt );
     assert( ( areaSbOrg <= 0 && areaSbDest >= 0 ) || ( areaSbOrg >= 0 && areaSbDest <= 0 ) );
 
-    const auto nomSimple = FastInt128( areaSaOrg ) * FastInt128( areaSbDest ) - FastInt128( areaSbOrg ) * FastInt128( areaSaDest );
+    const auto nomSimple = Int64Mul128( areaSaOrg ) * Int64Mul128( areaSbDest ) - Int64Mul128( areaSbOrg ) * Int64Mul128( areaSaDest );
     if ( nomSimple != 0 )
     {
         // happy not-degenerated path

--- a/source/MRMesh/MRPrecisePredicates2.cpp
+++ b/source/MRMesh/MRPrecisePredicates2.cpp
@@ -131,12 +131,12 @@ bool orientParaboloid3d( const Vector2i & a0, const Vector2i & b0, const Vector2
     const Vector3i64 c( c0.x, c0.y, sqr( std::int64_t( c0.x ) ) + sqr( std::int64_t( c0.y ) ) );
 
     //e**0
-    if ( auto v = mixed( Vector3i128fast( a ), Vector3i128fast( b ), Vector3i128fast( c ) ) )
+    if ( auto v = dot( Vector3i128fast( a ), cross( Vector3i64mul( b ), Vector3i64mul( c ) ) ) )
         return v > 0;
 
     // e**1
     const auto bxy_cxy = cross( Vector2i64{ b.x, b.y }, Vector2i64{ c.x, c.y } );
-    if ( auto v = -cross( Vector2i128fast{ b.x, b.z }, Vector2i128fast{ c.x, c.z } ) + Int64Mul128( 2 * a.y ) * Int64Mul128( bxy_cxy ) )
+    if ( auto v = -cross( Vector2i64mul{ b.x, b.z }, Vector2i64mul{ c.x, c.z } ) + Int64Mul128( 2 * a.y ) * Int64Mul128( bxy_cxy ) )
         return v > 0;
 
     // e**2
@@ -145,14 +145,14 @@ bool orientParaboloid3d( const Vector2i & a0, const Vector2i & b0, const Vector2
 
     // e**3
     assert( bxy_cxy == 0 );
-    if ( auto v = cross( Vector2i128fast{ b.y, b.z }, Vector2i128fast{ c.y, c.z } ) ) // + 2 * a.x * bxy_cxy;
+    if ( auto v = cross( Vector2i64mul{ b.y, b.z }, Vector2i64mul{ c.y, c.z } ) ) // + 2 * a.x * bxy_cxy;
         return v > 0;
 
     // e**6 same as e**2
 
     // e**9
     const auto axy_cxy = cross( Vector2i64{ a.x, a.y }, Vector2i64{ c.x, c.y } );
-    if ( auto v = cross( Vector2i128fast{ a.x, a.z }, Vector2i128fast{ c.x, c.z } ) - Int64Mul128( 2 * b.y ) * Int64Mul128( axy_cxy ) )
+    if ( auto v = cross( Vector2i64mul{ a.x, a.z }, Vector2i64mul{ c.x, c.z } ) - Int64Mul128( 2 * b.y ) * Int64Mul128( axy_cxy ) )
         return v > 0;
 
     // e**10

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -4,6 +4,7 @@
 #include "MRTimer.h"
 #include "MRVector.h"
 #include "MRHighPrecision.h"
+#include "MRInt64Mul128.h"
 #include "MRVector2.h"
 #include "MRBox.h"
 #include "MRDivRound.h"
@@ -114,7 +115,7 @@ Int128 volume( const Vector3i & a, const Vector3i & b, const Vector3i & c, const
 
 bool orient3d( const Vector3i & a, const Vector3i& b, const Vector3i& c )
 {
-    auto vhp = dot( Vector3i128fast{ a }, Vector3i128fast{ cross( Vector3i64{ b }, Vector3i64{ c } ) } );
+    auto vhp = dot( Vector3i64mul{ a }, Vector3i64mul{ cross( Vector3i64{ b }, Vector3i64{ c } ) } );
     if ( vhp ) return vhp > 0;
 
     auto v = cross( Vector2i64{ b.x, b.y }, Vector2i64{ c.x, c.y } );
@@ -456,14 +457,14 @@ std::optional<Vector3i> findTwoSegmentsIntersection( const Vector3i& ai, const V
     const auto abc = cross( ab, ac );
     const auto abd = cross( ab, ad );
 
-    if ( dot( Vector3i128fast( abc ), Vector3i128fast( abd ) ) > 0 )
+    if ( dot( Vector3i64mul( abc ), Vector3i64mul( abd ) ) > 0 )
         return std::nullopt; // CD is on one side of AB
 
     const auto cd = Vector3i64{ di - ci };
     const auto cb = Vector3i64{ bi - ci };
     const auto cda = cross( cd, -ac );
     const auto cdb = cross( cd, cb );
-    if ( dot( Vector3i128fast( cda ), Vector3i128fast( cdb ) ) > 0 )
+    if ( dot( Vector3i64mul( cda ), Vector3i64mul( cdb ) ) > 0 )
         return std::nullopt; // AB is on one side of CD
 
     constexpr Vector3i64 zero;
@@ -487,8 +488,8 @@ std::optional<Vector3i> findTwoSegmentsIntersection( const Vector3i& ai, const V
 
     // common intersection - AB and CD are non-collinear
     const Vector3i64 n = abc - abd; // not unit
-    FastInt128 ck = dot( Vector3i128fast( n ), Vector3i128fast( abc ) );
-    FastInt128 dk = dot( Vector3i128fast( n ), Vector3i128fast( abd ) );
+    FastInt128 ck = dot( Vector3i64mul( n ), Vector3i64mul( abc ) );
+    FastInt128 dk = dot( Vector3i64mul( n ), Vector3i64mul( abd ) );
     assert( ck >=0 && dk <= 0 );
 
     // scale down ck and dk to make sure that below products can be computed in 128 bits
@@ -512,10 +513,10 @@ Vector3f findTriangleSegmentIntersectionPrecise(
     auto ci = converters.toInt( c );
     auto di = converters.toInt( d );
     auto ei = converters.toInt( e );
-    auto abcd = dot( Vector3i128fast{ ai - di }, Vector3i128fast{ cross( Vector3i64{ bi - di }, Vector3i64{ ci - di } ) } );
+    auto abcd = dot( Vector3i64mul{ ai - di }, Vector3i64mul{ cross( Vector3i64{ bi - di }, Vector3i64{ ci - di } ) } );
     if ( abcd < 0 )
         abcd = -abcd;
-    auto abce = dot( Vector3i128fast{ ai - ei }, Vector3i128fast{ cross( Vector3i64{ bi - ei }, Vector3i64{ ci - ei } ) } );
+    auto abce = dot( Vector3i64mul{ ai - ei }, Vector3i64mul{ cross( Vector3i64{ bi - ei }, Vector3i64{ ci - ei } ) } );
     if ( abce < 0 )
         abce = -abce;
     auto sum = abcd + abce;

--- a/source/MRMesh/MRVector3.h
+++ b/source/MRMesh/MRVector3.h
@@ -200,8 +200,8 @@ inline auto sqr( const Vector3<T> & a ) -> decltype( a.lengthSq() )
 }
 
 /// mixed product
-template <typename T>
-inline auto mixed( const Vector3<T> & a, const Vector3<T> & b, const Vector3<T> & c ) -> decltype( dot( a, cross( b, c ) ) )
+template <typename T, typename U>
+inline auto mixed( const Vector3<T> & a, const Vector3<U> & b, const Vector3<U> & c ) -> decltype( dot( a, cross( b, c ) ) )
 {
     return dot( a, cross( b, c ) );
 }

--- a/source/MRTest/MRInt64Mul128Tests.cpp
+++ b/source/MRTest/MRInt64Mul128Tests.cpp
@@ -1,0 +1,49 @@
+#include <MRMesh/MRInt64Mul128.h>
+#include <MRMesh/MRVector3.h>
+#include <gtest/gtest.h>
+#include <random>
+
+namespace MR
+{
+
+TEST( MRMesh, Int64Mul128 )
+{
+    constexpr std::int64_t edge[] = { 0, 1, -1, 2, -2, INT64_MAX, INT64_MIN, INT64_MAX - 1, INT64_MIN + 1,
+        std::int64_t( 1 ) << 62, -( std::int64_t( 1 ) << 62 ), 0x7FFFFFFF, -0x80000000LL };
+    for ( auto a : edge )
+        for ( auto b : edge )
+            EXPECT_TRUE( Int64Mul128( a ) * Int64Mul128( b ) == FastInt128( a ) * FastInt128( b ) );
+
+    std::mt19937_64 gen( 12345 );
+    for ( int i = 0; i < 10000; ++i )
+    {
+        const auto a = std::int64_t( gen() );
+        const auto b = std::int64_t( gen() );
+        EXPECT_TRUE( Int64Mul128( a ) * Int64Mul128( b ) == FastInt128( a ) * FastInt128( b ) );
+
+        // additions of Int64Mul128 stay 64-bit, so test them on values that cannot overflow
+        const auto c = std::int64_t( std::int32_t( a ) );
+        const auto d = std::int64_t( std::int32_t( b ) );
+        EXPECT_EQ( Int64Mul128( c ) + Int64Mul128( d ), c + d );
+        EXPECT_EQ( Int64Mul128( c ) - Int64Mul128( d ), c - d );
+        EXPECT_EQ( -Int64Mul128( c ), -c );
+    }
+}
+
+TEST( MRMesh, Int64Mul128Vector )
+{
+    std::mt19937_64 gen( 54321 );
+    for ( int i = 0; i < 1000; ++i )
+    {
+        const Vector3i64 u{ std::int64_t( gen() ), std::int64_t( gen() ), std::int64_t( gen() ) };
+        const Vector3i64 v{ std::int64_t( std::int32_t( gen() ) ), std::int64_t( std::int32_t( gen() ) ), std::int64_t( std::int32_t( gen() ) ) };
+
+        EXPECT_TRUE( dot( Vector3i64mul{ u }, Vector3i64mul{ v } ) ==
+            FastInt128( u.x ) * v.x + FastInt128( u.y ) * v.y + FastInt128( u.z ) * v.z );
+
+        const Vector3i64 d = Vector3i64mul{ v } - Vector3i64mul{ v / 2 };
+        EXPECT_EQ( d, v - v / 2 );
+    }
+}
+
+} //namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -92,6 +92,7 @@
     <ClCompile Include="MRFillContours2DTests.cpp" />
     <ClCompile Include="MRFinallyTests.cpp" />
     <ClCompile Include="MRIdTests.cpp" />
+    <ClCompile Include="MRInt64Mul128Tests.cpp" />
     <ClCompile Include="MRIntersectionTests.cpp" />
     <ClCompile Include="MRIterativeSamplingTests.cpp" />
     <ClCompile Include="MRLine3Tests.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -115,6 +115,9 @@
     <ClCompile Include="MRPrecisePredicatesTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRInt64Mul128Tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="MRCylinderApproximation.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation

A dot or cross product of vectors with 64-bit components needs an exact 128-bit result, and today it is obtained by widening the arguments to 128 bits first: `dot( Vector3i128fast( n ), Vector3i128fast( abc ) )`. That asks the compiler for a full 128x128 multiplication, while a single widening 64x64 -> 128 machine instruction is enough, since the upper halves of both arguments are known to be zero.

This is an MSVC problem only. GCC and Clang both narrow a product of two sign-extended 64-bit values back to a single `imul` on their own, so `FastInt128` is already optimal there. MSVC does not: `MR::dot<std::_Signed128>` is compiled as an out-of-line function of 158 instructions with 9 multiplications, and one such dot product costs 15 ns.

So the changed call sites below produce byte-identical code on GCC and Clang - the whole gain is on Windows.

### What is added

`Int64Mul128` - a 64-bit integer whose product with another one is an exact `FastInt128`, computed by one widening multiplication (`imul r64` on x64, `_mul128` / `__mulh` on MSVC). Addition and subtraction stay 64-bit and can overflow, exactly like `std::int64_t`.

Together with `Vector2i64mul` / `Vector3i64mul` this makes `dot()`, `cross()` and `lengthSq()` optimal with almost no change in `MRVector2.h` / `MRVector3.h`: after #6571 and #6573 they all deduce the element type of their result, which becomes `FastInt128`, and the products are accumulated with 128-bit `add`/`adc`.

### Where it is used

`MRPrecisePredicates3.cpp` - all 7 dot products of 64-bit vectors: in `orient3d`, `findTwoSegmentsIntersection` and `findTriangleSegmentIntersectionPrecise`.

`MRPrecisePredicates2.cpp` - the 3 cross products and the mixed product in `orientParaboloid3d`, and the products of two 64-bit values there and in `findSegmentSegmentIntersectionPrecise`.

In the mixed product the 6 multiplications of the cross become widening ones, and only the 3 of the dot stay 128x128.

Left as is: the places where an argument or the result really needs more than 64 or 128 bits (`W = dot( Vector3i256{ w }, Vector3i256{ w } )`, `ck * Vector3i128fast{ di }`), and the crosses that already fit in 64 bits (`bxy_cxy`, `axy_cxy`).

### Measurements

16383 dot products, minimum of 25 runs, x64, /O2 and -O2. One process measures both input widths and all three types, interleaved, and every compiler prints the same checksum. The Windows rows were measured on one machine and the Linux ones on a Compiler Explorer host, so compare within a group, not across.

| compiler | type | 32-bit values | full 64-bit | 64/32 |
| --- | --- | --- | --- | --- |
| MSVC 14.51 | `Vector3i128` | 1.101 ms | 1.923 ms | 1.75x |
| | `Vector3i128fast` | 0.254 ms | 0.252 ms | 0.99x |
| | `Vector3i64mul` | **0.025 ms** | **0.025 ms** | 1.00x |
| Clang 20 (Windows) | `Vector3i128` | 0.271 ms | 0.277 ms | 1.02x |
| | `Vector3i128fast` | 0.012 ms | 0.013 ms | 1.01x |
| | `Vector3i64mul` | 0.012 ms | 0.012 ms | 1.01x |
| GCC 15.2 (Linux) | `Vector3i128` | 0.618 ms | 0.735 ms | 1.19x |
| | `Vector3i128fast` | 0.030 ms | 0.029 ms | 0.97x |
| | `Vector3i64mul` | 0.028 ms | 0.028 ms | 1.00x |
| Clang 20 (Linux) | `Vector3i128` | 0.474 ms | 0.470 ms | 0.99x |
| | `Vector3i128fast` | 0.015 ms | 0.015 ms | 0.99x |
| | `Vector3i64mul` | 0.015 ms | 0.015 ms | 1.00x |

On MSVC the new type is 10x faster than `Vector3i128fast` and 44-77x faster than `Vector3i128`. On GCC and Clang it is indistinguishable from `Vector3i128fast`, as expected: `dot` over `Vector3<__int128>` built from `int64` and over `Vector3<Int64Mul128>` compile to the same 14 instructions with 3 `imulq` (GCC 15.2, -O2). Boost stays 16-77x behind on every compiler because of its sign-magnitude representation - GCC inlines its whole `dot` into 214 instructions, against 15 for `__int128`.

The last column is the only place where the magnitude of the values matters, and it matters only for boost. For `FastInt128` and `Int64Mul128` the emitted code does not depend on the magnitude at all, and the measurements agree. Boost on MSVC is 1.75x slower with full 64-bit values because there it is a non-trivial backend of four 32-bit limbs with a *dynamic* limb count: a value that fits in 64 bits occupies 2 limbs, and the schoolbook multiplication is quadratic in the number of limbs. On GCC and Clang boost is trivial - a single `unsigned __int128` plus a sign - so the limb effect disappears, and only a small residue is left on GCC (1.19x), presumably the data-dependent branching of its sign-magnitude addition.

Since every call site changed here previously used `FastInt128`, not boost, the effect on GCC and Clang is nil by construction: `MRPrecisePredicates3.cpp` compiles to byte-identical assembly before and after with Clang (9336 instructions, 167 multiplications either way; the only textual differences are assert line numbers shifted by the added `#include`). The boost column matters for the `InSphereTester` follow-up below, not for this diff.

Instruction counts in the caller alone are not comparable between these three types, because for `Vector3i128` nearly all the work sits in out-of-line callees. On MSVC the caller has 99 instructions and 9 calls, into `Vector3<Int128>::Vector3<int64>` (57 instructions), `eval_multiply` (225, with 11 calls of its own), `subtract_unsigned` (195) and `add_unsigned` (147); `Vector3i128fast` has 49 in the caller plus a 158-instruction `MR::dot<std::_Signed128>`; `Vector3i64mul` has 38 and nothing out of line.

Whole translation units on MSVC 14.51 x64 /O2 (on GCC and Clang they are unchanged, see above):

| file | instructions |
| --- | --- |
| `MRPrecisePredicates3.cpp` | 22861 -> 22603 |
| `MRPrecisePredicates2.cpp` | 11450 -> 11094 |

`MR::dot<std::_Signed128>` is not emitted at all any more. Per function, in the caller (these are before/after of the same function, so they are comparable, unlike the numbers across types above):

| function | instructions | out-of-line calls |
| --- | --- | --- |
| `orient3d` | 198 -> 157 | 3 -> 2 |
| `findTwoSegmentsIntersection` | 621 -> 554 | 9 -> 5 |
| `findTriangleSegmentIntersectionPrecise` | 606 -> 584 | 24 -> 22 |
| `orientParaboloid3d` | 333 -> 316 | 8 -> 4 |

The static count of multiplications inside these functions grows, because one shared 9-multiplication callee is replaced by inlined 3-multiplication sequences at each call site.

### One change in MRVector3.h

`mixed()` takes the element type of its first argument separately from the other two:

```cpp
template <typename T, typename U>
inline auto mixed( const Vector3<T> & a, const Vector3<U> & b, const Vector3<U> & c ) -> decltype( dot( a, cross( b, c ) ) )
```

The reason is that `cross( b, c )` is already wider than `b` and `c`, so with a single element type `dot( a, cross( b, c ) )` had nothing to deduce once `b` and `c` became `Int64Mul128`. Now `mixed( Vector3i128fast( a ), Vector3i64mul( b ), Vector3i64mul( c ) )` works and is what `orientParaboloid3d` uses; only 3 of the 9 multiplications stay 128x128.

All existing calls pass three vectors of the same type and are unaffected. `instantiate_templates.h` names the arguments explicitly now (`mixed<T, T>`); the instantiated signatures are identical to master's, checked with `-ast-dump`:

```
mixed 'auto (const Vector3<float> &, const Vector3<float> &, const Vector3<float> &) -> decltype(dot(a, cross(b, c)))'
```

### Notes

After #6571 and #6573, `dot()`, `cross()`, `lengthSq()` and `sqr()` all deduce the type of their result and so work for `Vector2i64mul` / `Vector3i64mul`, together with unary and binary `+` and `-`.

`Vector3i64mul` cannot be the first argument of `mixed()`: `a` is multiplied by the already-wide `cross( b, c )`, so it has to be `Vector3i128fast` anyway. Nothing is lost by that - a 64x128 product is not cheaper than widening `a` first.

`operator /` is present only to make `Vector3<Int64Mul128>` instantiable: the declaration of `Vector3::operator /` needs `decltype( T / T )`.

### Tests

`MRInt64Mul128Tests.cpp` compares the product against the plain `FastInt128` one on a grid of edge values (including `INT64_MIN`, `INT64_MAX`, +-2^62) and on random pairs, and checks `dot()` of `Vector3i64mul` against the straightforward wide computation.

All 336 tests of MRTest pass locally on Windows x64 Release, including the 20 precise-predicate and inSphere ones.

Separately, every rewritten expression of `orientParaboloid3d` was compared against its previous form on 1M random paraboloid points and on 1M full-range `int64` triples, under both MSVC and Clang: bit-identical in all cases.

### Not done here

`InSphereTester` computes the same dot products via boost `Int128`, which is even slower (124 instructions on Clang, 99 plus 9 out-of-line calls on MSVC). Switching it needs a conversion from `FastInt128` to `Int256` / `Int1024`, which boost provides for `__int128` but not for `std::_Signed128`. Can be done here or separately.
