### PR TITLE
findAlphaShape: return the vertex duplications

### DIFF
--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -380,7 +380,7 @@ Triangulation findAlphaShapeAllTriangles( const PointCloud & cloud, float radius
 }
 
 std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius,
-    std::vector<MeshBuilder::VertDuplication> * dups, const ProgressCallback& cb, AlphaShapeStats * stats )
+    const ProgressCallback& cb, std::vector<MeshBuilder::VertDuplication> * dups, AlphaShapeStats * stats )
 {
     MR_TIMER;
     const auto sd = getAlphaShapeData( cloud, radius, true );
@@ -409,7 +409,7 @@ std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius,
 Mesh findAlphaShape( const PointCloud & cloud, float radius,
     std::vector<MeshBuilder::VertDuplication> * dups, AlphaShapeStats * stats )
 {
-    auto maybe = findAlphaShape( cloud, radius, dups, ProgressCallback{}, stats );
+    auto maybe = findAlphaShape( cloud, radius, ProgressCallback{}, dups, stats );
     assert( maybe.has_value() );
     Mesh res;
     if ( maybe.has_value() )

--- a/source/MRMesh/MRAlphaShape.cpp
+++ b/source/MRMesh/MRAlphaShape.cpp
@@ -379,7 +379,8 @@ Triangulation findAlphaShapeAllTriangles( const PointCloud & cloud, float radius
     return res;
 }
 
-std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius, const ProgressCallback& cb, AlphaShapeStats * stats )
+std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius,
+    std::vector<MeshBuilder::VertDuplication> * dups, const ProgressCallback& cb, AlphaShapeStats * stats )
 {
     MR_TIMER;
     const auto sd = getAlphaShapeData( cloud, radius, true );
@@ -399,15 +400,16 @@ std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius, cons
     };
 
     int skippedFaceCount = 0;
-    auto res = Mesh::fromTrianglesDuplicatingNonManifoldVertices( cloud.points, *maybeTris, nullptr,
+    auto res = Mesh::fromTrianglesDuplicatingNonManifoldVertices( cloud.points, *maybeTris, dups,
         { .skippedFaceCount = &skippedFaceCount }, betterCont );
     assert( skippedFaceCount == 0 );
     return res;
 }
 
-Mesh findAlphaShape( const PointCloud & cloud, float radius, AlphaShapeStats * stats )
+Mesh findAlphaShape( const PointCloud & cloud, float radius,
+    std::vector<MeshBuilder::VertDuplication> * dups, AlphaShapeStats * stats )
 {
-    auto maybe = findAlphaShape( cloud, radius, ProgressCallback{}, stats );
+    auto maybe = findAlphaShape( cloud, radius, dups, ProgressCallback{}, stats );
     assert( maybe.has_value() );
     Mesh res;
     if ( maybe.has_value() )

--- a/source/MRMesh/MRAlphaShape.h
+++ b/source/MRMesh/MRAlphaShape.h
@@ -133,9 +133,12 @@ MRMESH_API void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v,
 [[nodiscard]] MRMESH_API std::optional<Triangulation> findAlphaShapeAllTriangles( const PointCloud & cloud,
     const AlphaShapeData & data, const ProgressCallback & cb, AlphaShapeStats * stats = nullptr );
 
-/// builds alpha-shape mesh with negative alpha = -1/radius
+/// builds alpha-shape mesh with negative alpha = -1/radius;
+/// the mesh vertices are the cloud points with the same ids plus the ones appended by the
+/// duplication of non-manifold vertices, which \param dups (if given) receives
 [[nodiscard]] MRMESH_API std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius,
-    const ProgressCallback & cb, AlphaShapeStats * stats = nullptr );
-[[nodiscard]] MRMESH_API Mesh findAlphaShape( const PointCloud & cloud, float radius, AlphaShapeStats * stats = nullptr );
+    std::vector<MeshBuilder::VertDuplication> * dups, const ProgressCallback & cb, AlphaShapeStats * stats = nullptr );
+[[nodiscard]] MRMESH_API Mesh findAlphaShape( const PointCloud & cloud, float radius,
+    std::vector<MeshBuilder::VertDuplication> * dups = nullptr, AlphaShapeStats * stats = nullptr );
 
 } //namespace MR

--- a/source/MRMesh/MRAlphaShape.h
+++ b/source/MRMesh/MRAlphaShape.h
@@ -137,7 +137,7 @@ MRMESH_API void findAlphaShapeNeiTriangles( const PointCloud & cloud, VertId v,
 /// the mesh vertices are the cloud points with the same ids plus the ones appended by the
 /// duplication of non-manifold vertices, which \param dups (if given) receives
 [[nodiscard]] MRMESH_API std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius,
-    std::vector<MeshBuilder::VertDuplication> * dups, const ProgressCallback & cb, AlphaShapeStats * stats = nullptr );
+    const ProgressCallback & cb, std::vector<MeshBuilder::VertDuplication> * dups = nullptr, AlphaShapeStats * stats = nullptr );
 [[nodiscard]] MRMESH_API Mesh findAlphaShape( const PointCloud & cloud, float radius,
     std::vector<MeshBuilder::VertDuplication> * dups = nullptr, AlphaShapeStats * stats = nullptr );
 

--- a/source/MRTest/MRAlphaShapeTests.cpp
+++ b/source/MRTest/MRAlphaShapeTests.cpp
@@ -147,7 +147,8 @@ TEST( MRMesh, AlphaShapeCrossingGrids )
     cloud.validPoints.autoResizeSet( 0_v, (int)cloud.points.size(), true );
 
     AlphaShapeStats stats;
-    const auto mesh = findAlphaShape( cloud, 0.1f, &stats );
+    std::vector<MeshBuilder::VertDuplication> dups;
+    const auto mesh = findAlphaShape( cloud, 0.1f, &dups, &stats );
     // the counters are about 99000, 47600 and 1324000 here, but not exactly the same on every
     // platform, because the neighbourhood of a point is searched in floating point
     EXPECT_GT( stats.consideredTris, stats.touchableTris );
@@ -155,6 +156,13 @@ TEST( MRMesh, AlphaShapeCrossingGrids )
     EXPECT_EQ( mesh.topology.numValidFaces(), 584 );
     EXPECT_EQ( mesh.topology.numValidVerts(), 322 );
     EXPECT_EQ( MeshComponents::getNumComponents( mesh ), 1 );
+    EXPECT_EQ( mesh.points.size(), cloud.points.size() + dups.size() );
+    EXPECT_EQ( dups.size(), 136 );
+    for ( const auto & d : dups )
+    {
+        EXPECT_LT( (int)d.srcVert, (int)cloud.points.size() );
+        EXPECT_GE( (int)d.dupVert, (int)cloud.points.size() );
+    }
 }
 
 namespace


### PR DESCRIPTION
`findAlphaShape` builds its result with `Mesh::fromTrianglesDuplicatingNonManifoldVertices`, which appends a vertex for every non-manifold vertex it splits, and it passed `nullptr` for that function's `dups` out-parameter. So the appended vertices were invisible to the caller and a per-point attribute of the cloud — colors, normals, any custom field — could not be mapped onto the vertices of the mesh.

```cpp
[[nodiscard]] MRMESH_API std::optional<Mesh> findAlphaShape( const PointCloud & cloud, float radius,
    const ProgressCallback & cb, std::vector<MeshBuilder::VertDuplication> * dups = nullptr, AlphaShapeStats * stats = nullptr );
[[nodiscard]] MRMESH_API Mesh findAlphaShape( const PointCloud & cloud, float radius,
    std::vector<MeshBuilder::VertDuplication> * dups = nullptr, AlphaShapeStats * stats = nullptr );
```

`dups` sits after `cb` in the overload that has one, so that it can carry a default argument: a defaulted parameter may not precede a non-defaulted one, and putting `dups` first would have made it mandatory for every caller. In the overload without a `ProgressCallback` it goes right after `radius`, where `Mesh::fromTrianglesDuplicatingNonManifoldVertices` and `MeshBuilder::duplicateNonManifoldVertices` also put it.

### Callers

Verified by compiling each form against the new header:

| call | status |
| --- | --- |
| `findAlphaShape( cloud, radius )` | unchanged |
| `findAlphaShape( cloud, radius, cb )` | unchanged |
| `findAlphaShape( cloud, radius, &stats )` | → `findAlphaShape( cloud, radius, nullptr, &stats )` |
| `findAlphaShape( cloud, radius, cb, &stats )` | → `findAlphaShape( cloud, radius, cb, nullptr, &stats )` |

Both changed forms fail to compile rather than silently rebinding, since `AlphaShapeStats *` does not convert to `std::vector<MeshBuilder::VertDuplication> *`.

Inside this repo only `MRAlphaShapeTests.cpp` used the third form. **In MeshInspectorCode** two call sites use the fourth and will need `nullptr` inserted when the gitlink is bumped: `MRPointsTriangulationDevPlugin.cpp` and the new `MRAlphaShapePlugin.cpp` from MeshInspector/MeshInspectorCode#7720.

### Testing

`AlphaShapeCrossingGrids` now collects the duplications and pins them, in the same spirit as the face and vertex counts it already pins: 136 duplications, `mesh.points.size() == cloud.points.size() + dups.size()`, and every duplication maps an original point on an appended vertex. All four `*AlphaShape*` tests pass in a local x64/Release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
