### PR TITLE
Use the -O3+PGO+ThinLTO clang 22.1.8_2 keg on the self-hosted arm runners

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -64,11 +64,11 @@ jobs:
           - arch: arm64
             config: Debug
             compiler: brew-llvm22
-            # Use a specific PGO+LTO-optimized LLVM version.
-            # Held in place by `brew pin llvm` on the self-hosted runners.
-            llvm-prefix-template: BREW_PREFIX/Cellar/llvm/22.1.7
-            cxx-compiler-template: BREW_PREFIX/Cellar/llvm/22.1.7/bin/clang++
-            c-compiler-template: BREW_PREFIX/Cellar/llvm/22.1.7/bin/clang
+            # The -O3+PGO+ThinLTO keg, built on each runner via the local/pgo
+            # tap (llvm.rb with ENV.O3, installed with --build-bottle).
+            llvm-prefix-template: BREW_PREFIX/Cellar/llvm-pgo/22.1.8_2
+            cxx-compiler-template: BREW_PREFIX/Cellar/llvm-pgo/22.1.8_2/bin/clang++
+            c-compiler-template: BREW_PREFIX/Cellar/llvm-pgo/22.1.8_2/bin/clang
             runner: [ self-hosted, macos, arm64, build ] #  any macos version
             instance: self-hosted-arm
     permissions:


### PR DESCRIPTION
Switch every build step on the self-hosted macOS Arm runners -- app compile, mrbind build, binding generation/compilation, and `llvm-cxxfilt` -- to the `-O3`+PGO+ThinLTO clang 22.1.8_2 keg (`Cellar/llvm-pgo/22.1.8_2`, built on each runner from a local-tap copy of `llvm.rb` with `ENV.O3`, installed with `--build-bottle` to enable the formula's PGO pipeline). `llvm-prefix-template` resolves the per-machine homebrew prefix, so the single matrix row covers both fleet members.

Why: the PGO keg benches 25-26% faster than the pinned June 22.1.7 keg on both machines (1.13 s vs 1.52/1.50 s, min-of-7 interleaved), and the real-workload validation on the app side showed ~-20% on full Build steps (2:30 -> 2:01 Release, 2:04 -> 1:41 Debug). This PR's own arm Debug run doubles as the validation for this repo.

Notes:

- The mrbind build/bindings caches key on `llvm-prefix-template`, so they re-key and rebuild once against the new keg's libclang.
- GitHub-hosted rows are untouched (AppleClang app compiler, `llvm@N` fallback for mrbind).
- The June 22.1.7 kegs stay on the runners as a known-good fallback: reverting is a one-line template change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
