### PR TITLE
DO NOT MERGE: hammer the .mru load path 1600 times under wasm64

### DIFF
--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -307,12 +307,15 @@ jobs:
     if: ${{ !inputs.definitions_only }}
     needs: emscripten-build
     timeout-minutes: 35
-    runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         package_name:
           - emscripten-multithreaded-64bit
+        # the wasm bundle is architecture-independent, so the same build runs on both:
+        # x64 is where the stall was seen, arm is the control that came back clean
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
 
     steps:

--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -306,15 +306,14 @@ jobs:
   emscripten-test:
     if: ${{ !inputs.definitions_only }}
     needs: emscripten-build
-    timeout-minutes: 10
+    timeout-minutes: 35
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
         package_name:
-          - emscripten-singlethreaded
-          - emscripten-multithreaded
           - emscripten-multithreaded-64bit
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
 
     steps:
       - name: Download MRTest bundle
@@ -326,7 +325,7 @@ jobs:
           run-id: ${{ github.run_id }}
 
       - name: Unit Tests
-        timeout-minutes: 5
+        timeout-minutes: 30
         working-directory: mrtest-bundle
         run: |
           python3 emrun.py \
@@ -334,4 +333,4 @@ jobs:
             --browser-args="--headless" \
             --safe-firefox-profile \
             --kill-exit \
-            ./MRTest.html
+            ./MRTest.html --gtest_filter=MRMesh.SceneLoadStress

--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -333,4 +333,4 @@ jobs:
             --browser-args="--headless" \
             --safe-firefox-profile \
             --kill-exit \
-            ./MRTest.html --gtest_filter=MRMesh.SceneLoadStress
+            ./MRTest.html -- --gtest_filter=MRMesh.SceneLoadStress

--- a/source/MRTest/MRSceneLoadStressTests.cpp
+++ b/source/MRTest/MRSceneLoadStressTests.cpp
@@ -8,27 +8,68 @@
 #include "MRMesh/MRTimer.h"
 #include "MRMesh/MRUniqueTemporaryFolder.h"
 #include "MRPch/MRSpdlog.h"
+#include "MRPch/MRWasm.h"
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
 #include <filesystem>
+#include <string>
+#include <thread>
+
+#if defined( __EMSCRIPTEN__ ) && defined( __EMSCRIPTEN_PTHREADS__ )
+#include <emscripten/threading.h>
+#endif
 
 namespace MR
 {
 
-// Reloads one and the same scene archive many times, hunting a rare stall seen
-// twice in a wasm64 browser build: loadObjectFromFile never returned while the
-// page itself stayed responsive. Three meshes, sized after the archive that
-// stalled: ~3.4 MB, ~10 KB, ~250 B of .ply.
+namespace
+{
+
+constexpr int cIterations = 2000;
+constexpr int cStallSeconds = 120;
+
+void addMesh( Object& root, std::string name, Mesh mesh )
+{
+    auto obj = std::make_shared<ObjectMesh>();
+    obj->setName( std::move( name ) );
+    obj->setMesh( std::make_shared<Mesh>( std::move( mesh ) ) );
+    root.addChild( std::move( obj ) );
+}
+
+// Keeps the calling thread awake without letting it fall asleep on a futex: on the
+// emscripten main thread this also drains the proxying queue, which is what the app's
+// UI thread does between frames.
+void stayAwake( int ms )
+{
+#if defined( __EMSCRIPTEN__ ) && defined( __EMSCRIPTEN_PTHREADS__ )
+    emscripten_thread_sleep( ms );
+#else
+    std::this_thread::sleep_for( std::chrono::milliseconds( ms ) );
+#endif
+}
+
+// The wedged thread cannot be joined, so the process has to leave without it.
+[[noreturn]] void leaveNow( int code )
+{
+#ifdef __EMSCRIPTEN__
+    emscripten_force_exit( code );
+#endif
+    std::_Exit( code );
+}
+
+} // namespace
+
+// Reloads one and the same scene archive many times, hunting a rare stall seen twice in
+// a wasm64 browser build: loadObjectFromFile never returned while the page itself stayed
+// responsive. The load therefore runs on a worker thread while this thread stays awake and
+// watches it, mirroring the app, where the loader is a pthread and the UI thread keeps
+// pumping. A previous round doing the same loads on the main thread found nothing in 1600
+// of them, which is why the thread the load runs on is now part of the experiment.
 TEST( MRMesh, SceneLoadStress )
 {
-    auto addMesh = [] ( Object& root, std::string name, Mesh mesh )
-    {
-        auto obj = std::make_shared<ObjectMesh>();
-        obj->setName( std::move( name ) );
-        obj->setMesh( std::make_shared<Mesh>( std::move( mesh ) ) );
-        root.addChild( std::move( obj ) );
-    };
-
     Object root;
     root.setName( "Root" );
     addMesh( root, "big", makeUVSphere( 1.0f, 300, 300 ) );
@@ -44,15 +85,74 @@ TEST( MRMesh, SceneLoadStress )
     std::error_code ec;
     spdlog::info( "stress.mru: {} bytes", std::filesystem::file_size( mruPath, ec ) );
 
-    constexpr int iterations = 200;
-    for ( int i = 0; i < iterations; ++i )
+#if !defined( __EMSCRIPTEN__ ) || defined( __EMSCRIPTEN_PTHREADS__ )
+    std::atomic<int> done{ 0 };
+    std::atomic<bool> broken{ false };
+    std::string error;
+
+    std::thread loader( [&]
+    {
+        for ( int i = 0; i < cIterations; ++i )
+        {
+            Timer t( "t" );
+            auto loaded = loadObjectFromFile( mruPath );
+            if ( !loaded )
+                error = loaded.error();
+            else if ( loaded->objs.empty() )
+                error = "no objects loaded";
+            if ( !error.empty() )
+            {
+                broken.store( true, std::memory_order_release );
+                return;
+            }
+            spdlog::info( "iteration {}/{}: {} sec", i + 1, cIterations, t.secondsPassed() );
+            done.store( i + 1, std::memory_order_release );
+        }
+    } );
+
+    int seen = 0;
+    int ticks = 0;
+    auto lastProgress = std::chrono::steady_clock::now();
+    while ( done.load( std::memory_order_acquire ) < cIterations && !broken.load( std::memory_order_acquire ) )
+    {
+        stayAwake( 250 );
+
+        const int now = done.load( std::memory_order_acquire );
+        if ( now != seen )
+        {
+            seen = now;
+            lastProgress = std::chrono::steady_clock::now();
+        }
+        else
+        {
+            const auto idle = std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - lastProgress ).count();
+            if ( idle >= cStallSeconds )
+            {
+                spdlog::error( "STALLED: the loader made no progress for {} s after {} loads", idle, seen );
+                spdlog::error( "this thread is still running, so the stall is in the loader thread alone" );
+                leaveNow( 3 );
+            }
+        }
+
+        // once a second, so a stalled log still shows this thread alive next to a silent loader
+        if ( ++ticks % 4 == 0 )
+            spdlog::info( "watching: {} loads done", seen );
+    }
+
+    loader.join();
+    ASSERT_FALSE( broken.load( std::memory_order_acquire ) ) << error;
+    EXPECT_EQ( done.load( std::memory_order_acquire ), cIterations );
+#else
+    for ( int i = 0; i < cIterations; ++i )
     {
         Timer t( "t" );
         auto loaded = loadObjectFromFile( mruPath );
         ASSERT_TRUE( loaded.has_value() ) << "iteration " << i << ": " << loaded.error();
         ASSERT_FALSE( loaded->objs.empty() ) << "iteration " << i;
-        spdlog::info( "iteration {}/{}: {} sec", i + 1, iterations, t.secondsPassed() );
+        spdlog::info( "iteration {}/{}: {} sec", i + 1, cIterations, t.secondsPassed() );
     }
+#endif
 }
 
 } // namespace MR

--- a/source/MRTest/MRSceneLoadStressTests.cpp
+++ b/source/MRTest/MRSceneLoadStressTests.cpp
@@ -1,0 +1,58 @@
+#include "MRMesh/MRCube.h"
+#include "MRMesh/MRMakeSphereMesh.h"
+#include "MRMesh/MRMesh.h"
+#include "MRMesh/MRObject.h"
+#include "MRMesh/MRObjectLoad.h"
+#include "MRMesh/MRObjectMesh.h"
+#include "MRMesh/MRObjectSave.h"
+#include "MRMesh/MRTimer.h"
+#include "MRMesh/MRUniqueTemporaryFolder.h"
+#include "MRPch/MRSpdlog.h"
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+namespace MR
+{
+
+// Reloads one and the same scene archive many times, hunting a rare stall seen
+// twice in a wasm64 browser build: loadObjectFromFile never returned while the
+// page itself stayed responsive. Three meshes, sized after the archive that
+// stalled: ~3.4 MB, ~10 KB, ~250 B of .ply.
+TEST( MRMesh, SceneLoadStress )
+{
+    auto addMesh = [] ( Object& root, std::string name, Mesh mesh )
+    {
+        auto obj = std::make_shared<ObjectMesh>();
+        obj->setName( std::move( name ) );
+        obj->setMesh( std::make_shared<Mesh>( std::move( mesh ) ) );
+        root.addChild( std::move( obj ) );
+    };
+
+    Object root;
+    root.setName( "Root" );
+    addMesh( root, "big", makeUVSphere( 1.0f, 300, 300 ) );
+    addMesh( root, "small", makeUVSphere( 1.0f, 16, 16 ) );
+    addMesh( root, "tiny", makeCube() );
+
+    UniqueTemporaryFolder folder;
+    ASSERT_TRUE( bool( folder ) );
+    const auto mruPath = folder / "stress.mru";
+    const auto saved = serializeObjectTree( root, mruPath );
+    ASSERT_TRUE( saved.has_value() ) << saved.error();
+
+    std::error_code ec;
+    spdlog::info( "stress.mru: {} bytes", std::filesystem::file_size( mruPath, ec ) );
+
+    constexpr int iterations = 200;
+    for ( int i = 0; i < iterations; ++i )
+    {
+        Timer t( "t" );
+        auto loaded = loadObjectFromFile( mruPath );
+        ASSERT_TRUE( loaded.has_value() ) << "iteration " << i << ": " << loaded.error();
+        ASSERT_FALSE( loaded->objs.empty() ) << "iteration " << i;
+        spdlog::info( "iteration {}/{}: {} sec", i + 1, iterations, t.secondsPassed() );
+    }
+}
+
+} // namespace MR

--- a/source/MRTest/MRSceneLoadStressTests.cpp
+++ b/source/MRTest/MRSceneLoadStressTests.cpp
@@ -29,7 +29,6 @@ namespace
 {
 
 constexpr int cIterations = 2000;
-constexpr int cStallSeconds = 120;
 
 void addMesh( Object& root, std::string name, Mesh mesh )
 {
@@ -38,6 +37,10 @@ void addMesh( Object& root, std::string name, Mesh mesh )
     obj->setMesh( std::make_shared<Mesh>( std::move( mesh ) ) );
     root.addChild( std::move( obj ) );
 }
+
+#if !defined( __EMSCRIPTEN__ ) || defined( __EMSCRIPTEN_PTHREADS__ )
+
+constexpr int cStallSeconds = 120;
 
 // Keeps the calling thread awake without letting it fall asleep on a futex: on the
 // emscripten main thread this also drains the proxying queue, which is what the app's
@@ -59,6 +62,8 @@ void stayAwake( int ms )
 #endif
     std::_Exit( code );
 }
+
+#endif
 
 } // namespace
 

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -55,6 +55,7 @@
     <ClCompile Include="MRPolylineTrimWithPlane.cpp" />
     <ClCompile Include="MRPrecisePredicatesTests.cpp" />
     <ClCompile Include="MRReducePathTests.cpp" />
+    <ClCompile Include="MRSceneLoadStressTests.cpp" />
     <ClCompile Include="MRSerializeTests.cpp" />
     <ClCompile Include="MRSpdlog.cpp" />
     <ClCompile Include="MRStreamOperatorsTests.cpp" />


### PR DESCRIPTION
**Throwaway experiment -- do not merge, do not review.** The branch gets deleted once it has answered the question.

A wasm64 browser build has twice frozen inside a scene load that never returns while the page itself stays responsive: once in the zip write path before an upload, once in `loadObjectFromFile` on a downloaded `.mru`, with the console going silent right after `Temporary folder created` and the progress dialog frozen at 75% with a live Cancel button. Roughly one occurrence per 350 imports, always on the 64-bit multithreaded build, never on the singlethreaded or 32-bit ones. This tries to make it happen on demand.

`MRMesh.SceneLoadStress` saves one scene and then reloads it 200 times through `loadObjectFromFile`. The scene is three meshes sized after the archive that stalled -- a 300x300 UV sphere at ~3.4 MB of `.ply`, a 16x16 one at ~10 KB, and a cube at ~250 B -- so the archive has the same shape as the real one without shipping a binary fixture. `emscripten-test` runs that test and nothing else, on the `emscripten-multithreaded-64bit` bundle only, across 8 shards: 1600 loads per CI run.

Why 1600 and not 100: at ~1/700 per load (2 stalls, one of them in this stage, over ~700-850 loads since the wasm suite landed on 07-31) 100 loads would be a ~13% shot, 1600 is ~90%. The shards run in parallel so it costs one build plus about ten minutes.

This lands here rather than in the app repo because MeshLib's `emscripten-test` already runs `MRTest.html` in headless Firefox through emrun -- a real browser, real wasm64, real pthreads -- on a runner that is free for a public repo, and because `loadObjectFromFile` is MeshLib code, so nothing about the app is needed to exercise it.

Reading the result:

* a shard that times out is the reproduction. #6656 just landed, so the log now brackets the unzip: if the last lines are `Decompressing N zip entries` with no `Decompressed N zip entries`, it is stuck in libzip, otherwise in `deserializeObjectTreeFromFolder`. Each iteration also logs its own duration, so the log says exactly which load hung.
* a clean 1600 is not proof this stage is innocent. It would be evidence that the stall needs the surrounding pipeline -- the compress, upload and download work that this test deliberately removes -- or that it needs x64: CI here is `ubuntu-24.04-arm`, while the failures were on an x64 runner.

Non-emscripten platforms are disabled. Nothing outside `source/MRTest/` and the emscripten workflow is touched, so no shipping code changes.
