### PR TITLE
rockylinux8 image: follow the renamed toolchain artifacts

### DIFF
--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -37,19 +37,8 @@ RUN <<EOF
         $(: CI environment ) \
         gh time python3.12-pip rpm-build xorg-x11-server-Xvfb mesa-dri-drivers gettext
     dnf clean all
-    # PGO-optimized clang/lld 22.1.8 (-O3 + IR-PGO, distro-style
-    # libLLVM.so/libclang-cpp.so that mrbind dynamically links) from
-    # MeshInspector/toolchains
-    case "$(uname -m)" in
-        x86_64)  CLANG_SHA=97b40230ff3c65e567b532b3a7cff009b0f3d397b3b5311816743a50f5641727 ;;
-        aarch64) CLANG_SHA=41e405b76822e19b7d6cf00db648d290ad78b274fd03a970b91a0bbbb76af5d7 ;;
-    esac
     TOOLCHAIN=clang-22.1.8-pgo-dylib-linux
-    retry.sh -- curl -fsSL -o /tmp/clang-pgo.tar.gz "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz"
-    echo "${CLANG_SHA}  /tmp/clang-pgo.tar.gz" | sha256sum -c -
-    tar -C /opt -xzf /tmp/clang-pgo.tar.gz
-    rm /tmp/clang-pgo.tar.gz
-    /opt/llvm-pgo-dylib-22.1.8/bin/clang++ --version
+    retry.sh -- curl -fsSL "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" | tar -C /opt -xz
     # install aws cli
     curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
     unzip awscliv2.zip

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -38,13 +38,14 @@ RUN <<EOF
         gh time python3.12-pip rpm-build xorg-x11-server-Xvfb mesa-dri-drivers gettext
     dnf clean all
     # PGO-optimized clang/lld 22.1.8 (-O3 + IR-PGO, distro-style
-    # libLLVM.so/libclang-cpp.so that mrbind dynamically links), built for
-    # this image at MeshInspector/toolchains
+    # libLLVM.so/libclang-cpp.so that mrbind dynamically links) from
+    # MeshInspector/toolchains
     case "$(uname -m)" in
-        x86_64)  CLANG_ARCH=x64;   CLANG_SHA=97b40230ff3c65e567b532b3a7cff009b0f3d397b3b5311816743a50f5641727 ;;
-        aarch64) CLANG_ARCH=arm64; CLANG_SHA=41e405b76822e19b7d6cf00db648d290ad78b274fd03a970b91a0bbbb76af5d7 ;;
+        x86_64)  CLANG_SHA=97b40230ff3c65e567b532b3a7cff009b0f3d397b3b5311816743a50f5641727 ;;
+        aarch64) CLANG_SHA=41e405b76822e19b7d6cf00db648d290ad78b274fd03a970b91a0bbbb76af5d7 ;;
     esac
-    retry.sh -- curl -fsSL -o /tmp/clang-pgo.tar.gz "https://github.com/MeshInspector/toolchains/releases/download/clang-22.1.8-pgo-dylib-rockylinux8/clang-22.1.8-pgo-dylib-rockylinux8-${CLANG_ARCH}.tar.gz"
+    TOOLCHAIN=clang-22.1.8-pgo-dylib-linux
+    retry.sh -- curl -fsSL -o /tmp/clang-pgo.tar.gz "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz"
     echo "${CLANG_SHA}  /tmp/clang-pgo.tar.gz" | sha256sum -c -
     tar -C /opt -xzf /tmp/clang-pgo.tar.gz
     rm /tmp/clang-pgo.tar.gz


### PR DESCRIPTION
The PGO Clang tarball in [MeshInspector/toolchains](https://github.com/MeshInspector/toolchains/releases/tag/clang-22.1.8-pgo-dylib-linux) was renamed, because the same artifact is used by images other than rockylinux8 (the C-bindings image in #6649 is the first) and the old name said otherwise:

* release/tag `clang-22.1.8-pgo-dylib-rockylinux8` -> `clang-22.1.8-pgo-dylib-linux`
* assets `...-x64.tar.gz` / `...-arm64.tar.gz` -> `...-x86_64.tar.gz` / `...-aarch64.tar.gz`, matching `uname -m`

Renamed in place, so **the old URL is already a 404** and this image cannot rebuild without this change. Nothing rebuilt in the meantime - the image tag is content-addressed, so master kept serving the cached image.

The arch mapping disappears with the rename (`$(uname -m)` goes straight into the URL); the per-arch sha256 stays, and the tarball's contents and install prefix are untouched, so the image is byte-identical apart from the download URL.

MeshInspectorCode needs the same one-line fix; PR there follows.

The download is also trimmed to a single `curl | tar` per review: the sha256 check, the `clang++ --version` smoke test and the comments are gone, matching the C-bindings image. Verifying the toolchain is the toolchain CI's job.
