### PR TITLE
Fix Unity nuget test on Linux after Unity Hub 3.20.0 moved its install path

### DIFF
--- a/.github/workflows/unity-nuget-test.yml
+++ b/.github/workflows/unity-nuget-test.yml
@@ -33,9 +33,6 @@ jobs:
       matrix:
         os: [ windows-latest, ubuntu-latest, macos-latest, macos-15-intel ]
     runs-on: ${{ matrix.os }}
-    # Windows is the release gate; other legs cover the remaining package
-    # natives and stay non-blocking until proven stable.
-    continue-on-error: ${{ matrix.os != 'windows-latest' }}
     env:
       UNITY_PROJECT: test_unity/NugetTestProj
     steps:
@@ -94,6 +91,13 @@ jobs:
           $xml = [xml](Get-Content -Path $xmlPath)
           $xml.packages.package.version = $pkgVersion
           $xml.Save($xmlPath)
+
+      # Unity Hub 3.20.0 repackaged with Electron Forge: it installs into
+      # /usr/lib/unityhub, while unity-setup hardcodes /opt/unityhub. The link
+      # dangles until the next step's apt run unpacks the Hub.
+      - name: Point legacy Unity Hub path at the Electron Forge layout
+        if: runner.os == 'Linux'
+        run: sudo ln -sfT /usr/lib/unityhub /opt/unityhub
 
       - name: Install Unity editor
         # The one step with a live external dependency (Unity CDN); a hung


### PR DESCRIPTION
The `unity-nuget-test` **ubuntu-latest** leg has been failing on every run, master included, right at the start of *Install Unity editor*:

```
Error: ENOENT: no such file or directory, access '/opt/unityhub/unityhub'
    at UnityHub.installHub (…/@rage-against-the-pixel/unity-cli/dist/unity-hub.js:504)
```

## Cause

Unity Hub **3.20.0** was repackaged from electron-builder/fpm to Electron Forge, which moved the install prefix. Its own `postinst` documents the change:

> the Forge deb/rpm makers pin the package name to `unityhub` … so electron-installer-common lays the app out under /usr/lib/unityhub and ships the /usr/bin/unityhub symlink in the package payload itself
>
> Packages up to Hub 3.x created /usr/bin/unityhub themselves via update-alternatives (pointing at /opt/unityhub)

`unity-cli`, bundled in `buildalon/unity-setup`, still hardcodes `/opt/unityhub/unityhub`. The apt install inside the action succeeds — 3.20.0 unpacks fine — and only the `fs.access` right after it fails, so the leg never reached the test. Nothing else on Linux is broken: the last green ubuntu run (2026-07-13) predates 3.20.0.

## Fix

One symlink, created before the setup action runs. It is dangling at that moment; `Install()` fails its first `access`, calls `installHub`, and apt populates the target before the final check.

Symlinking the *directory* rather than the binary is what keeps this to one line — three separate consumers need the old path:

- `this.executable` = `/opt/unityhub/unityhub`, checked by `access()` in both `Install` and `installHub`;
- `this.rootDirectory` = its parent, from which the Hub version is read as `resources/app.asar`;
- `/usr/bin/unity-hub`, the wrapper the action itself writes as `xvfb-run --auto-servernum /opt/unityhub/unityhub "$@"`, and which `UnityHub.Exec` always invokes on Linux.

That last one is why the `UNITY_HUB_PATH` env var that `unity-cli` honors is *not* sufficient: it would fix the checks and still leave every Hub invocation pointing at the missing path.

`continue-on-error` is dropped, so all four legs now gate.

## Verification

`unity-nuget-test.yml` dispatched on this branch against `v3.1.3.473`'s `.nupkg` — https://github.com/MeshInspector/MeshLib/actions/runs/31433292365 — all four legs green. The ubuntu leg logs `Unity Hub 3.20.0 installed successfully` (i.e. the version read through the symlink) and `Test run result: Passed (total=1 passed=1 failed=0 skipped=0)`, with the current Hub rather than a pinned old one.

The alternative fix, `hub-version: 3.19.5`, would also work — the old debs use `/opt/unityhub` — but it pins CI to a Hub version Unity will eventually drop from the apt repo.

Worth reporting upstream so the workaround can go away; `unity-setup` v2.6.0 is the latest release and still carries the old path.
