### PR TITLE
Support LLVM_PREFIX to select the macOS LLVM keg by full path

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -66,13 +66,11 @@ jobs:
             compiler: brew-llvm22
             # Use a specific PGO+LTO-optimized LLVM version.
             # Held in place by `brew pin llvm` on the self-hosted runners.
-            llvm-version: 22.1.7
+            llvm-prefix-template: BREW_PREFIX/Cellar/llvm/22.1.7
             cxx-compiler-template: BREW_PREFIX/Cellar/llvm/22.1.7/bin/clang++
             c-compiler-template: BREW_PREFIX/Cellar/llvm/22.1.7/bin/clang
             runner: [ self-hosted, macos, arm64, build ] #  any macos version
             instance: self-hosted-arm
-    env:
-      LLVM_VERSION: ${{ matrix.llvm-version }}
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
@@ -83,6 +81,13 @@ jobs:
 
       - name: macOS Diagnostics
         uses: ./.github/actions/macos-diagnostics
+
+      # LLVM_PREFIX selects the LLVM keg for the build and the mrbind scripts;
+      # resolved per machine since the self-hosted label set spans runners
+      # with different homebrew prefixes.
+      - name: Resolve LLVM prefix
+        if: ${{ matrix.llvm-prefix-template }}
+        run: echo "LLVM_PREFIX=$(echo '${{ matrix.llvm-prefix-template }}' | sed "s|BREW_PREFIX|$(brew --prefix)|")" >> $GITHUB_ENV
 
       - name: Checkout third-party submodules
         run: |
@@ -127,7 +132,7 @@ jobs:
           # Shared with pip-build.yml's macOS section where the two also match.
           cache-key-prefix: ${{ matrix.instance }}-clang
           build-script: scripts/mrbind/install_mrbind_macos.sh
-          extra-cache-key: ${{ matrix.llvm-version }}${{ hashFiles('scripts/mrbind/clang_version_macos.txt') }}-${{ steps.thirdparty.outputs.brew-hash }}
+          extra-cache-key: ${{ matrix.llvm-prefix-template }}${{ hashFiles('scripts/mrbind/clang_version_macos.txt') }}-${{ steps.thirdparty.outputs.brew-hash }}
 
       - name: Create virtualenv
         run: |
@@ -177,8 +182,8 @@ jobs:
 
       - name: MRMesh Exported Symbols
         run: |
-          if [[ -n "${LLVM_VERSION:-}" ]]; then
-            export PATH="$(brew --prefix)/Cellar/llvm/$LLVM_VERSION/bin:$PATH"
+          if [[ -n "${LLVM_PREFIX:-}" ]]; then
+            export PATH="$LLVM_PREFIX/bin:$PATH"
           else
             export PATH="$(brew --prefix llvm@22)/bin:$PATH"
           fi

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -245,9 +245,9 @@ MACOS_MIN_VER :=
 ifneq ($(HOST_IS_WINDOWS),)
 CXX_FOR_BINDINGS := clang++
 else ifneq ($(HOST_IS_MACOS),)
-# LLVM_VERSION selects an exact version (used for self-hosted runners).
-ifneq ($(LLVM_VERSION),)
-CXX_FOR_BINDINGS := $(HOMEBREW_DIR)/Cellar/llvm/$(LLVM_VERSION)/bin/clang++
+# LLVM_PREFIX selects a keg by full path (used for self-hosted runners).
+ifneq ($(LLVM_PREFIX),)
+CXX_FOR_BINDINGS := $(LLVM_PREFIX)/bin/clang++
 else
 CXX_FOR_BINDINGS := $(HOMEBREW_DIR)/opt/llvm@$(strip $(file <$(makefile_dir)clang_version_macos.txt))/bin/clang++
 endif

--- a/scripts/mrbind/install_deps_macos.sh
+++ b/scripts/mrbind/install_deps_macos.sh
@@ -7,7 +7,7 @@
 brew update
 brew install --quiet make grep lld
 
-if [[ -z "${LLVM_VERSION}" ]] ; then
+if [[ -z "${LLVM_PREFIX}" ]] ; then
   # Read the Clang version from `clang_version_macos.txt`. `xargs` trims the whitespace.
   # Some versions of MacOS seem to lack `realpath`, so not using it here.
   SCRIPT_DIR="$(dirname "$BASH_SOURCE")"

--- a/scripts/mrbind/install_mrbind_macos.sh
+++ b/scripts/mrbind/install_mrbind_macos.sh
@@ -22,8 +22,8 @@ rm -rf build
 # Add `make` to PATH.
 export PATH="$HOMEBREW_DIR/opt/make/libexec/gnubin:$PATH"
 # Add Clang to PATH.
-if [[ -n "${LLVM_VERSION:-}" ]]; then
-    export PATH="$HOMEBREW_DIR/Cellar/llvm/$LLVM_VERSION/bin:$PATH"
+if [[ -n "${LLVM_PREFIX:-}" ]]; then
+    export PATH="$LLVM_PREFIX/bin:$PATH"
 else
     export PATH="$HOMEBREW_DIR/opt/llvm@$CLANG_VER/bin:$PATH"
 fi


### PR DESCRIPTION
Supersedes #6614 (its history got tangled against the no-force-push ruleset while addressing review; content identical). Adds optional `LLVM_PREFIX` support to the macOS mrbind tooling, as the single keg override (per review, `LLVM_VERSION` is removed): `install_deps_macos.sh` skips installing `llvm@N` when it is set, `install_mrbind_macos.sh` / `generate.mk` use `$LLVM_PREFIX/bin`, and the workflow resolves it per machine from a `llvm-prefix-template` matrix key (`BREW_PREFIX/Cellar/llvm/22.1.7` -- no behavior change for this repo's CI). Unset means today's behavior, unchanged.

Motivation: selecting a keg by version only works inside the `Cellar/llvm` rack. A `-O3`+PGO+ThinLTO clang built from a local tap (`brew install --build-bottle` of an `ENV.O3` copy of `llvm.rb`) lives in its own rack -- e.g. `Cellar/llvm-pgo/22.1.8_2` -- and benches ~26% faster than the pinned 22.1.7 keg (real-world app `Build` step: ~-20%). A full-path override is the only way to point mrbind and the binding compilation at it. This is also the `LLVM_PREFIX` shape originally suggested in the #6601 review -- the version-only form turned out to be insufficient once PGO kegs entered the picture.

First consumer is the self-hosted CI config; workflow changes to use it come separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
