### PR TITLE
Copy the boundary sub-topology out of the mesh in mesh-space planar triangulation

### DIFF
--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -199,8 +199,8 @@ struct RegionCopy
 // ONE local vertex whose ring keeps the mesh's cyclic edge order - the arrangement the rebuild had to
 // re-derive by welding coincident duplicates; an edge traversed twice becomes one local edge with its
 // net winding recorded. Loops of fewer than 3 edges are skipped, like contours of fewer than 3 points.
-static RegionCopy buildRegionTopology_( const Mesh& mesh, const EdgeLoops& loops, [[maybe_unused]] SignedAxis projAxis,
-    std::vector<EdgePath>* outBoundaries )
+static RegionCopy buildRegionTopology_( const Mesh& mesh, const EdgeLoops& loops, SignedAxis projAxis,
+    std::vector<EdgePath>* outBoundaries, WholeEdgeMap* outBd2meshEdges )
 {
     MR_TIMER;
     RegionCopy res;
@@ -288,6 +288,11 @@ static RegionCopy buildRegionTopology_( const Mesh& mesh, const EdgeLoops& loops
     res.localToMesh.reserve( n );
     res.tp.vertReserve( n );
     res.tp.edgeReserve( size_t( 2 ) * n );
+    if ( outBd2meshEdges )
+    {
+        outBd2meshEdges->clear();
+        outBd2meshEdges->reserve( n );
+    }
     for ( int p = 0; p < n; ++p )
     {
         auto& pi = pos[p];
@@ -299,7 +304,11 @@ static RegionCopy buildRegionTopology_( const Mesh& mesh, const EdgeLoops& loops
         else
             pi.localOrg = pos[pi.vertRepPos].localOrg;
         if ( pi.edgeRepPos == p )
+        {
             pi.localEdge = res.tp.makeEdge();
+            if ( outBd2meshEdges )
+                outBd2meshEdges->push_back( pi.meshEdge ); // ids in creation order, one per distinct edge
+        }
         else
         {
             const auto& rep = pos[pi.edgeRepPos];
@@ -343,6 +352,20 @@ static RegionCopy buildRegionTopology_( const Mesh& mesh, const EdgeLoops& loops
             base += sz;
         }
     }
+    // mesh rings run counterclockwise around the surface's own orientation, which the loops' winding
+    // (and so projAxis) may oppose - e.g. on the outer boundary of a bowtie patch pinched at a vertex.
+    // The filtered ring has to follow the projection, so take the sense from the faces at the rim;
+    // faceless boundaries (no right faces anywhere) keep the forward walk
+    bool ringsReversed = false;
+    if ( std::adjacent_find( vps.begin(), vps.end(), [] ( const auto& a, const auto& b ) { return a.first == b.first; } ) != vps.end() )
+    {
+        Vector3d surf;
+        for ( int p = 0; p < n; ++p )
+            if ( auto f = mesh.topology.right( pos[p].meshEdge ) )
+                surf += Vector3d( mesh.dirDblArea( f ) );
+        const double along = isNegative( projAxis ) ? -surf[int( axis( projAxis ) )] : surf[int( axis( projAxis ) )];
+        ringsReversed = along < 0;
+    }
     for ( size_t i = 0; i < vps.size(); )
     {
         size_t j = i + 1;
@@ -365,7 +388,7 @@ static RegionCopy buildRegionTopology_( const Mesh& mesh, const EdgeLoops& loops
                         res.tp.splice( prevLocal, localOut );
                     prevLocal = localOut;
                 }
-                me = mesh.topology.next( me );
+                me = ringsReversed ? mesh.topology.prev( me ) : mesh.topology.next( me );
             } while ( me != start );
         }
         i = j;
@@ -1761,13 +1784,13 @@ std::optional<Mesh> triangulateDisjointContours( const Contours2d& contours, con
     return triangulateDisjointContours( contsf, holeVertsIds, outBoundaries );
 }
 
-std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, SignedAxis axis, std::vector<EdgePath>* outBoundaries /*= nullptr*/ )
+std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, SignedAxis axis, std::vector<EdgePath>* outBoundaries /*= nullptr*/, WholeEdgeMap* outBd2meshEdges /*= nullptr*/ )
 {
     if ( loops.empty() )
         return Mesh();
     // copy the boundary sub-topology out of the mesh: vertices and edges several loops share arrive
     // already shared, in the mesh's own ring order, instead of being re-derived by coordinate welding
-    RegionCopy region = buildRegionTopology_( mesh, loops, axis, outBoundaries );
+    RegionCopy region = buildRegionTopology_( mesh, loops, axis, outBoundaries, outBd2meshEdges );
     SweepLineQueue triangulator( meshSpacePredicates( mesh, region.localToMesh, axis ), region,
         { nullptr, true, WindingMode::NonZero, false, true } );
     return triangulator.run();

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -138,37 +138,16 @@ static std::vector<int> getContourSizes( const Contours2f& contours )
     return sizes;
 }
 
-// map an input vertex (its index within the concatenated hole loops) back to its source mesh VertId;
-// mirrors the walk in mergeSamePoints_
-static VertId holeSourceVertId( const HolesVertIds& holes, VertId v )
-{
-    int idx = int( v );
-    for ( const auto& hole : holes )
-    {
-        if ( idx < int( hole.size() ) )
-            return hole[idx];
-        idx -= int( hole.size() );
-    }
-    assert( false ); // a disjoint triangulation outputs only input vertices, all covered by holes
-    return {};
-}
-
 // mesh-space predicates: triangulate hole boundary loops of `mesh` in the mesh's own 3D coordinates,
 // orienting around `normal`. Combinatorics run on the dominant-axis projection (reusing the exact 2D
 // predicates via setPts2Predicates). point() restores each output vertex's exact original mesh position
-// through `holeVertIds` (no separate coordinate copy, no projection round-trip).
-// `mesh`, `loops` and `holeVertIds` only need to outlive the run.
-static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, const HolesVertIds& holeVertIds )
+// through `localToMesh` (no separate coordinate copy, no projection round-trip).
+// `mesh` and `localToMesh` only need to outlive the run.
+static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const std::vector<VertId>& localToMesh, const Vector3f& normal )
 {
     Box3f box;
-    int pointsSize = 0;
-    for ( const auto& loop : loops )
-    {
-        for ( EdgeId e : loop )
-            box.include( mesh.orgPnt( e ) );
-        if ( loop.size() >= 3 )
-            pointsSize += int( loop.size() );
-    }
+    for ( VertId mv : localToMesh )
+        box.include( mesh.points[mv] );
 
     // drop the axis most aligned with the normal; order the two kept axes so the 2D ccw of the
     // projection equals the 3D orientation around +normal (swap them when normal points the other way)
@@ -182,27 +161,234 @@ static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoop
         std::swap( kx, ky );
 
     auto pts2 = std::make_shared<Vector<Vector2i, VertId>>(); // dominant-axis projection, drives every predicate
-    pts2->reserve( pointsSize );
+    pts2->resize( localToMesh.size() );
     auto toInt = getToIntConverter( Box3d( box ) ); // Vector3f -> Vector3i
+    // every vertex is known up front (the topology arrives prebuilt), so fill the projection here
+    for ( size_t i = 0; i < localToMesh.size(); ++i )
+    {
+        const Vector3i q = toInt( mesh.points[localToMesh[i]] );
+        ( *pts2 )[VertId( i )] = Vector2i( q[kx], q[ky] );
+    }
 
     SweepLinePredicates p;
     setPts2Predicates( p, pts2 );
-    p.addInputPoint = [&mesh, &loops, pts2, toInt, kx, ky] ( VertId v, int contourId, int pointId )
-    {
-        const Vector3i q = toInt( mesh.orgPnt( loops[contourId][pointId] ) );
-        pts2->autoResizeSet( v, Vector2i( q[kx], q[ky] ) );
-    };
+    // addInputPoint stays unset: it drives the contour rebuild, which this path replaces
     p.addIntersectionPoint = [pts2] ( VertId v, VertId a, VertId b, VertId c, VertId d )
     {
         pts2->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( ( *pts2 )[a], ( *pts2 )[b], ( *pts2 )[c], ( *pts2 )[d] ) );
     };
     // disjoint triangulation creates no output intersection vertices, so every output vertex is an input
-    // vertex: restore its exact original mesh position via the (already-built) holeVertIds identity map
-    p.point = [&mesh, &holeVertIds] ( VertId v )
+    // vertex: restore its exact original mesh position via the identity map
+    p.point = [&mesh, &localToMesh] ( VertId v )
     {
-        return mesh.points[holeSourceVertId( holeVertIds, v )];
+        return mesh.points[localToMesh[v]];
     };
     return p;
+}
+
+// the sweep's working topology for mesh hole loops: the boundary sub-topology copied out of the mesh
+struct RegionCopy
+{
+    MeshTopology tp;                 // compact-id copy of the boundary, mesh ring order preserved
+    std::vector<VertId> localToMesh; // local VertId -> source mesh vertex
+    // winding modifiers for edges the boundary traverses more than once (0 = a slit: winding equal on
+    // both of its sides); single-traversal edges follow the default direction rule
+    std::vector<std::pair<UndirectedEdgeId, int>> windingExceptions;
+};
+
+// copies the sub-topology induced by the boundary `loops` out of `mesh`. Vertices and edges get compact
+// local ids in first-occurrence order along the concatenated loops, so on simple inputs the result is
+// bit-identical to the contour rebuild it replaces. A vertex the boundary visits several times becomes
+// ONE local vertex whose ring keeps the mesh's cyclic edge order - the arrangement the rebuild had to
+// re-derive by welding coincident duplicates; an edge traversed twice becomes one local edge with its
+// net winding recorded. Loops of fewer than 3 edges are skipped, like contours of fewer than 3 points.
+static RegionCopy buildRegionTopology_( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal,
+    std::vector<EdgePath>* outBoundaries )
+{
+    MR_TIMER;
+    RegionCopy res;
+    if ( outBoundaries )
+        outBoundaries->resize( loops.size() );
+
+    int n = 0;
+    Vector3d sumCross;
+    for ( const auto& loop : loops )
+    {
+        if ( loop.size() < 3 )
+            continue;
+        n += int( loop.size() );
+        for ( EdgeId e : loop )
+            sumCross += cross( Vector3d( mesh.orgPnt( e ) ), Vector3d( mesh.destPnt( e ) ) );
+    }
+    if ( n == 0 )
+        return res;
+    // mesh rings run counterclockwise around the surface orientation of the loops; walk them reversed
+    // when the sweep's plane (ccw around +normal) sees the loops wound the other way
+    const bool sameSense = dot( Vector3f( sumCross ), normal ) >= 0.f;
+
+    struct PosInfo
+    {
+        EdgeId meshEdge;         // the loop's directed mesh edge at this position
+        EdgeId localEdge;        // its copy, directed along this traversal
+        VertId localOrg;         // local vertex at the traversal's origin
+        int vertRepPos{ -1 };    // first position sharing this mesh origin
+        int edgeRepPos{ -1 };    // first position traversing this mesh edge
+        bool orgRepeated{ false };
+    };
+    std::vector<PosInfo> pos;
+    pos.reserve( n );
+    std::vector<std::pair<VertId, int>> vps;         // (mesh origin, position)
+    std::vector<std::pair<UndirectedEdgeId, int>> eps; // (mesh edge, position)
+    vps.reserve( n );
+    eps.reserve( n );
+    for ( const auto& loop : loops )
+    {
+        if ( loop.size() < 3 )
+            continue;
+        for ( EdgeId e : loop )
+        {
+            const int p = int( pos.size() );
+            pos.push_back( { .meshEdge = e } );
+            vps.emplace_back( mesh.topology.org( e ), p );
+            eps.emplace_back( e.undirected(), p );
+        }
+    }
+    std::sort( vps.begin(), vps.end() );
+    std::sort( eps.begin(), eps.end() );
+
+    // resolve repeated vertices/edges: each run of equal ids shares its first position as representative
+    for ( size_t i = 0; i < vps.size(); )
+    {
+        size_t j = i + 1;
+        while ( j < vps.size() && vps[j].first == vps[i].first )
+            ++j;
+        for ( size_t k = i; k < j; ++k )
+        {
+            pos[vps[k].second].vertRepPos = vps[i].second;
+            pos[vps[k].second].orgRepeated = ( j - i ) > 1;
+        }
+        i = j;
+    }
+    for ( size_t i = 0; i < eps.size(); )
+    {
+        size_t j = i + 1;
+        while ( j < eps.size() && eps[j].first == eps[i].first )
+            ++j;
+        for ( size_t k = i; k < j; ++k )
+            pos[eps[k].second].edgeRepPos = eps[i].second;
+        i = j;
+    }
+
+    // create local vertices and edges in first-occurrence order (matching the rebuild's flat order)
+    res.localToMesh.reserve( n );
+    res.tp.vertReserve( n );
+    res.tp.edgeReserve( size_t( 2 ) * n );
+    for ( int p = 0; p < n; ++p )
+    {
+        auto& pi = pos[p];
+        if ( pi.vertRepPos == p )
+        {
+            pi.localOrg = res.tp.addVertId();
+            res.localToMesh.push_back( mesh.topology.org( pi.meshEdge ) );
+        }
+        else
+            pi.localOrg = pos[pi.vertRepPos].localOrg;
+        if ( pi.edgeRepPos == p )
+            pi.localEdge = res.tp.makeEdge();
+        else
+        {
+            const auto& rep = pos[pi.edgeRepPos];
+            pi.localEdge = rep.meshEdge == pi.meshEdge ? rep.localEdge : rep.localEdge.sym();
+        }
+    }
+    // net winding of multiply-traversed edges: +1 along the local edge's direction, -1 against
+    for ( size_t i = 0; i < eps.size(); )
+    {
+        size_t j = i + 1;
+        while ( j < eps.size() && eps[j].first == eps[i].first )
+            ++j;
+        if ( j - i > 1 )
+        {
+            const auto& rep = pos[eps[i].second];
+            int delta = 0;
+            for ( size_t k = i; k < j; ++k )
+                delta += pos[eps[k].second].meshEdge == rep.meshEdge ? 1 : -1;
+            res.windingExceptions.emplace_back( rep.localEdge.undirected(), delta );
+        }
+        i = j;
+    }
+
+    // vertex rings: a once-visited vertex has only its loop's in- and out-edge (the rebuild's chain);
+    // a repeated vertex copies the mesh's cyclic order of the region's edges around it
+    {
+        int base = 0;
+        for ( const auto& loop : loops )
+        {
+            if ( loop.size() < 3 )
+                continue;
+            const int sz = int( loop.size() );
+            for ( int j = 0; j < sz; ++j )
+            {
+                const int p = base + j;
+                if ( pos[p].orgRepeated )
+                    continue;
+                const int q = base + ( j + sz - 1 ) % sz;
+                res.tp.splice( pos[p].localEdge, pos[q].localEdge.sym() );
+            }
+            base += sz;
+        }
+    }
+    for ( size_t i = 0; i < vps.size(); )
+    {
+        size_t j = i + 1;
+        while ( j < vps.size() && vps[j].first == vps[i].first )
+            ++j;
+        if ( j - i > 1 )
+        {
+            const VertId meshV = vps[i].first;
+            EdgeId prevLocal;
+            const EdgeId start = mesh.topology.edgeWithOrg( meshV );
+            EdgeId me = start;
+            do
+            {
+                const auto it = std::lower_bound( eps.begin(), eps.end(), std::make_pair( me.undirected(), INT_MIN ) );
+                if ( it != eps.end() && it->first == me.undirected() )
+                {
+                    const auto& rep = pos[it->second];
+                    const EdgeId localOut = rep.meshEdge == me ? rep.localEdge : rep.localEdge.sym();
+                    if ( prevLocal )
+                        res.tp.splice( prevLocal, localOut );
+                    prevLocal = localOut;
+                }
+                me = sameSense ? mesh.topology.next( me ) : mesh.topology.prev( me );
+            } while ( me != start );
+        }
+        i = j;
+    }
+
+    // origins after the rings are complete, so one call covers each whole ring
+    for ( int p = 0; p < n; ++p )
+        if ( pos[p].vertRepPos == p )
+            res.tp.setOrg( pos[p].localEdge, pos[p].localOrg );
+
+    {
+        int boundId = -1, base = 0;
+        for ( const auto& loop : loops )
+        {
+            ++boundId;
+            if ( loop.size() < 3 )
+                continue;
+            if ( outBoundaries )
+            {
+                auto& bd = ( *outBoundaries )[boundId];
+                bd.resize( loop.size() );
+                for ( int j = 0; j < int( loop.size() ); ++j )
+                    bd[j] = pos[base + j].localEdge;
+            }
+            base += int( loop.size() );
+        }
+    }
+    return res;
 }
 
 int findClosestToFront( const MeshTopology& tp, const SweepLinePredicates& predicates,
@@ -305,6 +491,10 @@ public:
     // otherwise only merge the ones with same initial vertId
     SweepLineQueue( SweepLinePredicates predicates, std::vector<int> contourSizes, const SweepLineParams& params );
 
+    // constructor taking the working topology prebuilt (copied out of a mesh): no contour rebuild,
+    // no vertex merging - shared vertices and edges arrive already shared, with their winding recorded
+    SweepLineQueue( SweepLinePredicates predicates, RegionCopy& region, const SweepLineParams& params );
+
     size_t vertSize() const { return tp_.vertSize(); }
     std::optional<Mesh> run( IntersectionsMap* interMap = nullptr );
 
@@ -321,6 +511,8 @@ private:
 // INITIALIZATION CLASS BLOCK
     // make base mesh only containing input contours as edge loops
     void initMeshByContours_( const std::vector<int>& contourSizes );
+    // fill sortedVerts_ with all vertices ordered along the sweep
+    void sortVerts_();
     // merge same points on base mesh
     void mergeSamePoints_( const HolesVertIds* holesVertId );
     void mergeSinglePare_( VertId unique, VertId same );
@@ -452,6 +644,18 @@ SweepLineQueue::SweepLineQueue( SweepLinePredicates predicates, std::vector<int>
 {
     initMeshByContours_( contourSizes );
     mergeSamePoints_( params.holesVertId );
+    setupStartVertices_();
+}
+
+SweepLineQueue::SweepLineQueue( SweepLinePredicates predicates, RegionCopy& region, const SweepLineParams& params ) :
+    tp_{ std::move( region.tp ) },
+    predicates_{ std::move( predicates ) },
+    params_{ params }
+{
+    windingInfo_.resize( tp_.undirectedEdgeSize() );
+    for ( const auto& [ue, delta] : region.windingExceptions )
+        windingInfo_[ue].windingModifier = delta;
+    sortVerts_();
     setupStartVertices_();
 }
 
@@ -632,7 +836,18 @@ Mesh SweepLineQueue::triangulate()
     // Delone flips could cross a contour edge between two inside regions and smear the face winding map
     if ( !params_.needOutline && !params_.outFaceWinding )
     {
-        makeDeloneEdgeFlips( mesh, {}, 300 );
+        // an edge whose crossing does not change the winding (a slit the region touches from both sides)
+        // has filled faces on both of its sides; a flip across it would break the boundary correspondence
+        UndirectedEdgeBitSet notFlippable;
+        for ( UndirectedEdgeId ue{ 0 }; ue < windingInfo_.size(); ++ue )
+        {
+            if ( windingInfo_[ue].windingModifier != 0 )
+                continue;
+            if ( notFlippable.empty() )
+                notFlippable.resize( mesh.topology.undirectedEdgeSize() );
+            notFlippable.set( ue );
+        }
+        makeDeloneEdgeFlips( mesh, { .notFlippable = notFlippable.empty() ? nullptr : &notFlippable }, 300 );
     }
     return mesh;
 }
@@ -1073,6 +1288,15 @@ void SweepLineQueue::initMeshByContours_( const std::vector<int>& contourSizes )
             tp_.splice( edgePerVert[VertId( firstVert + i )], edgePerVert[VertId( firstVert + ( ( i + int( size ) - 1 ) % size ) )].sym() );
         firstVert += size;
     }
+}
+
+void SweepLineQueue::sortVerts_()
+{
+    MR_TIMER;
+    sortedVerts_.reserve( tp_.vertSize() );
+    for ( int i = 0; i < tp_.vertSize(); ++i )
+        sortedVerts_.emplace_back( VertId( i ) );
+    tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r ) { return predicates_.less( l, r ); } );
 }
 
 void SweepLineQueue::mergeSamePoints_( const HolesVertIds* holesVertId )
@@ -1536,14 +1760,11 @@ std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoo
 {
     if ( loops.empty() )
         return Mesh();
-    // boundary loops may share mesh vertices: this identity map drives both vertex merging and exact
-    // point restoration (so the patch reuses the original mesh coordinates instead of projected ones)
-    const HolesVertIds holeVertIds = findHoleVertIdsByHoleEdges( mesh.topology, loops );
-    std::vector<int> sizes( loops.size() );
-    for ( int i = 0; i < int( loops.size() ); ++i )
-        sizes[i] = int( loops[i].size() ) + 1; // +1 matches the queue's closed-contour convention (it allocates size-1 verts)
-    SweepLineQueue triangulator( meshSpacePredicates( mesh, loops, normal, holeVertIds ), std::move( sizes ),
-        { &holeVertIds, true, WindingMode::NonZero, false, true, outBoundaries } );
+    // copy the boundary sub-topology out of the mesh: vertices and edges several loops share arrive
+    // already shared, in the mesh's own ring order, instead of being re-derived by coordinate welding
+    RegionCopy region = buildRegionTopology_( mesh, loops, normal, outBoundaries );
+    SweepLineQueue triangulator( meshSpacePredicates( mesh, region.localToMesh, normal ), region,
+        { nullptr, true, WindingMode::NonZero, false, true } );
     return triangulator.run();
 }
 

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -143,21 +143,18 @@ static std::vector<int> getContourSizes( const Contours2f& contours )
 // predicates via setPts2Predicates). point() restores each output vertex's exact original mesh position
 // through `localToMesh` (no separate coordinate copy, no projection round-trip).
 // `mesh` and `localToMesh` only need to outlive the run.
-static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const std::vector<VertId>& localToMesh, const Vector3f& normal )
+static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const std::vector<VertId>& localToMesh, SignedAxis projAxis )
 {
     Box3f box;
     for ( VertId mv : localToMesh )
         box.include( mesh.points[mv] );
 
-    // drop the axis most aligned with the normal; order the two kept axes so the 2D ccw of the
-    // projection equals the 3D orientation around +normal (swap them when normal points the other way)
-    int dropAx = 0;
-    for ( int i = 1; i < 3; ++i )
-        if ( normal[i] * normal[i] > normal[dropAx] * normal[dropAx] )
-            dropAx = i;
+    // drop the projection axis; order the two kept axes so the 2D ccw of the projection equals the
+    // 3D orientation around the axis (swap them when it points against its coordinate axis)
+    const int dropAx = int( axis( projAxis ) );
     int kx = ( dropAx + 1 ) % 3;
     int ky = ( dropAx + 2 ) % 3;
-    if ( normal[dropAx] < 0 )
+    if ( isNegative( projAxis ) )
         std::swap( kx, ky );
 
     auto pts2 = std::make_shared<Vector<Vector2i, VertId>>(); // dominant-axis projection, drives every predicate
@@ -202,7 +199,7 @@ struct RegionCopy
 // ONE local vertex whose ring keeps the mesh's cyclic edge order - the arrangement the rebuild had to
 // re-derive by welding coincident duplicates; an edge traversed twice becomes one local edge with its
 // net winding recorded. Loops of fewer than 3 edges are skipped, like contours of fewer than 3 points.
-static RegionCopy buildRegionTopology_( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal,
+static RegionCopy buildRegionTopology_( const Mesh& mesh, const EdgeLoops& loops, [[maybe_unused]] SignedAxis projAxis,
     std::vector<EdgePath>* outBoundaries )
 {
     MR_TIMER;
@@ -211,20 +208,28 @@ static RegionCopy buildRegionTopology_( const Mesh& mesh, const EdgeLoops& loops
         outBoundaries->resize( loops.size() );
 
     int n = 0;
-    Vector3d sumCross;
     for ( const auto& loop : loops )
-    {
-        if ( loop.size() < 3 )
-            continue;
-        n += int( loop.size() );
-        for ( EdgeId e : loop )
-            sumCross += cross( Vector3d( mesh.orgPnt( e ) ), Vector3d( mesh.destPnt( e ) ) );
-    }
+        if ( loop.size() >= 3 )
+            n += int( loop.size() );
     if ( n == 0 )
         return res;
-    // mesh rings run counterclockwise around the surface orientation of the loops; walk them reversed
-    // when the sweep's plane (ccw around +normal) sees the loops wound the other way
-    const bool sameSense = dot( Vector3f( sumCross ), normal ) >= 0.f;
+
+#ifndef NDEBUG
+    // The copy takes the mesh's own ring order, which runs counterclockwise around the surface
+    // orientation of the loops, and the predicates read that order as counterclockwise around
+    // projAxis. So the loops have to wind that way; the opposite direction is a caller error rather
+    // than something to detect and adapt to (which is what the axis argument replaces).
+    {
+        Vector3d sumCross;
+        for ( const auto& loop : loops )
+            if ( loop.size() >= 3 )
+                for ( EdgeId e : loop )
+                    sumCross += cross( Vector3d( mesh.orgPnt( e ) ), Vector3d( mesh.destPnt( e ) ) );
+        const double alongAxis = isNegative( projAxis )
+            ? -sumCross[int( axis( projAxis ) )] : sumCross[int( axis( projAxis ) )];
+        assert( alongAxis >= 0 ); // loops wound clockwise around projAxis
+    }
+#endif
 
     struct PosInfo
     {
@@ -360,7 +365,7 @@ static RegionCopy buildRegionTopology_( const Mesh& mesh, const EdgeLoops& loops
                         res.tp.splice( prevLocal, localOut );
                     prevLocal = localOut;
                 }
-                me = sameSense ? mesh.topology.next( me ) : mesh.topology.prev( me );
+                me = mesh.topology.next( me );
             } while ( me != start );
         }
         i = j;
@@ -1756,14 +1761,14 @@ std::optional<Mesh> triangulateDisjointContours( const Contours2d& contours, con
     return triangulateDisjointContours( contsf, holeVertsIds, outBoundaries );
 }
 
-std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, std::vector<EdgePath>* outBoundaries /*= nullptr*/ )
+std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, SignedAxis axis, std::vector<EdgePath>* outBoundaries /*= nullptr*/ )
 {
     if ( loops.empty() )
         return Mesh();
     // copy the boundary sub-topology out of the mesh: vertices and edges several loops share arrive
     // already shared, in the mesh's own ring order, instead of being re-derived by coordinate welding
-    RegionCopy region = buildRegionTopology_( mesh, loops, normal, outBoundaries );
-    SweepLineQueue triangulator( meshSpacePredicates( mesh, region.localToMesh, normal ), region,
+    RegionCopy region = buildRegionTopology_( mesh, loops, axis, outBoundaries );
+    SweepLineQueue triangulator( meshSpacePredicates( mesh, region.localToMesh, axis ), region,
         { nullptr, true, WindingMode::NonZero, false, true } );
     return triangulator.run();
 }

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "MRMeshFwd.h"
 #include "MRId.h"
+#include "MRAxis.h"
 #include <optional>
 
 namespace MR
@@ -114,15 +115,19 @@ MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2d& co
 MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours, const HolesVertIds* holeVertsIds = nullptr, std::vector<EdgePath>* outBoundaries = nullptr );
 
 /**
- * @brief triangulate hole boundary loops of \p mesh in the mesh's own 3d space, orienting faces around \p normal
- * combinatorics run on the dominant-axis projection of \p normal; output vertices keep the exact mesh coordinates
+ * @brief triangulate hole boundary loops of \p mesh in the mesh's own 3d space
+ * combinatorics run on the projection along \p axis; output vertices keep the exact mesh coordinates
  * (no projection round-trip). The sweep works on a copy of the boundary sub-topology, so vertices and edges
  * several loops share stay shared, with the mesh's own ring order defining the arrangement at such vertices;
  * an edge two loops traverse in opposite directions (a slit) gets filled faces on both of its sides.
  * @param loops one closed EdgeLoop per contour (as produced by trackRightBoundaryLoop on each hole edge)
+ * @param axis the coordinate axis to project along, and the direction the loops wind counterclockwise
+ *        around - the only thing the algorithm takes from a plane normal, so pass
+ *        dominantSignedAxis() of the region's normal. The loops must really wind that way (asserted):
+ *        this function does not accept the opposite direction and silently adapt to it
  * @return std::nullopt if the loops self-intersect, otherwise the patch mesh
  */
-MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, std::vector<EdgePath>* outBoundaries = nullptr );
+MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, SignedAxis axis, std::vector<EdgePath>* outBoundaries = nullptr );
 
 }
 }

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -125,9 +125,12 @@ MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& co
  *        around - the only thing the algorithm takes from a plane normal, so pass
  *        dominantSignedAxis() of the region's normal. The loops must really wind that way (asserted):
  *        this function does not accept the opposite direction and silently adapt to it
+ * @param outBd2meshEdges optional output: for every boundary edge of the patch (by undirected id)
+ *        the mesh edge it copies, directed along the patch edge; patch edges past its size are the
+ *        triangulation's own. Lets a caller anchor on mesh edges without matching boundary paths
  * @return std::nullopt if the loops self-intersect, otherwise the patch mesh
  */
-MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, SignedAxis axis, std::vector<EdgePath>* outBoundaries = nullptr );
+MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, SignedAxis axis, std::vector<EdgePath>* outBoundaries = nullptr, WholeEdgeMap* outBd2meshEdges = nullptr );
 
 }
 }

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -116,7 +116,9 @@ MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& co
 /**
  * @brief triangulate hole boundary loops of \p mesh in the mesh's own 3d space, orienting faces around \p normal
  * combinatorics run on the dominant-axis projection of \p normal; output vertices keep the exact mesh coordinates
- * (no projection round-trip), and loops sharing a mesh vertex are merged by identity.
+ * (no projection round-trip). The sweep works on a copy of the boundary sub-topology, so vertices and edges
+ * several loops share stay shared, with the mesh's own ring order defining the arrangement at such vertices;
+ * an edge two loops traverse in opposite directions (a slit) gets filled faces on both of its sides.
  * @param loops one closed EdgeLoop per contour (as produced by trackRightBoundaryLoop on each hole edge)
  * @return std::nullopt if the loops self-intersect, otherwise the patch mesh
  */

--- a/source/MRMesh/MRAxis.h
+++ b/source/MRMesh/MRAxis.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "MRVector3.h"
 
 namespace MR
 {
@@ -9,4 +10,33 @@ namespace MR
      Z,
      Count
  };
+
+/// one of the six signed coordinate axes; the order lets axis() and isNegative() be index arithmetic
+enum class SignedAxis
+{
+    PlusX,
+    PlusY,
+    PlusZ,
+    MinusX,
+    MinusY,
+    MinusZ,
+    Count
+};
+
+/// the coordinate axis (a) is directed along
+[[nodiscard]] inline Axis axis( SignedAxis a ) { return Axis( int( a ) % 3 ); }
+
+/// whether (a) points against its coordinate axis
+[[nodiscard]] inline bool isNegative( SignedAxis a ) { return int( a ) >= 3; }
+
+/// the signed axis (v) is most aligned with: its largest-magnitude component, and that component's sign
+template <typename T>
+[[nodiscard]] SignedAxis dominantSignedAxis( const Vector3<T>& v )
+{
+    int d = 0;
+    for ( int i = 1; i < 3; ++i )
+        if ( v[i] * v[i] > v[d] * v[d] )
+            d = i;
+    return SignedAxis( v[d] < 0 ? d + 3 : d );
+}
 }

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -12,6 +12,8 @@
 #include "MRColor.h"
 #include "MRMeshFillHole.h"
 #include "MRBox.h"
+#include "MRMapEdge.h"
+#include "MRBitSet.h"
 #include <cfloat>
 
 namespace MR
@@ -244,58 +246,111 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
     if ( minEdgeLenSq < 1e-12f * loopBox.size().lengthSq() )
         return unexpected( "Hole boundary has a degenerate edge" );
 
-    std::vector<EdgePath> newPaths;
-    auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, dominantSignedAxis( sumCross ), &newPaths );
+    // patch boundary edge (by undirected id) -> the mesh edge it copies; the peel below anchors on
+    // mesh edges through it, so no boundary paths and no positional alignment are needed
+    WholeEdgeMap bd2mesh;
+    auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, dominantSignedAxis( sumCross ), nullptr, &bd2mesh );
     if ( !patch )
         return unexpected( "Cannot triangulate contours with self-intersections" );
 
-    if ( auto v = validateAndFixPatch( patch->topology, loops, newPaths ); !v )
-        return unexpected( std::move( v.error() ) );
-
     const auto& pTp = patch->topology;
-    const auto& ip = loops.front();
-    auto& np = newPaths.front();
     HoleFillPlan res;
     res.numTris = pTp.numValidFaces();
     if ( res.numTris == 1 )
         return res;
-    auto size = int( np.size() );
-    assert( size > 3 );
-    res.items.reserve( size - 3 );
 
-    for ( ;;)
+    // the copy guarantees one patch boundary edge per loop position, faces on its left and the void
+    // on its right - except a degenerate (zero area) hole, which SoS can fill on the wrong side
+    if ( pTp.right( EdgeId( 0 ) ) )
+        return unexpected( "Incorrect filling" );
+
+    const int n = int( loops.front().size() );
+    assert( n > 3 );
+    // interior patch edges the plan must create: of the 3 * numTris face sides, each boundary edge
+    // covers one and each interior edge two
+    const int numChords = ( 3 * res.numTris - int( bd2mesh.size() ) ) / 2;
+
+    // the peel's current polygon: one slot per boundary edge, the rings implicit in succ
+    struct Slot
     {
-        for ( int i0 = 0; i0 < np.size(); ++i0 )
+        EdgeId cur;   // current polygon edge in the patch, invalid = consumed position
+        int refCode;  // plan code of cur: not-negative absolute mesh EdgeId, negative - earlier plan edge
+        int succ;     // next slot around the polygon
+    };
+    std::vector<Slot> slots;
+    slots.reserve( n );
+    // seed the polygon from the patch boundary itself: EdgeId( 0 ) is the first boundary edge the
+    // copy created, so for a plain loop the slots repeat the loop order (and the plan its old form).
+    // Turn::Leftmost keeps the walk in the same region corner at a pinch vertex, reproducing the
+    // input loop's own pairing there; the default tight-right turn would pair the arrival with the
+    // other cavity's exit, seeding rings that do not bound the peel's sub-polygons
+    auto walkRing = [&]( EdgeId b0, UndirectedEdgeBitSet* visited )
+    {
+        const int first = int( slots.size() );
+        EdgeId b = b0;
+        do
         {
-            auto e0 = np[i0];
-            if ( !e0 )
-                continue; // skip unused/encoded 
-            auto i1 = int( pTp.dest( np[i0] ) );
-            if ( i1 < 0 )
-                return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
-            auto e1 = np[i1];
-            if ( !e1 )
-                return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
-            auto ne = pTp.next( e0 );
-            auto dest = pTp.dest( ne );
-            if ( dest != pTp.dest( e1 ) )
+            if ( int( slots.size() ) >= n )
+                return false;
+            if ( visited )
+                visited->set( b.undirected() );
+            slots.push_back( { b, int( mapEdge( bd2mesh, b ) ), int( slots.size() ) + 1 } );
+            b = pTp.nextLeftBd( b, nullptr, Turn::Leftmost );
+        } while ( b != b0 );
+        slots.back().succ = first;
+        return true;
+    };
+    if ( !walkRing( EdgeId( 0 ), nullptr ) )
+        return unexpected( "Incorrect filling" );
+    if ( int( slots.size() ) != n )
+    {
+        // a pinched hole: the boundary is several rings sharing vertices; reseed recording visits
+        slots.clear();
+        UndirectedEdgeBitSet visited( bd2mesh.size() );
+        for ( UndirectedEdgeId ue{ 0 }; ue < bd2mesh.size(); ++ue )
+        {
+            if ( visited.test( ue ) )
                 continue;
-            FillHoleItem fhi;
-            int i01 = ( i0 + 1 ) % size;
-            fhi.edgeCode1 = i1 == i01 ? ip[i0] : int( np[i01] );
-            i1 = dest;
-            e1 = np[i1];
-            if ( !e1 )
+            const EdgeId b{ ue };
+            const bool bdFwd = !pTp.right( b ), bdBack = !pTp.left( b );
+            if ( bdFwd == bdBack ) // an edge the hole boundary traverses twice: no face side to seed from
                 return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
-            int i11 = ( i1 + 1 ) % size;
-            fhi.edgeCode2 = ( pTp.dest( e1 ) == i11 ) ? ip[i1] : int( np[i11] );
-            res.items.push_back( std::move( fhi ) );
-            if ( res.items.size() == size - 3 )
-                return res;
-            np[i0] = ne;
-            np[i01] = EdgeId( FillHoleItemEdge{ .item = int( res.items.size() ) - 1 }.encode() ); // encode the just pushed plan edge in free slot
+            if ( !walkRing( bdFwd ? b : b.sym(), &visited ) )
+                return unexpected( "Incorrect filling" );
         }
+        if ( int( slots.size() ) != n )
+            return unexpected( "Incorrect filling" );
     }
+
+    res.items.reserve( numChords );
+    while ( int( res.items.size() ) < numChords )
+    {
+        bool progress = false;
+        for ( int s0 = 0; s0 < int( slots.size() ) && int( res.items.size() ) < numChords; ++s0 )
+        {
+            if ( !slots[s0].cur )
+                continue; // consumed position
+            const int s1 = slots[s0].succ;
+            const int s2 = slots[s1].succ;
+            if ( slots[s2].succ == s0 )
+                continue; // triangle ring: its last face needs no new edge
+            const EdgeId ne = pTp.next( slots[s0].cur );
+            if ( pTp.dest( ne ) != pTp.dest( slots[s1].cur ) )
+                continue; // left face of cur[s0] is not an ear here
+            if ( ne.undirected() < bd2mesh.size() )
+                slots[s0] = { ne, int( mapEdge( bd2mesh, ne ) ), s2 }; // pinched ring: the closing edge exists in the mesh
+            else
+            {
+                res.items.push_back( { slots[s0].refCode, slots[s2].refCode } );
+                slots[s0] = { ne, FillHoleItemEdge{ .item = int( res.items.size() ) - 1 }.encode(), s2 };
+            }
+            slots[s1].cur = {};
+            progress = true;
+        }
+        if ( !progress )
+            return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
+    }
+    return res;
 }
 
 Expected<void> fillPlanarHole( ObjectMeshData& data, std::vector<EdgeLoop>& holeContours )

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -225,7 +225,8 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
     EdgeLoops loops( 1 );
     loops.front() = trackRightBoundaryLoop( mesh.topology, holeEdgeId );
 
-    // the hole loop winds counterclockwise around this direction, same as around the fitted plane's normal it replaces
+    // the hole loop winds counterclockwise around this direction, same as around the fitted plane's
+    // normal it replaces; only its dominant signed axis reaches the triangulation
     Vector3d sumCross;
     Box3f loopBox;
     float minEdgeLenSq = FLT_MAX;
@@ -244,7 +245,7 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
         return unexpected( "Hole boundary has a degenerate edge" );
 
     std::vector<EdgePath> newPaths;
-    auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f( sumCross.normalized() ), &newPaths );
+    auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, dominantSignedAxis( sumCross ), &newPaths );
     if ( !patch )
         return unexpected( "Cannot triangulate contours with self-intersections" );
 

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -146,7 +146,7 @@ TEST( MRMesh, PlanarTriangulationMeshSpace )
     const EdgeLoop loop = trackRightBoundaryLoop( mesh.topology, e0 );
     ASSERT_GE( loop.size(), size_t( 3 ) );
 
-    const auto res = PlanarTriangulation::triangulateDisjointContours( mesh, EdgeLoops{ loop }, normal );
+    const auto res = PlanarTriangulation::triangulateDisjointContours( mesh, EdgeLoops{ loop }, dominantSignedAxis( normal ) );
     ASSERT_TRUE( res.has_value() );
     const Mesh& patch = *res;
 
@@ -234,7 +234,7 @@ TEST( MRMesh, PlanarTriangulationMeshSpacePinch )
 
     const EdgeLoops loops = { { eA0, eA1, eA2, eA3 }, { eB0, eB1, eB2, eB3 } };
     std::vector<EdgePath> bds;
-    const auto res = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f::plusZ(), &bds );
+    const auto res = PlanarTriangulation::triangulateDisjointContours( mesh, loops, SignedAxis::PlusZ, &bds );
     ASSERT_TRUE( res.has_value() );
     const Mesh& patch = *res;
 
@@ -288,7 +288,7 @@ TEST( MRMesh, PlanarTriangulationMeshSpaceSharedEdge )
 
     const EdgeLoops loops = { { eBL, eC, eTL, eL }, { eBR, eR, eTR, eC.sym() } };
     std::vector<EdgePath> bds;
-    const auto res = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f::plusZ(), &bds );
+    const auto res = PlanarTriangulation::triangulateDisjointContours( mesh, loops, SignedAxis::PlusZ, &bds );
     ASSERT_TRUE( res.has_value() );
     const Mesh& patch = *res;
 
@@ -322,7 +322,7 @@ TEST( MRMesh, PlanarTriangulationMeshSpaceAnnulus )
     ASSERT_EQ( loops[1].size(), size_t( 4 ) );
 
     std::vector<EdgePath> bds;
-    const auto res = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f::plusZ(), &bds );
+    const auto res = PlanarTriangulation::triangulateDisjointContours( mesh, loops, SignedAxis::PlusZ, &bds );
     ASSERT_TRUE( res.has_value() );
     const Mesh& patch = *res;
 

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -173,6 +173,167 @@ TEST( MRMesh, PlanarTriangulationMeshSpace )
 
 namespace
 {
+
+// checks that the patch's boundary loops correspond 1:1 to the input mesh loops:
+// same sizes, patch side filled (left face valid), exact original coordinates at every origin
+void checkPatchBorders( const Mesh& mesh, const EdgeLoops& loops, const Mesh& patch, const std::vector<EdgePath>& bds )
+{
+    ASSERT_EQ( bds.size(), loops.size() );
+    for ( size_t i = 0; i < loops.size(); ++i )
+    {
+        ASSERT_EQ( bds[i].size(), loops[i].size() );
+        for ( size_t j = 0; j < loops[i].size(); ++j )
+        {
+            EXPECT_TRUE( patch.topology.left( bds[i][j] ).valid() );
+            EXPECT_EQ( patch.points[patch.topology.org( bds[i][j] )], mesh.points[mesh.topology.org( loops[i][j] )] );
+            EXPECT_EQ( patch.points[patch.topology.dest( bds[i][j] )], mesh.points[mesh.topology.dest( loops[i][j] )] );
+        }
+    }
+}
+
+}
+
+TEST( MRMesh, PlanarTriangulationMeshSpacePinch )
+{
+    // two ccw square loops sharing exactly one mesh vertex v0 (a bowtie): the configuration a cut
+    // contour leaves when it touches the removed face's boundary at a vertex
+    Mesh mesh;
+    auto& tp = mesh.topology;
+    const VertId v0 = tp.addVertId(); // shared
+    const VertId a1 = tp.addVertId(), a2 = tp.addVertId(), a3 = tp.addVertId(); // lower-left square
+    const VertId b1 = tp.addVertId(), b2 = tp.addVertId(), b3 = tp.addVertId(); // upper-right square
+    mesh.points.autoResizeSet( v0, Vector3f( 0, 0, 0 ) );
+    mesh.points.autoResizeSet( a1, Vector3f( -1, 0, 0 ) );
+    mesh.points.autoResizeSet( a2, Vector3f( -1, -1, 0 ) );
+    mesh.points.autoResizeSet( a3, Vector3f( 0, -1, 0 ) );
+    mesh.points.autoResizeSet( b1, Vector3f( 1, 0, 0 ) );
+    mesh.points.autoResizeSet( b2, Vector3f( 1, 1, 0 ) );
+    mesh.points.autoResizeSet( b3, Vector3f( 0, 1, 0 ) );
+
+    const EdgeId eA0 = tp.makeEdge(), eA1 = tp.makeEdge(), eA2 = tp.makeEdge(), eA3 = tp.makeEdge();
+    const EdgeId eB0 = tp.makeEdge(), eB1 = tp.makeEdge(), eB2 = tp.makeEdge(), eB3 = tp.makeEdge();
+    // rings at the simple vertices: in-edge and out-edge only
+    tp.splice( eA0.sym(), eA1 );
+    tp.splice( eA1.sym(), eA2 );
+    tp.splice( eA2.sym(), eA3 );
+    tp.splice( eB0.sym(), eB1 );
+    tp.splice( eB1.sym(), eB2 );
+    tp.splice( eB2.sym(), eB3 );
+    // ring at v0 in ccw order around +Z: toward b1 (0), b3 (90), a1 (180), a3 (270);
+    // each loop's interior wedge stays contiguous, as in a real mesh
+    tp.splice( eB0, eB3.sym() );
+    tp.splice( eB3.sym(), eA0 );
+    tp.splice( eA0, eA3.sym() );
+    tp.setOrg( eA0, v0 );
+    tp.setOrg( eA1, a1 );
+    tp.setOrg( eA2, a2 );
+    tp.setOrg( eA3, a3 );
+    tp.setOrg( eB1, b1 );
+    tp.setOrg( eB2, b2 );
+    tp.setOrg( eB3, b3 );
+
+    const EdgeLoops loops = { { eA0, eA1, eA2, eA3 }, { eB0, eB1, eB2, eB3 } };
+    std::vector<EdgePath> bds;
+    const auto res = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f::plusZ(), &bds );
+    ASSERT_TRUE( res.has_value() );
+    const Mesh& patch = *res;
+
+    EXPECT_EQ( patch.topology.numValidFaces(), 4 ); // 2 triangles per square
+    EXPECT_NEAR( patch.area(), 2.0f, 1e-5f );
+    // one figure-eight boundary loop: the hole walk passes the shared vertex twice
+    EXPECT_EQ( patch.topology.findHoleRepresentiveEdges().size(), 1 );
+    for ( auto f : patch.topology.getValidFaces() )
+        EXPECT_GT( dot( patch.normal( f ), Vector3f::plusZ() ), 0.f );
+    checkPatchBorders( mesh, loops, patch, bds );
+}
+
+TEST( MRMesh, PlanarTriangulationMeshSpaceSharedEdge )
+{
+    // square [0,3]^2 split by a chord: two ccw loops traverse the chord edge in opposite directions —
+    // exactly what a cut contour crossing a removed face leaves for the joint per-face fill
+    Mesh mesh;
+    auto& tp = mesh.topology;
+    const VertId c0 = tp.addVertId(), m1 = tp.addVertId(), c1 = tp.addVertId();
+    const VertId c2 = tp.addVertId(), m2 = tp.addVertId(), c3 = tp.addVertId();
+    mesh.points.autoResizeSet( c0, Vector3f( 0, 0, 0 ) );
+    mesh.points.autoResizeSet( m1, Vector3f( 1.5f, 0, 0 ) );
+    mesh.points.autoResizeSet( c1, Vector3f( 3, 0, 0 ) );
+    mesh.points.autoResizeSet( c2, Vector3f( 3, 3, 0 ) );
+    mesh.points.autoResizeSet( m2, Vector3f( 1.5f, 3, 0 ) );
+    mesh.points.autoResizeSet( c3, Vector3f( 0, 3, 0 ) );
+
+    const EdgeId eBL = tp.makeEdge(); // c0 -> m1
+    const EdgeId eBR = tp.makeEdge(); // m1 -> c1
+    const EdgeId eR = tp.makeEdge();  // c1 -> c2
+    const EdgeId eTR = tp.makeEdge(); // c2 -> m2
+    const EdgeId eTL = tp.makeEdge(); // m2 -> c3
+    const EdgeId eL = tp.makeEdge();  // c3 -> c0
+    const EdgeId eC = tp.makeEdge();  // m1 -> m2, the chord
+    tp.splice( eL.sym(), eBL );      // c0
+    tp.splice( eBR.sym(), eR );      // c1
+    tp.splice( eR.sym(), eTR );      // c2
+    tp.splice( eTL.sym(), eL );      // c3
+    // ring at m1, ccw: toward c1 (0), m2 (90), c0 (180)
+    tp.splice( eBR, eC );
+    tp.splice( eC, eBL.sym() );
+    // ring at m2, ccw: toward c2 (0), c3 (180), m1 (270)
+    tp.splice( eTR.sym(), eTL );
+    tp.splice( eTL, eC.sym() );
+    tp.setOrg( eBL, c0 );
+    tp.setOrg( eBR, m1 );
+    tp.setOrg( eR, c1 );
+    tp.setOrg( eTR, c2 );
+    tp.setOrg( eTL, m2 );
+    tp.setOrg( eL, c3 );
+
+    const EdgeLoops loops = { { eBL, eC, eTL, eL }, { eBR, eR, eTR, eC.sym() } };
+    std::vector<EdgePath> bds;
+    const auto res = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f::plusZ(), &bds );
+    ASSERT_TRUE( res.has_value() );
+    const Mesh& patch = *res;
+
+    EXPECT_NEAR( patch.area(), 9.0f, 1e-5f ); // both sides of the chord filled
+    EXPECT_EQ( patch.topology.findHoleRepresentiveEdges().size(), 1 ); // one outer boundary, chord interior
+    for ( auto f : patch.topology.getValidFaces() )
+        EXPECT_GT( dot( patch.normal( f ), Vector3f::plusZ() ), 0.f );
+    checkPatchBorders( mesh, loops, patch, bds );
+    // the two loops' chord entries are one shared patch edge seen from both sides, as in the mesh
+    ASSERT_EQ( bds.size(), size_t( 2 ) );
+    ASSERT_EQ( bds[0].size(), size_t( 4 ) );
+    ASSERT_EQ( bds[1].size(), size_t( 4 ) );
+    EXPECT_EQ( bds[0][1], bds[1][3].sym() );
+    EXPECT_TRUE( patch.topology.left( bds[0][1] ).valid() );
+    EXPECT_TRUE( patch.topology.right( bds[0][1] ).valid() );
+}
+
+TEST( MRMesh, PlanarTriangulationMeshSpaceAnnulus )
+{
+    // nested square loops with no shared vertices: the copy path must reproduce the classic case exactly
+    const std::vector<Vector3f> outer = { { 0, 0, 0 }, { 3, 0, 0 }, { 3, 3, 0 }, { 0, 3, 0 } };
+    const std::vector<Vector3f> inner = { { 1, 1, 0 }, { 1, 2, 0 }, { 2, 2, 0 }, { 2, 1, 0 } }; // cw: a hole in the fill
+
+    Mesh mesh;
+    const EdgeId o0 = mesh.addSeparateEdgeLoop( outer );
+    const EdgeId i0 = mesh.addSeparateEdgeLoop( inner );
+    EdgeLoops loops( 2 );
+    loops[0] = trackRightBoundaryLoop( mesh.topology, o0 );
+    loops[1] = trackRightBoundaryLoop( mesh.topology, i0 );
+    ASSERT_EQ( loops[0].size(), size_t( 4 ) );
+    ASSERT_EQ( loops[1].size(), size_t( 4 ) );
+
+    std::vector<EdgePath> bds;
+    const auto res = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f::plusZ(), &bds );
+    ASSERT_TRUE( res.has_value() );
+    const Mesh& patch = *res;
+
+    EXPECT_NEAR( patch.area(), 8.0f, 1e-5f ); // 9 - 1
+    EXPECT_EQ( patch.topology.numValidFaces(), 8 ); // annulus on 8 boundary verts
+    EXPECT_EQ( patch.topology.findHoleRepresentiveEdges().size(), 2 );
+    checkPatchBorders( mesh, loops, patch, bds );
+}
+
+namespace
+{
 // circle of n points (closed: first == last)
 Contour2d circle( int n, double r, const Vector2d& center )
 {

--- a/source/MRTest/MRFillContours2DTests.cpp
+++ b/source/MRTest/MRFillContours2DTests.cpp
@@ -4,6 +4,9 @@
 #include <MRMesh/MRMakeSphereMesh.h>
 #include <MRMesh/MRMeshTrimWithPlane.h>
 #include <MRMesh/MRPlane3.h>
+#include <MRMesh/MRRegionBoundary.h>
+#include <MRMesh/MRMeshFillHole.h>
+#include <MRMesh/MRMeshFixer.h>
 #include <gtest/gtest.h>
 #include <limits>
 
@@ -57,6 +60,56 @@ TEST( MRMesh, fillContours2DTiltedPlane )
     // the current fill emits slivers, and the exact triangulation is not a stable invariant to guard.
     for ( FaceId f = firstNewFace; f <= mesh.topology.lastValidFace(); ++f )
         EXPECT_GT( dot( mesh.normal( f ), -normal ), 0.99f );
+}
+
+// A pinched hole: an island triangle touches the cavity's outer arc at one vertex, so the hole
+// boundary is a single 8-edge loop passing through that vertex twice (a pinched annulus). The old
+// positional peel identified peel positions with patch vertex ids, so the repeated vertex made it
+// fail with "Incorrect filling" and the caller fell back on the metric fill; the boundary-seeded
+// peel plans and fills it.
+TEST( MRMesh, fillContours2DPlanPinchedHole )
+{
+    VertCoords points;
+    points.vec_ = {
+        { 0.f, 0.f, 0.f },                                                     // the pinch vertex
+        { 1.2f, -0.4f, 0.f }, { 1.5f, 0.9f, 0.f }, { 0.2f, 1.6f, 0.f }, { -1.1f, 0.9f, 0.f }, // outer arc
+        { 0.7f, 0.3f, 0.f }, { 0.1f, 0.75f, 0.f },                             // island touching the pinch
+        { 1.9f, -1.4f, 0.f }, { 2.8f, 1.5f, 0.f }, { 0.3f, 2.8f, 0.f },        // outer pentagon
+        { -2.6f, 0.6f, 0.f }, { -1.2f, -1.7f, 0.f }
+    }; // generic position: no two boundary directions at the pinch are collinear (ties are SoS-fragile)
+    const Triangulation t{
+        { VertId( 0 ), VertId( 5 ), VertId( 6 ) },   // the island
+        { VertId( 0 ), VertId( 4 ), VertId( 10 ) }, { VertId( 0 ), VertId( 10 ), VertId( 11 ) },
+        { VertId( 0 ), VertId( 11 ), VertId( 7 ) }, { VertId( 0 ), VertId( 7 ), VertId( 1 ) },
+        { VertId( 1 ), VertId( 7 ), VertId( 2 ) }, { VertId( 2 ), VertId( 7 ), VertId( 8 ) },
+        { VertId( 2 ), VertId( 8 ), VertId( 3 ) }, { VertId( 3 ), VertId( 8 ), VertId( 9 ) },
+        { VertId( 3 ), VertId( 9 ), VertId( 4 ) }, { VertId( 4 ), VertId( 9 ), VertId( 10 ) } };
+    Mesh mesh = Mesh::fromTriangles( points, t );
+    ASSERT_EQ( mesh.topology.numValidFaces(), 11 );
+
+    // two holes: the outer pentagon outline and the pinched cavity; the cavity is the 8-edge one
+    EdgeId holeEdge;
+    for ( EdgeId e : mesh.topology.findHoleRepresentiveEdges() )
+        if ( trackRightBoundaryLoop( mesh.topology, e ).size() == 8 )
+            holeEdge = e;
+    ASSERT_TRUE( holeEdge.valid() );
+    const EdgeLoop loop = trackRightBoundaryLoop( mesh.topology, holeEdge );
+    int pinchVisits = 0;
+    for ( EdgeId e : loop )
+        if ( mesh.topology.org( e ) == VertId( 0 ) )
+            ++pinchVisits;
+    ASSERT_EQ( pinchVisits, 2 );
+
+    auto plan = fillContours2DPlan( mesh, holeEdge );
+    ASSERT_TRUE( plan.has_value() ) << plan.error();
+    EXPECT_EQ( plan->numTris, 6 ); // the pinched 8-gon fills like a disk: n - 2 triangles
+    EXPECT_EQ( plan->items.size(), size_t( 5 ) ); // and n - 3 chords
+
+    executeHoleFillPlan( mesh, holeEdge, *plan );
+    EXPECT_EQ( mesh.topology.numValidFaces(), 17 );
+    EXPECT_EQ( mesh.topology.findHoleRepresentiveEdges().size(), size_t( 1 ) ); // the pentagon outline remains
+    auto multiples = findMultipleEdges( mesh.topology );
+    EXPECT_TRUE( multiples.has_value() && multiples->empty() );
 }
 
 }


### PR DESCRIPTION
### Why

`PlanarTriangulation`'s mesh-space entry used to rebuild its working topology from the hole loops: one fresh vertex per loop *occurrence*, then `mergeSamePoints_` re-discovered which of them were the same vertex by sorting projected integer coordinates and welding, choosing each welded edge's ring position by angular order with SoS tie-breaks.

The mesh already knows that answer exactly. This copies the boundary sub-topology out of the mesh instead, so vertices and edges that several loops share arrive shared, in the mesh's own ring order.

That matters now because `cutMesh` is moving to filling all holes of one removed face together in a single swept run, where loops of one region genuinely touch — at a vertex where a cut contour meets the face boundary, or along a slit edge the region occupies from both sides.

### Commits (reviewable one by one)

1. **Copy the boundary sub-topology** — new `buildRegionTopology_`: compact local ids in first-occurrence order, one edge per distinct undirected boundary edge, rings spliced from the loop chain at simple vertices (no mesh access at all) and taken from the mesh `orgRing` only at repeated vertices; slit winding as a sparse exception list. Duplicate detection is two sorted flat arrays — no hashing, no O(mesh) scratch. Drops `findHoleVertIdsByHoleEdges` and one of the two exact-predicate `parallel_sort`s from this path.
2. **`SignedAxis` instead of a plane normal** — the sweep only ever consumed the normal's dominant axis and that component's sign, so the parameter now says exactly that (new `SignedAxis` + `dominantSignedAxis()` in `MRAxis.h`). Being over-specified is what previously allowed a caller to pass a sign contradicting the loops' winding; that is now asserted rather than detected and compensated, which removes a next-vs-prev branch from the ring walk.
3. **Seed the fill plan from the patch boundary through an edge map** — optional output mapping each patch boundary edge to the mesh edge it copies. `fillContours2DPlan` walks the patch boundary itself and anchors plan items through that map, replacing the peel that identified peel positions with patch vertex ids.

### What changes observably

- A **pinched hole** — one loop passing through a vertex twice, e.g. an island touching a cavity's boundary — is now planned and filled. The positional peel failed that class with `Incorrect filling`, so callers fell back on the metric fill.
- A **slit edge** the boundary traverses in both directions gets faces on both sides; `MRMesh.PlanarTriangulationMeshSpaceSharedEdge` (added here) fails on master with a dangling boundary entry.
- Everything else is bit-identical, see below.

### Verification

- `MRTest --no-python-tests`: **340/340**, including 4 new tests (pinch, slit, annulus, pinched-hole plan).
- **Byte-identical results** on a geometric digest of boolean/cutMesh-driven workloads, at both the shipping swept threshold and at `cMinSweptHoleSize=3` where every hole above 3 verts takes the swept path — same plans bit-for-bit, same fallback set.
- Not slower, measured locally with interleaved A/B and a change-insensitive control:
  - per-hole `fillContours2DPlan`: −1.6…−6.5% across n = 4…16;
  - two-sphere boolean benchmark (3366 verts, DifferenceAB, 2000 iterations) at threshold 3: median 18.29 → 17.91 ms, 4/4 rounds, non-overlapping per-round ranges;
  - the 2D contour path (`triangulateContours`), which this does not touch, stays neutral within ±1.2% with mixed signs — it doubles as a library-level control.

Draft because the caller this is built for — `cutMesh`'s joint per-old-face fill — is not in this PR. Follow-ups: drop `outBoundaries` from the mesh-space signature once the multi-hole peel re-seeds from the edge map, then the multi-hole plan entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
