### PR TITLE
Support sym anchors and edges-only execution in HoleFillPlan

### DIFF
--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -292,7 +292,7 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
             if ( res.items.size() == size - 3 )
                 return res;
             np[i0] = ne;
-            np[i01] = EdgeId( encodeFillHoleItemRef( { .item = int( res.items.size() ) - 1 } ) ); // encode the just pushed plan edge in free slot
+            np[i01] = EdgeId( encodeFillHoleItemEdge( { .item = int( res.items.size() ) - 1 } ) ); // encode the just pushed plan edge in free slot
         }
     }
 }

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -292,7 +292,7 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
             if ( res.items.size() == size - 3 )
                 return res;
             np[i0] = ne;
-            np[i01] = EdgeId( -int( res.items.size() ) ); // encode newly created plan edge in free slot
+            np[i01] = EdgeId( -int( 2 * res.items.size() - 1 ) ); // encode forward direction of the new plan edge in free slot
         }
     }
 }

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -292,7 +292,7 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
             if ( res.items.size() == size - 3 )
                 return res;
             np[i0] = ne;
-            np[i01] = EdgeId( -int( 2 * res.items.size() - 1 ) ); // encode forward direction of the new plan edge in free slot
+            np[i01] = EdgeId( fillHoleItemCode( { .item = int( res.items.size() ) - 1 } ) ); // encode the just pushed plan edge in free slot
         }
     }
 }

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -292,7 +292,7 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
             if ( res.items.size() == size - 3 )
                 return res;
             np[i0] = ne;
-            np[i01] = EdgeId( encodeFillHoleItemEdge( { .item = int( res.items.size() ) - 1 } ) ); // encode the just pushed plan edge in free slot
+            np[i01] = EdgeId( FillHoleItemEdge{ .item = int( res.items.size() ) - 1 }.encode() ); // encode the just pushed plan edge in free slot
         }
     }
 }

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -292,7 +292,7 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
             if ( res.items.size() == size - 3 )
                 return res;
             np[i0] = ne;
-            np[i01] = EdgeId( fillHoleItemCode( { .item = int( res.items.size() ) - 1 } ) ); // encode the just pushed plan edge in free slot
+            np[i01] = EdgeId( encodeFillHoleItemRef( { .item = int( res.items.size() ) - 1 } ) ); // encode the just pushed plan edge in free slot
         }
     }
 }

--- a/source/MRMesh/MRHoleFillPlan.h
+++ b/source/MRMesh/MRHoleFillPlan.h
@@ -4,10 +4,12 @@
 namespace MR
 {
 
+/// one edge to add, connecting the origins of the two edges given by the codes
 struct FillHoleItem
 {
-    // if not-negative number then it is edgeid;
-    // otherwise it refers to the edge created recently
+    /// if not-negative number then it is edgeid;
+    /// otherwise it refers to the edge created by an earlier item: -( 2 * item + sym + 1 ),
+    /// where sym tells to take that edge in the opposite direction (so with the other origin)
     int edgeCode1, edgeCode2;
 };
 
@@ -15,7 +17,10 @@ struct FillHoleItem
 struct HoleFillPlan
 {
     std::vector<FillHoleItem> items;
-    int numTris = 0; // the number of triangles in the filling
+    /// the number of triangles in the filling;
+    /// zero means that the plan only adds the edges of items and creates no faces,
+    /// e.g. it splits a hole in several holes
+    int numTris = 0;
 };
 
 }

--- a/source/MRMesh/MRHoleFillPlan.h
+++ b/source/MRMesh/MRHoleFillPlan.h
@@ -7,7 +7,7 @@ namespace MR
 
 /// one edge to add, connecting the origins of the two edges given by the codes;
 /// a not-negative code is an EdgeId, a negative one refers to the edge created by an earlier item
-/// of the same plan - see \ref fillHoleItemCode
+/// of the same plan - see \ref encodeFillHoleItemRef
 struct FillHoleItem
 {
     int edgeCode1, edgeCode2;
@@ -23,14 +23,14 @@ struct FillHoleItemRef
 };
 
 /// encodes the reference to the edge of an earlier item in a negative code
-[[nodiscard]] inline int fillHoleItemCode( FillHoleItemRef ref )
+[[nodiscard]] inline int encodeFillHoleItemRef( FillHoleItemRef ref )
 {
     assert( ref.item >= 0 );
     return -( 2 * ref.item + int( ref.sym ) + 1 );
 }
 
 /// decodes a negative code back in the reference it holds
-[[nodiscard]] inline FillHoleItemRef fillHoleItemRef( int code )
+[[nodiscard]] inline FillHoleItemRef decodeFillHoleItemRef( int code )
 {
     assert( code < 0 );
     const int r = -( code + 1 );

--- a/source/MRMesh/MRHoleFillPlan.h
+++ b/source/MRMesh/MRHoleFillPlan.h
@@ -6,15 +6,16 @@ namespace MR
 {
 
 /// one edge to add, connecting the origins of the two edges given by the codes;
-/// a not-negative code is an EdgeId, a negative one refers to the edge created by an earlier item
-/// of the same plan - see \ref encodeFillHoleItemRef
+/// a not-negative code is an EdgeId, a negative one denotes an edge that an earlier item
+/// of the same plan creates - see \ref FillHoleItemEdge
 struct FillHoleItem
 {
     int edgeCode1, edgeCode2;
 };
 
-/// reference to the edge created by an earlier item of the same plan
-struct FillHoleItemRef
+/// an edge created by an item of the plan, given in the same way as EdgeId gives an edge of a mesh:
+/// what the edge is, plus which of its two directions is meant
+struct FillHoleItemEdge
 {
     /// index of the item creating the edge
     int item = 0;
@@ -22,19 +23,19 @@ struct FillHoleItemRef
     bool sym = false;
 };
 
-/// encodes the reference to the edge of an earlier item in a negative code
-[[nodiscard]] inline int encodeFillHoleItemRef( FillHoleItemRef ref )
+/// encodes the edge of an earlier item in a negative code
+[[nodiscard]] inline int encodeFillHoleItemEdge( FillHoleItemEdge e )
 {
-    assert( ref.item >= 0 );
-    return -( 2 * ref.item + int( ref.sym ) + 1 );
+    assert( e.item >= 0 );
+    return -( 2 * e.item + int( e.sym ) + 1 );
 }
 
-/// decodes a negative code back in the reference it holds
-[[nodiscard]] inline FillHoleItemRef decodeFillHoleItemRef( int code )
+/// decodes a negative code back in the edge it denotes
+[[nodiscard]] inline FillHoleItemEdge decodeFillHoleItemEdge( int code )
 {
     assert( code < 0 );
-    const int r = -( code + 1 );
-    return { .item = r >> 1, .sym = ( r & 1 ) != 0 };
+    const int c = -( code + 1 );
+    return { .item = c >> 1, .sym = ( c & 1 ) != 0 };
 }
 
 /// concise representation of proposed hole triangulation

--- a/source/MRMesh/MRHoleFillPlan.h
+++ b/source/MRMesh/MRHoleFillPlan.h
@@ -21,22 +21,22 @@ struct FillHoleItemEdge
     int item = 0;
     /// take that edge in the opposite direction, so with the other origin
     bool sym = false;
+
+    /// encodes this edge in a negative code
+    [[nodiscard]] int encode() const
+    {
+        assert( item >= 0 );
+        return -( 2 * item + int( sym ) + 1 );
+    }
+
+    /// decodes a negative code back in the edge it denotes
+    [[nodiscard]] static FillHoleItemEdge decode( int code )
+    {
+        assert( code < 0 );
+        const int c = -( code + 1 );
+        return { .item = c >> 1, .sym = ( c & 1 ) != 0 };
+    }
 };
-
-/// encodes the edge of an earlier item in a negative code
-[[nodiscard]] inline int encodeFillHoleItemEdge( FillHoleItemEdge e )
-{
-    assert( e.item >= 0 );
-    return -( 2 * e.item + int( e.sym ) + 1 );
-}
-
-/// decodes a negative code back in the edge it denotes
-[[nodiscard]] inline FillHoleItemEdge decodeFillHoleItemEdge( int code )
-{
-    assert( code < 0 );
-    const int c = -( code + 1 );
-    return { .item = c >> 1, .sym = ( c & 1 ) != 0 };
-}
 
 /// concise representation of proposed hole triangulation
 struct HoleFillPlan

--- a/source/MRMesh/MRHoleFillPlan.h
+++ b/source/MRMesh/MRHoleFillPlan.h
@@ -1,17 +1,41 @@
 #pragma once
+#include <cassert>
 #include <vector>
 
 namespace MR
 {
 
-/// one edge to add, connecting the origins of the two edges given by the codes
+/// one edge to add, connecting the origins of the two edges given by the codes;
+/// a not-negative code is an EdgeId, a negative one refers to the edge created by an earlier item
+/// of the same plan - see \ref fillHoleItemCode
 struct FillHoleItem
 {
-    /// if not-negative number then it is edgeid;
-    /// otherwise it refers to the edge created by an earlier item: -( 2 * item + sym + 1 ),
-    /// where sym tells to take that edge in the opposite direction (so with the other origin)
     int edgeCode1, edgeCode2;
 };
+
+/// reference to the edge created by an earlier item of the same plan
+struct FillHoleItemRef
+{
+    /// index of the item creating the edge
+    int item = 0;
+    /// take that edge in the opposite direction, so with the other origin
+    bool sym = false;
+};
+
+/// encodes the reference to the edge of an earlier item in a negative code
+[[nodiscard]] inline int fillHoleItemCode( FillHoleItemRef ref )
+{
+    assert( ref.item >= 0 );
+    return -( 2 * ref.item + int( ref.sym ) + 1 );
+}
+
+/// decodes a negative code back in the reference it holds
+[[nodiscard]] inline FillHoleItemRef fillHoleItemRef( int code )
+{
+    assert( code < 0 );
+    const int r = -( code + 1 );
+    return { .item = r >> 1, .sym = ( r & 1 ) != 0 };
+}
 
 /// concise representation of proposed hole triangulation
 struct HoleFillPlan

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -534,7 +534,7 @@ inline EdgeId executedPlanEdge( const HoleFillPlan & plan, int code )
 {
     if ( code >= 0 )
         return EdgeId( code );
-    const auto ref = fillHoleItemRef( code );
+    const auto ref = decodeFillHoleItemRef( code );
     const EdgeId e( plan.items[ref.item].edgeCode1 );
     return ref.sym ? e.sym() : e;
 }
@@ -630,7 +630,7 @@ bool isFillingMultipleEdgeFree( const MeshTopology & topology, const HoleFillPla
         // taken in the opposite direction is the origin of the second code of its item
         while ( code < 0 )
         {
-            const auto ref = fillHoleItemRef( code );
+            const auto ref = decodeFillHoleItemRef( code );
             const auto & item = plan.items[ref.item];
             code = ref.sym ? item.edgeCode2 : item.edgeCode1;
         }
@@ -820,14 +820,14 @@ HoleFillPlan HoleFillPlanner::run( const Mesh& mesh, EdgeId a0, const FillHolePa
 
         if ( distA >= 2 && distA <= loopEdgesCounter - 2 )
         {
-            auto newEdgeCode = fillHoleItemCode( { .item = int( res.items.size() ) } ); // the item about to be pushed
+            auto newEdgeCode = encodeFillHoleItemRef( { .item = int( res.items.size() ) } ); // the item about to be pushed
             res.items.push_back( { (int)edgeMap_[curConn.first.prevA], (int)edgeMap_[curConn.first.a] } );
             newEdgesQueue_.push( { newEdgesMap_[curConn.first.a][curConn.first.prevA], newEdgeCode } );
         }
 
         if ( distB >= 2 && distB <= loopEdgesCounter - 2 )
         {
-            auto newEdgeCode = fillHoleItemCode( { .item = int( res.items.size() ) } ); // the item about to be pushed
+            auto newEdgeCode = encodeFillHoleItemRef( { .item = int( res.items.size() ) } ); // the item about to be pushed
             res.items.push_back( { (int)curConn.second, (int)edgeMap_[curConn.first.prevA] } );
             newEdgesQueue_.push( { newEdgesMap_[curConn.first.prevA][curConn.first.b], newEdgeCode } );
         }

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -534,9 +534,9 @@ inline EdgeId executedPlanEdge( const HoleFillPlan & plan, int code )
 {
     if ( code >= 0 )
         return EdgeId( code );
-    const auto itemEdge = decodeFillHoleItemEdge( code );
-    const EdgeId e( plan.items[itemEdge.item].edgeCode1 );
-    return itemEdge.sym ? e.sym() : e;
+    const auto [item, sym] = FillHoleItemEdge::decode( code );
+    const EdgeId e( plan.items[item].edgeCode1 );
+    return sym ? e.sym() : e;
 }
 
 // adds the edges of the plan without creating any face
@@ -630,9 +630,8 @@ bool isFillingMultipleEdgeFree( const MeshTopology & topology, const HoleFillPla
         // taken in the opposite direction is the origin of the second code of its item
         while ( code < 0 )
         {
-            const auto itemEdge = decodeFillHoleItemEdge( code );
-            const auto & item = plan.items[itemEdge.item];
-            code = itemEdge.sym ? item.edgeCode2 : item.edgeCode1;
+            const auto [item, sym] = FillHoleItemEdge::decode( code );
+            code = sym ? plan.items[item].edgeCode2 : plan.items[item].edgeCode1;
         }
         return topology.org( EdgeId( code ) );
     };
@@ -820,14 +819,14 @@ HoleFillPlan HoleFillPlanner::run( const Mesh& mesh, EdgeId a0, const FillHolePa
 
         if ( distA >= 2 && distA <= loopEdgesCounter - 2 )
         {
-            auto newEdgeCode = encodeFillHoleItemEdge( { .item = int( res.items.size() ) } ); // the item about to be pushed
+            auto newEdgeCode = FillHoleItemEdge{ .item = int( res.items.size() ) }.encode(); // the item about to be pushed
             res.items.push_back( { (int)edgeMap_[curConn.first.prevA], (int)edgeMap_[curConn.first.a] } );
             newEdgesQueue_.push( { newEdgesMap_[curConn.first.a][curConn.first.prevA], newEdgeCode } );
         }
 
         if ( distB >= 2 && distB <= loopEdgesCounter - 2 )
         {
-            auto newEdgeCode = encodeFillHoleItemEdge( { .item = int( res.items.size() ) } ); // the item about to be pushed
+            auto newEdgeCode = FillHoleItemEdge{ .item = int( res.items.size() ) }.encode(); // the item about to be pushed
             res.items.push_back( { (int)curConn.second, (int)edgeMap_[curConn.first.prevA] } );
             newEdgesQueue_.push( { newEdgesMap_[curConn.first.prevA][curConn.first.b], newEdgeCode } );
         }

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -528,8 +528,36 @@ inline EdgeId makeNewEdge( MeshTopology & topology, EdgeId a, EdgeId b )
     return newEdge;
 }
 
+// resolves the code of an already executed item into the edge it denotes,
+// which requires edgeCode1 of every earlier item to be overwritten with the created edge
+inline EdgeId executedPlanEdge( const HoleFillPlan & plan, int code )
+{
+    if ( code >= 0 )
+        return EdgeId( code );
+    const int ref = -( code + 1 );
+    const EdgeId e( plan.items[ ref >> 1 ].edgeCode1 );
+    return ( ref & 1 ) ? e.sym() : e;
+}
+
+// adds the edges of the plan without creating any face
+void executeEdgesOnlyPlan( MeshTopology & topology, HoleFillPlan & plan )
+{
+    assert( !plan.items.empty() ); // nothing to add, most likely a default-constructed plan
+    for ( int i = 0; i < plan.items.size(); ++i )
+    {
+        EdgeId a = executedPlanEdge( plan, plan.items[i].edgeCode1 );
+        EdgeId b = executedPlanEdge( plan, plan.items[i].edgeCode2 );
+        plan.items[i].edgeCode1 = (int)makeNewEdge( topology, a, b );
+    }
+}
+
 void executeHoleFillPlan( Mesh & mesh, EdgeId a0, HoleFillPlan & plan, FaceBitSet * outNewFaces )
 {
+    if ( plan.numTris == 0 )
+    {
+        executeEdgesOnlyPlan( mesh.topology, plan );
+        return;
+    }
     [[maybe_unused]] const auto fsz0 = mesh.topology.faceSize();
     const FaceId f0 = mesh.topology.left( a0 );
     if ( plan.items.empty() )
@@ -555,17 +583,11 @@ void executeHoleFillPlan( Mesh & mesh, EdgeId a0, HoleFillPlan & plan, FaceBitSe
     {
         if ( f0 )
             mesh.topology.setLeft( a0, {} );
-        auto getEdge = [&]( int code )
-        {
-            if ( code >= 0 )
-                return EdgeId( code );
-            return EdgeId( plan.items[ -(code+1) ].edgeCode1 );
-        };
         // make new edges
         for ( int i = 0; i < plan.items.size(); ++i )
         {
-            EdgeId a = getEdge( plan.items[i].edgeCode1 );
-            EdgeId b = getEdge( plan.items[i].edgeCode2 );
+            EdgeId a = executedPlanEdge( plan, plan.items[i].edgeCode1 );
+            EdgeId b = executedPlanEdge( plan, plan.items[i].edgeCode2 );
             EdgeId c = makeNewEdge( mesh.topology, a, b );
             plan.items[i].edgeCode1 = (int)c;
         }
@@ -604,8 +626,14 @@ bool isFillingMultipleEdgeFree( const MeshTopology & topology, const HoleFillPla
 
     auto getVert = [&]( int code )
     {
+        // makeNewEdge( a, b ) runs from org(a) to org(b), so the origin of a not yet created edge
+        // taken in the opposite direction is the origin of the second code of its item
         while ( code < 0 )
-            code = plan.items[ -(code+1) ].edgeCode1;
+        {
+            const int ref = -( code + 1 );
+            const auto & item = plan.items[ ref >> 1 ];
+            code = ( ref & 1 ) ? item.edgeCode2 : item.edgeCode1;
+        }
         return topology.org( EdgeId( code ) );
     };
     for ( int i = 0; i < plan.items.size(); ++i )
@@ -792,14 +820,14 @@ HoleFillPlan HoleFillPlanner::run( const Mesh& mesh, EdgeId a0, const FillHolePa
 
         if ( distA >= 2 && distA <= loopEdgesCounter - 2 )
         {
-            auto newEdgeCode = -int( res.items.size() + 1 );
+            auto newEdgeCode = -int( 2 * res.items.size() + 1 ); // forward direction of the item about to be pushed
             res.items.push_back( { (int)edgeMap_[curConn.first.prevA], (int)edgeMap_[curConn.first.a] } );
             newEdgesQueue_.push( { newEdgesMap_[curConn.first.a][curConn.first.prevA], newEdgeCode } );
         }
 
         if ( distB >= 2 && distB <= loopEdgesCounter - 2 )
         {
-            auto newEdgeCode = -int( res.items.size() + 1 );
+            auto newEdgeCode = -int( 2 * res.items.size() + 1 ); // forward direction of the item about to be pushed
             res.items.push_back( { (int)curConn.second, (int)edgeMap_[curConn.first.prevA] } );
             newEdgesQueue_.push( { newEdgesMap_[curConn.first.prevA][curConn.first.b], newEdgeCode } );
         }

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -534,9 +534,9 @@ inline EdgeId executedPlanEdge( const HoleFillPlan & plan, int code )
 {
     if ( code >= 0 )
         return EdgeId( code );
-    const auto ref = decodeFillHoleItemRef( code );
-    const EdgeId e( plan.items[ref.item].edgeCode1 );
-    return ref.sym ? e.sym() : e;
+    const auto itemEdge = decodeFillHoleItemEdge( code );
+    const EdgeId e( plan.items[itemEdge.item].edgeCode1 );
+    return itemEdge.sym ? e.sym() : e;
 }
 
 // adds the edges of the plan without creating any face
@@ -630,9 +630,9 @@ bool isFillingMultipleEdgeFree( const MeshTopology & topology, const HoleFillPla
         // taken in the opposite direction is the origin of the second code of its item
         while ( code < 0 )
         {
-            const auto ref = decodeFillHoleItemRef( code );
-            const auto & item = plan.items[ref.item];
-            code = ref.sym ? item.edgeCode2 : item.edgeCode1;
+            const auto itemEdge = decodeFillHoleItemEdge( code );
+            const auto & item = plan.items[itemEdge.item];
+            code = itemEdge.sym ? item.edgeCode2 : item.edgeCode1;
         }
         return topology.org( EdgeId( code ) );
     };
@@ -820,14 +820,14 @@ HoleFillPlan HoleFillPlanner::run( const Mesh& mesh, EdgeId a0, const FillHolePa
 
         if ( distA >= 2 && distA <= loopEdgesCounter - 2 )
         {
-            auto newEdgeCode = encodeFillHoleItemRef( { .item = int( res.items.size() ) } ); // the item about to be pushed
+            auto newEdgeCode = encodeFillHoleItemEdge( { .item = int( res.items.size() ) } ); // the item about to be pushed
             res.items.push_back( { (int)edgeMap_[curConn.first.prevA], (int)edgeMap_[curConn.first.a] } );
             newEdgesQueue_.push( { newEdgesMap_[curConn.first.a][curConn.first.prevA], newEdgeCode } );
         }
 
         if ( distB >= 2 && distB <= loopEdgesCounter - 2 )
         {
-            auto newEdgeCode = encodeFillHoleItemRef( { .item = int( res.items.size() ) } ); // the item about to be pushed
+            auto newEdgeCode = encodeFillHoleItemEdge( { .item = int( res.items.size() ) } ); // the item about to be pushed
             res.items.push_back( { (int)curConn.second, (int)edgeMap_[curConn.first.prevA] } );
             newEdgesQueue_.push( { newEdgesMap_[curConn.first.prevA][curConn.first.b], newEdgeCode } );
         }

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -534,9 +534,9 @@ inline EdgeId executedPlanEdge( const HoleFillPlan & plan, int code )
 {
     if ( code >= 0 )
         return EdgeId( code );
-    const int ref = -( code + 1 );
-    const EdgeId e( plan.items[ ref >> 1 ].edgeCode1 );
-    return ( ref & 1 ) ? e.sym() : e;
+    const auto ref = fillHoleItemRef( code );
+    const EdgeId e( plan.items[ref.item].edgeCode1 );
+    return ref.sym ? e.sym() : e;
 }
 
 // adds the edges of the plan without creating any face
@@ -630,9 +630,9 @@ bool isFillingMultipleEdgeFree( const MeshTopology & topology, const HoleFillPla
         // taken in the opposite direction is the origin of the second code of its item
         while ( code < 0 )
         {
-            const int ref = -( code + 1 );
-            const auto & item = plan.items[ ref >> 1 ];
-            code = ( ref & 1 ) ? item.edgeCode2 : item.edgeCode1;
+            const auto ref = fillHoleItemRef( code );
+            const auto & item = plan.items[ref.item];
+            code = ref.sym ? item.edgeCode2 : item.edgeCode1;
         }
         return topology.org( EdgeId( code ) );
     };
@@ -820,14 +820,14 @@ HoleFillPlan HoleFillPlanner::run( const Mesh& mesh, EdgeId a0, const FillHolePa
 
         if ( distA >= 2 && distA <= loopEdgesCounter - 2 )
         {
-            auto newEdgeCode = -int( 2 * res.items.size() + 1 ); // forward direction of the item about to be pushed
+            auto newEdgeCode = fillHoleItemCode( { .item = int( res.items.size() ) } ); // the item about to be pushed
             res.items.push_back( { (int)edgeMap_[curConn.first.prevA], (int)edgeMap_[curConn.first.a] } );
             newEdgesQueue_.push( { newEdgesMap_[curConn.first.a][curConn.first.prevA], newEdgeCode } );
         }
 
         if ( distB >= 2 && distB <= loopEdgesCounter - 2 )
         {
-            auto newEdgeCode = -int( 2 * res.items.size() + 1 ); // forward direction of the item about to be pushed
+            auto newEdgeCode = fillHoleItemCode( { .item = int( res.items.size() ) } ); // the item about to be pushed
             res.items.push_back( { (int)curConn.second, (int)edgeMap_[curConn.first.prevA] } );
             newEdgesQueue_.push( { newEdgesMap_[curConn.first.prevA][curConn.first.b], newEdgeCode } );
         }

--- a/source/MRTest/MRFillHoleTests.cpp
+++ b/source/MRTest/MRFillHoleTests.cpp
@@ -287,7 +287,7 @@ TEST( MRMesh, HoleFillPlanEdgesOnly )
     // of the first item: -( 2 * item + sym + 1 ) == -2
     HoleFillPlan plan;
     plan.items.push_back( { (int)he[2], (int)he[0] } ); // chord org( he2 ) -> org( he0 )
-    plan.items.push_back( { -2, (int)he[4] } );         // chord org( he0 ) -> org( he4 )
+    plan.items.push_back( { fillHoleItemCode( { .item = 0, .sym = true } ), (int)he[4] } ); // org( he0 ) -> org( he4 )
 
     executeHoleFillPlan( mesh, e, plan );
     EXPECT_EQ( mesh.topology.numValidFaces(), 0 );
@@ -316,7 +316,7 @@ TEST( MRMesh, HoleFillPlanSymAnchorMultipleEdge )
     // resolving its sym code by the first item's edgeCode1 would look at the other end and miss it
     HoleFillPlan plan;
     plan.items.push_back( { (int)he[2], (int)he[0] } );
-    plan.items.push_back( { -2, (int)he[4] } );
+    plan.items.push_back( { fillHoleItemCode( { .item = 0, .sym = true } ), (int)he[4] } );
     EXPECT_FALSE( isFillingMultipleEdgeFree( mesh.topology, plan ) );
 }
 

--- a/source/MRTest/MRFillHoleTests.cpp
+++ b/source/MRTest/MRFillHoleTests.cpp
@@ -287,7 +287,7 @@ TEST( MRMesh, HoleFillPlanEdgesOnly )
     // of the first item: -( 2 * item + sym + 1 ) == -2
     HoleFillPlan plan;
     plan.items.push_back( { (int)he[2], (int)he[0] } ); // chord org( he2 ) -> org( he0 )
-    plan.items.push_back( { encodeFillHoleItemEdge( { .item = 0, .sym = true } ), (int)he[4] } ); // org( he0 ) -> org( he4 )
+    plan.items.push_back( { FillHoleItemEdge{ .item = 0, .sym = true }.encode(), (int)he[4] } ); // org( he0 ) -> org( he4 )
 
     executeHoleFillPlan( mesh, e, plan );
     EXPECT_EQ( mesh.topology.numValidFaces(), 0 );
@@ -316,7 +316,7 @@ TEST( MRMesh, HoleFillPlanSymAnchorMultipleEdge )
     // resolving its sym code by the first item's edgeCode1 would look at the other end and miss it
     HoleFillPlan plan;
     plan.items.push_back( { (int)he[2], (int)he[0] } );
-    plan.items.push_back( { encodeFillHoleItemEdge( { .item = 0, .sym = true } ), (int)he[4] } );
+    plan.items.push_back( { FillHoleItemEdge{ .item = 0, .sym = true }.encode(), (int)he[4] } );
     EXPECT_FALSE( isFillingMultipleEdgeFree( mesh.topology, plan ) );
 }
 

--- a/source/MRTest/MRFillHoleTests.cpp
+++ b/source/MRTest/MRFillHoleTests.cpp
@@ -2,6 +2,7 @@
 #include <MRMesh/MRMesh.h>
 #include <MRMesh/MRMeshBuilder.h>
 #include <MRMesh/MRMeshFixer.h>
+#include <MRMesh/MRRingIterator.h>
 #include <gtest/gtest.h>
 
 namespace MR
@@ -249,6 +250,74 @@ TEST( MRMesh, HoleFillPlan4 )
     EXPECT_EQ( mesh1.topology.numValidFaces(), 4 );
     EXPECT_TRUE( mesh1.topology.isClosed() );
     EXPECT_FALSE( hasMultipleEdges( mesh1.topology ) );
+}
+
+// hexagonal hole, and the edges of the hole to the left of the returned one
+static Mesh makeHexagonHole( EdgeId & e, std::vector<EdgeId> & holeEdges )
+{
+    Mesh mesh;
+    e = mesh.addSeparateEdgeLoop
+    ( {
+        {  2,  0, 0 },
+        {  1,  2, 0 },
+        { -1,  2, 0 },
+        { -2,  0, 0 },
+        { -1, -2, 0 },
+        {  1, -2, 0 }
+    } );
+    holeEdges.clear();
+    for ( auto ei : leftRing( mesh.topology, e ) )
+        holeEdges.push_back( ei );
+    return mesh;
+}
+
+TEST( MRMesh, HoleFillPlanEdgesOnly )
+{
+    EdgeId e;
+    std::vector<EdgeId> he;
+    auto mesh = makeHexagonHole( e, he );
+    ASSERT_EQ( he.size(), 6 );
+    std::vector<VertId> v;
+    for ( auto ei : he )
+        v.push_back( mesh.topology.org( ei ) );
+    EXPECT_EQ( mesh.topology.findHoleRepresentiveEdges().size(), 2 );
+
+    // numTris stays zero: the plan only splits the hole in parts and creates no face.
+    // the second chord starts where the first one ends, which is expressible only as the sym
+    // of the first item: -( 2 * item + sym + 1 ) == -2
+    HoleFillPlan plan;
+    plan.items.push_back( { (int)he[2], (int)he[0] } ); // chord org( he2 ) -> org( he0 )
+    plan.items.push_back( { -2, (int)he[4] } );         // chord org( he0 ) -> org( he4 )
+
+    executeHoleFillPlan( mesh, e, plan );
+    EXPECT_EQ( mesh.topology.numValidFaces(), 0 );
+    EXPECT_EQ( mesh.topology.findHoleRepresentiveEdges().size(), 4 ); // 3 parts and the other side
+    EXPECT_TRUE( mesh.topology.findEdge( v[2], v[0] ).valid() );
+    EXPECT_TRUE( mesh.topology.findEdge( v[0], v[4] ).valid() );
+    // without the sym bit the second chord would have started at the other end of the first one
+    EXPECT_FALSE( mesh.topology.findEdge( v[2], v[4] ).valid() );
+}
+
+TEST( MRMesh, HoleFillPlanSymAnchorMultipleEdge )
+{
+    EdgeId e;
+    std::vector<EdgeId> he;
+    auto mesh = makeHexagonHole( e, he );
+    ASSERT_EQ( he.size(), 6 );
+    const auto v0 = mesh.topology.org( he[0] );
+    const auto v4 = mesh.topology.org( he[4] );
+
+    HoleFillPlan pre;
+    pre.items.push_back( { (int)he[0], (int)he[4] } );
+    executeHoleFillPlan( mesh, e, pre );
+    ASSERT_TRUE( mesh.topology.findEdge( v0, v4 ).valid() );
+
+    // the second item would add org( he0 ) -> org( he4 ) once more, which already exists;
+    // resolving its sym code by the first item's edgeCode1 would look at the other end and miss it
+    HoleFillPlan plan;
+    plan.items.push_back( { (int)he[2], (int)he[0] } );
+    plan.items.push_back( { -2, (int)he[4] } );
+    EXPECT_FALSE( isFillingMultipleEdgeFree( mesh.topology, plan ) );
 }
 
 } //namespace MR

--- a/source/MRTest/MRFillHoleTests.cpp
+++ b/source/MRTest/MRFillHoleTests.cpp
@@ -287,7 +287,7 @@ TEST( MRMesh, HoleFillPlanEdgesOnly )
     // of the first item: -( 2 * item + sym + 1 ) == -2
     HoleFillPlan plan;
     plan.items.push_back( { (int)he[2], (int)he[0] } ); // chord org( he2 ) -> org( he0 )
-    plan.items.push_back( { fillHoleItemCode( { .item = 0, .sym = true } ), (int)he[4] } ); // org( he0 ) -> org( he4 )
+    plan.items.push_back( { encodeFillHoleItemRef( { .item = 0, .sym = true } ), (int)he[4] } ); // org( he0 ) -> org( he4 )
 
     executeHoleFillPlan( mesh, e, plan );
     EXPECT_EQ( mesh.topology.numValidFaces(), 0 );
@@ -316,7 +316,7 @@ TEST( MRMesh, HoleFillPlanSymAnchorMultipleEdge )
     // resolving its sym code by the first item's edgeCode1 would look at the other end and miss it
     HoleFillPlan plan;
     plan.items.push_back( { (int)he[2], (int)he[0] } );
-    plan.items.push_back( { fillHoleItemCode( { .item = 0, .sym = true } ), (int)he[4] } );
+    plan.items.push_back( { encodeFillHoleItemRef( { .item = 0, .sym = true } ), (int)he[4] } );
     EXPECT_FALSE( isFillingMultipleEdgeFree( mesh.topology, plan ) );
 }
 

--- a/source/MRTest/MRFillHoleTests.cpp
+++ b/source/MRTest/MRFillHoleTests.cpp
@@ -287,7 +287,7 @@ TEST( MRMesh, HoleFillPlanEdgesOnly )
     // of the first item: -( 2 * item + sym + 1 ) == -2
     HoleFillPlan plan;
     plan.items.push_back( { (int)he[2], (int)he[0] } ); // chord org( he2 ) -> org( he0 )
-    plan.items.push_back( { encodeFillHoleItemRef( { .item = 0, .sym = true } ), (int)he[4] } ); // org( he0 ) -> org( he4 )
+    plan.items.push_back( { encodeFillHoleItemEdge( { .item = 0, .sym = true } ), (int)he[4] } ); // org( he0 ) -> org( he4 )
 
     executeHoleFillPlan( mesh, e, plan );
     EXPECT_EQ( mesh.topology.numValidFaces(), 0 );
@@ -316,7 +316,7 @@ TEST( MRMesh, HoleFillPlanSymAnchorMultipleEdge )
     // resolving its sym code by the first item's edgeCode1 would look at the other end and miss it
     HoleFillPlan plan;
     plan.items.push_back( { (int)he[2], (int)he[0] } );
-    plan.items.push_back( { encodeFillHoleItemRef( { .item = 0, .sym = true } ), (int)he[4] } );
+    plan.items.push_back( { encodeFillHoleItemEdge( { .item = 0, .sym = true } ), (int)he[4] } );
     EXPECT_FALSE( isFillingMultipleEdgeFree( mesh.topology, plan ) );
 }
 


### PR DESCRIPTION
Two additions to the plan format, both needed by the upcoming monotonation mode of the sweep-line triangulation, and both useful on their own. Independent of #6575 — this branch is off `master` and does not rename anything.

### Sym anchors

An item connects the origins of the two edges its codes denote. A negative code refers to an edge created by an earlier item, and so far it could only mean that edge's **forward** direction — so an item could never attach to the *far end* of an earlier item's edge. That is a real restriction, because an edge and its sym have different origins and are therefore different anchors for `makeNewEdge`.

Negative codes now carry the direction: `-( 2 * item + sym + 1 )`. All three existing producers emit `sym = 0`, so nothing changes for them.

The `isFillingMultipleEdgeFree` resolver needed more than the shift: it chases codes to find an origin, and since `makeNewEdge( a, b )` runs from `org( a )` to `org( b )`, the origin of a not yet created edge taken in the opposite direction is the origin of the **second** code of its item. Resolving it by `edgeCode1` would silently compare the wrong vertex and let a duplicate edge through.

### Edges-only execution

`executeHoleFillPlan` now treats `numTris == 0` as "add the edges of the items and create no face" — e.g. a plan that splits one hole into several. No new parameter: `numTris` is already the plan's contract for how many faces it produces, so zero triangles means no faces, and the executor's closing invariant `numTris == fsz - fsz0 + ( f0 ? 1 : 0 )` holds unchanged. The value was free to claim: executing such a plan was previously invalid, both empty-items branches assert `numTris == 1` or `>= 3`. A default-constructed plan still trips an assert.

### Verification

* `MRTest --no-python-tests`: **336/336** (334 + the two new tests).
* Two new tests, and both were checked to **fail** when the sym bit is ignored while the pre-existing `HoleFillPlan3/4` keep passing — so they are load-bearing, not decoration:
  * `HoleFillPlanEdgesOnly` — an edges-only plan whose second chord anchors on the sym of the first; without the bit the chord starts at the other end and merges two holes instead of splitting one.
  * `HoleFillPlanSymAnchorMultipleEdge` — the `isFillingMultipleEdgeFree` case above; without the fix it reports a duplicate-free filling that is not.
* Equivalence: geometric digest (boolean sweep of 128 transform combinations, big booleans, inner-contour-on-face, self-boolean — verts/faces/holes/area/volume) **byte-identical** against a `master` build.
* Perf, master vs branch, 6 rounds with rotated order, every measurement in its own process: `MRMesh.MeshBoolean` median 27.0 ms and min 27 ms on both sides (n=90/side); `MRMesh.MultiwayICPTorus` control flat. The decode is one shift and one predicated select on a path that then splices edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
* Perf on a deeper batch, since the cost is per plan *item* and `MRMesh.MeshBoolean` is a shallow one (~30 holes per call): the coincident-spheres / boolean-sweep / big-boolean workloads, 10 rounds with both sides run adjacently so machine drift cancels within a round. Paired per-round deltas disagree in sign and all sit inside the per-round noise — spheres median −0.72%, sweep −0.05%, big +0.71%, with per-round ranges of ±2..6% — and the insensitive decimate control comes out balanced (5 of 10, median +0.04%). No measurable effect.
