### PR TITLE
cross: deduce the element type of the result, like dot

### DIFF
--- a/source/MRMesh/MRVector2.h
+++ b/source/MRMesh/MRVector2.h
@@ -157,7 +157,7 @@ inline T distance( const Vector2<T> & a, const Vector2<T> & b )
 
 /// cross product
 template <typename T>
-inline T cross( const Vector2<T> & a, const Vector2<T> & b )
+inline auto cross( const Vector2<T> & a, const Vector2<T> & b ) -> decltype( a.x * b.x )
 {
     return a.x * b.y - a.y * b.x;
 }

--- a/source/MRMesh/MRVector3.h
+++ b/source/MRMesh/MRVector3.h
@@ -176,7 +176,7 @@ inline T distance( const Vector3<T> & a, const Vector3<T> & b )
 
 /// cross product
 template <typename T>
-inline Vector3<T> cross( const Vector3<T> & a, const Vector3<T> & b )
+inline auto cross( const Vector3<T> & a, const Vector3<T> & b ) -> Vector3<decltype( a.x * b.x )>
 {
     return {
         a.y * b.z - a.z * b.y,


### PR DESCRIPTION
`dot` already deduces its result type from the product of the components; `cross` did not — it forced the result back to the element type it was given:

```cpp
template <typename T>
inline Vector3<T> cross( const Vector3<T> & a, const Vector3<T> & b )   // MRVector3.h
template <typename T>
inline T cross( const Vector2<T> & a, const Vector2<T> & b )            // MRVector2.h
```

Now both follow `dot`, in the same spelling used a few lines below them:

```cpp
template <typename T>
inline auto cross( const Vector3<T> & a, const Vector3<T> & b ) -> Vector3<decltype( a.x * b.x )>
template <typename T>
inline auto cross( const Vector2<T> & a, const Vector2<T> & b ) -> decltype( a.x * b.x )
```

The 2D `cross` produces a scalar rather than a vector, so there it is literally the `dot` treatment; the 3D one deduces the element type of the resulting `Vector3`.

For every element type MeshLib instantiates these with — `float`, `double`, `int`, `Int128`…`Int1024` — `decltype( a.x * b.x )` is exactly `T`, so the signatures and the generated code are unchanged. For element types narrower than `int` the components are multiplied after integral promotion, in `int`, and the old return type truncated the result back:

```cpp
cross( Vector2<int16_t>{ 300, 0 }, Vector2<int16_t>{ 0, 300 } );  // was 24464, now 90000
```

Same class of change as #6568 for `sqr`/`distanceSq`.

### Checked

* The explicit instantiations in `scripts/mrbind/extra_headers/instantiate_templates.h` — `template Vector3<T> cross( const Vector3<T> &, const Vector3<T> & );` and `template T cross( const Vector2<T> &, const Vector2<T> & );` for `float`/`double`/`int` — still match: the return type is a non-deduced context, `T` comes from the parameters, and substituting gives back `Vector3<float>` / `float`.
* No stray specializations of the kind that broke #6568: `-Xclang -ast-dump -Xclang -ast-dump-filter=cross` over the real headers plus that instantiation list yields exactly two specializations each for `float`, `double` and `int` (the 2D and the 3D overload) and nothing with a reference or cv-qualified template argument.
* The generated C bindings are unchanged: the `CBindings` artifact of this run diffs clean against the master baseline for every emitted header and source. The only difference in the whole tree is three `"pretty"` strings inside mrbind's intermediate `temp/meshlib.generated.json`, where `cross`'s return type now prints as the canonical `MR::Vector3f`/`Vector3d`/`Vector3i` instead of `MR::Vector3<float>`/`<double>`/`<int>`, because the deduced type resolves to the preferred name. `MR_cross_float_MR_Vector3f` and friends keep their exact signatures.
* `static_assert`s that `decltype( cross( … ) )` is unchanged for `Vector2`/`Vector3` of `float`/`double`/`int`, and that it becomes `Vector3i`/`int` for `int16_t` elements; compiled under clang (`-std=c++20` and `c++23`) and MSVC 14.5 `/permissive- /W4`.

### Not changed

* `MR::Cuda::cross` in `MRCudaFloat.cuh` takes `float2`/`float3` and is not a template, so there is nothing to deduce.
* `mixed`, `angle` and `Quaternion`'s `dot` still return `T`; those are separate from this change.
