### PR TITLE
Document the meshlib-core headless package

### DIFF
--- a/doxygen/general_pages/About.dox
+++ b/doxygen/general_pages/About.dox
@@ -43,7 +43,7 @@ pip install meshlib
 \endcode
 
 For headless environments — servers, docker, CI — `pip install meshlib-core` provides everything
-except the interactive viewer at a 25–31% smaller download.
+except the interactive viewer at a about 30% smaller download.
 
 For C++, C#, and C developers, head to our \ref InstallationGuide "Installation Guide" for more details on integrating MeshLib into your environment.
 

--- a/doxygen/general_pages/About.dox
+++ b/doxygen/general_pages/About.dox
@@ -42,6 +42,9 @@ For Python users, install MeshLib via pip:
 pip install meshlib
 \endcode
 
+For headless environments — servers, docker, CI — `pip install meshlib-core` provides everything
+except the interactive viewer at a 25–31% smaller download.
+
 For C++, C#, and C developers, head to our \ref InstallationGuide "Installation Guide" for more details on integrating MeshLib into your environment.
 
 ## Tutorials

--- a/doxygen/general_pages/PythonSetupGuide.dox
+++ b/doxygen/general_pages/PythonSetupGuide.dox
@@ -54,7 +54,9 @@ MeshLib is available on [PyPI](https://pypi.org/project/meshlib/) for Windows, m
 pip install meshlib
 \endcode
 
-It pulls in `numpy` (>= 1.19), MeshLib's only dependency.
+It installs two packages: `meshlib-core` — the headless core with `mrmeshpy`, `mrmeshnumpy`
+and `mrcudapy` — and the `meshlib` wheel on top of it, adding the interactive viewer
+(`mrviewerpy`) with its UI resources. `numpy` (>= 1.19) is the only external dependency.
 
 On \b Windows that command works as written. A virtual environment is still worth using once you
 have more than one project, so their dependencies cannot collide:
@@ -74,6 +76,18 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install meshlib
 \endcode
+
+### Headless installation {#PythonSetupHeadless}
+On servers, in docker images, and in CI — anywhere the interactive viewer is never opened —
+install just the core:
+\code{.sh}
+pip install meshlib-core
+\endcode
+The download is 25–31% smaller and provides everything except `meshlib.mrviewerpy`; every other
+import (`from meshlib import mrmeshpy`, `mrmeshnumpy`, `mrcudapy`) works exactly as with the full
+package. Installing `meshlib` later adds the viewer on top, and `pip uninstall meshlib` removes
+only the viewer part again. Both packages are versioned in lockstep: `meshlib` of a given version
+requires exactly `meshlib-core` of the same version.
 
 ### Verify the installation {#PythonSetupVerify}
 `pip install` reporting success is not the same as a working install: the wheel is tens of megabytes of prebuilt native code, and it can install cleanly and still fail to load. This one command covers the whole chain — import the package, load the native module, run a real geometry call:

--- a/doxygen/general_pages/PythonSetupGuide.dox
+++ b/doxygen/general_pages/PythonSetupGuide.dox
@@ -83,7 +83,7 @@ install just the core:
 \code{.sh}
 pip install meshlib-core
 \endcode
-The download is 25–31% smaller and provides everything except `meshlib.mrviewerpy`; every other
+The download is about 30% smaller and provides everything except `meshlib.mrviewerpy`; every other
 import (`from meshlib import mrmeshpy`, `mrmeshnumpy`, `mrcudapy`) works exactly as with the full
 package. Installing `meshlib` later adds the viewer on top, and `pip uninstall meshlib` removes
 only the viewer part again. Both packages are versioned in lockstep: `meshlib` of a given version

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,8 @@ For Python, simply install via pip:
 pip install meshlib
 ```
 
+For headless environments (servers, docker, CI), `pip install meshlib-core` provides everything except the interactive viewer at a 25–31% smaller download.
+
 If your choice is C++, C or C#, check out our [Installation Guide](https://meshlib.io/documentation/InstallationGuide.html).
 
 Here, you can find our [tutorials](https://meshlib.io/documentation/Tutorials.html) and [code samples](https://meshlib.io/documentation/Examples.html) to master our SDK quickly and with ease.

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ For Python, simply install via pip:
 pip install meshlib
 ```
 
-For headless environments (servers, docker, CI), `pip install meshlib-core` provides everything except the interactive viewer at a 25–31% smaller download.
+For headless environments (servers, docker, CI), `pip install meshlib-core` provides everything except the interactive viewer at a about 30% smaller download.
 
 If your choice is C++, C or C#, check out our [Installation Guide](https://meshlib.io/documentation/InstallationGuide.html).
 


### PR DESCRIPTION
Documents the `meshlib` / `meshlib-core` package split from #6528:

- **Python Setup Guide**: the install section now explains that `pip install meshlib` installs the two packages, and a new "Headless installation" subsection introduces `pip install meshlib-core` (servers/docker/CI: about 30% smaller download, everything except `mrviewerpy`, identical imports, lockstep versioning, `pip uninstall meshlib` removes only the viewer part).
- **About** and **readme.md**: one-sentence pointer to `meshlib-core` next to the existing `pip install meshlib`.

No code changes. Documentation is published only with a release, so this can merge at any moment.
