### PR TITLE
CI: pass matrix c-compiler to the main arm64 build

### DIFF
--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -160,6 +160,7 @@ jobs:
         env:
           MESHLIB_BUILD_RELEASE: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Release'] }}
           MESHLIB_BUILD_DEBUG: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Debug'] }}
+          CMAKE_C_COMPILER: ${{ matrix.c-compiler }}
           CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
           MR_VERSION: ${{ inputs.app_version }}
           # options to be passed to cmake


### PR DESCRIPTION
The `Build` step of `ubuntu-arm-build-test` passed only `CMAKE_CXX_COMPILER` to `scripts/build_source.sh`, so the `c-compiler` value declared in the matrix was never used for the library build itself and CMake resolved the C compiler from the docker image default `cc`.

Effect in the nightly run [32923043542](https://github.com/MeshInspector/MeshLib/actions/runs/32923043542):

| leg | CXX compiler | C compiler actually used |
| --- | --- | --- |
| ubuntu24 | GNU 14.3.0 (`g++-14`) | GNU 13.3.0 (default `cc`) |
| ubuntu22 | Clang 14.0.0 (`clang++-14`) | GNU 11.4.0 (default `cc`) |

The later `Build C examples` step already uses `-D CMAKE_C_COMPILER=${{ matrix.c-compiler }}`, and the sibling `build-test-ubuntu-x64.yml` already exports both `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` in its `Build` step, so this just adds the missing line and both languages now come from the matrix (`gcc-14`/`g++-14` on ubuntu24, `clang-14`/`clang++-14` on ubuntu22).

Only `ubuntu-arm64` is affected, other platforms are disabled for this PR.
