### PR TITLE
meshToDensePointCloud: sample by the covering radius, not by the enclosing circle

### DIFF
--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -25,12 +25,16 @@ PointCloud meshToPointCloud( const Mesh& mesh, bool saveNormals /*= true */, con
 namespace
 {
 
-/// returns the smallest power of two, which is not less than given value (and not less than 1)
-int ceilPow2( float v )
+/// returns the smallest power of two n (and not less than 1) with n * n * bSq >= aSq, that is
+/// n >= sqrt( aSq / bSq ): no square root and no division are needed, and quadrupling is exact
+int ceilPow2Sq( float aSq, float bSq )
 {
     int res = 1;
-    while ( res < v && res < ( 1 << 24 ) )
+    while ( bSq < aSq && res < ( 1 << 24 ) )
+    {
         res <<= 1;
+        bSq *= 4;
+    }
     return res;
 }
 
@@ -61,7 +65,7 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
         // radius, so a triangle with a smaller one is covered by its own vertices and is not divided;
         // the minimal enclosing circle bounds that radius from above and is cheaper to find
         faceDivs[f] = mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq ? 1
-            : ceilPow2( std::sqrt( coveringRadiusSq( v[0], v[1], v[2] ) ) / radius );
+            : ceilPow2Sq( coveringRadiusSq( v[0], v[1], v[2] ), radiusSq );
     }, faceDivsCb ) )
         return unexpectedOperationCanceled();
 

--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -41,6 +41,7 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
     MR_TIMER;
     if ( !( radius > 0 ) )
         return unexpected( "meshToDensePointCloud: radius must be positive" );
+    const float radiusSq = radius * radius;
     const auto& mesh = mp.mesh;
     const auto& topology = mesh.topology;
     const auto& faces = topology.getFaceIds( mp.region );
@@ -57,8 +58,10 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
         Vector3f v[3];
         mesh.getTriPoints( f, v );
         // by definition no point of a triangle is farther from the nearest vertex than the covering
-        // radius, so a triangle with a smaller one is covered by its own vertices and is not divided
-        faceDivs[f] = ceilPow2( std::sqrt( coveringRadiusSq( v[0], v[1], v[2] ) ) / radius );
+        // radius, so a triangle with a smaller one is covered by its own vertices and is not divided;
+        // the minimal enclosing circle bounds that radius from above and is cheaper to find
+        faceDivs[f] = mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq ? 1
+            : ceilPow2( std::sqrt( coveringRadiusSq( v[0], v[1], v[2] ) ) / radius );
     }, faceDivsCb ) )
         return unexpectedOperationCanceled();
 

--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -41,7 +41,6 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
     MR_TIMER;
     if ( !( radius > 0 ) )
         return unexpected( "meshToDensePointCloud: radius must be positive" );
-    const float diameter = 2 * radius;
     const auto& mesh = mp.mesh;
     const auto& topology = mesh.topology;
     const auto& faces = topology.getFaceIds( mp.region );
@@ -57,15 +56,15 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
     {
         Vector3f v[3];
         mesh.getTriPoints( f, v );
-        // no point of a triangle is farther from the nearest vertex than the radius of the minimal enclosing
-        // circle, which is the circumcircle for non-obtuse triangles and half of the longest edge otherwise
-        faceDivs[f] = ceilPow2( std::sqrt( mincircleDiameterSq( v[0], v[1], v[2] ) ) / diameter );
+        // by definition no point of a triangle is farther from the nearest vertex than the covering
+        // radius, so a triangle with a smaller one is covered by its own vertices and is not divided
+        faceDivs[f] = ceilPow2( std::sqrt( coveringRadiusSq( v[0], v[1], v[2] ) ) / radius );
     }, faceDivsCb ) )
         return unexpectedOperationCanceled();
 
-    // in how many equal parts each edge is divided: enough to make every part not longer than 2*radius,
-    // and not less than the sampled incident faces divide it; the edges without such faces
-    // (including the lone ones) are not sampled at all
+    // in how many equal parts each edge is divided: as much as the sampled faces incident to it
+    // divide it, and not at all if there are no such faces (including the lone edges); the edges
+    // of an undivided face need no samples of their own, because that face covers them already
     Buffer<int, UndirectedEdgeId> edgeDivs( topology.undirectedEdgeSize() );
     if ( !ParallelFor( 0_ue, edgeDivs.endId(), [&]( UndirectedEdgeId ue )
     {
@@ -74,8 +73,6 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
         for ( auto f : { topology.left( e ), topology.right( e ) } )
             if ( f && ( wholeMesh || faces.test( f ) ) )
                 divs = std::max( divs, faceDivs[f] );
-        if ( divs > 0 )
-            divs = std::max( divs, ceilPow2( mesh.edgeLength( ue ) / diameter ) );
         edgeDivs[ue] = divs;
     }, edgeDivsCb ) )
         return unexpectedOperationCanceled();

--- a/source/MRMesh/MRMeshToPointCloud.h
+++ b/source/MRMesh/MRMeshToPointCloud.h
@@ -16,8 +16,9 @@ MRMESH_API PointCloud meshToPointCloud( const Mesh& mesh, bool saveNormals = tru
 /// the cloud, because every point of that surface is within the radius from some point of the cloud.
 /// The cloud consists of
 /// 1) all vertices of the sampled faces, having the same ids as in the mesh;
-/// 2) samples on each edge longer than 2*radius;
-/// 3) samples inside each triangle, which cannot be covered by its vertices alone.
+/// 2) samples inside every triangle that its own vertices cannot cover, and on the edges of it.
+/// A triangle needs no samples at all, however long its edges are, if every point of it is within
+/// the radius from one of its vertices, as in a sliver with the third vertex near the longest edge.
 /// Please note that the number of samples grows as 1/radius^2.
 /// \param mp the mesh or the part of it to be covered; nothing outside the part is sampled
 /// \param saveNormals if true then the normals of the cloud are set as well: the normals of the mesh

--- a/source/MRMesh/MRTriMath.h
+++ b/source/MRMesh/MRTriMath.h
@@ -70,6 +70,62 @@ template <typename T>
 MR_BIND_TEMPLATE(  float mincircleDiameterSq( const Vector3f & a, const Vector3f & b, const Vector3f & c ) );
 MR_BIND_TEMPLATE( double mincircleDiameterSq( const Vector3d & a, const Vector3d & b, const Vector3d & c ) );
 
+/// Computes the squared maximal distance from a point of the segment AB to the nearest of the points
+/// A, B and C: this is where the balls of that radius around the three points stop covering the segment
+/// \ingroup MathGroup
+template <typename T>
+[[nodiscard]] T edgeCoveringRadiusSq( const Vector3<T> & a, const Vector3<T> & b, const Vector3<T> & c )
+{
+    const auto d = b - a;
+    const auto lSq = d.lengthSq();
+    if ( lSq <= 0 )
+        return T( 0 );
+    const auto l = std::sqrt( lSq );
+    const auto ac = c - a;
+    const auto acSq = ac.lengthSq();
+    const auto s = dot( ac, d ) / l;                   // where C projects on the segment
+    const auto hSq = std::max( T( 0 ), acSq - s * s ); // squared distance from C to the line AB
+
+    // the distance to the nearest point is maximal where the two nearest of them are equidistant
+    auto sqDistToNearest = [&]( T t )
+    {
+        t = std::clamp( t, T( 0 ), l );
+        return std::min( { t * t, ( l - t ) * ( l - t ), hSq + ( t - s ) * ( t - s ) } );
+    };
+    auto res = sqDistToNearest( l / 2 );                                          // A and B
+    if ( s > 0 )
+        res = std::max( res, sqDistToNearest( acSq / ( 2 * s ) ) );               // A and C
+    if ( s < l )
+        res = std::max( res, sqDistToNearest( ( lSq - acSq ) / ( 2 * ( l - s ) ) ) ); // B and C
+    return res;
+}
+
+MR_BIND_TEMPLATE(  float edgeCoveringRadiusSq( const Vector3f & a, const Vector3f & b, const Vector3f & c ) );
+MR_BIND_TEMPLATE( double edgeCoveringRadiusSq( const Vector3d & a, const Vector3d & b, const Vector3d & c ) );
+
+/// Computes the squared maximal distance from a point of the triangle ABC to the nearest of its
+/// vertices, so the balls of that radius around the vertices cover the whole triangle.
+/// For non-obtuse triangles it is the squared circumradius, and for obtuse ones it can be much
+/// smaller than in the minimal enclosing circle, e.g. when the third vertex is near the longest edge
+/// \ingroup MathGroup
+template <typename T>
+[[nodiscard]] T coveringRadiusSq( const Vector3<T> & a, const Vector3<T> & b, const Vector3<T> & c )
+{
+    const auto ab = ( b - a ).lengthSq();
+    const auto ca = ( a - c ).lengthSq();
+    const auto bc = ( c - b ).lengthSq();
+    // a non-obtuse triangle contains its circumcenter, which is the farthest point from the vertices
+    if ( ca < bc + ab && bc < ab + ca && ab < ca + bc )
+        return circumcircleDiameterSq( a, b, c ) / T( 4 );
+    // otherwise that point is on the boundary, where the two nearest vertices are equidistant
+    return std::max( { edgeCoveringRadiusSq( a, b, c ),
+                       edgeCoveringRadiusSq( b, c, a ),
+                       edgeCoveringRadiusSq( c, a, b ) } );
+}
+
+MR_BIND_TEMPLATE(  float coveringRadiusSq( const Vector3f & a, const Vector3f & b, const Vector3f & c ) );
+MR_BIND_TEMPLATE( double coveringRadiusSq( const Vector3d & a, const Vector3d & b, const Vector3d & c ) );
+
 /// Computes the center of the the triangle's 0AB circumcircle
 template <typename T>
 [[nodiscard]] Vector3<T> circumcircleCenter( const Vector3<T> & a, const Vector3<T> & b )

--- a/source/MRMesh/MRTriMath.h
+++ b/source/MRMesh/MRTriMath.h
@@ -80,23 +80,23 @@ template <typename T>
     const auto lSq = d.lengthSq();
     if ( lSq <= 0 )
         return T( 0 );
-    const auto l = std::sqrt( lSq );
     const auto ac = c - a;
     const auto acSq = ac.lengthSq();
-    const auto s = dot( ac, d ) / l;                   // where C projects on the segment
-    const auto hSq = std::max( T( 0 ), acSq - s * s ); // squared distance from C to the line AB
+    const auto p = dot( ac, d ); // where C projects on the segment, times its length
 
-    // the distance to the nearest point is maximal where the two nearest of them are equidistant
+    // squared distance from the point in the given relative position to the nearest of A, B and C
     auto sqDistToNearest = [&]( T t )
     {
-        t = std::clamp( t, T( 0 ), l );
-        return std::min( { t * t, ( l - t ) * ( l - t ), hSq + ( t - s ) * ( t - s ) } );
+        t = std::clamp( t, T( 0 ), T( 1 ) );
+        return std::max( T( 0 ), std::min( { t * t * lSq, ( 1 - t ) * ( 1 - t ) * lSq,
+            acSq - 2 * t * p + t * t * lSq } ) );
     };
-    auto res = sqDistToNearest( l / 2 );                                          // A and B
-    if ( s > 0 )
-        res = std::max( res, sqDistToNearest( acSq / ( 2 * s ) ) );               // A and C
-    if ( s < l )
-        res = std::max( res, sqDistToNearest( ( lSq - acSq ) / ( 2 * ( l - s ) ) ) ); // B and C
+    // that distance is maximal where the two nearest of the points are equidistant
+    auto res = sqDistToNearest( T( 0.5 ) );                                         // A and B
+    if ( p > 0 )
+        res = std::max( res, sqDistToNearest( acSq / ( 2 * p ) ) );                 // A and C
+    if ( p < lSq )
+        res = std::max( res, sqDistToNearest( ( lSq - acSq ) / ( 2 * ( lSq - p ) ) ) ); // B and C
     return res;
 }
 

--- a/source/MRMesh/MRTriMath.h
+++ b/source/MRMesh/MRTriMath.h
@@ -119,10 +119,14 @@ template <typename T>
     // guards in it can trigger here: a triangle with a zero side or zero area is obtuse by the test
     if ( ca < bc + ab && bc < ab + ca && ab < ca + bc )
         return ab * ca * bc / ( 4 * cross( b - a, c - a ).lengthSq() );
-    // otherwise that point is on the boundary, where the two nearest vertices are equidistant
-    return std::max( { edgeCoveringRadiusSq( a, b, c ),
-                       edgeCoveringRadiusSq( b, c, a ),
-                       edgeCoveringRadiusSq( c, a, b ) } );
+    // otherwise that point is on the boundary, where the two nearest vertices are equidistant, and
+    // always on the longest edge: the circumcenter is beyond it, the distance along every bisector
+    // grows towards the circumcenter, so each bisector is maximal where it meets that edge
+    if ( ab >= bc && ab >= ca )
+        return edgeCoveringRadiusSq( a, b, c );
+    if ( bc >= ca )
+        return edgeCoveringRadiusSq( b, c, a );
+    return edgeCoveringRadiusSq( c, a, b );
 }
 
 MR_BIND_TEMPLATE(  float coveringRadiusSq( const Vector3f & a, const Vector3f & b, const Vector3f & c ) );

--- a/source/MRMesh/MRTriMath.h
+++ b/source/MRMesh/MRTriMath.h
@@ -114,9 +114,11 @@ template <typename T>
     const auto ab = ( b - a ).lengthSq();
     const auto ca = ( a - c ).lengthSq();
     const auto bc = ( c - b ).lengthSq();
-    // a non-obtuse triangle contains its circumcenter, which is the farthest point from the vertices
+    // a non-obtuse triangle contains its circumcenter, which is the farthest point from the vertices;
+    // this is circumcircleDiameterSq / 4 written on the lengths already at hand, and none of the
+    // guards in it can trigger here: a triangle with a zero side or zero area is obtuse by the test
     if ( ca < bc + ab && bc < ab + ca && ab < ca + bc )
-        return circumcircleDiameterSq( a, b, c ) / T( 4 );
+        return ab * ca * bc / ( 4 * cross( b - a, c - a ).lengthSq() );
     // otherwise that point is on the boundary, where the two nearest vertices are equidistant
     return std::max( { edgeCoveringRadiusSq( a, b, c ),
                        edgeCoveringRadiusSq( b, c, a ),

--- a/source/MRTest/MRMeshToPointCloudTests.cpp
+++ b/source/MRTest/MRMeshToPointCloudTests.cpp
@@ -146,8 +146,32 @@ TEST( MRMesh, MeshToDensePointCloudPart )
     EXPECT_LE( maxCloudToSurfaceDist( { mesh, &region }, *part ), 1e-6f );
 }
 
+// two triangles share a long edge, and the vertices opposite to it are close to it, so the balls
+// around the four vertices cover both triangles and no sample is needed at all
+TEST( MRMesh, MeshToDensePointCloudCloseApexes )
+{
+    Triangulation t;
+    t.push_back( { 0_v, 1_v, 2_v } );
+    t.push_back( { 1_v, 0_v, 3_v } );
+    const auto mesh = Mesh::fromTriangles( VertCoords{
+        Vector3f{ 0, 0, 0 }, Vector3f{ 10, 0, 0 }, Vector3f{ 5, 0.05f, 0 }, Vector3f{ 5, -0.05f, 0 } }, t );
+
+    // the covering radius of both triangles is about 2.5, while the edge is 10 long
+    const float radius = 3;
+    const auto cloud = meshToDensePointCloud( mesh, radius );
+    ASSERT_TRUE( cloud.has_value() );
+    EXPECT_EQ( cloud->points.size(), 4 );
+    EXPECT_LE( maxSurfaceToCloudDist( mesh, *cloud, 64 ), radius );
+
+    // a smaller radius does require samples
+    const auto dense = meshToDensePointCloud( mesh, 1.0f );
+    ASSERT_TRUE( dense.has_value() );
+    EXPECT_GT( dense->points.size(), 4 );
+    EXPECT_LE( maxSurfaceToCloudDist( mesh, *dense, 64 ), 1.0f );
+}
+
 // a triangle with all vertices on one line has infinite circumradius, but it still requires
-// a finite number of samples, because it is covered by the circle on its longest side
+// a finite number of samples, because its own vertices cover it within 1/4 of its length
 TEST( MRMesh, MeshToDensePointCloudDegenerate )
 {
     Triangulation t;
@@ -156,8 +180,9 @@ TEST( MRMesh, MeshToDensePointCloudDegenerate )
 
     const auto cloud = meshToDensePointCloud( mesh, 0.1f );
     ASSERT_TRUE( cloud.has_value() );
-    // every side is divided in 8 parts (as the face is), which gives 3 + 3*7 + 7*6/2 points
-    EXPECT_EQ( cloud->points.size(), 45 );
+    // the covering radius is 0.25, so every side is divided in 4 parts (as the face is),
+    // which gives 3 + 3*3 + 3*2/2 points
+    EXPECT_EQ( cloud->points.size(), 15 );
     EXPECT_LE( maxSurfaceToCloudDist( mesh, *cloud, 64 ), 0.1f );
 }
 

--- a/source/MRTest/MRTriMathTests.cpp
+++ b/source/MRTest/MRTriMathTests.cpp
@@ -6,6 +6,37 @@
 namespace MR
 {
 
+// the largest distance from a point of the triangle to the nearest vertex of it
+TEST( MRMesh, CoveringRadius )
+{
+    // equilateral triangle with side 1: the circumcenter is inside, and the circumradius is 1/sqrt(3)
+    EXPECT_NEAR( coveringRadiusSq( Vector3d{ 0, 0, 0 }, Vector3d{ 1, 0, 0 },
+        Vector3d{ 0.5, std::sqrt( 0.75 ), 0 } ), 1 / 3., 1e-15 );
+
+    // right triangle: the farthest point is the middle of the hypotenuse
+    EXPECT_NEAR( coveringRadiusSq( Vector3d{ 0, 0, 0 }, Vector3d{ 1, 0, 0 }, Vector3d{ 0, 1, 0 } ),
+        0.5, 1e-15 );
+
+    // a sliver with the third vertex right above the middle of the long edge: the minimal enclosing
+    // circle has radius 5, but the balls of radius ~2.5 around the vertices already cover it
+    const Vector3d a{ 0, 0, 0 }, b{ 10, 0, 0 }, c{ 5, 0.1, 0 };
+    EXPECT_NEAR( mincircleDiameterSq( a, b, c ) / 4, 25., 1e-12 );
+    EXPECT_NEAR( std::sqrt( coveringRadiusSq( a, b, c ) ), 2.5010, 1e-3 );
+
+    // ... and with the third vertex near an end of the long edge it does not help much
+    EXPECT_GT( std::sqrt( coveringRadiusSq( a, b, Vector3d{ 1, 0.1, 0 } ) ), 4.4 );
+
+    // degenerate triangles have infinite circumradius, but a finite covering one
+    EXPECT_NEAR( std::sqrt( coveringRadiusSq( a, b, Vector3d{ 5, 0, 0 } ) ), 2.5, 1e-12 );
+    EXPECT_EQ( coveringRadiusSq( a, a, a ), 0. );
+
+    // the covering radius never exceeds the radius of the minimal enclosing circle
+    for ( double x = -2; x <= 12; x += 0.7 )
+        for ( double y = 0; y <= 8; y += 0.7 )
+            EXPECT_LE( coveringRadiusSq( a, b, Vector3d{ x, y, 0 } ),
+                mincircleDiameterSq( a, b, Vector3d{ x, y, 0 } ) / 4 + 1e-12 );
+}
+
 TEST( MRMesh, TriMath )
 {
     EXPECT_EQ( circumcircleCenter( Vector3d{ 0, 0, 0 }, Vector3d{ 1, 0, 0 }, Vector3d{ 0, 1, 0 } ), Vector3d( 0.5, 0.5, 0 ) );

--- a/source/MRTest/MRTriMathTests.cpp
+++ b/source/MRTest/MRTriMathTests.cpp
@@ -30,6 +30,20 @@ TEST( MRMesh, CoveringRadius )
     EXPECT_NEAR( std::sqrt( coveringRadiusSq( a, b, Vector3d{ 5, 0, 0 } ) ), 2.5, 1e-12 );
     EXPECT_EQ( coveringRadiusSq( a, a, a ), 0. );
 
+    // the value does not depend on the order of the vertices, which the choice of the edge to
+    // examine must respect
+    for ( double x = -2; x <= 12; x += 0.7 )
+        for ( double y = 0.01; y <= 8; y += 0.7 )
+        {
+            const Vector3d p{ x, y, 0 };
+            const auto expected = coveringRadiusSq( a, b, p );
+            EXPECT_NEAR( coveringRadiusSq( b, p, a ), expected, 1e-12 );
+            EXPECT_NEAR( coveringRadiusSq( p, a, b ), expected, 1e-12 );
+            EXPECT_NEAR( coveringRadiusSq( b, a, p ), expected, 1e-12 );
+            EXPECT_NEAR( coveringRadiusSq( a, p, b ), expected, 1e-12 );
+            EXPECT_NEAR( coveringRadiusSq( p, b, a ), expected, 1e-12 );
+        }
+
     // the covering radius never exceeds the radius of the minimal enclosing circle
     for ( double x = -2; x <= 12; x += 0.7 )
         for ( double y = 0; y <= 8; y += 0.7 )


### PR DESCRIPTION
Follow-up to #6709: fewer samples for the same guarantee.

### The observation

The number of samples was driven by the **minimal enclosing circle** of a triangle, which for an obtuse triangle is the circle on its longest edge and therefore ignores the third vertex entirely. A sliver whose apex sits close to a long edge was treated as if the apex were not there: the face was divided, and the long edge with it.

But the property we need is not "the triangle fits in a ball of the radius", it is "**every point of the triangle is within the radius of one of its vertices**". Those differ exactly in the case above.

### The covering radius

`coveringRadiusSq( a, b, c )` in `MRTriMath.h` returns the squared largest distance from a point of the triangle to the *nearest* of its vertices. It has a closed form, because that maximum is attained either

* in the circumcenter, when the triangle is non-obtuse and hence contains it — the old answer, or
* on the boundary, at a point where the two nearest vertices are equidistant. Per edge those candidates are its middle and the two points where the bisectors with the opposite vertex cross it, so `edgeCoveringRadiusSq` evaluates three points and the whole thing costs at most ten distance evaluations.

`coveringRadiusSq <= mincircleDiameterSq / 4` always, which the tests check over a grid of triangle shapes, so **the sample count can only go down**, and for near-equilateral meshes it does not change at all: the circumcenter is inside and both give the circumradius.

### The edge rule disappears

Sampling an edge because it is longer than `2*radius` is no longer needed. An edge belongs to its incident triangles, so if each of them is covered by its own vertices, the edge is covered too. Edges are still divided as much as the incident *divided* faces require, purely to keep the face grids conforming.

That is exactly the case in the title: a long edge whose left and right apexes lie close to it now gets no samples at all.

### Measured on the tests

| case | before | after |
|---|---|---|
| two triangles sharing an edge of 10, apexes 0.05 away, radius 3 | 9 points | **4 points** — only the vertices |
| degenerate triangle (all vertices on one line), radius 0.1 | 45 points | **15 points** |

### Measured on a real mesh

A building STL of 169k faces and 106k vertices, bounding box diagonal 27.7, against master; best of 4 runs, each the minimum of 3 calls:

| radius | master | this PR |
|---|---|---|
| 0.2 | 646 727 points, 3.77 ms | **591 789 points** (-8.5%), 3.65 ms |
| 0.5 | 193 581 points, 2.41 ms | **185 353 points** (-4.3%), 2.35 ms |

The cover itself is unchanged: the largest surface-to-cloud distance stays 0.1863 and 0.4688, i.e. 93% of the radius in both versions, because the worst covered spot is not in a triangle the criterion treats differently.

A few percent is what a mesh of well-shaped triangles has to give: there the circumcenter is inside and both criteria agree. The sliver cases above are where the difference is large.

Getting there took the performance work in the later commits. The exact covering radius first cost 0.7 ms more per call than the enclosing circle, the same at both radii and therefore a fixed price per face: `edgeCoveringRadiusSq` now works in the relative position along the segment and needs no square root, and the enclosing circle, being an upper bound, is tested first, so the exact value is computed only for faces that may be divided at all.

Two more followed from review questions. The circumradius is now computed from the squared lengths `coveringRadiusSq` already has: the compiler did share them with `circumcircleDiameterSq`, but its four guards against a zero side or a zero area survived, and none of them can trigger from that branch. And only the longest edge is examined on the obtuse path, because the circumcenter lies beyond that edge and the distance along every bisector grows towards it, so each bisector is maximal where it meets that edge - checked on 3743 random obtuse triangles against both the three-edge maximum and a brute force maximum over a dense grid. Together: 119 instructions with MSVC /O2 against 154 as first written, and the whole call is now faster than master's while producing fewer points.

`MRMesh.CoveringRadius` covers the equilateral, right, sliver, apex-near-the-end, degenerate and single-point cases, plus the inequality against the enclosing circle. `MRMesh.MeshToDensePointCloudCloseApexes` is the new sliver pair, and every existing test of the guarantee still passes unchanged - the covering property is verified by probing each triangle in its centre, its side middles and random points.
