### PR TITLE
ubuntu images: use our PGO clang - 18 on ubuntu22, 22 on ubuntu24

### DIFF
--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -56,15 +56,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Add our Clang to PATH
-        # Via GITHUB_ENV, like build-test-linux-vcpkg.yml: a GITHUB_PATH entry
-        # makes the runner drop any PATH exported through GITHUB_ENV.
-        run: |
-          # LLVM_PREFIX is set by the image, see docker/ubuntu2*Dockerfile.
-          if [ -z "${LLVM_PREFIX:-}" ] ; then
-            echo "LLVM_PREFIX is empty: image predates the PGO clang switch" >&2
-            exit 1
-          fi
-          echo "PATH=${LLVM_PREFIX}/bin:${PATH}" >> $GITHUB_ENV
+        run: echo "PATH=${LLVM_PREFIX}/bin:${PATH}" >> $GITHUB_ENV
 
       - name: Collect runner's system stats
         if: ${{ inputs.internal_build }}
@@ -147,8 +139,7 @@ jobs:
           CMAKE_C_COMPILER: ${{ matrix.c-compiler }}
           CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
           MR_VERSION: ${{ inputs.app_version }}
-          # options to be passed to cmake; matrix.extra-cmake-options is the
-          # per-row hook (ubuntu24 Clang needs fmt 9.1 consteval disabled)
+          # options to be passed to cmake
           MR_CMAKE_OPTIONS: >
             -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
             -DMESHLIB_BUILD_MRCUDA=${{ matrix.build_mrcuda }}
@@ -156,7 +147,6 @@ jobs:
             -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
             -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
             -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
-            ${{ matrix.extra-cmake-options }}
 
       - name: PCH size (diagnostic)
         run: find ./build/${{ matrix.config }} -name 'cmake_pch.hxx.gch' -exec ls -lh {} +

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -143,7 +143,8 @@ jobs:
           CMAKE_C_COMPILER: ${{ matrix.c-compiler }}
           CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
           MR_VERSION: ${{ inputs.app_version }}
-          # options to be passed to cmake
+          # options to be passed to cmake; matrix.extra-cmake-options is the
+          # per-row hook (ubuntu24 Clang needs fmt 9.1 consteval disabled)
           MR_CMAKE_OPTIONS: >
             -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
             -DMESHLIB_BUILD_MRCUDA=${{ matrix.build_mrcuda }}
@@ -151,6 +152,7 @@ jobs:
             -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
             -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
             -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
+            ${{ matrix.extra-cmake-options }}
 
       - name: PCH size (diagnostic)
         run: find ./build/${{ matrix.config }} -name 'cmake_pch.hxx.gch' -exec ls -lh {} +

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -81,6 +81,13 @@ jobs:
           ln -s /usr/local/lib/meshlib-thirdparty-lib/include ./include
           ln -s /usr/local/lib/meshlib-thirdparty-lib/share ./share
 
+      - name: Add our Clang to PATH
+        # Via GITHUB_ENV, like build-test-linux-vcpkg.yml: a GITHUB_PATH entry
+        # makes the runner drop any PATH exported through GITHUB_ENV.
+        run: |
+          : "${LLVM_PREFIX:?provided by docker/ubuntu2*Dockerfile}"
+          echo "PATH=${LLVM_PREFIX}/bin:${PATH}" >> $GITHUB_ENV
+
       - name: Install MRBind
         if: ${{ inputs.mrbind || inputs.mrbind_c }}
         uses: ./.github/actions/build-mrbind

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -59,7 +59,11 @@ jobs:
         # Via GITHUB_ENV, like build-test-linux-vcpkg.yml: a GITHUB_PATH entry
         # makes the runner drop any PATH exported through GITHUB_ENV.
         run: |
-          : "${LLVM_PREFIX:?provided by docker/ubuntu2*Dockerfile}"
+          # LLVM_PREFIX is set by the image, see docker/ubuntu2*Dockerfile.
+          if [ -z "${LLVM_PREFIX:-}" ] ; then
+            echo "LLVM_PREFIX is empty: image predates the PGO clang switch" >&2
+            exit 1
+          fi
           echo "PATH=${LLVM_PREFIX}/bin:${PATH}" >> $GITHUB_ENV
 
       - name: Collect runner's system stats

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Add our Clang to PATH
+        # Via GITHUB_ENV, like build-test-linux-vcpkg.yml: a GITHUB_PATH entry
+        # makes the runner drop any PATH exported through GITHUB_ENV.
+        run: |
+          : "${LLVM_PREFIX:?provided by docker/ubuntu2*Dockerfile}"
+          echo "PATH=${LLVM_PREFIX}/bin:${PATH}" >> $GITHUB_ENV
+
       - name: Collect runner's system stats
         if: ${{ inputs.internal_build }}
         id: collect-runner-stats
@@ -80,13 +87,6 @@ jobs:
           ln -s /usr/local/lib/meshlib-thirdparty-lib/lib ./lib
           ln -s /usr/local/lib/meshlib-thirdparty-lib/include ./include
           ln -s /usr/local/lib/meshlib-thirdparty-lib/share ./share
-
-      - name: Add our Clang to PATH
-        # Via GITHUB_ENV, like build-test-linux-vcpkg.yml: a GITHUB_PATH entry
-        # makes the runner drop any PATH exported through GITHUB_ENV.
-        run: |
-          : "${LLVM_PREFIX:?provided by docker/ubuntu2*Dockerfile}"
-          echo "PATH=${LLVM_PREFIX}/bin:${PATH}" >> $GITHUB_ENV
 
       - name: Install MRBind
         if: ${{ inputs.mrbind || inputs.mrbind_c }}

--- a/.github/workflows/matrix/ubuntu-x64-full-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-full-config.json
@@ -46,7 +46,7 @@
       "compiler": "Clang",
       "cxx-compiler": "clang++",
       "c-compiler": "clang",
-      "extra-cmake-options": "-D CMAKE_CXX_FLAGS=-DFMT_USE_CONSTEVAL=0",
+      "extra-cmake-options": "-D CMAKE_CXX_FLAGS=-DFMT_CONSTEVAL=",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "OFF"
@@ -57,7 +57,7 @@
       "compiler": "Clang",
       "cxx-compiler": "clang++",
       "c-compiler": "clang",
-      "extra-cmake-options": "-D CMAKE_CXX_FLAGS=-DFMT_USE_CONSTEVAL=0",
+      "extra-cmake-options": "-D CMAKE_CXX_FLAGS=-DFMT_CONSTEVAL=",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "OFF"

--- a/.github/workflows/matrix/ubuntu-x64-full-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-full-config.json
@@ -46,7 +46,6 @@
       "compiler": "Clang",
       "cxx-compiler": "clang++",
       "c-compiler": "clang",
-      "extra-cmake-options": "-D CMAKE_CXX_FLAGS=-DFMT_CONSTEVAL=",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "OFF"
@@ -57,7 +56,6 @@
       "compiler": "Clang",
       "cxx-compiler": "clang++",
       "c-compiler": "clang",
-      "extra-cmake-options": "-D CMAKE_CXX_FLAGS=-DFMT_CONSTEVAL=",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "OFF"

--- a/.github/workflows/matrix/ubuntu-x64-full-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-full-config.json
@@ -44,8 +44,8 @@
       "os": "ubuntu24",
       "config": "Release",
       "compiler": "Clang",
-      "cxx-compiler": "/usr/bin/clang++-18",
-      "c-compiler": "/usr/bin/clang-18",
+      "cxx-compiler": "clang++",
+      "c-compiler": "clang",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "OFF"
@@ -54,8 +54,8 @@
       "os": "ubuntu24",
       "config": "Debug",
       "compiler": "Clang",
-      "cxx-compiler": "/usr/bin/clang++-18",
-      "c-compiler": "/usr/bin/clang-18",
+      "cxx-compiler": "clang++",
+      "c-compiler": "clang",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "OFF"

--- a/.github/workflows/matrix/ubuntu-x64-full-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-full-config.json
@@ -46,6 +46,7 @@
       "compiler": "Clang",
       "cxx-compiler": "clang++",
       "c-compiler": "clang",
+      "extra-cmake-options": "-D CMAKE_CXX_FLAGS=-DFMT_USE_CONSTEVAL=0",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "OFF"
@@ -56,6 +57,7 @@
       "compiler": "Clang",
       "cxx-compiler": "clang++",
       "c-compiler": "clang",
+      "extra-cmake-options": "-D CMAKE_CXX_FLAGS=-DFMT_USE_CONSTEVAL=0",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "OFF"

--- a/.github/workflows/update-docs-manual.yml
+++ b/.github/workflows/update-docs-manual.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           cache-key-prefix: ubuntu-docs-clang
           build-script: scripts/mrbind/install_mrbind_ubuntu.sh
-          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt') }}
+          extra-cache-key: ${{ hashFiles('scripts/mrbind/clang_version.txt', 'docker/ubuntu22Dockerfile') }}
 
       - name: Create virtualenv
         run: |

--- a/cmake/Modules/CompilerOptions.cmake
+++ b/cmake/Modules/CompilerOptions.cmake
@@ -186,6 +186,16 @@ IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_G
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wno-sfinae-incomplete")
 ENDIF()
 
+# fmt before 12 cannot be compiled by Clang 20+: the `FMT_STRING` compile-time check
+# evaluates `&*context_.begin()`, no longer a constant expression. spdlog's
+# daily_file_sink.h uses FMT_STRING, and e.g. Ubuntu 24.04 ships fmt 9.1.
+IF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 20)
+  find_package(fmt QUIET)
+  IF(NOT fmt_VERSION OR fmt_VERSION VERSION_LESS 12)
+    add_compile_definitions(FMT_CONSTEVAL=)
+  ENDIF()
+ENDIF()
+
 # Apple Clang 17 conflicts with OpenVDB 12.1
 IF(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 17)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++23-attribute-extensions")

--- a/cmake/Modules/CompilerOptions.cmake
+++ b/cmake/Modules/CompilerOptions.cmake
@@ -186,9 +186,9 @@ IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_G
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wno-sfinae-incomplete")
 ENDIF()
 
-# fmt before 12 cannot be compiled by Clang 20+: the `FMT_STRING` compile-time check
-# evaluates `&*context_.begin()`, no longer a constant expression. spdlog's
-# daily_file_sink.h uses FMT_STRING, and e.g. Ubuntu 24.04 ships fmt 9.1.
+# Clang 20+ conflicts with fmt prior to 12
+# https://github.com/fmtlib/fmt/issues/4177
+# https://github.com/fmtlib/fmt/issues/4247
 IF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 20)
   find_package(fmt QUIET)
   IF(NOT fmt_VERSION OR fmt_VERSION VERSION_LESS 12)

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -58,9 +58,6 @@ RUN <<EOF
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh
-    # Our -O3 + IR-PGO clang/lld 18, in place of the distro / apt.llvm.org one.
-    # Built in rockylinux:8, so its glibc 2.28 floor is below jammy's 2.35 and
-    # noble's 2.39 - one tarball serves every Linux image.
     TOOLCHAIN=clang-${LLVM_VERSION}-pgo-dylib-linux
     curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" | tar -C /opt -xz
     ./scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -12,7 +12,7 @@ COPY requirements requirements
 COPY scripts/mrbind-pybind11/python_versions.txt scripts/mrbind-pybind11/python_versions.txt
 COPY scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
 
-ENV LLVM_VERSION=18.1.8
+ENV LLVM_VERSION=22.1.8
 ENV LLVM_PREFIX=/opt/llvm-pgo-dylib-$LLVM_VERSION
 
 ENV MR_STATE=DOCKER_BUILD
@@ -58,7 +58,7 @@ RUN <<EOF
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh
-    # Our -O3 + IR-PGO clang/lld 18, in place of the distro / apt.llvm.org one.
+    # Our -O3 + IR-PGO clang/lld 22, in place of the apt.llvm.org LLVM 18 stack.
     # Built in rockylinux:8, so its glibc 2.28 floor is below jammy's 2.35 and
     # noble's 2.39 - one tarball serves every Linux image.
     TOOLCHAIN=clang-${LLVM_VERSION}-pgo-dylib-linux

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -12,7 +12,7 @@ COPY requirements requirements
 COPY scripts/mrbind-pybind11/python_versions.txt scripts/mrbind-pybind11/python_versions.txt
 COPY scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
 
-ENV LLVM_VERSION=22.1.8
+ENV LLVM_VERSION=18.1.8
 ENV LLVM_PREFIX=/opt/llvm-pgo-dylib-$LLVM_VERSION
 
 ENV MR_STATE=DOCKER_BUILD
@@ -58,7 +58,7 @@ RUN <<EOF
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh
-    # Our -O3 + IR-PGO clang/lld 22, in place of the apt.llvm.org LLVM 18 stack.
+    # Our -O3 + IR-PGO clang/lld 18, in place of the distro / apt.llvm.org one.
     # Built in rockylinux:8, so its glibc 2.28 floor is below jammy's 2.35 and
     # noble's 2.39 - one tarball serves every Linux image.
     TOOLCHAIN=clang-${LLVM_VERSION}-pgo-dylib-linux

--- a/docker/ubuntu22Dockerfile
+++ b/docker/ubuntu22Dockerfile
@@ -8,11 +8,12 @@ WORKDIR "/usr/local/lib/meshlib-thirdparty-lib/"
 
 COPY scripts/install_apt_requirements.sh scripts/install_apt_requirements.sh
 COPY scripts/install_apt_cuda.sh scripts/install_apt_cuda.sh
-COPY scripts/mrbind/install_deps_ubuntu.sh scripts/mrbind/install_deps_ubuntu.sh
-COPY scripts/mrbind/clang_version.txt scripts/mrbind/clang_version.txt
 COPY requirements requirements
 COPY scripts/mrbind-pybind11/python_versions.txt scripts/mrbind-pybind11/python_versions.txt
 COPY scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
+
+ENV LLVM_VERSION=18.1.8
+ENV LLVM_PREFIX=/opt/llvm-pgo-dylib-$LLVM_VERSION
 
 ENV MR_STATE=DOCKER_BUILD
 
@@ -53,11 +54,15 @@ RUN <<EOF
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
         gh g++-12 clang-14 \
-        tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
+        tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext gawk procps
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh
-    ./scripts/mrbind/install_deps_ubuntu.sh
+    # Our -O3 + IR-PGO clang/lld 18, in place of the distro / apt.llvm.org one.
+    # Built in rockylinux:8, so its glibc 2.28 floor is below jammy's 2.35 and
+    # noble's 2.39 - one tarball serves every Linux image.
+    TOOLCHAIN=clang-${LLVM_VERSION}-pgo-dylib-linux
+    curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" | tar -C /opt -xz
     ./scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
     # clean downloaded files
     apt-get clean

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -8,11 +8,12 @@ WORKDIR "/usr/local/lib/meshlib-thirdparty-lib/"
 
 COPY scripts/install_apt_requirements.sh scripts/install_apt_requirements.sh
 COPY scripts/install_apt_cuda.sh scripts/install_apt_cuda.sh
-COPY scripts/mrbind/install_deps_ubuntu.sh scripts/mrbind/install_deps_ubuntu.sh
-COPY scripts/mrbind/clang_version.txt scripts/mrbind/clang_version.txt
 COPY requirements requirements
 COPY scripts/mrbind-pybind11/python_versions.txt scripts/mrbind-pybind11/python_versions.txt
 COPY scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
+
+ENV LLVM_VERSION=18.1.8
+ENV LLVM_PREFIX=/opt/llvm-pgo-dylib-$LLVM_VERSION
 
 ENV MR_STATE=DOCKER_BUILD
 
@@ -51,12 +52,16 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh g++-13 gcc-14 g++-14 clang-18 \
-        tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext
+        gh g++-13 gcc-14 g++-14 \
+        tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext gawk procps
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh
-    ./scripts/mrbind/install_deps_ubuntu.sh
+    # Our -O3 + IR-PGO clang/lld 18, in place of the distro / apt.llvm.org one.
+    # Built in rockylinux:8, so its glibc 2.28 floor is below jammy's 2.35 and
+    # noble's 2.39 - one tarball serves every Linux image.
+    TOOLCHAIN=clang-${LLVM_VERSION}-pgo-dylib-linux
+    curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" | tar -C /opt -xz
     ./scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
     # clean downloaded files
     apt-get clean

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -57,9 +57,6 @@ RUN <<EOF
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh
-    # Our -O3 + IR-PGO clang/lld 22, in place of the distro clang-18.
-    # Built in rockylinux:8, so its glibc 2.28 floor is below jammy's 2.35 and
-    # noble's 2.39 - one tarball serves every Linux image.
     TOOLCHAIN=clang-${LLVM_VERSION}-pgo-dylib-linux
     curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" | tar -C /opt -xz
     ./scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -12,7 +12,7 @@ COPY requirements requirements
 COPY scripts/mrbind-pybind11/python_versions.txt scripts/mrbind-pybind11/python_versions.txt
 COPY scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
 
-ENV LLVM_VERSION=18.1.8
+ENV LLVM_VERSION=22.1.8
 ENV LLVM_PREFIX=/opt/llvm-pgo-dylib-$LLVM_VERSION
 
 ENV MR_STATE=DOCKER_BUILD
@@ -57,7 +57,7 @@ RUN <<EOF
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh
-    # Our -O3 + IR-PGO clang/lld 18, in place of the distro / apt.llvm.org one.
+    # Our -O3 + IR-PGO clang/lld 22, in place of the distro clang-18.
     # Built in rockylinux:8, so its glibc 2.28 floor is below jammy's 2.35 and
     # noble's 2.39 - one tarball serves every Linux image.
     TOOLCHAIN=clang-${LLVM_VERSION}-pgo-dylib-linux

--- a/scripts/devops/docker_image_source_checksum.sh
+++ b/scripts/devops/docker_image_source_checksum.sh
@@ -26,8 +26,6 @@ ubuntu=(
   scripts/install_apt_requirements.sh
   scripts/install_apt_cuda.sh
   scripts/install_thirdparty.sh
-  scripts/mrbind/install_deps_ubuntu.sh
-  scripts/mrbind/clang_version.txt
   scripts/mrbind-pybind11/python_versions.txt
   scripts/mrbind-pybind11/install_all_python_versions_ubuntu_pkgs.sh
 )

--- a/scripts/mrbind/README-updating-clang.md
+++ b/scripts/mrbind/README-updating-clang.md
@@ -6,7 +6,7 @@ The Linux images that set `LLVM_PREFIX` (`docker/rockylinux8-vcpkgDockerfile`,
 `docker/ubuntu22Dockerfile`, `docker/ubuntu24Dockerfile`,
 `docker/emscripten-generate-c-bindingsDockerfile`) build the bindings with our own PGO-optimized
 Clang instead, unpacked into `/opt` from a [MeshInspector/toolchains](https://github.com/MeshInspector/toolchains)
-release and pinned in those Dockerfiles - bump it there. `clang_version.txt` still drives the apt
+release and pinned in those Dockerfiles (currently 18.1.8 for ubuntu22, 22.1.8 elsewhere) - bump it there. `clang_version.txt` still drives the apt
 packages everywhere else.
 
 On Windows (MSYS2), you can only lock the latest Clang version they offer.

--- a/scripts/mrbind/README-updating-clang.md
+++ b/scripts/mrbind/README-updating-clang.md
@@ -6,7 +6,7 @@ The Linux images that set `LLVM_PREFIX` (`docker/rockylinux8-vcpkgDockerfile`,
 `docker/ubuntu22Dockerfile`, `docker/ubuntu24Dockerfile`,
 `docker/emscripten-generate-c-bindingsDockerfile`) build the bindings with our own PGO-optimized
 Clang instead, unpacked into `/opt` from a [MeshInspector/toolchains](https://github.com/MeshInspector/toolchains)
-release and pinned in those Dockerfiles (currently 18.1.8 for ubuntu22, 22.1.8 elsewhere) - bump it there. `clang_version.txt` still drives the apt
+release and pinned in those Dockerfiles (currently 22.1.8 everywhere) - bump it there. `clang_version.txt` still drives the apt
 packages everywhere else.
 
 On Windows (MSYS2), you can only lock the latest Clang version they offer.

--- a/scripts/mrbind/README-updating-clang.md
+++ b/scripts/mrbind/README-updating-clang.md
@@ -6,7 +6,7 @@ The Linux images that set `LLVM_PREFIX` (`docker/rockylinux8-vcpkgDockerfile`,
 `docker/ubuntu22Dockerfile`, `docker/ubuntu24Dockerfile`,
 `docker/emscripten-generate-c-bindingsDockerfile`) build the bindings with our own PGO-optimized
 Clang instead, unpacked into `/opt` from a [MeshInspector/toolchains](https://github.com/MeshInspector/toolchains)
-release and pinned in those Dockerfiles (currently 22.1.8 everywhere) - bump it there. `clang_version.txt` still drives the apt
+release and pinned in those Dockerfiles (currently 18.1.8 for ubuntu22, 22.1.8 elsewhere) - bump it there. `clang_version.txt` still drives the apt
 packages everywhere else.
 
 On Windows (MSYS2), you can only lock the latest Clang version they offer.

--- a/scripts/mrbind/README-updating-clang.md
+++ b/scripts/mrbind/README-updating-clang.md
@@ -2,11 +2,9 @@
 
 Update the number in `scripts/mrbind/clang_version.txt` for Linux and in `scripts/mrbind/clang_version_macos.txt` for macOS.
 
-The Linux images that set `LLVM_PREFIX` (`docker/rockylinux8-vcpkgDockerfile`,
-`docker/ubuntu22Dockerfile`, `docker/ubuntu24Dockerfile`,
-`docker/emscripten-generate-c-bindingsDockerfile`) build the bindings with our own PGO-optimized
+The Linux images build the bindings with our own PGO-optimized
 Clang instead, unpacked into `/opt` from a [MeshInspector/toolchains](https://github.com/MeshInspector/toolchains)
-release and pinned in those Dockerfiles (currently 18.1.8 for ubuntu22, 22.1.8 elsewhere) - bump it there. `clang_version.txt` still drives the apt
+release and pinned in those Dockerfiles - bump it there. `clang_version.txt` still drives the apt
 packages everywhere else.
 
 On Windows (MSYS2), you can only lock the latest Clang version they offer.

--- a/scripts/mrbind/README-updating-clang.md
+++ b/scripts/mrbind/README-updating-clang.md
@@ -3,6 +3,7 @@
 Update the number in `scripts/mrbind/clang_version.txt` for Linux and in `scripts/mrbind/clang_version_macos.txt` for macOS.
 
 The Linux images that set `LLVM_PREFIX` (`docker/rockylinux8-vcpkgDockerfile`,
+`docker/ubuntu22Dockerfile`, `docker/ubuntu24Dockerfile`,
 `docker/emscripten-generate-c-bindingsDockerfile`) build the bindings with our own PGO-optimized
 Clang instead, unpacked into `/opt` from a [MeshInspector/toolchains](https://github.com/MeshInspector/toolchains)
 release and pinned in those Dockerfiles - bump it there. `clang_version.txt` still drives the apt


### PR DESCRIPTION
The ubuntu22/24 images get their Clang 18 from `scripts/mrbind/install_deps_ubuntu.sh`: noble has `clang-18` in its own repos, jammy does not, so ubuntu22 pulls the whole LLVM 18 stack from apt.llvm.org. They now unpack our `-O3` + IR-PGO clang/lld from [MeshInspector/toolchains](https://github.com/MeshInspector/toolchains/releases) into `/opt` and point `LLVM_PREFIX` at it, the same way the rockylinux8-vcpkg image (#6648) and the C-bindings image (#6649) already do.

The two images land on different versions, and the reason is the distros, not preference:

* **ubuntu22 -> [clang 18.1.8](https://github.com/MeshInspector/toolchains/releases/tag/clang-18.1.8-pgo-dylib-linux)**, the same major it replaces. Its product rows are clang-14 / g++-12 and stay that way, so this is purely the MRBind and bindings toolchain, as the apt Clang 18 was. **Clang 22 is not an option here** - see the Boost note below.
* **ubuntu24 -> [clang 22.1.8](https://github.com/MeshInspector/toolchains/releases/tag/clang-22.1.8-pgo-dylib-linux)**, the same tarball the rockylinux8-vcpkg and C-bindings images use. Its two Clang product rows move off apt clang-18 onto it, so this is a compiler *upgrade* there, not just a swap, and it is the one place needing a workaround.

This is the ubuntu half that was cut out of #6649.

### What it buys us

* **The bindings and MRBind get the PGO Clang on every ubuntu row.** The bindings were always compiled by `clang++-18`, even on the GCC rows - the matrix `CXX` only feeds `CXX_FOR_ABI`.
* **ubuntu24's Clang product rows build with it too**, which is where the compile-time win lands, as on rockylinux8.
* **ubuntu22 stops depending on apt.llvm.org entirely.** `llvm.sh` now refuses jammy ("Distribution 'ubuntu' in version '22.04.5 LTS' is not supported"), so that image was one input-change away from being unbuildable - the same wall that blocked #6649. This PR rebuilds it, which proves the dependency is gone.
* Smaller images: the LLVM 18 apt stack (`clang-18 lld-18 clang-tools-18 libclang-18-dev llvm-18-dev`) goes away.

### The one wart: noble's fmt 9.1

Clang >= 20 rejects `FMT_STRING` inside spdlog's `daily_file_sink.h`: "call to consteval function ... is not a constant expression", the note pointing at `&*context_.begin()` (`fmt/core.h:2982` in fmt 9.1). `MRPch/MRSpdlog.h` is the only header that includes it, but `MR_PCH_USE_EXTRA_HEADERS=ON` puts it in the PCH, so it reaches every MeshLib TU - it does not affect the bindings, which is why ubuntu22 needs nothing here.

The two ubuntu24 Clang rows therefore pass `-DFMT_CONSTEVAL=` through a new per-row `matrix.extra-cmake-options` hook. `FMT_CONSTEVAL` is the `#ifndef`-guarded gate at `core.h:263`, and defining it externally also leaves `FMT_HAS_CONSTEVAL` unset, which drops the `parse_format_string<true>` block (its only use, `core.h:3154`) that does the failing constant evaluation. The cost is fmt's compile-time format-string checking in the TUs that include spdlog: a bad format string becomes a runtime `format_error` instead of a compile error.

Bounds, checked on Godbolt against a faithful copy of `daily_filename_calculator::calc_filename` rather than assumed, because both halves of the folklore turned out wrong:

| | fmt 9.1.0 (noble) | | fmt vs clang 22.1.0 |
| --- | --- | --- | --- |
| clang 17.0.1 / 18.1.0 / **19.1.0** | OK | fmt 9.1.0 / 10.0.0 / 10.2.1 / 11.0.0 | fails |
| clang 20.1.0 / 21.1.0 / 22.1.0 | fails | fmt **12.0.0** / trunk | OK |

So the boundary is **clang 20, not 19**, and the fix landed in **fmt 12, not 10.x** - noble's fmt 9.1 is not unusually broken, every fmt through 11.0.0 has the same pattern. `-DFMT_CONSTEVAL=` was verified to fix fmt 9.1.0 under both clang 20.1.0 and 22.1.0. This also affects *users* building MeshLib on Ubuntu 24.04 with any clang >= 20 against the distro fmt/spdlog, not only our CI.

### Why ubuntu22 cannot have Clang 22

Tried, and it broke `Generate and build Python bindings` on the ubuntu22 arm64 row. jammy ships **Boost 1.74**, where `boost/numeric/conversion` instantiates `mpl_::integral_c` over an enum whose `next`/`prior` typedefs `static_cast` outside the enum's range; Clang made that a hard error in constant expressions, so `boost/mpl/aux_/integral_wrapper.hpp:73` fails with "non-type template argument is not a constant expression". `MRSignal.h` pulls `boost/signals2` in, so the bindings cannot compile. noble's Boost 1.83 has the upstream fix, which is why ubuntu24 is fine.

Unlike the fmt issue, there is **no flag for this** - Clang removed the escape hatch, verified on Godbolt with an out-of-range enum used as a non-type template argument:

| clang | plain | with `-Wno-enum-constexpr-conversion` |
| --- | --- | --- |
| 18.1.0 / 19.1.0 | error | OK |
| 20.1.0 / 22.1.0 | error | error - option no longer recognized |

Getting ubuntu22 onto Clang 22 would mean a newer Boost than jammy packages. Since the PGO Clang there only builds the bindings, that is not worth it; 18.1.8 stays.

### Changes

* `docker/ubuntu22Dockerfile`, `docker/ubuntu24Dockerfile` - `ENV LLVM_VERSION` (18.1.8 / 22.1.8) feeds both the prefix and the download URL, so the version is pinned in one place per image. `install_deps_ubuntu.sh` is no longer called (nor is it or `clang_version.txt` COPYed in); its five non-LLVM packages already come from the apt list and `requirements/ubuntu.txt` except `gawk` and `procps`, which move into the list. ubuntu24 also drops `clang-18` from the apt list.
* `matrix/ubuntu-x64-full-config.json` - the two ubuntu24 Clang rows become version-free `clang++` / `clang`, like the linux-vcpkg matrix, and carry the `extra-cmake-options` above. `build-test-ubuntu-x64.yml` prepends `$LLVM_PREFIX/bin` to `PATH` through `GITHUB_ENV` so those names resolve, and appends `matrix.extra-cmake-options` to `MR_CMAKE_OPTIONS`. Dropping the absolute paths also removes the `/` characters from the `Timing_Logs_*` artifact names.
* `update-docs-manual.yml` - that job runs in the ubuntu22 image, so its MRBind cache key gains the Dockerfile hash. Without it a cached MRBind linked against `/usr/lib/llvm-18` would be restored into an image that no longer has it - the loader error seen in #6648.
* `docker_image_source_checksum.sh` - `install_deps_ubuntu.sh` and `clang_version.txt` leave the ubuntu image inputs, since the images no longer read either. Both files stay in the tree: MIC's ubuntu images and `README-generating.md` still use them.

`scripts/mrbind/install_mrbind_ubuntu.sh` and `generate.mk` already honour `LLVM_PREFIX` (#6649), so neither needed a change here.

### Notes

* The tarballs are built in `rockylinux:8`, so their glibc floor is 2.28, below jammy's 2.35 and noble's 2.39. MRBind's libstdc++ >= 12 requirement (`std::hash<fs::path>`) is met by g++-12 on jammy and g++-13/14 on noble.
* `MESHLIB_HAVE_LLD` stays enabled on ubuntu24 without any apt `lld`: `check_linker_flag(-fuse-ld=lld)` runs with our Clang, which finds its own `bin/ld.lld` next to itself. `generate.mk` links the bindings with `-fuse-ld=lld` unconditionally, so this is load-bearing. ubuntu22 was already `Failed` there (clang-14 never saw lld-18) and is unchanged.
* nvcc is unaffected by either compiler change: on Linux `CMAKE_CUDA_HOST_COMPILER` is only set when `MRCUDA_OVERRIDE_HOST_COMPILER=ON` (default OFF), so nvcc keeps its own gcc host compiler.
* Image source checksums: ubuntu22 `658ba33adc66558a` -> `02fb031a507b03ff`, ubuntu24 `4f98ce0799c99a3b` -> `a765a8f67c3bdbf6`, so both images rebuild.
* The runner-stats step runs `$cxx_compiler --version`, which cannot resolve the bare `clang++` of the ubuntu24 rows, so the `PATH` export now precedes it; previously stats collection failed and its upload was skipped.
* Windows, macOS, emscripten and linux-vcpkg are untouched and disabled for this run.

Measured numbers are in the comments below; they were taken on the first revision, which used Clang 18 on both images, and are being re-measured against Clang 22.

Note for reviewers: the commit messages on `a86476498` and earlier repeat the "clang >= 19 / fmt fixed in 10.x" version bounds that the Godbolt check above corrected to "clang >= 20 / fmt 12"; force-push is blocked on this repo, so the correction lives here rather than in rewritten history.
