### PR TITLE
Fix scene saving when an object name is cut to 12 characters ending with a space

### DIFF
--- a/source/MRMesh/MRObject.cpp
+++ b/source/MRMesh/MRObject.cpp
@@ -21,7 +21,11 @@ const std::filesystem::path cSharedFolder = "SharedModels";
 std::string composeKey( const std::string& objectName, const int prefix )
 {
     constexpr int maxFileNameLen = 12; // keep file names not too long to avoid hitting limit in some OSes
-    return std::to_string( prefix ) + "_" + utf8substr( replaceProhibitedChars( objectName ).c_str(), 0, maxFileNameLen );
+    auto name = utf8substr( replaceProhibitedChars( objectName ).c_str(), 0, maxFileNameLen );
+    // Windows silently drops trailing spaces and dots from a created folder, and then cannot find it by the original name
+    while ( !name.empty() && ( name.back() == ' ' || name.back() == '.' ) )
+        name.pop_back();
+    return std::to_string( prefix ) + "_" + name;
 }
 
 struct KeyObjectModel

--- a/source/MRTest/MRSerializeTests.cpp
+++ b/source/MRTest/MRSerializeTests.cpp
@@ -58,6 +58,35 @@ TEST( MRMesh, SerializeObjectMesh )
     EXPECT_NE( m0->mesh(), m1->mesh() );
 }
 
+// Zendesk #1121: the name is cut to 12 characters, and the cut used to end with a space
+TEST( MRMesh, SerializeObjectNameCutOnSpace )
+{
+    Object o;
+    o.setName( "root" );
+    auto group = std::make_shared<Object>();
+    group->setName( "Planner FTA Teeth" ); // first 12 characters are "Planner FTA "
+    o.addChild( group );
+    auto om = std::make_shared<ObjectMesh>();
+    om->setName( "Tooth_UL1" );
+    om->setMesh( std::make_shared<Mesh>( makeCube() ) );
+    group->addChild( om );
+
+    UniqueTemporaryFolder f;
+    auto mruPath = f / "cutOnSpace.mru";
+    auto s = serializeObjectTree( o, mruPath );
+    EXPECT_TRUE( s.has_value() ) << ( s.has_value() ? "" : s.error() );
+    auto l = loadSceneFromAnySupportedFormat( mruPath );
+    EXPECT_TRUE( l.has_value() );
+    ASSERT_TRUE( l->obj );
+    ASSERT_EQ( l->obj->children().size(), 1 );
+    EXPECT_EQ( l->obj->children()[0]->name(), "Planner FTA Teeth" );
+    ASSERT_EQ( l->obj->children()[0]->children().size(), 1 );
+    auto m = dynamic_cast<const ObjectMesh*>( l->obj->children()[0]->children()[0].get() );
+    ASSERT_TRUE( m );
+    ASSERT_TRUE( m->mesh() );
+    EXPECT_EQ( m->mesh()->topology.numValidFaces(), 12 );
+}
+
 TEST( MRMesh, SerializeSharedObjectMesh )
 {
     auto cubeMesh = std::make_shared<Mesh>( makeCube() );


### PR DESCRIPTION
## Problem

Zendesk #1121: a customer cannot save a scene, always with the same error:

```
Error saving scene: Cannot open file for writing
C:\Users\brius\AppData\Local\Temp\MeshInspectorScene1787931443\0_Root\11_Planner FTA \0_Tooth_UL1.ply
```

Note the folder in that path: `11_Planner FTA ` — `Teeth` is missing and the name ends with a space (invisible in the error dialog, where it falls on a line wrap).

`composeKey()` cuts an object name to 12 characters to build its folder/file name in the scene:

```cpp
constexpr int maxFileNameLen = 12; // keep file names not too long to avoid hitting limit in some OSes
return std::to_string( prefix ) + "_" + utf8substr( replaceProhibitedChars( objectName ).c_str(), 0, maxFileNameLen );
```

The group was named `Planner FTA Teeth`, whose first 12 characters are `Planner FTA ` — the cut lands right after a space.

Windows silently drops a trailing space when *creating* a folder, but keeps it when resolving that folder as an *intermediate* component of a path. So `create_directories()` succeeds (it creates `11_Planner FTA`), and the child model write to `...\11_Planner FTA \0_Tooth_UL1.ply` then fails with `ENOENT`. Reproduced standalone:

```
dirs actually created: ['11_Planner FTA']
write FAILED: [Errno 2] No such file or directory: '...\11_Planner FTA \0_Tooth_UL1.ply'
control '11_Planner F-T-': OK
```

This matches all three of the customer's observations exactly:

| group name | first 12 characters | result |
| --- | --- | --- |
| `Planner Teeth` | `Planner Teet` | saves |
| `Planner FTA Teeth` | `Planner FTA ` (trailing space) | **fails** |
| `Planner F-T-A Teeth` | `Planner F-T-` | saves |

Any object name whose 12th character is a space hits this, as does any name that simply ends with a space (`Planner ` -> `0_Planner `). The `.mru` is a ZIP archive, so such an entry would be unreliable on extraction even where the filesystem accepts it.

## Fix

Trim trailing spaces and dots from the composed key. Deserialization reads the key back from the scene JSON, so this is backward compatible: names that hit this bug could never be saved in the first place.

## Test

`MRMesh.SerializeObjectNameCutOnSpace` in `MRSerializeTests.cpp` round-trips the customer's tree — root -> group `Planner FTA Teeth` -> mesh `Tooth_UL1`. It fails on Windows before the fix and passes after; on other platforms a trailing space in a folder name is legal, so it passes either way.

Disabled macos / ubuntu-arm64 / emscripten / linux-vcpkg builds: the change is 6 lines in one core file, and Windows plus ubuntu-x64 cover both the failing platform and cross-platform compilation of the test.
