### PR TITLE
Use the PGO llvm keg for mrbind/bindings on hosted x64 runners

### DIFF
--- a/.github/actions/install-llvm-pgo-keg/action.yml
+++ b/.github/actions/install-llvm-pgo-keg/action.yml
@@ -1,8 +1,9 @@
 name: Install the llvm-pgo keg
 description: >
-  Fetch the PGO-optimized LLVM keg from MeshInspector/toolchains releases and
-  extract it into the homebrew Cellar. No-op when the keg is already present
-  (self-hosted runners build it locally). arm64 `/opt/homebrew` only.
+  Fetch the PGO-optimized LLVM keg for this runner's architecture from
+  MeshInspector/toolchains releases and extract it into the homebrew Cellar.
+  No-op when the keg is already present (self-hosted runners build it
+  locally).
 
 runs:
   using: composite
@@ -10,15 +11,24 @@ runs:
     - name: Install llvm-pgo keg
       shell: bash
       run: |
-        KEG=/opt/homebrew/Cellar/llvm-pgo/22.1.8_2
+        if [[ "$(uname -m)" == "arm64" ]]; then
+          PREFIX=/opt/homebrew
+          ASSET=llvm-pgo-22.1.8_2-arm64/llvm-pgo-22.1.8_2.arm64_opt-homebrew.tar.gz
+          SHA=94f76fb55ec64490605d0e68115259426a428a78f269f7e9160726d90a22e197
+        else
+          PREFIX=/usr/local
+          ASSET=llvm-pgo-22.1.8_2-x64/llvm-pgo-22.1.8_2.x86_64_usr-local.tar.gz
+          SHA=8f1f1d97e4a5391c7f871bc5cf9601a9b4a1262e6e61f1538327bb48d7ef71ed
+        fi
+        [[ "$(brew --prefix)" == "$PREFIX" ]] || { echo "unexpected brew prefix $(brew --prefix), keg targets $PREFIX" >&2; exit 1; }
+        KEG="$PREFIX/Cellar/llvm-pgo/22.1.8_2"
         if [[ -d "$KEG" ]]; then
           echo "llvm-pgo keg already present"
           exit 0
         fi
-        curl -fsSL -o /tmp/llvm-pgo.tar.gz \
-          https://github.com/MeshInspector/toolchains/releases/download/llvm-pgo-22.1.8_2-arm64/llvm-pgo-22.1.8_2.arm64_opt-homebrew.tar.gz
-        echo "94f76fb55ec64490605d0e68115259426a428a78f269f7e9160726d90a22e197  /tmp/llvm-pgo.tar.gz" | shasum -a 256 -c -
-        tar -xzf /tmp/llvm-pgo.tar.gz -C /opt/homebrew/Cellar
-        ln -sfn ../Cellar/llvm-pgo/22.1.8_2 /opt/homebrew/opt/llvm-pgo
+        curl -fsSL -o /tmp/llvm-pgo.tar.gz "https://github.com/MeshInspector/toolchains/releases/download/$ASSET"
+        echo "$SHA  /tmp/llvm-pgo.tar.gz" | shasum -a 256 -c -
+        tar -xzf /tmp/llvm-pgo.tar.gz -C "$PREFIX/Cellar"
+        ln -sfn ../Cellar/llvm-pgo/22.1.8_2 "$PREFIX/opt/llvm-pgo"
         brew install --quiet zstd xz
         "$KEG/bin/clang++" --version | head -n1

--- a/.github/actions/install-llvm-pgo-keg/action.yml
+++ b/.github/actions/install-llvm-pgo-keg/action.yml
@@ -2,8 +2,8 @@ name: Install the llvm-pgo keg
 description: >
   Fetch the PGO-optimized LLVM keg for this runner's architecture from
   MeshInspector/toolchains releases and extract it into the homebrew Cellar.
-  No-op when the keg is already present (self-hosted runners build it
-  locally).
+  No-op when the keg is already present under this machine's brew prefix
+  (self-hosted runners build it locally, including non-standard prefixes).
 
 runs:
   using: composite
@@ -11,24 +11,26 @@ runs:
     - name: Install llvm-pgo keg
       shell: bash
       run: |
-        if [[ "$(uname -m)" == "arm64" ]]; then
-          PREFIX=/opt/homebrew
-          ASSET=llvm-pgo-22.1.8_2-arm64/llvm-pgo-22.1.8_2.arm64_opt-homebrew.tar.gz
-          SHA=94f76fb55ec64490605d0e68115259426a428a78f269f7e9160726d90a22e197
-        else
-          PREFIX=/usr/local
-          ASSET=llvm-pgo-22.1.8_2-x64/llvm-pgo-22.1.8_2.x86_64_usr-local.tar.gz
-          SHA=8f1f1d97e4a5391c7f871bc5cf9601a9b4a1262e6e61f1538327bb48d7ef71ed
-        fi
-        [[ "$(brew --prefix)" == "$PREFIX" ]] || { echo "unexpected brew prefix $(brew --prefix), keg targets $PREFIX" >&2; exit 1; }
-        KEG="$PREFIX/Cellar/llvm-pgo/22.1.8_2"
+        BP="$(brew --prefix)"
+        KEG="$BP/Cellar/llvm-pgo/22.1.8_2"
         if [[ -d "$KEG" ]]; then
           echo "llvm-pgo keg already present"
           exit 0
         fi
+        # The published kegs are built for the standard prefixes only.
+        if [[ "$(uname -m)" == "arm64" ]]; then
+          NEED=/opt/homebrew
+          ASSET=llvm-pgo-22.1.8_2-arm64/llvm-pgo-22.1.8_2.arm64_opt-homebrew.tar.gz
+          SHA=94f76fb55ec64490605d0e68115259426a428a78f269f7e9160726d90a22e197
+        else
+          NEED=/usr/local
+          ASSET=llvm-pgo-22.1.8_2-x64/llvm-pgo-22.1.8_2.x86_64_usr-local.tar.gz
+          SHA=8f1f1d97e4a5391c7f871bc5cf9601a9b4a1262e6e61f1538327bb48d7ef71ed
+        fi
+        [[ "$BP" == "$NEED" ]] || { echo "no published keg for brew prefix $BP (need $NEED) and none installed locally" >&2; exit 1; }
         curl -fsSL -o /tmp/llvm-pgo.tar.gz "https://github.com/MeshInspector/toolchains/releases/download/$ASSET"
         echo "$SHA  /tmp/llvm-pgo.tar.gz" | shasum -a 256 -c -
-        tar -xzf /tmp/llvm-pgo.tar.gz -C "$PREFIX/Cellar"
-        ln -sfn ../Cellar/llvm-pgo/22.1.8_2 "$PREFIX/opt/llvm-pgo"
+        tar -xzf /tmp/llvm-pgo.tar.gz -C "$BP/Cellar"
+        ln -sfn ../Cellar/llvm-pgo/22.1.8_2 "$BP/opt/llvm-pgo"
         brew install --quiet zstd xz
         "$KEG/bin/clang++" --version | head -n1

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -50,6 +50,9 @@ jobs:
             compiler: AppleClang
             cxx-compiler-template: /usr/bin/clang++
             c-compiler-template: /usr/bin/clang
+            # mrbind and the bindings use the PGO keg fetched from
+            # MeshInspector/toolchains releases; the app stays on AppleClang.
+            llvm-prefix-template: BREW_PREFIX/Cellar/llvm-pgo/22.1.8_2
             # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners
             runner: macos-15-intel # github hosted
             instance: macos-15-intel

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -547,6 +547,9 @@ jobs:
             plat-name: macosx_12_0_x86_64
             instance: macos-15-intel
             brewpath: /usr/local
+            # mrbind and the bindings use the PGO keg fetched from
+            # MeshInspector/toolchains releases.
+            llvm-prefix-template: BREW_PREFIX/Cellar/llvm-pgo/22.1.8_2
           - platform: "arm64"
             plat-name: macosx_12_0_arm64
             instance: macos-14


### PR DESCRIPTION
Completes #6638 for the Intel side: the hosted x64 legs (`macos-15-intel` in build-test and the x86 wheel leg of pip-build) move mrbind and the Python bindings to the `-O3`+PGO+ThinLTO clang 22.1.8_2 keg. The app compiler stays AppleClang, same rationale as arm.

`install-llvm-pgo-keg` now selects the asset by runner architecture: arm64 -> the `/opt/homebrew` keg, x86_64 -> the `/usr/local` keg built on the self-hosted Intel runner and published at [MeshInspector/toolchains](https://github.com/MeshInspector/toolchains/releases/tag/llvm-pgo-22.1.8_2-x64), with a brew-prefix sanity guard and per-arch sha256 pinning.

Validation, three independent measurements:

- **Compile microbench** (7-round interleaved vs the `llvm@22` bottle, same VM): macos-15-intel **3.11 s vs 4.34 s (-28%)**, macos-26-intel **3.70 s vs 5.03 s (-26%)** -- the macOS-12-built keg runs fine through macOS 26.
- **Real bindings pipeline, A/B/A in one job on one `macos-15-intel` VM** (mrbind rebuilt from scratch per pass + full `make -B` generation/compilation): `llvm@22` 20:21, **PGO 16:04**, `llvm@22` again 28:31. The A-passes reveal heavy within-job VM degradation, so the conservative bound is **-21% (PGO vs the best llvm@22 pass)** and the drift-adjusted estimate is **~-30%**, matching the microbench.
- Note: step times across *separate* hosted x64 runs are not comparable -- master's bindings step ranges 12:46-23:53 (~+/-30% VM lottery), which is why the evidence above is within-VM only.

Also removes the `llvm@22` install from these legs (`LLVM_PREFIX` makes `install_deps_macos.sh` skip it); the keg fetch itself takes ~1 min on the Intel images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
