### PR TITLE
CI: Fix .pot auto update workflow

### DIFF
--- a/.github/workflows/pot-auto-update.yml
+++ b/.github/workflows/pot-auto-update.yml
@@ -53,8 +53,14 @@ jobs:
       - name: Check for changes
         id: check-diff
         run: |
-          # ignore auto-updated timestamp, ignore source line comments
-          pot_diff () { git diff --unified=0 --ignore-matching-lines="POT-Creation-Date.*" --ignore-matching-lines="#: .*" locale/*.pot ; }
+          # ignore auto-updated timestamp, ignore source line comments, ignore format flags
+          pot_diff () {
+            git diff --unified=0 \
+              --ignore-matching-lines="POT-Creation-Date.*" \
+              --ignore-matching-lines="^#: .*" \
+              --ignore-matching-lines="^#, (c-format|no-c-format|c\+\+-format)$" \
+              locale/*.pot
+          }
           pot_diff
           if [ -n "$(pot_diff)" ] ; then
             echo "need_update=true" >> $GITHUB_OUTPUT
@@ -79,6 +85,7 @@ jobs:
           GH_TOKEN: ${{ secrets.MESHINSPECTOR_BOT_VCPKG_UPDATE_TOKEN }} # TODO: replace token?
         run: |
           gh pr create --title "Auto CI: Update translation templates" \
+                       --body "Templates regenerated from source." \
                        --base master \
                        --head $GIT_BRANCH_NAME \
                        --reviewer oitel,Grantim


### PR DESCRIPTION
`gh pr create` has been failing since the workflow's first scheduled run: with `--title` given but no `--body`, gh refuses to proceed non-interactively.

```
must provide `--title` and `--body` (or `--fill` or `fill-first` or `--fillverbose`) when not running interactively
```

`continue-on-error: true` on that step — present so that a run against an already-open pull request is not an error — hid the failure, so every run still reported success.

The push had already succeeded by that point, which compounded the effect: from the next day on `auto-ci/update_pot_files` already contained the regenerated templates, so `pot_diff` came back empty, `need_update` was `false`, and the run reverted and did nothing. The pending update (`Project-Id-Version`, the `PACKAGE` -> `MeshLib` license line, two new messages) sat on a branch with no pull request for two weeks.

Changes:
* pass `--body` to `gh pr create`;
* ignore `#, c-format` / `#, no-c-format` / `#, c++-format` lines in the change check as well, and anchor the `#: ` pattern at the line start, so that flag-only regeneration noise does not open a pull request.

The stale `auto-ci/update_pot_files` branch is gone, so the next run starts it from master and actually opens the pull request. Had the branch survived, this fix alone would not have been enough: the change check would have kept reporting `need_update=false`.
