### PR TITLE
Use the PGO llvm keg for mrbind/bindings on hosted arm64 runners

### DIFF
--- a/.github/actions/install-llvm-pgo-keg/action.yml
+++ b/.github/actions/install-llvm-pgo-keg/action.yml
@@ -1,0 +1,24 @@
+name: Install the llvm-pgo keg
+description: >
+  Fetch the PGO-optimized LLVM keg from MeshInspector/toolchains releases and
+  extract it into the homebrew Cellar. No-op when the keg is already present
+  (self-hosted runners build it locally). arm64 `/opt/homebrew` only.
+
+runs:
+  using: composite
+  steps:
+    - name: Install llvm-pgo keg
+      shell: bash
+      run: |
+        KEG=/opt/homebrew/Cellar/llvm-pgo/22.1.8_2
+        if [[ -d "$KEG" ]]; then
+          echo "llvm-pgo keg already present"
+          exit 0
+        fi
+        curl -fsSL -o /tmp/llvm-pgo.tar.gz \
+          https://github.com/MeshInspector/toolchains/releases/download/llvm-pgo-22.1.8_2-arm64/llvm-pgo-22.1.8_2.arm64_opt-homebrew.tar.gz
+        echo "94f76fb55ec64490605d0e68115259426a428a78f269f7e9160726d90a22e197  /tmp/llvm-pgo.tar.gz" | shasum -a 256 -c -
+        tar -xzf /tmp/llvm-pgo.tar.gz -C /opt/homebrew/Cellar
+        ln -sfn ../Cellar/llvm-pgo/22.1.8_2 /opt/homebrew/opt/llvm-pgo
+        brew install --quiet zstd xz
+        "$KEG/bin/clang++" --version | head -n1

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -58,6 +58,9 @@ jobs:
             compiler: AppleClang
             cxx-compiler-template: /usr/bin/clang++
             c-compiler-template: /usr/bin/clang
+            # mrbind and the bindings use the PGO keg fetched from
+            # MeshInspector/toolchains releases; the app stays on AppleClang.
+            llvm-prefix-template: BREW_PREFIX/Cellar/llvm-pgo/22.1.8_2
             # Pinned to the same image pip-build.yml uses so the mrbind cache is shared.
             runner: macos-14
             instance: macos-14
@@ -95,6 +98,10 @@ jobs:
           # https://github.com/actions/checkout/issues/1779
           # Retried via retry.sh: submodule endpoints occasionally 500.
           bash scripts/retry.sh --timeout 300 -- scripts/clone_submodules_macos.sh
+
+      - name: Install llvm-pgo keg
+        if: ${{ contains(matrix.llvm-prefix-template, 'llvm-pgo') }}
+        uses: ./.github/actions/install-llvm-pgo-keg
 
       - name: Install thirdparty libs
         id: thirdparty

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -551,6 +551,9 @@ jobs:
             plat-name: macosx_12_0_arm64
             instance: macos-14
             brewpath: /opt/homebrew
+            # mrbind and the bindings use the PGO keg fetched from
+            # MeshInspector/toolchains releases.
+            llvm-prefix-template: BREW_PREFIX/Cellar/llvm-pgo/22.1.8_2
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -584,6 +587,16 @@ jobs:
           cache-instance: ${{ matrix.instance }}
           cache-compiler: AppleClang
 
+      # LLVM_PREFIX selects the LLVM keg for the mrbind scripts; same scheme
+      # as build-test-macos.yml.
+      - name: Resolve LLVM prefix
+        if: ${{ matrix.llvm-prefix-template }}
+        run: echo "LLVM_PREFIX=$(echo '${{ matrix.llvm-prefix-template }}' | sed "s|BREW_PREFIX|$(brew --prefix)|")" >> $GITHUB_ENV
+
+      - name: Install llvm-pgo keg
+        if: ${{ contains(matrix.llvm-prefix-template, 'llvm-pgo') }}
+        uses: ./.github/actions/install-llvm-pgo-keg
+
       - name: Install MRBind deps
         env:
           HOMEBREW_NO_INSTALL_UPGRADE: '1'   # don't upgrade an already-installed llvm/lld, no z3, no rebuild
@@ -597,7 +610,7 @@ jobs:
           # build-test-macos.yml when its matrix.instance matches.
           cache-key-prefix: ${{ matrix.instance }}-clang
           build-script: scripts/mrbind/install_mrbind_macos.sh
-          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version_macos.txt') }}-${{ steps.thirdparty.outputs.brew-hash }}
+          extra-cache-key: ${{ matrix.llvm-prefix-template }}${{ hashFiles('scripts/mrbind/clang_version_macos.txt') }}-${{ steps.thirdparty.outputs.brew-hash }}
 
       - name: Build
         run: ./scripts/build_source.sh


### PR DESCRIPTION
Extends the PGO toolchain to the GitHub-hosted arm64 macOS legs: mrbind and the Python bindings on the `macos-14` rows (build-test and the arm64 wheel leg of pip-build) now use the `-O3`+PGO+ThinLTO clang 22.1.8_2 keg instead of the plain `llvm@22` bottle. The app compiler stays AppleClang.

The keg is the one built on a self-hosted runner for `/opt/homebrew` -- the same prefix hosted runners use, so it works with a plain extract, no relocation. It is published at [MeshInspector/toolchains](https://github.com/MeshInspector/toolchains/releases/tag/llvm-pgo-22.1.8_2-arm64) and installed by the new `install-llvm-pgo-keg` action: tokenless download, sha256-verified, `opt/llvm-pgo` symlink, `zstd`/`xz` deps; a no-op on self-hosted runners where the keg already exists.

Validated on hosted `macos-14`/`macos-15` (7-round interleaved compile bench): **1.28-1.40 s vs 1.90-2.00 s for the `llvm@22` bottle (-30..33%)**. **Real workload, this PR's hosted arm64 Release leg: `Generate and build Python bindings` 8:01 vs 11:58 on the latest master run (-33%)**, keg install itself 14 s. Also saves the `llvm@22` install (~1 min) since `LLVM_PREFIX` makes `install_deps_macos.sh` skip it.

Notes:
- `x64` hosted legs are untouched (the keg is arm64; Intel keeps the `llvm@N` fallback).
- The mrbind cache keys include `llvm-prefix-template` in both workflows, so they re-key once and remain shared between build-test-macos.yml and pip-build.yml on `macos-14`.
- On the clang-23 migration the release asset gets rebuilt and the template/sha updated -- same explicit-pin philosophy as the self-hosted kegs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
