### PR TITLE
PlaneWidget: import plane object in world coordinates

### DIFF
--- a/source/MRViewer/MRPlaneWidget.cpp
+++ b/source/MRViewer/MRPlaneWidget.cpp
@@ -254,7 +254,9 @@ bool PlaneWidget::importPlaneObj_( Object& obj )
     if ( !planeObj )
         return false;
 
-    plane_ = Plane3f::fromDirAndPt( planeObj->getNormal(), planeObj->getCenter() );
+    // the object's normal and center are in the parent's space, while the widget's plane is in the world space
+    const auto parentXf = planeObj->parent() ? planeObj->parent()->worldXf() : AffineXf3f();
+    plane_ = transformed( Plane3f::fromDirAndPt( planeObj->getNormal(), planeObj->getCenter() ), parentXf );
     definePlane();
     updatePlane( plane_ );
     setLocalMode( true );

--- a/source/MRViewer/MRPlaneWidget.cpp
+++ b/source/MRViewer/MRPlaneWidget.cpp
@@ -254,9 +254,10 @@ bool PlaneWidget::importPlaneObj_( Object& obj )
     if ( !planeObj )
         return false;
 
+    plane_ = Plane3f::fromDirAndPt( planeObj->getNormal(), planeObj->getCenter() );
     // the object's normal and center are in the parent's space, while the widget's plane is in the world space
-    const auto parentXf = planeObj->parent() ? planeObj->parent()->worldXf() : AffineXf3f();
-    plane_ = transformed( Plane3f::fromDirAndPt( planeObj->getNormal(), planeObj->getCenter() ), parentXf );
+    if ( planeObj->parent() )
+        plane_ = transformed( plane_, planeObj->parent()->worldXf() );
     definePlane();
     updatePlane( plane_ );
     setLocalMode( true );


### PR DESCRIPTION
### Problem

"Import Plane" in the Section tool (and in every other user of `PlaneWidget`, e.g. Mirror) places the plane in a wrong position if the imported `PlaneObject` is a child of an object with a non-identity transformation. The section is then made far away from the mesh, and with "Clip Objects" enabled nothing is clipped at all.

This is easy to hit: a plane created by Best Fit becomes a child of the picked object, so any scan that carries a transformation (alignment, orientation, a scene loaded from a session) reproduces it.

### Cause

`PlaneObject::getNormal()` and `PlaneObject::getCenter()` return the object's own `xf()` components, i.e. they are expressed in the parent's space. The plane of `PlaneWidget` is in the world space: its `planeObj_` is a child of the scene root, and consumers apply `invTransformed( getPlane(), obj->worldXf() )` to it.

### Fix

Transform the imported plane by the world transformation of the plane object's parent.

### Testing

Add a mesh with a non-identity transformation, create a plane feature on it (Best Fit), then Section -> Import Plane: before this change the section plane is offset by the mesh transformation, after it the section is taken exactly at the plane.

CI is limited to Ubuntu x64; the change was compiled locally with MSVC as well.
