### PR TITLE
Store SparsePolynomial terms in a sorted vector instead of std::map

### DIFF
--- a/source/MRMesh/MRSparsePolynomial.h
+++ b/source/MRMesh/MRSparsePolynomial.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include <map>
+#include <algorithm>
+#include <cassert>
+#include <utility>
+#include <vector>
 
 namespace MR
 {
@@ -10,7 +13,8 @@ class SparsePolynomial;
 template <typename C, typename D, D M>
 SparsePolynomial<C,D,M> operator *( const SparsePolynomial<C,D,M>& a, const SparsePolynomial<C,D,M>& b );
 
-/// The class to store a polynomial with a large number of zero coefficient (only non-zeros are stored in std::map)
+/// The class to store a polynomial with a large number of zero coefficients
+/// (only non-zeros are stored in a vector of terms sorted by ascending degree)
 /// \tparam C - type of coefficients
 /// \tparam D - type of degrees
 /// \tparam M - maximum degree to store in the polynomial
@@ -19,11 +23,15 @@ class SparsePolynomial
 {
     static_assert( M > 0 );
 public:
+    /// a not-zero coefficient with its degree
+    using Term = std::pair<D, C>;
+
     /// constructs zero polynomial
     SparsePolynomial() = default;
 
-    /// takes existing coefficients in ownership
-    SparsePolynomial( std::map<D, C> && );
+    /// takes existing terms in ownership, which must be sorted by ascending degree
+    /// with not-zero coefficients and no repeating degrees
+    SparsePolynomial( std::vector<Term> && );
 
     /// constructs polynomial c0 + c1*x^d1
     SparsePolynomial( C c0, D d1, C c1 );
@@ -32,33 +40,45 @@ public:
     SparsePolynomial( C c0, D d1, C c1, D d2, C c2 );
 
     /// sets coefficient for given degree to zero
-    void setZeroCoeff( D d ) { map_.erase( d ); }
+    void setZeroCoeff( D d )
+    {
+        auto it = std::lower_bound( terms_.begin(), terms_.end(), d,
+            []( const Term & t, D d ) { return t.first < d; } );
+        if ( it != terms_.end() && it->first == d )
+            terms_.erase( it );
+    }
 
     /// returns true if no single polynomial coefficient is defined
-    [[nodiscard]] bool empty() const { return map_.empty(); }
+    [[nodiscard]] bool empty() const { return terms_.empty(); }
 
     /// returns true if the coefficient for the smallest not-zero degress is positive
     [[nodiscard]] bool isPositive() const;
 
     /// gets read-only access to all not-zero coefficients
-    [[nodiscard]] const std::map<D, C> & get() const { return map_; }
+    [[nodiscard]] const std::vector<Term> & get() const { return terms_; }
 
     SparsePolynomial& operator +=( const SparsePolynomial& b );
     SparsePolynomial& operator -=( const SparsePolynomial& b );
+    [[nodiscard]] friend SparsePolynomial operator +( SparsePolynomial a, const SparsePolynomial& b ) { a += b; return a; }
+    [[nodiscard]] friend SparsePolynomial operator -( SparsePolynomial a, const SparsePolynomial& b ) { a -= b; return a; }
     friend SparsePolynomial operator *<>( const SparsePolynomial& a, const SparsePolynomial& b );
 
 private:
-    std::map<D, C> map_; // degree -> not-zero coefficient
+    /// merges the terms of a degree-sorted sequence, dropping the vanished ones
+    void mergeTerms_();
+
+    std::vector<Term> terms_; // sorted by ascending degree
 };
 
 template <typename C, typename D, D M>
-SparsePolynomial<C,D,M>::SparsePolynomial( std::map<D, C> && m ) : map_( std::move( m ) )
+SparsePolynomial<C,D,M>::SparsePolynomial( std::vector<Term> && terms ) : terms_( std::move( terms ) )
 {
 #ifndef NDEBUG
-    for ( const auto & [deg, cf] : map_ )
+    for ( size_t i = 0; i < terms_.size(); ++i )
     {
-        assert( deg <= M );
-        assert( cf != 0 );
+        assert( terms_[i].first <= M );
+        assert( terms_[i].second != 0 );
+        assert( i == 0 || terms_[i - 1].first < terms_[i].first );
     }
 #endif
 }
@@ -69,9 +89,9 @@ SparsePolynomial<C,D,M>::SparsePolynomial( C c0, D d1, C c1 )
     assert( c1 != 0 );
     assert( d1 != 0 );
     if ( c0 != 0 )
-        map_[D(0)] = c0;
+        terms_.emplace_back( D(0), c0 );
     if ( d1 <= M )
-        map_[d1] = c1;
+        terms_.emplace_back( d1, c1 );
 }
 
 template <typename C, typename D, D M>
@@ -83,87 +103,110 @@ SparsePolynomial<C,D,M>::SparsePolynomial( C c0, D d1, C c1, D d2, C c2 )
     assert( d2 != 0 );
     assert( d1 != d2 );
     if ( c0 != 0 )
-        map_[D(0)] = c0;
+        terms_.emplace_back( D(0), c0 );
+    if ( d1 > d2 )
+    {
+        std::swap( d1, d2 );
+        std::swap( c1, c2 );
+    }
     if ( d1 <= M )
-        map_[d1] = c1;
+        terms_.emplace_back( d1, c1 );
     if ( d2 <= M )
-        map_[d2] = c2;
+        terms_.emplace_back( d2, c2 );
 }
 
 template <typename C, typename D, D M>
 bool SparsePolynomial<C,D,M>::isPositive() const
 {
-    if ( !map_.empty() )
-        return map_.begin()->second > 0;
+    if ( !terms_.empty() )
+        return terms_.front().second > 0;
 
     assert (false);
     return false;
 }
 
 template <typename C, typename D, D M>
+void SparsePolynomial<C,D,M>::mergeTerms_()
+{
+    size_t out = 0;
+    for ( size_t i = 0; i < terms_.size(); )
+    {
+        auto deg = terms_[i].first;
+        auto cf = std::move( terms_[i].second );
+        for ( ++i; i < terms_.size() && terms_[i].first == deg; ++i )
+            cf += terms_[i].second;
+        if ( cf != 0 )
+            terms_[out++] = { deg, std::move( cf ) };
+    }
+    terms_.resize( out );
+}
+
+template <typename C, typename D, D M>
 SparsePolynomial<C,D,M>& SparsePolynomial<C,D,M>::operator +=( const SparsePolynomial& b )
 {
-    for ( const auto & [degB, cfB] : b.map_ )
-    {
-        assert( cfB != 0 );
-        auto [it,inserted] = map_.insert( { degB, cfB } );
-        if ( !inserted )
-        {
-            const auto sum = it->second + cfB;
-            if ( sum != 0 )
-                it->second = sum;
-            else
-                map_.erase( it );
-        }
-    }
+    std::vector<Term> res;
+    res.reserve( terms_.size() + b.terms_.size() );
+    std::merge( std::make_move_iterator( terms_.begin() ), std::make_move_iterator( terms_.end() ),
+        b.terms_.begin(), b.terms_.end(), std::back_inserter( res ),
+        []( const Term & x, const Term & y ) { return x.first < y.first; } );
+    terms_ = std::move( res );
+    mergeTerms_();
     return * this;
 }
 
 template <typename C, typename D, D M>
 SparsePolynomial<C,D,M>& SparsePolynomial<C,D,M>::operator -=( const SparsePolynomial& b )
 {
-    for ( const auto & [degB, cfB] : b.map_ )
+    std::vector<Term> res;
+    res.reserve( terms_.size() + b.terms_.size() );
+    auto itA = terms_.begin();
+    auto itB = b.terms_.begin();
+    while ( itA != terms_.end() && itB != b.terms_.end() )
     {
-        assert( cfB != 0 );
-        auto [it,inserted] = map_.insert( { degB, -cfB } );
-        if ( !inserted )
+        if ( itB->first < itA->first )
         {
-            const auto sum = it->second - cfB;
-            if ( sum != 0 )
-                it->second = sum;
-            else
-                map_.erase( it );
+            res.emplace_back( itB->first, -itB->second );
+            ++itB;
+        }
+        else
+        {
+            res.push_back( std::move( *itA ) );
+            ++itA;
         }
     }
+    for ( ; itA != terms_.end(); ++itA )
+        res.push_back( std::move( *itA ) );
+    for ( ; itB != b.terms_.end(); ++itB )
+        res.emplace_back( itB->first, -itB->second );
+    terms_ = std::move( res );
+    mergeTerms_();
     return * this;
 }
 
 template <typename C, typename D, D M>
 [[nodiscard]] SparsePolynomial<C,D,M> operator *( const SparsePolynomial<C,D,M>& a, const SparsePolynomial<C,D,M>& b )
 {
-    std::map<D,C> resMap;
-    for ( const auto & [degA, cfA] : a.map_ )
+    using Term = typename SparsePolynomial<C,D,M>::Term;
+    std::vector<Term> res;
+    res.reserve( a.terms_.size() * b.terms_.size() );
+    for ( const auto & [degA, cfA] : a.terms_ )
     {
         assert( cfA != 0 );
-        for ( const auto & [degB, cfB] : b.map_ )
+        for ( const auto & [degB, cfB] : b.terms_ )
         {
             assert( cfB != 0 );
             const auto deg = degA + degB;
             if ( deg > M )
                 break;
-            const auto cf = cfA * cfB;
-            auto [it,inserted] = resMap.insert( { deg, cf } );
-            if ( !inserted )
-            {
-                const auto sum = it->second + cf;
-                if ( sum != 0 )
-                    it->second = sum;
-                else
-                    resMap.erase( it );
-            }
+            res.emplace_back( deg, cfA * cfB );
         }
     }
-    return resMap;
+    std::sort( res.begin(), res.end(),
+        []( const Term & x, const Term & y ) { return x.first < y.first; } );
+    SparsePolynomial<C,D,M> r;
+    r.terms_ = std::move( res );
+    r.mergeTerms_();
+    return r;
 }
 
 } //namespace MR


### PR DESCRIPTION
## Summary

`SparsePolynomial` keeps its public interface, but the terms now live in one contiguous `std::vector<std::pair<D, C>>` sorted by ascending degree instead of a `std::map<D, C>`:

- `+=` / `-=` are linear merges of two sorted sequences;
- `*` collects all the pair products below the degree cap `M` (the ascending inner loop keeps the early `deg > M` break) and sorts them once, then merges equal degrees;
- `isPositive()` reads `front()`; `setZeroCoeff()` is a binary search;
- the 3-term constructor sorts its two degrees, and the take-ownership constructor accepts a pre-sorted term vector (checked by debug asserts) instead of a `std::map`;
- the binary `+` / `-` operators, which the class lacked, are added.

## Performance

Measured on the documented worst case of the precise predicates — `segmentIntersectionOrder` with all points sharing one position and only ids distinct (the configuration that defined `cMaxPolyD`), best of 5 runs, identical results:

| | `std::map` | sorted vector |
|---|---|---|
| 3D order (8 points) | 2.38 us/call | 1.92 us/call |
| 2D order (6 points) | 0.48 us/call | 0.39 us/call |

The coefficients of the predicates are trivially copyable `FastInt128`, so the container overhead dominates there and the contiguous storage wins about 19%. These ties fire on regular/degenerate inputs of mesh booleans, so the win is on a real path.

## Motivation

Split out of #6600, where the full simulation-of-simplicity inSphere evaluation reuses `SparsePolynomial` with `VarBigInt` coefficients; this rework benefits the existing predicates on master independently of that PR.
