### PR TITLE
Build the C# bindings on Windows arm64 too

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -45,10 +45,8 @@ jobs:
       actions: read   # This is required for wait-for-job
 
     env:
-      # x64-only: MRDotNet2{,Static,Test}.csproj hard-code BaseOutputPath ..\..\source\x64
-      # and PlatformTarget x64, so C# needs its own change before it can run on arm64.
-      BUILD_C_SHARP: ${{ matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild' && matrix.arch != 'arm64' }}
-      PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\x64\${{ matrix.config }}
+      BUILD_C_SHARP: ${{ matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild' }}
+      PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\${{ matrix.arch || 'x64' }}\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
       # Upload a developer distributive per Visual Studio toolchain so
       # update-win-version can repackage each into MeshLibDistVS{19,22,26}.zip.
@@ -214,7 +212,7 @@ jobs:
           call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}} || exit /b 1
           call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}} CSHARP_STATIC_DLLIMPORT=1 || exit /b 1
-          dotnet build examples/c-sharp-examples -c ${{matrix.config}} || exit /b 1
+          dotnet build examples/c-sharp-examples -c ${{matrix.config}} -p:Platform=%MSBUILD_PLATFORM% -p:MeshLibArch=%MR_ARCH% || exit /b 1
 
       - name: Build
         shell: cmd
@@ -331,8 +329,8 @@ jobs:
         if: ${{ env.BUILD_C_SHARP == 'true' }}
         timeout-minutes: 10
         run: |
-          dotnet build source\MRDotNet2Test -c ${{ matrix.config }}
-          source\x64\${{ matrix.config }}\MRDotNet2Test.exe --result="_report_nunit.xml"
+          dotnet build source\MRDotNet2Test -c ${{ matrix.config }} -p:MeshLibArch=${{ env.MR_ARCH }}
+          source\${{ env.MR_ARCH }}\${{ matrix.config }}\MRDotNet2Test.exe --result="_report_nunit.xml"
           # convert report to JUnit format
           [Environment]::CurrentDirectory = $pwd
           $xslt = New-Object System.Xml.Xsl.XslCompiledTransform
@@ -449,7 +447,9 @@ jobs:
           compression-level: 0
 
       - name: Create and fix fake Wheel for NuGet
-        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
+        # x64 only: the paths below, the artifact names and the package layout all assume
+        # one architecture. An arm64 NuGet payload is a separate change.
+        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' && matrix.arch != 'arm64' }}
         run: |
           py -3 -m venv wheel_venv
           wheel_venv\Scripts\Activate
@@ -457,7 +457,7 @@ jobs:
           py -3 ./scripts/nuget_patch/patch_library_deps.py ./patched_content/ ./source/x64/Release/MeshLibC2.dll ./source/x64/Release/MeshLibC2Cuda.dll
 
       - name: Upload NuGet files to Artifacts
-        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
+        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' && matrix.arch != 'arm64' }}
         uses: actions/upload-artifact@v7
         with:
           name: DotNetPatchArchiveWindows-x64
@@ -466,7 +466,7 @@ jobs:
           overwrite: true
 
       - name: Upload NuGet library DLL and XML to Artifacts
-        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
+        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' && matrix.arch != 'arm64' }}
         uses: actions/upload-artifact@v7
         with:
           name: DotNetDllXml

--- a/examples/c-sharp-examples/c-sharp-examples.csproj
+++ b/examples/c-sharp-examples/c-sharp-examples.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>c_sharp_examples</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Platforms>x64</Platforms>
+    <Platforms>x64;ARM64</Platforms>
     <BaseOutputPath>..\..\source</BaseOutputPath>
   </PropertyGroup>
 
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>$(Platform)</PlatformTarget>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/examples/c-sharp-examples/c-sharp-examples.sln
+++ b/examples/c-sharp-examples/c-sharp-examples.sln
@@ -9,12 +9,18 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
 		Release|x64 = Release|x64
+		Debug|ARM64 = Debug|ARM64
+		Release|ARM64 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{AB3537AC-298A-4D0D-A16D-D8B9DA8ED241}.Debug|x64.ActiveCfg = Debug|x64
 		{AB3537AC-298A-4D0D-A16D-D8B9DA8ED241}.Debug|x64.Build.0 = Debug|x64
 		{AB3537AC-298A-4D0D-A16D-D8B9DA8ED241}.Release|x64.ActiveCfg = Release|x64
 		{AB3537AC-298A-4D0D-A16D-D8B9DA8ED241}.Release|x64.Build.0 = Release|x64
+		{AB3537AC-298A-4D0D-A16D-D8B9DA8ED241}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{AB3537AC-298A-4D0D-A16D-D8B9DA8ED241}.Debug|ARM64.Build.0 = Debug|ARM64
+		{AB3537AC-298A-4D0D-A16D-D8B9DA8ED241}.Release|ARM64.ActiveCfg = Release|ARM64
+		{AB3537AC-298A-4D0D-A16D-D8B9DA8ED241}.Release|ARM64.Build.0 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -1194,7 +1194,9 @@ generate:
 .DEFAULT_GOAL := build
 .PHONY: build
 build: generate
-	dotnet build $(call quote,$(CSHARP_CODE_OUTPUT_DIR)) $(if $(CSHARP_MODE),-c $(CSHARP_MODE))
+# MeshLibArch places the assembly next to the native output; unset off Windows, where the
+# csproj default stands.
+	dotnet build $(call quote,$(CSHARP_CODE_OUTPUT_DIR)) $(if $(CSHARP_MODE),-c $(CSHARP_MODE)) $(if $(MSVC_ARCH),-p:MeshLibArch=$(MSVC_ARCH))
 # # Can't compile sub-libraries separately yet, because we can't define the same C# partial class (which we use as namespaces) in different C# assemblies.
 # $(foreach m,$(MODULES),\
 # 	$(if $($m_CSharpSubLibraryOutputProject),\

--- a/source/MRDotNet2/MRDotNet2.csproj
+++ b/source/MRDotNet2/MRDotNet2.csproj
@@ -7,7 +7,10 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <BaseOutputPath>..\..\source\x64</BaseOutputPath>
+    <!-- Architecture of the native MeshLib output dir these assemblies sit next to.
+         CI passes -p:MeshLibArch=arm64 on the arm64 leg. -->
+    <MeshLibArch Condition="'$(MeshLibArch)' == ''">x64</MeshLibArch>
+    <BaseOutputPath>..\..\source\$(MeshLibArch)</BaseOutputPath>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 
     <!-- Suppressed warnings:

--- a/source/MRDotNet2Static/MRDotNet2Static.csproj
+++ b/source/MRDotNet2Static/MRDotNet2Static.csproj
@@ -7,7 +7,10 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <BaseOutputPath>..\..\source\x64</BaseOutputPath>
+    <!-- Architecture of the native MeshLib output dir these assemblies sit next to.
+         CI passes -p:MeshLibArch=arm64 on the arm64 leg. -->
+    <MeshLibArch Condition="'$(MeshLibArch)' == ''">x64</MeshLibArch>
+    <BaseOutputPath>..\..\source\$(MeshLibArch)</BaseOutputPath>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
 
     <!-- Suppressed warnings:

--- a/source/MRDotNet2Test/MRDotNet2Test.csproj
+++ b/source/MRDotNet2Test/MRDotNet2Test.csproj
@@ -5,8 +5,11 @@
     <TargetFramework>net8</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <BaseOutputPath>..\x64</BaseOutputPath>
-    <Platforms>x64</Platforms>
+    <!-- Architecture of the native MeshLib output dir these assemblies sit next to.
+         CI passes -p:MeshLibArch=arm64 on the arm64 leg. -->
+    <MeshLibArch Condition="'$(MeshLibArch)' == ''">x64</MeshLibArch>
+    <BaseOutputPath>..\$(MeshLibArch)</BaseOutputPath>
+    <Platforms>x64;ARM64</Platforms>
 	<LangVersion>12</LangVersion>
   </PropertyGroup>
 
@@ -22,7 +25,8 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget Condition="'$(MeshLibArch)' == 'arm64'">ARM64</PlatformTarget>
+    <PlatformTarget Condition="'$(PlatformTarget)' == ''">x64</PlatformTarget>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
Follow-up to #6721, which added the arm64 MSBuild leg but kept `BUILD_C_SHARP` off there
because the C# projects hard-coded x64. Nothing about C# is architecture-bound — the managed
assemblies are `netstandard2.0` — it was only ever the output paths and the test executable.

## Two mechanisms, because there are two

The projects reach the architecture in different ways, so the fix does too:

* **`MRDotNet2`, `MRDotNet2Static`, `MRDotNet2Test`** are built directly by
  `dotnet build <dir>`. `Platform` is `AnyCPU` there and contributes no path segment, so
  their `BaseOutputPath` carries the architecture itself. A new **`MeshLibArch`** property
  supplies it, defaulting to `x64`, and CI passes `-p:MeshLibArch=arm64`.
* **`c-sharp-examples`** builds through its own `.sln`, which declared only `Debug|x64` and
  `Release|x64` — that is what puts its output under `source\x64`. The solution gains
  `Debug|ARM64` and `Release|ARM64`, and the project takes `PlatformTarget` from
  `$(Platform)` instead of pinning x64.

`MRDotNet2Test` is an executable that P/Invokes the native DLLs, so its `PlatformTarget`
follows `MeshLibArch` — an x64-targeted test host on arm64 would run emulated and then fail
to load arm64 natives. The two `netstandard2.0` libraries stay architecture-neutral; only
where they are written changes.

## Still x64-only

The three NuGet steps. Their source paths, artifact names (`DotNetPatchArchiveWindows-x64`)
and the package layout all assume a single architecture, so they now also require
`matrix.arch != 'arm64'`. Shipping an arm64 NuGet payload means a `runtimes/win-arm64/native/`
package layout, which is a distribution decision rather than a CI one.
