### PR TITLE
CI: skip the ubuntu24 arm64 leg on update-doc-only PRs

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -107,6 +107,8 @@ jobs:
       internal_build:        ${{ needs.config.outputs.internal_build == 'true' }}
       upload_artifacts:      ${{ needs.config.outputs.upload_artifacts == 'true' }}
       upload_test_artifacts: ${{ needs.config.outputs.upload_test_artifacts == 'true' }}
+      # keep every leg whenever the debs are actually published
+      stubs_only:            ${{ needs.config.outputs.update_doc_only == 'true' && needs.config.outputs.upload_artifacts != 'true' }}
     secrets: inherit
 
   ubuntu-x64-build-test:

--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -102,13 +102,12 @@ jobs:
     uses: ./.github/workflows/build-test-ubuntu-arm64.yml
     with:
       app_version:           ${{ needs.config.outputs.app_version }}
+      config_matrix:         ${{ needs.config.outputs.ubuntu_arm64_config_matrix }}
       docker_image_tag:      ${{ needs.config.outputs.docker_image_tag }}
       full_config_build:     ${{ needs.config.outputs.full_config_build == 'true' }}
       internal_build:        ${{ needs.config.outputs.internal_build == 'true' }}
       upload_artifacts:      ${{ needs.config.outputs.upload_artifacts == 'true' }}
       upload_test_artifacts: ${{ needs.config.outputs.upload_test_artifacts == 'true' }}
-      # keep every leg whenever the debs are actually published
-      stubs_only:            ${{ needs.config.outputs.update_doc_only == 'true' && needs.config.outputs.upload_artifacts != 'true' }}
     secrets: inherit
 
   ubuntu-x64-build-test:
@@ -378,6 +377,21 @@ jobs:
     # Reusable workflows do not see repository secrets unless the caller
     # passes them; the unity test needs UNITY_USERNAME / UNITY_PASSWORD.
     secrets: inherit
+
+  nuget-consumer-test:
+    if: >-
+      ${{ !cancelled()
+        && needs.config.outputs.upload_artifacts == 'true'
+        && needs.config.outputs.build_enable_windows == 'true'
+        && needs.create-nuget-package.result == 'success'
+        && needs.upload-distributions.result == 'success' }}
+    needs:
+      - config
+      - create-nuget-package
+      - upload-distributions
+    uses: ./.github/workflows/nuget-consumer-test.yml
+    with:
+      release_tag: ${{ needs.config.outputs.release_tag }}
 
   test-distribution:
     # Skip if publishing was skipped, so we don't test against an empty release.

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -6,6 +6,9 @@ on:
       app_version:
         required: true
         type: string
+      config_matrix:
+        required: true
+        type: string
       docker_image_tag:
         required: true
         type: string
@@ -30,27 +33,19 @@ on:
         default: true
         required: false
         type: boolean
-      stubs_only:
-        description: "Build only the leg that produces the artifacts the doc build needs"
-        default: false
-        required: false
-        type: boolean
 
 jobs:
   ubuntu-arm-build-test:
+    # the entries carry every compiler field, so spell out the two that identify a leg
+    name: ubuntu-arm-build-test (${{ matrix.os }}, ${{ matrix.config }})
     timeout-minutes: 60
     runs-on: ubuntu-24.04-arm
     container:
       image: meshlib/meshlib-${{matrix.os}}-arm64:${{inputs.docker_image_tag}}
     strategy:
       fail-fast: false
-      # `stubs_only` drops the ubuntu24/GCC leg: PythonStubs and CsharpBindings come
-      # from ubuntu22/clang alone. Whole-matrix expression rather than `os: ${{ ... }}`,
-      # because an `include` entry whose `os` is absent becomes an extra combination.
-      matrix: >-
-        ${{ fromJSON( inputs.stubs_only
-        && '{"os":["ubuntu22"],"config":["Release"],"include":[{"os":"ubuntu22","compiler":"clang","cxx-compiler":"/usr/bin/clang++-14","c-compiler":"/usr/bin/clang-14","cxx-standard":20}]}'
-        || '{"os":["ubuntu22","ubuntu24"],"config":["Release"],"include":[{"os":"ubuntu22","compiler":"clang","cxx-compiler":"/usr/bin/clang++-14","c-compiler":"/usr/bin/clang-14","cxx-standard":20},{"os":"ubuntu24","compiler":"GCC","cxx-compiler":"/usr/bin/g++-14","c-compiler":"/usr/bin/gcc-14","cxx-standard":23}]}' ) }}
+      matrix:
+        include: ${{ fromJSON( inputs.config_matrix ) }}
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -30,6 +30,11 @@ on:
         default: true
         required: false
         type: boolean
+      stubs_only:
+        description: "Build only the leg that produces the artifacts the doc build needs"
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   ubuntu-arm-build-test:
@@ -39,20 +44,13 @@ jobs:
       image: meshlib/meshlib-${{matrix.os}}-arm64:${{inputs.docker_image_tag}}
     strategy:
       fail-fast: false
-      matrix:
-        os: [ ubuntu22, ubuntu24 ]
-        config: [ Release ]
-        include:
-          - os: ubuntu22
-            compiler: clang
-            cxx-compiler: /usr/bin/clang++-14
-            c-compiler: /usr/bin/clang-14
-            cxx-standard: 20
-          - os: ubuntu24
-            compiler: GCC
-            cxx-compiler: /usr/bin/g++-14
-            c-compiler: /usr/bin/gcc-14
-            cxx-standard: 23
+      # `stubs_only` drops the ubuntu24/GCC leg: PythonStubs and CsharpBindings come
+      # from ubuntu22/clang alone. Whole-matrix expression rather than `os: ${{ ... }}`,
+      # because an `include` entry whose `os` is absent becomes an extra combination.
+      matrix: >-
+        ${{ fromJSON( inputs.stubs_only
+        && '{"os":["ubuntu22"],"config":["Release"],"include":[{"os":"ubuntu22","compiler":"clang","cxx-compiler":"/usr/bin/clang++-14","c-compiler":"/usr/bin/clang-14","cxx-standard":20}]}'
+        || '{"os":["ubuntu22","ubuntu24"],"config":["Release"],"include":[{"os":"ubuntu22","compiler":"clang","cxx-compiler":"/usr/bin/clang++-14","c-compiler":"/usr/bin/clang-14","cxx-standard":20},{"os":"ubuntu24","compiler":"GCC","cxx-compiler":"/usr/bin/g++-14","c-compiler":"/usr/bin/gcc-14","cxx-standard":23}]}' ) }}
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -32,6 +32,9 @@ on:
       release_tag:
         description: "Version with namespace (if it exists): v1.2.3.4-namespace"
         value: ${{ jobs.prepare-config.outputs.release_tag }}
+      ubuntu_arm64_config_matrix:
+        description: "Config matrix for Ubuntu arm64 builds"
+        value: ${{ jobs.prepare-config.outputs.ubuntu_arm64_config_matrix }}
       ubuntu_x64_config_matrix:
         description: "Config matrix for Ubuntu x64 builds"
         value: ${{ jobs.prepare-config.outputs.ubuntu_x64_config_matrix }}
@@ -41,9 +44,6 @@ on:
       update_doc:
         description:
         value: ${{ jobs.prepare-config.outputs.tag-update-doc == 'true' || jobs.prepare-config.outputs.tag-update-doc-only == 'true' }}
-      update_doc_only:
-        description:
-        value: ${{ jobs.prepare-config.outputs.tag-update-doc-only == 'true' }}
       upload_artifacts:
         description:
         value: ${{ github.event_name == 'push' || github.event_name == 'schedule' || jobs.prepare-config.outputs.tag-full-ci == 'true' || jobs.prepare-config.outputs.tag-upload-binaries == 'true' }}
@@ -57,8 +57,8 @@ on:
         description: "True when full-ci, scheduled, or tag-build-release-windows is set"
         value: ${{ github.event_name == 'schedule' || jobs.prepare-config.outputs.tag-full-ci == 'true' || jobs.prepare-config.outputs.tag-build-release-windows == 'true' }}
       test_pip_build:
-        description:
-        value: ${{ jobs.prepare-config.outputs.tag-test-pip-build == 'true' }}
+        description: "True when scheduled or tag-test-pip-build is set"
+        value: ${{ github.event_name == 'schedule' || jobs.prepare-config.outputs.tag-test-pip-build == 'true' }}
       build-release-win:
         description: "True when full-ci, scheduled, or tag-build-release-windows is set"
         value: ${{ github.event_name == 'schedule' || jobs.prepare-config.outputs.tag-full-ci == 'true' || jobs.prepare-config.outputs.tag-build-release-windows == 'true' }}
@@ -90,6 +90,7 @@ jobs:
       release_tag:              ${{ steps.version-tag.outputs.release_tag }}
       need-linux-image-rebuild: ${{ steps.select-docker-image-tag.outputs.need_rebuild }}
       need-linux-vcpkg-rebuild: ${{ steps.select-vcpkg-docker-image-tag.outputs.need_rebuild }}
+      ubuntu_arm64_config_matrix: ${{ steps.set-ubuntu-arm64-matrix.outputs.matrix }}
       ubuntu_x64_config_matrix: ${{ steps.set-ubuntu-x64-matrix.outputs.matrix }}
       windows_x64_config_matrix: ${{ steps.set-windows-x64-matrix.outputs.matrix }}
       vcpkg-docker-image-tag:   ${{ steps.select-vcpkg-docker-image-tag.outputs.image_tag }}
@@ -297,6 +298,34 @@ jobs:
           else
             echo "matrix=$(jq -c . < .github/workflows/matrix/ubuntu-x64-minimal-config.json)" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set matrix for ubuntu-arm64 builds
+        id: set-ubuntu-arm64-matrix
+        uses: ./scripts/actions/matrix-builder
+        with:
+          matrix: |
+            os:
+              - ubuntu22
+              - ubuntu24
+            config:
+              - Release
+          rules: |
+            - extend:
+                - os: ubuntu22
+                  compiler: clang
+                  cxx-compiler: /usr/bin/clang++-14
+                  c-compiler: /usr/bin/clang-14
+                  cxx-standard: 20
+                - os: ubuntu24
+                  compiler: GCC
+                  cxx-compiler: /usr/bin/g++-14
+                  c-compiler: /usr/bin/gcc-14
+                  cxx-standard: 23
+            # A docs-only run still needs ubuntu22 - PythonStubs and CsharpBindings come from
+            # it - but nothing reads the ubuntu24 leg unless the debs are published.
+            - if: ${{ steps.live-labels.outputs.tag-update-doc-only == 'true' && env.upload_artifacts != 'true' }}
+              exclude:
+                os: ubuntu24
 
       - name: Set matrix for windows-x64 builds
         id: set-windows-x64-matrix

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -41,6 +41,9 @@ on:
       update_doc:
         description:
         value: ${{ jobs.prepare-config.outputs.tag-update-doc == 'true' || jobs.prepare-config.outputs.tag-update-doc-only == 'true' }}
+      update_doc_only:
+        description:
+        value: ${{ jobs.prepare-config.outputs.tag-update-doc-only == 'true' }}
       upload_artifacts:
         description:
         value: ${{ github.event_name == 'push' || github.event_name == 'schedule' || jobs.prepare-config.outputs.tag-full-ci == 'true' || jobs.prepare-config.outputs.tag-upload-binaries == 'true' }}


### PR DESCRIPTION
## Problem

`update-doc-only` switches off every platform except `ubuntu-arm64` — `build_enable_ubuntu_arm64` is the only `build_enable_*` output in `config.yml` that does not OR in `tag-update-doc-only`. That exemption is deliberate: `update-dev-documentation` needs artifacts only the arm64 job produces — `PythonStubs` and `CsharpBindings` are uploaded by its `ubuntu22 / Release / clang` leg, and `update-docs.yml` aborts when the stubs are missing.

The `ubuntu24 / GCC` leg produces nothing the doc build reads. On a documentation PR it was a second full arm64 build — mrbind toolchain, Python bindings, unit/Python/regression tests, deb, C++ and C examples — for no consumer. See #6680, where both legs ran while everything else was skipped.

## Change

The arm64 matrix is now built by `scripts/actions/matrix-builder` in `prepare-config`, next to the ubuntu-x64 and windows matrices, and handed to the workflow as `config_matrix` — the same input `build-test-ubuntu-x64.yml` already takes. Dropping the ubuntu24 leg is one declarative rule:

```yaml
- if: ${{ steps.live-labels.outputs.tag-update-doc-only == 'true' && env.upload_artifacts != 'true' }}
  exclude:
    os: ubuntu24
```

The `upload_artifacts` half keeps both legs whenever the debs are actually published, so a doc-only PR that also carries `upload-binaries`/`full-ci` still builds `Distributives_ubuntu24_arm64`.

Nothing changes when the label is absent. Downstream `Timing_Logs*` / `Distributives*` / `ArtifactStats*` consumers are all glob-based, and `fetch_job_id.py` matches `GITHUB_JOB` as a substring of the display name, which still holds.

## Job names

matrix-builder emits an entry list, so the job consumes it as `matrix.include` — which would otherwise name the jobs after every field in the entry, the way `ubuntu-x64-build-test (ubuntu24, Release, GCC, /usr/bin/g++-14, ...)` reads today. An explicit `name:` keeps the current `ubuntu-arm-build-test (ubuntu22, Release)`. This deviates from ubuntu-x64 on purpose: its rows are not unique on `(os, config)`, arm64's are.

## Testing

Run 32955847481 (first revision of this branch, `disable-build-*` labels) confirmed the two legs and their names.

Both branches of the rule were then run through the bundled action locally:

* `if` false → the current two legs, field for field;
* `if` true → the `ubuntu22` leg alone.
