### PR TITLE
Measure the Windows distributive, not the internal build-output archive

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -181,6 +181,7 @@ jobs:
     with:
       vcpkg_version: ${{ needs.config.outputs.vcpkg_version }}
       app_version: ${{ needs.config.outputs.app_version }}
+      internal_build: ${{ needs.config.outputs.internal_build == 'true' }}
     secrets: inherit
 
   create-nuget-package:

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -426,15 +426,6 @@ jobs:
           # The payload is already a .zip; don't re-Deflate it (no size gain).
           compression-level: 0
 
-      - name: Collect artifact stats
-        if: ${{ inputs.internal_build && env.job_upload_artifact == 'true' }}
-        continue-on-error: true
-        uses: ./.github/actions/collect-artifact-stats
-        with:
-          artifact_path: ${{ github.workspace }}
-          artifact_glob: MREDist_${{ env.VS_TAG }}_${{ matrix.upload_name || matrix.config }}.zip
-          stats_file_suffix: -${{ steps.collect-runner-stats.outputs.job_id }}
-
       - name: Upload MeshLibC2 headers archive
         if: ${{ env.job_upload_artifact == 'true' && matrix.cxx_compiler == 'msvc-2019' && matrix.config == 'Release' && inputs.mrbind_c }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/update-win-version.yml
+++ b/.github/workflows/update-win-version.yml
@@ -22,10 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         # One developer distributive per Visual Studio toolchain. The MREDist_*
-        # inputs are produced by the matching VS build in build-test-windows.yml
-        # (named via its VS_TAG); `cxx_compiler`/`build_system`/`build_config`
-        # name that build, so the size of the distributive is reported against
-        # the toolchain it came from.
+        # inputs are produced by the matching VS CMake build in
+        # build-test-windows.yml (named via its VS_TAG).
         include:
           - vcpkg_triplet: x64-windows-vs2019-meshlib
             extract_release: MREDist_VS19_Release.zip
@@ -116,8 +114,6 @@ jobs:
       - name: Archive Distribution
         run: py -3.10 scripts\zip_distribution.py install example_plugin ${{ matrix.output_zip }}
 
-      # Measure the archive users actually download: the main distributive, whose
-      # symbols the `Archive Symbols` step above already moved into the companion.
       - name: Collect artifact stats
         if: ${{ inputs.internal_build }}
         continue-on-error: true

--- a/.github/workflows/update-win-version.yml
+++ b/.github/workflows/update-win-version.yml
@@ -9,6 +9,10 @@ on:
       app_version:
         required: true
         type: string
+      internal_build:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   update-win-version:
@@ -18,8 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         # One developer distributive per Visual Studio toolchain. The MREDist_*
-        # inputs are produced by the matching VS CMake build in
-        # build-test-windows.yml (named via its VS_TAG).
+        # inputs are produced by the matching VS build in build-test-windows.yml
+        # (named via its VS_TAG); `cxx_compiler`/`build_system`/`build_config`
+        # name that build, so the size of the distributive is reported against
+        # the toolchain it came from.
         include:
           - vcpkg_triplet: x64-windows-vs2019-meshlib
             extract_release: MREDist_VS19_Release.zip
@@ -27,23 +33,35 @@ jobs:
             output_zip: MeshLibDistVS19.zip
             pdb_zip: MeshLibDistVS19-PDB.zip
             artifact_name: DistributivesWin-VS19
+            cxx_compiler: msvc-2019
+            build_system: CMake
+            build_config: Release
           - vcpkg_triplet: x64-windows-vs2022-meshlib
             extract_release: MREDist_VS22_Release.zip
             extract_debug: MREDist_VS22_Debug.zip
             output_zip: MeshLibDistVS22.zip
             pdb_zip: MeshLibDistVS22-PDB.zip
             artifact_name: DistributivesWin-VS22
+            cxx_compiler: msvc-2022
+            build_system: CMake
+            build_config: Release
           - vcpkg_triplet: x64-windows-meshlib
             extract_release: MREDist_VS26_Release.zip
             extract_debug: MREDist_VS26_Debug.zip
             output_zip: MeshLibDistVS26.zip
             pdb_zip: MeshLibDistVS26-PDB.zip
             artifact_name: DistributivesWin-VS26
+            cxx_compiler: msvc-2026
+            build_system: MSBuild
+            build_config: Release
           - vcpkg_triplet: x64-windows-meshlib-iterator-debug
             extract_debug: MREDist_VS19_Debug-IteratorDebug.zip
             output_zip: MeshLibDist-IteratorDebug.zip
             pdb_zip: MeshLibDist-IteratorDebug-PDB.zip
             artifact_name: DistributivesWin-IteratorDebug
+            cxx_compiler: msvc-2019
+            build_system: CMake
+            build_config: Debug
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-vs2019-meshlib' }}
     steps:
@@ -51,6 +69,18 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: true
+
+      - name: Collect runner's system stats
+        if: ${{ inputs.internal_build }}
+        id: collect-runner-stats
+        continue-on-error: true
+        uses: ./.github/actions/collect-runner-stats
+        with:
+          target_os: windows
+          target_arch: x64
+          cxx_compiler: ${{ matrix.cxx_compiler }}
+          build_config: ${{ matrix.build_config }}
+          build_system: ${{ matrix.build_system }}
 
       - name: Set up vcpkg
         uses: ./.github/actions/setup-vcpkg-windows
@@ -85,6 +115,17 @@ jobs:
 
       - name: Archive Distribution
         run: py -3.10 scripts\zip_distribution.py install example_plugin ${{ matrix.output_zip }}
+
+      # Measure the archive users actually download: the main distributive, whose
+      # symbols the `Archive Symbols` step above already moved into the companion.
+      - name: Collect artifact stats
+        if: ${{ inputs.internal_build }}
+        continue-on-error: true
+        uses: ./.github/actions/collect-artifact-stats
+        with:
+          artifact_path: ${{ github.workspace }}
+          artifact_glob: ${{ matrix.output_zip }}
+          stats_file_suffix: -${{ steps.collect-runner-stats.outputs.job_id }}
 
       - name: Test Example Plugin # call it after archive not to pack build results
         env:


### PR DESCRIPTION
### Problem

The Windows leg of the artifact-size stats measured `MREDist_<VS_TAG>_<config>.zip`, which is
`tar --format zip` of `source/x64/<config>` — a **CI-internal hand-off**: `retention-days: 1`,
consumed only by `update-win-version`, then deleted by its `cleanup-win-archives` job. Nothing
outside CI ever downloads it, and no doc references the name.

Every other platform already measures the shipped package (`meshlib_*.deb`, `*.pkg`,
`linux-vcpkg-*.tar.xz`, the emscripten zip). Windows was the only outlier.

That made the `MeshLib Windows Artifact Size` chart report a 118.6 -> 306.3 MB jump on #6657,
read as a 2.6x regression in what users download. It was neither:

| what | before #6657 | after #6657 |
|---|---|---|
| `MREDist_VS19_Release.zip` (internal) | 118.6 MB | 320.1 MB |
| `MeshLibDistVS19.zip` (**what users download**) | 545.4 MB | **338.2 MB** |
| `MeshLibDistVS19-PDB.zip` (companion) | - | 402.5 MB |

The internal archive grew because the 23 new Release linker `.pdb` files (190.6 MB of today's
320.1 MB) have to ride to the packaging job — `make_install_folder.py` copies `source/x64` into
`install/lib`, and only then does `split_install_pdb.py` move them into the companion. So the
old measurement tracked symbol *traffic*, and moved in the opposite direction from the archive
it was supposed to describe.

### Change

Collect the artifact stats in `update-win-version`, on `${{ matrix.output_zip }}` — the main
distributive, after `Archive Symbols` has already moved the `.pdb` files out. The exact glob
excludes the `-PDB.zip` companion (`collect_ci_stats.py` sums every entry of the stats file).

`collect_ci_stats.py` only emits a job row when `RunnerSysStats-<job_id>.json` exists, so the
packaging job now collects runner stats too, and the matrix says which build each distributive
came from:

| distributive | compiler | config | build system |
|---|---|---|---|
| `MeshLibDistVS19.zip` | msvc-2019 | Release | CMake |
| `MeshLibDistVS22.zip` | msvc-2022 | Release | CMake |
| `MeshLibDistVS26.zip` | msvc-2026 | Release | MSBuild |
| `MeshLibDist-IteratorDebug.zip` | msvc-2019 | Debug | CMake |

Those are the toolchains that produce the `MREDist_*` inputs
(`.github/workflows/matrix/windows-*-config.json`). The collector lowercases both values, so the
existing dashboard filter (`os='windows' and build_config='release' and build_system='cmake'`)
keeps matching the VS19 and VS22 rows with no dashboard change — it just describes the
distributive now instead of the build directory. VS26 stays on `msbuild`, as its row did before.

A distributive spans both configurations; each row is tagged with the Release build behind it
(Debug for the Debug-only IteratorDebug package), which is also what the row carried before.

### Trade-off

`update-win-version` runs only when `build-release-win` is set — schedule, `full-ci`, or the
`build-release-windows` label — not on every push to `master`. The Windows series therefore
drops from ~1 point per master push to ~1 per nightly. That is the real cadence at which a
Windows distributive is produced; the denser series was measuring something else.

Also gains a side effect worth having: `update-win-version` now appears in the CI-stats job
table, so its duration and step timings become visible like every other build job.

### Testing

Labelled `build-release-windows` + `upload-binaries` so `update-win-version` actually runs, with
the other platforms disabled. Verify in the run: each of the four packaging jobs uploads
`ArtifactStats-<job_id>.json` and `RunnerSysStats-<job_id>.json`, and the `collect-stats` job
prints an `artifact_size` for them matching the `MeshLibDist*.zip` sizes.
