### PR TITLE
[BENCH, do not merge] Measure -fomit-frame-pointer and --icf=all on the macOS bindings

### DIFF
--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -211,6 +211,43 @@ jobs:
             PYTHON_PKGCONF_NAME=python-3.10-embed \
             MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin
 
+      # TEMPORARY, not for merge: -Oz already leaves no alignment padding, so these two are
+      # the size levers left for the bindings. --icf=all is link-only and reuses the objects
+      # just built; -fomit-frame-pointer is a compile flag, so its fragments are rebuilt.
+      - name: Measure the size levers
+        if: ${{ inputs.mrbind }}
+        env:
+          PATH: ${{ steps.thirdparty.outputs.brew-prefix }}/opt/make/libexec/gnubin:${{ steps.thirdparty.outputs.brew-prefix }}/opt/grep/libexec/gnubin:${{env.PATH}}
+          CXX: ${{ steps.thirdparty.outputs.cxx-compiler }}
+        run: |
+          target=build/${{matrix.config}}/bin/meshlib/mrmeshpy.so
+          MK="make -f scripts/mrbind/generate.mk PYTHON_PKGCONF_NAME=python-3.10-embed MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin"
+          report() # $1 = label
+          {
+            printf '%-26s %12s bytes   __text %12s\n' "$1" \
+              "$( stat -f%z "$target" )" "$( size -m "$target" | awk '/Section __text/ { print $3 }' )"
+          }
+          link_cmd() # $@ = extra make variables; prints the link recipe of the target
+          {
+            rm -f "$target"
+            $MK "$@" -n "$target" | grep -E 'clang\+\+.* -o .*mrmeshpy\.so' | tail -n 1
+          }
+
+          report "baseline (as built)"
+
+          cmd="$( link_cmd )"
+          [[ -n "$cmd" ]] || { echo "no link command found" >&2 ; exit 1 ; }
+          bash -c "$cmd -Wl,--icf=all"
+          report "--icf=all"
+
+          rm -f build/binds_python/mrmesh.fragment.*.o "$target"
+          $MK EXTRA_CFLAGS=-fomit-frame-pointer "$target" -j"$( sysctl -n hw.logicalcpu )"
+          report "-fomit-frame-pointer"
+
+          cmd="$( link_cmd EXTRA_CFLAGS=-fomit-frame-pointer )"
+          bash -c "$cmd -Wl,--icf=all"
+          report "both"
+
       - name: Run Start-and-Exit Tests
         timeout-minutes: 3
         run: ./build/${{ matrix.config }}/bin/MeshViewer -tryHidden -noEventLoop -unloadPluginsAtEnd

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -212,41 +212,60 @@ jobs:
             MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin
 
       # TEMPORARY, not for merge: -Oz already leaves no alignment padding, so these two are
-      # the size levers left for the bindings. --icf=all is link-only and reuses the objects
-      # just built; -fomit-frame-pointer is a compile flag, so its fragments are rebuilt.
-      - name: Measure the size levers
+      # the size levers left for the bindings. Each variant is both measured and exercised by
+      # the Python sanity suite, because a smaller module that cannot unwind is worthless.
+      # The baseline module is restored afterwards, so the rest of the job is unaffected.
+      - name: Measure and test the size levers
         if: ${{ inputs.mrbind }}
         env:
           PATH: ${{ steps.thirdparty.outputs.brew-prefix }}/opt/make/libexec/gnubin:${{ steps.thirdparty.outputs.brew-prefix }}/opt/grep/libexec/gnubin:${{env.PATH}}
           CXX: ${{ steps.thirdparty.outputs.cxx-compiler }}
         run: |
-          target=build/${{matrix.config}}/bin/meshlib/mrmeshpy.so
-          MK="make -f scripts/mrbind/generate.mk PYTHON_PKGCONF_NAME=python-3.10-embed MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin"
-          report() # $1 = label
-          {
-            printf '%-26s %12s bytes   __text %12s\n' "$1" \
-              "$( stat -f%z "$target" )" "$( size -m "$target" | awk '/Section __text/ { print $3 }' )"
-          }
+          bin=build/${{matrix.config}}/bin
+          target=$bin/meshlib/mrmeshpy.so
+          MK="make -f scripts/mrbind/generate.mk PYTHON_PKGCONF_NAME=python-3.10-embed MESHLIB_SHLIB_DIR=$bin"
+          cp "$target" /tmp/baseline-mrmeshpy.so
+          results=""
+
           link_cmd() # $@ = extra make variables; prints the link recipe of the target
           {
             rm -f "$target"
             $MK "$@" -n "$target" | grep -E 'clang\+\+.* -o .*mrmeshpy\.so' | tail -n 1
           }
+          check() # $1 = label; the module to test is already in place
+          {
+            local size text verdict
+            size="$( stat -f%z "$target" )"
+            text="$( size -m "$target" | awk '/Section __text/ { print $3 }' )"
+            if ( cd "$bin" && python3 -u ./../../../scripts/run_python_test_script.py -d '../test_python' ) \
+                 > /tmp/pytest-$1.log 2>&1 ; then
+              verdict=pass
+            else
+              verdict=FAIL
+              echo "=== $1 failed the sanity suite:"
+              grep -aE "uncaught exception|Fatal Python error|ERROR|assert" /tmp/pytest-$1.log | head -n 5
+            fi
+            results="$results$( printf '%-22s %12s bytes  __text %12s  sanity %s\n' "$1" "$size" "$text" "$verdict" )"$'\n'
+          }
 
-          report "baseline (as built)"
+          check "baseline"
 
           cmd="$( link_cmd )"
           [[ -n "$cmd" ]] || { echo "no link command found" >&2 ; exit 1 ; }
           bash -c "$cmd -Wl,--icf=all"
-          report "--icf=all"
+          check "icf"
 
           rm -f build/binds_python/mrmesh.fragment.*.o "$target"
           $MK EXTRA_CFLAGS=-fomit-frame-pointer "$target" -j"$( sysctl -n hw.logicalcpu )"
-          report "-fomit-frame-pointer"
+          check "omit-frame-pointer"
 
           cmd="$( link_cmd EXTRA_CFLAGS=-fomit-frame-pointer )"
           bash -c "$cmd -Wl,--icf=all"
-          report "both"
+          check "both"
+
+          cp /tmp/baseline-mrmeshpy.so "$target"   # the rest of the job tests what we ship
+          echo "=== ${{matrix.arch}} ${{matrix.config}}"
+          printf '%s' "$results"
 
       - name: Run Start-and-Exit Tests
         timeout-minutes: 3

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -278,6 +278,38 @@ jobs:
           call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
           call ./scripts/mrbind/generate_win.bat -B --trace MODE=none VS_MODE=${{matrix.config}} || exit /b 1
 
+      # TEMPORARY, not for merge: the bindings link with lld here too (clang64/MinGW driver,
+      # so GNU-style flags), and --icf=all is measured on macOS in the same PR. Windows builds
+      # them with MODE=none, i.e. no -Oz and no ThinLTO, so this is ICF on its own.
+      - name: Measure ICF on the bindings
+        if: ${{ inputs.mrbind && matrix.vcpkg_triplet != 'x64-windows-meshlib-iterator-debug' }}
+        shell: pwsh
+        env:
+          MSYS2_DIR: C:\msys64
+        run: |
+          $bin = "source\${{ env.MR_ARCH }}\${{ matrix.config }}"
+          $pyd = "$bin\meshlib\mrmeshpy.pyd"
+          Copy-Item $pyd "$env:RUNNER_TEMP\baseline-mrmeshpy.pyd" -Force
+          function Sanity {
+            Push-Location $bin
+            py -3 -u ..\..\..\scripts\run_python_test_script.py -d '..\test_python' > "$env:RUNNER_TEMP\sanity.log" 2>&1
+            $ok = $LASTEXITCODE -eq 0
+            Pop-Location
+            if ( -not $ok ) { Select-String -Path "$env:RUNNER_TEMP\sanity.log" -Pattern 'error|Error|assert' | Select-Object -First 5 }
+            return $( if ( $ok ) { 'pass' } else { 'FAIL' } )
+          }
+          $rows = @()
+          $rows += '{0,-12} {1,12:N0} bytes  sanity {2}' -f 'baseline', (Get-Item $pyd).Length, (Sanity)
+
+          Remove-Item -Force $pyd
+          cmd /c 'call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} && call .\scripts\mrbind\generate_win.bat --trace MODE=none VS_MODE=${{matrix.config}} EXTRA_LDFLAGS=-Wl,--icf=all'
+          if ( $LASTEXITCODE -ne 0 ) { throw 'the --icf=all link failed' }
+          $rows += '{0,-12} {1,12:N0} bytes  sanity {2}' -f '--icf=all', (Get-Item $pyd).Length, (Sanity)
+
+          Copy-Item "$env:RUNNER_TEMP\baseline-mrmeshpy.pyd" $pyd -Force   # the rest of the job tests what we ship
+          Write-Host "=== ${{ env.MR_ARCH }} ${{ matrix.config }}"
+          $rows | ForEach-Object { Write-Host $_ }
+
       - name: Diagnostic — output bin DLL inventory + MRMesh imports
         if: ${{ always() }}
         shell: pwsh


### PR DESCRIPTION
**Benchmark only, not for merge.** Measures the two size levers that are left for the bindings after `-Oz` and ThinLTO, on the macOS legs.

Why these two, and not the usual suspects: I scanned the published `mrmeshpy.so` of 3.1.3.429 and `-Oz` already leaves **477 bytes** of alignment padding in a 34.7 MB `__text`, so `-falign-functions` and friends have nothing to recover. What the scan did find is **202,218** `push rbp; mov rbp,rsp` prologues in the macOS x86_64 build against **3** in the Linux one — Apple's Clang keeps frame pointers on x86-64, Linux Clang omits them at `-O2`+ — worth roughly 1.2 MB with the epilogues, plus whatever freeing `rbp` saves in spills.

`--icf=all` is [restricted to Linux](https://github.com/MeshInspector/MeshLib/blob/master/scripts/mrbind/generate.mk#L331) with the note "until lld-link (Windows) and ld64.lld (macOS) get their own measurements", where it removed 11% of the module. This is that measurement for macOS.

The step prints file size and `__text` for four variants:

| variant | how |
| --- | --- |
| baseline | the module the job just built |
| `--icf=all` | re-link of the same objects, link-only flag |
| `-fomit-frame-pointer` | fragments recompiled, then linked |
| both | re-link of those fragments with ICF |

Only one recompile round is needed, so this adds roughly 15-25 min per macOS leg. Every non-macOS platform is disabled by label. I will close this PR and delete the branch once the numbers are in.

Note that neither flag touches the actual x86-64 vs arm64 gap (`__text` 34.7 MB vs 21.4 MB on macOS, 34.4 vs 21.9 on Linux) — that is instruction encoding and register count, and no flag fixes it.
