### PR TITLE
Add CITATION.cff and citation guidance to README and docs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use MeshLib in research, please cite it using the metadata below. Always cite the exact version you used."
+title: "MeshLib: 3D Mesh Processing Library"
+abstract: "MeshLib is a cross-platform 3D mesh and point-cloud processing SDK written in C++ with bindings for C, C#, Python and WebAssembly: boolean operations, mesh healing, decimation, offsetting, registration (ICP), voxel/volumetric processing and 3D file I/O."
+type: software
+authors:
+  - name: "MeshLib Development Team"
+    website: "https://meshlib.io"
+repository-code: "https://github.com/MeshInspector/MeshLib"
+url: "https://meshlib.io"
+version: 3.1.3.429
+date-released: "2026-08-03"
+license-url: "https://github.com/MeshInspector/MeshLib/blob/master/LICENSE"
+keywords:
+  - mesh processing
+  - computational geometry
+  - mesh boolean
+  - point cloud
+  - 3D

--- a/doxygen/general_pages/Citation.dox
+++ b/doxygen/general_pages/Citation.dox
@@ -1,0 +1,20 @@
+/**
+\page Citation Citation
+
+If MeshLib supports your research, please cite it, including the exact version you used.
+
+\code{.txt}
+@software{meshlib,
+  author       = {{MeshLib Development Team}},
+  title        = {{MeshLib}: 3D Mesh Processing Library},
+  organization = {AMV Consulting LLC},
+  year         = {2026},
+  version      = {3.1.3.429},
+  url          = {https://meshlib.io},
+  note         = {Please cite the exact version used in your work}
+}
+\endcode
+
+For APA, IEEE and Chicago forms, and for citing a specific algorithm,
+[see the citation guide](https://meshlib.io/citation-guide/).
+*/

--- a/doxygen/layout_templates/base_struct.xml
+++ b/doxygen/layout_templates/base_struct.xml
@@ -13,6 +13,7 @@
       <tab type="user" url="__BEGIN_URL__MeshLibCmakeSetupGuide__END_URL__" title="CMake"/>
     </tab>
     <tab type="user" url="__BEGIN_URL__License__END_URL__" title="License" />
+    <tab type="user" url="__BEGIN_URL__Citation__END_URL__" title="How to cite" />
     <tab type="usergroup" url="__BEGIN_URL__Tutorials__END_URL__" title="Tutorials">
       <tab type="user" url="__BEGIN_URL__FirstPluginTutorial__END_URL__" title="Create First Plugin using C++"/>
       <tab type="user" url="__BEGIN_URL__SupportGeneratorTutorial__END_URL__" title="Support Generator Tool using C++"/>

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ The MeshLib SDK is an open-source library that provides advanced algorithms for 
 ![MeshLib_SDK_Mesh_Processing_Library](https://github.com/user-attachments/assets/a65dc95f-675d-4fb8-ac17-6857c9a91554)
 ## Why Choose Us
 
-**Fully Open Source.** You can also fork the code for your own unique use cases.
+**Source Available.** Read the code, fork it, and use it free for non-commercial and educational work — commercial use requires a license.
 
 **Multi-Language Support.** Written in C++ with bindings for C, C#, and Python, our library integrates easily into AI pipelines and workflows.
 
@@ -77,6 +77,24 @@ pip install meshlib
 If your choice is C++, C or C#, check out our [Installation Guide](https://meshlib.io/documentation/InstallationGuide.html).
 
 Here, you can find our [tutorials](https://meshlib.io/documentation/Tutorials.html) and [code samples](https://meshlib.io/documentation/Examples.html) to master our SDK quickly and with ease.
+
+## Citing MeshLib
+
+If MeshLib supports your research, please cite it. Cite the exact version you used — find it with `pip show meshlib`.
+
+```bibtex
+@software{meshlib,
+  author       = {{MeshLib Development Team}},
+  title        = {{MeshLib}: 3D Mesh Processing Library},
+  organization = {AMV Consulting LLC},
+  year         = {2026},
+  version      = {3.1.3.429},
+  url          = {https://meshlib.io},
+  note         = {Please cite the exact version used in your work}
+}
+```
+
+Other styles (APA, IEEE, Chicago) and guidance on citing a specific algorithm: [meshlib.io/citation-guide](https://meshlib.io/citation-guide/). Using MeshLib in a paper? Tell us in [GitHub Discussions](https://github.com/MeshInspector/MeshLib/discussions) — we list published work that uses MeshLib.
 
 ## **License**
 


### PR DESCRIPTION
## Summary

MeshLib is used in published research, but the repository has offered no canonical citation at the points where researchers actually look: the repo page, PyPI, and the documentation. This PR makes the library citable in one consistent format:

- **`CITATION.cff`** (CFF 1.2.0, validated with `cffconvert`) — GitHub now shows a "Cite this repository" button with APA/BibTeX for the canonical entry.
- **`readme.md`** — new "Citing MeshLib" section with the canonical BibTeX. The README is also the PyPI long description verbatim, so the same edit covers the PyPI page.
- **Docs** — new `Citation` page (`doxygen/general_pages/Citation.dox`) plus a "How to cite" nav tab next to the existing License tab in `base_struct.xml`.
- **License wording** — the "Why Choose Us" bullet claimed "Fully Open Source", which contradicts the non-commercial & education `LICENSE`; reworded to "Source Available", in line with `doxygen/general_pages/License.dox`.

The author string `MeshLib Development Team` and the title `MeshLib: 3D Mesh Processing Library` match the citation already in print (ISPRS 2024). Google Scholar clusters citations by these strings, not by DOI, so please keep both stable in future edits.

`version` / `date-released` in `CITATION.cff` (currently 3.1.3.429, the latest PyPI release) need a bump when a new version ships — worth a line in the release checklist.

## Test plan

- `cffconvert --validate` → "Citation metadata are valid according to schema version 1.2.0."
- `xmllint --noout doxygen/layout_templates/base_struct.xml` → well-formed; the new tab copies the License tab syntax and `Citation` matches the `\page` id.
- `Citation.dox` follows the structure of `License.dox`; `\code{.txt}` is the convention sibling pages already use.
- All URLs added in this PR return HTTP 200.
- `pip show meshlib` verified as the way to read the installed version (the wheel exposes no `meshlib.__version__`).
- Version string 3.1.3.429 consistent across `CITATION.cff`, `readme.md`, `Citation.dox`.
