### PR TITLE
Rename HoleFillPlan to TriangulationPlan

### DIFF
--- a/source/MRMesh/MRContoursCut.cpp
+++ b/source/MRMesh/MRContoursCut.cpp
@@ -367,11 +367,11 @@ PreCutResult doPreCutMesh( Mesh& mesh, const OneMeshContours& contours )
     return res;
 }
 
-void executeTriangulateContourPlan( Mesh& mesh, EdgeId e, HoleFillPlan& plan, FaceId oldFace, FaceMap* new2OldMap, NewEdgesMap* new2OldEdgeMap )
+void executeTriangulateContourPlan( Mesh& mesh, EdgeId e, TriangulationPlan& plan, FaceId oldFace, FaceMap* new2OldMap, NewEdgesMap* new2OldEdgeMap )
 {
     const auto fsz0 = mesh.topology.faceSize();
     const auto uesz0 = mesh.topology.undirectedEdgeSize();
-    executeHoleFillPlan( mesh, e, plan );
+    executeTriangulationPlan( mesh, e, plan );
     if ( new2OldMap )
     {
         assert( oldFace.valid() );

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -214,7 +214,7 @@ Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepres
     return {};
 }
 
-Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
+Expected<TriangulationPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
 {
     assert( !mesh.topology.left( holeEdgeId ) );
     if ( mesh.topology.left( holeEdgeId ) )
@@ -254,7 +254,7 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
     const auto& pTp = patch->topology;
     const auto& ip = loops.front();
     auto& np = newPaths.front();
-    HoleFillPlan res;
+    TriangulationPlan res;
     res.numTris = pTp.numValidFaces();
     if ( res.numTris == 1 )
         return res;
@@ -279,7 +279,7 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
             auto dest = pTp.dest( ne );
             if ( dest != pTp.dest( e1 ) )
                 continue;
-            FillHoleItem fhi;
+            TriangulationPlanItem fhi;
             int i01 = ( i0 + 1 ) % size;
             fhi.edgeCode1 = i1 == i01 ? ip[i0] : int( np[i01] );
             i1 = dest;

--- a/source/MRMesh/MRFillContours2D.h
+++ b/source/MRMesh/MRFillContours2D.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MRHoleFillPlan.h"
+#include "MRTriangulationPlan.h"
 #include "MRExpected.h"
 
 namespace MR
@@ -23,7 +23,7 @@ MRMESH_API Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>&
  * edge should have invalid left face (FaceId == -1)
  * @return Expected with has_value()=true if hole plan is prepared, otherwise - string error
  */
-MRMESH_API Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId );
+MRMESH_API Expected<TriangulationPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId );
 
 /// computes the transformation that maps
 /// O into center mass of contours' points

--- a/source/MRMesh/MRHoleFillPlan.h
+++ b/source/MRMesh/MRHoleFillPlan.h
@@ -1,21 +1,3 @@
 #pragma once
-#include <vector>
-
-namespace MR
-{
-
-struct FillHoleItem
-{
-    // if not-negative number then it is edgeid;
-    // otherwise it refers to the edge created recently
-    int edgeCode1, edgeCode2;
-};
-
-/// concise representation of proposed hole triangulation
-struct HoleFillPlan
-{
-    std::vector<FillHoleItem> items;
-    int numTris = 0; // the number of triangles in the filling
-};
-
-}
+/// \deprecated this header was renamed, include MRTriangulationPlan.h instead
+#include "MRTriangulationPlan.h"

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -115,7 +115,7 @@ Mesh Mesh::fromFaceSoup(
     reportProgress( cb, 0.9f );
 
     for ( size_t i = 0; i < holeRepresentativeEdges.size(); ++i )
-        executeHoleFillPlan( res, holeRepresentativeEdges[i], fillPlans[i] );
+        executeTriangulationPlan( res, holeRepresentativeEdges[i], fillPlans[i] );
 
     reportProgress( cb, 1.0f );
 

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -22,6 +22,7 @@
     <ClInclude Include="MRLinesLoadSettings.h" />
     <ClInclude Include="MRLoadedMeshData.h" />
     <ClInclude Include="MRMapOrHashMap.h" />
+    <ClInclude Include="MRTriangulationPlan.h" />
     <ClInclude Include="MRAABBTreeBase.h" />
     <ClInclude Include="MRAABBTreeBase.hpp" />
     <ClInclude Include="MRAABBTreeMaker.hpp" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1428,6 +1428,9 @@
     <ClInclude Include="MRHoleFillPlan.h">
       <Filter>Source Files\MeshAlgorithm</Filter>
     </ClInclude>
+    <ClInclude Include="MRTriangulationPlan.h">
+      <Filter>Source Files\MeshAlgorithm</Filter>
+    </ClInclude>
     <ClInclude Include="MRSplineProject.h">
       <Filter>Source Files\AABBTree</Filter>
     </ClInclude>

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -528,7 +528,7 @@ inline EdgeId makeNewEdge( MeshTopology & topology, EdgeId a, EdgeId b )
     return newEdge;
 }
 
-void executeHoleFillPlan( Mesh & mesh, EdgeId a0, HoleFillPlan & plan, FaceBitSet * outNewFaces )
+void executeTriangulationPlan( Mesh & mesh, EdgeId a0, TriangulationPlan & plan, FaceBitSet * outNewFaces )
 {
     [[maybe_unused]] const auto fsz0 = mesh.topology.faceSize();
     const FaceId f0 = mesh.topology.left( a0 );
@@ -597,7 +597,12 @@ void executeHoleFillPlan( Mesh & mesh, EdgeId a0, HoleFillPlan & plan, FaceBitSe
     assert( plan.numTris == int( fsz - fsz0 + ( f0 ? 1 : 0 ) ) );
 }
 
-bool isFillingMultipleEdgeFree( const MeshTopology & topology, const HoleFillPlan & plan )
+void executeHoleFillPlan( Mesh & mesh, EdgeId a0, TriangulationPlan & plan, FaceBitSet * outNewFaces )
+{
+    executeTriangulationPlan( mesh, a0, plan, outNewFaces );
+}
+
+bool isFillingMultipleEdgeFree( const MeshTopology & topology, const TriangulationPlan & plan )
 {
     if ( plan.items.empty() )
         return true;
@@ -623,8 +628,8 @@ bool isFillingMultipleEdgeFree( const MeshTopology & topology, const HoleFillPla
 class HoleFillPlanner
 {
 public:
-    HoleFillPlan run( const Mesh& mesh, EdgeId e, const FillHoleParams& params = {} );
-    HoleFillPlan runPlanar( const Mesh& mesh, EdgeId e, bool allowSweptLine = true );
+    TriangulationPlan run( const Mesh& mesh, EdgeId e, const FillHoleParams& params = {} );
+    TriangulationPlan runPlanar( const Mesh& mesh, EdgeId e, bool allowSweptLine = true );
     unsigned concurrentSmallHoleSize = 0; ///< if hole size is smaller than this value preffer concurrent processing, sometimes it better than isolated parallelism overhead
 private:
     std::vector<EdgeId> edgeMap_;
@@ -635,9 +640,9 @@ private:
 };
 
 // Sub cubic complexity
-HoleFillPlan HoleFillPlanner::run( const Mesh& mesh, EdgeId a0, const FillHoleParams& params )
+TriangulationPlan HoleFillPlanner::run( const Mesh& mesh, EdgeId a0, const FillHoleParams& params )
 {
-    HoleFillPlan res;
+    TriangulationPlan res;
     if ( params.stopBeforeBadTriangulation )
         *params.stopBeforeBadTriangulation = false;
     if ( params.maxPolygonSubdivisions < 2 )
@@ -809,7 +814,7 @@ HoleFillPlan HoleFillPlanner::run( const Mesh& mesh, EdgeId a0, const FillHolePa
     return res;
 }
 
-HoleFillPlan HoleFillPlanner::runPlanar( const Mesh& mesh, EdgeId e, bool allowSweptLine )
+TriangulationPlan HoleFillPlanner::runPlanar( const Mesh& mesh, EdgeId e, bool allowSweptLine )
 {
     if ( allowSweptLine )
     {
@@ -838,15 +843,15 @@ HoleFillPlan HoleFillPlanner::runPlanar( const Mesh& mesh, EdgeId e, bool allowS
     return res;
 }
 
-HoleFillPlan getHoleFillPlan( const Mesh& mesh, EdgeId e, const FillHoleParams& params )
+TriangulationPlan getHoleFillPlan( const Mesh& mesh, EdgeId e, const FillHoleParams& params )
 {
     return HoleFillPlanner{}.run( mesh, e, params );
 }
 
-std::vector<HoleFillPlan> getHoleFillPlans( const Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges, const FillHoleParams& params )
+std::vector<TriangulationPlan> getHoleFillPlans( const Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges, const FillHoleParams& params )
 {
     MR_TIMER;
-    std::vector<HoleFillPlan> fillPlans( holeRepresentativeEdges.size() );
+    std::vector<TriangulationPlan> fillPlans( holeRepresentativeEdges.size() );
     tbb::enumerable_thread_specific<HoleFillPlanner> threadData_;
     ParallelFor( holeRepresentativeEdges, threadData_, [&]( size_t i, HoleFillPlanner& planner )
     {
@@ -860,15 +865,15 @@ std::vector<HoleFillPlan> getHoleFillPlans( const Mesh& mesh, const std::vector<
     return fillPlans;
 }
 
-HoleFillPlan getPlanarHoleFillPlan( const Mesh& mesh, EdgeId e, bool allowSwept )
+TriangulationPlan getPlanarHoleFillPlan( const Mesh& mesh, EdgeId e, bool allowSwept )
 {
     return HoleFillPlanner{}.runPlanar( mesh, e, allowSwept );
 }
 
-std::vector<HoleFillPlan> getPlanarHoleFillPlans( const Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges )
+std::vector<TriangulationPlan> getPlanarHoleFillPlans( const Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges )
 {
     MR_TIMER;
-    std::vector<HoleFillPlan> fillPlans( holeRepresentativeEdges.size() );
+    std::vector<TriangulationPlan> fillPlans( holeRepresentativeEdges.size() );
     tbb::enumerable_thread_specific<HoleFillPlanner> threadData_;
     ParallelFor( holeRepresentativeEdges, threadData_, [&]( size_t i, HoleFillPlanner& planner )
     {
@@ -950,7 +955,7 @@ void fillHole( Mesh& mesh, EdgeId a0, const FillHoleParams& params )
     if ( params.stopBeforeBadTriangulation && *params.stopBeforeBadTriangulation )
         return;
 
-    executeHoleFillPlan( mesh, a0, plan, params.outNewFaces );
+    executeTriangulationPlan( mesh, a0, plan, params.outNewFaces );
 }
 
 void fillHoles( Mesh& mesh, const std::vector<EdgeId> & as, const FillHoleParams& params )

--- a/source/MRMesh/MRMeshFillHole.h
+++ b/source/MRMesh/MRMeshFillHole.h
@@ -3,7 +3,7 @@
 #include "MRMeshFwd.h"
 #include "MRMeshMetrics.h"
 #include "MRId.h"
-#include "MRHoleFillPlan.h"
+#include "MRTriangulationPlan.h"
 #include <functional>
 #include <memory>
 
@@ -160,28 +160,33 @@ MRMESH_API void fillHoles( Mesh& mesh, const std::vector<EdgeId> & as, const Fil
 
 /// prepares the plan how to triangulate the face or hole to the left of (e) (not filling it immediately),
 /// several getHoleFillPlan can work in parallel
-[[nodiscard]] MRMESH_API HoleFillPlan getHoleFillPlan( const Mesh& mesh, EdgeId e, const FillHoleParams& params = {} );
+[[nodiscard]] MRMESH_API TriangulationPlan getHoleFillPlan( const Mesh& mesh, EdgeId e, const FillHoleParams& params = {} );
 
 /// prepares the plans how to triangulate the faces or holes, each given by a boundary edge (with filling target to the left),
 /// the plans are prepared in parallel with minimal memory allocation compared to manual calling of several getHoleFillPlan(), but it can inefficient when some holes are very complex
-[[nodiscard]] MRMESH_API std::vector<HoleFillPlan> getHoleFillPlans( const Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges, const FillHoleParams& params = {} );
+[[nodiscard]] MRMESH_API std::vector<TriangulationPlan> getHoleFillPlans( const Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges, const FillHoleParams& params = {} );
 
 /// prepares the plan how to triangulate the planar face or planar hole to the left of (e) (not filling it immediately),
 /// several getPlanarHoleFillPlan can work in parallel
 /// if `allowSweptLine` is set - tries to use faster swept line triangulation for larger holes but do not resolve multiple edges in any way (OK in most cases)
-[[nodiscard]] MRMESH_API HoleFillPlan getPlanarHoleFillPlan( const Mesh& mesh, EdgeId e, bool allowSweptLine = true );
+[[nodiscard]] MRMESH_API TriangulationPlan getPlanarHoleFillPlan( const Mesh& mesh, EdgeId e, bool allowSweptLine = true );
 
 /// prepares the plans how to triangulate the planar faces or holes, each given by a boundary edge (with filling target to the left),
 /// the plans are prepared in parallel with minimal memory allocation compared to manual calling of several getPlanarHoleFillPlan(), but it can inefficient when some holes are very complex
-[[nodiscard]] MRMESH_API std::vector<HoleFillPlan> getPlanarHoleFillPlans( const Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges );
+[[nodiscard]] MRMESH_API std::vector<TriangulationPlan> getPlanarHoleFillPlans( const Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges );
 
-/// quickly triangulates the face or hole to the left of (e) given the plan (quickly compared to fillHole function)
-MRMESH_API void executeHoleFillPlan( Mesh & mesh, EdgeId a0, HoleFillPlan & plan, FaceBitSet * outNewFaces = nullptr );
+/// quickly adds the edges of the plan in the mesh, triangulating the face or hole to the left of (e)
+/// (quickly compared to fillHole function)
+MRMESH_API void executeTriangulationPlan( Mesh & mesh, EdgeId a0, TriangulationPlan & plan, FaceBitSet * outNewFaces = nullptr );
 
-/// returns true if executeHoleFillPlan() with the same topology and plan
+/// \deprecated use executeTriangulationPlan() instead
+[[deprecated( "Use `executeTriangulationPlan` instead." )]]
+MRMESH_API MR_BIND_IGNORE void executeHoleFillPlan( Mesh & mesh, EdgeId a0, TriangulationPlan & plan, FaceBitSet * outNewFaces = nullptr );
+
+/// returns true if executeTriangulationPlan() with the same topology and plan
 /// does not introduce any edge with the same end-vertices as any existed edge in the mesh;
 /// note: this function can be used for checking a fill plan that was generated before filling other holes
-[[nodiscard]] MRMESH_API bool isFillingMultipleEdgeFree( const MeshTopology & topology, const HoleFillPlan & plan );
+[[nodiscard]] MRMESH_API bool isFillingMultipleEdgeFree( const MeshTopology & topology, const TriangulationPlan & plan );
 
 /** \brief Triangulates face of hole in mesh trivially\n
   * \ingroup FillHoleGroup

--- a/source/MRMesh/MRTriangulationPlan.h
+++ b/source/MRMesh/MRTriangulationPlan.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "MRPch/MRBindingMacros.h"
+#include <vector>
+
+namespace MR
+{
+
+struct TriangulationPlanItem
+{
+    // if not-negative number then it is edgeid;
+    // otherwise it refers to the edge created recently
+    int edgeCode1, edgeCode2;
+};
+
+/// concise representation of the edges to add in a topology, e.g. of a proposed hole triangulation
+struct TriangulationPlan
+{
+    std::vector<TriangulationPlanItem> items;
+    int numTris = 0; // the number of triangles in the filling
+};
+
+using FillHoleItem [[deprecated( "Use `TriangulationPlanItem` instead." )]] MR_BIND_IGNORE = TriangulationPlanItem;
+using HoleFillPlan [[deprecated( "Use `TriangulationPlan` instead." )]] MR_BIND_IGNORE = TriangulationPlan;
+
+}

--- a/source/MRTest/MRFillHoleTests.cpp
+++ b/source/MRTest/MRFillHoleTests.cpp
@@ -196,12 +196,12 @@ TEST( MRMesh, HoleFillPlan3 )
     EXPECT_EQ( p1.numTris, 1 );
 
     EXPECT_TRUE( isFillingMultipleEdgeFree( mesh.topology, p0 ) );
-    executeHoleFillPlan( mesh, e, p0 );
+    executeTriangulationPlan( mesh, e, p0 );
     EXPECT_EQ( mesh.topology.numValidFaces(), 1 );
     EXPECT_FALSE( mesh.topology.isClosed() );
 
     EXPECT_TRUE( isFillingMultipleEdgeFree( mesh.topology, p1 ) );
-    executeHoleFillPlan( mesh, e.sym(), p1 );
+    executeTriangulationPlan( mesh, e.sym(), p1 );
     EXPECT_EQ( mesh.topology.numValidFaces(), 2 );
     EXPECT_TRUE( mesh.topology.isClosed() );
 }
@@ -226,7 +226,7 @@ TEST( MRMesh, HoleFillPlan4 )
     EXPECT_EQ( p1.numTris, 2 );
 
     EXPECT_TRUE( isFillingMultipleEdgeFree( mesh.topology, p0 ) );
-    executeHoleFillPlan( mesh, e, p0 );
+    executeTriangulationPlan( mesh, e, p0 );
     EXPECT_EQ( mesh.topology.numValidFaces(), 2 );
     EXPECT_FALSE( mesh.topology.isClosed() );
     EXPECT_FALSE( hasMultipleEdges( mesh.topology ) );
@@ -235,7 +235,7 @@ TEST( MRMesh, HoleFillPlan4 )
 
     // independently produced plans can result in multiple edges after execution:
     EXPECT_FALSE( isFillingMultipleEdgeFree( mesh.topology, p1 ) );
-    executeHoleFillPlan( mesh, e.sym(), p1 );
+    executeTriangulationPlan( mesh, e.sym(), p1 );
     EXPECT_EQ( mesh.topology.numValidFaces(), 4 );
     EXPECT_TRUE( mesh.topology.isClosed() );
     EXPECT_TRUE( hasMultipleEdges( mesh.topology ) );
@@ -245,7 +245,7 @@ TEST( MRMesh, HoleFillPlan4 )
     EXPECT_EQ( p11.items.size(), 1 );
     EXPECT_EQ( p11.numTris, 2 );
     EXPECT_TRUE( isFillingMultipleEdgeFree( mesh1.topology, p11 ) );
-    executeHoleFillPlan( mesh1, e.sym(), p11 );
+    executeTriangulationPlan( mesh1, e.sym(), p11 );
     EXPECT_EQ( mesh1.topology.numValidFaces(), 4 );
     EXPECT_TRUE( mesh1.topology.isClosed() );
     EXPECT_FALSE( hasMultipleEdges( mesh1.topology ) );


### PR DESCRIPTION
A plan is a list of edges to add in a topology, not necessarily a hole filling. The upcoming monotonation mode of the sweep-line triangulation will emit a plan whose edges split a region into monotone parts and create **no faces at all**, so the hole-specific name no longer fits the type.

| old | new |
| --- | --- |
| `HoleFillPlan` | `TriangulationPlan` |
| `FillHoleItem` | `TriangulationPlanItem` |
| `executeHoleFillPlan` | `executeTriangulationPlan` |
| `MRHoleFillPlan.h` | `MRTriangulationPlan.h` |

Producers keep their names — `getHoleFillPlan`, `getPlanarHoleFillPlan(s)` and `fillContours2DPlan` really do plan hole fills; only the type and the executor are generic.

Nothing else changes: no logic, no data layout, no defaults.

### Compatibility

* **Source: compatible.** `MRHoleFillPlan.h` stays as a forwarding header, and the old names remain as `[[deprecated]]` aliases plus an exported `executeHoleFillPlan` forwarder.
* **Binary: not compatible.** C++ mangling embeds the struct name and ignores typedefs, so all seven plan-related exports change symbol (`?…AEAUHoleFillPlan@1@…` -> `?…AEAUTriangulationPlan@1@…`). Consumers must be recompiled, not merely relinked.

Deprecated declarations are marked `MR_BIND_IGNORE` so the generated bindings never reference the old names.

### Verification

* `MRTest --no-python-tests`: **334/334**, same as master.
* Perf A/B, master vs branch, 6 rounds with rotated order, every measurement in its own process: `MRMesh.MeshBoolean` median 27.0 ms on both sides (n=90/side, min 27 both, mean 27.72 vs 27.69); `MRMesh.MultiwayICPTorus` control flat (median 64.0 both). Neutral, as expected.
* No references to the renamed symbols exist under `examples/`, so the mrbind-generated C names used there are unaffected.

### Follow-up

MeshInspectorCode calls `executeHoleFillPlan` in `MRPlugins/Lines/MRLinesExtrusionBody.cpp`; it keeps compiling through the deprecated forwarder, and the call should be renamed when the submodule is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)