### PR TITLE
Report Azure Cobalt 100 and AWS Graviton by name on Linux arm64

### DIFF
--- a/scripts/devops/collect_runner_sys_stats.py
+++ b/scripts/devops/collect_runner_sys_stats.py
@@ -44,7 +44,13 @@ ARM_VENDORS = {
     0x70: "Phytium", 0xc0: "Ampere",
 }
 
-def get_arm_cpu_model():
+# the real name of a cloud CPU lives in SMBIOS type 4, which is root-only, so brand
+# the known ones by DMI vendor + MIDR pair (Cobalt 100 is a stock Neoverse-N2 core)
+BRANDED_ARM_CPUS = {
+    ("Microsoft Corporation", 0x41, 0xd49): "Cobalt 100",
+}
+
+def read_arm_midr():
     implementer, part = -1, -1
     with open('/proc/cpuinfo') as f:
         for line in f:
@@ -54,6 +60,20 @@ def get_arm_cpu_model():
                 part = int(line.split(':', 1)[1], 0)
             if implementer >= 0 and part >= 0:
                 break
+    return implementer, part
+
+def get_dmi_sys_vendor():
+    try:
+        with open('/sys/class/dmi/id/sys_vendor') as f:
+            return f.read().strip()
+    except OSError:
+        return None
+
+def get_branded_arm_cpu_model():
+    return BRANDED_ARM_CPUS.get((get_dmi_sys_vendor(), *read_arm_midr()))
+
+def get_arm_cpu_model():
+    implementer, part = read_arm_midr()
 
     name = ARM_CPU_NAMES.get((implementer, part))
     if name:
@@ -83,6 +103,11 @@ def get_cpu_model():
         output = subprocess.check_output(['sysctl', '-n', 'machdep.cpu.brand_string'], text=True)
         return output.strip()
     elif system == "Linux":
+        if platform.machine() in ('aarch64', 'arm64'):
+            # must win over lscpu, which reports only the licensed core name
+            branded = get_branded_arm_cpu_model()
+            if branded:
+                return branded
         output = subprocess.check_output(['lscpu'], text=True)
         for line in output.splitlines():
             if line.startswith('Model name:'):

--- a/scripts/devops/collect_runner_sys_stats.py
+++ b/scripts/devops/collect_runner_sys_stats.py
@@ -45,9 +45,13 @@ ARM_VENDORS = {
 }
 
 # the real name of a cloud CPU lives in SMBIOS type 4, which is root-only, so brand
-# the known ones by DMI vendor + MIDR pair (Cobalt 100 is a stock Neoverse-N2 core)
+# the known ones by DMI vendor + MIDR pair: Cobalt and Graviton are stock ARM cores
 BRANDED_ARM_CPUS = {
     ("Microsoft Corporation", 0x41, 0xd49): "Cobalt 100",
+    ("Amazon EC2",            0x41, 0xd08): "AWS Graviton",
+    ("Amazon EC2",            0x41, 0xd0c): "AWS Graviton2",
+    ("Amazon EC2",            0x41, 0xd40): "AWS Graviton3",
+    ("Amazon EC2",            0x41, 0xd4f): "AWS Graviton4",
 }
 
 def read_arm_midr():

--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -424,13 +424,22 @@ std::string GetCpuId()
     }
 
     // a cloud CPU's real name is only in SMBIOS, which needs root, so brand the known
-    // ones by DMI vendor: Azure's Cobalt 100 reports as a stock ARM Neoverse-N2 core
-    if ( implementer == 0x41 && part == 0xd49 )
+    // ones by DMI vendor: Cobalt and Graviton both report as stock ARM cores
+    struct BrandedArmCpu { const char* vendor; int implementer, part; const char* name; };
+    static constexpr BrandedArmCpu brandedArmCpus[] = {
+        { "Microsoft Corporation", 0x41, 0xd49, "Cobalt 100" },
+        { "Amazon EC2",            0x41, 0xd08, "AWS Graviton" },
+        { "Amazon EC2",            0x41, 0xd0c, "AWS Graviton2" },
+        { "Amazon EC2",            0x41, 0xd40, "AWS Graviton3" },
+        { "Amazon EC2",            0x41, 0xd4f, "AWS Graviton4" },
+    };
     {
         std::ifstream sysVendor( "/sys/class/dmi/id/sys_vendor" );
-        if ( std::string vendor; std::getline( sysVendor, vendor )
-                && vendor.starts_with( "Microsoft Corporation" ) )
-            return "Cobalt 100";
+        if ( std::string vendor; std::getline( sysVendor, vendor ) )
+            for ( const auto& c : brandedArmCpus )
+                if ( c.implementer == implementer && c.part == part
+                        && vendor.starts_with( c.vendor ) )
+                    return c.name;
     }
 
     struct ArmCpuName { int implementer, part; const char* name; };

--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -423,6 +423,16 @@ std::string GetCpuId()
         }
     }
 
+    // a cloud CPU's real name is only in SMBIOS, which needs root, so brand the known
+    // ones by DMI vendor: Azure's Cobalt 100 reports as a stock ARM Neoverse-N2 core
+    if ( implementer == 0x41 && part == 0xd49 )
+    {
+        std::ifstream sysVendor( "/sys/class/dmi/id/sys_vendor" );
+        if ( std::string vendor; std::getline( sysVendor, vendor )
+                && vendor.starts_with( "Microsoft Corporation" ) )
+            return "Cobalt 100";
+    }
+
     struct ArmCpuName { int implementer, part; const char* name; };
     static constexpr ArmCpuName armCpuNames[] = {
         { 0x41, 0xd03, "ARM Cortex-A53" },   { 0x41, 0xd05, "ARM Cortex-A55" },


### PR DESCRIPTION
### Problem

arm64 has no CPUID-like brand-string instruction, so on Linux both `GetCpuId()` and the CI
stats collector can only decode the MIDR implementer/part pair. Cloud CPUs are licensed ARM
cores, so they are reported by their core name and their real identity is lost:

| CPU | MIDR part | reported today |
| --- | --- | --- |
| Azure Cobalt 100 | `0xd49` | `ARM Neoverse-N2` / `Neoverse-N2` |
| AWS Graviton4 | `0xd4f` | `ARM Neoverse-V2` / `Neoverse-V2` |

The marketing name does exist in SMBIOS type 4 "Processor Version" - which is exactly where
Windows' `ProcessorNameString` comes from, and why the same Cobalt machine running Windows
reports `Cobalt 100` while Linux reports `Neoverse-N2` - but reading it needs root:

```
$ sudo dmidecode -t processor
        Manufacturer: MICROSOFT CORPORATION
        Version: Cobalt 100
        Max Speed: 3400 MHz
```

Neither CI nor the application has root. On the GitHub `ubuntu-24.04-arm` image every
unprivileged path to that string is closed - `/sys/firmware/dmi/tables/*` and
`/sys/firmware/acpi/tables/*` are `-r--------` root:root, `/sys/firmware/dmi/entries/` does
not exist (no `dmi-sysfs` module), `dmidecode` is not setuid and has no file capabilities,
`dmesg_restrict=1` - and our own AWS arm64 runners have no passwordless sudo either
(`sudo: a password is required`, then the same `Permission denied` on the DMI table).

### Fix

Brand the known cloud CPUs from two values that *are* readable unprivileged: the MIDR pair
and the DMI system vendor. Measured on the two hosts we actually build on:

| | `/sys/class/dmi/id/sys_vendor` | `midr_el1` | part | branded as |
| --- | --- | --- | --- | --- |
| hosted `ubuntu-24.04-arm` | `Microsoft Corporation` | `0x00000000410fd490` | `0xd49` | `Cobalt 100` |
| our AWS arm64 spot pool (`c8g`) | `Amazon EC2` | `0x00000000410fd4f1` | `0xd4f` | `AWS Graviton4` |

Both changes share one table keyed on `(sys_vendor, implementer, part)`, so the C++ and the
Python decoding stay in step:

* `GetCpuId()` returns `Cobalt 100` - the exact string the Windows registry branch already
  returns, so the two platforms finally agree - or `AWS Graviton<N>`.
* the CI collector reports the same in `cpu_model`, checked before `lscpu`, because `lscpu`
  only ever prints the licensed core name and would otherwise win.

The Graviton generations follow the published core mapping: `0xd08` Cortex-A72 = Graviton
(`a1`), `0xd0c` Neoverse-N1 = Graviton2 (`*6g`), `0xd40` Neoverse-V1 = Graviton3 (`*7g`),
`0xd4f` Neoverse-V2 = Graviton4 (`*8g`). Only the Graviton4 row is measured, on a `c8g`
runner; the older three are from the published mapping, since we have no such instances to
run on. Graviton3E (`c7gn`, `hpc7g`) is also Neoverse-V1 and will report as `AWS Graviton3`.

### Verification

* 16 cases against `scripts/devops/collect_runner_sys_stats.py` with faked `/proc/cpuinfo`,
  `sys_vendor` and `lscpu`. Both branded hosts resolve, using the values measured above.
  Everything else is untouched: N2 or V2 under any other vendor, with `sys_vendor`
  unreadable, or with the file absent, still gives the plain core name; N2 under `Amazon
  EC2` and V2 under `Microsoft Corporation` are deliberately *not* branded; Ampere Altra
  (`0xd0c`) under Microsoft DMI stays `Neoverse-N1`; AmpereOne and x86_64 Linux unchanged.
  The Windows branch was re-run for real and still returns the CIM name.
* the new `GetCpuId()` block was compiled and run standalone under `/std:c++20 /W4`, clean,
  over the same 10 combinations.
* the `ubuntu-24.04-arm` leg of this PR is the end-to-end check: it builds the changed
  `MRSystem.cpp` for arm64 and its `collect-runner-stats` step prints the resulting
  `cpu_model` on a real Cobalt host.

Only `ubuntu-arm64` is left enabled: the new C++ is inside `defined(__ARM_CPU__)` and not
`_WIN32`, so no other platform compiles it, and that leg also exercises the shared Python
refactoring.

### Caveats worth stating

This is inference, not a read of the name. A future Azure or AWS arm64 host with a different
core needs a table row, and an N2 guest under some other Hyper-V deployment would be branded
`Cobalt 100` wrongly. The alternative, a `sudo dmidecode` call, is available to neither the
application nor CI. Inferring from these registers is what `lscpu` already does for the core
name; this only adds the vendor as a second key.

Note for the stats database: arm64 Linux rows change value at this commit (`Neoverse-N2` ->
`Cobalt 100`, `Neoverse-V2` -> `AWS Graviton4`), so a query spanning it should treat the old
and new names as the same hardware. The upside is that arm64 Linux and arm64 Windows rows
now carry one name instead of two, and that AWS rows name the CPU rather than the core.
