### PR TITLE
Log the start and end of zip decompression

### DIFF
--- a/source/MRMesh/MRZip.cpp
+++ b/source/MRMesh/MRZip.cpp
@@ -5,6 +5,7 @@
 #include "MRStringConvert.h"
 #include "MRTimer.h"
 #include "MRZlib.h"
+#include "MRPch/MRSpdlog.h"
 
 #if (defined(__APPLE__) && defined(__clang__)) || defined(__EMSCRIPTEN__)
 #pragma clang diagnostic push
@@ -315,7 +316,9 @@ Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetF
     zip_stat_t stats;
     zip_file_t* zfile;
     std::vector<char> fileBufer;
-    for ( int i = 0; i < zip_get_num_entries( zip, 0 ); ++i )
+    const auto numEntries = zip_get_num_entries( zip, 0 );
+    spdlog::info( "Decompressing {} zip entries into {}", numEntries, utf8string( targetFolder ) );
+    for ( zip_int64_t i = 0; i < numEntries; ++i )
     {
         if ( zip_stat_index( zip, i, 0, &stats ) == -1 )
             return unexpected( "Cannot process zip content" );
@@ -358,6 +361,7 @@ Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetF
             ofs.close();
         }
     }
+    spdlog::info( "Decompressed {} zip entries", numEntries );
     return {};
 }
 


### PR DESCRIPTION
`decompressZip` logs nothing, so when a `.mru` scene load stalls there is no way to tell the unzip apart from the deserialization that follows it. `deserializeObjectTree` logs `Temporary folder created: ...` from `UniqueTemporaryFolder`, and the next line in the log is already the first model's progress tick from `deserializeObjectTreeFromFolder`. Everything in between is silent.

That gap is not hypothetical: we have a wasm scene load that wedges in there for 600 s -- all network I/O long finished, the UI still rendering and its Cancel button live -- and the log cannot say which of the two stages is stuck.

So log the entry count on the way in and again on the way out:

```
[info] Decompressing 7 zip entries into /tmp/MeshInspectorScene1787479520
[info] Decompressed 7 zip entries
```

Both go in `decompressZip_`, so the two public `decompressZip` overloads and every caller (`.mru`, plain zip import, 3MF) get it. `compressZip` needs nothing similar -- it reports progress per file already.

Drive-by in the same loop: `zip_get_num_entries` was re-read on every iteration and is now hoisted, and the index gets its natural `zip_int64_t` type instead of `int`.

Verified: MRMesh builds clean with MSVC `/Wall /WX`.
