### PR TITLE
CI: run test-pip-build on the nightly schedule

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -54,8 +54,8 @@ on:
         description: "True when full-ci, scheduled, or tag-build-release-windows is set"
         value: ${{ github.event_name == 'schedule' || jobs.prepare-config.outputs.tag-full-ci == 'true' || jobs.prepare-config.outputs.tag-build-release-windows == 'true' }}
       test_pip_build:
-        description:
-        value: ${{ jobs.prepare-config.outputs.tag-test-pip-build == 'true' }}
+        description: "True when scheduled or tag-test-pip-build is set"
+        value: ${{ github.event_name == 'schedule' || jobs.prepare-config.outputs.tag-test-pip-build == 'true' }}
       build-release-win:
         description: "True when full-ci, scheduled, or tag-build-release-windows is set"
         value: ${{ github.event_name == 'schedule' || jobs.prepare-config.outputs.tag-full-ci == 'true' || jobs.prepare-config.outputs.tag-build-release-windows == 'true' }}

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -677,8 +677,10 @@ jobs:
 
   upload-wheels-to-release:
     # On the `workflow_call` path the tag is empty unless the PR also carries `upload-binaries` (or `full-ci`).
+    # Nightly builds wheels only as a smoke test: on schedule `release_tag` is real, so
+    # without this ~350 MB of wheels would pile onto every nightly draft release.
     if: >-
-      ${{ !cancelled() && needs.setup.outputs.release_tag != ''
+      ${{ !cancelled() && github.event_name != 'schedule' && needs.setup.outputs.release_tag != ''
         && needs.manylinux-pip-build.result != 'failure'
         && needs.windows-pip-build.result != 'failure'
         && needs.macos-pip-build.result != 'failure' }}


### PR DESCRIPTION
`test-pip-build` — the pip wheel build plus its 24 install tests across 7 Python versions and 5 platforms — only ran when someone put the `test-pip-build` label on a PR. The last full execution was PR #6673 on 08-25; before that, #6665 on 08-24. Between labelled PRs master can sit for weeks with a broken wheel build and nothing notices.

`build-test-distribute.yml` already has a nightly cron at 02:00 UTC. This enables `test_pip_build` on `schedule`, matching how `run_unity_nuget_test` and `build-release-win` right next to it already treat scheduled runs.

### Why this is close to free

MeshLib is public, so every runner the pip legs use — `ubuntu-latest`, `ubuntu-24.04-arm`, `windows-2022/2025`, `macos-14/15/26`, `macos-15-intel/26-intel` — is a free standard GitHub-hosted runner. No larger runners are involved, so there is no Actions bill. The only machines of ours it occupies are the two self-hosted pip-test legs (`macos-12-intel`, `macos-13`), about 11 minutes combined.

It also does not lengthen the nightly. Measured on the last full run (32877202196), the longest pip chain is `macos-pip-build (x86)` at 54 min followed by `macos-pip-test` at 7 min, so ~61 min. The 08-26 nightly took 89 min end to end, with `macos-build-test (x64)` alone at 57 min, so the pip legs fit inside the existing critical path. Peak simultaneous macOS jobs goes from 1 to 3.

### Nothing gets published

On the `workflow_call` path `publish_prod` and `publish_test` are both false — `github.event_name` is `schedule`, not `release`, and `inputs.publish` is not passed — so `upload-to-testpypi`, `upload-to-release`, `post-release-test`, `update-documentation` and `generate-wasm-definitions` all stay skipped. No PyPI, no TestPyPI.

`upload-wheels-to-release` is the one job that would have fired, and it is carved out here. It gates on `release_tag != ''`, and unlike the label path a scheduled run has a real tag because `upload_artifacts` is true on `schedule`. Without the carve-out every nightly draft release would accumulate ~350 MB of wheels (7 Python versions x 5 platforms) on top of the 15 distributives it already carries. The nightly builds wheels as a smoke test, not as a deliverable, so the upload is skipped and the wheels stay as run artifacts.

The trade-off worth naming: a pip-build failure will now turn the whole nightly red, so the nightly stops being a pure "did master build" signal. That is the point of putting it there, but it is a change in what a red nightly means.

### Testing

This PR carries `test-pip-build` and `upload-binaries` so the pip legs run and `release_tag` is non-empty — that exercises `upload-wheels-to-release` on the `pull_request` path, where the new `github.event_name != 'schedule'` term must *not* fire. The scheduled behaviour itself cannot be tested from a PR; it will first show up on the 02:00 UTC run after merge.

`disable-ubuntu-x64` and `disable-ubuntu-arm64` trim the legs pip-build does not use. Emscripten is deliberately left enabled: `create-nuget-package` needs `emscripten-c-bindings-build-test` but does not gate on `build_enable_emscripten`, so `disable-emscripten` would let it run against a missing artifact.
