### PR TITLE
Optimize rayBoxIntersect: add a NEON path for ARM64, load the box as vectors for SSE

### DIFF
--- a/source/MRMesh/MRIntersectionPrecomputes.h
+++ b/source/MRMesh/MRIntersectionPrecomputes.h
@@ -155,7 +155,7 @@ struct IntersectionPrecomputes
 template<>
 struct IntersectionPrecomputes<float>
 {
-    // {1.f / dir}
+    // {1.f / dir} in the first three lanes, the last one is unused
     MR_BIND_IGNORE __m128 invDir;
     // [0]max, [1]next, [2]next-next
     // f.e. {1,2,-3} => {2,1,0}
@@ -176,10 +176,10 @@ struct IntersectionPrecomputes<float>
         Sz = float( 1 ) / dir[maxDimIdxZ];
 
         invDir = _mm_set_ps(
-            ( dir.x == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.x,
-            ( dir.y == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.y,
+            1,
             ( dir.z == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.z,
-            1 );
+            ( dir.y == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.y,
+            ( dir.x == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.x );
     }
 
 };

--- a/source/MRMesh/MRIntersectionPrecomputes.h
+++ b/source/MRMesh/MRIntersectionPrecomputes.h
@@ -5,6 +5,8 @@
 
 #if defined(__x86_64__) || defined(_M_X64)
 #include <xmmintrin.h> //SSE instructions
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h> //NEON instructions
 #endif
 
 namespace MR
@@ -182,9 +184,52 @@ struct IntersectionPrecomputes<float>
 
 };
 
-/// \}
+/* CPU(ARM64) - AArch64 */
+#elif defined(__aarch64__) || defined(_M_ARM64)
+
+/// packs three coordinates and one extra component in a NEON register
+MR_BIND_IGNORE inline float32x4_t toFloat32x4( float x, float y, float z, float w )
+{
+    const float a[4] = { x, y, z, w };
+    return vld1q_f32( a );
+}
+
+template<>
+struct IntersectionPrecomputes<float>
+{
+    // {1.f / dir} in the first three lanes, 1 in the last one
+    MR_BIND_IGNORE float32x4_t invDir;
+    // [0]max, [1]next, [2]next-next
+    // f.e. {1,2,-3} => {2,1,0}
+    int maxDimIdxZ = 2;
+    int idxX = 0;
+    int idxY = 1;
+
+    /// precomputed factors
+    MR_BIND_IGNORE float Sx, Sy, Sz;
+
+    IntersectionPrecomputes() = default;
+    IntersectionPrecomputes( const Vector3<float>& dir )
+    {
+        findMaxVectorDim( idxX, idxY, maxDimIdxZ, dir );
+
+        Sx = dir[idxX] / dir[maxDimIdxZ];
+        Sy = dir[idxY] / dir[maxDimIdxZ];
+        Sz = float( 1 ) / dir[maxDimIdxZ];
+
+        invDir = toFloat32x4(
+            ( dir.x == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.x,
+            ( dir.y == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.y,
+            ( dir.z == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.z,
+            1 );
+    }
+
+};
 
 #else
     #pragma message("IntersectionPrecomputes<float>: no hardware optimized instructions")
 #endif
+
+/// \}
+
 }

--- a/source/MRMesh/MRRayBoxIntersection.h
+++ b/source/MRMesh/MRRayBoxIntersection.h
@@ -27,6 +27,15 @@ struct RayOrigin<float>
     MR_BIND_IGNORE __m128 p;
     RayOrigin( const Vector3f & ro ) { p = _mm_set_ps( ro.x, ro.y, ro.z, 0 ); }
 };
+
+/* CPU(ARM64) - AArch64 */
+#elif defined(__aarch64__) || defined(_M_ARM64)
+template<>
+struct RayOrigin<float>
+{
+    MR_BIND_IGNORE float32x4_t p;
+    RayOrigin( const Vector3f & ro ) { p = toFloat32x4( ro.x, ro.y, ro.z, 0 ); }
+};
 #endif
 
 /// finds intersection between the Ray and the Box.
@@ -59,6 +68,21 @@ bool rayBoxIntersect( const Box3<T>& box, const RayOrigin<T> & rayOrigin, T & t0
         __m128 bbb = _mm_shuffle_ps( bb, bb, 1 );
         bbb = _mm_min_ss( bbb, bb );
         t1 = _mm_cvtss_f32( bbb );
+
+        return t0 <= t1;
+    }
+    else
+    #elif defined(__aarch64__) || defined(_M_ARM64)
+    if constexpr (std::is_same_v<T, float>)
+    {
+        // the 4-th lane carries t0/t1 itself, since the origin is 0 and the inverted direction is 1 there
+        float32x4_t l = toFloat32x4( box.min.x, box.min.y, box.min.z, t0 );
+        float32x4_t r = toFloat32x4( box.max.x, box.max.y, box.max.z, t1 );
+        l = vmulq_f32( vsubq_f32( l, rayOrigin.p ), prec.invDir );
+        r = vmulq_f32( vsubq_f32( r, rayOrigin.p ), prec.invDir );
+
+        t0 = vmaxvq_f32( vminq_f32( l, r ) );
+        t1 = vminvq_f32( vmaxq_f32( l, r ) );
 
         return t0 <= t1;
     }

--- a/source/MRMesh/MRRayBoxIntersection.h
+++ b/source/MRMesh/MRRayBoxIntersection.h
@@ -39,6 +39,8 @@ struct RayOrigin<float>
 #endif
 
 /// finds intersection between the Ray and the Box.
+/// The box must be valid: for a box with min greater than max in some dimension the answer is
+/// platform-dependent, because only the generic implementation reports no intersection there.
 /// Precomputed values could be useful for several calls with the same direction,
 /// see "An Efficient and Robust Ray-Box Intersection Algorithm" at https://people.csail.mit.edu/amy/papers/box-jgt.pdf
 template <typename T = float>
@@ -113,6 +115,7 @@ bool rayBoxIntersect( const Box3<T>& box, const RayOrigin<T> & rayOrigin, T & t0
     }
 }
 
+/// finds intersection between the Ray and the Box, which must be valid, see above
 template <typename T = float>
 bool rayBoxIntersect( const Box3<T>& box, const Line3<T>& line, T t0, T t1 )
 {

--- a/source/MRMesh/MRRayBoxIntersection.h
+++ b/source/MRMesh/MRRayBoxIntersection.h
@@ -25,7 +25,7 @@ template<>
 struct RayOrigin<float>
 {
     MR_BIND_IGNORE __m128 p;
-    RayOrigin( const Vector3f & ro ) { p = _mm_set_ps( ro.x, ro.y, ro.z, 0 ); }
+    RayOrigin( const Vector3f & ro ) { p = _mm_set_ps( 0, ro.z, ro.y, ro.x ); }
 };
 
 /* CPU(ARM64) - AArch64 */
@@ -47,27 +47,27 @@ bool rayBoxIntersect( const Box3<T>& box, const RayOrigin<T> & rayOrigin, T & t0
     #if defined(__x86_64__) || defined(_M_X64)
     if constexpr (std::is_same_v<T, float>)
     {
-        __m128 l = _mm_set_ps( box.min.x, box.min.y, box.min.z, t0 );
-        __m128 r = _mm_set_ps( box.max.x, box.max.y, box.max.z, t1 );
-        l = _mm_sub_ps( l, rayOrigin.p );
-        r = _mm_sub_ps( r, rayOrigin.p );
-        l = _mm_mul_ps( l, prec.invDir );
-        r = _mm_mul_ps( r, prec.invDir );
+        // both loads stay within the box, and the second one is the max corner shifted by one lane
+        static_assert( sizeof( Box3f ) == 6 * sizeof( float ) );
+        const float * const c = &box.min.x;
+        __m128 l = _mm_loadu_ps( c );
+        __m128 h = _mm_loadu_ps( c + 2 );
+        __m128 r = _mm_shuffle_ps( h, h, _MM_SHUFFLE( 3, 3, 2, 1 ) );
+
+        l = _mm_mul_ps( _mm_sub_ps( l, rayOrigin.p ), prec.invDir );
+        r = _mm_mul_ps( _mm_sub_ps( r, rayOrigin.p ), prec.invDir );
 
         __m128 a = _mm_min_ps( l, r );
         __m128 b = _mm_max_ps( l, r );
 
-        __m128 aa = _mm_movehl_ps( a, a );
-        aa = _mm_max_ps( aa, a );
-        __m128 aaa = _mm_shuffle_ps( aa, aa, 1 );
-        aaa = _mm_max_ss( aaa, aa );
-        t0 = _mm_cvtss_f32( aaa );
+        // the 4-th lane holds garbage, so only the first three are reduced
+        __m128 az = _mm_shuffle_ps( a, a, _MM_SHUFFLE( 2, 2, 2, 2 ) );
+        __m128 ay = _mm_shuffle_ps( a, a, _MM_SHUFFLE( 1, 1, 1, 1 ) );
+        t0 = _mm_cvtss_f32( _mm_max_ss( _mm_max_ss( _mm_max_ss( a, az ), ay ), _mm_load_ss( &t0 ) ) );
 
-        __m128 bb = _mm_movehl_ps( b, b );
-        bb = _mm_min_ps( bb, b );
-        __m128 bbb = _mm_shuffle_ps( bb, bb, 1 );
-        bbb = _mm_min_ss( bbb, bb );
-        t1 = _mm_cvtss_f32( bbb );
+        __m128 bz = _mm_shuffle_ps( b, b, _MM_SHUFFLE( 2, 2, 2, 2 ) );
+        __m128 by = _mm_shuffle_ps( b, b, _MM_SHUFFLE( 1, 1, 1, 1 ) );
+        t1 = _mm_cvtss_f32( _mm_min_ss( _mm_min_ss( _mm_min_ss( b, bz ), by ), _mm_load_ss( &t1 ) ) );
 
         return t0 <= t1;
     }

--- a/source/MRMesh/MRRayBoxIntersection.h
+++ b/source/MRMesh/MRRayBoxIntersection.h
@@ -3,6 +3,7 @@
 #include "MRIntersectionPrecomputes.h"
 #include "MRMesh/MRMacros.h"
 #include "MRPch/MRBindingMacros.h"
+#include <cassert>
 
 namespace MR
 {
@@ -39,13 +40,14 @@ struct RayOrigin<float>
 #endif
 
 /// finds intersection between the Ray and the Box.
-/// The box must be valid: for a box with min greater than max in some dimension the answer is
-/// platform-dependent, because only the generic implementation reports no intersection there.
+/// The box must be valid, otherwise the result is undefined.
 /// Precomputed values could be useful for several calls with the same direction,
 /// see "An Efficient and Robust Ray-Box Intersection Algorithm" at https://people.csail.mit.edu/amy/papers/box-jgt.pdf
 template <typename T = float>
 bool rayBoxIntersect( const Box3<T>& box, const RayOrigin<T> & rayOrigin, T & t0, T & t1, const IntersectionPrecomputes<T>& prec )
 {
+    assert( box.valid() );
+
     #if defined(__x86_64__) || defined(_M_X64)
     if constexpr (std::is_same_v<T, float>)
     {
@@ -115,7 +117,7 @@ bool rayBoxIntersect( const Box3<T>& box, const RayOrigin<T> & rayOrigin, T & t0
     }
 }
 
-/// finds intersection between the Ray and the Box, which must be valid, see above
+/// finds intersection between the Ray and the Box, which must be valid
 template <typename T = float>
 bool rayBoxIntersect( const Box3<T>& box, const Line3<T>& line, T t0, T t1 )
 {

--- a/source/MRMesh/MRRayBoxIntersection.h
+++ b/source/MRMesh/MRRayBoxIntersection.h
@@ -75,9 +75,14 @@ bool rayBoxIntersect( const Box3<T>& box, const RayOrigin<T> & rayOrigin, T & t0
     #elif defined(__aarch64__) || defined(_M_ARM64)
     if constexpr (std::is_same_v<T, float>)
     {
+        // both loads stay within the box, and the second one is the max corner shifted by one lane;
         // the 4-th lane carries t0/t1 itself, since the origin is 0 and the inverted direction is 1 there
-        float32x4_t l = toFloat32x4( box.min.x, box.min.y, box.min.z, t0 );
-        float32x4_t r = toFloat32x4( box.max.x, box.max.y, box.max.z, t1 );
+        static_assert( sizeof( Box3f ) == 6 * sizeof( float ) );
+        const float * const c = &box.min.x;
+        float32x4_t h = vld1q_f32( c + 2 );
+        float32x4_t l = vsetq_lane_f32( t0, vld1q_f32( c ), 3 );
+        float32x4_t r = vsetq_lane_f32( t1, vextq_f32( h, h, 1 ), 3 );
+
         l = vmulq_f32( vsubq_f32( l, rayOrigin.p ), prec.invDir );
         r = vmulq_f32( vsubq_f32( r, rayOrigin.p ), prec.invDir );
 

--- a/source/MRTest/MRRayBoxIntersectionTests.cpp
+++ b/source/MRTest/MRRayBoxIntersectionTests.cpp
@@ -1,0 +1,97 @@
+#include <MRMesh/MRRayBoxIntersection.h>
+#include <gtest/gtest.h>
+#include <cfloat>
+#include <cmath>
+#include <random>
+
+namespace MR
+{
+
+namespace
+{
+
+Vector3f invertDir( const Vector3f & dir )
+{
+    Vector3f res;
+    for ( int i = 0; i < 3; ++i )
+        res[i] = ( dir[i] == 0 ) ? std::numeric_limits<float>::max() : 1 / dir[i];
+    return res;
+}
+
+/// straightforward implementation to validate the hardware optimized one against
+bool refRayBoxIntersect( const Box3f & box, const Vector3f & org, float & t0, float & t1, const Vector3f & invDir )
+{
+    for ( int i = 0; i < 3; ++i )
+    {
+        const float a = ( box.min[i] - org[i] ) * invDir[i];
+        const float b = ( box.max[i] - org[i] ) * invDir[i];
+        t0 = std::max( std::min( a, b ), t0 );
+        t1 = std::min( std::max( a, b ), t1 );
+    }
+    return t0 <= t1;
+}
+
+} //anonymous namespace
+
+TEST( MRMesh, RayBoxIntersect )
+{
+    const Box3f box{ Vector3f{ 1, 1, 1 }, Vector3f{ 2, 2, 2 } };
+    const Vector3f org{ 0, 1.5f, 1.5f };
+    const IntersectionPrecomputes<float> alongX( Vector3f{ 1, 0, 0 } );
+
+    float t0 = 0, t1 = FLT_MAX;
+    EXPECT_TRUE( rayBoxIntersect( box, RayOrigin<float>{ org }, t0, t1, alongX ) );
+    EXPECT_EQ( t0, 1 );
+    EXPECT_EQ( t1, 2 );
+
+    // the box is beyond the segment end
+    t0 = 0; t1 = 0.5f;
+    EXPECT_FALSE( rayBoxIntersect( box, RayOrigin<float>{ org }, t0, t1, alongX ) );
+
+    // the ray is directed away from the box
+    t0 = 0; t1 = FLT_MAX;
+    EXPECT_FALSE( rayBoxIntersect( box, RayOrigin<float>{ org }, t0, t1,
+        IntersectionPrecomputes<float>( Vector3f{ -1, 0, 0 } ) ) );
+
+    // the ray is parallel to the box and misses it
+    t0 = 0; t1 = FLT_MAX;
+    EXPECT_FALSE( rayBoxIntersect( box, RayOrigin<float>{ Vector3f{ 0, 0, 1.5f } }, t0, t1, alongX ) );
+}
+
+// rayBoxIntersect for floats is implemented in SIMD instructions on some platforms,
+// here it is verified to produce exactly the same results as the straightforward code
+TEST( MRMesh, RayBoxIntersectSimd )
+{
+    std::mt19937 gen( 12345 );
+    std::uniform_real_distribution<float> coord( -10, 10 );
+    // small integer directions have zero components, which turn into huge inverted directions
+    std::uniform_int_distribution<int> smallInt( -2, 2 );
+
+    for ( int i = 0; i < 10000; ++i )
+    {
+        Box3f box;
+        box.include( Vector3f{ coord( gen ), coord( gen ), coord( gen ) } );
+        box.include( Vector3f{ coord( gen ), coord( gen ), coord( gen ) } );
+
+        const Vector3f org{ coord( gen ), coord( gen ), coord( gen ) };
+        const Vector3f dir = ( i % 4 == 0 )
+            ? Vector3f{ float( smallInt( gen ) ), float( smallInt( gen ) ), float( smallInt( gen ) ) }
+            : Vector3f{ coord( gen ), coord( gen ), coord( gen ) };
+        if ( dir == Vector3f{} )
+            continue;
+
+        const float rayEnd = ( i % 3 == 0 ) ? std::abs( coord( gen ) ) : FLT_MAX;
+
+        float t0 = 0, t1 = rayEnd;
+        const bool res = rayBoxIntersect( box, RayOrigin<float>{ org }, t0, t1, IntersectionPrecomputes<float>( dir ) );
+
+        float refT0 = 0, refT1 = rayEnd;
+        const bool refRes = refRayBoxIntersect( box, org, refT0, refT1, invertDir( dir ) );
+
+        ASSERT_EQ( res, refRes ) << "iteration " << i;
+        ASSERT_EQ( t0, refT0 ) << "iteration " << i;
+        ASSERT_EQ( t1, refT1 ) << "iteration " << i;
+    }
+}
+
+} //namespace MR

--- a/source/MRTest/MRRayBoxIntersectionTests.cpp
+++ b/source/MRTest/MRRayBoxIntersectionTests.cpp
@@ -1,8 +1,8 @@
+#include <MRMesh/MRLine3.h>
 #include <MRMesh/MRRayBoxIntersection.h>
 #include <gtest/gtest.h>
 #include <cfloat>
-#include <cmath>
-#include <random>
+#include <limits>
 
 namespace MR
 {
@@ -10,88 +10,84 @@ namespace MR
 namespace
 {
 
-Vector3f invertDir( const Vector3f & dir )
+// the cases are given in doubles and checked in both float and double, so that both the SIMD
+// specializations and the generic implementation are verified against the same expected values;
+// every value is exactly representable in float, so the comparisons below are exact
+struct RayBoxCase
 {
-    Vector3f res;
-    for ( int i = 0; i < 3; ++i )
-        res[i] = ( dir[i] == 0 ) ? std::numeric_limits<float>::max() : 1 / dir[i];
-    return res;
-}
+    const char * name;
+    Vector3d boxMin, boxMax;
+    Vector3d org, dir;
+    double rayStart, rayEnd; // cUnbounded means the largest representable value
+    bool expected;
+    double t0, t1;           // only checked when the ray does intersect
+};
 
-/// straightforward implementation to validate the hardware optimized one against
-bool refRayBoxIntersect( const Box3f & box, const Vector3f & org, float & t0, float & t1, const Vector3f & invDir )
+constexpr double cUnbounded = -1;
+
+const RayBoxCase cRayBoxCases[] = {
+    { "hit along +x",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 0, 1.5, 1.5 }, { 1, 0, 0 }, 0, cUnbounded, true, 1, 2 },
+    { "oblique hit",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 0, 0.5, 1.5 }, { 2, 1, 0 }, 0, cUnbounded, true, 0.5, 1 },
+    { "hit from the far side, negative direction",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 3, 1.5, 1.5 }, { -1, 0, 0 }, 0, cUnbounded, true, 1, 2 },
+    { "diagonal through the opposite corners",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 0, 0, 0 }, { 1, 1, 1 }, 0, cUnbounded, true, 1, 2 },
+    { "origin inside the box",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 1.5, 1.5, 1.5 }, { 1, 0, 0 }, 0, cUnbounded, true, 0, 0.5 },
+    { "origin exactly on the near face",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 1, 1.5, 1.5 }, { 1, 0, 0 }, 0, cUnbounded, true, 0, 1 },
+    // the zero direction components make the box bounds coincide with the origin along y and z,
+    // which is the reason the inverted direction is limited to the largest value instead of infinity
+    { "origin exactly on the near corner",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 1, 1, 1 }, { 1, 0, 0 }, 0, cUnbounded, true, 0, 1 },
+    { "grazing the box edge",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 0, 1, 1 }, { 1, 0, 0 }, 0, cUnbounded, true, 1, 2 },
+    { "flat box, ray along its normal",
+      { 1, 1, 1 }, { 2, 2, 1 }, { 1.5, 1.5, 0 }, { 0, 0, 1 }, 0, cUnbounded, true, 1, 1 },
+    { "segment starting inside the box",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 0, 1.5, 1.5 }, { 1, 0, 0 }, 1.5, cUnbounded, true, 1.5, 2 },
+    { "directed away from the box",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 0, 1.5, 1.5 }, { -1, 0, 0 }, 0, cUnbounded, false, 0, 0 },
+    { "box beyond the segment end",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 0, 1.5, 1.5 }, { 1, 0, 0 }, 0, 0.5, false, 0, 0 },
+    { "parallel to the box and missing it",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 0, 0, 1.5 }, { 1, 0, 0 }, 0, cUnbounded, false, 0, 0 },
+    { "diagonal missing the box",
+      { 1, 1, 1 }, { 2, 2, 2 }, { 0, 0, 0 }, { 1, 1, -1 }, 0, cUnbounded, false, 0, 0 },
+};
+
+template <typename T>
+void testRayBoxCases()
 {
-    for ( int i = 0; i < 3; ++i )
+    for ( const auto & c : cRayBoxCases )
     {
-        const float a = ( box.min[i] - org[i] ) * invDir[i];
-        const float b = ( box.max[i] - org[i] ) * invDir[i];
-        t0 = std::max( std::min( a, b ), t0 );
-        t1 = std::min( std::max( a, b ), t1 );
+        const Box3<T> box{ Vector3<T>( c.boxMin ), Vector3<T>( c.boxMax ) };
+        T t0 = T( c.rayStart );
+        T t1 = c.rayEnd == cUnbounded ? std::numeric_limits<T>::max() : T( c.rayEnd );
+        const bool res = rayBoxIntersect( box, RayOrigin<T>( Vector3<T>( c.org ) ), t0, t1,
+            IntersectionPrecomputes<T>( Vector3<T>( c.dir ) ) );
+        EXPECT_EQ( res, c.expected ) << c.name;
+        if ( !c.expected || !res )
+            continue;
+        EXPECT_EQ( t0, T( c.t0 ) ) << c.name;
+        EXPECT_EQ( t1, T( c.t1 ) ) << c.name;
     }
-    return t0 <= t1;
 }
 
 } //anonymous namespace
 
 TEST( MRMesh, RayBoxIntersect )
 {
+    // float takes the SIMD specialization where the platform has one, double is always generic
+    testRayBoxCases<float>();
+    testRayBoxCases<double>();
+
+    // the overload taking a line and computing the precomputes itself
     const Box3f box{ Vector3f{ 1, 1, 1 }, Vector3f{ 2, 2, 2 } };
-    const Vector3f org{ 0, 1.5f, 1.5f };
-    const IntersectionPrecomputes<float> alongX( Vector3f{ 1, 0, 0 } );
-
-    float t0 = 0, t1 = FLT_MAX;
-    EXPECT_TRUE( rayBoxIntersect( box, RayOrigin<float>{ org }, t0, t1, alongX ) );
-    EXPECT_EQ( t0, 1 );
-    EXPECT_EQ( t1, 2 );
-
-    // the box is beyond the segment end
-    t0 = 0; t1 = 0.5f;
-    EXPECT_FALSE( rayBoxIntersect( box, RayOrigin<float>{ org }, t0, t1, alongX ) );
-
-    // the ray is directed away from the box
-    t0 = 0; t1 = FLT_MAX;
-    EXPECT_FALSE( rayBoxIntersect( box, RayOrigin<float>{ org }, t0, t1,
-        IntersectionPrecomputes<float>( Vector3f{ -1, 0, 0 } ) ) );
-
-    // the ray is parallel to the box and misses it
-    t0 = 0; t1 = FLT_MAX;
-    EXPECT_FALSE( rayBoxIntersect( box, RayOrigin<float>{ Vector3f{ 0, 0, 1.5f } }, t0, t1, alongX ) );
-}
-
-// rayBoxIntersect for floats is implemented in SIMD instructions on some platforms,
-// here it is verified to produce exactly the same results as the straightforward code
-TEST( MRMesh, RayBoxIntersectSimd )
-{
-    std::mt19937 gen( 12345 );
-    std::uniform_real_distribution<float> coord( -10, 10 );
-    // small integer directions have zero components, which turn into huge inverted directions
-    std::uniform_int_distribution<int> smallInt( -2, 2 );
-
-    for ( int i = 0; i < 10000; ++i )
-    {
-        Box3f box;
-        box.include( Vector3f{ coord( gen ), coord( gen ), coord( gen ) } );
-        box.include( Vector3f{ coord( gen ), coord( gen ), coord( gen ) } );
-
-        const Vector3f org{ coord( gen ), coord( gen ), coord( gen ) };
-        const Vector3f dir = ( i % 4 == 0 )
-            ? Vector3f{ float( smallInt( gen ) ), float( smallInt( gen ) ), float( smallInt( gen ) ) }
-            : Vector3f{ coord( gen ), coord( gen ), coord( gen ) };
-        if ( dir == Vector3f{} )
-            continue;
-
-        const float rayEnd = ( i % 3 == 0 ) ? std::abs( coord( gen ) ) : FLT_MAX;
-
-        float t0 = 0, t1 = rayEnd;
-        const bool res = rayBoxIntersect( box, RayOrigin<float>{ org }, t0, t1, IntersectionPrecomputes<float>( dir ) );
-
-        float refT0 = 0, refT1 = rayEnd;
-        const bool refRes = refRayBoxIntersect( box, org, refT0, refT1, invertDir( dir ) );
-
-        ASSERT_EQ( res, refRes ) << "iteration " << i;
-        ASSERT_EQ( t0, refT0 ) << "iteration " << i;
-        ASSERT_EQ( t1, refT1 ) << "iteration " << i;
-    }
+    EXPECT_TRUE( rayBoxIntersect( box, Line3f{ Vector3f{ 0, 1.5f, 1.5f }, Vector3f{ 1, 0, 0 } }, 0.f, FLT_MAX ) );
+    EXPECT_FALSE( rayBoxIntersect( box, Line3f{ Vector3f{ 0, 1.5f, 1.5f }, Vector3f{ 1, 0, 0 } }, 0.f, 0.5f ) );
 }
 
 } //namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="MRPolylineSubdivideTests.cpp" />
     <ClCompile Include="MRPolylineTopologyTests.cpp" />
     <ClCompile Include="MRQuadraticFormTests.cpp" />
+    <ClCompile Include="MRRayBoxIntersectionTests.cpp" />
     <ClCompile Include="MRRectIndexerTests.cpp" />
     <ClCompile Include="MRRegionBoundaryTests.cpp" />
     <ClCompile Include="MRRegularGridMeshTests.cpp" />

--- a/source/MRTest/MRTest.vcxproj.filters
+++ b/source/MRTest/MRTest.vcxproj.filters
@@ -58,6 +58,9 @@
     <ClCompile Include="MRBoxTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MRRayBoxIntersectionTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="MRMeshIntersectTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
Two optimizations of `rayBoxIntersect` for `float`: a NEON implementation for ARM64, which had no hardware-optimized path at all, and a faster way of feeding the box into the existing SSE one. Plus a test for the function and a precondition it always had but never stated.

## NEON for ARM64

`rayBoxIntersect` was hand-optimized in SSE intrinsics under `#if defined(__x86_64__) || defined(_M_X64)`, so every ARM64 platform we ship — macOS arm64, Linux arm64, Windows arm64 — took the scalar fallback and printed `#pragma message("rayBoxIntersect: no hardware optimized instructions")`. This adds the NEON counterpart together with the matching `IntersectionPrecomputes<float>` and `RayOrigin<float>` specializations:

```cpp
static_assert( sizeof( Box3f ) == 6 * sizeof( float ) );
const float * const c = &box.min.x;
float32x4_t h = vld1q_f32( c + 2 );
float32x4_t l = vsetq_lane_f32( t0, vld1q_f32( c ), 3 );
float32x4_t r = vsetq_lane_f32( t1, vextq_f32( h, h, 1 ), 3 );

l = vmulq_f32( vsubq_f32( l, rayOrigin.p ), prec.invDir );
r = vmulq_f32( vsubq_f32( r, rayOrigin.p ), prec.invDir );

t0 = vmaxvq_f32( vminq_f32( l, r ) );
t1 = vminvq_f32( vmaxq_f32( l, r ) );
```

Same trick as the SSE code: the ray parameter rides in the spare 4th lane, where the origin is 0 and the inverted direction is 1, so it joins the cross-lane reduction for free instead of being clamped separately.

AArch64 reduces across lanes in a single instruction, `FMAXV` / `FMINV`, so it needs no counterpart to the `movehl` / `shuffle` tree the SSE version uses — clang compiles the whole function to 21 instructions against 39 for SSE. The guard is `__aarch64__` / `_M_ARM64` rather than "has NEON" on purpose: those across-vector reductions do not exist in 32-bit ARMv7 NEON, which only has the pairwise forms. `arm_neon.h` is the right header for MSVC too, since it forwards to `arm64_neon.h`, where all seven intrinsics used here are defined.

Packing the lanes from two loads rather than from four scalars was aimed at MSVC specifically, which materializes the latter with a `dup` and three `ins` per vector where clang and gcc fold them into a vector load: it takes the ARM64 output from 29 to 23 instructions. It turned out not to move the measured time on Cobalt 100 at all (see below), and is kept for the code size at every inlined call site and for symmetry with the SSE branch, not for speed.

## Loading the box as vectors in SSE

The lanes were in the order `_mm_set_ps` takes its arguments, which is the reverse of the box's memory layout, so each vector had to be assembled element by element. Putting the lanes in memory order instead allows two changes:

- the box becomes two overlapping 16-byte loads plus one shuffle instead of six scalar loads and four shuffles. `_mm_loadu_ps( &box.min.x )` already is `{min.x, min.y, min.z, ...}`, and the load two floats later, rotated left by one lane, is `{max.x, max.y, max.z, ...}`. Both reads stay inside the box, which a `static_assert` on its size now guards.
- the ray parameter no longer rides in the spare lane, so the reduction covers three lanes and `t0` / `t1` are clamped with two extra scalar `max` / `min`. As a side effect the SSE branch now treats `t0 > t1` the way the generic branch does, instead of silently swapping the two.

Two further variants were measured and dropped: keeping the ray parameter in lane 3 and inserting it into the loaded vector is slower than the code that was there before, and folding both reductions into one chain by sign-flipping the far side wins in the sparse scene, loses in the dense one, and is considerably harder to read.

## A precondition, now written down

For a box with `min` greater than `max` in some dimension the two kinds of implementation disagree, and always have: taking `min` and `max` of the two products normalizes the inverted interval, so the SIMD branches answer as if the bounds were swapped, while the generic branch picks the corner facing the ray and reports no intersection. A default-constructed `Box3f` therefore intersects everything on x64 and arm64 and nothing in wasm or in double precision. Nothing here changed that; it reproduces identically on master.

Making the SIMD paths agree means selecting the corner by the direction sign, as the generic branch does. That is free on NEON, where `vbslq_f32` is one instruction (21 to 22 instructions), but costs 22% sparse / 11% dense on SSE2, where a select is three instructions — more than the box loading above just saved, and enough to leave the SSE path slower than master. `_mm_blendv_ps` would make it free there too, but that is SSE4.1, and MeshLib sets no `/arch:` or `-march=` anywhere today, so raising the x64 floor deserves its own PR.

So the header states the contract — the box must be valid, otherwise the result is undefined — and an `assert( box.valid() )` catches violations in Debug builds. Callers that may hold an invalid box can check `Box::valid()` once outside their loop. Nothing in MeshLib should trip the assert: the ray-mesh and ray-polyline traversals bail out on an empty tree before touching a box, and every node box is computed from geometry.

## Test

`MRRayBoxIntersectionTests.cpp` is a table of 14 explicit cases with the expected `t0` / `t1` spelled out, so the expectations can be checked by reading them and reproduced in another language. Each case runs through both `float`, which takes the SIMD specialization where the platform has one, and `double`, which always takes the generic implementation — so both are verified against the same written-down values rather than against each other. Every value is exactly representable in `float`, so the comparisons are exact.

The cases cover an axis-aligned and an oblique hit, a hit from the far side with a negative direction, the corner-to-corner diagonal, an origin inside the box / on its face / on its corner, a ray grazing an edge, a flat box, a segment starting inside the box, and four kinds of miss: directed away, box beyond the segment end, parallel and missing, and diagonally missing.

The origin-on-the-corner case is the one that pins down why the inverted direction is limited to the largest representable value instead of infinity: the zero direction components there make a box bound coincide with the origin, and `0 * FLT_MAX` is 0 where `0 * inf` would be a NaN.

## Measurements

Microbenchmark of `rayBoxIntersect` alone: 256 rays x 2048 boxes per pass, precomputes built once per ray as `rayMeshIntersect` does, 5 warmup + 25 timed passes, min ns/call, 3+ repetitions. The same benchmark TU is compiled against each header tree being compared, `-O3 -DNDEBUG` / `/O2 /DNDEBUG`, C++20. Two scenes: `sparse`, where 0.13% of the tests hit, and `dense`, where 9.2% do. Sequential and shuffled box order agreed within noise, so only sequential is shown. Every row is a within-job comparison: the trees are built with identical flags in the same job and the runs interleaved.

### ARM64, against master's scalar fallback

| CPU | compiler | master | this branch | speedup |
|---|---|---|---|---|
| Azure Cobalt 100 (`ubuntu-24.04-arm`) | gcc 13 | 11.36 / 12.82 ns | 2.45 / 3.46 ns | **4.6x / 3.7x** |
| Azure Cobalt 100 | clang 18 | 5.00 / 5.00 ns | 3.26 / 3.26 ns | **1.5x** |
| Azure Cobalt 100 (`windows-11-vs2026-arm`) | MSVC 19.51, VS2026 | 4.40 / 5.37 ns | 2.56 / 3.48 ns | **1.7x / 1.5x** |
| Apple M1 (`macos-14`) | AppleClang 15 | 2.44 / 2.54 ns | 1.42 / 1.42 ns | **1.7x / 1.8x** |

The first three rows are the same CPU, so they are directly comparable. How bad the scalar fallback was depended almost entirely on the compiler — gcc 13 needed 11-13 ns/call, clang 18 5.0, MSVC 4.4-5.4. With the intrinsics all three land at 2.4-3.5 ns, so the result no longer depends on which compiler builds the leg. On Apple M1 the NEON version is faster than the SSE version on either x64 runner, and it is the only variant here that is insensitive to the hit rate.

### x64, the SSE change against the previous SSE code

| CPU | compiler | before | after |
|---|---|---|---|
| AMD EPYC 7763 (`windows-2025`) | MSVC 19.51 | 3.27 / 5.27 ns | 2.77 / 4.67 ns (**-15% / -11%**) |
| AMD EPYC 9V74 (`ubuntu-24.04`) | gcc 13 | 3.21 / 5.68 ns | 2.76 / 5.26 ns (**-14% / -7%**) |
| AMD EPYC 9V74 | clang 18 | 4.21 / 5.73 ns | 4.21 / 5.54 ns (-0% / -3%) |

Also reproduced against the real headers, with an `origin/master` worktree on a local MSVC 19.51 x64 box: 4.70 / 6.03 to 4.04 / 5.37 ns, i.e. -14% / -11%.

The Intel macOS runner, `macos-15-intel`, was too noisy to use for this comparison: 11-14 ns/call with about 20% run-to-run spread, and the scalar reference beating the SSE code on some repetitions. Those numbers are left out rather than reported as a result.

### NEON packing: shorter code, same time

| CPU | compiler | packing from scalars | packing from loads |
|---|---|---|---|
| Azure Cobalt 100 | MSVC 19.51 arm64 | 2.556 / 3.475 ns | 2.555 / 3.477 ns |
| Azure Cobalt 100 | gcc 13 | 2.455 / 3.441 ns | 2.454 / 3.463 ns |
| Apple M1 | AppleClang 15 | 1.417 / 1.420 ns | 1.417 / 1.419 ns |

MSVC's ARM64 output drops from 29 to 23 instructions and clang's from 22 to 21, and the clock does not move. With independent iterations the out-of-order engine already hides the packing; throughput is set by the `FMAXV` / `FMINV` reduction and the `t0` / `t1` store-reload. A control job on the same runner also ruled out `/DNDEBUG` as a factor, with all four build combinations landing within 0.4% of each other over four interleaved repetitions.

### Caveat

Both figures measure the box test in isolation. Inside `rayMeshIntersect` it is interleaved with tree traversal and triangle tests, so the end-to-end gain on a real ray cast will be a fraction of the above.

## Correctness

Beyond the test above, both SIMD paths were run over 1000000 random boxes, origins and directions — 119804 of them with a zero direction component — and compared bit-for-bit against a scalar reference: no mismatches, and the hit count is unchanged from before either optimization. That sweep was a development check and is not part of the test suite, which is the explicit table instead.

The ARM64 CI runners independently reported checksums identical to master's scalar branch, in every benchmark scene, on real Neoverse-N2 and Apple M1 hardware.

<details>
<summary>How the measurements were taken</summary>

Throwaway branches carrying a `bench/raybox_bench.cpp`, or a standalone multi-variant harness, plus `push`-triggered workflows; each workflow adds `git worktree` checkouts of the trees being compared and builds the same benchmark against each. Runs 33163671521, 33164242134, 33164365727, 33167031385, 33167837112, 33168083114. All those branches are deleted and nothing from them is part of this PR.

An earlier revision of this description reported 1.24x for MSVC on ARM64 and 3.5x / 3.0x for gcc. Those came from run 33164242134, where the NEON build measured 3.55 ns against the same 4.40 ns master. The ARM64 code is byte-identical between the two commits involved — every difference is inside the x86 branch — `/DNDEBUG` was ruled out by the control job, and 2.55 ns has since reproduced in two independent runs while 3.55 ns has not. The earlier figures are treated as runner-state noise and the tables above use the reproduced numbers.
</details>

