### PR TITLE
DO NOT MERGE: hammer MEMFS from 8 threads to reproduce the wasm stall

### DIFF
--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -306,15 +306,16 @@ jobs:
   emscripten-test:
     if: ${{ !inputs.definitions_only }}
     needs: emscripten-build
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
         package_name:
-          - emscripten-singlethreaded
-          - emscripten-multithreaded
           - emscripten-multithreaded-64bit
+          - emscripten-multithreaded
+          - emscripten-singlethreaded
+        shard: [1, 2, 3, 4]
 
     steps:
       - name: Download MRTest bundle
@@ -326,7 +327,7 @@ jobs:
           run-id: ${{ github.run_id }}
 
       - name: Unit Tests
-        timeout-minutes: 5
+        timeout-minutes: 15
         working-directory: mrtest-bundle
         run: |
           python3 emrun.py \
@@ -334,4 +335,4 @@ jobs:
             --browser-args="--headless" \
             --safe-firefox-profile \
             --kill-exit \
-            ./MRTest.html
+            ./MRTest.html -- --gtest_filter=MRMesh.MemfsConcurrentStress

--- a/source/MRTest/MRMemfsStressTests.cpp
+++ b/source/MRTest/MRMemfsStressTests.cpp
@@ -1,0 +1,188 @@
+#include "MRMesh/MRUniqueTemporaryFolder.h"
+#include "MRPch/MRSpdlog.h"
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if defined( __EMSCRIPTEN__ ) && defined( __EMSCRIPTEN_PTHREADS__ )
+#include <emscripten/threading.h>
+#endif
+
+namespace MR
+{
+
+namespace
+{
+
+#ifdef __EMSCRIPTEN__
+constexpr int cSeconds = 240;
+#else
+// desktop CI runs this file too, and the target is a wasm-only suspicion there
+constexpr int cSeconds = 2;
+#endif
+
+/// entry sizes taken from the archives the app has stalled on
+constexpr size_t cSizes[] = { 195, 78603, 245796, 1021928 };
+
+/// one round of exactly what the zip paths ask of the filesystem: make sure the parent
+/// exists, write a file, read it back, drop it
+bool fileRound( const std::filesystem::path& dir, int tid, long long i, std::vector<char>& buf )
+{
+    std::error_code ec;
+    const auto sub = dir / ( "t" + std::to_string( tid ) );
+    if ( !std::filesystem::exists( sub, ec ) )
+        std::filesystem::create_directories( sub, ec );
+
+    const size_t size = cSizes[i % 4];
+    const auto path = sub / ( std::to_string( i % 4 ) + ".bin" );
+    buf.assign( size, char( i ) );
+
+    {
+        std::ofstream ofs( path, std::ios::binary );
+        if ( !ofs )
+            return false;
+        if ( !ofs.write( buf.data(), (std::streamsize)buf.size() ) )
+            return false;
+        ofs.close();
+    }
+    {
+        std::ifstream ifs( path, std::ios::binary );
+        if ( !ifs )
+            return false;
+        ifs.read( buf.data(), (std::streamsize)buf.size() );
+        if ( (size_t)ifs.gcount() != size )
+            return false;
+    }
+    std::filesystem::remove( path, ec );
+    return true;
+}
+
+#if !defined( __EMSCRIPTEN__ ) || defined( __EMSCRIPTEN_PTHREADS__ )
+
+/// deliberately above a CI runner's core count, so the pool has to hand out threads it
+/// does not have spare
+constexpr int cThreads = 8;
+constexpr int cStallSeconds = 60;
+
+/// keeps this thread awake without parking it on a futex; on the emscripten main thread
+/// it also drains the proxying queue, which is what the app's UI thread does between frames
+void stayAwake( int ms )
+{
+#if defined( __EMSCRIPTEN__ ) && defined( __EMSCRIPTEN_PTHREADS__ )
+    emscripten_thread_sleep( ms );
+#else
+    std::this_thread::sleep_for( std::chrono::milliseconds( ms ) );
+#endif
+}
+
+/// a wedged thread cannot be joined, so the process has to leave without it
+[[noreturn]] void leaveNow( int code )
+{
+#ifdef __EMSCRIPTEN__
+    emscripten_force_exit( code );
+#endif
+    std::_Exit( code );
+}
+
+#endif
+
+} // namespace
+
+// Every stall seen in the field has been a filesystem call on a worker thread: twice inside
+// compressZip, whose ParallelFor puts several threads in the filesystem at once, and four
+// times inside decompressZip, once pinned to the ofstream constructor and once to ofs.write.
+// The singlethreaded build has never stalled. So this hammers MEMFS from more threads than
+// the runner has cores, with no zip and no scene code in the way: if it wedges, the
+// reproducer is small enough to hand upstream.
+TEST( MRMesh, MemfsConcurrentStress )
+{
+    UniqueTemporaryFolder folder;
+    ASSERT_TRUE( bool( folder ) );
+    const std::filesystem::path dir = folder;
+
+#if !defined( __EMSCRIPTEN__ ) || defined( __EMSCRIPTEN_PTHREADS__ )
+    std::atomic<long long> done{ 0 };
+    std::atomic<int> finished{ 0 };
+    std::atomic<bool> broken{ false };
+    std::vector<std::atomic<long long>> perThread( cThreads );
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds( cSeconds );
+    std::vector<std::thread> threads;
+    threads.reserve( cThreads );
+    for ( int tid = 0; tid < cThreads; ++tid )
+    {
+        threads.emplace_back( [&, tid]
+        {
+            std::vector<char> buf;
+            for ( long long i = 0; std::chrono::steady_clock::now() < deadline && !broken.load( std::memory_order_acquire ); ++i )
+            {
+                if ( !fileRound( dir, tid, i, buf ) )
+                {
+                    broken.store( true, std::memory_order_release );
+                    break;
+                }
+                perThread[tid].fetch_add( 1, std::memory_order_relaxed );
+                done.fetch_add( 1, std::memory_order_relaxed );
+            }
+            finished.fetch_add( 1, std::memory_order_release );
+        } );
+    }
+
+    long long seen = 0;
+    int ticks = 0;
+    auto lastProgress = std::chrono::steady_clock::now();
+    while ( finished.load( std::memory_order_acquire ) < cThreads )
+    {
+        stayAwake( 250 );
+
+        const long long now = done.load( std::memory_order_relaxed );
+        if ( now != seen )
+        {
+            seen = now;
+            lastProgress = std::chrono::steady_clock::now();
+        }
+        else
+        {
+            const auto idle = std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - lastProgress ).count();
+            if ( idle >= cStallSeconds )
+            {
+                spdlog::error( "STALLED: no filesystem progress for {} s after {} rounds", idle, seen );
+                for ( int tid = 0; tid < cThreads; ++tid )
+                    spdlog::error( "  thread {}: {} rounds, finished {}", tid,
+                        perThread[tid].load( std::memory_order_relaxed ),
+                        finished.load( std::memory_order_relaxed ) );
+                leaveNow( 3 );
+            }
+        }
+
+        // once every five seconds, so a stalled log shows this thread alive next to silent workers
+        if ( ++ticks % 20 == 0 )
+            spdlog::info( "{} rounds across {} threads", seen, cThreads );
+    }
+
+    for ( auto& t : threads )
+        t.join();
+
+    ASSERT_FALSE( broken.load( std::memory_order_acquire ) ) << "a filesystem call failed";
+    spdlog::info( "done: {} rounds in {} s across {} threads", seen, cSeconds, cThreads );
+    EXPECT_GT( seen, 0 );
+#else
+    std::vector<char> buf;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds( cSeconds );
+    long long i = 0;
+    for ( ; std::chrono::steady_clock::now() < deadline; ++i )
+        ASSERT_TRUE( fileRound( dir, 0, i, buf ) ) << "round " << i;
+    spdlog::info( "done: {} single-threaded rounds", i );
+    EXPECT_GT( i, 0 );
+#endif
+}
+
+} // namespace MR

--- a/source/MRTest/MRMemfsStressTests.cpp
+++ b/source/MRTest/MRMemfsStressTests.cpp
@@ -66,10 +66,17 @@ bool fileRound( const std::filesystem::path& dir, int tid, long long i, std::vec
 
 #if !defined( __EMSCRIPTEN__ ) || defined( __EMSCRIPTEN_PTHREADS__ )
 
-/// deliberately above a CI runner's core count, so the pool has to hand out threads it
-/// does not have spare
-constexpr int cThreads = 8;
 constexpr int cStallSeconds = 60;
+
+/// PTHREAD_POOL_SIZE is navigator.hardwareConcurrency, and a thread past that one needs a
+/// Worker spawned on demand, which needs the main thread to reach the browser event loop --
+/// which this test's watchdog never does. Asking for more than the pool holds therefore
+/// deadlocks the test itself and says nothing about the filesystem.
+int poolSizedThreadCount()
+{
+    const unsigned hc = std::thread::hardware_concurrency();
+    return int( hc ? hc : 4 );
+}
 
 /// keeps this thread awake without parking it on a futex; on the emscripten main thread
 /// it also drains the proxying queue, which is what the app's UI thread does between frames
@@ -111,11 +118,13 @@ TEST( MRMesh, MemfsConcurrentStress )
     std::atomic<long long> done{ 0 };
     std::atomic<int> finished{ 0 };
     std::atomic<bool> broken{ false };
+    const int cThreads = poolSizedThreadCount();
+    spdlog::info( "{} threads, {} s", cThreads, cSeconds );
     std::vector<std::atomic<long long>> perThread( cThreads );
 
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds( cSeconds );
     std::vector<std::thread> threads;
-    threads.reserve( cThreads );
+    threads.reserve( size_t( cThreads ) );
     for ( int tid = 0; tid < cThreads; ++tid )
     {
         threads.emplace_back( [&, tid]

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -43,6 +43,7 @@
     <ClCompile Include="MRMeshIntersectTests.cpp" />
     <ClCompile Include="MRMeshLoadSaveTest.cpp" />
     <ClCompile Include="MRMeshMeshDistanceTests.cpp" />
+    <ClCompile Include="MRMemfsStressTests.cpp" />
     <ClCompile Include="MRMeshTests.cpp" />
     <ClCompile Include="MRMeshTopologyTests.cpp" />
     <ClCompile Include="MRMultiwayICPTests.cpp" />


### PR DESCRIPTION
**Throwaway experiment -- do not merge, do not review.** Deleted once it has answered.

Six stalls in the app now, and every one has been a filesystem call on a worker thread:

| stage | occurrences | pinned to |
|---|---|---|
| `compressZip` | 08-20, 08-27 | inside the `ParallelFor` that deflates each file |
| `decompressZip` | 08-23, 08-24, 08-26 x2 | once the `ofstream` constructor, once `ofs.write` |

Never in `fileBufer.resize`, never in `zip_fread`, with the heap flat at 646 MB. The singlethreaded build has never stalled, on either side. What separates every stalling configuration from every clean one is **several pthreads in the filesystem at once** -- `compressZip`'s phase A puts one per file there, and `decompressZip` runs alongside whatever else touches MEMFS, spdlog's file sink included.

Everything ruled out so far: the archive contents (structurally valid, opens 200 times), heap growth, libzip, host architecture, emsdk version (stalls continue on 4.0.19), and the instrumentation itself (08-27 stalled with #6669 reverted).

So `MRMesh.MemfsConcurrentStress` does nothing but what the zip paths ask of the filesystem -- ensure the parent directory exists, write a file, read it back, delete it -- from **8 threads**, deliberately more than a runner has cores, for 240 s, with the entry sizes taken from the archives that stalled (195 / 78,603 / 245,796 / 1,021,928 bytes). No zip, no scene code, no converter. Each thread owns its files, so any wedge is in the filesystem layer rather than in the test.

A watchdog on the test thread stays awake through `emscripten_thread_sleep` -- which drains the proxying queue, unlike a futex sleep, and unlike `join()` does not park the main thread and manufacture a different deadlock. If the round counter stops moving for 60 s it prints each thread's tally and exits 3, so a hit fails the job in a minute rather than hanging it for the full timeout.

The matrix runs all three configs x 4 shards. `emscripten-singlethreaded` is the control: it takes the fallback path and does the same rounds on one thread, so if it stalls too, threads are not the variable.

Why this is worth a try when three repro attempts have failed: #6659's 49,600 loads never tested this. `decompressZip_` is serial, so those runs put exactly **one** worker in the filesystem. Nothing so far has hammered it concurrently.

`MRTest` compiles clean with MSVC `/Wall /WX`. Non-emscripten builds run the same rounds for 2 s so desktop CI is not slowed.
