### PR TITLE
emscripten image: use our PGO clang instead of emsdk's stock one

### DIFF
--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -2,43 +2,28 @@
 
 # Any changes in this file should probably be mirrored in `emscripten-build-c-bindings-X-Y-ZDockerfile`.
 
-# emsdk's clang is built with ThinLTO but no PGO. Ours is the same llvm-project
-# revision rebuilt with -O3 + PGO: -22.6% on an -O3 template-heavy TU.
-#
-# It replaces emsdk's copy in place rather than living beside it, and /emsdk is
-# then copied into a clean ubuntu base. Swapping the compiler in a layer on top
-# of emscripten/emsdk would ship both: a deleted or overwritten file still
-# occupies its bytes in the immutable lower layer, and emsdk keeps its whole
-# tree - LLVM included - in a single 533 MB layer.
+# emsdk ships clang without PGO; ours is the same llvm-project revision with
+# -O3 + PGO. It replaces emsdk's copy in place and /emsdk is then copied into a
+# clean ubuntu: swapped in a layer on top, both compilers would ship.
 FROM emscripten/emsdk:4.0.19-arm64 AS emsdk
 
 ENV EMSDK_VERSION=4.0.19
 
 RUN <<EOF
     set -e
-    echo "before: /emsdk $(du -sm /emsdk | cut -f1) MB, llvm $(du -sm /emsdk/upstream/bin | cut -f1) MB"
     TOOLCHAIN=clang-emsdk-${EMSDK_VERSION}-pgo
     curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" \
         | tar -C /emsdk/upstream --strip-components=1 -xz
-    # the only stock LLVM binary our toolchain does not replace, and emscripten
-    # never invokes it; wasm-opt and the other binaryen tools stay
     rm -f /emsdk/upstream/bin/clang-scan-deps
-    # a stable path for node, so PATH below need not hardcode its version
+    # PATH below points here, keeping node's version out of it
     ln -s /emsdk/node/*/bin /emsdk/node-bin
-    echo "unstripped: llvm $(du -sm /emsdk/upstream/bin | cut -f1) MB"
-    # emsdk strips its own toolchain (docker/Dockerfile in emscripten-core/emsdk);
-    # ours comes straight out of ninja install-distribution, so do the same
+    # emsdk strips its own toolchain, ours arrives unstripped
     find /emsdk/upstream/bin -type f -exec strip -s {} + || true
-    /emsdk/upstream/bin/clang --version | head -n1
-    echo "after:  /emsdk $(du -sm /emsdk | cut -f1) MB, llvm $(du -sm /emsdk/upstream/bin | cut -f1) MB"
 EOF
 
 
 FROM ubuntu:22.04 AS base
 
-# /emsdk carries emscripten, binaryen, node and now our clang; the packages
-# below are the ones the emscripten/emsdk image installed on top of the same
-# ubuntu, plus the handful this repository needs.
 COPY --from=emsdk /emsdk /emsdk
 
 ENV EMSDK=/emsdk
@@ -75,9 +60,7 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        $(: the same packages the emscripten/emsdk image installs, read out ) \
-        $(: of its own config blob; openjdk is needed by --closure=1 and ) \
-        $(: xz-utils by the thirdparty tarballs ) \
+        $(: what the emscripten/emsdk image installs on the same ubuntu ) \
         sudo libxml2 ca-certificates python3 python3-pip wget curl zip unzip \
         xz-utils git git-lfs ssh-client build-essential make ant libidn12 \
         cmake openjdk-11-jre-headless \
@@ -86,7 +69,6 @@ RUN <<EOF
         gettext \
         $(: to generate TypeScript documentation ) \
         doxygen
-    emcc --version | head -n1
     # clean downloaded files
     apt-get clean
     rm -rf /var/lib/apt/lists/*

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -20,10 +20,10 @@ RUN <<EOF
     TOOLCHAIN=clang-emsdk-${EMSDK_VERSION}-pgo
     curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" \
         | tar -C /emsdk/upstream --strip-components=1 -xz
-    $(: the only stock LLVM binary our toolchain does not replace; emscripten )
-    $(: never invokes it, while wasm-opt and the other binaryen tools stay )
+    # the only stock LLVM binary our toolchain does not replace, and emscripten
+    # never invokes it; wasm-opt and the other binaryen tools stay
     rm -f /emsdk/upstream/bin/clang-scan-deps
-    $(: a stable path for node, so PATH below does not hardcode its version )
+    # a stable path for node, so PATH below need not hardcode its version
     ln -s /emsdk/node/*/bin /emsdk/node-bin
     /emsdk/upstream/bin/clang --version | head -n1
     du -sh /emsdk /emsdk/upstream/bin

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -25,6 +25,10 @@ RUN <<EOF
     rm -f /emsdk/upstream/bin/clang-scan-deps
     # a stable path for node, so PATH below need not hardcode its version
     ln -s /emsdk/node/*/bin /emsdk/node-bin
+    echo "unstripped: llvm $(du -sm /emsdk/upstream/bin | cut -f1) MB"
+    # emsdk strips its own toolchain (docker/Dockerfile in emscripten-core/emsdk);
+    # ours comes straight out of ninja install-distribution, so do the same
+    find /emsdk/upstream/bin -type f -exec strip -s {} + || true
     /emsdk/upstream/bin/clang --version | head -n1
     echo "after:  /emsdk $(du -sm /emsdk | cut -f1) MB, llvm $(du -sm /emsdk/upstream/bin | cut -f1) MB"
 EOF

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -2,12 +2,45 @@
 
 # Any changes in this file should probably be mirrored in `emscripten-build-c-bindings-X-Y-ZDockerfile`.
 
-FROM emscripten/emsdk:4.0.19-arm64 AS base
-
 # emsdk's clang is built with ThinLTO but no PGO. Ours is the same llvm-project
 # revision rebuilt with -O3 + PGO: -22.6% on an -O3 template-heavy TU.
+#
+# It replaces emsdk's copy in place rather than living beside it, and /emsdk is
+# then copied into a clean ubuntu base. Swapping the compiler in a layer on top
+# of emscripten/emsdk would ship both: a deleted or overwritten file still
+# occupies its bytes in the immutable lower layer, and emsdk keeps its whole
+# tree - LLVM included - in a single 533 MB layer.
+FROM emscripten/emsdk:4.0.19-arm64 AS emsdk
+
 ENV EMSDK_VERSION=4.0.19
-ENV EM_LLVM_ROOT=/opt/llvm-emsdk-$EMSDK_VERSION-pgo/bin
+
+RUN <<EOF
+    set -e
+    du -sh /emsdk /emsdk/upstream/bin
+    TOOLCHAIN=clang-emsdk-${EMSDK_VERSION}-pgo
+    curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" \
+        | tar -C /emsdk/upstream --strip-components=1 -xz
+    $(: the only stock LLVM binary our toolchain does not replace; emscripten )
+    $(: never invokes it, while wasm-opt and the other binaryen tools stay )
+    rm -f /emsdk/upstream/bin/clang-scan-deps
+    $(: a stable path for node, so PATH below does not hardcode its version )
+    ln -s /emsdk/node/*/bin /emsdk/node-bin
+    /emsdk/upstream/bin/clang --version | head -n1
+    du -sh /emsdk /emsdk/upstream/bin
+EOF
+
+
+FROM ubuntu:22.04 AS base
+
+# /emsdk carries emscripten, binaryen, node and now our clang; the packages
+# below are the ones the emscripten/emsdk image installed on top of the same
+# ubuntu, plus the handful this repository needs.
+COPY --from=emsdk /emsdk /emsdk
+
+ENV EMSDK=/emsdk
+ENV PATH=/emsdk:/emsdk/upstream/emscripten:/emsdk/node-bin:$PATH
+WORKDIR /src
+ENTRYPOINT ["/emsdk/docker/entrypoint.sh"]
 
 COPY <<EOF /etc/apt/sources.list.d/ubuntu.sources
 Types: deb
@@ -38,13 +71,14 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        tzdata curl git pkg-config ninja-build \
+        $(: the emscripten/emsdk image's own set ) \
+        ca-certificates python3 python3-pip cmake curl wget zip unzip git \
+        tzdata pkg-config ninja-build \
         $(: to compile translation files ) \
         gettext \
         $(: to generate TypeScript documentation ) \
         doxygen
-    TOOLCHAIN=clang-emsdk-${EMSDK_VERSION}-pgo
-    curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" | tar -C /opt -xz
+    emcc --version | head -n1
     # clean downloaded files
     apt-get clean
     rm -rf /var/lib/apt/lists/*

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -71,8 +71,12 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        $(: the same packages the emscripten/emsdk image installs ) \
-        ca-certificates python3 python3-pip cmake curl wget zip unzip git \
+        $(: the same packages the emscripten/emsdk image installs, read out ) \
+        $(: of its own config blob; openjdk is needed by --closure=1 and ) \
+        $(: xz-utils by the thirdparty tarballs ) \
+        sudo libxml2 ca-certificates python3 python3-pip wget curl zip unzip \
+        xz-utils git git-lfs ssh-client build-essential make ant libidn12 \
+        cmake openjdk-11-jre-headless \
         tzdata pkg-config ninja-build \
         $(: to compile translation files ) \
         gettext \

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -33,7 +33,7 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        tzdata git pkg-config ninja-build \
+        tzdata curl git pkg-config ninja-build \
         $(: to compile translation files ) \
         gettext \
         $(: to generate TypeScript documentation ) \
@@ -41,6 +41,37 @@ RUN <<EOF
     # clean downloaded files
     apt-get clean
     rm -rf /var/lib/apt/lists/*
+EOF
+
+
+# Replace emsdk's stock clang/lld with our rebuild of the very same
+# llvm-project revision (12f392cff, clang 22.0.0git), which adds -O3 + IR-PGO
+# on top of upstream's ThinLTO-only release configuration. Measured -22.6% on
+# an -O3 template-heavy translation unit; see the release notes.
+#
+# Only bin/ is overlaid. The resource headers and the prebuilt wasm sysroot
+# under lib/ stay exactly as the image shipped them, which is safe precisely
+# because the revision is identical -- and the binaryen tools in bin/ that we
+# do not build (wasm-opt and friends) are left untouched for the same reason.
+ARG PGO_TOOLCHAIN=clang-emsdk-4.0.19-pgo
+ARG PGO_PREFIX=llvm-emsdk-4.0.19-pgo
+ARG PGO_SHA256=a740be411d2333189f28783af80a35b9efcbcabcdb5ef2ebd5d0650c9d9b764a
+RUN <<EOF
+    set -e
+    # this image is built on arm64 runners only; no other checksum is pinned
+    if [ "$(uname -m)" != aarch64 ]; then
+        echo "unexpected arch $(uname -m): no pinned toolchain checksum" >&2
+        exit 1
+    fi
+    asset="${PGO_TOOLCHAIN}-aarch64.tar.gz"
+    cd /tmp
+    curl -fsSL -O "https://github.com/MeshInspector/toolchains/releases/download/${PGO_TOOLCHAIN}/${asset}"
+    echo "${PGO_SHA256}  ${asset}" | sha256sum -c -
+    tar -xzf "${asset}"
+    cp -a "${PGO_PREFIX}/bin/." /emsdk/upstream/bin/
+    rm -rf "${PGO_PREFIX}" "${asset}"
+    /emsdk/upstream/bin/clang --version | head -1
+    emcc --version | head -1
 EOF
 
 

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -4,6 +4,11 @@
 
 FROM emscripten/emsdk:4.0.19-arm64 AS base
 
+# emsdk's clang is built with ThinLTO but no PGO. Ours is the same llvm-project
+# revision rebuilt with -O3 + PGO: -22.6% on an -O3 template-heavy TU.
+ENV EMSDK_VERSION=4.0.19
+ENV EM_LLVM_ROOT=/opt/llvm-emsdk-$EMSDK_VERSION-pgo/bin
+
 COPY <<EOF /etc/apt/sources.list.d/ubuntu.sources
 Types: deb
 URIs: http://archive.ubuntu.com/ubuntu/ http://mirror.eu.ossplanet.net/ubuntu/
@@ -38,40 +43,11 @@ RUN <<EOF
         gettext \
         $(: to generate TypeScript documentation ) \
         doxygen
+    TOOLCHAIN=clang-emsdk-${EMSDK_VERSION}-pgo
+    curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" | tar -C /opt -xz
     # clean downloaded files
     apt-get clean
     rm -rf /var/lib/apt/lists/*
-EOF
-
-
-# Replace emsdk's stock clang/lld with our rebuild of the very same
-# llvm-project revision (12f392cff, clang 22.0.0git), which adds -O3 + IR-PGO
-# on top of upstream's ThinLTO-only release configuration. Measured -22.6% on
-# an -O3 template-heavy translation unit; see the release notes.
-#
-# Only bin/ is overlaid. The resource headers and the prebuilt wasm sysroot
-# under lib/ stay exactly as the image shipped them, which is safe precisely
-# because the revision is identical -- and the binaryen tools in bin/ that we
-# do not build (wasm-opt and friends) are left untouched for the same reason.
-ARG PGO_TOOLCHAIN=clang-emsdk-4.0.19-pgo
-ARG PGO_PREFIX=llvm-emsdk-4.0.19-pgo
-ARG PGO_SHA256=a740be411d2333189f28783af80a35b9efcbcabcdb5ef2ebd5d0650c9d9b764a
-RUN <<EOF
-    set -e
-    # this image is built on arm64 runners only; no other checksum is pinned
-    if [ "$(uname -m)" != aarch64 ]; then
-        echo "unexpected arch $(uname -m): no pinned toolchain checksum" >&2
-        exit 1
-    fi
-    asset="${PGO_TOOLCHAIN}-aarch64.tar.gz"
-    cd /tmp
-    curl -fsSL -O "https://github.com/MeshInspector/toolchains/releases/download/${PGO_TOOLCHAIN}/${asset}"
-    echo "${PGO_SHA256}  ${asset}" | sha256sum -c -
-    tar -xzf "${asset}"
-    cp -a "${PGO_PREFIX}/bin/." /emsdk/upstream/bin/
-    rm -rf "${PGO_PREFIX}" "${asset}"
-    /emsdk/upstream/bin/clang --version | head -1
-    emcc --version | head -1
 EOF
 
 

--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -16,7 +16,7 @@ ENV EMSDK_VERSION=4.0.19
 
 RUN <<EOF
     set -e
-    du -sh /emsdk /emsdk/upstream/bin
+    echo "before: /emsdk $(du -sm /emsdk | cut -f1) MB, llvm $(du -sm /emsdk/upstream/bin | cut -f1) MB"
     TOOLCHAIN=clang-emsdk-${EMSDK_VERSION}-pgo
     curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" \
         | tar -C /emsdk/upstream --strip-components=1 -xz
@@ -26,7 +26,7 @@ RUN <<EOF
     # a stable path for node, so PATH below need not hardcode its version
     ln -s /emsdk/node/*/bin /emsdk/node-bin
     /emsdk/upstream/bin/clang --version | head -n1
-    du -sh /emsdk /emsdk/upstream/bin
+    echo "after:  /emsdk $(du -sm /emsdk | cut -f1) MB, llvm $(du -sm /emsdk/upstream/bin | cut -f1) MB"
 EOF
 
 
@@ -71,7 +71,7 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        $(: the emscripten/emsdk image's own set ) \
+        $(: the same packages the emscripten/emsdk image installs ) \
         ca-certificates python3 python3-pip cmake curl wget zip unzip git \
         tzdata pkg-config ninja-build \
         $(: to compile translation files ) \


### PR DESCRIPTION
The Emscripten image compiled with the clang that emsdk ships, which the emscripten-releases bots build with ThinLTO and assertions off but **without PGO** — `src/build.py` has no `LLVM_BUILD_INSTRUMENTED`, no `LLVM_PROFDATA_FILE`, no BOLT. Every other Linux image we build already uses a PGO clang from [MeshInspector/toolchains](https://github.com/MeshInspector/toolchains); this was the last one on a stock compiler.

| | master | this PR |
| --- | --- | --- |
| image size | 888.7 MB | **868.3 MB** (-20.4 MB) |
| `/emsdk/upstream/bin` | 482 MB, stock LLVM (emsdk strips it) | **420 MB**, ours, stripped the same way |
| compiler | stock emsdk clang, ThinLTO, no PGO | clang 22.0.0git, -O3 + IR-PGO + ThinLTO |

### What the toolchain is

[`clang-emsdk-4.0.19-pgo`](https://github.com/MeshInspector/toolchains/releases/tag/clang-emsdk-4.0.19-pgo) is the **same llvm-project revision emsdk 4.0.19 ships** — `12f392cff`, `clang version 22.0.0git`, read out of emscripten-releases' `DEPS` — rebuilt with `-O3` + IR-PGO + ThinLTO. Same revision is the point: emcc's `EXPECTED_LLVM_VERSION = 22` check stays satisfied and the prebuilt wasm sysroot stays valid, so this is a compiler swap and nothing else.

It was built inside `emscripten/emsdk:4.0.19-arm64` itself, so the binaries are guaranteed to run here, and training could drive the image's own `embuilder`: emscripten's system libraries for wasm32 *and* wasm64, plus a slice of LLVM for the frontend and middle-end. Compile time against the stock compiler, same runner, template-heavy TU, `em++ -O3 -std=c++20 -c`, min of 5, warm caches: **-18.9%** on x86_64 and **-22.6%** on aarch64.

### Why the image is rebased rather than just extended

Installing the toolchain beside emsdk's grew the image by 119 MB, because both compilers were then in it, and `/emsdk/upstream/bin` is not small:

    before: /emsdk 1538 MB, llvm 482 MB
    after:  /emsdk 1542 MB, llvm 486 MB

The two compilers are the same size, so the whole regression was duplication — and deleting the stock one in a later layer cannot help, because emsdk keeps its entire tree in a single 533 MB layer and a file removed or overwritten higher up still occupies its bytes below. Both variants measured within 1 MB of each other (1007.9 MB overlaying `/emsdk/upstream/bin`, 1006.9 MB installing to `/opt` with `EM_LLVM_ROOT`).

So the tarball is unpacked **over** `/emsdk/upstream` in a throwaway stage, and `/emsdk` is copied from there into a clean `ubuntu:22.04` that reinstates the packages `emscripten/emsdk` installs on the same ubuntu — taken verbatim from that image's config blob, since a partial reading of it cost a build on a missing `xz-utils`. `openjdk-11-jre-headless` is among them and stays: `source/MRWasmModule` passes `--closure=1`, which needs Java.

The result carries exactly one compiler. `clang-scan-deps` — the only stock LLVM binary our toolchain does not replace, and one emscripten never invokes — is dropped; binaryen (`wasm-opt` and friends), node and emscripten itself come across untouched. `PATH`, `EMSDK`, `WORKDIR` and `ENTRYPOINT` are re-declared to match the base image's own config, with node reached through a version-independent `/emsdk/node-bin` symlink so the next emsdk bump does not silently drop it from `PATH`.

### CI

Every emscripten leg is green: the image build, all three `emscripten-build` variants, both `wasm-module-build` variants (so the closure/Java path works in the rebased base), all three browser `emscripten-test` legs, and all four `emscripten-build-c-bindings` legs.

`Build` step time against ten same-day master runs, in minutes. Every job below ran on a 4-core `Neoverse-N2` runner, checked through `cpu_model` in the runner-stats step for this PR and three of the master runs:

| job | this PR | master median | delta | master spread |
| --- | --- | --- | --- | --- |
| `emscripten-build (Singlethreaded)` | **4.4** | 5.0 | **-11.8%** | 4.7 - 5.5 |
| `emscripten-build (Multithreaded)` | **4.8** | 5.0 | -4.5% | 4.8 - 5.2 |
| `emscripten-build (Multithreaded-64Bit)` | **5.1** | 5.8 | **-11.4%** | 5.5 - 6.4 |
| `wasm-module-build (Singlethreaded)` | **3.6** | 4.4 | **-17.8%** | 4.1 - 4.7 |
| `wasm-module-build (Multithreaded)` | **3.9** | 4.3 | -8.9% | 4.0 - 4.7 |

Control: `emscripten-build-c-bindings (4.0.19)` runs on the same runner class from an image this PR does not touch, and lands at 3.6 vs a 3.6 median (0.0%) and 3.9 vs 3.8 (+2.4%). So the noise band here is about +/-4%, the deltas above sit outside it, and three of the five are below *every one* of the ten master runs.

Two things deliberately not claimed:

* The `3.1.38` C-bindings legs look 21-46% faster, and that is hardware, not this PR: they run on x64 hosted runners, where the same four runs drew an EPYC 9V45, an EPYC 9V74, an EPYC 7763 and a Xeon 8573C, with master alone spanning 5.5-8.1 min.
* `wasm-module-build` has no `cpu_model` in its log, because the runner-stats step only runs in `emscripten-build`. It uses the same runner label, but those two rows are corroboration rather than like-for-like proof.

A `Build` step is more than compiling: it also configures cmake, links with `wasm-ld` (ours, so it gains), runs `wasm-opt` from stock binaryen (untouched here) and packages files. -9% to -18% at step level is the expected dilution of the compiler's -22.6% on pure compile, and it is the number that shows up in CI wall clock.

### Not in this PR

`docker/emscripten-build-c-bindingsDockerfile` still uses stock compilers. Its 3.1.38 leg is clang 17.0.0git, where this toolchain does not apply, so switching only its 4.0.19 leg needs a per-version conditional — a separate change. That also means the "mirror changes here" note at the top of this Dockerfile is deliberately not honoured yet.

