### PR TITLE
c-bindings image: use our PGO clang for both emsdk versions

### DIFF
--- a/.github/workflows/prepare-images.yml
+++ b/.github/workflows/prepare-images.yml
@@ -287,6 +287,7 @@ jobs:
               -f docker/emscripten-build-c-bindingsDockerfile \
               -t "${repo}:${tag}" \
               --build-arg BASE_EMSDK_IMAGE=${{matrix.emsdk_image}} \
+              --build-arg USE_PGO_CLANG=${{ startsWith(matrix.emsdk_image, '4.') && '1' || '0' }} \
               --secret id=AWS_ACCESS_KEY_ID \
               --secret id=AWS_SECRET_ACCESS_KEY \
               --secret id=AWS_SESSION_TOKEN \

--- a/docker/emscripten-build-c-bindingsDockerfile
+++ b/docker/emscripten-build-c-bindingsDockerfile
@@ -5,16 +5,23 @@
 
 ARG BASE_EMSDK_IMAGE
 
-# Both emsdk images this file is built from (3.1.38 and 4.0.19) ship clang built
-# with ThinLTO but no PGO. Ours is clang 22 with -O3 + PGO, unpacked over
-# emsdk's copy; /emsdk is then carried into a clean ubuntu so only one compiler
-# is in the image (a file overwritten in a later layer still occupies its bytes
-# below). emsdk 3.1.38 expects LLVM 17 and only warns about the mismatch, hence
-# -Wno-version-check below; its sysroot is rebuilt by whichever clang is here.
+# emsdk ships clang without PGO; ours is clang 22 with -O3 + PGO, unpacked over
+# emsdk's copy, with /emsdk then carried into a clean ubuntu so only one compiler
+# is in the image. Enabled per emsdk version by the caller: clang 22 lowers
+# setjmp to __wasm_setjmp / __wasm_setjmp_test, which emscripten 3.1.38's libc
+# does not provide, so that leg keeps its own clang 17 (turbojpeg fails to link
+# otherwise).
 FROM emscripten/emsdk:$BASE_EMSDK_IMAGE AS emsdk
+
+ARG USE_PGO_CLANG=0
 
 RUN <<EOF
     set -e
+    if [ "${USE_PGO_CLANG}" != "1" ]; then
+        echo "keeping the emsdk toolchain"
+        ln -s /emsdk/node/*/bin /emsdk/node-bin
+        exit 0
+    fi
     TOOLCHAIN=clang-emsdk-4.0.19-pgo
     curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" \
         | tar -C /emsdk/upstream --strip-components=1 -xz
@@ -32,8 +39,6 @@ COPY --from=emsdk /emsdk /emsdk
 
 ENV EMSDK=/emsdk
 ENV PATH=/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:/emsdk/node-bin:$PATH
-# 3.1.38 expects LLVM 17 and warns about clang 22; the build passes -Werror
-ENV EMCC_CFLAGS=-Wno-version-check
 WORKDIR /src
 ENTRYPOINT ["/emsdk/docker/entrypoint.sh"]
 

--- a/docker/emscripten-build-c-bindingsDockerfile
+++ b/docker/emscripten-build-c-bindingsDockerfile
@@ -5,7 +5,37 @@
 
 ARG BASE_EMSDK_IMAGE
 
-FROM emscripten/emsdk:$BASE_EMSDK_IMAGE AS base
+# Both emsdk images this file is built from (3.1.38 and 4.0.19) ship clang built
+# with ThinLTO but no PGO. Ours is clang 22 with -O3 + PGO, unpacked over
+# emsdk's copy; /emsdk is then carried into a clean ubuntu so only one compiler
+# is in the image (a file overwritten in a later layer still occupies its bytes
+# below). emsdk 3.1.38 expects LLVM 17 and only warns about the mismatch, hence
+# -Wno-version-check below; its sysroot is rebuilt by whichever clang is here.
+FROM emscripten/emsdk:$BASE_EMSDK_IMAGE AS emsdk
+
+RUN <<EOF
+    set -e
+    TOOLCHAIN=clang-emsdk-4.0.19-pgo
+    curl -fsSL --retry 5 --retry-all-errors "https://github.com/MeshInspector/toolchains/releases/download/${TOOLCHAIN}/${TOOLCHAIN}-$(uname -m).tar.gz" \
+        | tar -C /emsdk/upstream --strip-components=1 -xz
+    rm -f /emsdk/upstream/bin/clang-scan-deps
+    # PATH below points here, keeping node's version out of it
+    ln -s /emsdk/node/*/bin /emsdk/node-bin
+    # emsdk strips its own toolchain, ours arrives unstripped
+    find /emsdk/upstream/bin -type f -exec strip -s {} + || true
+EOF
+
+
+FROM ubuntu:22.04 AS base
+
+COPY --from=emsdk /emsdk /emsdk
+
+ENV EMSDK=/emsdk
+ENV PATH=/emsdk:/emsdk/upstream/emscripten:/emsdk/upstream/bin:/emsdk/node-bin:$PATH
+# 3.1.38 expects LLVM 17 and warns about clang 22; the build passes -Werror
+ENV EMCC_CFLAGS=-Wno-version-check
+WORKDIR /src
+ENTRYPOINT ["/emsdk/docker/entrypoint.sh"]
 
 ARG VERSION_CODENAME=jammy
 COPY <<EOF /etc/apt/sources.list.d/ubuntu.sources
@@ -37,7 +67,11 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        tzdata git pkg-config ninja-build gettext
+        $(: what the emscripten/emsdk image installs on the same ubuntu ) \
+        sudo libxml2 ca-certificates python3 python3-pip wget curl zip unzip \
+        xz-utils git git-lfs ssh-client build-essential make ant libidn12 \
+        cmake openjdk-11-jre-headless \
+        tzdata pkg-config ninja-build gettext
     # clean downloaded files
     apt-get clean
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
`docker/emscripten-build-c-bindingsDockerfile` was the last image on a stock compiler after #6691 and MeshInspectorCode#7719. Same treatment: our clang 22 (`-O3` + IR-PGO + ThinLTO, the revision emsdk 4.0.19 ships) is unpacked **over** `/emsdk/upstream`, then `/emsdk` is copied into a clean `ubuntu:22.04`, so the image carries one compiler rather than two. Both emsdk images this file builds from are `ubuntu:jammy` based, so the toolchain runs on both.

## The interesting part: the 3.1.38 leg

That leg keeps **emsdk 3.1.38** as requested, but gets **clang 22** instead of the clang 17 it ships. That is a deliberate mismatch, and it is not obviously safe:

* `tools/shared.py` in 3.1.38 has `EXPECTED_LLVM_VERSION = 17` and `check_llvm_version()` only emits a `version-check` **warning**, not an error - so emcc will run. Since the build passes `-Werror`, the image sets `EMCC_CFLAGS=-Wno-version-check`; `version-check` is a registered diagnostic in both 3.1.38 and 4.0.19, so the flag is understood either way.
* the prebuilt sysroot in that image was compiled by clang 17; it gets rebuilt by whichever clang is present, so the risk is a 2023 emscripten driving a 2025 clang - flags it passes may have been removed, and its JS/wasm assumptions may not match.

So this PR is a test, not a claim. The four `emscripten-build-c-bindings` legs are the verdict:

* if all four pass, both emsdk versions work with the PGO clang;
* if only the 3.1.38 legs fail, the fallback is to swap the compiler for the 4.0.19 image only and leave 3.1.38 stock, which is still the majority of that matrix's work.

Measured sizes go here once CI pushes the images.
