### PR TITLE
CI: bump the gettext container to fedora:44

### DIFF
--- a/.github/workflows/pot-auto-update.yml
+++ b/.github/workflows/pot-auto-update.yml
@@ -9,7 +9,7 @@ jobs:
   update-pot-files:
     runs-on: ubuntu-latest
     container:
-      image: fedora:43  # gettext 0.25.1
+      image: fedora:44  # gettext 0.26
 
     env:
       GIT_BRANCH_NAME: auto-ci/update_pot_files


### PR DESCRIPTION
`fedora:43` ships gettext 0.25.1, which predates the heuristic fix in gettext 0.26 (July 2025):

> xgettext's heuristic recognition of format strings has been improved: strings like `"100% complete"` (with a space flag in a format directive) are no longer flagged as format strings by default, unless they occur in a context that requires a format string.

Under 0.25.1, a UI string whose literal percent happens to parse as a conversion — `"1% of tolerance"` gives `% o`, i.e. a space flag plus `%o`; `"0% - no expansion"` gives `% - s` — is marked `#, c-format` even though nothing ever formats it. Wherever a `.pot` is then merged into `.po` catalogs, msgmerge re-checks such an entry's translation against the msgid's directives and marks every mismatch fuzzy, which disables the translation; `MeshInspector/MeshInspector-translations#6` was 54 such lines.

This job only regenerates the templates, and its change detection has ignored flag lines since #6612, so the exposure here is mild: a flag flip on its own will not open a pull request, it would only ride along with some unrelated real change. `locale/MeshLib.pot` also has no such false positive today — `" %"` from `MRUnitInfo.cpp:56` is not flagged, since a trailing percent is not a valid directive, and the two `%s` entries are genuine.

The reason to bump is therefore alignment rather than a live bug: CI and local runs currently disagree, so a maintainer on gettext >= 0.26 regenerates a different template than CI does, and the file ping-pongs depending on who ran last. `fedora:43` will never get 0.26 — Fedora does not rebase gettext mid-release.

`fedora:44` ships gettext 0.26. Not rawhide, which is on gettext 1.0 — a larger jump for no benefit here.

### Tested

Dispatched against this branch: [run 32360836345](https://github.com/MeshInspector/MeshLib/actions/runs/32360836345), green in 35s. The container resolved `gettext 0.26-5.fc44`, `gh 2.97.0`, `git 2.55.0`, `python3 3.14.7`; both extraction scripts ran clean on Python 3.14, up from 3.12 on `fedora:43`, which was the least obvious part of this bump. `Check for changes` found no difference, so `Push changes` and `Create pull request` were skipped and no `auto-ci/update_pot_files` branch was created. Note this run cannot distinguish "flags unchanged" from "flags changed but filtered", since the filter hides flag-only diffs.
