### PR TITLE
Add a Windows arm64 leg to the Python wheels

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -842,11 +842,31 @@ jobs:
           name: Windows-${{ matrix.platform }}
           merge-multiple: true
 
+      # Two steps rather than one interpolated list: setup-python wants real newlines,
+      # and an expression cannot produce them.
       - name: Python setup
+        if: ${{ matrix.platform != 'arm64' }}
         uses: actions/setup-python@v7
         with:
-          # python.org publishes no win-arm64 build before 3.11
-          python-version: ${{ matrix.platform == 'arm64' && '3.11, 3.12, 3.13, 3.14' || '3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14' }}
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+            3.14
+
+      - name: Python setup (arm64)
+        # python.org publishes no win-arm64 build before 3.11
+        if: ${{ matrix.platform == 'arm64' }}
+        uses: actions/setup-python@v7
+        with:
+          python-version: |
+            3.11
+            3.12
+            3.13
+            3.14
 
       # One step per Python ABI so the GitHub Actions UI shows per-version
       # status / timing / logs. Each step is a thin wrapper around the

--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -440,21 +440,54 @@ jobs:
     needs: setup
     if: ${{ inputs.disable_windows != true }}
     timeout-minutes: 90
-    runs-on:  [windows-2025]
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
+      matrix:
+        platform: [x64, arm64]
+        include:
+          - platform: x64
+            runner: windows-2025
+            vcpkg-triplet: x64-windows-meshlib
+            msbuild-platform: x64
+            msbuild-architecture: x86
+            vs-dev-args: -arch=amd64 -host_arch=x86
+            plat-name: win-amd64
+            msys2-env: clang64
+            msys2-pkgs: _clang22
+            mrbind-cache-prefix: windows-clang22
+            cuda-version: '12.0.1'
+            cuda-major: '12'
+            cuda-minor: '0'
+            cuda-platform-toolset: v143
+          # no CUDA toolkit exists for Windows arm64, so MRCuda is not built there
+          - platform: arm64
+            runner: windows-11-vs2026-arm
+            vcpkg-triplet: arm64-windows-meshlib
+            msbuild-platform: ARM64
+            msbuild-architecture: arm64
+            vs-dev-args: -arch=arm64 -host_arch=arm64
+            plat-name: win-arm64
+            msys2-env: clangarm64
+            msys2-pkgs: _clangarm64
+            mrbind-cache-prefix: windows-clangarm64
+            cuda-version: ''
+            cuda-major: ''
+            cuda-minor: ''
+            cuda-platform-toolset: ''
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
     env:
       VCPKG-VERSION: '2026.07.29'
-      CUDA-VERSION: '12.0.1'
-      CUDA-MAJOR: '12'
-      CUDA-MINOR: '0'
-      VCPKG_DEFAULT_TRIPLET: x64-windows-meshlib
+      CUDA-VERSION: ${{ matrix.cuda-version }}
+      CUDA-MAJOR: ${{ matrix.cuda-major }}
+      CUDA-MINOR: ${{ matrix.cuda-minor }}
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg-triplet }}
       VCVARS_VER: '14.5'
       PLATFORM_TOOLSET: v145
-      CUDA_PLATFORM_TOOLSET: v143
+      CUDA_PLATFORM_TOOLSET: ${{ matrix.cuda-platform-toolset }}
+      MSYS2_ENV: ${{ matrix.msys2-env }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -477,6 +510,7 @@ jobs:
         run: scripts/mrbind-pybind11/install_all_python_versions_windows.bat
 
       - name: Install CUDA
+        if: ${{ matrix.cuda-version != '' }}
         uses: ./.github/actions/install-cuda
         with:
           cuda-version: ${{ env.CUDA-VERSION }}
@@ -484,6 +518,7 @@ jobs:
           cuda-minor: ${{ env.CUDA-MINOR }}
 
       - name: Set up CUDA
+        if: ${{ matrix.cuda-version != '' }}
         uses: ./.github/actions/setup-cuda
         with:
           cuda-major: ${{ env.CUDA-MAJOR }}
@@ -491,19 +526,26 @@ jobs:
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
+        with:
+          # an x86 MSBuild would make the VC props pick an x86 host compiler, whose address
+          # space is too small for our PCH when targeting ARM64
+          msbuild-architecture: ${{ matrix.msbuild-architecture }}
 
       - name: Build
-        run: msbuild -m source\MeshLib.sln -p:Configuration=Release -p:VcpkgTriplet=${{ env.VCPKG_DEFAULT_TRIPLET }} -p:PlatformToolset=${{ env.PLATFORM_TOOLSET }} -p:MRCudaPlatformToolset=${{ env.CUDA_PLATFORM_TOOLSET }} -p:MR_PCH_USE_EXTRA_HEADERS=ON
+        run: msbuild -m source\MeshLib.sln -p:Configuration=Release -p:Platform=${{ matrix.msbuild-platform }} -p:VcpkgTriplet=${{ env.VCPKG_DEFAULT_TRIPLET }} -p:PlatformToolset=${{ env.PLATFORM_TOOLSET }} -p:MRCudaPlatformToolset=${{ env.CUDA_PLATFORM_TOOLSET }} -p:MR_PCH_USE_EXTRA_HEADERS=ON
 
       - name: Install MSYS2 for MRBind
         uses: ./.github/actions/install-msys2-mrbind
+        with:
+          packages-suffix: ${{ matrix.msys2-pkgs }}
 
       - name: Build MRBind
         uses: ./.github/actions/build-mrbind
         with:
-          cache-key-prefix: windows-clang22
+          cache-key-prefix: ${{ matrix.mrbind-cache-prefix }}
           build-script: scripts/mrbind/install_mrbind_windows_msys2.bat
-          extra-cache-key: ${{ hashFiles('scripts/mrbind/msys2_package_hashes_clang22.txt') }}
+          extra-cache-key: ${{ hashFiles(format('scripts/mrbind/msys2_package_hashes{0}.txt', matrix.msys2-pkgs)) }}
+          msys2-env: ${{ matrix.msys2-env }}
 
       - name: Generate and build MRBind bindings
         shell: cmd
@@ -512,25 +554,25 @@ jobs:
         # `|| exit /b 1` — cmd.exe does not stop on a failed command, so guard each
         # one to fail the step on a generation error instead of swallowing it.
         run: |
-          call "${{ env.VC_PATH }}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=x86 -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          call "${{ env.VC_PATH }}\Common7\Tools\VsDevCmd.bat" ${{ matrix.vs-dev-args }} -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           call ./scripts/mrbind/generate_win.bat -B --trace FOR_WHEEL=1 || exit /b 1
 
       - name: Run Test
-        working-directory: source\x64\Release
+        working-directory: source\${{ matrix.platform }}\Release
         run: .\MeshViewer.exe -tryHidden -noEventLoop
 
       - name: Verify meshlib.mrmeshpy import
         timeout-minutes: 3
         uses: ./.github/actions/verify-meshlib-python-import
         with:
-          build-bin-dir: source\x64\Release
+          build-bin-dir: source\${{ matrix.platform }}\Release
 
       - name: Unit Tests
         timeout-minutes: 10
-        run: source\x64\Release\MRTest.exe
+        run: source\${{ matrix.platform }}\Release\MRTest.exe
 
       - name: Python Tests
-        working-directory: source\x64\Release
+        working-directory: source\${{ matrix.platform }}\Release
         run: py -3 -u ..\..\..\scripts\run_python_test_script.py -multi-cmd
 
       - name: Create and fix Wheel
@@ -538,12 +580,12 @@ jobs:
           py -3.11 -m venv venv
           venv\Scripts\Activate
           python -m pip install --upgrade pip
-          python .\scripts\wheel\build_wheel.py --plat-name=win-amd64 --version ${{ needs.setup.outputs.wheel_version }}
+          python .\scripts\wheel\build_wheel.py --plat-name=${{ matrix.plat-name }} --version ${{ needs.setup.outputs.wheel_version }}
 
       - name: Upload to Test Artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: Windows
+          name: Windows-${{ matrix.platform }}
           path: wheelhouse_core\meshlib*.whl
           retention-days: 1
 
@@ -699,7 +741,7 @@ jobs:
       - name: Download Wheels Artifacts
         uses: actions/download-artifact@v8
         with:
-          pattern: Windows
+          pattern: Windows-*
           merge-multiple: true
 
       - name: Download Wheels Artifacts
@@ -781,7 +823,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [windows-2022, windows-2025]
+        include:
+          - platform: x64
+            runner: windows-2022
+          - platform: x64
+            runner: windows-2025
+          - platform: arm64
+            runner: windows-11-vs2026-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -791,33 +839,30 @@ jobs:
       - name: Download Meshlib wheel from Artifact
         uses: actions/download-artifact@v8
         with:
-          name: Windows
+          name: Windows-${{ matrix.platform }}
           merge-multiple: true
 
       - name: Python setup
         uses: actions/setup-python@v7
         with:
-          python-version: |
-            3.8
-            3.9
-            3.10
-            3.11
-            3.12
-            3.13
-            3.14
+          # python.org publishes no win-arm64 build before 3.11
+          python-version: ${{ matrix.platform == 'arm64' && '3.11, 3.12, 3.13, 3.14' || '3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14' }}
 
       # One step per Python ABI so the GitHub Actions UI shows per-version
       # status / timing / logs. Each step is a thin wrapper around the
       # shared `test_wheel_windows.ps1` script.
       - name: Test wheel against Python 3.8
+        if: ${{ matrix.platform != 'arm64' }}
         shell: pwsh
         run: ./scripts/wheel/test_wheel_windows.ps1 -Version 3.8
 
       - name: Test wheel against Python 3.9
+        if: ${{ matrix.platform != 'arm64' }}
         shell: pwsh
         run: ./scripts/wheel/test_wheel_windows.ps1 -Version 3.9
 
       - name: Test wheel against Python 3.10
+        if: ${{ matrix.platform != 'arm64' }}
         shell: pwsh
         run: ./scripts/wheel/test_wheel_windows.ps1 -Version 3.10
 
@@ -926,7 +971,7 @@ jobs:
       - name: Download Wheels Artifacts
         uses: actions/download-artifact@v8
         with:
-          pattern: Windows
+          pattern: Windows-*
           merge-multiple: true
 
       - name: Download Wheels Artifacts
@@ -969,7 +1014,7 @@ jobs:
       - name: Download Wheels Artifacts
         uses: actions/download-artifact@v8
         with:
-          pattern: Windows
+          pattern: Windows-*
           merge-multiple: true
 
       - name: Download Wheels Artifacts

--- a/doxygen/general_pages/PythonSetupGuide.dox
+++ b/doxygen/general_pages/PythonSetupGuide.dox
@@ -25,8 +25,9 @@ Python 3.8 (end-of-life since October 2024) and 3.9 (end-of-life since October 2
 no longer receive security updates, and remain listed only because the published
 wheels still install on them.
 
- - On \b Windows: 3.8 to 3.14, 64-bit x64 only. There is no ARM64 and no
-   32-bit wheel; on Windows on ARM, use the x64 build of Python.
+ - On \b Windows: 3.8 to 3.14 on x64, and 3.11 to 3.14 on ARM64. There is no
+   32-bit wheel. ARM64 starts at 3.11 because python.org publishes no earlier
+   win-arm64 installer; on ARM64 with an older Python, use the x64 build instead.
  - On \b macOS: 3.9 to 3.14, on macOS 12 or newer. Both arm64 (Apple Silicon)
    and x86_64 (Intel) are supported.
  - On \b Linux: 3.8 to 3.14 for distributions
@@ -126,7 +127,7 @@ The failures new installations actually hit, with the message each one produces.
 | Path | Symptom | Cause | Fix |
 |------|---------|-------|-----|
 | Linux distribution Python, Homebrew Python on macOS | `pip install meshlib` stops before downloading anything with `error: externally-managed-environment`, then `× This environment is externally managed`. | Not a MeshLib problem: pip 23.0 and newer refuse to install any package into an interpreter the OS package manager owns (PEP 668, marked by a `EXTERNALLY-MANAGED` file next to the standard library). | Install into a virtual environment, as \ref PythonSetupInstall "Installation Process" above shows. `pip install --break-system-packages meshlib` also installs, but into the system interpreter — prefer the virtual environment. |
-| Any | `ERROR: Could not find a version that satisfies the requirement meshlib (from versions: none)`, then `ERROR: No matching distribution found for meshlib`. | No published wheel matches this interpreter: the Python version is outside the range in \ref PythonSetupPrerequisites "Prerequisites" above, the interpreter is 32-bit, or the platform has no wheel at all — there is no `win_arm64` wheel, so Windows on Arm needs the x64 build of Python. | Check what pip is matching against — `python -c "import sys, sysconfig; print(sys.version, sysconfig.get_platform())"` — and install a Python listed in \ref PythonSetupPrerequisites "Prerequisites". |
+| Any | `ERROR: Could not find a version that satisfies the requirement meshlib (from versions: none)`, then `ERROR: No matching distribution found for meshlib`. | No published wheel matches this interpreter: the Python version is outside the range in \ref PythonSetupPrerequisites "Prerequisites" above, the interpreter is 32-bit, or the platform has no wheel at all — on ARM64 Windows the wheels start at Python 3.11, so an older interpreter there needs the x64 build. | Check what pip is matching against — `python -c "import sys, sysconfig; print(sys.version, sysconfig.get_platform())"` — and install a Python listed in \ref PythonSetupPrerequisites "Prerequisites". |
 | Any, most likely macOS with Python 3.8 | Install and import both succeed, but a documented function is missing — `AttributeError: module 'meshlib.mrmeshpy' has no attribute ...` — or `pip show meshlib` prints a version well behind the latest. | The package requires Python 3.8 or newer overall, but each release's wheel tags are narrower than that and move forward over time. When no wheel of the newest release matches your interpreter, pip does not fail: it silently installs the newest *older* release that does. On macOS with Python 3.8 that is 3.0.8.247 instead of the current release, because the current macOS wheels are tagged 3.9 and up. | `pip show meshlib`, and compare with the version on the [PyPI page](https://pypi.org/project/meshlib/). If it is behind, move to a Python version listed in \ref PythonSetupPrerequisites "Prerequisites" and reinstall with `pip install --upgrade --force-reinstall meshlib`. |
 
 Anything not listed here: please open an issue at [MeshLib Issues](https://github.com/MeshInspector/MeshLib/issues), quoting the full `pip` output or traceback.

--- a/scripts/mrbind-pybind11/install_all_python_versions_windows.bat
+++ b/scripts/mrbind-pybind11/install_all_python_versions_windows.bat
@@ -15,7 +15,15 @@ echo Finished downloading to: %tempfile%
 rem Extract the version numbers from the page and version-sort them. Write the result to `%tempfile%2`.
 powershell (type %tempfile%) -match 'href=""""3\.' -replace '.*^>(.*)/^<.*','$1' "|" Sort-Object { $_ -as [version] } -Descending >%tempfile%2
 
-for /f %%x in (%~dp0\python_versions.txt) do (
+rem Installer architecture. python.org ships win-arm64 installers only from 3.11 on, so
+rem an arm64 host also drops the older entries from the version list.
+if "%PY_ARCH%" == "" (
+    if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (set PY_ARCH=arm64) else (set PY_ARCH=amd64)
+)
+echo Installing %PY_ARCH% Pythons.
+powershell -Command "Get-Content '%~dp0python_versions.txt' | Where-Object { '%PY_ARCH%' -ne 'arm64' -or [version]$_ -ge [version]'3.11' } | Set-Content %tempfile%3"
+
+for /f %%x in (%tempfile%3) do (
     echo.
     echo -----------------------
     echo.
@@ -57,9 +65,9 @@ rem --- Now some functions:
 for /f %%y in ('findstr %1\. %tempfile%2') do (
     if !done! == 0 (
         echo Trying version: %%y
-        set installer=%tmp%\python-%%y-amd64.exe
+        set installer=%tmp%\python-%%y-!PY_ARCH!.exe
         del /S /Q "!installer!" >nul 2>nul
-        powershell -Command "Invoke-WebRequest https://www.python.org/ftp/python/%%y/python-%%y-amd64.exe -OutFile !installer!" >nul
+        powershell -Command "Invoke-WebRequest https://www.python.org/ftp/python/%%y/python-%%y-!PY_ARCH!.exe -OutFile !installer!" >nul
         if exist "!installer!" (
             echo Download successful.
 

--- a/scripts/mrbind-pybind11/install_all_python_versions_windows.bat
+++ b/scripts/mrbind-pybind11/install_all_python_versions_windows.bat
@@ -20,6 +20,8 @@ rem an arm64 host also drops the older entries from the version list.
 if "%PY_ARCH%" == "" (
     if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" (set PY_ARCH=arm64) else (set PY_ARCH=amd64)
 )
+rem arm64 installers use a suffixed target directory, which the check below must match.
+if /i "%PY_ARCH%" == "arm64" (set PY_DIR_SUFFIX=-arm64) else (set PY_DIR_SUFFIX=)
 echo Installing %PY_ARCH% Pythons.
 powershell -Command "Get-Content '%~dp0python_versions.txt' | Where-Object { '%PY_ARCH%' -ne 'arm64' -or [version]$_ -ge [version]'3.11' } | Set-Content %tempfile%3"
 
@@ -32,7 +34,7 @@ for /f %%x in (%tempfile%3) do (
     rem Set `!ver_terse!` to the version number without the dot, such as `313`.
     set ver_terse=%%x
     set ver_terse=!ver_terse:.=!
-    if exist %localappdata%\Programs\Python\Python!ver_terse!\python.exe (
+    if exist %localappdata%\Programs\Python\Python!ver_terse!!PY_DIR_SUFFIX!\python.exe (
         echo Python %%x - already installed
     ) else (
         echo Python %%x - installing...

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -349,9 +349,12 @@ override localappdata := $(subst \,/,$(LOCALAPPDATA))
 # directory suffix, which belongs in the paths but must not leak into the version numbers.
 # Substitute `3%` for what each use needs - `3*` to glob, `@XY@` for the compiler flags.
 PYTHON_DIR := $(localappdata)/Programs/Python/Python
-PYTHON_DIR_PATTERN := $(PYTHON_DIR)3%$(if $(filter arm64,$(MSVC_ARCH)),-arm64)
+# python.org installs win-arm64 Pythons into suffixed directories (`Python311-arm64`),
+# so the suffix belongs in the paths but must not leak into the version numbers.
+PYTHON_DIR_SUFFIX := $(if $(filter arm64,$(MSVC_ARCH)),-arm64)
 ifneq ($(FOR_WHEEL),)
 # On Windows wheel we use all versions we can find in appdata.
+PYTHON_DIR_PATTERN := $(PYTHON_DIR)3%$(PYTHON_DIR_SUFFIX)
 PYTHON_VERSIONS := $(patsubst $(PYTHON_DIR_PATTERN),3.%,$(filter $(PYTHON_DIR_PATTERN),$(wildcard $(subst 3%,3*,$(PYTHON_DIR_PATTERN)))))
 # with an empty suffix the glob also matches the suffixed dirs, so drop those
 PYTHON_VERSIONS := $(filter-out %-arm64 %-32,$(PYTHON_VERSIONS))
@@ -389,8 +392,8 @@ PYTHON_CFLAGS :=
 PYTHON_LDFLAGS :=
 ifneq ($(and $(IS_WINDOWS),$(BUILD_SHIMS)),)
 # On Windows wheel, hardcode the flags to point to appdata.
-PYTHON_CFLAGS := -I$(subst 3%,@XY@,$(PYTHON_DIR_PATTERN))/Include
-PYTHON_LDFLAGS := -L$(subst 3%,@XY@,$(PYTHON_DIR_PATTERN))/libs -lpython@XY@
+PYTHON_CFLAGS := -I$(PYTHON_DIR)@XY@$(PYTHON_DIR_SUFFIX)/Include
+PYTHON_LDFLAGS := -L$(PYTHON_DIR)@XY@$(PYTHON_DIR_SUFFIX)/libs -lpython@XY@
 endif
 
 ifeq ($(PYTHON_CFLAGS)$(PYTHON_LDFLAGS),) # If no custom flags are specified...

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -345,12 +345,10 @@ $(info MODE: $(MODE))
 # When setting this manually, both spaces and commas work as separators.
 ifneq ($(IS_WINDOWS),)
 override localappdata := $(subst \,/,$(LOCALAPPDATA))
-# Where python.org installs interpreters, as a pattern: the win-arm64 ones get a `-arm64`
-# directory suffix, which belongs in the paths but must not leak into the version numbers.
-# Substitute `3%` for what each use needs - `3*` to glob, `@XY@` for the compiler flags.
+# Where python.org installs interpreters. The win-arm64 ones land in suffixed directories
+# (`Python311-arm64`), so the suffix belongs in the paths but must not leak into the
+# version numbers.
 PYTHON_DIR := $(localappdata)/Programs/Python/Python
-# python.org installs win-arm64 Pythons into suffixed directories (`Python311-arm64`),
-# so the suffix belongs in the paths but must not leak into the version numbers.
 PYTHON_DIR_SUFFIX := $(if $(filter arm64,$(MSVC_ARCH)),-arm64)
 ifneq ($(FOR_WHEEL),)
 # On Windows wheel we use all versions we can find in appdata.

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -345,12 +345,14 @@ $(info MODE: $(MODE))
 # When setting this manually, both spaces and commas work as separators.
 ifneq ($(IS_WINDOWS),)
 override localappdata := $(subst \,/,$(LOCALAPPDATA))
-# python.org installs win-arm64 Pythons into suffixed directories (`Python311-arm64`),
-# so the suffix belongs in the paths but must not leak into the version numbers.
-PYTHON_DIR_SUFFIX := $(if $(filter arm64,$(MSVC_ARCH)),-arm64)
+# Where python.org installs interpreters, as a pattern: the win-arm64 ones get a `-arm64`
+# directory suffix, which belongs in the paths but must not leak into the version numbers.
+# Substitute `3%` for what each use needs - `3*` to glob, `@XY@` for the compiler flags.
+PYTHON_DIR := $(localappdata)/Programs/Python/Python
+PYTHON_DIR_PATTERN := $(PYTHON_DIR)3%$(if $(filter arm64,$(MSVC_ARCH)),-arm64)
 ifneq ($(FOR_WHEEL),)
 # On Windows wheel we use all versions we can find in appdata.
-PYTHON_VERSIONS := $(patsubst $(localappdata)/Programs/Python/Python3%$(PYTHON_DIR_SUFFIX),3.%,$(filter $(localappdata)/Programs/Python/Python3%$(PYTHON_DIR_SUFFIX),$(wildcard $(localappdata)/Programs/Python/Python3*$(PYTHON_DIR_SUFFIX))))
+PYTHON_VERSIONS := $(patsubst $(PYTHON_DIR_PATTERN),3.%,$(filter $(PYTHON_DIR_PATTERN),$(wildcard $(subst 3%,3*,$(PYTHON_DIR_PATTERN)))))
 # with an empty suffix the glob also matches the suffixed dirs, so drop those
 PYTHON_VERSIONS := $(filter-out %-arm64 %-32,$(PYTHON_VERSIONS))
 else
@@ -387,8 +389,8 @@ PYTHON_CFLAGS :=
 PYTHON_LDFLAGS :=
 ifneq ($(and $(IS_WINDOWS),$(BUILD_SHIMS)),)
 # On Windows wheel, hardcode the flags to point to appdata.
-PYTHON_CFLAGS := -I$(localappdata)/Programs/Python/Python@XY@$(PYTHON_DIR_SUFFIX)/Include
-PYTHON_LDFLAGS := -L$(localappdata)/Programs/Python/Python@XY@$(PYTHON_DIR_SUFFIX)/libs -lpython@XY@
+PYTHON_CFLAGS := -I$(subst 3%,@XY@,$(PYTHON_DIR_PATTERN))/Include
+PYTHON_LDFLAGS := -L$(subst 3%,@XY@,$(PYTHON_DIR_PATTERN))/libs -lpython@XY@
 endif
 
 ifeq ($(PYTHON_CFLAGS)$(PYTHON_LDFLAGS),) # If no custom flags are specified...

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -345,9 +345,14 @@ $(info MODE: $(MODE))
 # When setting this manually, both spaces and commas work as separators.
 ifneq ($(IS_WINDOWS),)
 override localappdata := $(subst \,/,$(LOCALAPPDATA))
+# python.org installs win-arm64 Pythons into suffixed directories (`Python311-arm64`),
+# so the suffix belongs in the paths but must not leak into the version numbers.
+PYTHON_DIR_SUFFIX := $(if $(filter arm64,$(MSVC_ARCH)),-arm64)
 ifneq ($(FOR_WHEEL),)
 # On Windows wheel we use all versions we can find in appdata.
-PYTHON_VERSIONS := $(patsubst $(localappdata)/Programs/Python/Python3%,3.%,$(filter $(localappdata)/Programs/Python/Python3%,$(wildcard $(localappdata)/Programs/Python/Python3*)))
+PYTHON_VERSIONS := $(patsubst $(localappdata)/Programs/Python/Python3%$(PYTHON_DIR_SUFFIX),3.%,$(filter $(localappdata)/Programs/Python/Python3%$(PYTHON_DIR_SUFFIX),$(wildcard $(localappdata)/Programs/Python/Python3*$(PYTHON_DIR_SUFFIX))))
+# with an empty suffix the glob also matches the suffixed dirs, so drop those
+PYTHON_VERSIONS := $(filter-out %-arm64 %-32,$(PYTHON_VERSIONS))
 else
 # On Windows non-wheel we detect only one version by default, the one in pkg-config.
 PYTHON_VERSIONS := $(patsubst python-%-embed,%,$(basename $(notdir $(lastword $(sort $(wildcard $(DEPS_BASE_DIR)/lib/pkgconfig/python-*-embed.pc))))))
@@ -382,8 +387,8 @@ PYTHON_CFLAGS :=
 PYTHON_LDFLAGS :=
 ifneq ($(and $(IS_WINDOWS),$(BUILD_SHIMS)),)
 # On Windows wheel, hardcode the flags to point to appdata.
-PYTHON_CFLAGS := -I$(localappdata)/Programs/Python/Python@XY@/Include
-PYTHON_LDFLAGS := -L$(localappdata)/Programs/Python/Python@XY@/libs -lpython@XY@
+PYTHON_CFLAGS := -I$(localappdata)/Programs/Python/Python@XY@$(PYTHON_DIR_SUFFIX)/Include
+PYTHON_LDFLAGS := -L$(localappdata)/Programs/Python/Python@XY@$(PYTHON_DIR_SUFFIX)/libs -lpython@XY@
 endif
 
 ifeq ($(PYTHON_CFLAGS)$(PYTHON_LDFLAGS),) # If no custom flags are specified...

--- a/scripts/run_python_test_script.py
+++ b/scripts/run_python_test_script.py
@@ -54,10 +54,21 @@ if args.cmd:
     python_cmds = [str(args.cmd).strip()]
 elif args.multi_cmd:
     with open(os.path.dirname(os.path.realpath(__file__)) + "/mrbind-pybind11/python_versions.txt") as file:
-        if platform.system() == "Windows":
-            python_cmds = ["py -" + line.rstrip() for line in file]
-        else:
-            python_cmds = ["python" + line.rstrip() for line in file]
+        versions = [line.rstrip() for line in file if line.strip()]
+    if platform.system() == "Windows":
+        # Not every listed version exists on every host: python.org ships no win-arm64
+        # installer before 3.11, so ask the launcher which ones are actually here.
+        installed = []
+        for v in versions:
+            probe = subprocess.run(f"py -{v} --version", shell=True,
+                                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if probe.returncode == 0:
+                installed.append(v)
+            else:
+                print(f"Python {v} is not installed, skipping")
+        python_cmds = ["py -" + v for v in installed]
+    else:
+        python_cmds = ["python" + v for v in versions]
 
 directory = os.getcwd()
 try:

--- a/scripts/wheel/build_constants.py
+++ b/scripts/wheel/build_constants.py
@@ -3,6 +3,10 @@ from pathlib import Path
 
 SYSTEM = platform.system()
 
+# Windows output dirs are named after the target architecture; the building
+# interpreter is native, so its own machine tells us which one.
+WIN_ARCH = "arm64" if platform.machine().lower() in ("arm64", "aarch64") else "x64"
+
 MODULES = [
     "mrmeshpy",
     "mrmeshnumpy",
@@ -24,6 +28,6 @@ LIB_EXTENSION = {
 LIB_DIR = {
     'Darwin': SOURCE_DIR / "build" / "Release" / "bin",
     'Linux': SOURCE_DIR / "build" / "Release" / "bin",
-    'Windows': SOURCE_DIR / "source" / "x64" / "Release",
+    'Windows': SOURCE_DIR / "source" / WIN_ARCH / "Release",
 }[SYSTEM]
 LIB_DIR_MESHLIB = LIB_DIR / "meshlib"

--- a/scripts/wheel/setup_workspace.py
+++ b/scripts/wheel/setup_workspace.py
@@ -8,7 +8,11 @@ WHEEL_SRC_DIR = os.path.join(os.getcwd(), "scripts/wheel/meshlib/meshlib/")
 WHEEL_ROOT_DIR = os.path.join(os.getcwd(), "scripts/wheel/meshlib/")
 WHEEL_SCRIPT_DIR = os.path.join(os.getcwd(), "scripts/wheel/")
 
-PYLIB_PATH = {"Windows": r'./source/x64/Release/*.pyd',
+# Windows output dirs are named after the target architecture; the building
+# interpreter is native, so its own machine tells us which one.
+WIN_ARCH = "arm64" if platform.machine().lower() in ("arm64", "aarch64") else "x64"
+
+PYLIB_PATH = {"Windows": f'./source/{WIN_ARCH}/Release/*.pyd',
               "Linux": r'./build/Release/bin/meshlib/mr*.so',
               "Darwin": r'./build/Release/bin/meshlib/mr*.so'}
 


### PR DESCRIPTION
`windows-pip-build` becomes a matrix over `x64` and `arm64`, producing a **`win-arm64`** wheel
alongside `win-amd64`, and `windows-pip-test` gains an arm64 runner so the wheel is installed
and pytest-ed there rather than only built.

## Python is the one real limit

python.org publishes win-arm64 installers only from **3.11** on — verified against the FTP
listings:

```
3.8.10   python-3.8.10-amd64.exe
3.9.13   python-3.9.13-amd64.exe
3.10.11  python-3.10.11-amd64.exe
3.11.9   python-3.11.9-amd64.exe  python-3.11.9-arm64.exe
3.12.10  ...-amd64.exe  ...-arm64.exe
3.13.7   ...-amd64.exe  ...-arm64.exe
3.14.0   ...-amd64.exe  ...-arm64.exe
```

So the arm64 wheel covers **3.11–3.14** while x64 keeps 3.8–3.14. Nothing can be done about
3.8–3.10 there: those interpreters do not exist for the platform.

## Changes

* **`install_all_python_versions_windows.bat`** takes the installer architecture from
  `PROCESSOR_ARCHITECTURE` (overridable via `PY_ARCH`) for both the download URL and the local
  filename, and filters pre-3.11 entries out of the version list when installing arm64 ones.
* **`run_python_test_script.py -multi-cmd`** asked the `py` launcher for every version in
  `python_versions.txt` and would fail on the three that cannot exist on arm64. It now probes
  which are actually installed and skips the rest — useful on any partially-provisioned host,
  not just arm64.
* **`build_constants.py`** and **`setup_workspace.py`** derive the Windows output directory
  from `platform.machine()`. The interpreter building the wheel is native, so it knows.
* **The arm64 leg** skips both CUDA steps (no toolkit exists for the platform), builds the
  solution with `-p:Platform=ARM64`, uses the CLANGARM64 MSYS2 set for mrbind, and asks
  `setup-msbuild` for the arm64 MSBuild so the VC props select the native host compiler.
* **Artifacts** become `Windows-x64` and `Windows-arm64`; the three publishing jobs already
  glob `Macos-*` and `ManyLinux-*`, so their `pattern: Windows` becomes `Windows-*` and picks
  up both.

`mrcudapy` still ships in the arm64 wheel: `generate.mk` emits it as a dummy module whose
`isCudaAvailable()` returns false when CUDA is off, exactly as the macOS wheels have always
done.

## Testing

Needs the `test-pip-build` label to run here, which is set. Untested on arm64 hardware
otherwise — the likeliest rough edges are the batch installer changes, which I could not
exercise locally.
