### PR TITLE
emscripten image: drop ant and openjdk

### DIFF
--- a/docker/emscriptenDockerfile
+++ b/docker/emscriptenDockerfile
@@ -61,9 +61,10 @@ RUN <<EOF
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
         $(: what the emscripten/emsdk image installs on the same ubuntu ) \
+        $(: minus ant and openjdk: emscripten runs the native closure ) \
+        $(: compiler and only falls back to java if that fails ) \
         sudo libxml2 ca-certificates python3 python3-pip wget curl zip unzip \
-        xz-utils git git-lfs ssh-client build-essential make ant libidn12 \
-        cmake openjdk-11-jre-headless \
+        xz-utils git git-lfs ssh-client build-essential make libidn12 cmake \
         tzdata pkg-config ninja-build \
         $(: to compile translation files ) \
         gettext \


### PR DESCRIPTION
`ant` and `openjdk-11-jre-headless` are in this image only because they are part of the package set `emscripten/emsdk` installs, which #6691 reinstated verbatim when the image was rebased onto a clean ubuntu.

The only thing that wants java is emscripten's `--closure`, and even there java is a **fallback**, not the primary path. From `tools/building.py` at the emscripten revision emsdk 4.0.19 pins:

```python
native_closure_compiler_works = check_closure_compiler(closure_cmd, user_args, env, allowed_to_fail=True)
if not native_closure_compiler_works and not any(a.startswith('--platform') for a in user_args):
    # Run with Java Closure compiler as a fallback if the native version does not work.
    # This can happen, for example, on arm64 macOS machines that do not have Rosetta installed.
    logger.warning('falling back to java version of closure compiler')
    user_args.append('--platform=java')
```

So emscripten uses the native binary from the npm `google-closure-compiler` package and only reaches for java when that binary cannot run - the cited example being arm64 macOS without Rosetta, which is not our case.

## What this run actually tests

`source/MRWasmModule/CMakeLists.txt` passes `--closure=1`, so unlike the same change in the MeshInspector image, closure genuinely runs here. The two `wasm-module-build` legs are the check: if they stay green without java installed, the native compiler handled it. If they fail, java was load-bearing after all and this gets closed with a comment in the Dockerfile explaining why the packages stay.

Expected saving is on the order of 150-200 MB on disk. The measured image size goes here once CI has pushed it.

For reference, the equivalent change in the MeshInspector image took 71.3 MB off a comparable image, but that one never invokes closure at all.
