### PR TITLE
Bracket each stage of a zip entry, and log the wasm heap size

### DIFF
--- a/source/MRMesh/MRZip.cpp
+++ b/source/MRMesh/MRZip.cpp
@@ -6,6 +6,11 @@
 #include "MRTimer.h"
 #include "MRZlib.h"
 #include "MRPch/MRSpdlog.h"
+#include "MRPch/MRFmt.h"
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten/heap.h>
+#endif
 
 #if (defined(__APPLE__) && defined(__clang__)) || defined(__EMSCRIPTEN__)
 #pragma clang diagnostic push
@@ -29,6 +34,17 @@ namespace MR
 {
 
 namespace {
+
+/// on wasm the heap size at the moment of an allocation, empty elsewhere; the suspicion
+/// is that a stall in decompressZip is the heap failing to grow
+std::string heapNote()
+{
+#ifdef __EMSCRIPTEN__
+    return fmt::format( ", heap {} MB", emscripten_get_heap_size() >> 20 );
+#else
+    return {};
+#endif
+}
 
 struct ProgressData
 {
@@ -336,6 +352,7 @@ Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetF
         }
         else
         {
+            spdlog::info( "zip entry {}/{}: {}", i + 1, numEntries, nameFixed );
             zfile = zip_fopen_index(zip,i,0);
             if ( !zfile )
                 return unexpected( "Cannot open zip file " + nameFixed );
@@ -350,10 +367,10 @@ Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetF
             if ( !ofs || ofs.bad() )
                 return unexpected( "Cannot create file " + utf8string( newItemPath ) );
 
-            // the two lines around the buffer allocation split a stall here into
-            // "died growing the heap" and "died in libzip", which the surrounding
-            // start/end pair cannot distinguish
-            spdlog::info( "zip entry {}/{}: {}, {} bytes", i + 1, numEntries, nameFixed, stats.size );
+            // each line brackets one thing that can stall, so the last line surviving in
+            // a log says whether the entry died opening files, growing the heap, inside
+            // libzip, or writing the result out
+            spdlog::info( "zip entry {}/{}: opened, allocating {} bytes{}", i + 1, numEntries, stats.size, heapNote() );
             fileBufer.resize(stats.size);
             spdlog::info( "zip entry {}/{}: buffer ready, reading", i + 1, numEntries );
             auto bitesRead = zip_fread(zfile,(void*)fileBufer.data(),fileBufer.size());
@@ -361,6 +378,7 @@ Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetF
                 return unexpected( "Cannot read file from zip " + nameFixed );
 
             zip_fclose(zfile);
+            spdlog::info( "zip entry {}/{}: read {} bytes, writing", i + 1, numEntries, bitesRead );
             if ( !ofs.write( fileBufer.data(), fileBufer.size() ) )
                 return unexpected( "Cannot write file from zip " + utf8string( newItemPath ) );
             ofs.close();

--- a/source/MRMesh/MRZip.cpp
+++ b/source/MRMesh/MRZip.cpp
@@ -350,7 +350,12 @@ Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetF
             if ( !ofs || ofs.bad() )
                 return unexpected( "Cannot create file " + utf8string( newItemPath ) );
 
+            // the two lines around the buffer allocation split a stall here into
+            // "died growing the heap" and "died in libzip", which the surrounding
+            // start/end pair cannot distinguish
+            spdlog::info( "zip entry {}/{}: {}, {} bytes", i + 1, numEntries, nameFixed, stats.size );
             fileBufer.resize(stats.size);
+            spdlog::info( "zip entry {}/{}: buffer ready, reading", i + 1, numEntries );
             auto bitesRead = zip_fread(zfile,(void*)fileBufer.data(),fileBufer.size());
             if ( bitesRead != (zip_int64_t)stats.size )
                 return unexpected( "Cannot read file from zip " + nameFixed );


### PR DESCRIPTION
Follow-up to #6656, which bracketed `decompressZip_` as a whole. That bracket caught a real stall on 08-24: a wasm scene load logged `Decompressing 5 zip entries` and then went silent for 600 s, with no `Decompressed 5 zip entries`, while the page kept rendering and its Cancel button stayed live. So the stall is inside this extraction loop -- but the loop does four separable things per entry, any of which could be the one that hangs.

This brackets all four. Whichever line is last in a stalled log names the phase:

| last line | died in |
|---|---|
| `zip entry i/N: <name>` | `zip_fopen_index` / `create_directories` / opening the output file |
| `opened, allocating N bytes, heap H MB` | `fileBufer.resize` -- growing the heap |
| `buffer ready, reading` | `zip_fread` -- inside libzip |
| `read N bytes, writing` | `ofs.write` / `close` |

The allocation line carries the wasm heap size because a heap growth that never completes is the leading suspect: every stall so far has been in an allocation-heavy stage (this one in the unzip, an earlier one in `compressZip` before an upload), always on a multithreaded build and never on the singlethreaded one, and MeshLib links `-s ALLOW_MEMORY_GROWTH=1` alongside `-Wno-pthreads-mem-growth`, which silences emscripten's own warning about that exact combination. `heapNote()` is empty off wasm, so nothing changes for desktop builds.

Verbosity is four info lines per *file* entry; directory entries log nothing, since the logging sits in the branch that allocates. A six-entry `.mru` produces 16 lines on a path that runs once per scene load or import.

Field-tested before asking for review: MIC ran this branch's predecessor against the app by pointing its gitlink at the PR head, opening a real scene 200 times. Sample of one load, and the timings it gives:

```
Decompressing 6 zip entries into /tmp/MeshInspectorScene1787655944
zip entry 5/6: 0_Root/0_NIST_CTC_05_/0_=_[0_1_1_2].ply, 1021928 bytes
zip entry 5/6: buffer ready, reading
```

Over 50 loads the unzip averaged 533 ms, and the `resize` of that 1 MB entry averaged 5.6 ms with a tail to 43 ms -- an 8x swing that is at least consistent with occasional heap growth being expensive.

`MRMesh` builds clean with MSVC `/Wall /WX`.
