### PR TITLE
Add bridgeFillAllHoles( mesh, params )

### DIFF
--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -1434,4 +1434,19 @@ std::vector<EdgeId> makeInterHoleBridgeEdges( Mesh& mesh, const std::vector<Edge
     return bridgesCreated;
 }
 
+bool bridgeFillAllHoles( Mesh& mesh, const FillHoleParams& params )
+{
+    MR_TIMER;
+    auto holes = mesh.topology.findHoleRepresentiveEdges();
+    if ( holes.empty() )
+        return false;
+
+    // every bridge merges two holes in one, so the representative edges have to be found again
+    if ( !makeInterHoleBridgeEdges( mesh, holes ).empty() )
+        holes = mesh.topology.findHoleRepresentiveEdges();
+
+    fillHoles( mesh, holes, params );
+    return true;
+}
+
 } //namespace MR

--- a/source/MRMesh/MRMeshFillHole.h
+++ b/source/MRMesh/MRMeshFillHole.h
@@ -269,6 +269,10 @@ MRMESH_API EdgeId makeBridgeEdge( MeshTopology & topology, EdgeId a, EdgeId b );
 MRMESH_API std::vector<EdgeId> makeInterHoleBridgeEdges( Mesh& mesh, const std::vector<EdgeId>& holeRepresentativeEdges );
 MRMESH_API std::vector<EdgeId> makeInterHoleBridgeEdges( MeshTopology& topology, const VertCoords& points, const std::vector<EdgeId>& holeRepresentativeEdges );
 
+/// creates bridge edges between all holes of the mesh by calling makeInterHoleBridgeEdges, and fills all remaining holes;
+/// \return false if the mesh had no holes and was not changed, true otherwise
+MRMESH_API bool bridgeFillAllHoles( Mesh& mesh, const FillHoleParams& params = {} );
+
 /// given quadrangle face to the left of a, splits it in two triangles with new diagonal edge via dest(a)
 MRMESH_API void splitQuad( MeshTopology & topology, EdgeId a, FaceBitSet * outNewFaces = nullptr );
 

--- a/source/MRTest/MRFillHoleTests.cpp
+++ b/source/MRTest/MRFillHoleTests.cpp
@@ -178,6 +178,33 @@ TEST( MRMesh, makeInterHoleBridgeEdges )
     EXPECT_TRUE( makeInterHoleBridgeEdges( mesh2, bdEdges ).empty() );
 }
 
+TEST( MRMesh, bridgeFillAllHoles )
+{
+    // two separate triangles, one on top of the other with opposite orientations, with a hole around each
+    Triangulation t{
+        { 0_v, 1_v, 2_v },
+        { 3_v, 5_v, 4_v }
+    };
+    Mesh mesh;
+    mesh.topology = MeshBuilder::fromTriangles( t );
+    mesh.points.emplace_back( 0.f, 0.f, 0.f ); // VertId{0}
+    mesh.points.emplace_back( 1.f, 0.f, 0.f ); // VertId{1}
+    mesh.points.emplace_back( 0.f, 1.f, 0.f ); // VertId{2}
+    mesh.points.emplace_back( 0.f, 0.f, 1.f ); // VertId{3}
+    mesh.points.emplace_back( 1.f, 0.f, 1.f ); // VertId{4}
+    mesh.points.emplace_back( 0.f, 1.f, 1.f ); // VertId{5}
+
+    // three bridges appear and the three holes in between them get filled
+    EXPECT_TRUE( bridgeFillAllHoles( mesh ) );
+    EXPECT_EQ( mesh.topology.numValidVerts(), 6 );
+    EXPECT_TRUE( mesh.topology.findHoleRepresentiveEdges().empty() );
+
+    // nothing to do in the closed mesh now
+    const auto numFaces = mesh.topology.numValidFaces();
+    EXPECT_FALSE( bridgeFillAllHoles( mesh ) );
+    EXPECT_EQ( mesh.topology.numValidFaces(), numFaces );
+}
+
 TEST( MRMesh, HoleFillPlan3 )
 {
     Mesh mesh;


### PR DESCRIPTION
New function

```cpp
bool bridgeFillAllHoles( Mesh& mesh, const FillHoleParams& params = {} );
```

first connects the holes of the mesh with bridge edges by `makeInterHoleBridgeEdges`, then fills every remaining hole by `fillHoles`. This gives a nicer patch than filling each hole separately when the holes are close to one another (e.g. the two sides of a thin cut).

It returns `false` if the mesh had no holes and was not changed, `true` otherwise.

Since each created bridge merges two holes in one, the hole representative edges are searched again after `makeInterHoleBridgeEdges` (only if at least one bridge was created), because the edges found before would then represent one and the same hole.

Covered by a new gtest `MRMesh.bridgeFillAllHoles`; the full local MRTest suite passes (373 tests).
