### PR TITLE
Add duplicateMultiHoleVertices( mesh, maxHoles ) overload

### DIFF
--- a/source/MRMesh/MRMeshFixer.cpp
+++ b/source/MRMesh/MRMeshFixer.cpp
@@ -19,47 +19,43 @@
 namespace MR
 {
 
-// given a vertex, returns two edges with the origin in this vertex consecutive in the vertex ring without left faces both;
-// both edges may be the same if there is only one edge without left face;
-// or both edges can be invalid if all vertex edges have left face
-static EdgePair getTwoSeqNoLeftAtVertex( const MeshTopology & m, VertId a )
+// returns the first edge with the origin in given vertex and without left face
+// if the number of such edges in the vertex ring is larger than given limit, otherwise returns invalid edge
+static EdgeId findNoLeftEdgeAboveLimit( const MeshTopology & m, VertId a, int limit )
 {
     EdgeId e0 = m.edgeWithOrg( a );
     if ( !e0.valid() )
         return {}; //invalid vertex
 
-    // find first hole edge
-    EdgeId eh = e0;
+    EdgeId eh; // first found edge without left face
+    int holes = 0;
+    EdgeId e = e0;
     for (;;)
     {
-        if ( !m.left( eh ).valid() )
-            break;
-        eh = m.next( eh );
-        if ( eh == e0 )
-            return {}; // no single hole near a
-    }
-
-    // find second hole edge
-    for ( EdgeId e = m.next( eh ); e != e0; e = m.next( e ) )
-    {
         if ( !m.left( e ).valid() )
-            return { eh, e }; // another hole near a
+        {
+            if ( !eh.valid() )
+                eh = e;
+            if ( ++holes > limit )
+                return eh;
+        }
+        e = m.next( e );
+        if ( e == e0 )
+            return {};
     }
-
-    return { eh, eh };
 }
 
-int duplicateMultiHoleVertices( Mesh & mesh )
+int duplicateMultiHoleVertices( Mesh & mesh, int maxHoles )
 {
+    assert( maxHoles >= 1 );
     int duplicates = 0;
     const auto lastVert = mesh.topology.lastValidVert();
     for ( VertId v{0}; v <= lastVert; ++v )
     {
-        auto ee = getTwoSeqNoLeftAtVertex( mesh.topology, v );
-        if ( ee.first == ee.second )
+        EdgeId e1 = findNoLeftEdgeAboveLimit( mesh.topology, v, maxHoles );
+        if ( !e1.valid() )
             continue;
 
-        EdgeId e1 = ee.first;
         EdgeId e0 = e1;
         while ( mesh.topology.right( e0 ).valid() )
             e0 = mesh.topology.prev( e0 );
@@ -76,6 +72,11 @@ int duplicateMultiHoleVertices( Mesh & mesh )
     }
 
     return duplicates;
+}
+
+int duplicateMultiHoleVertices( Mesh & mesh )
+{
+    return duplicateMultiHoleVertices( mesh, 1 );
 }
 
 Expected<std::vector<MultipleEdge>> findMultipleEdges( const MeshTopology& topology, ProgressCallback cb )

--- a/source/MRMesh/MRMeshFixer.cpp
+++ b/source/MRMesh/MRMeshFixer.cpp
@@ -47,28 +47,38 @@ static EdgeId findNoLeftEdgeAboveLimit( const MeshTopology & m, VertId a, int li
 
 int duplicateMultiHoleVertices( Mesh & mesh, int maxHoles )
 {
+    MR_TIMER;
     assert( maxHoles >= 1 );
-    int duplicates = 0;
-    const auto lastVert = mesh.topology.lastValidVert();
-    for ( VertId v{0}; v <= lastVert; ++v )
+
+    VertBitSet vertsForDup( mesh.topology.vertSize() );
+    BitSetParallelFor( mesh.topology.getValidVerts(), [&]( VertId v )
     {
-        EdgeId e1 = findNoLeftEdgeAboveLimit( mesh.topology, v, maxHoles );
-        if ( !e1.valid() )
-            continue;
+        if ( findNoLeftEdgeAboveLimit( mesh.topology, v, maxHoles ).valid() )
+            vertsForDup.set( v );
+    } );
 
-        EdgeId e0 = e1;
-        while ( mesh.topology.right( e0 ).valid() )
-            e0 = mesh.topology.prev( e0 );
+    int duplicates = 0;
+    for ( auto v : vertsForDup )
+    {
+        for (;;)
+        {
+            EdgeId e1 = findNoLeftEdgeAboveLimit( mesh.topology, v, maxHoles );
+            if ( !e1.valid() )
+                break;
 
-        // unsplice [e0, e1] and create new vertex for it
-        mesh.topology.splice( mesh.topology.prev( e0 ), e1 );
-        assert( !mesh.topology.org( e0 ).valid() );
+            EdgeId e0 = e1;
+            while ( mesh.topology.right( e0 ).valid() )
+                e0 = mesh.topology.prev( e0 );
 
-        auto vDup = mesh.addPoint( mesh.points[v] );
-        mesh.topology.setOrg( e0, vDup );
+            // unsplice [e0, e1] and create new vertex for it
+            mesh.topology.splice( mesh.topology.prev( e0 ), e1 );
+            assert( !mesh.topology.org( e0 ).valid() );
 
-        ++duplicates;
-        --v;
+            auto vDup = mesh.addPoint( mesh.points[v] );
+            mesh.topology.setOrg( e0, vDup );
+
+            ++duplicates;
+        }
     }
 
     return duplicates;

--- a/source/MRMesh/MRMeshFixer.h
+++ b/source/MRMesh/MRMeshFixer.h
@@ -15,7 +15,14 @@ namespace MR
 /// \{
 
 /// Duplicates all vertices having more than two boundary edges (and returns the number of duplications);
+/// this is equivalent to duplicateMultiHoleVertices( mesh, 1 )
 MRMESH_API int duplicateMultiHoleVertices( Mesh & mesh );
+
+/// Duplicates each vertex having more than \p maxHoles edges without left face in its edge ring
+/// until at most \p maxHoles such edges remain everywhere, and returns the number of duplications;
+/// after calling it with maxHoles = 2, MeshBuilder::fromTriangles can reconstruct this mesh from its triangulation
+/// without dropping any face, and the vertices with just two triangle fans are not duplicated unnecessarily
+MRMESH_API int duplicateMultiHoleVertices( Mesh & mesh, int maxHoles );
 
 /// finds multiple edges in the mesh
 using MultipleEdge = VertPair;

--- a/source/MRTest/MRMeshBuildDeleteTest.cpp
+++ b/source/MRTest/MRMeshBuildDeleteTest.cpp
@@ -1,5 +1,7 @@
 #include <MRMesh/MRMeshBuilder.h>
 #include <MRMesh/MRMeshTopology.h>
+#include <MRMesh/MRMesh.h>
+#include <MRMesh/MRMeshFixer.h>
 #include <MRMesh/MRBitSet.h>
 #include <MRMesh/MRExpandShrink.h>
 #include <MRMesh/MRRegionBoundary.h>
@@ -103,6 +105,62 @@ TEST(MRMesh, BuildQuadDelete)
     EXPECT_EQ( topology.numValidFaces(), 0 );
     EXPECT_EQ( topology.getValidVerts().count(), 0 );
     EXPECT_EQ( topology.computeNotLoneUndirectedEdges(), 0 );
+}
+
+TEST(MRMesh, DuplicateMultiHoleVertices)
+{
+    // fan of 6 triangles around central vertex #0
+    Triangulation t{
+        { 0_v, 1_v, 2_v },
+        { 0_v, 2_v, 3_v },
+        { 0_v, 3_v, 4_v },
+        { 0_v, 4_v, 5_v },
+        { 0_v, 5_v, 6_v },
+        { 0_v, 6_v, 1_v }
+    };
+    Mesh mesh;
+    mesh.points = {
+        {  0.f,  0.f, 0.f },
+        {  2.f,  0.f, 0.f },
+        {  1.f,  2.f, 0.f },
+        { -1.f,  2.f, 0.f },
+        { -2.f,  0.f, 0.f },
+        { -1.f, -2.f, 0.f },
+        {  1.f, -2.f, 0.f }
+    };
+    mesh.topology = MeshBuilder::fromTriangles( t );
+    EXPECT_EQ( mesh.topology.numValidFaces(), 6 );
+
+    // delete every other face, leaving three triangle fans joined at the central vertex only
+    FaceBitSet fs( 6 );
+    fs.set( 1_f );
+    fs.set( 3_f );
+    fs.set( 5_f );
+    mesh.topology.deleteFaces( fs );
+    EXPECT_EQ( mesh.topology.numValidVerts(), 7 );
+    EXPECT_EQ( mesh.topology.numValidFaces(), 3 );
+
+    // fromTriangles cannot attach the third fan to the central vertex and skips one triangle
+    auto lossyTopology = MeshBuilder::fromTriangles( mesh.topology.getTriangulation() );
+    EXPECT_EQ( lossyTopology.numValidFaces(), 2 );
+
+    // duplication of the central vertex alone makes the reconstruction lossless
+    Mesh fixed = mesh;
+    EXPECT_EQ( duplicateMultiHoleVertices( fixed, 2 ), 1 );
+    EXPECT_EQ( fixed.points.size(), 8 );
+    EXPECT_EQ( fixed.topology.numValidVerts(), 8 );
+    EXPECT_EQ( fixed.topology.numValidFaces(), 3 );
+    EXPECT_EQ( duplicateMultiHoleVertices( fixed, 2 ), 0 );
+
+    const auto fixedTriangulation = fixed.topology.getTriangulation();
+    auto rebuiltTopology = MeshBuilder::fromTriangles( fixedTriangulation );
+    EXPECT_EQ( rebuiltTopology.numValidFaces(), 3 );
+    EXPECT_EQ( rebuiltTopology.getTriangulation(), fixedTriangulation );
+
+    // classic version duplicates the central vertex twice, leaving a single fan everywhere
+    EXPECT_EQ( duplicateMultiHoleVertices( mesh ), 2 );
+    EXPECT_EQ( mesh.points.size(), 9 );
+    EXPECT_EQ( mesh.topology.numValidFaces(), 3 );
 }
 
 TEST(MRMesh, FlipEdge) 


### PR DESCRIPTION
Adds an overload `duplicateMultiHoleVertices( Mesh & mesh, int maxHoles )` that duplicates each vertex having more than `maxHoles` edges without left face in its ring, until at most `maxHoles` such edges remain everywhere. The classic `duplicateMultiHoleVertices( mesh )` now simply delegates with `maxHoles = 1`, and the common implementation is shared.

Motivation (support ticket): a user needs the round trip MR::Mesh -> (points, triangulation) -> `MeshBuilder::fromTriangles` to keep every triangle. `fromTriangles` cannot reconstruct a vertex where three or more triangle fans meet (such vertices appear e.g. after deleting faces), so one triangle per extra fan is silently skipped. Vertices with exactly two fans are reconstructed fine, so the classic function duplicates more vertices than necessary for this purpose. Calling the new overload with `maxHoles = 2` duplicates exactly the vertices that block the reconstruction and nothing else.

On the user's repro mesh (33755 verts / 63303 faces, one 3-fan vertex plus a dozen 2-fan vertices): `maxHoles = 2` duplicates 1 vertex and makes the round trip lossless and bit-exact, while the classic function duplicates 14.

A unit test covers: face deletion producing a 3-fan vertex, the lossy reconstruction without the fix, losslessness and idempotence after `duplicateMultiHoleVertices( mesh, 2 )`, and the unchanged classic behavior.
