### PR TITLE
macOS: fold identical functions in the bindings with --icf=all

### DIFF
--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -330,8 +330,9 @@ override EXTRA_LDFLAGS += -Oz -flto=thin $(if $(IS_MACOS),-Wl$(comma)-x,-s)# App
 # No -ffunction-sections needed: lld's LTO codegen of this preset always emits per-function
 # sections, which is also why this lives here and not next to the other link flags.
 # Not for Emscripten, whose wasm-ld has no ICF, and not for Windows, where lld-link is a
-# COFF driver that answers this spelling with `ignoring unknown argument '--icf=all'`; the
-# wheel build there does use this preset, so `/opt:icf` remains to be measured.
+# COFF driver that answers this spelling with `ignoring unknown argument '--icf=all'` and
+# folds by default anyway: on the wheel build `/opt:noicf` grows mrmeshpy.pyd from 56.2 to
+# 63.0 MB, while `/opt:icf` changes nothing.
 ifeq ($(IS_EMSCRIPTEN)$(IS_WINDOWS),)
 override EXTRA_LDFLAGS += -Wl,--icf=all
 endif

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -323,13 +323,6 @@ MODE := release
 ifeq ($(MODE),release)
 override EXTRA_CFLAGS += -Oz -flto=thin -DNDEBUG
 override EXTRA_LDFLAGS += -Oz -flto=thin $(if $(IS_MACOS),-Wl$(comma)-x,-s)# Apple's ld rejects `-s`; `-Wl,-x` drops local Mach-O symbols (most of __LINKEDIT) instead.
-ifneq ($(IS_LINUX),)
-# Fold byte-identical functions: the bindings are ~190k tiny near-duplicate template
-# instantiations, and ICF removes 11% of mrmeshpy.so (7 MB unpacked, 2.3 MB compressed).
-# Linux-only until lld-link (Windows) and ld64.lld (macOS) get their own measurements.
-# No -ffunction-sections needed: lld's LTO codegen always emits per-function sections.
-override EXTRA_LDFLAGS += -Wl,--icf=all
-endif
 else ifeq ($(MODE),debug)
 override EXTRA_CFLAGS += -g
 override EXTRA_LDFLAGS += -g
@@ -339,6 +332,20 @@ else
 $(error Unknown MODE=$(MODE))
 endif
 $(info MODE: $(MODE))
+
+# Fold byte-identical functions: the bindings are ~190k tiny near-duplicate template
+# instantiations. Measured on mrmeshpy, with the Python sanity suite passing every time:
+# -11% on Linux, -13.6% on macOS x86_64, -19.4% on macOS arm64 (fixed-width instructions
+# make more of the instantiations byte-identical there).
+# No -ffunction-sections needed: lld's LTO codegen always emits per-function sections.
+# Outside the MODE presets on purpose, because the Windows bindings are built with
+# MODE=none. Not for debug builds, where folded functions confuse breakpoints, and not for
+# Emscripten, whose wasm-ld has no ICF.
+ifeq ($(IS_EMSCRIPTEN),)
+ifneq ($(MODE),debug)
+override EXTRA_LDFLAGS += -Wl,--icf=all
+endif
+endif
 
 
 # The list of Python versions, in the format `X.Y`.

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -329,11 +329,10 @@ override EXTRA_LDFLAGS += -Oz -flto=thin $(if $(IS_MACOS),-Wl$(comma)-x,-s)# App
 # make more of the instantiations byte-identical there).
 # No -ffunction-sections needed: lld's LTO codegen of this preset always emits per-function
 # sections, which is also why this lives here and not next to the other link flags.
-# Not for Emscripten, whose wasm-ld has no ICF, and not for Windows, where lld-link is a
-# COFF driver that answers this spelling with `ignoring unknown argument '--icf=all'` and
-# folds by default anyway: on the wheel build `/opt:noicf` grows mrmeshpy.pyd from 56.2 to
-# 63.0 MB, while `/opt:icf` changes nothing.
-ifeq ($(IS_EMSCRIPTEN)$(IS_WINDOWS),)
+# Not for Windows, where lld-link is a COFF driver that answers this spelling with
+# `ignoring unknown argument '--icf=all'` and folds by default anyway: on the wheel build
+# `/opt:noicf` grows mrmeshpy.pyd from 56.2 to 63.0 MB, while `/opt:icf` changes nothing.
+ifeq ($(IS_WINDOWS),)
 override EXTRA_LDFLAGS += -Wl,--icf=all
 endif
 else ifeq ($(MODE),debug)

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -323,6 +323,18 @@ MODE := release
 ifeq ($(MODE),release)
 override EXTRA_CFLAGS += -Oz -flto=thin -DNDEBUG
 override EXTRA_LDFLAGS += -Oz -flto=thin $(if $(IS_MACOS),-Wl$(comma)-x,-s)# Apple's ld rejects `-s`; `-Wl,-x` drops local Mach-O symbols (most of __LINKEDIT) instead.
+# Fold byte-identical functions: the bindings are ~190k tiny near-duplicate template
+# instantiations. Measured on mrmeshpy, with the Python sanity suite passing every time:
+# -11% on Linux, -13.6% on macOS x86_64, -19.4% on macOS arm64 (fixed-width instructions
+# make more of the instantiations byte-identical there).
+# No -ffunction-sections needed: lld's LTO codegen of this preset always emits per-function
+# sections, which is also why this lives here and not next to the other link flags.
+# Not for Emscripten, whose wasm-ld has no ICF, and not for Windows, where lld-link is a
+# COFF driver that answers this spelling with `ignoring unknown argument '--icf=all'`; the
+# wheel build there does use this preset, so `/opt:icf` remains to be measured.
+ifeq ($(IS_EMSCRIPTEN)$(IS_WINDOWS),)
+override EXTRA_LDFLAGS += -Wl,--icf=all
+endif
 else ifeq ($(MODE),debug)
 override EXTRA_CFLAGS += -g
 override EXTRA_LDFLAGS += -g
@@ -332,23 +344,6 @@ else
 $(error Unknown MODE=$(MODE))
 endif
 $(info MODE: $(MODE))
-
-# Fold byte-identical functions: the bindings are ~190k tiny near-duplicate template
-# instantiations. Measured on mrmeshpy, with the Python sanity suite passing every time:
-# -11% on Linux, -13.6% on macOS x86_64, -19.4% on macOS arm64 (fixed-width instructions
-# make more of the instantiations byte-identical there).
-# No -ffunction-sections needed: lld's LTO codegen always emits per-function sections.
-# Outside the MODE presets on purpose, so that a MODE=none build folds too.
-# Not for debug builds, where folded functions confuse breakpoints; not for Emscripten,
-# whose wasm-ld has no ICF; and not for Windows, where lld-link is a COFF driver that
-# ignores this spelling (`lld-link: warning: ignoring unknown argument '--icf=all'`) and
-# would need `/opt:icf` plus something to fold - the Windows bindings are built with
-# MODE=none, so neither LTO nor -ffunction-sections gives it per-function sections.
-ifeq ($(IS_EMSCRIPTEN)$(IS_WINDOWS),)
-ifneq ($(MODE),debug)
-override EXTRA_LDFLAGS += -Wl,--icf=all
-endif
-endif
 
 
 # The list of Python versions, in the format `X.Y`.

--- a/scripts/mrbind/generate.mk
+++ b/scripts/mrbind/generate.mk
@@ -338,10 +338,13 @@ $(info MODE: $(MODE))
 # -11% on Linux, -13.6% on macOS x86_64, -19.4% on macOS arm64 (fixed-width instructions
 # make more of the instantiations byte-identical there).
 # No -ffunction-sections needed: lld's LTO codegen always emits per-function sections.
-# Outside the MODE presets on purpose, because the Windows bindings are built with
-# MODE=none. Not for debug builds, where folded functions confuse breakpoints, and not for
-# Emscripten, whose wasm-ld has no ICF.
-ifeq ($(IS_EMSCRIPTEN),)
+# Outside the MODE presets on purpose, so that a MODE=none build folds too.
+# Not for debug builds, where folded functions confuse breakpoints; not for Emscripten,
+# whose wasm-ld has no ICF; and not for Windows, where lld-link is a COFF driver that
+# ignores this spelling (`lld-link: warning: ignoring unknown argument '--icf=all'`) and
+# would need `/opt:icf` plus something to fold - the Windows bindings are built with
+# MODE=none, so neither LTO nor -ffunction-sections gives it per-function sections.
+ifeq ($(IS_EMSCRIPTEN)$(IS_WINDOWS),)
 ifneq ($(MODE),debug)
 override EXTRA_LDFLAGS += -Wl,--icf=all
 endif


### PR DESCRIPTION
`--icf=all` was added for Linux only, with the note *"until lld-link (Windows) and ld64.lld (macOS) get their own measurements"*. Those measurements are now in, and they say: turn it on for **macOS** and leave Windows alone, because it already folds.

The change is one guard in `scripts/mrbind/generate.mk`: `ifneq ($(IS_LINUX),)` becomes `ifeq ($(IS_WINDOWS),)`. It stays inside the `MODE=release` preset, since that is where `-flto=thin` comes from and lld's LTO codegen is what emits the per-function sections ICF folds — a `MODE=none` build has nothing to fold on any platform.

### macOS: measured, enabled

Each variant was linked and then run through the **full Python sanity suite**:

| leg | baseline | with `--icf=all` | sanity |
| --- | --- | --- | --- |
| x64 Release | 45,815,344 | **39,606,312 (-13.6%)** | pass |
| arm64 Release | 30,881,104 | **24,925,216 (-19.3%)** | pass |
| arm64 Debug | 32,046,672 | **25,803,472 (-19.5%)** | pass |

`__text` alone drops 12.8% on x64 and 20.1% on arm64. arm64 folds more, as expected: fixed-width instructions make more of the ~190k near-duplicate template instantiations byte-identical.

### Windows: already folding, nothing to do

Its bindings link through `lld-link`, the COFF driver, which answers the GNU spelling with `lld-link: warning: ignoring unknown argument '--icf=all'` and produces a byte-identical module. The COFF spelling `/opt:icf` is a no-op too, because ICF already comes with `/opt:ref` in non-debug links. Measured on the wheel build, which unlike `build-test-windows.yml` uses this preset:

| wheel module | baseline | `/opt:icf` | `/opt:noicf` |
| --- | --- | --- | --- |
| `mrmeshpy.pyd` | 56,210,432 | 56,210,432 | **63,037,440 (+12.1%)** |
| `mrcudapy.pyd` | 816,640 | 816,640 | 876,032 (+7.3%) |

So Windows has had the same ~11% all along; passing the flag there would only add a warning.

### Rejected: `-fomit-frame-pointer`

Measured in the same runs and **not** included. On macOS it *grows* the module by 12-15% while shaving under 2% of code — Apple's ABI expects a frame pointer, so dropping it pushes functions out of the compact-unwind encodings into much bulkier DWARF entries — and it breaks the sanity suite outright: `libc++abi: terminating due to uncaught exception of type pybind11::stop_iteration`, i.e. unwinding stops finding handlers. Alignment padding is already nil under `-Oz` (477 bytes in a 34.7 MB `__text`), so there was nothing to win there either.
