### PR TITLE
Ship Windows .pdb files in separate archives

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -321,9 +321,11 @@ jobs:
           shopt -s nullglob
           for PKG_FILE in MeshLibDist*.zip ; do
             case "$PKG_FILE" in
-              # Keep the historical layout for the iterator-debug archive:
-              # MeshLibDist-IteratorDebug.zip -> MeshLibDist_<version>-IteratorDebug.zip
-              *-IteratorDebug.zip) mv "$PKG_FILE" "${PKG_FILE/Dist/Dist_${{ needs.config.outputs.app_version }}}" ;;
+              # Keep the historical layout for the iterator-debug archives:
+              # MeshLibDist-IteratorDebug[-PDB].zip -> MeshLibDist_<version>-IteratorDebug[-PDB].zip
+              *-IteratorDebug.zip|*-IteratorDebug-PDB.zip) mv "$PKG_FILE" "${PKG_FILE/Dist/Dist_${{ needs.config.outputs.app_version }}}" ;;
+              # Companion symbols archives: MeshLibDistVS19-PDB.zip -> MeshLibDistVS19_<version>-PDB.zip
+              *-PDB.zip) mv "$PKG_FILE" "${PKG_FILE%-PDB.zip}_${{ needs.config.outputs.app_version }}-PDB.zip" ;;
               # Per-VS archives: MeshLibDistVS19.zip -> MeshLibDistVS19_<version>.zip
               *) mv "$PKG_FILE" "${PKG_FILE%.zip}_${{ needs.config.outputs.app_version }}.zip" ;;
             esac

--- a/.github/workflows/distro-release.yml
+++ b/.github/workflows/distro-release.yml
@@ -102,9 +102,11 @@ jobs:
           shopt -s nullglob
           for PKG_FILE in MeshLibDist*.zip ; do
             case "$PKG_FILE" in
-              # Keep the historical layout for the iterator-debug archive:
-              # MeshLibDist-IteratorDebug.zip -> MeshLibDist_<version>-IteratorDebug.zip
-              *-IteratorDebug.zip) mv "$PKG_FILE" "${PKG_FILE/Dist/Dist_${{ needs.config.outputs.app_version }}}" ;;
+              # Keep the historical layout for the iterator-debug archives:
+              # MeshLibDist-IteratorDebug[-PDB].zip -> MeshLibDist_<version>-IteratorDebug[-PDB].zip
+              *-IteratorDebug.zip|*-IteratorDebug-PDB.zip) mv "$PKG_FILE" "${PKG_FILE/Dist/Dist_${{ needs.config.outputs.app_version }}}" ;;
+              # Companion symbols archives: MeshLibDistVS19-PDB.zip -> MeshLibDistVS19_<version>-PDB.zip
+              *-PDB.zip) mv "$PKG_FILE" "${PKG_FILE%-PDB.zip}_${{ needs.config.outputs.app_version }}-PDB.zip" ;;
               # Per-VS archives: MeshLibDistVS19.zip -> MeshLibDistVS19_<version>.zip
               *) mv "$PKG_FILE" "${PKG_FILE%.zip}_${{ needs.config.outputs.app_version }}.zip" ;;
             esac

--- a/.github/workflows/update-win-version.yml
+++ b/.github/workflows/update-win-version.yml
@@ -25,20 +25,24 @@ jobs:
             extract_release: MREDist_VS19_Release.zip
             extract_debug: MREDist_VS19_Debug.zip
             output_zip: MeshLibDistVS19.zip
+            pdb_zip: MeshLibDistVS19-PDB.zip
             artifact_name: DistributivesWin-VS19
           - vcpkg_triplet: x64-windows-vs2022-meshlib
             extract_release: MREDist_VS22_Release.zip
             extract_debug: MREDist_VS22_Debug.zip
             output_zip: MeshLibDistVS22.zip
+            pdb_zip: MeshLibDistVS22-PDB.zip
             artifact_name: DistributivesWin-VS22
           - vcpkg_triplet: x64-windows-meshlib
             extract_release: MREDist_VS26_Release.zip
             extract_debug: MREDist_VS26_Debug.zip
             output_zip: MeshLibDistVS26.zip
+            pdb_zip: MeshLibDistVS26-PDB.zip
             artifact_name: DistributivesWin-VS26
           - vcpkg_triplet: x64-windows-meshlib-iterator-debug
             extract_debug: MREDist_VS19_Debug-IteratorDebug.zip
             output_zip: MeshLibDist-IteratorDebug.zip
+            pdb_zip: MeshLibDist-IteratorDebug-PDB.zip
             artifact_name: DistributivesWin-IteratorDebug
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-vs2019-meshlib' }}
@@ -74,6 +78,11 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
+      # The .pdb files are moved out of `install` first, so the main archive
+      # carries none of them and each toolchain gets a companion symbols archive.
+      - name: Archive Symbols
+        run: py -3.10 scripts\split_install_pdb.py install ${{ matrix.pdb_zip }}
+
       - name: Archive Distribution
         run: py -3.10 scripts\zip_distribution.py install example_plugin ${{ matrix.output_zip }}
 
@@ -90,7 +99,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
-          path: ${{ matrix.output_zip }}
+          path: |
+            ${{ matrix.output_zip }}
+            ${{ matrix.pdb_zip }}
           retention-days: 1
 
   cleanup-win-archives:

--- a/cmake/Modules/CompilerOptions.cmake
+++ b/cmake/Modules/CompilerOptions.cmake
@@ -207,6 +207,15 @@ IF(MSVC)
   string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
   string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
   string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+
+  # Emit debug symbols in Release as well, matching `common.props`, which enables them in every
+  # configuration; they are packed into a separate archive, see `scripts/split_install_pdb.py`.
+  # `/OPT:REF /OPT:ICF` are the defaults that `/DEBUG` turns off, so the binaries stay unchanged.
+  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Z7")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Z7")
+  FOREACH(TARGET_KIND EXE SHARED MODULE)
+    set(CMAKE_${TARGET_KIND}_LINKER_FLAGS_RELEASE "${CMAKE_${TARGET_KIND}_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
+  ENDFOREACH()
 ENDIF()
 
 # macOS: force Clang to use system libc++

--- a/doxygen/general_pages/CppSetupGuide.dox
+++ b/doxygen/general_pages/CppSetupGuide.dox
@@ -36,6 +36,10 @@ The release description links the three per-Visual-Studio archives; `IteratorDeb
 Take it if your project builds Debug with MSVC's default `_ITERATOR_DEBUG_LEVEL=2`: it ships `install/app/Debug` without `install/app/Release`, so it covers no Release build — but being a `v142` build it serves a newer Visual Studio too, under the rule above.
 Whichever archive you pick, step 2 must define **both** `_ITERATOR_DEBUG_LEVEL` and `MR_ITERATOR_DEBUG_LEVEL` to the value in the table — `0` for the three per-Visual-Studio archives, `2` for `IteratorDebug`.
 
+Debug symbols ship separately: every archive above has a companion `-PDB.zip` (`MeshLibDistVS26_<version>-PDB.zip`, `MeshLibDist_<version>-IteratorDebug-PDB.zip`, ...) holding only the `.pdb` files.
+Extract it over the same directory to put them back under `install/lib`, where the debugger looks for them.
+They are needed for symbolized call stacks only: without them the archive still compiles, links and runs, and is a few hundred megabytes smaller.
+
  1. **Download and Extract the Built Version**
   - Visit the [MeshLib GitHub Releases](https://github.com/MeshInspector/MeshLib/releases).
   - Download the archive for your Visual Studio toolset from the table above.

--- a/scripts/devops/release_table.txt
+++ b/scripts/devops/release_table.txt
@@ -9,19 +9,22 @@
     <tr>
       <td align="center">Windows x64 (Visual Studio 2019)</td>
       <td align="center">
-        <a href="RELEASE_PATH/MeshLibDistVS19_SHORT_VERSION.zip">zip</a>
+        <a href="RELEASE_PATH/MeshLibDistVS19_SHORT_VERSION.zip">zip</a> /
+        <a href="RELEASE_PATH/MeshLibDistVS19_SHORT_VERSION-PDB.zip">pdb</a>
       </td>
     </tr>
     <tr>
       <td align="center">Windows x64 (Visual Studio 2022)</td>
       <td align="center">
-        <a href="RELEASE_PATH/MeshLibDistVS22_SHORT_VERSION.zip">zip</a>
+        <a href="RELEASE_PATH/MeshLibDistVS22_SHORT_VERSION.zip">zip</a> /
+        <a href="RELEASE_PATH/MeshLibDistVS22_SHORT_VERSION-PDB.zip">pdb</a>
       </td>
     </tr>
     <tr>
       <td align="center">Windows x64 (Visual Studio 2026)</td>
       <td align="center">
-        <a href="RELEASE_PATH/MeshLibDistVS26_SHORT_VERSION.zip">zip</a>
+        <a href="RELEASE_PATH/MeshLibDistVS26_SHORT_VERSION.zip">zip</a> /
+        <a href="RELEASE_PATH/MeshLibDistVS26_SHORT_VERSION-PDB.zip">pdb</a>
       </td>
     </tr>
     <tr>

--- a/scripts/split_install_pdb.py
+++ b/scripts/split_install_pdb.py
@@ -1,0 +1,44 @@
+import os
+import shutil
+import subprocess
+import sys
+
+# The .pdb files dominate the developer distributive but are only needed when
+# debugging a crash, so they ship as a companion archive that keeps the same
+# internal layout: unpacking it over the main one restores the full folder.
+
+if len(sys.argv) < 3:
+	print("usage: split_install_pdb.py <install folder> <pdb archive>")
+	sys.exit(1)
+
+install_folder = sys.argv[1]
+pdb_archive = os.path.abspath(sys.argv[2])
+
+base_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+os.chdir(base_path)
+
+stage_root = install_folder + '-pdb'
+shutil.rmtree(stage_root, ignore_errors=True)
+stage = os.path.join(stage_root, os.path.basename(install_folder))
+
+moved = 0
+total = 0
+for address, dirs, files in os.walk(install_folder):
+	for file in files:
+		if not file.endswith('.pdb'):
+			continue
+		src = os.path.join(address, file)
+		dst = os.path.join(stage, os.path.relpath(address, install_folder), file)
+		os.makedirs(os.path.dirname(dst), exist_ok=True)
+		total += os.path.getsize(src)
+		shutil.move(src, dst)
+		moved += 1
+
+print("moved " + str(moved) + " .pdb files (" + str(total >> 20) + " MiB) into " + pdb_archive)
+if moved == 0:
+	print("error: no .pdb files found in " + install_folder)
+	sys.exit(1)
+
+res = subprocess.call(['tar', '-a', '-c', '-f', pdb_archive, '-C', stage_root, os.path.basename(install_folder)])
+shutil.rmtree(stage_root, ignore_errors=True)
+sys.exit(res)


### PR DESCRIPTION
### Why

`.pdb` files are the bulk of every Windows developer distributive, and they matter only when someone is debugging a crash. Read from the ZIP central directories of `v3.1.3.429`:

| archive | total | `.pdb` | rest |
|---|---|---|---|
| `MeshLibDistVS19` | 545 MB | 24 files, 211 MB (1694 MB raw) | 331 MB |
| `MeshLibDistVS22` | 551 MB | 23 files, 214 MB (1698 MB raw) | 333 MB |
| `MeshLibDistVS26` | 796 MB | 52 files, 429 MB (2988 MB raw) | 363 MB |
| `MeshLibDist-IteratorDebug` | 398 MB | 18 files, 188 MB (1522 MB raw) | 206 MB |

`VS26` stands out because it is the only MSBuild-based distributive: `source/common.props` sets `DebugInformationFormat` in an unconditional `ItemDefinitionGroup`, so its **Release** targets get linker `.pdb` files as well (26 files, 203 MB compressed). The CMake-based `VS19`/`VS22` builds used plain `-DCMAKE_BUILD_TYPE=Release`, nothing added `/Zi` or `/Z7`, and they shipped zero `lib/Release/*.pdb`. The other 30 MB of the `VS26` gap is the C#/.NET part (`MRDotNet2*`, NUnit, `c-sharp-examples`) plus `/Z7` debug info inside `MRPch.lib`, which is genuine extra payload.

### What

**1. Symbols move to companion archives.** `scripts/split_install_pdb.py` moves every `.pdb` out of `install/` into a staging tree and packs it **before** `zip_distribution.py` packs the rest, so no `.pdb` reaches the main archive. The companion keeps the same internal layout (`install/lib/<config>/…`), so extracting both zips into one directory reproduces exactly what the single archive contained until now. Four new release assets:

```
MeshLibDistVS19_<version>-PDB.zip
MeshLibDistVS22_<version>-PDB.zip
MeshLibDistVS26_<version>-PDB.zip
MeshLibDist_<version>-IteratorDebug-PDB.zip
```

**2. MSVC Release builds now generate symbols.** So that the `VS19`/`VS22` symbol archives cover Release as well as Debug, `cmake/Modules/CompilerOptions.cmake` adds `/Z7` to the Release compile flags and `/DEBUG` to the Release linker flags — matching what `common.props` has always done for the MSBuild build. `/DEBUG` flips the linker defaults from `/OPT:REF /OPT:ICF` to the `NO` variants, so both are restored explicitly and the Release binaries are unchanged. `/Z7` rather than `/Zi` for the same reason the existing code rewrites `/Zi` to `/Z7` in Debug and RelWithDebInfo: under Ninja a shared compiler `.pdb` breaks the precompiled header.

Expected result — the first three rows are exact (deflate is per-entry, so the measured sizes carry over), the Release-symbol figures for VS19/VS22 are estimated from VS26's Release PDBs minus its .NET-only targets:

| | main archive | companion `-PDB` |
|---|---|---|
| VS19 | ~337 MB (was 545) | ~400 MB (211 Debug + ~190 Release) |
| VS22 | ~339 MB (was 551) | ~404 MB (214 Debug + ~190 Release) |
| VS26 | 363 MB (was 796) | 429 MB (226 Debug + 203 Release) |
| IteratorDebug | 206 MB (was 398) | 188 MB (Debug only, by design) |

The three per-Visual-Studio symbol archives are linked from the release description next to the existing `zip` link (`scripts/devops/release_table.txt`); `IteratorDebug` keeps appearing in the asset list only, as before. `CppSetupGuide.dox` explains the companion archive.

The rename step in `build-test-distribute.yml` / `distro-release.yml` gained two cases so the new names come out as above; **every existing asset name is unchanged**, verified against all seven inputs.

### Costs of enabling Release debug info

Worth a conscious decision, since this part is not free:

- **Release compile time and disk grow.** `/Z7` writes debug info into every `.obj`. This hits the VS19/VS22 CI Release legs and every local Windows CMake Release build.
- **`MRPch.lib` grows in the main archive.** It is a static library, so its `/Z7` debug info lives inside the `.lib` and cannot be split out the way linker PDBs can. On VS26 that is +6.3 MB compressed over VS22, and VS19/VS22 should now pick up the same. It slightly works against the shrink, hence "~337 MB" rather than 331 MB above.
- Release binaries themselves do not change, thanks to the explicit `/OPT:REF /OPT:ICF`.

The alternative — leaving VS19/VS22 without Release symbols — keeps those two archives 6 MB smaller and their builds faster, at the price of the asymmetry this PR set out to remove.

### Why the split is safe

Every `.pdb` in these archives lives under `install/lib/{Debug,Release}` and belongs to a linked target (DLL/EXE), i.e. they are linker program databases that no consumer build reads. The two large static libs that a consumer *does* link, `MRPch.lib` and `fastmcpp_core.lib`, already had no matching `.pdb` in the archive, and the one compiler `.pdb` present (`lib/Debug/MRPch.pdb`, from the CMake Debug build) is referenced by absolute build-machine path, so it was never resolvable from the distributive anyway. `test-distribution.yml` downloads by exact/anchored pattern, so its `MeshLibDist*.zip` glob still resolves to a single file.

### Not addressed here

`install/lib/Release/MRTest.pdb` + `MRTestCuda.pdb` (21.6 MB) and `MRPch.lib` (66 MB uncompressed) are test/build-internal artifacts that arguably should not ship at all. Left alone to keep this change to the split.

### Testing

- `scripts/split_install_pdb.py` exercised locally on a synthetic `install/` tree: Debug, Release and nested Release `.pdb` all moved out, paths preserved, staging directory removed, non-`.pdb` files untouched.
- The new CMake flags verified locally on a minimal MSVC project: Release compiles as `/O2 /Ob2 /DNDEBUG /Z7`, links as `/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF`, and produces `mylib.pdb` next to `mylib.dll` in the runtime output directory — which is what the `xcopy` into `source/x64/<config>` and then `make_install_folder.py` need in order to pick it up. The `FOREACH` variable indirection checked with `cmake -P`.
- The rename `case` blocks checked against all seven archive names.
- `build-release-windows` **and** `upload-binaries` are both set so CI runs `update-win-version` and `upload-distributions` end to end: `build-release-win` alone is ANDed with `upload_artifacts`, which for a `pull_request` event only `upload-binaries` (or `full-ci`) turns on. The other platforms are disabled since nothing outside Windows packaging changed.
