### PR TITLE
rockylinux8-vcpkg: install expat so pyexpat keeps working

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -145,8 +145,9 @@ jobs:
 
       - name: Create virtualenv
         run: |
-          # `venv` runs ensurepip itself and forwards only its exit code; bootstrap pip
-          # explicitly below so a failure there reports why
+          # `venv` installs pip by running ensurepip in a subprocess whose output it captures,
+          # so a failure there shows up as a bare exit status. Skipping it leaves the bootstrap
+          # to the explicit ensurepip below, whose stderr reaches the log.
           python3.12 -m venv --without-pip .venv
           . .venv/bin/activate
           python3 -m ensurepip --upgrade

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -145,7 +145,9 @@ jobs:
 
       - name: Create virtualenv
         run: |
-          python3.12 -m venv .venv
+          # `venv` runs ensurepip itself and forwards only its exit code; bootstrap pip
+          # explicitly below so a failure there reports why
+          python3.12 -m venv --without-pip .venv
           . .venv/bin/activate
           python3 -m ensurepip --upgrade
           python3 -m pip install --upgrade pip

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -145,10 +145,7 @@ jobs:
 
       - name: Create virtualenv
         run: |
-          # `venv` installs pip by running ensurepip in a subprocess whose output it captures,
-          # so a failure there shows up as a bare exit status. Skipping it leaves the bootstrap
-          # to the explicit ensurepip below, whose stderr reaches the log.
-          python3.12 -m venv --without-pip .venv
+          python3.12 -m venv .venv
           . .venv/bin/activate
           python3 -m ensurepip --upgrade
           python3 -m pip install --upgrade pip

--- a/docker/rockylinux8-vcpkgDockerfile
+++ b/docker/rockylinux8-vcpkgDockerfile
@@ -32,8 +32,8 @@ RUN <<EOF
         curl zip unzip tar \
         $(: vcpkg package requirements ) \
         autoconf2.7x autoconf-archive bison dbus-libs libtool libudev-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXtst-devel mesa-libGL-devel perl-core \
-        $(: mrbind requirements ) \
-        python3.12-devel which zlib-devel \
+        $(: mrbind requirements; expat is explicit because nothing else pulls it and a stale one breaks pyexpat ) \
+        python3.12-devel which zlib-devel expat \
         $(: CI environment ) \
         gh time python3.12-pip rpm-build xorg-x11-server-Xvfb mesa-dri-drivers gettext
     dnf clean all


### PR DESCRIPTION
Every `linux-vcpkg` leg - x64 and arm64, Clang and GCC - fails on `Create virtualenv`
the moment the `rockylinux8-vcpkg` image is rebuilt:

```
ImportError: /usr/lib64/python3.12/lib-dynload/pyexpat.cpython-312-x86_64-linux-gnu.so:
  undefined symbol: XML_SetBillionLaughsAttackProtectionMaximumAmplification
```

## Cause

That symbol arrived in expat 2.4.0. A rebuild now pulls `python3.12-libs-3.12.14-1.el8`,
built against a newer `expat-2.2.5-y` than the base layer carries. RPM only depends on the
`libexpat.so.1` soname, and a soname does not encode symbols - so dnf is satisfied at
install time and `pyexpat` breaks at run time instead.

Nothing in the Dockerfile ever mentioned `expat`, so it was never a candidate for upgrade.
Naming it explicitly pulls the current build.

This is latent, not new: the last successful image build was 08-21, and any change to
`docker/rockylinux8-vcpkgDockerfile` or to `thirdparty/vcpkg` re-tags the image
(`scripts/devops/docker_image_source_checksum.sh`) and would have hit it. It surfaced via
#6705, which adds a vcpkg triplet file and therefore forces the rebuild.

## Finding it

`python3.12 -m venv` installs pip by running `ensurepip` in a subprocess whose output it
captures, so the first failing run reported nothing but

```
Command '[... '-m', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1
```

Creating the environment with `--without-pip` temporarily handed the bootstrap to the
explicit `ensurepip` on the next line, whose stderr reaches the log - that is what produced
the traceback above. That change is not part of this PR; the step is unmodified.

## Testing

CI here rebuilds the image (the Dockerfile changed), so a green `linux-vcpkg` on this PR is
the test. I could not verify locally - no Docker on this machine.
