### PR TITLE
Merge coincident points in the alpha-shape search

### DIFF
--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -187,11 +187,45 @@ void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v, const Alpha
     myStats.collectedNeis += neis.size();
 
     // the ball emptiness test below stops on the first point inside the ball,
-    // and the points closest to #v have the best chance to be there
+    // and the points closest to #v have the best chance to be there;
+    // the ordering by id makes the deduplication below keep the smallest id of a position
     std::sort( neis.begin(), neis.end(), []( const AlphaShapeNei & a, const AlphaShapeNei & b )
     {
-        return a.distSq < b.distSq;
+        return a.distSq < b.distSq || ( a.distSq == b.distSq && a.coords.id < b.coords.id );
     } );
+
+    // points sharing one position in the integer grid are merged: only the one with the smallest id
+    // participates in the search, so that the triangles found around all the points use the same
+    // representative of each position and together form a surface without cracks
+    for ( const auto & n : neis )
+    {
+        if ( n.coords.pt != p0.pt )
+            break; // the twins of #v have zero distance, so they are first after the sort
+        if ( n.coords.id < v )
+        {
+            // all the triangles of #v are made by this twin instead of it
+            neis.clear();
+            if ( stats )
+                *stats += myStats;
+            return;
+        }
+    }
+    size_t uniqueSize = 0;
+    for ( size_t i = 0; i < neis.size(); ++i )
+    {
+        if ( neis[i].coords.pt == p0.pt )
+            continue; // a twin of #v with a larger id
+        bool dup = false;
+        for ( size_t j = uniqueSize; j > 0 && neis[j - 1].distSq == neis[i].distSq; --j )
+            if ( neis[j - 1].coords.pt == neis[i].coords.pt )
+            {
+                dup = true;
+                break;
+            }
+        if ( !dup )
+            neis[uniqueSize++] = neis[i];
+    }
+    neis.resize( uniqueSize );
 
     // a neighbor p makes a farther neighbor x redundant if p is strictly inside every ball of the given
     // radius through #v having x inside or on it: then x can neither make a triangle with #v (p blocks

--- a/source/MRMesh/MRAlphaShape.h
+++ b/source/MRMesh/MRAlphaShape.h
@@ -111,11 +111,14 @@ struct AlphaShapeNei
 };
 
 /// finds all triangles of alpha-shape with negative alpha = -1/radius,
-/// where each triangle contains point #v and two other points
+/// where each triangle contains point #v and two other points;
+/// the valid points sharing one position in the integer grid are merged: only the point with
+/// the smallest id among them appears in the triangles (in particular, #v itself gets no
+/// triangles if it has such a twin), so the triangles found around all the points agree
 MRMESH_API void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v,
     const AlphaShapeData & data, ///< prepared by getAlphaShapeData for the same cloud and the same radius
     Triangulation & appendTris,  ///< found triangles will be appended here
-    std::vector<AlphaShapeNei> & neis, ///< temporary storage to avoid memory allocations, it will be filled with the neighbours of point #v within data.searchRadius sorted by distance, except the ones redundant for the search
+    std::vector<AlphaShapeNei> & neis, ///< temporary storage to avoid memory allocations, it will be filled with the neighbours of point #v within data.searchRadius sorted by distance, except the duplicates and the ones redundant for the search; cleared if #v duplicates a point with a smaller id
     bool onlyLargerVids,         ///< if true then two other points must have larger ids (to avoid finding same triangles several times)
     AlphaShapeStats * stats = nullptr ); ///< optional statistics of the work done, which is increased here
 

--- a/source/MRTest/MRAlphaShapeTests.cpp
+++ b/source/MRTest/MRAlphaShapeTests.cpp
@@ -7,10 +7,52 @@
 #include <chrono>
 #include <cmath>
 #include <iostream>
+#include <map>
 #include <random>
 
 namespace MR
 {
+
+TEST( MRMesh, AlphaShapeDuplicates )
+{
+    // four corners of a cube forming a tetrahedron, with the last one duplicated
+    PointCloud cloud;
+    cloud.points.push_back( {  0.5f,  0.5f, -0.5f } ); //0_v
+    cloud.points.push_back( { -0.5f,  0.5f,  0.5f } ); //1_v
+    cloud.points.push_back( {  0.5f,  0.5f,  0.5f } ); //2_v
+    cloud.points.push_back( {  0.5f, -0.5f,  0.5f } ); //3_v
+    cloud.points.push_back( {  0.5f, -0.5f,  0.5f } ); //4_v
+    cloud.validPoints.resize( cloud.points.size(), true );
+
+    const auto tris = findAlphaShapeAllTriangles( cloud, 1 );
+    EXPECT_EQ( tris.size(), 4 );
+
+    // the duplicated position is merged: only its smallest id appears in the triangles,
+    // and the tetrahedron surface is closed - every directed edge is balanced by its opposite
+    std::map<std::pair<VertId, VertId>, int> edges;
+    for ( const auto & t : tris )
+        for ( int i = 0; i < 3; ++i )
+        {
+            EXPECT_NE( t[i], 4_v );
+            ++edges[ { t[i], t[( i + 1 ) % 3] } ];
+        }
+    for ( const auto & [e, n] : edges )
+    {
+        auto it = edges.find( { e.second, e.first } );
+        EXPECT_EQ( n, it == edges.end() ? 0 : it->second );
+    }
+
+    // the duplicate point with the larger id gets no triangles of its own
+    Triangulation vTris;
+    std::vector<AlphaShapeNei> neis;
+    auto data = getAlphaShapeData( cloud, 1, false );
+    findAlphaShapeNeiTriangles( cloud, 4_v, data, vTris, neis, false );
+    EXPECT_TRUE( vTris.empty() );
+    EXPECT_TRUE( neis.empty() );
+    findAlphaShapeNeiTriangles( cloud, 3_v, data, vTris, neis, false );
+    EXPECT_EQ( vTris.size(), 3 );
+    EXPECT_EQ( neis.size(), 3 );
+}
 
 TEST( MRMesh, AlphaShape )
 {


### PR DESCRIPTION
## Problem

On a cloud with exactly duplicated points the alpha-shape surface comes out cracked. A duplicate of one of the three ball points lies exactly on every ball through its twin, and this on-sphere tie is resolved into Inside or Outside by the vertex ids (simulation-of-simplicity) independently for each triangle — so each triangle picks whichever twin its ids favor, and the found surface references both twins with no shared edge between such triangles.

Reproduced on master with a tetrahedron of four cube corners where one corner is given twice (`0.5 -0.5 0.5` as both `3_v` and `4_v`), radius 1:

```
tri 0 1 2 / tri 0 2 4 / tri 0 4 1 / tri 1 3 2
boundary edges: 1-3, 1-4, 2-3, 2-4
```

Geometrically closed, but topologically cracked: two faces use `4_v`, one uses `3_v`.

## Fix

`findAlphaShapeNeiTriangles` merges the valid points sharing one position in the integer grid: the neighbours are sorted by (distance, id) and deduplicated per position, neighbours coincident with `#v` are dropped, and if `#v` itself duplicates a smaller id it gets no triangles at all. Only the smallest id of each position makes triangles and blocks balls, so the triangles found around all the points agree:

```
tri 0 1 2 / tri 0 2 3 / tri 0 3 1 / tri 1 3 2   (closed, only 3_v)
```

The new gtest `MRMesh.AlphaShapeDuplicates` pins the closed tetrahedron, the balanced directed edges, and that the duplicate point gets no triangles of its own.

## Performance

The on-sphere tie resolutions for the twins of the ball points disappear together with the twins, so clouds with duplicates get slightly faster with identical triangle counts: 18820-point cloud with 107 duplicated positions, radii 0.01/0.03/0.1 of the bounding box diagonal — 0.75/19.5/110.4 s vs 0.81/20.2/110.9 s on master, triangle counts 31446/13616/6838 both. Clean clouds pay one extra `FastInt128` comparison per collected neighbour.

## Note

Split out of #6600, where this fix first appeared: it repairs a defect that exists on master independently of the full simulation-of-simplicity work, so it can land first.
