### PR TITLE
Optional output of duplications in duplicateMultiHoleVertices

### DIFF
--- a/source/MRMesh/MRMeshFixer.cpp
+++ b/source/MRMesh/MRMeshFixer.cpp
@@ -1,4 +1,5 @@
 #include "MRMeshFixer.h"
+#include "MRVertDuplication.h"
 #include "MRMesh.h"
 #include "MRTimer.h"
 #include "MRRingIterator.h"
@@ -45,10 +46,12 @@ static EdgeId findNoLeftEdgeAboveLimit( const MeshTopology & m, VertId a, int li
     }
 }
 
-int duplicateMultiHoleVertices( Mesh & mesh, int maxHoles )
+int duplicateMultiHoleVertices( Mesh & mesh, int maxHoles, std::vector<MeshBuilder::VertDuplication> * dups )
 {
     MR_TIMER;
     assert( maxHoles >= 1 );
+    if ( dups )
+        dups->clear();
 
     VertBitSet vertsForDup( mesh.topology.vertSize() );
     BitSetParallelFor( mesh.topology.getValidVerts(), [&]( VertId v )
@@ -76,6 +79,8 @@ int duplicateMultiHoleVertices( Mesh & mesh, int maxHoles )
 
             auto vDup = mesh.addPoint( mesh.points[v] );
             mesh.topology.setOrg( e0, vDup );
+            if ( dups )
+                dups->push_back( { .srcVert = v, .dupVert = vDup } );
 
             ++duplicates;
         }

--- a/source/MRMesh/MRMeshFixer.h
+++ b/source/MRMesh/MRMeshFixer.h
@@ -20,9 +20,10 @@ MRMESH_API int duplicateMultiHoleVertices( Mesh & mesh );
 
 /// Duplicates each vertex having more than \p maxHoles edges without left face in its edge ring
 /// until at most \p maxHoles such edges remain everywhere, and returns the number of duplications;
+/// (optional) \p dups receives the pair (source vertex, duplicate vertex) of every duplication made;
 /// after calling it with maxHoles = 2, MeshBuilder::fromTriangles can reconstruct this mesh from its triangulation
 /// without dropping any face, and the vertices with just two triangle fans are not duplicated unnecessarily
-MRMESH_API int duplicateMultiHoleVertices( Mesh & mesh, int maxHoles );
+MRMESH_API int duplicateMultiHoleVertices( Mesh & mesh, int maxHoles, std::vector<MeshBuilder::VertDuplication> * dups = nullptr );
 
 /// finds multiple edges in the mesh
 using MultipleEdge = VertPair;

--- a/source/MRTest/MRMeshBuildDeleteTest.cpp
+++ b/source/MRTest/MRMeshBuildDeleteTest.cpp
@@ -2,6 +2,7 @@
 #include <MRMesh/MRMeshTopology.h>
 #include <MRMesh/MRMesh.h>
 #include <MRMesh/MRMeshFixer.h>
+#include <MRMesh/MRVertDuplication.h>
 #include <MRMesh/MRBitSet.h>
 #include <MRMesh/MRExpandShrink.h>
 #include <MRMesh/MRRegionBoundary.h>
@@ -146,11 +147,16 @@ TEST(MRMesh, DuplicateMultiHoleVertices)
 
     // duplication of the central vertex alone makes the reconstruction lossless
     Mesh fixed = mesh;
-    EXPECT_EQ( duplicateMultiHoleVertices( fixed, 2 ), 1 );
+    std::vector<MeshBuilder::VertDuplication> dups;
+    EXPECT_EQ( duplicateMultiHoleVertices( fixed, 2, &dups ), 1 );
+    ASSERT_EQ( dups.size(), 1 );
+    EXPECT_EQ( dups[0].srcVert, 0_v );
+    EXPECT_EQ( dups[0].dupVert, 7_v );
     EXPECT_EQ( fixed.points.size(), 8 );
     EXPECT_EQ( fixed.topology.numValidVerts(), 8 );
     EXPECT_EQ( fixed.topology.numValidFaces(), 3 );
-    EXPECT_EQ( duplicateMultiHoleVertices( fixed, 2 ), 0 );
+    EXPECT_EQ( duplicateMultiHoleVertices( fixed, 2, &dups ), 0 );
+    EXPECT_TRUE( dups.empty() );
 
     const auto fixedTriangulation = fixed.topology.getTriangulation();
     auto rebuiltTopology = MeshBuilder::fromTriangles( fixedTriangulation );


### PR DESCRIPTION
Follow-up to #6633: adds an optional `std::vector<MeshBuilder::VertDuplication> * dups` output parameter to `duplicateMultiHoleVertices( Mesh & mesh, int maxHoles )`, receiving the pair (source vertex, duplicate vertex) of every duplication made — same convention as in `Mesh::fromTrianglesDuplicatingNonManifoldVertices`.

Motivation (same support ticket as #6633): after duplicating multi-hole vertices before exporting a mesh to flat arrays, the user needs the mapping between original and duplicated vertices; currently only the number of duplications is returned, and recovering the mapping afterwards requires searching.

The unit test now also checks the reported pairs and that the vector is cleared when nothing is duplicated.
