### PR TITLE
Take _ITERATOR_DEBUG_LEVEL from the distribution package instead of guessing 0

### DIFF
--- a/scripts/make_install_folder.py
+++ b/scripts/make_install_folder.py
@@ -60,7 +60,7 @@ def write_config_dist():
 	dst = os.path.join(it.path_to_includes, "MRMesh", "config_dist.h")
 	os.makedirs(os.path.dirname(dst), exist_ok=True)
 	with open(dst, "w", newline="\n") as f:
-		f.write("#pragma once\n\n#define MR_DIST_ITERATOR_DEBUG_LEVEL {}\n".format(level))
+		f.write("#pragma once\n\n#define MR_ITERATOR_DEBUG_LEVEL {}\n".format(level))
 
 def copy_includes():
 	prepare_includes_list()

--- a/scripts/make_install_folder.py
+++ b/scripts/make_install_folder.py
@@ -20,10 +20,13 @@ path_to_pybind11 = os.path.join(os.path.join(os.path.join(it.base_path,'thirdpar
 
 not_app_extentions = ['.lib','.obj','.pdb','.obj','.exp','.iobj','.ipdb']
 
-def vcpkg_dir():
-	vcpkg_triplet = "x64-windows-meshlib"
+def vcpkg_triplet_name():
 	if len(sys.argv) > 2:
-		vcpkg_triplet = sys.argv[2]
+		return sys.argv[2]
+	return "x64-windows-meshlib"
+
+def vcpkg_dir():
+	vcpkg_triplet = vcpkg_triplet_name()
 	vcpkg_exe_dir = ""
 	if len(sys.argv) > 3:
 		vcpkg_exe_dir = sys.argv[3]
@@ -50,6 +53,15 @@ def prepare_includes_list():
 	it.append_includes_list(path_to_pybind11, True)
 	it.append_includes_list(path_to_imgui, True)
 
+def write_config_dist():
+	# Tell consumers which _ITERATOR_DEBUG_LEVEL this package's binaries were built with,
+	# so MRMeshFwd.h can align their translation units instead of guessing zero.
+	level = 2 if "iterator-debug" in vcpkg_triplet_name() else 0
+	dst = os.path.join(it.path_to_includes, "MRMesh", "config_dist.h")
+	os.makedirs(os.path.dirname(dst), exist_ok=True)
+	with open(dst, "w", newline="\n") as f:
+		f.write("#pragma once\n\n#define MR_DIST_ITERATOR_DEBUG_LEVEL {}\n".format(level))
+
 def copy_includes():
 	prepare_includes_list()
 	for src,dst in it.includes_src_dst:
@@ -61,6 +73,7 @@ def copy_includes():
 		dst_folder = os.path.dirname(dst)
 		os.makedirs(dst_folder,exist_ok=True)
 		shutil.copyfile(src, dst)
+	write_config_dist()
 
 def copy_app():
 	shutil.copytree(os.path.join(it.path_to_sources,'x64'),it.path_to_app,dirs_exist_ok=True)

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -8,15 +8,18 @@
 
 // Not-zero _ITERATOR_DEBUG_LEVEL in Microsoft STL greatly reduces the performance of STL containers.
 //
-// Most MeshLib binaries are prepared with _ITERATOR_DEBUG_LEVEL=0, see
+// Pre-build binaries from MeshLib distribution are prepared with _ITERATOR_DEBUG_LEVEL=0
+// (except MeshLibDist-IteratorDebug, which uses 2 and states so in MRMesh/config_dist.h),
+// and if you build MeshLib by yourself then _ITERATOR_DEBUG_LEVEL=0 is also selected see
 // 1) vcpkg/triplets/x64-windows-meshlib.cmake and
 // 2) MeshLib/source/common.props
-// The exception is the MeshLibDist-IteratorDebug distribution, which is built with 2.
 // Please note that all other modules (.exe, .dll, .lib) with MS STL calls in your application also need
 // to define exactly the same value of _ITERATOR_DEBUG_LEVEL to be operational after linking.
 //
-// MR_ITERATOR_DEBUG_LEVEL is the level MeshLib itself was built with: a distribution package
-// states it in MRMesh/config_dist.h, otherwise it defaults to zero as all our triplets select.
+// If you deliberately would like to work with not zero _ITERATOR_DEBUG_LEVEL, then please define
+// additionally MR_ITERATOR_DEBUG_LEVEL with the same value to indicate that it is done intentionally
+// (and you are ok with up to 100x slowdown), the way
+// vcpkg/triplets/x64-windows-meshlib-iterator-debug.cmake does it for our own build.
 //
 #if defined _MSC_VER
     #if !defined MR_ITERATOR_DEBUG_LEVEL

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -15,24 +15,16 @@
 // Please note that all other modules (.exe, .dll, .lib) with MS STL calls in your application also need
 // to define exactly the same value of _ITERATOR_DEBUG_LEVEL to be operational after linking.
 //
-// MR_ITERATOR_DEBUG_LEVEL below is the level MeshLib itself was built with. A distribution
-// package states it in MRMesh/config_dist.h; defining it by hand overrides that and means
-// you take responsibility for the value matching the binaries you link against.
+// MR_ITERATOR_DEBUG_LEVEL is the level MeshLib itself was built with: a distribution package
+// states it in MRMesh/config_dist.h, otherwise it defaults to zero as all our triplets select.
 //
 #if defined _MSC_VER
     #if !defined MR_ITERATOR_DEBUG_LEVEL
-        #if defined MR_DIST_ITERATOR_DEBUG_LEVEL
-            #define MR_ITERATOR_DEBUG_LEVEL MR_DIST_ITERATOR_DEBUG_LEVEL
-        #else
-            #define MR_ITERATOR_DEBUG_LEVEL 0
-        #endif
+        #define MR_ITERATOR_DEBUG_LEVEL 0
     #endif
     // no CRT header has fixed the level yet, so this translation unit can still join MeshLib
     #if !defined _ITERATOR_DEBUG_LEVEL
         #define _ITERATOR_DEBUG_LEVEL MR_ITERATOR_DEBUG_LEVEL
-    #endif
-    #if defined MR_DIST_ITERATOR_DEBUG_LEVEL && MR_ITERATOR_DEBUG_LEVEL != MR_DIST_ITERATOR_DEBUG_LEVEL
-        #error MR_ITERATOR_DEBUG_LEVEL contradicts the MeshLib distribution being linked
     #endif
     #if _ITERATOR_DEBUG_LEVEL != MR_ITERATOR_DEBUG_LEVEL
         #error _ITERATOR_DEBUG_LEVEL is inconsistent with MeshLib

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -8,23 +8,31 @@
 
 // Not-zero _ITERATOR_DEBUG_LEVEL in Microsoft STL greatly reduces the performance of STL containers.
 //
-// Pre-build binaries from MeshLib distribution are prepared with _ITERATOR_DEBUG_LEVEL=0,
-// and if you build MeshLib by yourself then _ITERATOR_DEBUG_LEVEL=0 is also selected see
+// Most MeshLib binaries are prepared with _ITERATOR_DEBUG_LEVEL=0, see
 // 1) vcpkg/triplets/x64-windows-meshlib.cmake and
 // 2) MeshLib/source/common.props
+// The exception is the MeshLibDist-IteratorDebug distribution, which is built with 2.
 // Please note that all other modules (.exe, .dll, .lib) with MS STL calls in your application also need
 // to define exactly the same value of _ITERATOR_DEBUG_LEVEL to be operational after linking.
 //
-// If you deliberately would like to work with not zero _ITERATOR_DEBUG_LEVEL, then please define
-// additionally MR_ITERATOR_DEBUG_LEVEL with the same value to indicate that it is done intentionally
-// (and you are ok with up to 100x slowdown).
+// MR_ITERATOR_DEBUG_LEVEL below is the level MeshLib itself was built with. A distribution
+// package states it in MRMesh/config_dist.h; defining it by hand overrides that and means
+// you take responsibility for the value matching the binaries you link against.
 //
 #if defined _MSC_VER
-    #if !defined _ITERATOR_DEBUG_LEVEL
-        #define _ITERATOR_DEBUG_LEVEL 0
-    #endif
     #if !defined MR_ITERATOR_DEBUG_LEVEL
-        #define MR_ITERATOR_DEBUG_LEVEL 0
+        #if defined MR_DIST_ITERATOR_DEBUG_LEVEL
+            #define MR_ITERATOR_DEBUG_LEVEL MR_DIST_ITERATOR_DEBUG_LEVEL
+        #else
+            #define MR_ITERATOR_DEBUG_LEVEL 0
+        #endif
+    #endif
+    // no CRT header has fixed the level yet, so this translation unit can still join MeshLib
+    #if !defined _ITERATOR_DEBUG_LEVEL
+        #define _ITERATOR_DEBUG_LEVEL MR_ITERATOR_DEBUG_LEVEL
+    #endif
+    #if defined MR_DIST_ITERATOR_DEBUG_LEVEL && MR_ITERATOR_DEBUG_LEVEL != MR_DIST_ITERATOR_DEBUG_LEVEL
+        #error MR_ITERATOR_DEBUG_LEVEL contradicts the MeshLib distribution being linked
     #endif
     #if _ITERATOR_DEBUG_LEVEL != MR_ITERATOR_DEBUG_LEVEL
         #error _ITERATOR_DEBUG_LEVEL is inconsistent with MeshLib

--- a/source/MRMesh/config.h
+++ b/source/MRMesh/config.h
@@ -7,3 +7,8 @@
 #if defined( MR_USE_CMAKE_CONFIGURE_FILE ) && __has_include( "config_cmake.h" )
 #include "config_cmake.h"
 #endif
+
+// written by scripts/make_install_folder.py, present in distribution packages only
+#if __has_include( "config_dist.h" )
+#include "config_dist.h"
+#endif


### PR DESCRIPTION
## Summary

Found while answering discussion #6672, where a user got `#error _ITERATOR_DEBUG_LEVEL is inconsistent with MeshLib` from a VS2022 Debug build against `MeshLibDistVS22`.

The guard in `MRMeshFwd.h` was comparing two guesses:

```cpp
#if !defined _ITERATOR_DEBUG_LEVEL
    #define _ITERATOR_DEBUG_LEVEL 0     // guess about the consumer
#endif
#if !defined MR_ITERATOR_DEBUG_LEVEL
    #define MR_ITERATOR_DEBUG_LEVEL 0   // guess about our own binaries
#endif
```

so its outcome depended on **include order**:

| consumer's first include | today |
|---|---|
| `<vector>`, then a MeshLib header | `_ITERATOR_DEBUG_LEVEL` is already 2 in a Debug build → mismatch → `#error` |
| a MeshLib header | not defined yet → we set it to 0, `MR_` also 0, they agree → **no diagnostic**, the whole TU compiles at 0 |

For `MeshLibDistVS*` the second row happens to be correct, and that is what makes a Debug build "just work" for some users and fail for others. For `MeshLibDist-IteratorDebug`, whose binaries really are built with 2, the second row is wrong: the build succeeds and the process then dies inside the C++ runtime before `main` produces any output. The linker does not catch it either — `/FAILIFMISMATCH` directives live in the DLL's object files, not in the import library the consumer links, so there is no `LNK2038`.

## Change

`make_install_folder.py` already receives the vcpkg triplet, so it now writes one more header into the package next to `config.h`:

```cpp
// install/include/MRMesh/config_dist.h
#pragma once

#define MR_ITERATOR_DEBUG_LEVEL 2   // 0 for every other triplet
```

`config.h` picks it up via `__has_include`, the same way it already picks up `config_cmake.h`, so nothing changes for source builds — the file simply does not exist there.

`MRMeshFwd.h` then resolves `MR_ITERATOR_DEBUG_LEVEL` **first** and aligns the translation unit with *that* value instead of a hardcoded 0. The code change is just those two blocks swapped, plus `0` becoming `MR_ITERATOR_DEBUG_LEVEL`.

If a consumer passes a value that disagrees with the package, the unguarded redefinition in `config_dist.h` makes the package value win, and the existing `_ITERATOR_DEBUG_LEVEL != MR_ITERATOR_DEBUG_LEVEL` comparison then rejects the build. When the two agree the replacement token is identical, so there is no `C4005`.

## Result

Verified locally with a VS2022 `v143` Debug consumer (`cl 19.44`) against the real `v3.1.3.429` packages, unpacked and with the patched headers dropped in. `MRMesh.dll` in the `-IteratorDebug` package reports linker version `14.29`, i.e. `v142`; mixing its `/MDd` DLLs into a `v143` debug application is fine, both bind the same `MSVCP140D.dll` / `VCRUNTIME140D.dll` / `ucrtbased.dll`.

| package | consumer defines | first include | before | after |
|---|---|---|---|---|
| `DistVS22` | none | MeshLib | builds, runs | builds, runs |
| `DistVS22` | none | `<vector>` | `#error` | `#error` |
| `DistVS22` | `IDL=0`, `MR_IDL=0` | either | builds, runs | builds, runs |
| `-IteratorDebug` | `MR_IDL=2` | either | builds, runs | builds, runs |
| `-IteratorDebug` | none | MeshLib | **builds, then crashes** | builds, runs |
| `-IteratorDebug` | none | `<vector>` | `#error` | builds, runs |
| `-IteratorDebug` | `IDL=0`, `MR_IDL=0` | either | **builds, then crashes** | `#error` |

No row gets worse; the two silent crashes become a working build and a compile-time diagnostic. The `-IteratorDebug` package also stops needing any consumer-side define at all.

`write_config_dist()` was exercised directly for both triplets and emits `0` / `2` as expected.

## Notes

- `example_plugin.vcxproj`'s `MeshLibIteratorDebugLevel` property and the `/D_ITERATOR_DEBUG_LEVEL` flags in `test-distribution.yml` become redundant for the `-IteratorDebug` package, but they still agree with the package value, so I left them alone rather than widen the diff.
- Correction to an earlier revision of this description: I wrote that the docs never mention `_ITERATOR_DEBUG_LEVEL`, having grepped only `docs/`, `readme.md` and `examples/`. The user-facing guides live in `doxygen/`, and they cover it in detail — `common_files/CommonDistributionProperties.dox`, `general_pages/CppSetupGuide.dox` (archive table plus a troubleshooting row), `general_pages/CmakeSetupGuide.dox` and `general_pages/CSetupGuide.dox`. Those pages now overstate what a consumer must define, which is a docs follow-up.

## Test plan

- [ ] Windows CMake and MSBuild builds compile (`config_dist.h` absent, `MR_ITERATOR_DEBUG_LEVEL` comes from `CompilerOptions.cmake` / `common.props` as today)
- [ ] Ubuntu x64 build compiles (the new `__has_include` in `config.h` is the only non-MSVC-guarded line)
- [ ] `update-win-version` produces `install/include/MRMesh/config_dist.h` in all four archives, with `2` only in `MeshLibDist-IteratorDebug.zip`
- [ ] `test-distribution` still builds `examples/cpp-examples` for every archive
- [ ] `example_plugin.sln` still builds in both Debug and Release

`update-win-version` and `test-distribution` only run when `upload_artifacts` is true, which needs `upload-binaries` or `full-ci`. Those also push packages to the draft release, so I have not set either label — say the word and I will.

