### PR TITLE
Populate the pacman keyring when bootstrapping MSYS2 on arm64

### DIFF
--- a/.github/actions/install-msys2-mrbind/action.yml
+++ b/.github/actions/install-msys2-mrbind/action.yml
@@ -46,15 +46,11 @@ runs:
         if (-not (Test-Path 'C:\msys64\msys2_shell.cmd')) { throw 'MSYS2 extraction failed' }
         # first launch generates /etc and the user skeleton; pacman needs them
         & 'C:\msys64\msys2_shell.cmd' -no-start -defterm -here -c 'true'
-        # that init intermittently skips the local key signing, leaving every repo
-        # database at "unknown trust"; redo the keyring until `pacman -Sy` takes
-        # it. wget comes along because msys2-base has none, the scripts below do.
-        foreach ($i in 1..3) {
-          & 'C:\msys64\msys2_shell.cmd' -no-start -defterm -here -c 'pacman-key --init && pacman-key --populate msys2 && pacman-key --updatedb && pacman -Sy --noconfirm --needed wget'
-          if ($LASTEXITCODE -eq 0) { break }
-          Write-Host "MSYS2 keyring setup exited with code $LASTEXITCODE (attempt $i of 3)"
-          if ($i -eq 3) { throw 'MSYS2 keyring setup failed' }
-        }
+        # that init runs `pacman-key --populate msys2 || true` and intermittently
+        # dies before signing the keys, leaving every repo database at "unknown
+        # trust"; redo it here, plus the wget msys2-base lacks
+        & 'C:\msys64\msys2_shell.cmd' -no-start -defterm -here -c 'pacman-key --init && pacman-key --populate msys2 && pacman-key --updatedb && pacman -Sy --noconfirm --needed wget'
+        if ($LASTEXITCODE -ne 0) { throw "MSYS2 keyring setup exited with code $LASTEXITCODE" }
 
     - name: Install MSYS2 for MRBind
       # Pin clang to the version in the selected lockfile. Pinning only the

--- a/.github/actions/install-msys2-mrbind/action.yml
+++ b/.github/actions/install-msys2-mrbind/action.yml
@@ -46,8 +46,15 @@ runs:
         if (-not (Test-Path 'C:\msys64\msys2_shell.cmd')) { throw 'MSYS2 extraction failed' }
         # first launch generates /etc and the user skeleton; pacman needs them
         & 'C:\msys64\msys2_shell.cmd' -no-start -defterm -here -c 'true'
-        # msys2-base carries no wget, which msys2_download_packages.sh uses
-        & 'C:\msys64\msys2_shell.cmd' -no-start -defterm -here -c 'pacman -Sy --noconfirm --needed wget'
+        # that init intermittently skips the local key signing, leaving every repo
+        # database at "unknown trust"; redo the keyring until `pacman -Sy` takes
+        # it. wget comes along because msys2-base has none, the scripts below do.
+        foreach ($i in 1..3) {
+          & 'C:\msys64\msys2_shell.cmd' -no-start -defterm -here -c 'pacman-key --init && pacman-key --populate msys2 && pacman-key --updatedb && pacman -Sy --noconfirm --needed wget'
+          if ($LASTEXITCODE -eq 0) { break }
+          Write-Host "MSYS2 keyring setup exited with code $LASTEXITCODE (attempt $i of 3)"
+          if ($i -eq 3) { throw 'MSYS2 keyring setup failed' }
+        }
 
     - name: Install MSYS2 for MRBind
       # Pin clang to the version in the selected lockfile. Pinning only the


### PR DESCRIPTION
The Windows arm64 runner images ship no `C:\msys64`, so `install-msys2-mrbind` extracts `msys2-base` itself. That base's first-run keyring init is flaky: in [this run](https://github.com/MeshInspector/MeshLib/actions/runs/33420385036/job/99581222024) `pacman-key --populate msys2` stopped right after

```
==> Appending keys from msys2.gpg...
```

and never printed `Locally signing trusted keys in keyring...`, `Importing owner trust values...`, `Disabling revoked keys...` or the final trustdb update, all of which the preceding successful run on the same image and the same base archive did print. Without the local signatures the `pacman -Sy --needed wget` that follows rejects every repo database:

```
error: clangarm64: signature from "Christoph Reiter (MSYS2 development key) <reiter.christoph@gmail.com>" is unknown trust
...
error: failed to synchronize all databases (invalid or corrupted database (PGP signature))
```

and the whole arm64 job dies before MRBind is built.

MSYS2's own first-run setup swallows this: `filesystem/07-pacman-key.post` runs `pacman-key --populate msys2 || true`, then prints "Initial setup complete. MSYS2 is now ready to use." and exits 0 either way, which is why the job walked on to `pacman -Sy` with an unsigned keyring. (In the failed log `--refresh-keys` even ran in place of the signing stages, populate having already died.) The likely trigger is the MSYS2 runtime intermittently failing to fork: the stage between the two log lines spawns ~20 gpg processes for `key_is_lsigned`/`key_is_revoked`, and here the msys2 runtime is x86 emulated on an arm64 runner. It is the same class of flake the next step already retries over.

Redo the keyring explicitly (`pacman-key --init`, `--populate msys2`, `--updatedb`, all idempotent) chained with the `pacman -Sy`, and throw if it fails, so the failure is reported by the step that owns it. No retry: `pacman-key` would run over the `/etc/pacman.d/gnupg` the failed attempt left behind, so a retry is only worth adding together with wiping that directory. Affects every leg that bootstraps MSYS2, i.e. Windows arm64 in `build-test-windows` and `pip-build`.
