### PR TITLE
CI: pin Clang to GCC 13 when building the Ubuntu 24 bindings

### DIFF
--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -174,7 +174,10 @@ jobs:
           # `-fpch-codegen` hits clang defect llvm/llvm-project#203691 on libstdc++-12 (a `<filesystem>`
           # internal homed into the PCH object but never emitted, surfaces at import time). Disable on ubuntu22.
           PCH_CODEGEN: ${{ matrix.os == 'ubuntu22' && '0' || '1' }}
-        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin PCH_CODEGEN=${{env.PCH_CODEGEN}}
+          # The bindings always compile with clang++, which takes the newest GCC in the image (16 since
+          # #6717) and so needs GLIBCXX_3.4.35 - absent from stock Ubuntu 24.04. Pin the deb's own GCC 13.
+          CLANG_GCC_PIN: ${{ matrix.os == 'ubuntu24' && '--gcc-install-dir=/usr/lib/gcc/aarch64-linux-gnu/13' || '' }}
+        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin PCH_CODEGEN=${{env.PCH_CODEGEN}} EXTRA_CFLAGS="${{env.CLANG_GCC_PIN}}" EXTRA_LDFLAGS="${{env.CLANG_GCC_PIN}}"
 
       - name: Create Python Stubs
         if: ${{ inputs.mrbind && matrix.os == 'ubuntu22' && matrix.config == 'Release' && matrix.compiler == 'Clang' }}

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -162,7 +162,10 @@ jobs:
           # `-fpch-codegen` hits clang defect llvm/llvm-project#203691 on libstdc++-12 (a `<filesystem>`
           # internal homed into the PCH object but never emitted, surfaces at import time). Disable on ubuntu22.
           PCH_CODEGEN: ${{ matrix.os == 'ubuntu22' && '0' || '1' }}
-        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin ENABLE_CUDA=${{env.ENABLE_CUDA}} PCH_CODEGEN=${{env.PCH_CODEGEN}}
+          # The bindings always compile with clang++, which takes the newest GCC in the image (16 since
+          # #6717) and so needs GLIBCXX_3.4.35 - absent from stock Ubuntu 24.04. Pin the deb's own GCC 13.
+          CLANG_GCC_PIN: ${{ matrix.os == 'ubuntu24' && '--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/13' || '' }}
+        run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin ENABLE_CUDA=${{env.ENABLE_CUDA}} PCH_CODEGEN=${{env.PCH_CODEGEN}} EXTRA_CFLAGS="${{env.CLANG_GCC_PIN}}" EXTRA_LDFLAGS="${{env.CLANG_GCC_PIN}}"
 
       - name: Collect Timings
         run: ./scripts/devops/collect_timing_logs.sh ${{matrix.os}} ${{matrix.config}} "${{matrix.cxx-compiler}}"


### PR DESCRIPTION
### Problem

Every python test in `test-distribution / linux-{x64,arm64}-test (ubuntu:24.04)` fails at import since #6717:

```
ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.35' not found
            (required by /usr/local/lib/MeshLib/meshlib/mrmeshpy.so)
```

Stock Ubuntu 24.04 has libstdc++ 14 (GLIBCXX_3.4.33), so the published `ubuntu24-dev.deb` no longer imports on the distro it is named for. `MeshViewer` and `meshconv` from the same deb start fine.

### Cause

#6717 added `gcc-16 g++-16` from `ppa:ubuntu-toolchain-r/test` to the ubuntu24 image. The C++ libraries are still built by the matrix compiler (`g++-13`) and are unaffected, but `scripts/mrbind/generate.mk` always compiles and links the bindings with the `/opt` PGO clang++, and Clang silently picks the *newest* GCC installation on the system for its libstdc++ headers - now 16. Those headers put GLIBCXX_3.4.35 references into `mrmeshpy.so` and the pybind shim libs.

### Fix

Pass `--gcc-install-dir=/usr/lib/gcc/<triple>-linux-gnu/13` via `EXTRA_CFLAGS` / `EXTRA_LDFLAGS` on the ubuntu24 legs, so the parser, the compiler and the linker all use the same libstdc++ the shipped deb is built against. `pip-build.yml` and `build-test-linux-vcpkg.yml` already pin their rockylinux8 legs this way. ubuntu22 is untouched (the pin expression is empty there).

The ubuntu24 *Clang* build legs are deliberately left alone: they do not ship, and their GCC 16 header coverage is worth keeping alongside the `g++-16` legs.

`generate.mk` prints `Stdlib for parsing:` / `Stdlib for compilation:` with `_GLIBCXX_RELEASE`, so the pin is visible in the build log.

### Verification

Labelled `upload-binaries` so this PR publishes a draft release and runs the full `test-distribution` job - the same ubuntu:22.04 and ubuntu:24.04 containers that catch the regression on master. Windows, macOS, emscripten and linux-vcpkg are disabled, they cannot be affected by this change.
