### PR TITLE
Add a Windows arm64 payload to the NuGet package

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -202,7 +202,13 @@ jobs:
        uses: actions/download-artifact@v8
        with:
          pattern: DotNetPatchArchiveWindows-x64
-         path: windows_runtime
+         path: windows_x64_runtime
+
+     - name: Download NuGet Windows Arm Patch Archive
+       uses: actions/download-artifact@v8
+       with:
+         pattern: DotNetPatchArchiveWindows-arm64
+         path: windows_arm64_runtime
 
      - name: Download NuGet Linux x64 Patch Archive
        uses: actions/download-artifact@v8
@@ -253,7 +259,7 @@ jobs:
      - name: Generate NuGet specification
        run: |
         echo ${{ needs.config.outputs.app_version }}
-        py -3 scripts\nuget_patch\generate_nuget_spec.py dotnet_dll windows_runtime linux_x64_runtime linux_arm64_runtime macos_x64_runtime macos_arm64_runtime ${{ needs.config.outputs.app_version }}
+        py -3 scripts\nuget_patch\generate_nuget_spec.py dotnet_dll windows_x64_runtime windows_arm64_runtime linux_x64_runtime linux_arm64_runtime macos_x64_runtime macos_arm64_runtime ${{ needs.config.outputs.app_version }}
 
      - name: Download NuGet Executable
        run:  curl https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -o nuget.exe

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -258,8 +258,9 @@ jobs:
         run: msbuild -m source\MeshLibC2\MeshLibC2.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=%MSBUILD_PLATFORM% -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }};MR_PCH_USE_EXTRA_HEADERS=ON
 
       - name: Build C CUDA bindings with MSBuild
-        # ProjectReference to MRCuda, so it needs a CUDA toolkit
-        if: ${{ inputs.mrbind_c && matrix.build_system == 'MSBuild' && env.CUDA_VERSION != '' }}
+        # Needs a CUDA toolkit for its MRCuda ProjectReference, except on arm64, where no
+        # toolkit exists and the project builds the placeholder stubs instead.
+        if: ${{ inputs.mrbind_c && matrix.build_system == 'MSBuild' && ( env.CUDA_VERSION != '' || matrix.arch == 'arm64' ) }}
         shell: cmd
         env:
           VCPKG_ROOT: C:\vcpkg
@@ -438,25 +439,25 @@ jobs:
           compression-level: 0
 
       - name: Create and fix fake Wheel for NuGet
-        # x64 only: the paths below, the artifact names and the package layout all assume
-        # one architecture. An arm64 NuGet payload is a separate change.
-        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' && matrix.arch != 'arm64' }}
+        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
         run: |
           py -3 -m venv wheel_venv
           wheel_venv\Scripts\Activate
           py -3 -m pip install delvewheel
-          py -3 ./scripts/nuget_patch/patch_library_deps.py ./patched_content/ ./source/x64/Release/MeshLibC2.dll ./source/x64/Release/MeshLibC2Cuda.dll
+          py -3 ./scripts/nuget_patch/patch_library_deps.py ./patched_content/ ./source/${{ env.MR_ARCH }}/Release/MeshLibC2.dll ./source/${{ env.MR_ARCH }}/Release/MeshLibC2Cuda.dll
 
       - name: Upload NuGet files to Artifacts
-        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' && matrix.arch != 'arm64' }}
+        if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' }}
         uses: actions/upload-artifact@v7
         with:
-          name: DotNetPatchArchiveWindows-x64
+          name: DotNetPatchArchiveWindows-${{ env.MR_ARCH }}
           path: ./patched_content/*
           retention-days: 1
           overwrite: true
 
       - name: Upload NuGet library DLL and XML to Artifacts
+        # These are netstandard2.0 and carry no architecture, so take them from the x64
+        # leg only; the arm64 one would only overwrite them with equivalent assemblies.
         if: ${{ inputs.nuget_build && matrix.cxx_compiler == 'msvc-2026' && matrix.config == 'Release' && env.BUILD_C_SHARP == 'true' && matrix.arch != 'arm64' }}
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/nuget-consumer-test.yml
+++ b/.github/workflows/nuget-consumer-test.yml
@@ -18,8 +18,16 @@ permissions:
 
 jobs:
   nuget-consumer-test:
-    name: NuGet consumer test (net47, net10.0)
-    runs-on: windows-2025
+    name: NuGet consumer test (${{ matrix.arch }}, net47, net10.0)
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-2025
+          - arch: ARM64
+            runner: windows-11-vs2026-arm
     timeout-minutes: 30
     env:
       PROJECT_DIR: test_nuget/NugetTestProj
@@ -63,7 +71,7 @@ jobs:
       - name: Build consumers
         shell: pwsh
         run: |
-          dotnet build $env:PROJECT_DIR -c Release -p:MeshLibVersion=${{ steps.feed.outputs.package_version }}
+          dotnet build $env:PROJECT_DIR -c Release -p:MeshLibVersion=${{ steps.feed.outputs.package_version }} -p:PlatformTarget=${{ matrix.arch }}
 
       - name: Run consumers
         shell: pwsh

--- a/doxygen/general_pages/CSharpSetupGuide.dox
+++ b/doxygen/general_pages/CSharpSetupGuide.dox
@@ -20,14 +20,15 @@ The NuGet package ships prebuilt native libraries, so your OS and CPU architectu
 
 | OS | Architectures | Minimum version |
 |---|---|---|
-| Windows | x64 | Windows 10 |
+| Windows | x64, Arm64 | Windows 10 |
 | Linux | x64, Arm64 | glibc 2.28+ — e.g. Ubuntu 20.04+, Debian 10+, RHEL/Rocky/AlmaLinux 8+, Fedora 29+ |
 | macOS | Arm64 (Apple silicon) | macOS 14 |
 | macOS | x64 (Intel) | macOS 15 |
 
-\note Windows on Arm is not supported: the package ships no `win-arm64` native runtime. Installing it there
-succeeds, so the failure only surfaces on the first call into MeshLib. Building the project for `win-x64`
-instead runs it under the system's x64 emulation.
+\note On Windows on Arm, .NET 5 and newer resolve `win-arm64` by themselves. A \b .NET \b Framework
+project instead gets the runtime named by its `PlatformTarget`, so set `<PlatformTarget>ARM64</PlatformTarget>`
+to run natively; any other value gives it the `win-x64` libraries and the x64 emulation. Native Arm64
+.NET Framework requires 4.8.1, i.e. Windows 11.
 
 On \b Linux no extra system packages are required: beyond the C and C++ runtimes the libraries need only
 `libexpat1` and `zlib1g`, which a standard desktop or server install already provides. Every other dependency
@@ -201,7 +202,7 @@ and a `cube.stl` of about 700 bytes appears in the working directory.
 
 ## Package Size and Native Runtimes {#MeshLibCSharpPackageSize}
 
-The NuGet package carries prebuilt native libraries for **all five** supported platforms, so it is large: 200+ MB Nuget download, 700+ MB copied to the build directory by default.
+The NuGet package carries prebuilt native libraries for **all six** supported platforms, so it is large: 200+ MB Nuget download, 700+ MB copied to the build directory by default.
 
 For deployment, you might wish to publish for a single RID (single platform), which omits the unnecessary libraries for other platforms, e.g.:
 \code{.cmd}
@@ -210,7 +211,7 @@ dotnet publish -r linux-x64 --self-contained false
 
 This copies only about 180 MB of libraries to the output directory, as opposed to 700+ MB.
 
-Supported platform IDs are: `win-x64`, `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`.
+Supported platform IDs are: `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`.
 
 
 ## Using MeshLib with Unity {#MeshLibCSharpUnity}
@@ -236,7 +237,7 @@ System.DllNotFoundException: Unable to load DLL 'MeshLibC2' or one of its depend
 (on Linux and macOS: `Unable to load shared library 'MeshLibC2' or one of its dependencies`)
 
 The native libraries were not found at run time:
- - Check that your platform is \ref MeshLibCSharpPlatforms "supported" — in particular, the package contains no native libraries for Windows on Arm.
+ - Check that your platform is \ref MeshLibCSharpPlatforms "supported".
  - Check that the native libraries reached your build output: on .NET they are placed under `runtimes/<rid>/native/` in the output directory (see \ref MeshLibCSharpPackageSize "Package Size and Native Runtimes"), on .NET Framework next to the executable (`MeshLibC2.dll` and its dependencies on Windows).
 
 ### BadImageFormatException
@@ -249,6 +250,8 @@ MeshLib's native libraries are 64-bit only, and this exception means your applic
 <PlatformTarget>x64</PlatformTarget>
 <Prefer32Bit>false</Prefer32Bit>
 \endcode
+On Windows on Arm use `ARM64` rather than `x64` there: for .NET Framework projects that value also
+selects which of the package's native runtimes gets copied.
 
 ### A rebuilt local package is ignored
 

--- a/scripts/nuget_patch/MeshLib.targets
+++ b/scripts/nuget_patch/MeshLib.targets
@@ -2,7 +2,14 @@
     This file is included for .NET Framework projects (as opposed to newer .NET) to ensure that the native libraries get copied to the build output directory.
 -->
 <Project>
+  <PropertyGroup>
+    <!-- Which runtimes/ folder to copy from. .NET Framework 4.8.1 is the first version
+         that runs natively on Windows arm64; anything else (including AnyCPU) keeps the
+         x64 natives it has always got. MSBuild string comparison is case-insensitive. -->
+    <MeshLibNativeRid>win-x64</MeshLibNativeRid>
+    <MeshLibNativeRid Condition="'$(PlatformTarget)' == 'ARM64'">win-arm64</MeshLibNativeRid>
+  </PropertyGroup>
   <ItemGroup Condition="$([MSBuild]::VersionLessThan('$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))','5.0'))">
-    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\*" TargetPath="%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\runtimes\$(MeshLibNativeRid)\native\*" TargetPath="%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/scripts/nuget_patch/generate_nuget_spec.py
+++ b/scripts/nuget_patch/generate_nuget_spec.py
@@ -6,12 +6,13 @@ from string import Template
 
 WORK_DIR = Path(".")
 DOTNET_DLL_DIR = WORK_DIR / sys.argv[1]
-WINDOWS_RUNTIME_DIR = WORK_DIR / sys.argv[2]
-LINUX_X64_RUNTIME_DIR = WORK_DIR / sys.argv[3]
-LINUX_ARM_RUNTIME_DIR = WORK_DIR / sys.argv[4]
-MACOS_X64_RUNTIME_DIR = WORK_DIR / sys.argv[5]
-MACOS_ARM_RUNTIME_DIR = WORK_DIR / sys.argv[6]
-VERSION = sys.argv[7][1:]
+WINDOWS_X64_RUNTIME_DIR = WORK_DIR / sys.argv[2]
+WINDOWS_ARM_RUNTIME_DIR = WORK_DIR / sys.argv[3]
+LINUX_X64_RUNTIME_DIR = WORK_DIR / sys.argv[4]
+LINUX_ARM_RUNTIME_DIR = WORK_DIR / sys.argv[5]
+MACOS_X64_RUNTIME_DIR = WORK_DIR / sys.argv[6]
+MACOS_ARM_RUNTIME_DIR = WORK_DIR / sys.argv[7]
+VERSION = sys.argv[8][1:]
 
 SPEC_FILE = WORK_DIR / "Package.nuspec"
 LICENSE_FILE = WORK_DIR / "LICENSE"
@@ -34,7 +35,8 @@ FILES = ""
 add_files( DOTNET_DLL_DIR, "lib/netstandard2.0/" )
 
 # For platform names, see: https://learn.microsoft.com/en-us/dotnet/core/rid-catalog
-add_files( WINDOWS_RUNTIME_DIR, "runtimes/win-x64/native/" )
+add_files( WINDOWS_X64_RUNTIME_DIR, "runtimes/win-x64/native/" )
+add_files( WINDOWS_ARM_RUNTIME_DIR, "runtimes/win-arm64/native/" )
 add_files( LINUX_X64_RUNTIME_DIR, "runtimes/linux-x64/native/" )
 add_files( LINUX_ARM_RUNTIME_DIR, "runtimes/linux-arm64/native/" )
 add_files( MACOS_X64_RUNTIME_DIR, "runtimes/osx-x64/native/" )

--- a/source/MeshLibC2Cuda/MeshLibC2Cuda.vcxproj
+++ b/source/MeshLibC2Cuda/MeshLibC2Cuda.vcxproj
@@ -25,7 +25,9 @@
     <ProjectReference Include="..\MRPch\MRPch.vcxproj">
       <Project>{36516aee-2fb9-41c0-a176-a2d49c1c26b2}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\MRCuda\MRCuda.vcxproj">
+    <!-- No CUDA toolkit exists for Windows arm64, so MRCuda is not built there and
+         this project links only the placeholder stubs, as the CMake build does. -->
+    <ProjectReference Include="..\MRCuda\MRCuda.vcxproj" Condition="'$(Platform)'!='ARM64'">
       <Project>{16e3daf5-b110-4812-a3b8-495ba172089e}</Project>
     </ProjectReference>
     <ProjectReference Include="..\MeshLibC2\MeshLibC2.vcxproj">


### PR DESCRIPTION
Last of the Windows arm64 series (#6705, #6718, #6721, #6727, #6729). The NuGet package
gains **`runtimes/win-arm64/native/`**, so it now covers all six RIDs the .NET bindings
are built for: `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`.

## MeshLibC2Cuda on arm64

#6727 left the NuGet steps x64-only partly because the arm64 leg had no `MeshLibC2Cuda.dll`
to package: the MSBuild project has a `ProjectReference` to `MRCuda`, and no CUDA toolkit
exists for Windows on ARM.

It does not need one. The generated Cuda C bindings on a CUDA-less platform come from
`scripts/mrbind/cuda_placeholder_generated_c`, whose only includes are its own header and
`cuda_placeholder.h` — a header-only `isCudaAvailable()` returning false. The CMake build
already relies on this and links `bin\MeshLibC2Cuda.dll` on the arm64 leg today. Making the
`MRCuda` reference conditional on `'$(Platform)'!='ARM64'` lets the MSBuild project do the
same, so the arm64 runtime folder carries the same two libraries as every other platform
rather than being a special case consumers have to code around.

Verified locally with `msbuild -getItem:ProjectReference` that x64 still resolves all four
references, and that the platform condition does drop `MRCuda` (probed with `Win32`, since
this machine has no ARM64 VC platform props installed).

## MeshLib.targets

This ships inside the package for **.NET Framework** consumers, which have no RID-based
runtime asset resolution — the file copies the natives by hand, and hard-coded `win-x64`.
Shipping arm64 natives that it never reaches would be pointless, so the folder now comes
from `PlatformTarget`:

| `PlatformTarget` | RID folder | |
|---|---|---|
| `x64` | `win-x64` | unchanged |
| `ARM64` / `arm64` | `win-arm64` | new (MSBuild `==` is case-insensitive) |
| `AnyCPU`, anything else | `win-x64` | unchanged |
| — (net5.0+) | none copied | unchanged, the SDK resolves it |

Checked every row against a fake package layout with `-getItem:ContentWithTargetPath`.

## Changes

* **`MeshLibC2Cuda.vcxproj`** — `MRCuda` `ProjectReference` conditional on the platform.
* **`build-test-windows.yml`** — the C CUDA bindings step also runs on arm64; the three NuGet
  steps drop their `matrix.arch != 'arm64'` guard and take the architecture from `MR_ARCH`.
  The artifact becomes `DotNetPatchArchiveWindows-<arch>`.
* **`DotNetDllXml`** stays x64-only: `MRDotNet2`/`MRDotNet2Static` are `netstandard2.0` and
  carry no architecture, so the arm64 leg would only overwrite them with equivalents.
* **`generate_nuget_spec.py`** — one more runtime directory argument.
* **`build-test-distribute.yml`** — downloads the new artifact. A missing arm64 leg degrades
  the way the other arm64 RIDs already do: `download-artifact` treats a zero-match `pattern`
  as a no-op and `os.walk` over the empty directory contributes no files, so the package is
  built without those natives instead of failing.
* **`nuget-consumer-test.yml`** — becomes a two-entry matrix so the package is also consumed
  on `windows-11-vs2026-arm`, with `-p:PlatformTarget=ARM64` overriding the test project's
  pinned `x64`. This is the only step that actually exercises the new payload end to end.

## What is not here

The developer distributive: `job_upload_artifact` still excludes arm64, because `VS_TAG`
would collide with the x64 `MeshLibDistVS26.zip`. Separate change.

## Risk

The arm64 consumer leg is the untested part — it needs the `net47` output to run under
.NET Framework 4.8.1 on ARM64. If that turns out not to hold I will narrow that leg to
`net10.0` rather than drop the RID selection.


## Documentation

`CSharpSetupGuide.dox` claimed the opposite, so it is updated in the same PR: the "Windows on Arm is
not supported" note is gone, `win-arm64` joins the platform table and the RID list, and the note in
its place says what a **.NET Framework** project must do — `<PlatformTarget>ARM64</PlatformTarget>`,
since that is what `MeshLib.targets` reads. .NET 5+ needs nothing. The size figures are unchanged and
still correct: the six-RID package measures 224 MB compressed and 780 MB expanded.

`CppSetupGuide.dox` still says no native Arm64 Windows build is published — that remains true for the
C++ developer distributive and is the separate change noted above.
