### PR TITLE
sqr, lengthSq and mixed: deduce the result type

### DIFF
--- a/source/MRCuda/MRCudaMath.cuh
+++ b/source/MRCuda/MRCudaMath.cuh
@@ -437,7 +437,7 @@ __device__ inline void setBit( uint64_t* bitSet, const size_t bitNumber )
 }
 
 template <typename T>
-__device__ inline T sqr( T x )
+__device__ inline auto sqr( T x ) -> decltype( x * x )
 {
     return x * x;
 }

--- a/source/MRMesh/MRLineSegm.h
+++ b/source/MRMesh/MRLineSegm.h
@@ -20,7 +20,7 @@ struct LineSegm
     /// returns directional vector of the line
     [[nodiscard]] V dir() const { return b - a; }
     /// returns squared length of this line segment
-    [[nodiscard]] T lengthSq() const { return dir().lengthSq(); }
+    [[nodiscard]] auto lengthSq() const -> decltype( std::declval<V>().lengthSq() ) { return dir().lengthSq(); }
     /// returns the length of this line segment
     [[nodiscard]] T length() const { return dir().length(); }
     /// returns point on the line, where param=0 returns a and param=1 returns b

--- a/source/MRMesh/MRVector2.h
+++ b/source/MRMesh/MRVector2.h
@@ -59,7 +59,7 @@ struct Vector2
     constexpr const T & operator []( int e ) const noexcept { return *( ( ValueType *)this + e ); }
     constexpr       T & operator []( int e )       noexcept { return *( ( ValueType *)this + e ); }
 
-    T lengthSq() const { return x * x + y * y; }
+    auto lengthSq() const -> decltype( std::declval<T>() * std::declval<T>() ) { return x * x + y * y; }
     auto length() const
     {
         // Calling `sqrt` this way to hopefully support boost.multiprecision numbers.
@@ -171,7 +171,7 @@ inline auto dot( const Vector2<T> & a, const Vector2<T> & b ) -> decltype( a.x *
 
 /// squared length
 template <typename T>
-inline T sqr( const Vector2<T> & a )
+inline auto sqr( const Vector2<T> & a ) -> decltype( a.lengthSq() )
 {
     return a.lengthSq();
 }

--- a/source/MRMesh/MRVector3.h
+++ b/source/MRMesh/MRVector3.h
@@ -201,7 +201,7 @@ inline auto sqr( const Vector3<T> & a ) -> decltype( a.lengthSq() )
 
 /// mixed product
 template <typename T>
-inline T mixed( const Vector3<T> & a, const Vector3<T> & b, const Vector3<T> & c )
+inline auto mixed( const Vector3<T> & a, const Vector3<T> & b, const Vector3<T> & c ) -> decltype( dot( a, cross( b, c ) ) )
 {
     return dot( a, cross( b, c ) );
 }

--- a/source/MRMesh/MRVector3.h
+++ b/source/MRMesh/MRVector3.h
@@ -62,7 +62,7 @@ struct Vector3
     constexpr const T & operator []( int e ) const noexcept { return *( ( ValueType *)this + e ); }
     constexpr       T & operator []( int e )       noexcept { return *( ( ValueType *)this + e ); }
 
-    T lengthSq() const { return x * x + y * y + z * z; }
+    auto lengthSq() const -> decltype( std::declval<T>() * std::declval<T>() ) { return x * x + y * y + z * z; }
     auto length() const
     {
         // Calling `sqrt` this way to hopefully support boost.multiprecision numbers.
@@ -194,7 +194,7 @@ inline auto dot( const Vector3<T> & a, const Vector3<T> & b ) -> decltype( a.x *
 
 /// squared length
 template <typename T>
-inline T sqr( const Vector3<T> & a )
+inline auto sqr( const Vector3<T> & a ) -> decltype( a.lengthSq() )
 {
     return a.lengthSq();
 }

--- a/source/MRMesh/MRVector4.h
+++ b/source/MRMesh/MRVector4.h
@@ -50,7 +50,7 @@ struct Vector4
     constexpr const T & operator []( int e ) const noexcept { return *( ( ValueType *)this + e ); }
     constexpr       T & operator []( int e )       noexcept { return *( ( ValueType* )this + e ); }
 
-    T lengthSq() const
+    auto lengthSq() const -> decltype( std::declval<T>() * std::declval<T>() )
     {
         return x * x + y * y + z * z + w * w;
     }
@@ -158,7 +158,7 @@ inline auto dot( const Vector4<T> & a, const Vector4<T> & b ) -> decltype( a.x *
 
 /// squared length
 template <typename T>
-inline T sqr( const Vector4<T> & a )
+inline auto sqr( const Vector4<T> & a ) -> decltype( a.lengthSq() )
 {
     return a.lengthSq();
 }


### PR DESCRIPTION
Finishes the series started in #6568 (`sqr`/`distanceSq`) and #6571 (`cross`). The remaining squaring helpers still converted their result back to the element type they were given:

| | before | after |
|---|---|---|
| `Vector2/3/4<T>::lengthSq()` | `T` | `decltype( std::declval<T>() * std::declval<T>() )` |
| `LineSegm<V>::lengthSq()` | `T` | `decltype( std::declval<V>().lengthSq() )` |
| `sqr( const Vector2/3/4<T> & )` | `T` | `decltype( a.lengthSq() )` |
| `MR::Cuda::sqr( T )` | `T` | `decltype( x * x )` |
| `mixed( const Vector3<T> &, …, … )` | `T` | `decltype( dot( a, cross( b, c ) ) )` |

The members are spelled with `std::declval` rather than with `x * x`, following the note above the operators in the same classes — libclang 18 in the binding generator chokes on decltyping `a.x` inside the class. The free functions use the `dot`-style spelling that already works there.

For every element type MeshLib uses — `float`, `double`, `int`, `int64_t`, `Int128`…`Int1024` — the deduced type is exactly `T`, so signatures and generated code are unchanged. For element types narrower than `int` the components were multiplied after integral promotion, in `int`, and the result was truncated back:

```cpp
Vector2<int16_t>{ 300, 300 }.lengthSq();  // was -16608, now 180000
```

### The exported signatures that change

Diffing the `CBindings` artifact of this run against the master baseline, exactly five entry points change, all of them `lengthSq` on element types narrower than `int`:

```c
bool          MR_Vector2b_lengthSq( const MR_Vector2b * );                          // becomes int
bool          MR_Vector3b_lengthSq( const MR_Vector3b * );                          // becomes int
bool          MR_Vector4b_lengthSq( const MR_Vector4b * );                          // becomes int
unsigned char MR_Vector3_unsigned_char_lengthSq( const MR_Vector3_unsigned_char * ); // becomes int
unsigned char MR_Vector4_unsigned_char_lengthSq( const MR_Vector4_unsigned_char * ); // becomes int
```

In every one of them the old return value was truncated nonsense, which is the whole point of the change:

```cpp
Vector3<uint8_t>{ 255, 255, 255 }.lengthSq();  // was 3, now 195075
Vector3b{ true, true, true }.lengthSq();       // was true, now 3
```

`MR_Vector*b_length` and `MR_Vector*_unsigned_char_length` keep returning `double`, but their values change with it — `Vector3b{ true, true, true }.length()` was `sqrt( bool( 3 ) ) == 1` and is now `sqrt( 3 )`.

It is still a visible break in the C and Python APIs, so flagging it. Nothing in the repository is affected: the `bool` vectors are only ever box-corner selectors (`Box::corner`, `MRBoxNesting.cpp`, `MRNesting3mfExport.cpp`) and `Vector3<unsigned char>`/`Vector4<uint8_t>` are pixel and dash-pattern storage (`MRPng.cpp`, `ObjectLinesHolder::DashPattern`) — none of them calls `lengthSq`. Happy to exempt element types narrower than `int` if you would rather not touch the exported signatures.

Every other exported `lengthSq` is untouched: `float`, `double`, `int`, `int64_t` for `Vector2/3/4` and `float`/`double` for `LineSegm2/3`. No `sqr`, `cross`, `dot` or `mixed` entry point changes at all.

### Checked

* `-Xclang -ast-dump -Xclang -ast-dump-filter=sqr` over the real headers plus the explicit instantiation list from `scripts/mrbind/extra_headers/instantiate_templates.h` gives byte-identical specialization sets before and after, so none of the #6568 spurious-specialization problem.
* The explicit instantiations `template T sqr( const Vector3<T> & a );` still match: the trailing return type is a non-deduced context, `T` comes from the parameter, and `decltype( a.lengthSq() )` substitutes back to `T`.
* `static_assert`s that `decltype( … )` is unchanged for `Vector2/3/4` and `LineSegm` of `float`/`double`/`int`, and becomes `int` for `int16_t` elements; compiled under clang (`-std=c++20` and `c++23`) and MSVC 14.5 `/permissive- /W4`.

### Not changed

* `distanceSq( const Vector2/3/4<T> &, … )` and `SymMatrix*::normSq()` still return `T`; same story, separate change if you want it.
* `Quaternion`'s `dot` and `angle` likewise.

### A note on `mixed` with narrow element types

`mixed` is not callable at all when the element type is narrower than `int`, and this PR does not change that: since #6571 `cross( b, c )` widens to `Vector3i`, and `dot` requires both arguments to have the same element type, so `dot( Vector3<int16_t>, Vector3i )` finds no overload. The only difference here is that it is now a clean substitution failure on the declaration rather than a hard error inside the body. Nothing instantiates `mixed` with such types — the explicit instantiations are `float`/`double`/`int`. Relaxing `dot` to accept two different element types would fix it properly; happy to do that separately if it is worth having.
