### PR TITLE
Init the sweep mesh by copying hole loops from the input mesh

### DIFF
--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -1643,7 +1643,7 @@ std::optional<Mesh> triangulateDisjointContours( const Contours2d& contours, con
     return triangulateDisjointContours( contsf, holeVertsIds, outBoundaries );
 }
 
-std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, std::vector<EdgePath>* outBoundaries /*= nullptr*/ )
+std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, std::vector<EdgePath>* outBoundaries /*= nullptr*/, WholeEdgeMap* outPatchMap /*= nullptr*/ )
 {
     if ( loops.empty() )
         return Mesh();
@@ -1651,7 +1651,13 @@ std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoo
     {
         // copy the boundary sub-topology straight from the mesh: shared vertices and slit edges arrive
         // already shared, so no positional id contract and no coordinate-based merging is needed
-        WholeEdgeMap patchToInEdges;
+        WholeEdgeMap localMap;
+        WholeEdgeMap& patchToInEdges = outPatchMap ? *outPatchMap : localMap;
+        patchToInEdges.clear();
+        size_t numLoopEdges = 0;
+        for ( const auto& loop : loops )
+            numLoopEdges += loop.size();
+        patchToInEdges.reserve( numLoopEdges );
         SweepLineQueue triangulator( mesh.topology, meshSpacePredicates( mesh, loops, normal, patchToInEdges ), loops,
             { .abortWhenIntersect = true, .outPatchMap = &patchToInEdges } );
         return triangulator.run();

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -51,8 +51,9 @@ struct SweepLinePredicates
     std::function<void( VertId v, int contourId, int pointId )> addInputPoint;
     // compute and store the position of intersection vertex v of segments (a,b) and (c,d)
     std::function<void( VertId v, VertId a, VertId b, VertId c, VertId d )> addIntersectionPoint;
-    // position of vertex v in the output mesh
-    std::function<Vector3f( VertId v )> point;
+    // position of vertex v in the output mesh; tp is the topology v lives in, passed at call time
+    // because the queue's topology is moved into the output mesh before the points are filled
+    std::function<Vector3f( const MeshTopology& tp, VertId v )> point;
 };
 
 // the sweep-line predicates that depend only on the projected integer coordinates `pts2`;
@@ -122,7 +123,7 @@ static SweepLinePredicates precisePredicates( const Contours2f& contours )
     {
         pts->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( ( *pts )[a], ( *pts )[b], ( *pts )[c], ( *pts )[d] ) );
     };
-    p.point = [pts, toFloat] ( VertId v )
+    p.point = [pts, toFloat] ( const MeshTopology&, VertId v )
     {
         return to3dim( toFloat( ( *pts )[v] ) );
     };
@@ -138,27 +139,14 @@ static std::vector<int> getContourSizes( const Contours2f& contours )
     return sizes;
 }
 
-// map an input vertex (its index within the concatenated hole loops) back to its source mesh VertId;
-// mirrors the walk in mergeSamePoints_
-static VertId holeSourceVertId( const HolesVertIds& holes, VertId v )
-{
-    int idx = int( v );
-    for ( const auto& hole : holes )
-    {
-        if ( idx < int( hole.size() ) )
-            return hole[idx];
-        idx -= int( hole.size() );
-    }
-    assert( false ); // a disjoint triangulation outputs only input vertices, all covered by holes
-    return {};
-}
-
 // mesh-space predicates: triangulate hole boundary loops of `mesh` in the mesh's own 3D coordinates,
 // orienting around `normal`. Combinatorics run on the dominant-axis projection (reusing the exact 2D
 // predicates via setPts2Predicates). point() restores each output vertex's exact original mesh position
-// through `holeVertIds` (no separate coordinate copy, no projection round-trip).
-// `mesh`, `loops` and `holeVertIds` only need to outlive the run.
-static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, const HolesVertIds& holeVertIds )
+// through `patchToInEdges`, the patch->input edge map (no separate coordinate copy, no projection
+// round-trip, no positional vertex id contract); the caller may fill the map after construction but
+// before the run - the loops ctor fills it itself via SweepLineParams::outPatchMap.
+// `mesh`, `loops` and `patchToInEdges` only need to outlive the run.
+static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, const WholeEdgeMap& patchToInEdges )
 {
     Box3f box;
     int pointsSize = 0;
@@ -196,11 +184,22 @@ static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoop
     {
         pts2->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( ( *pts2 )[a], ( *pts2 )[b], ( *pts2 )[c], ( *pts2 )[d] ) );
     };
-    // disjoint triangulation creates no output intersection vertices, so every output vertex is an input
-    // vertex: restore its exact original mesh position via the (already-built) holeVertIds identity map
-    p.point = [&mesh, &holeVertIds] ( VertId v )
+    // disjoint triangulation creates no output intersection vertices, so every output vertex lies on a
+    // copied input edge: find one in its org ring (which by fill time also holds unmapped triangulation
+    // diagonals) and restore the exact original mesh position through the edge map
+    p.point = [&mesh, &patchToInEdges] ( const MeshTopology& patchTp, VertId v )
     {
-        return mesh.points[holeSourceVertId( holeVertIds, v )];
+        for ( EdgeId e : orgRing( patchTp, v ) )
+        {
+            if ( e.undirected() >= patchToInEdges.size() )
+                continue;
+            const EdgeId inE = patchToInEdges[e.undirected()];
+            if ( !inE )
+                continue;
+            return mesh.points[mesh.topology.org( e.odd() ? inE.sym() : inE )];
+        }
+        assert( false ); // a disjoint triangulation vertex always originates from a copied input edge
+        return Vector3f{};
     };
     return p;
 }
@@ -525,11 +524,11 @@ void SweepLineQueue::injectIntersections( IntersectionsMap* interMap )
             mapVal.uOrg = tp_.org( inter.upper );
             mapVal.uDest = tp_.dest( inter.upper );
 
-            auto iP = predicates_.point( inter.vId );
-            auto lO = predicates_.point( mapVal.lOrg );
-            auto lD = predicates_.point( mapVal.lDest );
-            auto uO = predicates_.point( mapVal.uOrg );
-            auto uD = predicates_.point( mapVal.uDest );
+            auto iP = predicates_.point( tp_, inter.vId );
+            auto lO = predicates_.point( tp_, mapVal.lOrg );
+            auto lD = predicates_.point( tp_, mapVal.lDest );
+            auto uO = predicates_.point( tp_, mapVal.uOrg );
+            auto uD = predicates_.point( tp_, mapVal.uDest );
             auto lVec = ( lD - lO );
             auto uVec = ( uD - uO );
             auto lVecLSq = lVec.lengthSq();
@@ -641,7 +640,7 @@ Mesh SweepLineQueue::triangulate()
     mesh.points.resize( mesh.topology.vertSize() );
     BitSetParallelFor( mesh.topology.getValidVerts(), [&] ( VertId v )
     {
-        mesh.points[v] = predicates_.point( v );
+        mesh.points[v] = predicates_.point( mesh.topology, v );
     } );
     // Delone flips could cross a contour edge between two inside regions and smear the face winding map
     if ( !params_.needOutline && !params_.outFaceWinding )
@@ -1648,13 +1647,30 @@ std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoo
 {
     if ( loops.empty() )
         return Mesh();
-    // boundary loops may share mesh vertices: this identity map drives both vertex merging and exact
-    // point restoration (so the patch reuses the original mesh coordinates instead of projected ones)
+    if ( !outBoundaries )
+    {
+        // copy the boundary sub-topology straight from the mesh: shared vertices and slit edges arrive
+        // already shared, so no positional id contract and no coordinate-based merging is needed
+        WholeEdgeMap patchToInEdges;
+        SweepLineQueue triangulator( mesh.topology, meshSpacePredicates( mesh, loops, normal, patchToInEdges ), loops,
+            { .abortWhenIntersect = true, .outPatchMap = &patchToInEdges } );
+        return triangulator.run();
+    }
+    // outBoundaries consumers (fillContours2D) need per-contour paths that only the rebuild-from-contours
+    // path provides, until the fill plan is built from SweepLineParams::outPatchMap instead
     const HolesVertIds holeVertIds = findHoleVertIdsByHoleEdges( mesh.topology, loops );
+    // initMeshByContours_ creates the patch undirected edges sequentially per non-degenerate contour, and
+    // merging collapses vertices, never edges, so the patch->input edge map here is positional
+    WholeEdgeMap patchToInEdges;
     std::vector<int> sizes( loops.size() );
     for ( int i = 0; i < int( loops.size() ); ++i )
+    {
         sizes[i] = int( loops[i].size() ) + 1; // +1 matches the queue's closed-contour convention (it allocates size-1 verts)
-    SweepLineQueue triangulator( meshSpacePredicates( mesh, loops, normal, holeVertIds ), std::move( sizes ),
+        if ( loops[i].size() >= 3 )
+            for ( EdgeId e : loops[i] )
+                patchToInEdges.push_back( e );
+    }
+    SweepLineQueue triangulator( meshSpacePredicates( mesh, loops, normal, patchToInEdges ), std::move( sizes ),
         { &holeVertIds, true, WindingMode::NonZero, false, true, outBoundaries } );
     return triangulator.run();
 }

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -51,8 +51,7 @@ struct SweepLinePredicates
     std::function<void( VertId v, int contourId, int pointId )> addInputPoint;
     // compute and store the position of intersection vertex v of segments (a,b) and (c,d)
     std::function<void( VertId v, VertId a, VertId b, VertId c, VertId d )> addIntersectionPoint;
-    // position of vertex v in the output mesh; tp is the topology v lives in, passed at call time
-    // because the queue's topology is moved into the output mesh before the points are filled
+    // position of vertex v; tp is passed at call time because the queue's topology is moved into the output mesh
     std::function<Vector3f( const MeshTopology& tp, VertId v )> point;
 };
 
@@ -142,10 +141,8 @@ static std::vector<int> getContourSizes( const Contours2f& contours )
 // mesh-space predicates: triangulate hole boundary loops of `mesh` in the mesh's own 3D coordinates,
 // orienting around `normal`. Combinatorics run on the dominant-axis projection (reusing the exact 2D
 // predicates via setPts2Predicates). point() restores each output vertex's exact original mesh position
-// through `patchToInEdges`, the patch->input edge map (no separate coordinate copy, no projection
-// round-trip, no positional vertex id contract); the caller may fill the map after construction but
-// before the run - the loops ctor fills it itself via SweepLineParams::outPatchMap.
-// `mesh`, `loops` and `patchToInEdges` only need to outlive the run.
+// through `patchToInEdges`, the patch->input edge map (no separate coordinate copy, no projection round-trip).
+// `mesh`, `loops` and `patchToInEdges` only need to outlive the run; the map may be filled after construction.
 static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, const WholeEdgeMap& patchToInEdges )
 {
     Box3f box;
@@ -184,9 +181,8 @@ static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoop
     {
         pts2->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( ( *pts2 )[a], ( *pts2 )[b], ( *pts2 )[c], ( *pts2 )[d] ) );
     };
-    // disjoint triangulation creates no output intersection vertices, so every output vertex lies on a
-    // copied input edge: find one in its org ring (which by fill time also holds unmapped triangulation
-    // diagonals) and restore the exact original mesh position through the edge map
+    // every output vertex lies on a copied input edge (disjoint triangulation adds no intersection
+    // vertices), so find one in its org ring, skipping the triangulation's own diagonals
     p.point = [&mesh, &patchToInEdges] ( const MeshTopology& patchTp, VertId v )
     {
         for ( EdgeId e : orgRing( patchTp, v ) )
@@ -1097,8 +1093,7 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
     WholeEdgeMap p2inCache; // TODO: can be cached
     WholeEdgeMap& p2in = params_.outPatchMap ? *params_.outPatchMap : p2inCache;
 
-    // upper bounds, capacity hints only (multiple traversals share one patch edge, shared vertices
-    // arrive shared): actual sizes come from the built topology
+    // upper bound: capacity hints only, actual sizes come from the built topology
     size_t numLoopEdges = 0;
     for ( const auto& loop : loops )
         if ( loop.size() >= 3 )
@@ -1109,12 +1104,9 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
     tp_.vertReserve( numLoopEdges );
     tp_.edgeReserve( 2 * numLoopEdges );
 
-    // when an edge's dest vertex is created fresh, the org ring of the next loop edge contains
-    // exactly one mapped edge - the one just created - so its search result is forced; the one
-    // exception is backtracking right along the same undirected edge (a spike): that second
-    // traversal is invisible to the dest search (its orgRing0 skips the edge itself), hence the
-    // prevInUE filter. A loop's closing edge always finds its dest mapped, so no carry survives
-    // into the next loop
+    // a fresh dest vertex has exactly one mapped edge in its ring - the one just created - so the next
+    // loop edge can skip the search below, unless it backtracks along the same undirected edge, which is
+    // a re-traversal the dest search cannot see (orgRing0 skips the edge itself)
     EdgeId prevFreshPE;
     UndirectedEdgeId prevInUE;
 
@@ -1123,7 +1115,7 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
         EdgeId newPE;
         if ( prevFreshPE && inE.undirected() != prevInUE )
         {
-            // org vertex is the previous edge's fresh dest: the only mapped ring edge is the carried one
+            // org is the previous edge's fresh dest: the carried edge is the only one to splice against
             newPE = tp_.makeEdge();
             tp_.splice( tp_.prev( prevFreshPE ), newPE );
         }
@@ -1142,9 +1134,8 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
             }
             if ( inFE == inE )
             {
-                // this edge was already traversed: fold this traversal into the winding modifier, seeding
-                // it with the first traversal's contribution (single-traversal edges keep the sentinel -
-                // the default parity rule in calculateWinding_ computes the same value for them)
+                // this edge was already traversed: accumulate both traversals in the winding modifier,
+                // seeding from the first one (a single traversal keeps the sentinel = default parity rule)
                 const EdgeId pFirst( pFE ); // created along the first traversal
                 auto& wind = windingInfo_.autoResizeAt( pFirst ).windingModifier;
                 if ( wind == INT_MAX )
@@ -1214,8 +1205,7 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
             addNewEdge( loop[lId], loopId, lId );
     }
 
-    // multi-traversal edges got explicit modifiers above, everything else keeps the sentinel and
-    // takes the default parity rule; sized from the actually built topology, not the loop count
+    // the sweep indexes windingInfo_ by every edge; those without an explicit modifier keep the sentinel
     windingInfo_.resize( tp_.undirectedEdgeSize() );
 
     sortedVerts_.reserve( tp_.vertSize() );
@@ -1690,8 +1680,7 @@ std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoo
         return Mesh();
     if ( !outBoundaries )
     {
-        // copy the boundary sub-topology straight from the mesh: shared vertices and slit edges arrive
-        // already shared, so no positional id contract and no coordinate-based merging is needed
+        // copy the boundary sub-topology from the mesh: shared vertices and slit edges arrive already shared
         WholeEdgeMap localMap;
         WholeEdgeMap& patchToInEdges = outPatchMap ? *outPatchMap : localMap;
         patchToInEdges.clear();
@@ -1703,11 +1692,10 @@ std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoo
             { .abortWhenIntersect = true, .outPatchMap = &patchToInEdges } );
         return triangulator.run();
     }
-    // outBoundaries consumers (fillContours2D) need per-contour paths that only the rebuild-from-contours
-    // path provides, until the fill plan is built from SweepLineParams::outPatchMap instead
+    // outBoundaries consumers (fillContours2D) still need the rebuild-from-contours path
     const HolesVertIds holeVertIds = findHoleVertIdsByHoleEdges( mesh.topology, loops );
-    // initMeshByContours_ creates the patch undirected edges sequentially per non-degenerate contour, and
-    // merging collapses vertices, never edges, so the patch->input edge map here is positional
+    // initMeshByContours_ creates edges sequentially per non-degenerate contour and merging never
+    // collapses edges, so the patch->input map here is positional
     WholeEdgeMap patchToInEdges;
     std::vector<int> sizes( loops.size() );
     for ( int i = 0; i < int( loops.size() ); ++i )

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -1097,6 +1097,18 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
     WholeEdgeMap p2inCache; // TODO: can be cached
     WholeEdgeMap& p2in = params_.outPatchMap ? *params_.outPatchMap : p2inCache;
 
+    // upper bounds, capacity hints only (multiple traversals share one patch edge, shared vertices
+    // arrive shared): actual sizes come from the built topology
+    size_t numLoopEdges = 0;
+    for ( const auto& loop : loops )
+        if ( loop.size() >= 3 )
+            numLoopEdges += loop.size();
+    in2p.reserve( numLoopEdges );
+    p2in.reserve( numLoopEdges );
+    windingInfo_.reserve( numLoopEdges );
+    tp_.vertReserve( numLoopEdges );
+    tp_.edgeReserve( 2 * numLoopEdges );
+
     auto addNewEdge = [&] ( EdgeId inE, int cId, int pId )
     {
         EdgeId inFE, newPE;
@@ -1112,10 +1124,15 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
         }
         if ( inFE == inE )
         {
-            // this edge was already added
+            // this edge was already traversed: fold this traversal into the winding modifier, seeding
+            // it with the first traversal's contribution (single-traversal edges keep the sentinel -
+            // the default parity rule in calculateWinding_ computes the same value for them)
+            const EdgeId pFirst( pFE ); // created along the first traversal
+            auto& wind = windingInfo_.autoResizeAt( pFirst ).windingModifier;
+            if ( wind == INT_MAX )
+                wind = predicates_.less( tp_.org( pFirst ), tp_.dest( pFirst ) ) ? 1 : -1;
             auto existingInE = p2in[pFE];
-            auto pE = existingInE == inFE ? EdgeId( pFE ) : EdgeId( pFE ).sym();
-            auto& wind = windingInfo_[pE].windingModifier;
+            const EdgeId pE = existingInE == inFE ? pFirst : pFirst.sym();
             predicates_.less( tp_.org( pE ), tp_.dest( pE ) ) ? ++wind : --wind;
         }
         else if ( inFE )
@@ -1162,8 +1179,6 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
                 predicates_.addInputPoint( v, cId, pId + 1 );
                 tp_.setOrg( newPE.sym(), v );
             }
-            auto& wind = windingInfo_.autoResizeAt( newPE ).windingModifier;
-            wind = predicates_.less( tp_.org( newPE ), tp_.dest( newPE ) ) ? 1 : -1;
         }
     };
 
@@ -1176,6 +1191,10 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
         for ( int lId = 0; lId < loop.size(); ++lId )
             addNewEdge( loop[lId], loopId, lId );
     }
+
+    // multi-traversal edges got explicit modifiers above, everything else keeps the sentinel and
+    // takes the default parity rule; sized from the actually built topology, not the loop count
+    windingInfo_.resize( tp_.undirectedEdgeSize() );
 
     sortedVerts_.reserve( tp_.vertSize() );
     for ( int i = 0; i < tp_.vertSize(); ++i )

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -1109,48 +1109,68 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
     tp_.vertReserve( numLoopEdges );
     tp_.edgeReserve( 2 * numLoopEdges );
 
+    // when an edge's dest vertex is created fresh, the org ring of the next loop edge contains
+    // exactly one mapped edge - the one just created - so its search result is forced; the one
+    // exception is backtracking right along the same undirected edge (a spike): that second
+    // traversal is invisible to the dest search (its orgRing0 skips the edge itself), hence the
+    // prevInUE filter. A loop's closing edge always finds its dest mapped, so no carry survives
+    // into the next loop
+    EdgeId prevFreshPE;
+    UndirectedEdgeId prevInUE;
+
     auto addNewEdge = [&] ( EdgeId inE, int cId, int pId )
     {
-        EdgeId inFE, newPE;
-        UndirectedEdgeId pFE;
-        for ( auto ne : orgRing( inTp, inE ) )
+        EdgeId newPE;
+        if ( prevFreshPE && inE.undirected() != prevInUE )
         {
-            auto it = in2p.find( ne.undirected() );
-            if ( it == in2p.end() )
-                continue;
-            inFE = ne;
-            pFE = it->second;
-            break;
-        }
-        if ( inFE == inE )
-        {
-            // this edge was already traversed: fold this traversal into the winding modifier, seeding
-            // it with the first traversal's contribution (single-traversal edges keep the sentinel -
-            // the default parity rule in calculateWinding_ computes the same value for them)
-            const EdgeId pFirst( pFE ); // created along the first traversal
-            auto& wind = windingInfo_.autoResizeAt( pFirst ).windingModifier;
-            if ( wind == INT_MAX )
-                wind = predicates_.less( tp_.org( pFirst ), tp_.dest( pFirst ) ) ? 1 : -1;
-            auto existingInE = p2in[pFE];
-            const EdgeId pE = existingInE == inFE ? pFirst : pFirst.sym();
-            predicates_.less( tp_.org( pE ), tp_.dest( pE ) ) ? ++wind : --wind;
-        }
-        else if ( inFE )
-        {
-            // another ring edge is added but not ours
-            auto existingInE = p2in[pFE];
-            auto pRE = existingInE == inFE ? EdgeId( pFE ) : EdgeId( pFE ).sym();
+            // org vertex is the previous edge's fresh dest: the only mapped ring edge is the carried one
             newPE = tp_.makeEdge();
-            tp_.splice( tp_.prev( pRE ), newPE );
+            tp_.splice( tp_.prev( prevFreshPE ), newPE );
         }
         else
         {
-            // no ring edges at all
-            VertId v = tp_.addVertId();
-            predicates_.addInputPoint( v, cId, pId );
-            newPE = tp_.makeEdge();
-            tp_.setOrg( newPE, v );
+            EdgeId inFE;
+            UndirectedEdgeId pFE;
+            for ( auto ne : orgRing( inTp, inE ) )
+            {
+                auto it = in2p.find( ne.undirected() );
+                if ( it == in2p.end() )
+                    continue;
+                inFE = ne;
+                pFE = it->second;
+                break;
+            }
+            if ( inFE == inE )
+            {
+                // this edge was already traversed: fold this traversal into the winding modifier, seeding
+                // it with the first traversal's contribution (single-traversal edges keep the sentinel -
+                // the default parity rule in calculateWinding_ computes the same value for them)
+                const EdgeId pFirst( pFE ); // created along the first traversal
+                auto& wind = windingInfo_.autoResizeAt( pFirst ).windingModifier;
+                if ( wind == INT_MAX )
+                    wind = predicates_.less( tp_.org( pFirst ), tp_.dest( pFirst ) ) ? 1 : -1;
+                auto existingInE = p2in[pFE];
+                const EdgeId pE = existingInE == inFE ? pFirst : pFirst.sym();
+                predicates_.less( tp_.org( pE ), tp_.dest( pE ) ) ? ++wind : --wind;
+            }
+            else if ( inFE )
+            {
+                // another ring edge is added but not ours
+                auto existingInE = p2in[pFE];
+                auto pRE = existingInE == inFE ? EdgeId( pFE ) : EdgeId( pFE ).sym();
+                newPE = tp_.makeEdge();
+                tp_.splice( tp_.prev( pRE ), newPE );
+            }
+            else
+            {
+                // no ring edges at all
+                VertId v = tp_.addVertId();
+                predicates_.addInputPoint( v, cId, pId );
+                newPE = tp_.makeEdge();
+                tp_.setOrg( newPE, v );
+            }
         }
+        prevFreshPE = {};
         if ( newPE )
         {
             in2p[inE.undirected()] = newPE.undirected();
@@ -1178,6 +1198,8 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
                 // `pId + 1` can never reach `size` because loops are closed and we will always be in previous "if" block
                 predicates_.addInputPoint( v, cId, pId + 1 );
                 tp_.setOrg( newPE.sym(), v );
+                prevFreshPE = newPE.sym();
+                prevInUE = inE.undirected();
             }
         }
     };

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -295,6 +295,9 @@ struct SweepLineParams
 
     /// optional out per-face winding numbers
     Vector<int, FaceId>* outFaceWinding{ nullptr };
+
+    /// optional map of patch topology edges->input topology edges
+    WholeEdgeMap* outPatchMap{ nullptr };
 };
 
 class SweepLineQueue
@@ -304,6 +307,8 @@ public:
     // if holesVertId is null - merge all vertices with same coordinates
     // otherwise only merge the ones with same initial vertId
     SweepLineQueue( SweepLinePredicates predicates, std::vector<int> contourSizes, const SweepLineParams& params );
+
+    SweepLineQueue( const MeshTopology& inTp, SweepLinePredicates predicates, const EdgeLoops& holes, const SweepLineParams& params );
 
     size_t vertSize() const { return tp_.vertSize(); }
     std::optional<Mesh> run( IntersectionsMap* interMap = nullptr );
@@ -321,6 +326,7 @@ private:
 // INITIALIZATION CLASS BLOCK
     // make base mesh only containing input contours as edge loops
     void initMeshByContours_( const std::vector<int>& contourSizes );
+    void initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops& loops );
     // merge same points on base mesh
     void mergeSamePoints_( const HolesVertIds* holesVertId );
     void mergeSinglePare_( VertId unique, VertId same );
@@ -452,6 +458,14 @@ SweepLineQueue::SweepLineQueue( SweepLinePredicates predicates, std::vector<int>
 {
     initMeshByContours_( contourSizes );
     mergeSamePoints_( params.holesVertId );
+    setupStartVertices_();
+}
+
+SweepLineQueue::SweepLineQueue( const MeshTopology& inTp, SweepLinePredicates predicates, const EdgeLoops& holes, const SweepLineParams& params ) :
+    predicates_{ std::move( predicates ) },
+    params_{ params }
+{
+    initMeshByLoops_( inTp, holes );
     setupStartVertices_();
 }
 
@@ -639,6 +653,7 @@ Mesh SweepLineQueue::triangulate()
 
 void SweepLineQueue::setupStartVertices_()
 {
+    // TODO: optimize, it seems we can avoid bitset allocation here (at least it can be cached)
     VertBitSet startVertices( tp_.vertSize() );
     BitSetParallelFor( tp_.getValidVerts(), [&] ( VertId v )
     {
@@ -1073,6 +1088,103 @@ void SweepLineQueue::initMeshByContours_( const std::vector<int>& contourSizes )
             tp_.splice( edgePerVert[VertId( firstVert + i )], edgePerVert[VertId( firstVert + ( ( i + int( size ) - 1 ) % size ) )].sym() );
         firstVert += size;
     }
+}
+
+void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops& loops )
+{
+    MR_TIMER;
+    //HashMap<>
+    UndirectedEdgeHashMap in2p; // TODO: can be cached
+    WholeEdgeMap p2inCache; // TODO: can be cached
+    WholeEdgeMap& p2in = params_.outPatchMap ? *params_.outPatchMap : p2inCache;
+
+    auto addNewEdge = [&] ( EdgeId inE, int cId, int pId )
+    {
+        EdgeId inFE, newPE;
+        UndirectedEdgeId pFE;
+        for ( auto ne : orgRing( inTp, inE ) )
+        {
+            auto it = in2p.find( ne.undirected() );
+            if ( it == in2p.end() )
+                continue;
+            inFE = ne;
+            pFE = it->second;
+            break;
+        }
+        if ( inFE == inE )
+        {
+            // this edge was already added
+            auto existingInE = p2in[pFE];
+            auto pE = existingInE == inFE ? EdgeId( pFE ) : EdgeId( pFE ).sym();
+            auto& wind = windingInfo_[pE].windingModifier;
+            predicates_.less( tp_.org( pE ), tp_.dest( pE ) ) ? ++wind : --wind;
+        }
+        else if ( inFE )
+        {
+            // another ring edge is added but not ours
+            auto existingInE = p2in[pFE];
+            auto pRE = existingInE == inFE ? EdgeId( pFE ) : EdgeId( pFE ).sym();
+            newPE = tp_.makeEdge();
+            tp_.splice( tp_.prev( pRE ), newPE );
+        }
+        else
+        {
+            // no ring edges at all
+            VertId v = tp_.addVertId();
+            predicates_.addInputPoint( v, cId, pId );
+            newPE = tp_.makeEdge();
+            tp_.setOrg( newPE, v );
+        }
+        if ( newPE )
+        {
+            in2p[inE.undirected()] = newPE.undirected();
+            p2in.autoResizeSet( newPE.undirected(), inE );
+            EdgeId inSE;
+            UndirectedEdgeId pSE;
+            for ( auto de : orgRing0( inTp, inE.sym() ) )
+            {
+                auto it = in2p.find( de.undirected() );
+                if ( it == in2p.end() )
+                    continue;
+                inSE = de;
+                pSE = it->second;
+                break;
+            }
+            if ( inSE )
+            {
+                auto existingInE = p2in[pSE];
+                auto pe = existingInE == inSE ? EdgeId( pSE ) : EdgeId( pSE ).sym();
+                tp_.splice( tp_.prev( pe ), newPE.sym() );
+            }
+            else
+            {
+                VertId v = tp_.addVertId();
+                // `pId + 1` can never reach `size` because loops are closed and we will always be in previous "if" block
+                predicates_.addInputPoint( v, cId, pId + 1 );
+                tp_.setOrg( newPE.sym(), v );
+            }
+            auto& wind = windingInfo_.autoResizeAt( newPE ).windingModifier;
+            wind = predicates_.less( tp_.org( newPE ), tp_.dest( newPE ) ) ? 1 : -1;
+        }
+    };
+
+
+    for ( int loopId = 0; loopId < int( loops.size() ); ++loopId )
+    {
+        const auto& loop = loops[loopId];
+        if ( loop.size() < 3 )
+            continue;
+        for ( int lId = 0; lId < loop.size(); ++lId )
+            addNewEdge( loop[lId], loopId, lId );
+    }
+
+    sortedVerts_.reserve( tp_.vertSize() );
+    for ( int i = 0; i < tp_.vertSize(); ++i )
+        sortedVerts_.emplace_back( VertId( i ) );
+    tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r )
+    {
+        return predicates_.less( l, r );
+    } );
 }
 
 void SweepLineQueue::mergeSamePoints_( const HolesVertIds* holesVertId )

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -118,10 +118,8 @@ MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& co
  * combinatorics run on the dominant-axis projection of \p normal; output vertices keep the exact mesh coordinates
  * (no projection round-trip), and loops sharing a mesh vertex are merged by identity.
  * @param loops one closed EdgeLoop per contour (as produced by trackRightBoundaryLoop on each hole edge)
- * @param outPatchMap optional output: for every boundary edge of the patch (by undirected id) the mesh
- *        edge it copies, directed along the patch edge; patch edges past its size are the triangulation's
- *        own. Lets a caller anchor on mesh edges without matching boundary paths. Not produced when
- *        \p outBoundaries is requested (that path rebuilds the patch from contours instead of copying)
+ * @param outPatchMap optional output: for each patch boundary edge (by undirected id) the mesh edge it copies,
+ *        directed along it; edges past its size are the triangulation's own. Not produced with \p outBoundaries
  * @return std::nullopt if the loops self-intersect, otherwise the patch mesh
  */
 MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, std::vector<EdgePath>* outBoundaries = nullptr, WholeEdgeMap* outPatchMap = nullptr );

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -118,9 +118,13 @@ MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& co
  * combinatorics run on the dominant-axis projection of \p normal; output vertices keep the exact mesh coordinates
  * (no projection round-trip), and loops sharing a mesh vertex are merged by identity.
  * @param loops one closed EdgeLoop per contour (as produced by trackRightBoundaryLoop on each hole edge)
+ * @param outPatchMap optional output: for every boundary edge of the patch (by undirected id) the mesh
+ *        edge it copies, directed along the patch edge; patch edges past its size are the triangulation's
+ *        own. Lets a caller anchor on mesh edges without matching boundary paths. Not produced when
+ *        \p outBoundaries is requested (that path rebuilds the patch from contours instead of copying)
  * @return std::nullopt if the loops self-intersect, otherwise the patch mesh
  */
-MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, std::vector<EdgePath>* outBoundaries = nullptr );
+MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, std::vector<EdgePath>* outBoundaries = nullptr, WholeEdgeMap* outPatchMap = nullptr );
 
 }
 }

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -245,8 +245,7 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
     if ( minEdgeLenSq < 1e-12f * loopBox.size().lengthSq() )
         return unexpected( "Hole boundary has a degenerate edge" );
 
-    // patch boundary edge (by undirected id) -> the mesh edge it copies; the peel below anchors on
-    // mesh edges through it, so no boundary paths and no positional alignment are needed
+    // patch boundary edge (by undirected id) -> the mesh edge it copies; the peel anchors through it
     WholeEdgeMap bd2mesh;
     auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f( sumCross.normalized() ), nullptr, &bd2mesh );
     if ( !patch )
@@ -258,15 +257,13 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
     if ( res.numTris == 1 )
         return res;
 
-    // the copy guarantees one patch boundary edge per loop position, faces on its left and the void
-    // on its right - except a degenerate (zero area) hole, which SoS can fill on the wrong side
+    // faces must lie on the left of the boundary; a degenerate (zero area) hole can be filled on the wrong side
     if ( pTp.right( EdgeId( 0 ) ) )
         return unexpected( "Incorrect filling" );
 
     const int n = int( loops.front().size() );
     assert( n > 3 );
-    // interior patch edges the plan must create: of the 3 * numTris face sides, each boundary edge
-    // covers one and each interior edge two
+    // interior edges: of the 3 * numTris face sides, each boundary edge covers one and each interior edge two
     const int numChords = ( 3 * res.numTris - int( bd2mesh.size() ) ) / 2;
 
     // the peel's current polygon: one slot per boundary edge, the rings implicit in succ
@@ -278,11 +275,9 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
     };
     std::vector<Slot> slots;
     slots.reserve( n );
-    // seed the polygon from the patch boundary itself: EdgeId( 0 ) is the first boundary edge the
-    // copy created, so for a plain loop the slots repeat the loop order (and the plan its old form).
-    // Turn::Leftmost keeps the walk in the same region corner at a pinch vertex, reproducing the
-    // input loop's own pairing there; the default tight-right turn would pair the arrival with the
-    // other cavity's exit, seeding rings that do not bound the peel's sub-polygons
+    // EdgeId( 0 ) is the first boundary edge the copy created, so a plain loop yields the loop order.
+    // Turn::Leftmost keeps the walk in the same region corner at a pinch vertex (the input loop's own
+    // pairing); the default tight-right turn would pair the arrival with the other cavity's exit
     auto walkRing = [&]( EdgeId b0, UndirectedEdgeBitSet* visited )
     {
         const int first = int( slots.size() );

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -12,6 +12,8 @@
 #include "MRColor.h"
 #include "MRMeshFillHole.h"
 #include "MRBox.h"
+#include "MRMapEdge.h"
+#include "MRBitSet.h"
 #include <cfloat>
 
 namespace MR
@@ -243,58 +245,111 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
     if ( minEdgeLenSq < 1e-12f * loopBox.size().lengthSq() )
         return unexpected( "Hole boundary has a degenerate edge" );
 
-    std::vector<EdgePath> newPaths;
-    auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f( sumCross.normalized() ), &newPaths );
+    // patch boundary edge (by undirected id) -> the mesh edge it copies; the peel below anchors on
+    // mesh edges through it, so no boundary paths and no positional alignment are needed
+    WholeEdgeMap bd2mesh;
+    auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f( sumCross.normalized() ), nullptr, &bd2mesh );
     if ( !patch )
         return unexpected( "Cannot triangulate contours with self-intersections" );
 
-    if ( auto v = validateAndFixPatch( patch->topology, loops, newPaths ); !v )
-        return unexpected( std::move( v.error() ) );
-
     const auto& pTp = patch->topology;
-    const auto& ip = loops.front();
-    auto& np = newPaths.front();
     HoleFillPlan res;
     res.numTris = pTp.numValidFaces();
     if ( res.numTris == 1 )
         return res;
-    auto size = int( np.size() );
-    assert( size > 3 );
-    res.items.reserve( size - 3 );
 
-    for ( ;;)
+    // the copy guarantees one patch boundary edge per loop position, faces on its left and the void
+    // on its right - except a degenerate (zero area) hole, which SoS can fill on the wrong side
+    if ( pTp.right( EdgeId( 0 ) ) )
+        return unexpected( "Incorrect filling" );
+
+    const int n = int( loops.front().size() );
+    assert( n > 3 );
+    // interior patch edges the plan must create: of the 3 * numTris face sides, each boundary edge
+    // covers one and each interior edge two
+    const int numChords = ( 3 * res.numTris - int( bd2mesh.size() ) ) / 2;
+
+    // the peel's current polygon: one slot per boundary edge, the rings implicit in succ
+    struct Slot
     {
-        for ( int i0 = 0; i0 < np.size(); ++i0 )
+        EdgeId cur;   // current polygon edge in the patch, invalid = consumed position
+        int refCode;  // plan code of cur: not-negative absolute mesh EdgeId, negative - earlier plan edge
+        int succ;     // next slot around the polygon
+    };
+    std::vector<Slot> slots;
+    slots.reserve( n );
+    // seed the polygon from the patch boundary itself: EdgeId( 0 ) is the first boundary edge the
+    // copy created, so for a plain loop the slots repeat the loop order (and the plan its old form).
+    // Turn::Leftmost keeps the walk in the same region corner at a pinch vertex, reproducing the
+    // input loop's own pairing there; the default tight-right turn would pair the arrival with the
+    // other cavity's exit, seeding rings that do not bound the peel's sub-polygons
+    auto walkRing = [&]( EdgeId b0, UndirectedEdgeBitSet* visited )
+    {
+        const int first = int( slots.size() );
+        EdgeId b = b0;
+        do
         {
-            auto e0 = np[i0];
-            if ( !e0 )
-                continue; // skip unused/encoded 
-            auto i1 = int( pTp.dest( np[i0] ) );
-            if ( i1 < 0 )
-                return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
-            auto e1 = np[i1];
-            if ( !e1 )
-                return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
-            auto ne = pTp.next( e0 );
-            auto dest = pTp.dest( ne );
-            if ( dest != pTp.dest( e1 ) )
+            if ( int( slots.size() ) >= n )
+                return false;
+            if ( visited )
+                visited->set( b.undirected() );
+            slots.push_back( { b, int( mapEdge( bd2mesh, b ) ), int( slots.size() ) + 1 } );
+            b = pTp.nextLeftBd( b, nullptr, Turn::Leftmost );
+        } while ( b != b0 );
+        slots.back().succ = first;
+        return true;
+    };
+    if ( !walkRing( EdgeId( 0 ), nullptr ) )
+        return unexpected( "Incorrect filling" );
+    if ( int( slots.size() ) != n )
+    {
+        // a pinched hole: the boundary is several rings sharing vertices; reseed recording visits
+        slots.clear();
+        UndirectedEdgeBitSet visited( bd2mesh.size() );
+        for ( UndirectedEdgeId ue{ 0 }; ue < bd2mesh.size(); ++ue )
+        {
+            if ( visited.test( ue ) )
                 continue;
-            FillHoleItem fhi;
-            int i01 = ( i0 + 1 ) % size;
-            fhi.edgeCode1 = i1 == i01 ? ip[i0] : int( np[i01] );
-            i1 = dest;
-            e1 = np[i1];
-            if ( !e1 )
+            const EdgeId b{ ue };
+            const bool bdFwd = !pTp.right( b ), bdBack = !pTp.left( b );
+            if ( bdFwd == bdBack ) // an edge the hole boundary traverses twice: no face side to seed from
                 return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
-            int i11 = ( i1 + 1 ) % size;
-            fhi.edgeCode2 = ( pTp.dest( e1 ) == i11 ) ? ip[i1] : int( np[i11] );
-            res.items.push_back( std::move( fhi ) );
-            if ( res.items.size() == size - 3 )
-                return res;
-            np[i0] = ne;
-            np[i01] = EdgeId( FillHoleItemEdge{ .item = int( res.items.size() ) - 1 }.encode() ); // encode the just pushed plan edge in free slot
+            if ( !walkRing( bdFwd ? b : b.sym(), &visited ) )
+                return unexpected( "Incorrect filling" );
         }
+        if ( int( slots.size() ) != n )
+            return unexpected( "Incorrect filling" );
     }
+
+    res.items.reserve( numChords );
+    while ( int( res.items.size() ) < numChords )
+    {
+        bool progress = false;
+        for ( int s0 = 0; s0 < int( slots.size() ) && int( res.items.size() ) < numChords; ++s0 )
+        {
+            if ( !slots[s0].cur )
+                continue; // consumed position
+            const int s1 = slots[s0].succ;
+            const int s2 = slots[s1].succ;
+            if ( slots[s2].succ == s0 )
+                continue; // triangle ring: its last face needs no new edge
+            const EdgeId ne = pTp.next( slots[s0].cur );
+            if ( pTp.dest( ne ) != pTp.dest( slots[s1].cur ) )
+                continue; // left face of cur[s0] is not an ear here
+            if ( ne.undirected() < bd2mesh.size() )
+                slots[s0] = { ne, int( mapEdge( bd2mesh, ne ) ), s2 }; // pinched ring: the closing edge exists in the mesh
+            else
+            {
+                res.items.push_back( { slots[s0].refCode, slots[s2].refCode } );
+                slots[s0] = { ne, FillHoleItemEdge{ .item = int( res.items.size() ) - 1 }.encode(), s2 };
+            }
+            slots[s1].cur = {};
+            progress = true;
+        }
+        if ( !progress )
+            return unexpected( "Incorrect filling" ); // most likely due to ties in input contour
+    }
+    return res;
 }
 
 Expected<void> fillPlanarHole( ObjectMeshData& data, std::vector<EdgeLoop>& holeContours )

--- a/source/MRTest/MRFillContours2DTests.cpp
+++ b/source/MRTest/MRFillContours2DTests.cpp
@@ -4,6 +4,9 @@
 #include <MRMesh/MRMakeSphereMesh.h>
 #include <MRMesh/MRMeshTrimWithPlane.h>
 #include <MRMesh/MRPlane3.h>
+#include <MRMesh/MRRegionBoundary.h>
+#include <MRMesh/MRMeshFillHole.h>
+#include <MRMesh/MRMeshFixer.h>
 #include <gtest/gtest.h>
 #include <limits>
 
@@ -57,6 +60,55 @@ TEST( MRMesh, fillContours2DTiltedPlane )
     // the current fill emits slivers, and the exact triangulation is not a stable invariant to guard.
     for ( FaceId f = firstNewFace; f <= mesh.topology.lastValidFace(); ++f )
         EXPECT_GT( dot( mesh.normal( f ), -normal ), 0.99f );
+}
+
+// A pinched hole: an island triangle touches the cavity's outer arc at one vertex, so the hole
+// boundary is a single 8-edge loop passing through that vertex twice (a pinched annulus). The old
+// positional peel identified peel positions with patch vertex ids, so the repeated vertex made it
+// fail with "Incorrect filling" and the caller fell back on the metric fill; the boundary-seeded
+// peel plans and fills it.
+TEST( MRMesh, fillContours2DPlanPinchedHole )
+{
+    VertCoords points;
+    points.vec_ = {
+        { 0.f, 0.f, 0.f },                                                     // the pinch vertex
+        { 1.2f, -0.4f, 0.f }, { 1.5f, 0.9f, 0.f }, { 0.2f, 1.6f, 0.f }, { -1.1f, 0.9f, 0.f }, // outer arc
+        { 0.7f, 0.3f, 0.f }, { 0.1f, 0.75f, 0.f },                             // island touching the pinch
+        { 1.9f, -1.4f, 0.f }, { 2.8f, 1.5f, 0.f }, { 0.3f, 2.8f, 0.f },        // outer pentagon
+        { -2.6f, 0.6f, 0.f }, { -1.2f, -1.7f, 0.f }
+    }; // generic position: no two boundary directions at the pinch are collinear (ties are SoS-fragile)
+    const Triangulation t{
+        { VertId( 0 ), VertId( 5 ), VertId( 6 ) },   // the island
+        { VertId( 0 ), VertId( 4 ), VertId( 10 ) }, { VertId( 0 ), VertId( 10 ), VertId( 11 ) },
+        { VertId( 0 ), VertId( 11 ), VertId( 7 ) }, { VertId( 0 ), VertId( 7 ), VertId( 1 ) },
+        { VertId( 1 ), VertId( 7 ), VertId( 2 ) }, { VertId( 2 ), VertId( 7 ), VertId( 8 ) },
+        { VertId( 2 ), VertId( 8 ), VertId( 3 ) }, { VertId( 3 ), VertId( 8 ), VertId( 9 ) },
+        { VertId( 3 ), VertId( 9 ), VertId( 4 ) }, { VertId( 4 ), VertId( 9 ), VertId( 10 ) } };
+    Mesh mesh = Mesh::fromTriangles( points, t );
+    ASSERT_EQ( mesh.topology.numValidFaces(), 11 );
+
+    // two holes: the outer pentagon outline and the pinched cavity; the cavity is the 8-edge one
+    EdgeId holeEdge;
+    for ( EdgeId e : mesh.topology.findHoleRepresentiveEdges() )
+        if ( trackRightBoundaryLoop( mesh.topology, e ).size() == 8 )
+            holeEdge = e;
+    ASSERT_TRUE( holeEdge.valid() );
+    const EdgeLoop loop = trackRightBoundaryLoop( mesh.topology, holeEdge );
+    int pinchVisits = 0;
+    for ( EdgeId e : loop )
+        if ( mesh.topology.org( e ) == VertId( 0 ) )
+            ++pinchVisits;
+    ASSERT_EQ( pinchVisits, 2 );
+
+    auto plan = fillContours2DPlan( mesh, holeEdge );
+    ASSERT_TRUE( plan.has_value() ) << plan.error();
+    EXPECT_EQ( plan->numTris, 6 ); // the pinched 8-gon fills like a disk: n - 2 triangles
+    EXPECT_EQ( plan->items.size(), size_t( 5 ) ); // and n - 3 chords
+    executeHoleFillPlan( mesh, holeEdge, *plan );
+    EXPECT_EQ( mesh.topology.numValidFaces(), 17 );
+    EXPECT_EQ( mesh.topology.findHoleRepresentiveEdges().size(), size_t( 1 ) ); // the pentagon outline remains
+    auto multiples = findMultipleEdges( mesh.topology );
+    EXPECT_TRUE( multiples.has_value() && multiples->empty() );
 }
 
 }

--- a/source/MRTest/MRFillContours2DTests.cpp
+++ b/source/MRTest/MRFillContours2DTests.cpp
@@ -62,11 +62,8 @@ TEST( MRMesh, fillContours2DTiltedPlane )
         EXPECT_GT( dot( mesh.normal( f ), -normal ), 0.99f );
 }
 
-// A pinched hole: an island triangle touches the cavity's outer arc at one vertex, so the hole
-// boundary is a single 8-edge loop passing through that vertex twice (a pinched annulus). The old
-// positional peel identified peel positions with patch vertex ids, so the repeated vertex made it
-// fail with "Incorrect filling" and the caller fell back on the metric fill; the boundary-seeded
-// peel plans and fills it.
+// A pinched hole: an island triangle touches the cavity's outer arc at one vertex, so the hole boundary
+// is a single 8-edge loop passing through that vertex twice
 TEST( MRMesh, fillContours2DPlanPinchedHole )
 {
     VertCoords points;


### PR DESCRIPTION
## What

`PlanarTriangulation::triangulateDisjointContours( const Mesh&, const EdgeLoops&, ... )` now builds the sweep mesh by copying the hole-boundary sub-topology straight out of the input mesh (`initMeshByLoops_`) instead of rebuilding it from contours and re-welding same-position vertices. `fillContours2DPlan` consumes the result through a patch→mesh edge map and peels the plan off the patch boundary, with no positional path alignment.

One logical step per commit:
1. 518028768 — `initMeshByLoops_`: incremental copy of the hole loops. Shared vertices arrive shared, doubly-traversed edges (slits) accumulate their winding modifier per traversal; `sortedVerts_` filled and sorted at the end.
2. d091dacb5 — the mesh-space `point()` predicate resolves through the patch→input edge map at call time (`(const MeshTopology&, VertId)`), replacing the separate vertex map; the map (`SweepLineParams::outPatchMap`) becomes the only id bridge.
3. 383bd7223 — `fillContours2DPlan` seeds a boundary ear peel through the map (new `outPatchMap` parameter on the mesh overload). Pinched holes (one loop passing a vertex twice) now plan and fill — gtest added; the old positional `for(;;)` rescan (a known hang class) is replaced by a guarded walk.
4. 09e483582 — upfront reserves + winding by default: single-traversal edges keep the sentinel, `calculateWinding_`'s default parity rule computes the same value the deleted per-edge writes stored.
5. 01f116bc7 — fresh-dest carry: when an edge's dest vertex is created fresh, the next loop edge's org-ring search has a forced result and is skipped; backtracking spikes are filtered back to the full search.

## Why

Prerequisite for cutMesh filling all holes of one removed face in a single swept run: those loops share vertices at contact points and whole edges (slits) where a chord splits the face — positional welding cannot represent that identity, copying preserves it. Supersedes #6579 (same goal, rebuilt on the incremental hash-based copy).

## Verification

- Differential test over ~5.6k generated hole cases vs the old path: every case where both paths succeed produces an identical executed triangle set. All divergences audited: old-path hangs and pinch failures now fill or error cleanly; the handful of new rejections are degenerate holes the old path under-filled, and the caller falls back to the metric fill for those. No regressions.
- End-to-end boolean digest (rotating spheres, 200 frames): byte-identical to master, including a face-order-sensitive hash.
- MRTest suite passes, including the new pinched-hole test.
- Perf, interleaved in-process A/B vs the contour-rebuild path (medians over 15 rounds, idle machine): 4000 small holes −11.8% (15/15 pairwise, ranges disjoint); single big trim loops (188–1508 edges) −1..−4% (12–15/15).

## Follow-ups (separate PRs)

1. Migrate `fillContours2D` itself onto the mesh overload (removes the plane-projection round-trip and the positional point snap-back).
2. Delete the then-unused `HolesVertIds` machinery and `outBoundaries` parameters.
3. cutMesh joint per-old-face hole fill on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
