### PR TITLE
CI: swap the Ubuntu 24 GCC 14 legs for GCC 16 and retire GCC 14

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -318,8 +318,8 @@ jobs:
                   cxx-standard: 20
                 - os: ubuntu24
                   compiler: GCC
-                  cxx-compiler: /usr/bin/g++-14
-                  c-compiler: /usr/bin/gcc-14
+                  cxx-compiler: /usr/bin/g++-13
+                  c-compiler: /usr/bin/gcc-13
                   cxx-standard: 23
             # A docs-only run still needs ubuntu22 - PythonStubs and CsharpBindings come from
             # it - but nothing reads the ubuntu24 leg unless the debs are published.

--- a/.github/workflows/matrix/ubuntu-x64-full-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-full-config.json
@@ -64,8 +64,8 @@
       "os": "ubuntu24",
       "config": "Release",
       "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-13",
-      "c-compiler": "/usr/bin/gcc-13",
+      "cxx-compiler": "/usr/bin/g++-14",
+      "c-compiler": "/usr/bin/gcc-14",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "ON"
@@ -74,8 +74,8 @@
       "os": "ubuntu24",
       "config": "Debug",
       "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-13",
-      "c-compiler": "/usr/bin/gcc-13",
+      "cxx-compiler": "/usr/bin/g++-14",
+      "c-compiler": "/usr/bin/gcc-14",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "OFF"
@@ -84,8 +84,8 @@
       "os": "ubuntu24",
       "config": "Release",
       "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-14",
-      "c-compiler": "/usr/bin/gcc-14",
+      "cxx-compiler": "/usr/bin/g++-16",
+      "c-compiler": "/usr/bin/gcc-16",
       "cxx-standard": 23,
       "build_mrcuda": "OFF",
       "upload_release": "OFF"
@@ -94,8 +94,8 @@
       "os": "ubuntu24",
       "config": "Debug",
       "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-14",
-      "c-compiler": "/usr/bin/gcc-14",
+      "cxx-compiler": "/usr/bin/g++-16",
+      "c-compiler": "/usr/bin/gcc-16",
       "cxx-standard": 23,
       "build_mrcuda": "OFF",
       "upload_release": "OFF"

--- a/.github/workflows/matrix/ubuntu-x64-full-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-full-config.json
@@ -64,8 +64,8 @@
       "os": "ubuntu24",
       "config": "Release",
       "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-14",
-      "c-compiler": "/usr/bin/gcc-14",
+      "cxx-compiler": "/usr/bin/g++-13",
+      "c-compiler": "/usr/bin/gcc-13",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "ON"
@@ -74,8 +74,8 @@
       "os": "ubuntu24",
       "config": "Debug",
       "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-14",
-      "c-compiler": "/usr/bin/gcc-14",
+      "cxx-compiler": "/usr/bin/g++-13",
+      "c-compiler": "/usr/bin/gcc-13",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "OFF"

--- a/.github/workflows/matrix/ubuntu-x64-minimal-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-minimal-config.json
@@ -14,8 +14,8 @@
       "os": "ubuntu24",
       "config": "Release",
       "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-14",
-      "c-compiler": "/usr/bin/gcc-14",
+      "cxx-compiler": "/usr/bin/g++-13",
+      "c-compiler": "/usr/bin/gcc-13",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "ON"

--- a/.github/workflows/matrix/ubuntu-x64-minimal-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-minimal-config.json
@@ -14,8 +14,8 @@
       "os": "ubuntu24",
       "config": "Release",
       "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-13",
-      "c-compiler": "/usr/bin/gcc-13",
+      "cxx-compiler": "/usr/bin/g++-14",
+      "c-compiler": "/usr/bin/gcc-14",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "ON"
@@ -24,8 +24,8 @@
       "os": "ubuntu24",
       "config": "Release",
       "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-14",
-      "c-compiler": "/usr/bin/gcc-14",
+      "cxx-compiler": "/usr/bin/g++-16",
+      "c-compiler": "/usr/bin/gcc-16",
       "cxx-standard": 23,
       "build_mrcuda": "OFF",
       "upload_release": "OFF"

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -54,6 +54,8 @@ RUN <<EOF
     apt-get install -qqy --no-install-recommends \
         gh gcc-13 g++-13 gcc-16 g++-16 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext gawk procps
+    # the GCC 16 snapshot ships cc1/cc1plus/lto1 unstripped so ICEs get symbolized backtraces; costs ~640 MB
+    bash -c 'strip --strip-debug /usr/libexec/gcc/*/16/{cc1,cc1plus,lto1}'
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     ./scripts/install_apt_cuda.sh

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -52,7 +52,7 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh gcc-14 g++-14 gcc-16 g++-16 \
+        gh g++-13 gcc-14 g++-14 gcc-16 g++-16 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext gawk procps
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -52,7 +52,7 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh g++-13 gcc-14 g++-14 gcc-16 g++-16 \
+        gh gcc-13 g++-13 gcc-16 g++-16 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext gawk procps
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -52,7 +52,7 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh g++-13 gcc-14 g++-14 \
+        gh gcc-14 g++-14 gcc-16 g++-16 \
         tzdata git sudo time xvfb curl wget unzip ninja-build patchelf gettext gawk procps
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'

--- a/source/MRMesh/MRMeshSubdivideCallbacks.h
+++ b/source/MRMesh/MRMeshSubdivideCallbacks.h
@@ -34,7 +34,7 @@ MRMESH_API OnEdgeSplit meshOnEdgeSplitVertAttribute( const Mesh& mesh, const Mes
 
 MRMESH_API OnEdgeSplit meshOnEdgeSplitFaceAttribute( const Mesh& mesh, const MeshAttributesToUpdate& params );
 
-#if __GNUC__ >= 13 // false positive stringop-overflow from GCC on the push_back below, seen on arm64
+#if __GNUC__ == 13 // false positive stringop-overflow from GCC 13 on the push_back below, arm64 only
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
@@ -53,7 +53,7 @@ auto onEdgeSplitVertAttribute( const Mesh& mesh, Vector<T, VertId>& data )
     return onEdgeSplit;
 }
 
-#if __GNUC__ >= 13
+#if __GNUC__ == 13
 #pragma GCC diagnostic pop
 #endif
 

--- a/source/MRMesh/MRMeshSubdivideCallbacks.h
+++ b/source/MRMesh/MRMeshSubdivideCallbacks.h
@@ -34,6 +34,11 @@ MRMESH_API OnEdgeSplit meshOnEdgeSplitVertAttribute( const Mesh& mesh, const Mes
 
 MRMESH_API OnEdgeSplit meshOnEdgeSplitFaceAttribute( const Mesh& mesh, const MeshAttributesToUpdate& params );
 
+#if __GNUC__ >= 13 // false positive stringop-overflow from GCC on the push_back below, seen on arm64
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+
 template <typename T>
 auto onEdgeSplitVertAttribute( const Mesh& mesh, Vector<T, VertId>& data )
 {
@@ -47,6 +52,10 @@ auto onEdgeSplitVertAttribute( const Mesh& mesh, Vector<T, VertId>& data )
 
     return onEdgeSplit;
 }
+
+#if __GNUC__ >= 13
+#pragma GCC diagnostic pop
+#endif
 
 template <typename T>
 auto onEdgeSplitFaceAttribute( const Mesh& mesh, Vector<T, FaceId>& data )


### PR DESCRIPTION
Replaces the non-shipping ubuntu24 GCC 14 pair with GCC 16, and retires GCC 14 from the ubuntu24 image
by moving the arm64 leg down to GCC 13.

x64 (`ubuntu-x64-full-config.json` and `ubuntu-x64-minimal-config.json`):

| ubuntu24 GCC leg | before | after | builds shipped deb |
| --- | --- | --- | --- |
| Release, `build_mrcuda: ON` | g++-13 | g++-13 (unchanged) | yes (`upload_release: ON`) |
| Debug, `build_mrcuda: ON` | g++-13 | g++-13 (unchanged) | no |
| Release, `build_mrcuda: OFF` | g++-14 | **g++-16** | no |
| Debug, `build_mrcuda: OFF` | g++-14 | **g++-16** | no |

arm64 (`config.yml`): the ubuntu24 leg moves from **g++-14 to g++-13**, matching the x64 shipping leg.
It was the last consumer of gcc-14 and shares `docker/ubuntu24Dockerfile` with x64, so 14 could not be
removed while it stayed. Note this changes the compiler behind the released arm64 deb, 14.3.0 -> 13.3.0.

gcc-16 is `16-20260315-1ubuntu1~24~ppa1` from `ppa:ubuntu-toolchain-r/test`, which the image already
configures; it is published for both amd64 and arm64.

### Image size

Measured on Docker Hub (compressed):

| image | master `latest` | this PR | without the strip below |
| --- | --- | --- | --- |
| `meshlib/meshlib-ubuntu24` | 1090.1 MB | **1112.7 MB** | 1374.2 MB |
| `meshlib/meshlib-ubuntu24-arm64` | 996.3 MB | **1019.2 MB** | 1288.5 MB |

So GCC 16 costs about 23 MB over the GCC 14 it replaces, once its executables are stripped.

### Why the strip is needed

The `gcc-16` source package enables `unstripped_exe` for amd64/arm64 in `debian/rules.defs`
("allows to write backtraces for ICEs"), which becomes `dh_strip ... -X/cc1` in
`rules.d/binary-cpp.mk` and the cxx/gcc equivalents, so `cc1`, `cc1plus` and `lto1` ship with full
debug info:

| package (amd64) | installed | .deb |
| --- | --- | --- |
| `cpp-14` / `g++-14` / `gcc-14` `-x86-64-linux-gnu` | 34.0 / 36.7 / 67.8 MB | 11.3 / 12.8 / 22.3 MB |
| `cpp-16` / `g++-16` / `gcc-16` `-x86-64-linux-gnu` | 242.8 / 258.5 / 278.8 MB | 79.3 / 85.7 / 91.0 MB |

That is +641 MB installed. It is a packaging choice, not GCC 16 being a bigger compiler: released
gcc-15.2.0 from the same PPA is 37.0 / 39.9 / 73.9 MB, its packaging has the same `unstripped_exe` block
commented out, and both packages are configured identically (`--enable-checking=release`,
`--with-build-config=bootstrap-lto-lean`, `BOOT_CFLAGS="-g -O2 -fno-stack-protector"`,
`profiledbootstrap-lean`).

The Dockerfile therefore runs `strip --strip-debug` on those three executables after install, which
recovered 261 MB x64 / 269 MB arm64 of compressed layer. The trade-off is losing symbolized backtraces
if GCC 16 ICEs. `bash -c` is required because the `RUN` heredoc runs under `sh`, which has no brace
expansion - the same reason the neighbouring `gdcm{...}` touch is wrapped.

### Source change

Moving arm64 to GCC 13 surfaced a false positive that GCC 14 did not emit: GCC 13.3 on arm64 rejects the
averaging `push_back` in `onEdgeSplitVertAttribute` with `writing 1 byte into a region of size 0
[-Werror=stringop-overflow=]`, reported through the inlined `std::vector` allocate/construct chain.
`MRMeshSubdivideCallbacks.h` wraps that template in `#if __GNUC__ == 13` +
`#pragma GCC diagnostic ignored "-Wstringop-overflow"`, the idiom already used in `MRInSphere.cpp`,
`MRAlphaShape.cpp` and `MRMeshFwd.h`. The guard is exact rather than open-ended because only GCC 13 on
arm64 emits it - the x64 g++-13 legs and the previous arm64 g++-14 leg are both green without it. Both
arm64 legs pass with the suppression in place.

### Status

**GCC 16 is a development snapshot and its two x64 legs are the experiment here.** Nothing shipped
depends on them: `Create Deb` and `Upload Ubuntu Developer Distribution` are gated on
`upload_release: ON`, which only the g++-13 Release leg carries. If GCC 16 turns out to emit the
stringop-overflow false positive too, its legs will fail and the guard gains `|| __GNUC__ == 16`.
