### PR TITLE
Revert "Bracket each stage of a zip entry, and log the wasm heap size (#6669)"

### DIFF
--- a/source/MRMesh/MRZip.cpp
+++ b/source/MRMesh/MRZip.cpp
@@ -6,11 +6,6 @@
 #include "MRTimer.h"
 #include "MRZlib.h"
 #include "MRPch/MRSpdlog.h"
-#include "MRPch/MRFmt.h"
-
-#ifdef __EMSCRIPTEN__
-#include <emscripten/heap.h>
-#endif
 
 #if (defined(__APPLE__) && defined(__clang__)) || defined(__EMSCRIPTEN__)
 #pragma clang diagnostic push
@@ -34,17 +29,6 @@ namespace MR
 {
 
 namespace {
-
-/// on wasm the heap size at the moment of an allocation, empty elsewhere; the suspicion
-/// is that a stall in decompressZip is the heap failing to grow
-std::string heapNote()
-{
-#ifdef __EMSCRIPTEN__
-    return fmt::format( ", heap {} MB", emscripten_get_heap_size() >> 20 );
-#else
-    return {};
-#endif
-}
 
 struct ProgressData
 {
@@ -352,7 +336,6 @@ Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetF
         }
         else
         {
-            spdlog::info( "zip entry {}/{}: {}", i + 1, numEntries, nameFixed );
             zfile = zip_fopen_index(zip,i,0);
             if ( !zfile )
                 return unexpected( "Cannot open zip file " + nameFixed );
@@ -367,18 +350,12 @@ Expected<void> decompressZip_( zip_t * zip, const std::filesystem::path& targetF
             if ( !ofs || ofs.bad() )
                 return unexpected( "Cannot create file " + utf8string( newItemPath ) );
 
-            // each line brackets one thing that can stall, so the last line surviving in
-            // a log says whether the entry died opening files, growing the heap, inside
-            // libzip, or writing the result out
-            spdlog::info( "zip entry {}/{}: opened, allocating {} bytes{}", i + 1, numEntries, stats.size, heapNote() );
             fileBufer.resize(stats.size);
-            spdlog::info( "zip entry {}/{}: buffer ready, reading", i + 1, numEntries );
             auto bitesRead = zip_fread(zfile,(void*)fileBufer.data(),fileBufer.size());
             if ( bitesRead != (zip_int64_t)stats.size )
                 return unexpected( "Cannot read file from zip " + nameFixed );
 
             zip_fclose(zfile);
-            spdlog::info( "zip entry {}/{}: read {} bytes, writing", i + 1, numEntries, bitesRead );
             if ( !ofs.write( fileBufer.data(), fileBufer.size() ) )
                 return unexpected( "Cannot write file from zip " + utf8string( newItemPath ) );
             ofs.close();


### PR DESCRIPTION
Reverts #6669 in full -- `MRZip.cpp` comes back byte-identical to its state before that commit, so the four per-entry lines, the `heapNote()` helper and the `<emscripten/heap.h>` / `MRFmt.h` includes all go. #6656's whole-loop `Decompressing N` / `Decompressed N` pair stays.

It has earned its keep. Two stalls were caught with it in place, and between them they answered the question it was added for:

| | run 32967677415 | run 32967707784 |
|---|---|---|
| stalling entry | 4/5, a tiny `.ply` | 5/5, 245,796 bytes |
| last line | `zip entry 4/5: <name>` | `zip entry 5/5: read 245796 bytes, writing` |
| died in | `zip_fopen_index` / `ofstream` open | `ofs.write` / `close` |
| heap | 646 MB, flat | 646 MB, flat |

Different entries, different sizes, different phases, both in emscripten MEMFS file I/O -- never in `fileBufer.resize`, never in `zip_fread`. That rules out the heap-growth theory the logging was written to test, and points at the filesystem layer instead.

Which is also why it should not stay. spdlog has a file sink, so every one of these lines is itself a MEMFS write, four per entry, inside the loop that stalls in MEMFS writes. The only two same-day stalls we have arrived on the first build carrying it, alongside a worse failure shape (Playwright's 660 s timeout and a hanging teardown instead of the clean in-page 600 s one). That is n=2 and confounded with an emsdk bump in the same window, so it is not evidence of anything on its own -- but there is no reason to keep four extra filesystem writes per entry in the hot path while we are trying to measure a rate.

If a future occurrence needs the finer split again, this is one revert away.
