### PR TITLE
Add a native Wasm SIMD path for rayBoxIntersect

### DIFF
--- a/source/MRMesh/MRIntersectionPrecomputes.h
+++ b/source/MRMesh/MRIntersectionPrecomputes.h
@@ -3,7 +3,9 @@
 #include "MRVector3.h"
 #include "MRPch/MRBindingMacros.h"
 
-#if defined(__x86_64__) || defined(_M_X64)
+// Emscripten emulates the SSE intrinsics on top of Wasm SIMD, but only with both -msimd128
+// (__wasm_simd128__) and one of the -msse* flags (__SSE__); without them the generic code is used
+#if defined(__x86_64__) || defined(_M_X64) || ( defined(__wasm_simd128__) && defined(__SSE__) )
 #include <xmmintrin.h> //SSE instructions
 #elif defined(__aarch64__) || defined(_M_ARM64)
 #include <arm_neon.h> //NEON instructions
@@ -150,8 +152,8 @@ struct IntersectionPrecomputes
 
 };
 
-/* CPU(X86_64) - AMD64 / Intel64 / x86_64 64-bit */
-#if defined(__x86_64__) || defined(_M_X64)
+/* CPU(X86_64) - AMD64 / Intel64 / x86_64 64-bit, and Wasm SIMD via Emscripten's SSE emulation */
+#if defined(__x86_64__) || defined(_M_X64) || ( defined(__wasm_simd128__) && defined(__SSE__) )
 template<>
 struct IntersectionPrecomputes<float>
 {

--- a/source/MRMesh/MRIntersectionPrecomputes.h
+++ b/source/MRMesh/MRIntersectionPrecomputes.h
@@ -3,12 +3,12 @@
 #include "MRVector3.h"
 #include "MRPch/MRBindingMacros.h"
 
-// Emscripten emulates the SSE intrinsics on top of Wasm SIMD, but only with both -msimd128
-// (__wasm_simd128__) and one of the -msse* flags (__SSE__); without them the generic code is used
-#if defined(__x86_64__) || defined(_M_X64) || ( defined(__wasm_simd128__) && defined(__SSE__) )
+#if defined(__x86_64__) || defined(_M_X64)
 #include <xmmintrin.h> //SSE instructions
 #elif defined(__aarch64__) || defined(_M_ARM64)
 #include <arm_neon.h> //NEON instructions
+#elif defined(__wasm_simd128__)
+#include <wasm_simd128.h> //Wasm SIMD instructions
 #endif
 
 namespace MR
@@ -152,8 +152,8 @@ struct IntersectionPrecomputes
 
 };
 
-/* CPU(X86_64) - AMD64 / Intel64 / x86_64 64-bit, and Wasm SIMD via Emscripten's SSE emulation */
-#if defined(__x86_64__) || defined(_M_X64) || ( defined(__wasm_simd128__) && defined(__SSE__) )
+/* CPU(X86_64) - AMD64 / Intel64 / x86_64 64-bit */
+#if defined(__x86_64__) || defined(_M_X64)
 template<>
 struct IntersectionPrecomputes<float>
 {
@@ -220,6 +220,40 @@ struct IntersectionPrecomputes<float>
         Sz = float( 1 ) / dir[maxDimIdxZ];
 
         invDir = toFloat32x4(
+            ( dir.x == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.x,
+            ( dir.y == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.y,
+            ( dir.z == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.z,
+            1 );
+    }
+
+};
+
+/* Wasm SIMD */
+#elif defined(__wasm_simd128__)
+template<>
+struct IntersectionPrecomputes<float>
+{
+    // {1.f / dir} in the first three lanes, the last one is unused
+    MR_BIND_IGNORE v128_t invDir;
+    // [0]max, [1]next, [2]next-next
+    // f.e. {1,2,-3} => {2,1,0}
+    int maxDimIdxZ = 2;
+    int idxX = 0;
+    int idxY = 1;
+
+    /// precomputed factors
+    MR_BIND_IGNORE float Sx, Sy, Sz;
+
+    IntersectionPrecomputes() = default;
+    IntersectionPrecomputes( const Vector3<float>& dir )
+    {
+        findMaxVectorDim( idxX, idxY, maxDimIdxZ, dir );
+
+        Sx = dir[idxX] / dir[maxDimIdxZ];
+        Sy = dir[idxY] / dir[maxDimIdxZ];
+        Sz = float( 1 ) / dir[maxDimIdxZ];
+
+        invDir = wasm_f32x4_make(
             ( dir.x == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.x,
             ( dir.y == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.y,
             ( dir.z == 0 ) ? std::numeric_limits<float>::max() : 1 / dir.z,

--- a/source/MRMesh/MRRayBoxIntersection.h
+++ b/source/MRMesh/MRRayBoxIntersection.h
@@ -20,8 +20,8 @@ struct RayOrigin
     RayOrigin( const Vector3<T> & ro ) : p( ro ) { }
 };
 
-/* CPU(X86_64) - AMD64 / Intel64 / x86_64 64-bit */
-#if defined(__x86_64__) || defined(_M_X64)
+/* CPU(X86_64) - AMD64 / Intel64 / x86_64 64-bit, and Wasm SIMD via Emscripten's SSE emulation */
+#if defined(__x86_64__) || defined(_M_X64) || ( defined(__wasm_simd128__) && defined(__SSE__) )
 template<>
 struct RayOrigin<float>
 {
@@ -48,7 +48,7 @@ bool rayBoxIntersect( const Box3<T>& box, const RayOrigin<T> & rayOrigin, T & t0
 {
     assert( box.valid() );
 
-    #if defined(__x86_64__) || defined(_M_X64)
+    #if defined(__x86_64__) || defined(_M_X64) || ( defined(__wasm_simd128__) && defined(__SSE__) )
     if constexpr (std::is_same_v<T, float>)
     {
         // both loads stay within the box, and the second one is the max corner shifted by one lane

--- a/source/MRMesh/MRRayBoxIntersection.h
+++ b/source/MRMesh/MRRayBoxIntersection.h
@@ -20,8 +20,8 @@ struct RayOrigin
     RayOrigin( const Vector3<T> & ro ) : p( ro ) { }
 };
 
-/* CPU(X86_64) - AMD64 / Intel64 / x86_64 64-bit, and Wasm SIMD via Emscripten's SSE emulation */
-#if defined(__x86_64__) || defined(_M_X64) || ( defined(__wasm_simd128__) && defined(__SSE__) )
+/* CPU(X86_64) - AMD64 / Intel64 / x86_64 64-bit */
+#if defined(__x86_64__) || defined(_M_X64)
 template<>
 struct RayOrigin<float>
 {
@@ -37,6 +37,15 @@ struct RayOrigin<float>
     MR_BIND_IGNORE float32x4_t p;
     RayOrigin( const Vector3f & ro ) { p = toFloat32x4( ro.x, ro.y, ro.z, 0 ); }
 };
+
+/* Wasm SIMD */
+#elif defined(__wasm_simd128__)
+template<>
+struct RayOrigin<float>
+{
+    MR_BIND_IGNORE v128_t p;
+    RayOrigin( const Vector3f & ro ) { p = wasm_f32x4_make( ro.x, ro.y, ro.z, 0 ); }
+};
 #endif
 
 /// finds intersection between the Ray and the Box.
@@ -48,7 +57,7 @@ bool rayBoxIntersect( const Box3<T>& box, const RayOrigin<T> & rayOrigin, T & t0
 {
     assert( box.valid() );
 
-    #if defined(__x86_64__) || defined(_M_X64) || ( defined(__wasm_simd128__) && defined(__SSE__) )
+    #if defined(__x86_64__) || defined(_M_X64)
     if constexpr (std::is_same_v<T, float>)
     {
         // both loads stay within the box, and the second one is the max corner shifted by one lane
@@ -92,6 +101,35 @@ bool rayBoxIntersect( const Box3<T>& box, const RayOrigin<T> & rayOrigin, T & t0
 
         t0 = vmaxvq_f32( vminq_f32( l, r ) );
         t1 = vminvq_f32( vmaxq_f32( l, r ) );
+
+        return t0 <= t1;
+    }
+    else
+    #elif defined(__wasm_simd128__)
+    if constexpr (std::is_same_v<T, float>)
+    {
+        // both loads stay within the box, and the second one is the max corner shifted by one lane
+        static_assert( sizeof( Box3f ) == 6 * sizeof( float ) );
+        const float * const c = &box.min.x;
+        v128_t l = wasm_v128_load( c );
+        v128_t h = wasm_v128_load( c + 2 );
+        v128_t r = wasm_i32x4_shuffle( h, h, 1, 2, 3, 3 );
+
+        l = wasm_f32x4_mul( wasm_f32x4_sub( l, rayOrigin.p ), prec.invDir );
+        r = wasm_f32x4_mul( wasm_f32x4_sub( r, rayOrigin.p ), prec.invDir );
+
+        v128_t a = wasm_f32x4_pmin( l, r );
+        v128_t b = wasm_f32x4_pmax( l, r );
+
+        // Wasm has neither a cross-lane reduction nor an operation on the first lane alone,
+        // so the three lanes are reduced at full width and the 4-th one is left out
+        v128_t az = wasm_i32x4_shuffle( a, a, 2, 2, 2, 2 );
+        v128_t ay = wasm_i32x4_shuffle( a, a, 1, 1, 1, 1 );
+        v128_t bz = wasm_i32x4_shuffle( b, b, 2, 2, 2, 2 );
+        v128_t by = wasm_i32x4_shuffle( b, b, 1, 1, 1, 1 );
+
+        t0 = std::max( t0, wasm_f32x4_extract_lane( wasm_f32x4_pmax( wasm_f32x4_pmax( a, az ), ay ), 0 ) );
+        t1 = std::min( t1, wasm_f32x4_extract_lane( wasm_f32x4_pmin( wasm_f32x4_pmin( b, bz ), by ), 0 ) );
 
         return t0 <= t1;
     }


### PR DESCRIPTION
Follow-up to #6719, which gave ARM64 a NEON path and left Wasm as the only platform still on the generic scalar code. This adds a `<wasm_simd128.h>` branch:

```cpp
static_assert( sizeof( Box3f ) == 6 * sizeof( float ) );
const float * const c = &box.min.x;
v128_t l = wasm_v128_load( c );
v128_t h = wasm_v128_load( c + 2 );
v128_t r = wasm_i32x4_shuffle( h, h, 1, 2, 3, 3 );

l = wasm_f32x4_mul( wasm_f32x4_sub( l, rayOrigin.p ), prec.invDir );
r = wasm_f32x4_mul( wasm_f32x4_sub( r, rayOrigin.p ), prec.invDir );

v128_t a = wasm_f32x4_pmin( l, r );
v128_t b = wasm_f32x4_pmax( l, r );
// three lanes reduced at full width, then one extract_lane and a scalar clamp
```

Wasm has no cross-lane reduction, the same as SSE and unlike AArch64 with its `FMAXV` / `FMINV`, so this follows the shape of the SSE branch: the box arrives in two overlapping loads plus a one-lane rotation, and the reduction is a shuffle tree. The guard is `__wasm_simd128__`, which `-msimd128` defines; MeshLib passes it from `MR_EMSCRIPTEN_WASM2023`, and with that option off the generic code is still selected.

Unlike the SSE branch this one clamps `t0` / `t1` with two scalar `max` / `min` rather than carrying the ray parameter in the spare lane, because Wasm has no equivalent of `_mm_max_ss`: nothing there operates on the first lane while preserving the rest. That is also what makes the alternative approach lose, see below.

## Why not simply reuse the SSE branch

Emscripten emulates the SSE intrinsics on top of Wasm SIMD, so widening the existing guards was the cheaper option and this PR started out doing exactly that. It compiles, and the results are identical, but it is not faster everywhere:

| host | generic | emulated SSE | **this PR**, `pmin`/`pmax` | native with `min`/`max` |
|---|---|---|---|---|
| aarch64, Cobalt 100 | 11.66 / 11.66 ns | 14.17 / 14.17 (**0.82x**) | **10.72 / 10.72 (1.09x)** | 8.73 / 8.73 (1.34x) |
| x86-64, Xeon 8573C | 30.49 / 34.42 ns | 15.72 / 18.16 (1.94x) | **10.00 / 15.02 (3.05x / 2.29x)** | 16.77 / 22.76 (1.82x / 1.51x) |

Two numbers per cell are the two scenes: `sparse`, where 0.13% of the tests hit, and `dense`, where 9.2% do. Four implementations in one binary with identical scene and timing code, built with the flags MeshLib passes (`-O3 -msimd128 -mbulk-memory -mnontrapping-fptoint -msse4.2`) and run under node, `emscripten/emsdk:4.0.19` on both hosts so that only the host architecture differs; 5 warmup and 25 timed passes, min ns/call, 3 repetitions. All four agreed on every hit count and checksum.

The aarch64 row is stable to 0.1% and reproduces with MeshLib's own Emscripten container as well as with the stock emsdk image. The x86 host is a shared runner whose absolute numbers moved by up to 45% between runs, so only the within-run ratios should be read from that row — the ordering was the same in every run.

`f32x4.pmin` / `pmax` exist to match x86 `minps` / `maxps`, so an engine compiling for x86 emits one instruction where an engine compiling for ARM emits a compare-and-select; `f32x4.min` / `max` are the mirror image. The emulation pays the ARM penalty twelve times over, because each of the six `_mm_min_ss` / `_mm_max_ss` becomes a full-width `pmin` / `pmax` plus a lane blend. This branch pays it six times, and a version built on `min` / `max` would not pay it on ARM but would pay the mirror penalty on x86.

Since one Wasm binary runs on both kinds of host and cannot choose at compile time, `pmin` / `pmax` is kept: its x86 gain is far the larger and ARM still improves slightly, where the `min` / `max` variant would trade most of the x86 gain for a bigger ARM one.

## Verification

- 1000000 random boxes, origins and directions, 119804 of them with a zero direction component, through this branch against a scalar reference: no mismatches, and the same hit count the SSE and NEON paths produce. Since the real headers cannot be compiled for `wasm32` without an emsdk sysroot, this ran the actual header text with the branch forced and the seven intrinsics replaced by a software model with the lane semantics of the spec.
- the 14-case table from #6719 passes on the same setup, with asserts live.
- `MRRayBoxIntersectionTests.cpp` runs `float` through whichever branch the platform builds, so the Emscripten CI legs check this one for real; `double` keeps taking the generic implementation, and both are compared against the same written-down values.
- x86-64 and aarch64 still compile clean under `-Wall -Wextra`; neither is touched by this change.
- compiled standalone for `wasm32`, the branch is 4 `v128.load`, 2 `f32x4.sub`, 2 `f32x4.mul`, 3 `f32x4.pmin`, 3 `f32x4.pmax`, 5 `i8x16.shuffle` and 2 `f32x4.extract_lane`, with no scalar fallback.

The labels keep the non-Wasm legs off this run, since nothing outside Emscripten is affected.
