### PR TITLE
meshToDensePointCloud: sample the faces in rows, and let every edge cover itself

### DIFF
--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -64,10 +64,7 @@ enum FaceKind
 /// how a face is sampled, in one word: the patterns above never apply together, so a single
 /// number serves them all, and 28 bits hold more parts than divsForStep can ever return.
 /// The fields have no initializers on purpose: that would make the type not trivially
-/// constructible, and Buffer would then construct every element instead of only allocating,
-/// touching the whole array in one thread before the parallel passes below get to it - 2.9 ms
-/// against 3.2 at radius 0.2 on a mesh of 169k faces, and 2.3 against 3.0 at radius 0.5.
-/// Every field is set right where a layout is made, including on the paths that return early
+/// constructible, and Buffer would then construct every element instead of only allocating
 struct FaceLayout
 {
     unsigned base : 2; ///< local index of the longest edge, going from v[base] to v[(base+1)%3]

--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -54,15 +54,22 @@ int ceilPow2Sq( float aSq, float bSq )
 
 /// how a face is sampled: by a grid of triangles similar to it, or in rows parallel to its longest
 /// edge, or by the samples of that edge alone, whichever of the three costs the fewest samples
+/// what covers a face, one way or another; the four are mutually exclusive
+enum FaceKind
+{
+    fkVertices, ///< its own three vertices, so it needs no samples at all
+    fkGrid,     ///< a grid of triangles similar to it, with `divs` parts of every side
+    fkEdge,     ///< the samples of its longest edge, which it asks to divide in `divs` parts
+    fkRows      ///< rows parallel to its longest edge, laid out where they are needed
+};
+
+/// how a face is sampled, in one word: the patterns above never apply together, so a single
+/// number serves them all, and 28 bits hold more parts than divsForStep can ever return
 struct FaceLayout
 {
-    int base;   ///< local index of the longest edge, going from v[base] to v[(base+1)%3]
-    int grid;   ///< in how many parts every side is divided for a grid; zero if it is not a grid
-    int wants;  ///< in how many parts the face wants its longest edge; zero if it does not care
-    bool rows;  ///< the face is sampled in rows parallel to its longest edge
-
-    /// the three vertices alone cover such a face, and it needs no samples of any kind
-    [[nodiscard]] bool covered() const { return grid <= 0 && wants <= 0 && !rows; }
+    unsigned base : 2; ///< local index of the longest edge, going from v[base] to v[(base+1)%3]
+    unsigned kind : 2; ///< one of FaceKind
+    unsigned divs : 28;///< the number of parts fkGrid and fkEdge need; unused by the others
 };
 
 /// the samples within a row are this far from each other, on every face
@@ -114,7 +121,7 @@ int numRowSamples( const RowLayout & l, float baseLen, float radius )
 /// chooses how a face is sampled, and what it needs of its longest edge
 FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
 {
-    FaceLayout res{ 0, 0, 0, false };
+    FaceLayout res{ 0, fkVertices, 0 };
     // no point of a triangle is farther from the nearest vertex than the covering radius, and the
     // minimal enclosing circle bounds that radius from above and is cheaper to find
     if ( mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq )
@@ -158,16 +165,25 @@ FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
         rowsCost += selfDivs[i] - 1;
 
     if ( stripCost <= rowsCost && stripCost <= gridCost )
-        res.wants = wants;
+    {
+        res.kind = fkEdge;
+        res.divs = wants;
+    }
     else if ( gridCost < rowsCost )
-        res.grid = grid;
+    {
+        res.kind = fkGrid;
+        res.divs = grid;
+    }
     else if ( rowLayout.num > 0 )
-        res.rows = true;
+        res.kind = fkRows;
     else
+    {
         // the rows are the cheapest and there are none of them: the samples of the longest edge
         // already cover the face, but it has to ask for them, or it will look covered by its
         // vertices and that edge will not be divided at all
-        res.wants = divsForStep( baseLen, 2 * radius );
+        res.kind = fkEdge;
+        res.divs = divsForStep( baseLen, 2 * radius );
+    }
     return res;
 }
 
@@ -210,17 +226,17 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
             if ( !f || !( wholeMesh || faces.test( f ) ) )
                 continue;
             const auto & l = layouts[f];
-            if ( l.covered() )
+            if ( l.kind == fkVertices )
                 continue;
             EdgeId es[3];
             topology.getTriEdges( f, es );
             const bool isBase = es[l.base].undirected() == ue;
-            if ( l.grid > 0 )
-                gridAsk = std::max( gridAsk, l.grid );
-            else if ( l.rows || isBase ) // the rows rely on all three edges covering themselves
+            if ( l.kind == fkGrid )
+                gridAsk = std::max( gridAsk, int( l.divs ) );
+            else if ( l.kind == fkRows || isBase ) // the rows rely on all three edges covering themselves
                 plainAsk = std::max( plainAsk, divsForStep( mesh.edgeLength( ue ), 2 * radius ) );
-            if ( isBase )
-                plainAsk = std::max( plainAsk, l.wants );
+            if ( isBase && l.kind == fkEdge )
+                plainAsk = std::max( plainAsk, int( l.divs ) );
         }
         if ( gridAsk <= 0 )
             edgeDivs[ue] = plainAsk;
@@ -245,13 +261,14 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
     if ( !BitSetParallelFor( faces, [&]( FaceId f )
     {
         const auto & l = layouts[f];
-        if ( l.grid > 0 )
+        if ( l.kind == fkGrid )
         {
-            faceSamples[f] = ( l.grid - 1 ) * ( l.grid - 2 ) / 2;
+            const int divs = l.divs;
+            faceSamples[f] = ( divs - 1 ) * ( divs - 2 ) / 2;
             return;
         }
         faceSamples[f] = 0;
-        if ( !l.rows )
+        if ( l.kind != fkRows )
             return; // nothing inside: the vertices or the longest edge alone cover this face
         Vector3f v[3];
         mesh.getTriPoints( f, v );
@@ -328,9 +345,9 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
                 n[i] = res.normals[ vs[i] ];
         }
         auto p = VertId( faceOffset[f] );
-        if ( l.grid > 0 )
+        if ( l.kind == fkGrid )
         {
-            const int divs = l.grid;
+            const int divs = l.divs;
             for ( int i = 1; i + 2 <= divs; ++i )
                 for ( int j = 1; i + j + 1 <= divs; ++j, ++p )
                 {
@@ -341,7 +358,7 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
                 }
             return;
         }
-        const int bi = l.base, bj = ( l.base + 1 ) % 3, bk = ( l.base + 2 ) % 3;
+        const int bi = l.base, bj = ( bi + 1 ) % 3, bk = ( bi + 2 ) % 3;
         float baseLen = 0;
         const auto rows = rowsOf( f, v, baseLen );
         for ( int i = 0; i < rows.num; ++i )

--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -44,6 +44,7 @@ struct FaceLayout
 {
     int base;      ///< local index of the longest edge, going from v[base] to v[(base+1)%3]
     int rows;      ///< the number of rows; zero if the longest edge alone covers the face
+    int wants;     ///< in how many parts this face wants its longest edge divided
     float first;   ///< the height of the first row over that edge
     float band;    ///< the distance between the rows
     float height;  ///< the height of the opposite vertex over that edge
@@ -51,9 +52,11 @@ struct FaceLayout
     bool covered;  ///< the three vertices alone cover the face, so it needs no samples at all
 };
 
-FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
+/// \param baseDivs in how many parts the longest edge is divided; zero on the first pass, when the
+/// face only tells in `wants` how many it would need for that edge to cover it alone
+FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq, int baseDivs = 0 )
 {
-    FaceLayout res{ 0, 0, 0, 0, 0, 0, false };
+    FaceLayout res{ 0, 0, 0, 0, 0, 0, 0, false };
     // no point of a triangle is farther from the nearest vertex than the covering radius, and the
     // minimal enclosing circle bounds that radius from above and is cheaper to find
     if ( mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq
@@ -79,9 +82,13 @@ FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
     const float baseLen = std::sqrt( baseLenSq );
     res.height = cross( v[1] - v[0], v[2] - v[0] ).length() / baseLen; // twice the area over the base
 
-    // no point of the base is farther than half a step from a sample of it, so those samples reach
-    // this far in the height; a face lower than that is covered by its longest edge alone
-    const float baseStep = baseLen / divsForStep( baseLen, 2 * radius );
+    // the samples of the base are not farther than half a step from any point of it and reach
+    // sqrt( radius^2 - (step/2)^2 ) in the height, so dividing it in this many parts makes the base
+    // alone cover the face; a face flat enough gets that for free from the step of 2*radius
+    if ( res.height < radius )
+        res.wants = divsForStep( baseLen, 2 * std::sqrt( radiusSq - res.height * res.height ) );
+
+    const float baseStep = baseLen / ( baseDivs > 0 ? baseDivs : divsForStep( baseLen, 2 * radius ) );
     res.first = std::sqrt( std::max( 0.0f, radiusSq - 0.25f * baseStep * baseStep ) );
     if ( res.height <= res.first )
         return res;
@@ -123,15 +130,23 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
     const auto [faceLayoutCb, edgeDivsCb, edgePointsCb, facePointsCb] = splitProgress( cb, 0.1f, 0.2f, 0.6f );
 
     Buffer<FaceLayout, FaceId> layouts( topology.faceSize() );
-    Buffer<int, FaceId> faceSamples( topology.faceSize() );
     if ( !BitSetParallelFor( faces, [&]( FaceId f )
     {
         Vector3f v[3];
         mesh.getTriPoints( f, v );
-        const auto l = layoutFace( v, radius, radiusSq );
+        auto l = layoutFace( v, radius, radiusSq );
+        const float baseLen = ( v[( l.base + 1 ) % 3] - v[l.base] ).length();
+        // asking the base for a finer division costs the samples it adds there, and saves all the
+        // rows; that trade is worth making only when the rows cost more
+        if ( l.rows > 0 && l.wants > 0 )
+        {
+            if ( l.wants - divsForStep( baseLen, 2 * radius ) < numFaceSamples( l, baseLen ) )
+                l.rows = 0; // the base will be divided finer, so no rows are needed at all, and
+                            // the other two edges of this face need no samples either
+            else
+                l.wants = 0;
+        }
         layouts[f] = l;
-        faceSamples[f] = l.rows <= 0 ? 0
-            : numFaceSamples( l, ( v[( l.base + 1 ) % 3] - v[l.base] ).length() );
     }, faceLayoutCb ) )
         return unexpectedOperationCanceled();
 
@@ -143,6 +158,7 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
     {
         const EdgeId e = ue;
         bool need = false;
+        int wanted = 0;
         for ( auto f : { topology.left( e ), topology.right( e ) } )
         {
             if ( !f || !( wholeMesh || faces.test( f ) ) )
@@ -150,18 +166,37 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
             const auto & l = layouts[f];
             if ( l.covered )
                 continue;
-            if ( l.rows > 0 )
+            EdgeId es[3];
+            topology.getTriEdges( f, es );
+            const bool isBase = es[l.base].undirected() == ue;
+            if ( l.rows > 0 || isBase )
                 need = true;
-            else
-            {
-                EdgeId es[3];
-                topology.getTriEdges( f, es );
-                if ( es[l.base].undirected() == ue )
-                    need = true;
-            }
+            if ( isBase )
+                wanted = std::max( wanted, l.wants ); // no divisibility here, so the maximum will do
         }
-        edgeDivs[ue] = need ? divsForStep( mesh.edgeLength( ue ), 2 * radius ) : 0;
+        edgeDivs[ue] = need
+            ? std::max( wanted, divsForStep( mesh.edgeLength( ue ), 2 * radius ) ) : 0;
     }, edgeDivsCb ) )
+        return unexpectedOperationCanceled();
+
+    // now that the edges are divided, a face may need fewer rows, or none at all
+    Buffer<int, FaceId> faceSamples( topology.faceSize() );
+    if ( !BitSetParallelFor( faces, [&]( FaceId f )
+    {
+        auto & l = layouts[f];
+        if ( l.covered )
+        {
+            faceSamples[f] = 0;
+            return;
+        }
+        Vector3f v[3];
+        mesh.getTriPoints( f, v );
+        EdgeId es[3];
+        topology.getTriEdges( f, es );
+        l = layoutFace( v, radius, radiusSq, edgeDivs[es[l.base].undirected()] );
+        faceSamples[f] = l.rows <= 0 ? 0
+            : numFaceSamples( l, ( v[( l.base + 1 ) % 3] - v[l.base] ).length() );
+    }, faceLayoutCb ) )
         return unexpectedOperationCanceled();
 
     // the samples of every edge and every face occupy a dedicated range in the resulting cloud;

--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -160,6 +160,11 @@ FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
         res.rows = 0;
         res.grid = grid;
     }
+    else if ( res.rows <= 0 )
+        // the rows are the cheapest and there are none of them: the samples of the longest edge
+        // already cover the face, but it has to ask for them, or it will look covered by its
+        // vertices and that edge will not be divided at all
+        res.wants = divsForStep( baseLen, 2 * radius );
     return res;
 }
 

--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -56,64 +56,65 @@ int ceilPow2Sq( float aSq, float bSq )
 /// edge, or by the samples of that edge alone, whichever of the three costs the fewest samples
 struct FaceLayout
 {
-    int base;      ///< local index of the longest edge, going from v[base] to v[(base+1)%3]
-    int grid;      ///< in how many parts every side is divided for a grid; zero if it is not a grid
-    int rows;      ///< the number of rows; zero if there are none
-    int wants;     ///< in how many parts the face wants its longest edge; zero if it does not care
-    float first;   ///< the height of the first row over the longest edge
-    float band;    ///< the distance between the rows
-    float height;  ///< the height of the opposite vertex over the longest edge
-    float step;    ///< the distance between the samples within a row
-    bool covered;  ///< the three vertices alone cover the face, so it needs no samples at all
+    int base;       ///< local index of the longest edge, going from v[base] to v[(base+1)%3]
+    int grid;       ///< in how many parts every side is divided for a grid; zero if not a grid
+    int rows;       ///< the number of rows parallel to the longest edge; zero if there are none
+    int wants;      ///< in how many parts the face wants its longest edge; zero if it does not care
+    float firstRow; ///< where the first row is, as a fraction of the height over the longest edge
+    float rowStep;  ///< the distance between the rows, as a fraction of that height
+
+    /// the three vertices alone cover such a face, and it needs no samples of any kind
+    [[nodiscard]] bool covered() const { return grid <= 0 && rows <= 0 && wants <= 0; }
 };
 
+/// the samples within a row are this far from each other, on every face
+float rowSampleStep( float radius )
+{
+    return radius * cSqrt2;
+}
+
 /// the number of samples inside a face sampled in rows
-int numRowSamples( const FaceLayout & l, float baseLen )
+int numRowSamples( const FaceLayout & l, float baseLen, float radius )
 {
     int res = 0;
     for ( int i = 0; i < l.rows; ++i )
     {
-        const float hf = ( l.first + i * l.band ) / l.height;
-        res += divsForStep( baseLen * ( 1 - hf ), l.step ) + 1;
+        const float hf = l.firstRow + i * l.rowStep;
+        res += divsForStep( baseLen * ( 1 - hf ), rowSampleStep( radius ) ) + 1;
     }
     return res;
 }
 
-/// lays out the rows parallel to the longest edge, given in how many parts that edge is divided
-void layoutRows( FaceLayout & res, float baseLen, float radius, float radiusSq, int baseDivs )
+/// lays out the rows parallel to the longest edge of a face, given the height over that edge and
+/// in how many parts it is divided
+void layoutRows( FaceLayout & res, float baseLen, float height, float radius, float radiusSq, int baseDivs )
 {
     res.rows = 0;
     // the samples of the base are not farther than half a step from any point of it, so they reach
     // sqrt( radius^2 - (step/2)^2 ) up in the height, and a face flatter than that needs no rows
     const float baseStep = baseLen / baseDivs;
-    res.first = std::sqrt( std::max( 0.0f, radiusSq - 0.25f * baseStep * baseStep ) );
-    if ( res.height <= res.first )
+    const float first = std::sqrt( std::max( 0.0f, radiusSq - 0.25f * baseStep * baseStep ) );
+    if ( height <= first )
         return;
     // a point above the rows is within a band from the row below it, which is never narrower than
     // the face is there, and within half a step along that row; sqrt(2)*radius along the row
     // against radius/sqrt(2) between the rows keeps both within the radius with the fewest samples
-    res.step = radius * cSqrt2;
-    res.rows = divsForStep( res.height - res.first, radius / cSqrt2 );
-    res.band = ( res.height - res.first ) / res.rows;
+    res.rows = divsForStep( height - first, radius / cSqrt2 );
+    res.firstRow = first / height;
+    res.rowStep = ( height - first ) / ( res.rows * height );
 }
 
 /// chooses how a face is sampled, and what it needs of its longest edge
 FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
 {
-    FaceLayout res{ 0, 0, 0, 0, 0, 0, 0, 0, false };
+    FaceLayout res{ 0, 0, 0, 0, 0, 0 };
     // no point of a triangle is farther from the nearest vertex than the covering radius, and the
     // minimal enclosing circle bounds that radius from above and is cheaper to find
     if ( mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq )
-    {
-        res.covered = true;
         return res;
-    }
     const auto coverSq = coveringRadiusSq( v[0], v[1], v[2] );
     if ( coverSq <= radiusSq )
-    {
-        res.covered = true;
         return res;
-    }
 
     // the longest edge is the base: the angles at its ends are acute, so every point of the face
     // projects on it inside it, and the sections parallel to it shrink towards the opposite vertex,
@@ -124,7 +125,7 @@ FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
         len[i] = ( v[( i + 1 ) % 3] - v[i] ).length();
     res.base = ( len[0] >= len[1] && len[0] >= len[2] ) ? 0 : ( len[1] >= len[2] ? 1 : 2 );
     const float baseLen = len[res.base];
-    res.height = cross( v[1] - v[0], v[2] - v[0] ).length() / baseLen; // twice the area over the base
+    const float height = cross( v[1] - v[0], v[2] - v[0] ).length() / baseLen; // 2*area over the base
     for ( int i = 0; i < 3; ++i )
         selfDivs[i] = divsForStep( len[i], 2 * radius ); // enough for an edge to cover itself
 
@@ -138,14 +139,14 @@ FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
 
     // the samples of the base alone cover a face flatter than the radius, once it is divided finely
     int stripCost = std::numeric_limits<int>::max(), wants = 0;
-    if ( res.height < radius )
+    if ( height < radius )
     {
-        wants = divsForStep( baseLen, 2 * std::sqrt( radiusSq - res.height * res.height ) );
+        wants = divsForStep( baseLen, 2 * std::sqrt( radiusSq - height * height ) );
         stripCost = wants - 1;
     }
 
-    layoutRows( res, baseLen, radius, radiusSq, selfDivs[res.base] );
-    int rowsCost = 2 * numRowSamples( res, baseLen );
+    layoutRows( res, baseLen, height, radius, radiusSq, selfDivs[res.base] );
+    int rowsCost = 2 * numRowSamples( res, baseLen, radius );
     for ( int i = 0; i < 3; ++i )
         rowsCost += selfDivs[i] - 1;
 
@@ -201,7 +202,7 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
             if ( !f || !( wholeMesh || faces.test( f ) ) )
                 continue;
             const auto & l = layouts[f];
-            if ( l.covered )
+            if ( l.covered() )
                 continue;
             EdgeId es[3];
             topology.getTriEdges( f, es );
@@ -231,15 +232,16 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
             return;
         }
         faceSamples[f] = 0;
-        if ( l.covered || l.wants > 0 )
+        if ( l.covered() || l.wants > 0 )
             return; // nothing inside: the vertices or the longest edge alone cover this face
         Vector3f v[3];
         mesh.getTriPoints( f, v );
         EdgeId es[3];
         topology.getTriEdges( f, es );
         const float baseLen = ( v[( l.base + 1 ) % 3] - v[l.base] ).length();
-        layoutRows( l, baseLen, radius, radiusSq, edgeDivs[es[l.base].undirected()] );
-        faceSamples[f] = numRowSamples( l, baseLen );
+        const float height = cross( v[1] - v[0], v[2] - v[0] ).length() / baseLen;
+        layoutRows( l, baseLen, height, radius, radiusSq, edgeDivs[es[l.base].undirected()] );
+        faceSamples[f] = numRowSamples( l, baseLen, radius );
     }, samplesCb ) )
         return unexpectedOperationCanceled();
 
@@ -327,10 +329,10 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
         const float baseLen = ( v[bj] - v[bi] ).length();
         for ( int i = 0; i < l.rows; ++i )
         {
-            const float hf = ( l.first + i * l.band ) / l.height;
+            const float hf = l.firstRow + i * l.rowStep;
             const auto rowOrg = v[bi] + hf * ( v[bk] - v[bi] );
             const auto rowDest = v[bj] + hf * ( v[bk] - v[bj] );
-            const int divs = divsForStep( baseLen * ( 1 - hf ), l.step );
+            const int divs = divsForStep( baseLen * ( 1 - hf ), rowSampleStep( radius ) );
             for ( int j = 0; j <= divs; ++j, ++p )
             {
                 const float g = float( j ) / divs;

--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -62,16 +62,17 @@ enum FaceKind
 };
 
 /// how a face is sampled, in one word: the patterns above never apply together, so a single
-/// number serves them all, and 28 bits hold more parts than divsForStep can ever return
+/// number serves them all, and 28 bits hold more parts than divsForStep can ever return.
+/// The fields have no initializers on purpose: that would make the type not trivially
+/// constructible, and Buffer would then construct every element instead of only allocating,
+/// touching the whole array in one thread before the parallel passes below get to it - 2.9 ms
+/// against 3.2 at radius 0.2 on a mesh of 169k faces, and 2.3 against 3.0 at radius 0.5.
+/// Every field is set right where a layout is made, including on the paths that return early
 struct FaceLayout
 {
-    unsigned base : 2 = 0;           ///< local index of the longest edge, from v[base] to v[base+1]
-    unsigned kind : 2 = fkVertices;  ///< one of FaceKind
-    unsigned divs : 28 = 0;          ///< the parts fkGrid and fkEdge need; unused by the others
-
-    FaceLayout() noexcept = default;
-    /// leaves the fields as they were, for Buffer to allocate without touching them
-    explicit FaceLayout( NoInit ) noexcept {}
+    unsigned base : 2; ///< local index of the longest edge, going from v[base] to v[(base+1)%3]
+    unsigned kind : 2; ///< one of FaceKind
+    unsigned divs : 28;///< the number of parts fkGrid and fkEdge need; unused by the others
 };
 
 /// the samples within a row are this far from each other, on every face
@@ -123,7 +124,7 @@ int numRowSamples( const RowLayout & l, float baseLen, float radius )
 /// chooses how a face is sampled, and what it needs of its longest edge
 FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
 {
-    FaceLayout res;
+    FaceLayout res{ 0, fkVertices, 0 };
     // no point of a triangle is farther from the nearest vertex than the covering radius, and the
     // minimal enclosing circle bounds that radius from above and is cheaper to find
     if ( mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq )

--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -56,15 +56,13 @@ int ceilPow2Sq( float aSq, float bSq )
 /// edge, or by the samples of that edge alone, whichever of the three costs the fewest samples
 struct FaceLayout
 {
-    int base;       ///< local index of the longest edge, going from v[base] to v[(base+1)%3]
-    int grid;       ///< in how many parts every side is divided for a grid; zero if not a grid
-    int rows;       ///< the number of rows parallel to the longest edge; zero if there are none
-    int wants;      ///< in how many parts the face wants its longest edge; zero if it does not care
-    float firstRow; ///< where the first row is, as a fraction of the height over the longest edge
-    float rowStep;  ///< the distance between the rows, as a fraction of that height
+    int base;   ///< local index of the longest edge, going from v[base] to v[(base+1)%3]
+    int grid;   ///< in how many parts every side is divided for a grid; zero if it is not a grid
+    int wants;  ///< in how many parts the face wants its longest edge; zero if it does not care
+    bool rows;  ///< the face is sampled in rows parallel to its longest edge
 
     /// the three vertices alone cover such a face, and it needs no samples of any kind
-    [[nodiscard]] bool covered() const { return grid <= 0 && rows <= 0 && wants <= 0; }
+    [[nodiscard]] bool covered() const { return grid <= 0 && wants <= 0 && !rows; }
 };
 
 /// the samples within a row are this far from each other, on every face
@@ -73,41 +71,50 @@ float rowSampleStep( float radius )
     return radius * cSqrt2;
 }
 
-/// the number of samples inside a face sampled in rows
-int numRowSamples( const FaceLayout & l, float baseLen, float radius )
+/// the rows parallel to the longest edge of a face, in the fractions of the height over that edge
+struct RowLayout
 {
-    int res = 0;
-    for ( int i = 0; i < l.rows; ++i )
-    {
-        const float hf = l.firstRow + i * l.rowStep;
-        res += divsForStep( baseLen * ( 1 - hf ), rowSampleStep( radius ) ) + 1;
-    }
-    return res;
-}
+    int num = 0;     ///< the number of rows
+    float first = 0; ///< where the first one is
+    float step = 0;  ///< the distance between them
+};
 
-/// lays out the rows parallel to the longest edge of a face, given the height over that edge and
-/// in how many parts it is divided
-void layoutRows( FaceLayout & res, float baseLen, float height, float radius, float radiusSq, int baseDivs )
+/// lays out the rows over a longest edge of the given length divided in the given number of parts,
+/// with the opposite vertex at the given height above it
+RowLayout layoutRows( float baseLen, float height, float radius, float radiusSq, int baseDivs )
 {
-    res.rows = 0;
+    RowLayout res;
     // the samples of the base are not farther than half a step from any point of it, so they reach
     // sqrt( radius^2 - (step/2)^2 ) up in the height, and a face flatter than that needs no rows
     const float baseStep = baseLen / baseDivs;
     const float first = std::sqrt( std::max( 0.0f, radiusSq - 0.25f * baseStep * baseStep ) );
     if ( height <= first )
-        return;
+        return res;
     // a point above the rows is within a band from the row below it, which is never narrower than
     // the face is there, and within half a step along that row; sqrt(2)*radius along the row
     // against radius/sqrt(2) between the rows keeps both within the radius with the fewest samples
-    res.rows = divsForStep( height - first, radius / cSqrt2 );
-    res.firstRow = first / height;
-    res.rowStep = ( height - first ) / ( res.rows * height );
+    res.num = divsForStep( height - first, radius / cSqrt2 );
+    res.first = first / height;
+    res.step = ( height - first ) / ( res.num * height );
+    return res;
+}
+
+/// the number of samples inside a face sampled in the given rows
+int numRowSamples( const RowLayout & l, float baseLen, float radius )
+{
+    int res = 0;
+    for ( int i = 0; i < l.num; ++i )
+    {
+        const float hf = l.first + i * l.step;
+        res += divsForStep( baseLen * ( 1 - hf ), rowSampleStep( radius ) ) + 1;
+    }
+    return res;
 }
 
 /// chooses how a face is sampled, and what it needs of its longest edge
 FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
 {
-    FaceLayout res{ 0, 0, 0, 0, 0, 0 };
+    FaceLayout res{ 0, 0, 0, false };
     // no point of a triangle is farther from the nearest vertex than the covering radius, and the
     // minimal enclosing circle bounds that radius from above and is cheaper to find
     if ( mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq )
@@ -145,22 +152,18 @@ FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
         stripCost = wants - 1;
     }
 
-    layoutRows( res, baseLen, height, radius, radiusSq, selfDivs[res.base] );
-    int rowsCost = 2 * numRowSamples( res, baseLen, radius );
+    const auto rowLayout = layoutRows( baseLen, height, radius, radiusSq, selfDivs[res.base] );
+    int rowsCost = 2 * numRowSamples( rowLayout, baseLen, radius );
     for ( int i = 0; i < 3; ++i )
         rowsCost += selfDivs[i] - 1;
 
     if ( stripCost <= rowsCost && stripCost <= gridCost )
-    {
-        res.rows = 0;
         res.wants = wants;
-    }
     else if ( gridCost < rowsCost )
-    {
-        res.rows = 0;
         res.grid = grid;
-    }
-    else if ( res.rows <= 0 )
+    else if ( rowLayout.num > 0 )
+        res.rows = true;
+    else
         // the rows are the cheapest and there are none of them: the samples of the longest edge
         // already cover the face, but it has to ask for them, or it will look covered by its
         // vertices and that edge will not be divided at all
@@ -214,7 +217,7 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
             const bool isBase = es[l.base].undirected() == ue;
             if ( l.grid > 0 )
                 gridAsk = std::max( gridAsk, l.grid );
-            else if ( l.rows > 0 || isBase ) // the rows rely on all three edges covering themselves
+            else if ( l.rows || isBase ) // the rows rely on all three edges covering themselves
                 plainAsk = std::max( plainAsk, divsForStep( mesh.edgeLength( ue ), 2 * radius ) );
             if ( isBase )
                 plainAsk = std::max( plainAsk, l.wants );
@@ -226,27 +229,35 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
     }, edgeDivsCb ) )
         return unexpectedOperationCanceled();
 
-    // with the edges divided, a face sampled in rows may need fewer of them, or none at all
+    // the rows of a face are laid out over its longest edge as divided above, which may leave it
+    // with fewer of them than the face expected, or with none at all
+    auto rowsOf = [&]( FaceId f, const Vector3f v[3], float & baseLen )
+    {
+        const auto & l = layouts[f];
+        EdgeId es[3];
+        topology.getTriEdges( f, es );
+        baseLen = ( v[( l.base + 1 ) % 3] - v[l.base] ).length();
+        const float height = cross( v[1] - v[0], v[2] - v[0] ).length() / baseLen;
+        return layoutRows( baseLen, height, radius, radiusSq, edgeDivs[es[l.base].undirected()] );
+    };
+
     Buffer<int, FaceId> faceSamples( topology.faceSize() );
     if ( !BitSetParallelFor( faces, [&]( FaceId f )
     {
-        auto & l = layouts[f];
+        const auto & l = layouts[f];
         if ( l.grid > 0 )
         {
             faceSamples[f] = ( l.grid - 1 ) * ( l.grid - 2 ) / 2;
             return;
         }
         faceSamples[f] = 0;
-        if ( l.covered() || l.wants > 0 )
+        if ( !l.rows )
             return; // nothing inside: the vertices or the longest edge alone cover this face
         Vector3f v[3];
         mesh.getTriPoints( f, v );
-        EdgeId es[3];
-        topology.getTriEdges( f, es );
-        const float baseLen = ( v[( l.base + 1 ) % 3] - v[l.base] ).length();
-        const float height = cross( v[1] - v[0], v[2] - v[0] ).length() / baseLen;
-        layoutRows( l, baseLen, height, radius, radiusSq, edgeDivs[es[l.base].undirected()] );
-        faceSamples[f] = numRowSamples( l, baseLen, radius );
+        float baseLen = 0;
+        const auto rows = rowsOf( f, v, baseLen ); // sets baseLen, so not in the call below
+        faceSamples[f] = numRowSamples( rows, baseLen, radius );
     }, samplesCb ) )
         return unexpectedOperationCanceled();
 
@@ -331,10 +342,11 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
             return;
         }
         const int bi = l.base, bj = ( l.base + 1 ) % 3, bk = ( l.base + 2 ) % 3;
-        const float baseLen = ( v[bj] - v[bi] ).length();
-        for ( int i = 0; i < l.rows; ++i )
+        float baseLen = 0;
+        const auto rows = rowsOf( f, v, baseLen );
+        for ( int i = 0; i < rows.num; ++i )
         {
-            const float hf = l.firstRow + i * l.rowStep;
+            const float hf = rows.first + i * rows.step;
             const auto rowOrg = v[bi] + hf * ( v[bk] - v[bi] );
             const auto rowDest = v[bj] + hf * ( v[bk] - v[bj] );
             const int divs = divsForStep( baseLen * ( 1 - hf ), rowSampleStep( radius ) );

--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -52,8 +52,6 @@ int ceilPow2Sq( float aSq, float bSq )
     return res;
 }
 
-/// how a face is sampled: by a grid of triangles similar to it, or in rows parallel to its longest
-/// edge, or by the samples of that edge alone, whichever of the three costs the fewest samples
 /// what covers a face, one way or another; the four are mutually exclusive
 enum FaceKind
 {
@@ -67,9 +65,13 @@ enum FaceKind
 /// number serves them all, and 28 bits hold more parts than divsForStep can ever return
 struct FaceLayout
 {
-    unsigned base : 2; ///< local index of the longest edge, going from v[base] to v[(base+1)%3]
-    unsigned kind : 2; ///< one of FaceKind
-    unsigned divs : 28;///< the number of parts fkGrid and fkEdge need; unused by the others
+    unsigned base : 2 = 0;           ///< local index of the longest edge, from v[base] to v[base+1]
+    unsigned kind : 2 = fkVertices;  ///< one of FaceKind
+    unsigned divs : 28 = 0;          ///< the parts fkGrid and fkEdge need; unused by the others
+
+    FaceLayout() noexcept = default;
+    /// leaves the fields as they were, for Buffer to allocate without touching them
+    explicit FaceLayout( NoInit ) noexcept {}
 };
 
 /// the samples within a row are this far from each other, on every face
@@ -121,7 +123,7 @@ int numRowSamples( const RowLayout & l, float baseLen, float radius )
 /// chooses how a face is sampled, and what it needs of its longest edge
 FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
 {
-    FaceLayout res{ 0, fkVertices, 0 };
+    FaceLayout res;
     // no point of a triangle is farther from the nearest vertex than the covering radius, and the
     // minimal enclosing circle bounds that radius from above and is cheaper to find
     if ( mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq )

--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -25,15 +25,84 @@ PointCloud meshToPointCloud( const Mesh& mesh, bool saveNormals /*= true */, con
 namespace
 {
 
-/// returns the smallest power of two n (and not less than 1) with n * n * bSq >= aSq, that is
-/// n >= sqrt( aSq / bSq ): no square root and no division are needed, and quadrupling is exact
-int ceilPow2Sq( float aSq, float bSq )
+constexpr float cSqrt2 = 1.41421356f;
+
+/// returns the smallest number of equal parts, and not less than one, in which a segment of the
+/// given length has to be divided to make every part not longer than the given step
+int divsForStep( float len, float step )
 {
-    int res = 1;
-    while ( bSq < aSq && res < ( 1 << 24 ) )
+    if ( !( len > 0 ) || !( step > 0 ) )
+        return 1;
+    int res = int( len / step );
+    while ( res * step < len && res < ( 1 << 24 ) )
+        ++res;
+    return std::max( 1, res );
+}
+
+/// how a face is sampled inside: in rows parallel to its longest edge
+struct FaceLayout
+{
+    int base;      ///< local index of the longest edge, going from v[base] to v[(base+1)%3]
+    int rows;      ///< the number of rows; zero if the longest edge alone covers the face
+    float first;   ///< the height of the first row over that edge
+    float band;    ///< the distance between the rows
+    float height;  ///< the height of the opposite vertex over that edge
+    float step;    ///< the distance between the samples within a row
+    bool covered;  ///< the three vertices alone cover the face, so it needs no samples at all
+};
+
+FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
+{
+    FaceLayout res{ 0, 0, 0, 0, 0, 0, false };
+    // no point of a triangle is farther from the nearest vertex than the covering radius, and the
+    // minimal enclosing circle bounds that radius from above and is cheaper to find
+    if ( mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq
+        || coveringRadiusSq( v[0], v[1], v[2] ) <= radiusSq )
     {
-        res <<= 1;
-        bSq *= 4;
+        res.covered = true;
+        return res;
+    }
+
+    // the longest edge is the base: the angles at its ends are acute, so every point of the face
+    // projects on it inside it, and the sections parallel to it shrink towards the opposite vertex,
+    // which makes a row below a point never narrower than the face is at that point
+    float baseLenSq = 0;
+    for ( int i = 0; i < 3; ++i )
+    {
+        const auto lenSq = ( v[( i + 1 ) % 3] - v[i] ).lengthSq();
+        if ( lenSq > baseLenSq )
+        {
+            baseLenSq = lenSq;
+            res.base = i;
+        }
+    }
+    const float baseLen = std::sqrt( baseLenSq );
+    res.height = cross( v[1] - v[0], v[2] - v[0] ).length() / baseLen; // twice the area over the base
+
+    // no point of the base is farther than half a step from a sample of it, so those samples reach
+    // this far in the height; a face lower than that is covered by its longest edge alone
+    const float baseStep = baseLen / divsForStep( baseLen, 2 * radius );
+    res.first = std::sqrt( std::max( 0.0f, radiusSq - 0.25f * baseStep * baseStep ) );
+    if ( res.height <= res.first )
+        return res;
+
+    // a point above the rows is within a band from the row below it and within half a step along
+    // that row; sqrt(2)*radius along the row against radius/sqrt(2) between the rows keeps both
+    // within the radius and gives the fewest samples
+    res.step = radius * cSqrt2;
+    res.rows = divsForStep( res.height - res.first, radius / cSqrt2 );
+    res.band = ( res.height - res.first ) / res.rows;
+    return res;
+}
+
+/// the number of samples inside a face with the given layout
+int numFaceSamples( const FaceLayout & l, float baseLen )
+{
+    int res = 0;
+    for ( int i = 0; i < l.rows; ++i )
+    {
+        const float hf = ( l.first + i * l.band ) / l.height;
+        res += divsForStep( baseLen * ( 1 - hf ), l.step ) + 1;
     }
     return res;
 }
@@ -51,36 +120,47 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
     const auto& faces = topology.getFaceIds( mp.region );
     // whole mesh: left/right of an edge is never a face outside faces, so it needs no test
     const bool wholeMesh = !mp.region;
-    const auto [faceDivsCb, edgeDivsCb, edgePointsCb, facePointsCb] = splitProgress( cb, 0.1f, 0.2f, 0.6f );
+    const auto [faceLayoutCb, edgeDivsCb, edgePointsCb, facePointsCb] = splitProgress( cb, 0.1f, 0.2f, 0.6f );
 
-    // in how many equal parts each side of the triangle is divided to split it in a grid of similar triangles,
-    // each covered by its own three corners; the number is a power of two, which makes the grid of a face
-    // conforming with (possibly finer) divisions of the face's edges
-    Buffer<int, FaceId> faceDivs( topology.faceSize() );
+    Buffer<FaceLayout, FaceId> layouts( topology.faceSize() );
+    Buffer<int, FaceId> faceSamples( topology.faceSize() );
     if ( !BitSetParallelFor( faces, [&]( FaceId f )
     {
         Vector3f v[3];
         mesh.getTriPoints( f, v );
-        // by definition no point of a triangle is farther from the nearest vertex than the covering
-        // radius, so a triangle with a smaller one is covered by its own vertices and is not divided;
-        // the minimal enclosing circle bounds that radius from above and is cheaper to find
-        faceDivs[f] = mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq ? 1
-            : ceilPow2Sq( coveringRadiusSq( v[0], v[1], v[2] ), radiusSq );
-    }, faceDivsCb ) )
+        const auto l = layoutFace( v, radius, radiusSq );
+        layouts[f] = l;
+        faceSamples[f] = l.rows <= 0 ? 0
+            : numFaceSamples( l, ( v[( l.base + 1 ) % 3] - v[l.base] ).length() );
+    }, faceLayoutCb ) )
         return unexpectedOperationCanceled();
 
-    // in how many equal parts each edge is divided: as much as the sampled faces incident to it
-    // divide it, and not at all if there are no such faces (including the lone edges); the edges
-    // of an undivided face need no samples of their own, because that face covers them already
+    // an edge is divided so that every point of it is within the radius from a sample of its own,
+    // and only if some incident face relies on that: a face covered by its vertices does not, and a
+    // face covered by its longest edge alone relies on that edge only
     Buffer<int, UndirectedEdgeId> edgeDivs( topology.undirectedEdgeSize() );
     if ( !ParallelFor( 0_ue, edgeDivs.endId(), [&]( UndirectedEdgeId ue )
     {
         const EdgeId e = ue;
-        int divs = 0;
+        bool need = false;
         for ( auto f : { topology.left( e ), topology.right( e ) } )
-            if ( f && ( wholeMesh || faces.test( f ) ) )
-                divs = std::max( divs, faceDivs[f] );
-        edgeDivs[ue] = divs;
+        {
+            if ( !f || !( wholeMesh || faces.test( f ) ) )
+                continue;
+            const auto & l = layouts[f];
+            if ( l.covered )
+                continue;
+            if ( l.rows > 0 )
+                need = true;
+            else
+            {
+                EdgeId es[3];
+                topology.getTriEdges( f, es );
+                if ( es[l.base].undirected() == ue )
+                    need = true;
+            }
+        }
+        edgeDivs[ue] = need ? divsForStep( mesh.edgeLength( ue ), 2 * radius ) : 0;
     }, edgeDivsCb ) )
         return unexpectedOperationCanceled();
 
@@ -94,12 +174,11 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
         if ( edgeDivs[ue] > 1 )
             numPoints += edgeDivs[ue] - 1;
     }
-    Buffer<size_t, FaceId> faceOffset( faceDivs.size() );
+    Buffer<size_t, FaceId> faceOffset( layouts.size() );
     for ( auto f : faces )
     {
         faceOffset[f] = numPoints;
-        if ( const auto divs = faceDivs[f]; divs > 2 )
-            numPoints += size_t( divs - 1 ) * ( divs - 2 ) / 2;
+        numPoints += faceSamples[f];
     }
 
     PointCloud res;
@@ -139,27 +218,37 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
 
     if ( !BitSetParallelFor( faces, [&]( FaceId f )
     {
-        const auto divs = faceDivs[f];
-        if ( divs <= 2 )
-            return; // the grid of this face has no points strictly inside it
+        const auto & l = layouts[f];
+        if ( l.rows <= 0 )
+            return;
         Vector3f v[3];
         mesh.getTriPoints( f, v );
-        Vector3f n[3];
+        const auto & a = v[l.base], & b = v[( l.base + 1 ) % 3], & c = v[( l.base + 2 ) % 3];
+        Vector3f na, nb, nc;
         if ( saveNormals )
         {
             const auto vs = topology.getTriVerts( f );
-            for ( int i = 0; i < 3; ++i )
-                n[i] = res.normals[ vs[i] ];
+            na = res.normals[ vs[l.base] ];
+            nb = res.normals[ vs[( l.base + 1 ) % 3] ];
+            nc = res.normals[ vs[( l.base + 2 ) % 3] ];
         }
+        const float baseLen = ( b - a ).length();
         auto p = VertId( faceOffset[f] );
-        for ( int i = 1; i + 2 <= divs; ++i )
-            for ( int j = 1; i + j + 1 <= divs; ++j, ++p )
+        for ( int i = 0; i < l.rows; ++i )
+        {
+            const float hf = ( l.first + i * l.band ) / l.height;
+            const auto rowOrg = a + hf * ( c - a );
+            const auto rowDest = b + hf * ( c - b );
+            const int divs = divsForStep( baseLen * ( 1 - hf ), l.step );
+            for ( int j = 0; j <= divs; ++j, ++p )
             {
-                const float a = float( i ) / divs, b = float( j ) / divs;
-                res.points[p] = v[0] + a * ( v[1] - v[0] ) + b * ( v[2] - v[0] );
+                const float g = float( j ) / divs;
+                res.points[p] = rowOrg + g * ( rowDest - rowOrg );
                 if ( saveNormals )
-                    res.normals[p] = ( ( 1 - a - b ) * n[0] + a * n[1] + b * n[2] ).normalized();
+                    res.normals[p] = ( ( 1 - hf ) * ( 1 - g ) * na
+                        + ( 1 - hf ) * g * nb + hf * nc ).normalized();
             }
+        }
     }, facePointsCb ) )
         return unexpectedOperationCanceled();
 

--- a/source/MRMesh/MRMeshToPointCloud.cpp
+++ b/source/MRMesh/MRMeshToPointCloud.cpp
@@ -39,28 +39,77 @@ int divsForStep( float len, float step )
     return std::max( 1, res );
 }
 
-/// how a face is sampled inside: in rows parallel to its longest edge
+/// returns the smallest power of two n (and not less than 1) with n * n * bSq >= aSq, that is
+/// n >= sqrt( aSq / bSq ): no square root and no division are needed, and quadrupling is exact
+int ceilPow2Sq( float aSq, float bSq )
+{
+    int res = 1;
+    while ( bSq < aSq && res < ( 1 << 24 ) )
+    {
+        res <<= 1;
+        bSq *= 4;
+    }
+    return res;
+}
+
+/// how a face is sampled: by a grid of triangles similar to it, or in rows parallel to its longest
+/// edge, or by the samples of that edge alone, whichever of the three costs the fewest samples
 struct FaceLayout
 {
     int base;      ///< local index of the longest edge, going from v[base] to v[(base+1)%3]
-    int rows;      ///< the number of rows; zero if the longest edge alone covers the face
-    int wants;     ///< in how many parts this face wants its longest edge divided
-    float first;   ///< the height of the first row over that edge
+    int grid;      ///< in how many parts every side is divided for a grid; zero if it is not a grid
+    int rows;      ///< the number of rows; zero if there are none
+    int wants;     ///< in how many parts the face wants its longest edge; zero if it does not care
+    float first;   ///< the height of the first row over the longest edge
     float band;    ///< the distance between the rows
-    float height;  ///< the height of the opposite vertex over that edge
+    float height;  ///< the height of the opposite vertex over the longest edge
     float step;    ///< the distance between the samples within a row
     bool covered;  ///< the three vertices alone cover the face, so it needs no samples at all
 };
 
-/// \param baseDivs in how many parts the longest edge is divided; zero on the first pass, when the
-/// face only tells in `wants` how many it would need for that edge to cover it alone
-FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq, int baseDivs = 0 )
+/// the number of samples inside a face sampled in rows
+int numRowSamples( const FaceLayout & l, float baseLen )
 {
-    FaceLayout res{ 0, 0, 0, 0, 0, 0, 0, false };
+    int res = 0;
+    for ( int i = 0; i < l.rows; ++i )
+    {
+        const float hf = ( l.first + i * l.band ) / l.height;
+        res += divsForStep( baseLen * ( 1 - hf ), l.step ) + 1;
+    }
+    return res;
+}
+
+/// lays out the rows parallel to the longest edge, given in how many parts that edge is divided
+void layoutRows( FaceLayout & res, float baseLen, float radius, float radiusSq, int baseDivs )
+{
+    res.rows = 0;
+    // the samples of the base are not farther than half a step from any point of it, so they reach
+    // sqrt( radius^2 - (step/2)^2 ) up in the height, and a face flatter than that needs no rows
+    const float baseStep = baseLen / baseDivs;
+    res.first = std::sqrt( std::max( 0.0f, radiusSq - 0.25f * baseStep * baseStep ) );
+    if ( res.height <= res.first )
+        return;
+    // a point above the rows is within a band from the row below it, which is never narrower than
+    // the face is there, and within half a step along that row; sqrt(2)*radius along the row
+    // against radius/sqrt(2) between the rows keeps both within the radius with the fewest samples
+    res.step = radius * cSqrt2;
+    res.rows = divsForStep( res.height - res.first, radius / cSqrt2 );
+    res.band = ( res.height - res.first ) / res.rows;
+}
+
+/// chooses how a face is sampled, and what it needs of its longest edge
+FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq )
+{
+    FaceLayout res{ 0, 0, 0, 0, 0, 0, 0, 0, false };
     // no point of a triangle is farther from the nearest vertex than the covering radius, and the
     // minimal enclosing circle bounds that radius from above and is cheaper to find
-    if ( mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq
-        || coveringRadiusSq( v[0], v[1], v[2] ) <= radiusSq )
+    if ( mincircleDiameterSq( v[0], v[1], v[2] ) <= 4 * radiusSq )
+    {
+        res.covered = true;
+        return res;
+    }
+    const auto coverSq = coveringRadiusSq( v[0], v[1], v[2] );
+    if ( coverSq <= radiusSq )
     {
         res.covered = true;
         return res;
@@ -69,47 +118,46 @@ FaceLayout layoutFace( const Vector3f v[3], float radius, float radiusSq, int ba
     // the longest edge is the base: the angles at its ends are acute, so every point of the face
     // projects on it inside it, and the sections parallel to it shrink towards the opposite vertex,
     // which makes a row below a point never narrower than the face is at that point
-    float baseLenSq = 0;
+    float len[3];
+    int selfDivs[3];
     for ( int i = 0; i < 3; ++i )
-    {
-        const auto lenSq = ( v[( i + 1 ) % 3] - v[i] ).lengthSq();
-        if ( lenSq > baseLenSq )
-        {
-            baseLenSq = lenSq;
-            res.base = i;
-        }
-    }
-    const float baseLen = std::sqrt( baseLenSq );
+        len[i] = ( v[( i + 1 ) % 3] - v[i] ).length();
+    res.base = ( len[0] >= len[1] && len[0] >= len[2] ) ? 0 : ( len[1] >= len[2] ? 1 : 2 );
+    const float baseLen = len[res.base];
     res.height = cross( v[1] - v[0], v[2] - v[0] ).length() / baseLen; // twice the area over the base
+    for ( int i = 0; i < 3; ++i )
+        selfDivs[i] = divsForStep( len[i], 2 * radius ); // enough for an edge to cover itself
 
-    // the samples of the base are not farther than half a step from any point of it and reach
-    // sqrt( radius^2 - (step/2)^2 ) in the height, so dividing it in this many parts makes the base
-    // alone cover the face; a face flat enough gets that for free from the step of 2*radius
+    // a grid of triangles similar to the face is covered by its own corners, but its nodes on an
+    // edge must be among the division points of that edge, which is why the number is rounded to a
+    // power of two: the maximum of two such numbers is a multiple of both
+    // the three costs below count the samples inside the face plus half of those on its edges,
+    // since an edge is shared, and a grid needs no self-covering edges: it covers them itself
+    const int grid = ceilPow2Sq( coverSq, radiusSq );
+    int gridCost = 2 * ( grid - 1 ) * ( grid - 2 ) / 2 + 3 * ( grid - 1 );
+
+    // the samples of the base alone cover a face flatter than the radius, once it is divided finely
+    int stripCost = std::numeric_limits<int>::max(), wants = 0;
     if ( res.height < radius )
-        res.wants = divsForStep( baseLen, 2 * std::sqrt( radiusSq - res.height * res.height ) );
-
-    const float baseStep = baseLen / ( baseDivs > 0 ? baseDivs : divsForStep( baseLen, 2 * radius ) );
-    res.first = std::sqrt( std::max( 0.0f, radiusSq - 0.25f * baseStep * baseStep ) );
-    if ( res.height <= res.first )
-        return res;
-
-    // a point above the rows is within a band from the row below it and within half a step along
-    // that row; sqrt(2)*radius along the row against radius/sqrt(2) between the rows keeps both
-    // within the radius and gives the fewest samples
-    res.step = radius * cSqrt2;
-    res.rows = divsForStep( res.height - res.first, radius / cSqrt2 );
-    res.band = ( res.height - res.first ) / res.rows;
-    return res;
-}
-
-/// the number of samples inside a face with the given layout
-int numFaceSamples( const FaceLayout & l, float baseLen )
-{
-    int res = 0;
-    for ( int i = 0; i < l.rows; ++i )
     {
-        const float hf = ( l.first + i * l.band ) / l.height;
-        res += divsForStep( baseLen * ( 1 - hf ), l.step ) + 1;
+        wants = divsForStep( baseLen, 2 * std::sqrt( radiusSq - res.height * res.height ) );
+        stripCost = wants - 1;
+    }
+
+    layoutRows( res, baseLen, radius, radiusSq, selfDivs[res.base] );
+    int rowsCost = 2 * numRowSamples( res, baseLen );
+    for ( int i = 0; i < 3; ++i )
+        rowsCost += selfDivs[i] - 1;
+
+    if ( stripCost <= rowsCost && stripCost <= gridCost )
+    {
+        res.rows = 0;
+        res.wants = wants;
+    }
+    else if ( gridCost < rowsCost )
+    {
+        res.rows = 0;
+        res.grid = grid;
     }
     return res;
 }
@@ -127,38 +175,27 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
     const auto& faces = topology.getFaceIds( mp.region );
     // whole mesh: left/right of an edge is never a face outside faces, so it needs no test
     const bool wholeMesh = !mp.region;
-    const auto [faceLayoutCb, edgeDivsCb, edgePointsCb, facePointsCb] = splitProgress( cb, 0.1f, 0.2f, 0.6f );
+    const auto [layoutCb, edgeDivsCb, samplesCb, edgePointsCb, facePointsCb] =
+        splitProgress( cb, 0.1f, 0.2f, 0.25f, 0.6f );
 
     Buffer<FaceLayout, FaceId> layouts( topology.faceSize() );
     if ( !BitSetParallelFor( faces, [&]( FaceId f )
     {
         Vector3f v[3];
         mesh.getTriPoints( f, v );
-        auto l = layoutFace( v, radius, radiusSq );
-        const float baseLen = ( v[( l.base + 1 ) % 3] - v[l.base] ).length();
-        // asking the base for a finer division costs the samples it adds there, and saves all the
-        // rows; that trade is worth making only when the rows cost more
-        if ( l.rows > 0 && l.wants > 0 )
-        {
-            if ( l.wants - divsForStep( baseLen, 2 * radius ) < numFaceSamples( l, baseLen ) )
-                l.rows = 0; // the base will be divided finer, so no rows are needed at all, and
-                            // the other two edges of this face need no samples either
-            else
-                l.wants = 0;
-        }
-        layouts[f] = l;
-    }, faceLayoutCb ) )
+        layouts[f] = layoutFace( v, radius, radiusSq );
+    }, layoutCb ) )
         return unexpectedOperationCanceled();
 
-    // an edge is divided so that every point of it is within the radius from a sample of its own,
-    // and only if some incident face relies on that: a face covered by its vertices does not, and a
-    // face covered by its longest edge alone relies on that edge only
+    // an edge is divided only if some incident face relies on that: a face covered by its own
+    // vertices does not, and a face covered by its longest edge relies on that edge alone. The
+    // number of parts is a multiple of what the grids ask, since their nodes must be among the
+    // division points, and not less than what the others ask, which needs no divisibility
     Buffer<int, UndirectedEdgeId> edgeDivs( topology.undirectedEdgeSize() );
     if ( !ParallelFor( 0_ue, edgeDivs.endId(), [&]( UndirectedEdgeId ue )
     {
         const EdgeId e = ue;
-        bool need = false;
-        int wanted = 0;
+        int gridAsk = 0, plainAsk = 0;
         for ( auto f : { topology.left( e ), topology.right( e ) } )
         {
             if ( !f || !( wholeMesh || faces.test( f ) ) )
@@ -169,34 +206,41 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
             EdgeId es[3];
             topology.getTriEdges( f, es );
             const bool isBase = es[l.base].undirected() == ue;
-            if ( l.rows > 0 || isBase )
-                need = true;
+            if ( l.grid > 0 )
+                gridAsk = std::max( gridAsk, l.grid );
+            else if ( l.rows > 0 || isBase ) // the rows rely on all three edges covering themselves
+                plainAsk = std::max( plainAsk, divsForStep( mesh.edgeLength( ue ), 2 * radius ) );
             if ( isBase )
-                wanted = std::max( wanted, l.wants ); // no divisibility here, so the maximum will do
+                plainAsk = std::max( plainAsk, l.wants );
         }
-        edgeDivs[ue] = need
-            ? std::max( wanted, divsForStep( mesh.edgeLength( ue ), 2 * radius ) ) : 0;
+        if ( gridAsk <= 0 )
+            edgeDivs[ue] = plainAsk;
+        else // the smallest multiple of what the grids ask that is not less than the rest
+            edgeDivs[ue] = gridAsk * ( ( std::max( plainAsk, gridAsk ) + gridAsk - 1 ) / gridAsk );
     }, edgeDivsCb ) )
         return unexpectedOperationCanceled();
 
-    // now that the edges are divided, a face may need fewer rows, or none at all
+    // with the edges divided, a face sampled in rows may need fewer of them, or none at all
     Buffer<int, FaceId> faceSamples( topology.faceSize() );
     if ( !BitSetParallelFor( faces, [&]( FaceId f )
     {
         auto & l = layouts[f];
-        if ( l.covered )
+        if ( l.grid > 0 )
         {
-            faceSamples[f] = 0;
+            faceSamples[f] = ( l.grid - 1 ) * ( l.grid - 2 ) / 2;
             return;
         }
+        faceSamples[f] = 0;
+        if ( l.covered || l.wants > 0 )
+            return; // nothing inside: the vertices or the longest edge alone cover this face
         Vector3f v[3];
         mesh.getTriPoints( f, v );
         EdgeId es[3];
         topology.getTriEdges( f, es );
-        l = layoutFace( v, radius, radiusSq, edgeDivs[es[l.base].undirected()] );
-        faceSamples[f] = l.rows <= 0 ? 0
-            : numFaceSamples( l, ( v[( l.base + 1 ) % 3] - v[l.base] ).length() );
-    }, faceLayoutCb ) )
+        const float baseLen = ( v[( l.base + 1 ) % 3] - v[l.base] ).length();
+        layoutRows( l, baseLen, radius, radiusSq, edgeDivs[es[l.base].undirected()] );
+        faceSamples[f] = numRowSamples( l, baseLen );
+    }, samplesCb ) )
         return unexpectedOperationCanceled();
 
     // the samples of every edge and every face occupy a dedicated range in the resulting cloud;
@@ -253,35 +297,47 @@ Expected<PointCloud> meshToDensePointCloud( const MeshPart& mp, float radius, bo
 
     if ( !BitSetParallelFor( faces, [&]( FaceId f )
     {
-        const auto & l = layouts[f];
-        if ( l.rows <= 0 )
+        if ( faceSamples[f] <= 0 )
             return;
+        const auto & l = layouts[f];
         Vector3f v[3];
         mesh.getTriPoints( f, v );
-        const auto & a = v[l.base], & b = v[( l.base + 1 ) % 3], & c = v[( l.base + 2 ) % 3];
-        Vector3f na, nb, nc;
+        Vector3f n[3];
         if ( saveNormals )
         {
             const auto vs = topology.getTriVerts( f );
-            na = res.normals[ vs[l.base] ];
-            nb = res.normals[ vs[( l.base + 1 ) % 3] ];
-            nc = res.normals[ vs[( l.base + 2 ) % 3] ];
+            for ( int i = 0; i < 3; ++i )
+                n[i] = res.normals[ vs[i] ];
         }
-        const float baseLen = ( b - a ).length();
         auto p = VertId( faceOffset[f] );
+        if ( l.grid > 0 )
+        {
+            const int divs = l.grid;
+            for ( int i = 1; i + 2 <= divs; ++i )
+                for ( int j = 1; i + j + 1 <= divs; ++j, ++p )
+                {
+                    const float a = float( i ) / divs, b = float( j ) / divs;
+                    res.points[p] = v[0] + a * ( v[1] - v[0] ) + b * ( v[2] - v[0] );
+                    if ( saveNormals )
+                        res.normals[p] = ( ( 1 - a - b ) * n[0] + a * n[1] + b * n[2] ).normalized();
+                }
+            return;
+        }
+        const int bi = l.base, bj = ( l.base + 1 ) % 3, bk = ( l.base + 2 ) % 3;
+        const float baseLen = ( v[bj] - v[bi] ).length();
         for ( int i = 0; i < l.rows; ++i )
         {
             const float hf = ( l.first + i * l.band ) / l.height;
-            const auto rowOrg = a + hf * ( c - a );
-            const auto rowDest = b + hf * ( c - b );
+            const auto rowOrg = v[bi] + hf * ( v[bk] - v[bi] );
+            const auto rowDest = v[bj] + hf * ( v[bk] - v[bj] );
             const int divs = divsForStep( baseLen * ( 1 - hf ), l.step );
             for ( int j = 0; j <= divs; ++j, ++p )
             {
                 const float g = float( j ) / divs;
                 res.points[p] = rowOrg + g * ( rowDest - rowOrg );
                 if ( saveNormals )
-                    res.normals[p] = ( ( 1 - hf ) * ( 1 - g ) * na
-                        + ( 1 - hf ) * g * nb + hf * nc ).normalized();
+                    res.normals[p] = ( ( 1 - hf ) * ( 1 - g ) * n[bi]
+                        + ( 1 - hf ) * g * n[bj] + hf * n[bk] ).normalized();
             }
         }
     }, facePointsCb ) )

--- a/source/MRTest/MRMeshToPointCloudTests.cpp
+++ b/source/MRTest/MRMeshToPointCloudTests.cpp
@@ -180,9 +180,9 @@ TEST( MRMesh, MeshToDensePointCloudDegenerate )
 
     const auto cloud = meshToDensePointCloud( mesh, 0.1f );
     ASSERT_TRUE( cloud.has_value() );
-    // the covering radius is 0.25, so every side is divided in 4 parts (as the face is),
-    // which gives 3 + 3*3 + 3*2/2 points
-    EXPECT_EQ( cloud->points.size(), 15 );
+    // the triangle is flat, so the samples of its longest side cover it: that side is divided
+    // in 5 parts, and the 3 vertices with the 4 samples between them is all the cloud has
+    EXPECT_EQ( cloud->points.size(), 7 );
     EXPECT_LE( maxSurfaceToCloudDist( mesh, *cloud, 64 ), 0.1f );
 }
 


### PR DESCRIPTION
Fewer points for the same guarantee, by dropping the grid of similar triangles altogether. Supersedes #6726 - the thin triangle it special-cases falls out of the new scheme with no rule of its own.

### What the grid cost

The samples inside a face were the nodes of a grid of `n*n` triangles similar to it, and `n` had to be a power of two: a face's nodes on an edge must be among that edge's division points, and `max` of two powers of two is a multiple of both. That coupling is expensive twice over - up to 4x in the interior from the rounding, and an edge dragged to its coarser neighbour's resolution.

### What replaces it

1. **Every edge covers itself.** It is divided so that every point of it is within the radius from one of its own samples, `ceil( len / 2r )` parts, exact. And only if some incident face relies on that: a face covered by its own three vertices does not, and a face covered by its longest edge alone relies on that edge only. Faces no longer constrain each other at all.
2. **A face is sampled in rows parallel to its longest edge.** Two properties of the longest edge make it work: the angles at its ends are acute, so every point of the face projects onto it *inside* the segment; and the sections parallel to it shrink monotonically towards the opposite vertex, so the row below a point is never narrower than the face is at that point. A point is therefore within one band of the row below it and within half a step along that row, and `sqrt(2)*radius` along a row against `radius/sqrt(2)` between rows keeps `sqrt( (step/2)^2 + band^2 ) <= radius` with the fewest samples.
3. **A face lower than its longest edge's samples reach needs no rows.** Those samples are within half a step of any point of the edge, so they reach `sqrt( radius^2 - (step/2)^2 )` up into the face; a face flatter than that is covered by that one edge. This is #6726's thin-triangle rule, now a consequence rather than a case.

### Measured

A building STL of 169k faces, 106k vertices, bounding box diagonal 27.7. One binary with `MRMesh.dll` swapped between the three variants and the runs interleaved; best of 4 runs, each the minimum of 3 calls:

| radius | master | #6726 | this PR |
|---|---|---|---|
| 0.2 | 591 789 points, 3.54 ms | 293 831, 3.02 ms | **207 214, 2.91 ms** |
| 0.5 | 185 353 points, 2.25 ms | 130 525, 2.29 ms | **121 822, 2.24 ms** |

65% fewer points than master at radius 0.2, 34% fewer at 0.5, and 29% / 7% fewer than #6726. The rows, the exact division counts and the two extra passes over the faces cost time, but a face layout packed into one 32-bit word - and a third of the samples to write - pay for them: 18% faster than master at radius 0.2 and level with it at 0.5. The objective was the point count; the speed came out even.

### Each face picks its pattern

The three patterns have different strengths. A grid puts its nodes in a triangular lattice, which covers about 2.5x more area per sample than the rectangular one the rows make - but it needs its nodes among the division points of its edges, which forces its number to a power of two and drags the neighbours' edges along with it. The rows need nothing of an edge but that it covers itself. And a flat face needs only its longest edge divided finely enough.

So a face counts what each of the three would cost - the samples inside it plus half of those on its edges, since an edge is shared, and a grid needs no self-covering edges because it covers them itself - and takes the cheapest. An edge then takes the smallest multiple of what the grids ask that is not less than what the rows and the flat faces ask, so the two kinds coexist on one edge.

Point counts for isolated shapes, radius 1 unless stated (one binary, `MRMesh.dll` swapped between the three; every count comes with 32 random probes per triangle confirming the cover):

| shape | master | #6726 | this PR |
|---|---|---|---|
| two slivers on an edge of 10, h = 0.05 | 25 | 9 | **9** |
| the same, h = 0.5 | 25 | 9 | **9** |
| the same, h = 0.9 | 25 | 15 | **15** |
| the same, h = 1.5 | 25 | 25 | **25** |
| the same, h = 3 | 25 | 25 | **25** |
| equilateral, side 10 | 45 | 45 | **45** |
| equilateral, side 10, radius 0.3 | 561 | 561 | **561** |
| right triangle, legs 10 and 1 | 45 | 45 | **17** |
| right triangle, legs 10 and 2 | 45 | 45 | **27** |
| right triangle, legs 10 and 3 | 45 | 45 | **35** |
| obtuse, base 10, apex 3 past its end at h = 2 | 45 | 45 | **28** |
| equilateral, side 10, radius 0.7 | 153 | 153 | **138** |
| base 10, apex over it at (2, 4), radius 0.5 | 153 | 153 | **134** |

It never loses to either predecessor on a single face: where the grid is the best pattern it is still the one chosen, and the counts coincide. It wins where the grid was paying for its own rigidity - a face far from equilateral but not flat enough for #6726's strip rule (the right and obtuse ones, up to 2.6x fewer points), or a radius whose exact division is not a power of two (0.7 on the equilateral, where the grid rounds 3 up to 4). Of 43 swept shapes it beat #6726 on 9 and tied on the rest.

### Tests

All the coverage tests pass unchanged, including the torus one that catches the failures of an unconforming grid. Only counts moved: the degenerate triangle needs 7 points instead of 15, exactly the case of rule 3. The worst surface-to-cloud distance on the building above is 93.2% of the radius at 0.2 and 93.6% at 0.5, the same as master's.


