### PR TITLE
Probe the ubuntu24 .deb on Ubuntu 26.04 in test-distribution

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -42,6 +42,7 @@ on:
 jobs:
   linux-x64-test:
     if: ${{ inputs.test_ubuntu_x64 }}
+    continue-on-error: ${{ matrix.experimental || false }}
     timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
@@ -49,18 +50,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu:22.04", "ubuntu:24.04" ]
+        os: [ "ubuntu:22.04", "ubuntu:24.04", "ubuntu:26.04" ]
         include:
           - os: "ubuntu:22.04"
             name: "ubuntu22"
             compiler: clang-14
             c-compiler: /usr/bin/clang-14
             cxx-compiler: /usr/bin/clang++-14
+            stdcxx-dev: libstdc++-10-dev
           - os: "ubuntu:24.04"
             name: "ubuntu24"
             compiler: clang-18
             c-compiler: /usr/bin/clang-18
             cxx-compiler: /usr/bin/clang++-18
+            stdcxx-dev: libstdc++-10-dev
+          # Forward-compatibility probe: the ubuntu24 deb on the next LTS. Not a
+          # supported combination, so continue-on-error keeps it from reddening
+          # a release; 26.04 has no libstdc++-10-dev and its clang is 21.
+          - os: "ubuntu:26.04"
+            name: "ubuntu24"
+            compiler: clang
+            c-compiler: /usr/bin/clang
+            cxx-compiler: /usr/bin/clang++
+            stdcxx-dev: libstdc++-15-dev
+            experimental: true
 
     steps:
       - name: Checkout
@@ -93,7 +106,7 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y upgrade && \
             apt-get -y install sudo xvfb curl libssl-dev python3-pip && \
-            apt-get -y install libstdc++-10-dev && \
+            apt-get -y install ${{ matrix.stdcxx-dev }} && \
             apt-get -y install ./*${{matrix.name}}-dev.deb
 
       - name: Create virtualenv


### PR DESCRIPTION
### Why

`test-distribution.yml` installs each released `.deb` only back into the container it was built in — the `ubuntu22` deb into `ubuntu:22.04`, the `ubuntu24` deb into `ubuntu:24.04`. So we have no CI answer to a question users do ask: does a package built for 24.04 still work on 26.04 (Resolute Raccoon, released April 2026)?

The reasoning says probably not — `dpkg` will resolve the `Depends`, since those are the unversioned names from `requirements/ubuntu.txt` and they still exist on 26.04, but the shipped `.so`s are linked against noble's sonames (Boost 1.83, OCCT 7.6, `libjsoncpp.so.25`, `libpython3.12.so.1.0`), and 26.04 ships different ones. Python is the hardest pin: 26.04's default is 3.14, and `mrmeshpy.so` is a CPython-3.12-ABI module. This row makes CI say it out loud instead.

### What

A third `linux-x64-test` matrix row: container `ubuntu:26.04`, `name: ubuntu24` so it downloads and installs the existing 24.04 package. No new build — it reuses the deb this run already publishes.

Two values had to become matrix keys because Resolute doesn't have them:

- `libstdc++-10-dev` exists only in jammy and noble → `stdcxx-dev`, `libstdc++-15-dev` on 26.04 (GCC 15.2 is the default there).
- `clang-18` → the unversioned `clang` metapackage, which is LLVM 21 on 26.04.

The row is marked `experimental: true` and the job is `continue-on-error: ${{ matrix.experimental || false }}`, so a failure here reports the incompatibility without reddening a real release run. If it turns out green, we drop `experimental` and gain a genuine forward-compatibility gate.

The install step runs before the venv/pytest steps, so the `apt-get install ./*.deb` result is visible in the log either way.

### Notes

- `linux-arm64-test` is left untouched — the question is arch-independent, and one probe row is enough to answer it. Mirroring it there is a one-line follow-up if we want it.
- Labels: `upload-binaries` so `test-distribution` runs at all (it needs a published release to download from), and the other platforms disabled since nothing here touches them.
