### PR TITLE
Do not read the ribbon schema in the python viewer

### DIFF
--- a/source/mrviewerpy/MRPythonViewer.cpp
+++ b/source/mrviewerpy/MRPythonViewer.cpp
@@ -104,6 +104,13 @@ enum class PythonKeyMod
 };
 MR_MAKE_FLAG_OPERATORS( PythonKeyMod )
 
+/// this viewer draws no ribbon, and the libraries owning the ribbon items are not loaded here,
+/// so reading the schema of their items would only warn that every one of them is not registered
+class MinimalRibbonMenu final : public RibbonMenu
+{
+    void readMenuItemsStructure_() override {}
+};
+
 /// viewer setup class for minimal configuration
 /// only loads config file (if available) and configures the scene and mouse controls
 class MinimalViewerSetup final : public ViewerSetup
@@ -111,7 +118,7 @@ class MinimalViewerSetup final : public ViewerSetup
 public:
     void setupBasePlugins( Viewer* viewer ) const override
     {
-        auto menu = std::make_shared<RibbonMenu>();
+        auto menu = std::make_shared<MinimalRibbonMenu>();
         menu->setMenuUIConfig( { .topLayout = RibbonTopPanelLayoutMode::None,.drawScenePanel = false,.drawToolbar = false } ); // no scene tree by default
         viewer->setMenuPlugin( menu );
     }


### PR DESCRIPTION
`mrviewerpy` launches the viewer with `MinimalViewerSetup`, which draws no ribbon (`topLayout = None`, no toolbar, no scene panel) and loads no extended libraries at all - `setupExtendedLibraries()` is overridden with an empty body. Yet `RibbonMenu::init` still calls `readMenuItemsStructure_()`, and `RibbonSchemaLoader::loadSchema()` scans the whole resources directory for `*.items.json`/`*.ui.json`. In a developer or CI layout that directory is the build's `bin/`, where MRCommonPlugins copies its two schema files, so every python viewer launch reads the schema of a library it never loads and then warns about all ~65 items of it:

```
[info] Reading .../build/Release/bin/MRRibbonCommonMenuStructure.items.json
[warning] Ribbon item "Undo" is not registered
[warning] Ribbon item "Open files" is not registered
... 60+ more
```

The new `MinimalRibbonMenu` overrides `readMenuItemsStructure_()` with an empty body, so nothing of the ribbon schema is read: the log stays clean and each launch saves the ~55 ms that pass takes in CI.

It stays a `RibbonMenu` on purpose. A plain `ImGuiMenu` would draw its own "Viewer" window, which `RibbonMenu` suppresses, and would silently disable `mrviewerpy.Viewer.showSceneTree()`, which needs `getMenuPluginAs<RibbonMenu>()` and the ribbon scene panel.
