### PR TITLE
Fix 2D triangulation of contours with collinear and coincident points

### DIFF
--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -120,8 +120,8 @@ static SweepLinePredicates precisePredicates( const Contours2f& contours )
     };
     p.addIntersectionPoint = [pts] ( VertId v, VertId a, VertId b, VertId c, VertId d )
     {
-        const PreciseVertCoords2 vs[4] = { { a, ( *pts )[a] }, { b, ( *pts )[b] }, { c, ( *pts )[c] }, { d, ( *pts )[d] } };
-        pts->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( vs ) );
+        pts->autoResizeSet( v, findSegmentSegmentIntersectionPrecise(
+            { PreciseVertCoords2{ a, ( *pts )[a] }, { b, ( *pts )[b] }, { c, ( *pts )[c] }, { d, ( *pts )[d] } } ) );
     };
     p.point = [pts, toFloat] ( const MeshTopology&, VertId v )
     {
@@ -180,8 +180,8 @@ static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoop
     };
     p.addIntersectionPoint = [pts2] ( VertId v, VertId a, VertId b, VertId c, VertId d )
     {
-        const PreciseVertCoords2 vs[4] = { { a, ( *pts2 )[a] }, { b, ( *pts2 )[b] }, { c, ( *pts2 )[c] }, { d, ( *pts2 )[d] } };
-        pts2->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( vs ) );
+        pts2->autoResizeSet( v, findSegmentSegmentIntersectionPrecise(
+            { PreciseVertCoords2{ a, ( *pts2 )[a] }, { b, ( *pts2 )[b] }, { c, ( *pts2 )[c] }, { d, ( *pts2 )[d] } } ) );
     };
     // every output vertex lies on a copied input edge (disjoint triangulation adds no intersection
     // vertices), so find one in its org ring, skipping the triangulation's own diagonals

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -120,7 +120,8 @@ static SweepLinePredicates precisePredicates( const Contours2f& contours )
     };
     p.addIntersectionPoint = [pts] ( VertId v, VertId a, VertId b, VertId c, VertId d )
     {
-        pts->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( ( *pts )[a], ( *pts )[b], ( *pts )[c], ( *pts )[d] ) );
+        const PreciseVertCoords2 vs[4] = { { a, ( *pts )[a] }, { b, ( *pts )[b] }, { c, ( *pts )[c] }, { d, ( *pts )[d] } };
+        pts->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( vs ) );
     };
     p.point = [pts, toFloat] ( const MeshTopology&, VertId v )
     {
@@ -179,7 +180,8 @@ static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoop
     };
     p.addIntersectionPoint = [pts2] ( VertId v, VertId a, VertId b, VertId c, VertId d )
     {
-        pts2->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( ( *pts2 )[a], ( *pts2 )[b], ( *pts2 )[c], ( *pts2 )[d] ) );
+        const PreciseVertCoords2 vs[4] = { { a, ( *pts2 )[a] }, { b, ( *pts2 )[b] }, { c, ( *pts2 )[c] }, { d, ( *pts2 )[d] } };
+        pts2->autoResizeSet( v, findSegmentSegmentIntersectionPrecise( vs ) );
     };
     // every output vertex lies on a copied input edge (disjoint triangulation adds no intersection
     // vertices), so find one in its org ring, skipping the triangulation's own diagonals
@@ -1331,6 +1333,8 @@ void SweepLineQueue::mergeSinglePare_( VertId unique, VertId same )
         {
             findClosestCache_.emplace_back( eUnique );
         }
+        if ( findClosestCache_.size() == 1 )
+            return; // unique - lost all edges during merges
         auto minEUnique = findClosestCache_[findClosestToFront( tp_, predicates_, findClosestCache_, false )];
         auto prev = tp_.prev( eSame );
         if ( prev != eSame )
@@ -1368,6 +1372,23 @@ void SweepLineQueue::mergeSinglePare_( VertId unique, VertId same )
                 tp_.splice( tp_.prev( minEUnique.sym() ), minEUnique.sym() );
                 tp_.setOrg( minEUnique, VertId{} );
                 tp_.setOrg( minEUnique.sym(), VertId{} );
+            }
+        }
+        else
+        {
+            // seating eSame here renamed its origin from `same` to `unique`; ids break exact
+            // coordinate ties in ccw, so the angular slot of eSame.sym() in its own origin ring
+            // can change with the rename - re-seat it to keep that ring in sweep order too
+            auto vFar = tp_.dest( eSame );
+            auto eFar = eSame.sym();
+            if ( auto p = tp_.prev( eFar ); vFar != unique && p != eFar )
+            {
+                tp_.splice( p, eFar ); // take eFar out (its org record clears automatically)
+                findClosestCache_.clear();
+                findClosestCache_.push_back( eFar );
+                for ( auto e : orgRing( tp_, vFar ) )
+                    findClosestCache_.emplace_back( e );
+                tp_.splice( findClosestCache_[findClosestToFront( tp_, predicates_, findClosestCache_, false )], eFar );
             }
         }
     }

--- a/source/MRMesh/MRPrecisePredicates2.cpp
+++ b/source/MRMesh/MRPrecisePredicates2.cpp
@@ -413,7 +413,7 @@ Vector2i findSegmentSegmentIntersectionPrecise(
     return Vector2i( divRound( Vector2i64( ab.min ) + Vector2i64( ab.max ), std::int64_t( 2 ) ) );
 }
 
-Vector2i findSegmentSegmentIntersectionPrecise( const PreciseVertCoords2* vs )
+Vector2i findSegmentSegmentIntersectionPrecise( const std::array<PreciseVertCoords2, 4> & vs )
 {
     const auto& ai = vs[0].pt;
     const auto& bi = vs[1].pt;

--- a/source/MRMesh/MRPrecisePredicates2.cpp
+++ b/source/MRMesh/MRPrecisePredicates2.cpp
@@ -4,6 +4,7 @@
 #include "MRPrecisePredicates3.h"
 #include "MRSparsePolynomial.h"
 #include "MRDivRound.h"
+#include "MRBox.h"
 
 namespace MR
 {
@@ -386,6 +387,13 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords2, 6> & vs )
     return res;
 }
 
+// intersection of segments (a,b) and (c,d) from the doubled areas abc = |area(a,b,c)| and
+// abd = |area(a,b,d)|, which must not be both zero
+static Vector2i intersectionByAreas( const Vector2i& ci, const Vector2i& di, std::int64_t abc, std::int64_t abd )
+{
+    return Vector2i( divRound( FastInt128( abc ) * Vector2i128fast( di ) + FastInt128( abd ) * Vector2i128fast( ci ), FastInt128( abc + abd ) ) );
+}
+
 Vector2i findSegmentSegmentIntersectionPrecise(
     const Vector2i& ai, const Vector2i& bi, const Vector2i& ci, const Vector2i& di )
 {
@@ -395,19 +403,40 @@ Vector2i findSegmentSegmentIntersectionPrecise(
     auto abd = cross( Vector2i64( ai - di ), Vector2i64( bi - di ) );
     if ( abd < 0 )
         abd = -abd;
-    const auto sum = abc + abd;
-    if ( sum != 0 )
-        return Vector2i( divRound( FastInt128( abc ) * Vector2i128fast( di ) + FastInt128( abd ) * Vector2i128fast( ci ), FastInt128( sum ) ) );
+    if ( abc + abd != 0 )
+        return intersectionByAreas( ci, di, abc, abd );
 
-    // degenerate case
-    auto adLSq = Vector2i64( di - ai ).lengthSq();
-    auto bcLSq = Vector2i64( bi - ci ).lengthSq();
-    if ( adLSq > bcLSq )
-        return ci;
-    else if ( bcLSq > adLSq )
-        return di;
-    else
-        return Vector2i( divRound( Vector2i64( ai ) + Vector2i64( bi ) + Vector2i64( ci ) + Vector2i64( di ), std::int64_t( 2 ) ) );
+    Box2i ab, cd;
+    ab.include( ai ); ab.include( bi );
+    cd.include( ci ); cd.include( di );
+    ab.intersect( cd );
+    return Vector2i( divRound( Vector2i64( ab.min ) + Vector2i64( ab.max ), std::int64_t( 2 ) ) );
+}
+
+Vector2i findSegmentSegmentIntersectionPrecise( const PreciseVertCoords2* vs )
+{
+    const auto& ai = vs[0].pt;
+    const auto& bi = vs[1].pt;
+    const auto& ci = vs[2].pt;
+    const auto& di = vs[3].pt;
+    auto abc = cross( Vector2i64( ai - ci ), Vector2i64( bi - ci ) );
+    if ( abc < 0 )
+        abc = -abc;
+    auto abd = cross( Vector2i64( ai - di ), Vector2i64( bi - di ) );
+    if ( abd < 0 )
+        abd = -abd;
+    if ( abc + abd != 0 )
+        return intersectionByAreas( ci, di, abc, abd );
+
+    // all four points lie on one line: simulation-of-simplicity lifts every point off the line
+    // by an amount steeply decreasing with the vertex id, so the two perturbed segments cross
+    // right next to the far end of the segment holding the smallest id; returning that end keeps
+    // the intersection on the same side of every other vertex as ccw reports
+    int m = 0;
+    for ( int i = 1; i < 4; ++i )
+        if ( vs[i].id < vs[m].id )
+            m = i;
+    return vs[m ^ 1].pt; // the other end of the segment of vs[m]
 }
 
 Vector2f findSegmentSegmentIntersectionPrecise(

--- a/source/MRMesh/MRPrecisePredicates2.h
+++ b/source/MRMesh/MRPrecisePredicates2.h
@@ -94,6 +94,11 @@ struct CoordinateConverters2
 [[nodiscard]] MRMESH_API Vector2i findSegmentSegmentIntersectionPrecise(
     const Vector2i& a, const Vector2i& b, const Vector2i& c, const Vector2i& d );
 
+/// same for segments (vs[0],vs[1]) and (vs[2],vs[3]); when all four points lie on one line,
+/// uses vertex ids to select the intersection position consistent with the simulation-of-simplicity
+/// answers of ccw about every other vertex
+[[nodiscard]] MRMESH_API Vector2i findSegmentSegmentIntersectionPrecise( const PreciseVertCoords2* vs );
+
 /// finds intersection precise, using high precision int inside
 /// this function input should have intersection
 [[nodiscard]] MRMESH_API Vector2f findSegmentSegmentIntersectionPrecise(

--- a/source/MRMesh/MRPrecisePredicates2.h
+++ b/source/MRMesh/MRPrecisePredicates2.h
@@ -94,10 +94,11 @@ struct CoordinateConverters2
 [[nodiscard]] MRMESH_API Vector2i findSegmentSegmentIntersectionPrecise(
     const Vector2i& a, const Vector2i& b, const Vector2i& c, const Vector2i& d );
 
-/// same for segments (vs[0],vs[1]) and (vs[2],vs[3]); when all four points lie on one line,
+/// same for segments AB (indices 01) and CD (indices 23); when all four points lie on one line,
 /// uses vertex ids to select the intersection position consistent with the simulation-of-simplicity
 /// answers of ccw about every other vertex
-[[nodiscard]] MRMESH_API Vector2i findSegmentSegmentIntersectionPrecise( const PreciseVertCoords2* vs );
+[[nodiscard]] MRMESH_API Vector2i findSegmentSegmentIntersectionPrecise(
+    const std::array<PreciseVertCoords2, 4> & vs );
 
 /// finds intersection precise, using high precision int inside
 /// this function input should have intersection

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -277,9 +277,7 @@ TEST( MRMesh, PlanarTriangulationPinchedMonotoneBlock2 )
     EXPECT_GT( mesh.topology.numValidFaces(), 0 );
 }
 
-// TODO: still fails - the merge orders the ring of a merged vertex by ids that later merges
-// rename, so the sweep line ends up in a state the predicates never produce
-TEST( MRMesh, DISABLED_PlanarTriangulationChainedActiveEdges )
+TEST( MRMesh, PlanarTriangulationChainedActiveEdges )
 {
     // four points on one line with two coincident pairs: (-15,-1) and (-10,-1) each appear twice
     Contour2f cont = {
@@ -289,6 +287,42 @@ TEST( MRMesh, DISABLED_PlanarTriangulationChainedActiveEdges )
     cont.push_back( cont.front() );
     Mesh mesh = PlanarTriangulation::triangulateContours( { cont } );
     EXPECT_GT( mesh.topology.numValidFaces(), 0 );
+}
+
+TEST( MRMesh, PlanarTriangulationChainedActiveEdges2 )
+{
+    // four points on y=0 walked back and forth, plus two points above
+    Contour2f cont = {
+        { 14, 0 }, { 7, 0 }, { 15, 0 }, { 14, 3 }, { 18, 4 }, { 13, 0 }
+    };
+    cont.push_back( cont.front() );
+    Mesh mesh = PlanarTriangulation::triangulateContours( { cont } );
+    EXPECT_GT( mesh.topology.numValidFaces(), 0 );
+}
+
+TEST( MRMesh, PlanarTriangulationMergeSameCascade2 )
+{
+    // one segment traversed back and forth three times: the merge cascade folds all three
+    // traversals into nothing
+    Contour2f cont = {
+        { 11, -12 }, { 7, -7 }, { 11, -12 }, { 7, -7 }, { 11, -12 }, { 7, -7 }
+    };
+    cont.push_back( cont.front() );
+    Mesh mesh = PlanarTriangulation::triangulateContours( { cont } );
+    EXPECT_EQ( mesh.topology.numValidFaces(), 0 ); // zero-area input: survive and produce nothing
+}
+
+TEST( MRMesh, PlanarTriangulationChainedActiveEdges3 )
+{
+    // six points on one line walked back and forth, ( 0.4, 0 ) visited twice; zero area;
+    // keep the float literals exact - the repro is sensitive to the float->int quantization
+    Contour2f cont = {
+        { 0.800000012f, 0.f }, { 0.400000006f, 0.f }, { 0.5f, 0.f },
+        { 0.349999994f, 0.f }, { 0.600000024f, 0.f }, { 0.400000006f, 0.f }
+    };
+    cont.push_back( cont.front() );
+    Mesh mesh = PlanarTriangulation::triangulateContours( { cont } );
+    EXPECT_GE( mesh.topology.numValidFaces(), 0 ); // completing without the assert is the test
 }
 
 namespace


### PR DESCRIPTION
Fixes the remaining sweep-line crashes on degenerate quantized contours (duplicate-id `ccw` asserts and an out-of-bounds read in the merge), follow-up to #6585:

* `mergeSinglePare_` re-seats the far end of every re-homed edge: ids break exact coordinate ties in the predicates, so a later merge renaming a vertex could leave a ring in an order the sweep never expects;
* `mergeSinglePare_` bails out when the target vertex has lost all its edges during a merge cascade (out-of-bounds read in `findClosestToFront`);
* new id-aware `findSegmentSegmentIntersectionPrecise( const PreciseVertCoords2* )`: for fully collinear overlapping segments the returned point follows the simulation-of-simplicity perturbation (the far end of the segment holding the smallest id), which keeps it on the correct side of every other vertex; the id-less overload keeps a symmetric overlap-midpoint fallback;
* regression tests `PlanarTriangulationChainedActiveEdges2`, `PlanarTriangulationChainedActiveEdges3`, `PlanarTriangulationMergeSameCascade2` added, `PlanarTriangulationChainedActiveEdges` enabled.

Verified: MRTest 355/355; the 720-case quantized-star corpus behind this crash family goes from 20 failing cases to 0 with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
