### PR TITLE
macOS: link the bindings with our own PGO ld64.lld

### DIFF
--- a/.github/actions/install-llvm-pgo-keg/action.yml
+++ b/.github/actions/install-llvm-pgo-keg/action.yml
@@ -1,9 +1,9 @@
 name: Install the llvm-pgo keg
 description: >
-  Fetch the PGO-optimized LLVM keg for this runner's architecture from
-  MeshInspector/toolchains releases and extract it into the homebrew Cellar.
-  No-op when the keg is already present under this machine's brew prefix
-  (self-hosted runners build it locally, including non-standard prefixes).
+  Fetch the PGO-optimized LLVM keg and the PGO ld64.lld for this runner's
+  architecture from MeshInspector/toolchains releases and put them into the
+  homebrew Cellar. Each half is a no-op when the machine already has it
+  (self-hosted runners carry both, including under non-standard prefixes).
 
 runs:
   using: composite
@@ -34,3 +34,30 @@ runs:
         ln -sfn ../Cellar/llvm-pgo/22.1.8_2 "$BP/opt/llvm-pgo"
         brew install --quiet zstd xz
         "$KEG/bin/clang++" --version | head -n1
+
+    - name: Install the PGO ld64.lld into the keg
+      shell: bash
+      run: |
+        KEG="$(brew --prefix)/Cellar/llvm-pgo/22.1.8_2"
+        # Homebrew has no `lld` bottle for Intel macOS since it became a Tier 3
+        # configuration, and brew's llvm@22 carries no ld64.lld either, so the linker
+        # comes from our own release. Next to clang++, which resolves `-fuse-ld=lld`
+        # in its own directory before PATH.
+        if [[ -x "$KEG/bin/ld64.lld" ]]; then
+          echo "ld64.lld already in the keg"
+        else
+          if [[ "$(uname -m)" == "arm64" ]]; then
+            ASSET=ld64.lld-22.1.8-pgo.arm64-macos13
+            SHA=8abf0ba324dea357ae4fbd8baee835353b560f62e9b1d001588a6df888755550
+          else
+            ASSET=ld64.lld-22.1.8-pgo.x86_64-macos12
+            SHA=8c329488b4f53141933d9688eb01311f84fa1df0937098f0b50620a0fb989311
+          fi
+          curl -fsSL -o /tmp/ld64.lld "https://github.com/MeshInspector/toolchains/releases/download/lld-22.1.8-pgo-macos/$ASSET"
+          echo "$SHA  /tmp/ld64.lld" | shasum -a 256 -c -
+          chmod +x /tmp/ld64.lld
+          mv -f /tmp/ld64.lld "$KEG/bin/ld64.lld"
+        fi
+        RESOLVED="$("$KEG/bin/clang++" -print-prog-name=ld64.lld)"
+        [[ "$RESOLVED" == "$KEG/bin/ld64.lld" ]] || { echo "clang resolves ld64.lld to $RESOLVED" >&2; exit 1; }
+        "$RESOLVED" --version

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -675,22 +675,7 @@ endif # TARGETING_EMSCRIPTEN
 
 
 
-# lld is used wherever it exists, as on the other platforms. There is no Homebrew bottle of
-# `lld` for Intel macOS since that became a Tier 3 configuration, so fall back to Apple's `ld`
-# when ld64.lld is absent; it consumes our ThinLTO bitcode via the `libLTO.dylib` that Clang
-# passes to it in `-lto_library`, and it linked the bindings no slower than lld on the CI
-# runners. Only macOS is probed, the other platforms always have lld next to Clang.
-LLD_FLAG := -fuse-ld=lld
-ifneq ($(IS_MACOS),)
-# Ask Clang itself: it looks for ld64.lld in its own directory and then in PATH,
-# and prints the bare name back when it finds nothing.
-ifeq ($(filter /%,$(shell $(CXX_FOR_BINDINGS) -print-prog-name=ld64.lld 2>/dev/null)),)
-$(info Found no ld64.lld, linking the bindings with the default linker)
-LLD_FLAG :=
-endif
-endif
-
-LINKER := $(CXX_FOR_BINDINGS) $(LLD_FLAG)
+LINKER := $(CXX_FOR_BINDINGS) -fuse-ld=lld
 # Unsure if `-dynamiclib` vs `-shared` makes any difference on MacOS. I'm using the former because that's what CMake does.
 # No $(PYTHON_LDFLAGS) here, that's only for our patched Pybind library.
 LINKER_FLAGS := $(EXTRA_LDFLAGS) $(if $(DEPS_LIB_DIR),-L$(DEPS_LIB_DIR)) $(if $(DEPS_BASE_DIR),-L$(DEPS_BASE_DIR)/lib) -L$(MESHLIB_SHLIB_DIR) $(if $(is_py),-lMRPython) $(if $(IS_MACOS),-dynamiclib,-shared) $(call load_file,$(makefile_dir)linker_flags.txt)

--- a/scripts/mrbind/install_deps_macos.sh
+++ b/scripts/mrbind/install_deps_macos.sh
@@ -7,19 +7,18 @@
 brew update
 brew install --quiet make grep
 
-# `lld` links the bindings on the other platforms too, but Homebrew has no bottle of it
-# for Intel macOS since that became a Tier 3 configuration, and building it from source
-# means building LLVM. Install it where it is bottled; `generate.mk` detects its absence.
-if [[ "$(uname -m)" == "arm64" ]] ; then
-  brew install --quiet lld
+# Nothing LLVM is installed from brew: the compiler and the linker both come from the
+# llvm-pgo keg of https://github.com/MeshInspector/toolchains. Homebrew has no `lld`
+# bottle for Intel macOS since it became a Tier 3 configuration, and its `llvm@N` builds
+# clang;clang-tools-extra;mlir;polly, so it contains no ld64.lld to fall back on either.
+if [[ -z "${LLVM_PREFIX}" ]] ; then
+  echo "LLVM_PREFIX is unset: install the llvm-pgo keg (see the toolchains repo) and" >&2
+  echo "point LLVM_PREFIX at it, e.g. \$(brew --prefix)/Cellar/llvm-pgo/22.1.8_2" >&2
+  exit 1
 fi
 
-if [[ -z "${LLVM_PREFIX}" ]] ; then
-  # Read the Clang version from `clang_version_macos.txt`. `xargs` trims the whitespace.
-  # Some versions of MacOS seem to lack `realpath`, so not using it here.
-  SCRIPT_DIR="$(dirname "$BASH_SOURCE")"
-  CLANG_VER="$(cat $SCRIPT_DIR/clang_version_macos.txt | xargs)"
-  [[ $CLANG_VER ]] || (echo "Not sure what version of Clang to use." && false)
-
-  brew install --quiet llvm@$CLANG_VER
+if [[ ! -x "${LLVM_PREFIX}/bin/ld64.lld" ]] ; then
+  echo "no ld64.lld in ${LLVM_PREFIX}/bin: the bindings are linked with lld, install it" >&2
+  echo "from the lld-22.1.8-pgo-macos release of the toolchains repo" >&2
+  exit 1
 fi


### PR DESCRIPTION
Puts our own PGO `ld64.lld` behind every macOS bindings link, and reverts the workaround that #6716 needed while there was no such linker to install.

### The four pieces

**1. Reverts #6716.** `generate.mk` goes back to the plain

```make
LINKER := $(CXX_FOR_BINDINGS) -fuse-ld=lld
```

The probe that dropped the flag when `ld64.lld` was missing existed only because the Intel runners had no lld at all; after this PR every macOS runner has one next to Clang, so there is nothing to probe for.

**2. Nothing LLVM is installed from brew.** `install_deps_macos.sh` drops both `brew install lld` and the `brew install llvm@$CLANG_VER` fallback. Neither can serve us any more: Homebrew stopped bottling `lld` for Intel macOS when it became a Tier 3 configuration, and `llvm@22` builds `clang;clang-tools-extra;mlir;polly`, i.e. no `ld64.lld` either. The script now fails with a clear message when `LLVM_PREFIX` or the linker is absent, instead of quietly pulling in a brew toolchain. Only `make` and `grep` still come from brew.

Every caller already sets `LLVM_PREFIX` to the keg — all three legs of `build-test-macos.yml` and both of `pip-build.yml`'s `macos-pip-build`, which are the only two places that run this script — so nothing loses its compiler.

**3. Self-hosted runners use the preinstalled linker.** All three of our macOS machines already carry the PGO `ld64.lld` in their own keg, installed once by [toolchains#1](https://github.com/MeshInspector/toolchains/pull/1); the action detects it and downloads nothing, exactly as it already does for the keg itself.

**4. Hosted runners fetch it.** The keg action gained a second step that installs `ld64.lld-22.1.8-pgo.{x86_64-macos12,arm64-macos13}` from the [lld-22.1.8-pgo-macos](https://github.com/MeshInspector/toolchains/releases/tag/lld-22.1.8-pgo-macos) release into `$KEG/bin`, checksum-verified. It then asserts that `clang++ -print-prog-name=ld64.lld` really resolves inside the keg, so a silent fallback to a Homebrew linker fails the job rather than the build 20 minutes later.

The binaries are built for macOS 12.0 (Intel) and 13.0 (arm64) and were verified linking on hosted `macos-15-intel`, `macos-26-intel` and `macos-15`.

### Why bother

Measured on the real `mrmeshpy.so` ThinLTO link in MeshInspector CI, min of 3, against the Homebrew `lld` each machine had:

| runner | before | after |
| --- | --- | --- |
| Mac Pro 2013, macOS 12, x86_64 | 164.0 s | **115.4 s** (-30%) |
| MacBook Pro M1 Pro, macOS 13, arm64 | 47.8 s | **36.0 s** (-25%) |

Ordinary dylib links of 0.1-0.4 s show no difference; the gain is in ThinLTO codegen, which is what the profile was trained on. The recipe and the numbers are documented in the toolchains README.

Windows, Ubuntu and Emscripten are disabled by label: this touches a macOS-only action, a macOS-only script, and one line of `generate.mk` that is restored to what those platforms have been building with all along.
