### PR TITLE
Add MR::bit_cast, usable without std::bit_cast

### DIFF
--- a/source/MRMesh/MRBitCast.h
+++ b/source/MRMesh/MRBitCast.h
@@ -9,8 +9,7 @@
 namespace MR
 {
 
-/// reinterprets the bits of (from) as a value of type To, which must be of the same size;
-/// std::bit_cast where the standard library provides it, and the intrinsic behind it otherwise
+/// std::bit_cast wrapper with the compiler's intrinsic fallback
 template <typename To, typename From>
 [[nodiscard]] constexpr To bit_cast( const From& from ) noexcept
 {

--- a/source/MRMesh/MRBitCast.h
+++ b/source/MRMesh/MRBitCast.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <version>
+
+#if __cpp_lib_bit_cast >= 201806L
+#include <bit>
+#endif
+
+namespace MR
+{
+
+/// reinterprets the bits of (from) as a value of type To, which must be of the same size;
+/// std::bit_cast where the standard library provides it, and the intrinsic behind it otherwise
+template <typename To, typename From>
+[[nodiscard]] constexpr To bit_cast( const From& from ) noexcept
+{
+#if __cpp_lib_bit_cast >= 201806L
+    return std::bit_cast<To>( from );
+#else
+    return __builtin_bit_cast( To, from );
+#endif
+}
+
+} //namespace MR

--- a/source/MRMesh/MRFastInt.cpp
+++ b/source/MRMesh/MRFastInt.cpp
@@ -20,7 +20,7 @@ constexpr int cMaxDoubleExp = 1023;
 [[nodiscard]] inline double exp2i( int e ) noexcept
 {
     assert( e >= -1022 && e <= cMaxDoubleExp );
-    return std::bit_cast<double>( std::uint64_t( e + cMaxDoubleExp ) << 52 );
+    return __builtin_bit_cast( double, std::uint64_t( e + cMaxDoubleExp ) << 52 );
 }
 
 } // anonymous namespace

--- a/source/MRMesh/MRFastInt.cpp
+++ b/source/MRMesh/MRFastInt.cpp
@@ -21,7 +21,7 @@ constexpr int cMaxDoubleExp = 1023;
 [[nodiscard]] inline double exp2i( int e ) noexcept
 {
     assert( e >= -1022 && e <= cMaxDoubleExp );
-    return MR::bit_cast<double>( std::uint64_t( e + cMaxDoubleExp ) << 52 );
+    return bit_cast<double>( std::uint64_t( e + cMaxDoubleExp ) << 52 );
 }
 
 } // anonymous namespace

--- a/source/MRMesh/MRFastInt.cpp
+++ b/source/MRMesh/MRFastInt.cpp
@@ -1,4 +1,5 @@
 #include "MRFastInt.h"
+#include "MRBitCast.h"
 #include <bit>
 #include <cassert>
 
@@ -20,7 +21,7 @@ constexpr int cMaxDoubleExp = 1023;
 [[nodiscard]] inline double exp2i( int e ) noexcept
 {
     assert( e >= -1022 && e <= cMaxDoubleExp );
-    return __builtin_bit_cast( double, std::uint64_t( e + cMaxDoubleExp ) << 52 );
+    return MR::bit_cast<double>( std::uint64_t( e + cMaxDoubleExp ) << 52 );
 }
 
 } // anonymous namespace

--- a/source/MRMesh/MRIsNaN.h
+++ b/source/MRMesh/MRIsNaN.h
@@ -7,12 +7,12 @@ namespace MR
 {
 
 constexpr float cQuietNan = std::numeric_limits<float>::quiet_NaN();
-constexpr int cQuietNanBits = MR::bit_cast<int>( cQuietNan );
+constexpr int cQuietNanBits = bit_cast<int>( cQuietNan );
 
 /// quickly tests whether given float is not-a-number
 inline bool isNanFast( float f )
 {
-    return MR::bit_cast<int>( f ) == cQuietNanBits;
+    return bit_cast<int>( f ) == cQuietNanBits;
 }
 
 } //namespace MR

--- a/source/MRMesh/MRIsNaN.h
+++ b/source/MRMesh/MRIsNaN.h
@@ -2,28 +2,16 @@
 
 #include <limits>
 
-#if __cpp_lib_bit_cast >= 201806L
-#include <bit>
-#else
-#include <cmath>
-#endif
-
 namespace MR
 {
 
 constexpr float cQuietNan = std::numeric_limits<float>::quiet_NaN();
-#if __cpp_lib_bit_cast >= 201806L
-constexpr int cQuietNanBits = std::bit_cast< int >( cQuietNan );
-#endif
+constexpr int cQuietNanBits = __builtin_bit_cast( int, cQuietNan );
 
 /// quickly tests whether given float is not-a-number
 inline bool isNanFast( float f )
 {
-#if __cpp_lib_bit_cast >= 201806L
-    return std::bit_cast< int >( f ) == cQuietNanBits;
-#else
-    return std::isnan( f );
-#endif
+    return __builtin_bit_cast( int, f ) == cQuietNanBits;
 }
 
 } //namespace MR

--- a/source/MRMesh/MRIsNaN.h
+++ b/source/MRMesh/MRIsNaN.h
@@ -1,17 +1,18 @@
 #pragma once
 
+#include "MRBitCast.h"
 #include <limits>
 
 namespace MR
 {
 
 constexpr float cQuietNan = std::numeric_limits<float>::quiet_NaN();
-constexpr int cQuietNanBits = __builtin_bit_cast( int, cQuietNan );
+constexpr int cQuietNanBits = MR::bit_cast<int>( cQuietNan );
 
 /// quickly tests whether given float is not-a-number
 inline bool isNanFast( float f )
 {
-    return __builtin_bit_cast( int, f ) == cQuietNanBits;
+    return MR::bit_cast<int>( f ) == cQuietNanBits;
 }
 
 } //namespace MR

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ClInclude Include="MRAlignContoursToMesh.h" />
     <ClInclude Include="MRAlphaShape.h" />
+    <ClInclude Include="MRBitCast.h" />
     <ClInclude Include="MRBoxNesting.h" />
     <ClInclude Include="MRCurve.h" />
     <ClInclude Include="MRDivRound.h" />

--- a/source/MRMesh/MRMesh.vcxproj.filters
+++ b/source/MRMesh/MRMesh.vcxproj.filters
@@ -1332,6 +1332,9 @@
     <ClInclude Include="MRTripleFaceIntersections.h">
       <Filter>Source Files\Contours</Filter>
     </ClInclude>
+    <ClInclude Include="MRBitCast.h">
+      <Filter>Source Files\Basic</Filter>
+    </ClInclude>
     <ClInclude Include="MRFastInt128.h">
       <Filter>Source Files\Math</Filter>
     </ClInclude>

--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -155,13 +155,7 @@ Expected<TriMesh> loadBinaryStlAsTriMesh( std::istream& in, const MeshLoadSettin
         // floats in Vector3f must be 4-bytes aligned on some platforms, so we use chars and cast them in Vector3f on access
         Vector3f vertex( int i ) const
         {
-        #if __cpp_lib_bit_cast >= 201806L
-            return std::bit_cast<Vector3f>( coords[i] );
-        #else
-            Vector3f v;
-            std::memcpy( &v, &coords[i], sizeof( coords[i] ) );
-            return v;
-        #endif
+            return __builtin_bit_cast( Vector3f, coords[i] );
         }
     };
     static_assert( sizeof( StlTriangle ) == 50 );

--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -1,4 +1,5 @@
 #include "MRMeshLoad.h"
+#include "MRBitCast.h"
 #include "MRMeshBuilder.h"
 #include "MRIdentifyVertices.h"
 #include "MRMesh.h"
@@ -155,7 +156,7 @@ Expected<TriMesh> loadBinaryStlAsTriMesh( std::istream& in, const MeshLoadSettin
         // floats in Vector3f must be 4-bytes aligned on some platforms, so we use chars and cast them in Vector3f on access
         Vector3f vertex( int i ) const
         {
-            return __builtin_bit_cast( Vector3f, coords[i] );
+            return MR::bit_cast<Vector3f>( coords[i] );
         }
     };
     static_assert( sizeof( StlTriangle ) == 50 );

--- a/source/MRMesh/MRMeshLoad.cpp
+++ b/source/MRMesh/MRMeshLoad.cpp
@@ -26,7 +26,6 @@
 #include "MRString.h"
 
 #include <array>
-#include <bit>
 #include <future>
 #include <sstream>
 #include <fstream>


### PR DESCRIPTION
`exp2i` in `MRFastInt.cpp` uses `std::bit_cast`, which is not available in every libc++ MeshLib is built against. It breaks the MeshInspectorCode macOS x64 build, where brew clang 22 is pointed at the Xcode 14.2 SDK's libc++ (`-nostdinc++ -isystem .../MacOSX.sdk/usr/include/c++/v1`):

```
MeshLib/source/MRMesh/MRFastInt.cpp:23:17: error: no member named 'bit_cast' in namespace 'std'; did you mean 'bad_cast'?
   23 |     return std::bit_cast<double>( std::uint64_t( e + cMaxDoubleExp ) << 52 );
      |                 ^~~~~~~~
MeshLib/source/MRMesh/MRFastInt.cpp:23:32: error: expected '(' for function-style cast or type construction
2 errors generated.
```

`<bit>` is included; that libc++ simply predates the `bit_cast` wrapper. `MRIsNaN.h` and `MRMeshLoad.cpp` already knew about the gap, and each carried its own `#if __cpp_lib_bit_cast >= 201806L` with a different fallback.

New `MRBitCast.h` holds that choice once:

```cpp
template <typename To, typename From>
[[nodiscard]] constexpr To bit_cast( const From& from ) noexcept
{
#if __cpp_lib_bit_cast >= 201806L
    return std::bit_cast<To>( from );
#else
    return __builtin_bit_cast( To, from );
#endif
}
```

`std::bit_cast` forwards to `__builtin_bit_cast` anyway, so the fallback is the same operation without the library wrapper, and it is available in clang 9+, GCC 11+ and MSVC 19.26+ (VS 2019 16.6) — all far below what `-std=c++23` already requires. The header includes `<version>` before testing the feature macro, so the test is not at the mercy of what some other header happened to pull in.

All three call sites now use `MR::bit_cast`, and the `#if` is gone from everywhere else. Both fallbacks go with it: `isNanFast` no longer degrades to `std::isnan`, and binary STL vertex reading no longer degrades to `std::memcpy` — a bit-cast is what both wanted on every platform.

Checked on Godbolt, with both branches of the `#if` forced, that the whole set — the `constexpr` NaN bit pattern, the `std::array<char, 12>` -> `Vector3f` cast and `exp2i` — compiles clean under `-Wall -Wextra -Werror -pedantic-errors` on GCC 12/14/15, clang 16/20 and MSVC latest. The generated code is byte-identical between the two branches, so nothing about this is a pessimisation on the standard path.

Incidental: `MRMeshLoad.cpp` never included `<cstring>` for the `std::memcpy` in its fallback branch, so that branch depended on a transitive include to compile at all. `MRIsNaN.h` no longer needs `<bit>` or `<cmath>` directly. `MRFastInt.cpp` keeps `<bit>` for `std::countl_zero`, which that old libc++ does provide.

MeshLib's own CI cannot reproduce the original failure: `build-test-macos.yml` compiles on `macos-15-intel` and `macos-14`, both with a recent SDK. `macos-12-intel` appears there only as an install/test target. The failing compile is in the downstream MeshInspectorCode build.
