### PR TITLE
getLargestComponentArea function

### DIFF
--- a/source/MRMesh/MRMeshComponents.cpp
+++ b/source/MRMesh/MRMeshComponents.cpp
@@ -54,22 +54,25 @@ VertBitSet getComponentVerts( const Mesh& mesh, VertId id, const VertBitSet* reg
 
 }
 
-FaceBitSet getLargestComponent( const MeshPart& meshPart, FaceIncidence incidence, const UndirectedEdgeBitSet * isCompBd, float minArea, int * numSmallerComponents )
+double getLargestComponentArea( const MeshPart& meshPart, FaceIncidence incidence, const UndirectedEdgeBitSet * isCompBd,
+    FaceBitSet * largestComponent, int * numSmallerComponents )
 {
     MR_TIMER;
+
+    if ( largestComponent )
+        largestComponent->clear();
 
     auto unionFindStruct = getUnionFindStructureFaces( meshPart, incidence, isCompBd );
     const auto& mesh = meshPart.mesh;
     const FaceBitSet& region = mesh.topology.getFaceIds( meshPart.region );
 
-    FaceBitSet maxAreaComponent;
     const auto& allRoots = unionFindStruct.roots();
     auto [uniqueRootsMap, k] = getUniqueRootIds( allRoots, region );
     if ( k <= 0 )
     {
         if ( numSmallerComponents )
             *numSmallerComponents = 0;
-        return maxAreaComponent;
+        return 0;
     }
 
     double maxDblArea = -DBL_MAX;
@@ -79,29 +82,45 @@ FaceBitSet getLargestComponent( const MeshPart& meshPart, FaceIncidence incidenc
     {
         auto index = uniqueRootsMap[f];
         auto& dblArea = dblAreas[index];
-        dblArea += meshPart.mesh.dblArea( f );
+        dblArea += mesh.dblArea( f );
         if ( dblArea > maxDblArea )
         {
             maxI = index;
             maxDblArea = dblArea;
         }
     }
-    if ( maxDblArea < 2 * minArea )
-    {
-        if ( numSmallerComponents )
-            *numSmallerComponents = k;
-        return maxAreaComponent;
-    }
     if ( numSmallerComponents )
         *numSmallerComponents = k - 1;
-    maxAreaComponent.resize( region.find_last() + 1 );
-    for ( auto f : region )
+    if ( largestComponent )
     {
-        auto index = uniqueRootsMap[f];
-        if ( index != maxI )
-            continue;
-        maxAreaComponent.set( f );
+        largestComponent->resize( region.find_last() + 1 );
+        for ( auto f : region )
+        {
+            auto index = uniqueRootsMap[f];
+            if ( index != maxI )
+                continue;
+            largestComponent->set( f );
+        }
     }
+    return 0.5 * maxDblArea;
+}
+
+FaceBitSet getLargestComponent( const MeshPart& meshPart, FaceIncidence incidence, const UndirectedEdgeBitSet * isCompBd, float minArea, int * numSmallerComponents )
+{
+    MR_TIMER;
+
+    FaceBitSet maxAreaComponent;
+    int numOtherComponents = 0;
+    const auto maxArea = getLargestComponentArea( meshPart, incidence, isCompBd, &maxAreaComponent, &numOtherComponents );
+    if ( maxArea < minArea )
+    {
+        // the largest component is not returned, so it is counted among smaller ones (if it exists at all)
+        if ( numSmallerComponents )
+            *numSmallerComponents = maxAreaComponent.any() ? numOtherComponents + 1 : 0;
+        return {};
+    }
+    if ( numSmallerComponents )
+        *numSmallerComponents = numOtherComponents;
     return maxAreaComponent;
 }
 

--- a/source/MRMesh/MRMeshComponents.h
+++ b/source/MRMesh/MRMeshComponents.h
@@ -37,6 +37,11 @@ enum FaceIncidence
 [[nodiscard]] MRMESH_API VertBitSet getLargeComponentVerts( const Mesh& mesh, int minVerts, const VertBitSet* region = nullptr );
 
 
+/// returns the area of the largest by surface area component, and zero if there are no components at all
+[[nodiscard]] MRMESH_API double getLargestComponentArea( const MeshPart& meshPart,
+    FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {}, FaceBitSet * largestComponent = nullptr, ///< optional output with the faces of the largest by area component
+    int * numSmallerComponents = nullptr ); ///< optional output: the number of components in addition to returned one
+
 /// returns the largest by surface area component or empty set if its area is smaller than \param minArea
 [[nodiscard]] MRMESH_API FaceBitSet getLargestComponent( const MeshPart& meshPart,
     FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {}, float minArea = 0,

--- a/source/MRTest/MRMeshComponentsTests.cpp
+++ b/source/MRTest/MRMeshComponentsTests.cpp
@@ -44,6 +44,38 @@ TEST(MRMesh, getAllComponentsEdges)
     ASSERT_EQ( comp[0].count(), 5 );
 }
 
+TEST(MRMesh, getLargestComponentArea)
+{
+    Triangulation t{
+        { 0_v, 1_v, 2_v },
+        { 3_v, 4_v, 5_v }
+    };
+    Mesh mesh;
+    mesh.topology = MeshBuilder::fromTriangles( t );
+    mesh.points.emplace_back( 0.f, 0.f, 0.f );
+    mesh.points.emplace_back( 1.f, 0.f, 0.f );
+    mesh.points.emplace_back( 0.f, 1.f, 0.f );
+    mesh.points.emplace_back( 10.f, 0.f, 0.f );
+    mesh.points.emplace_back( 12.f, 0.f, 0.f );
+    mesh.points.emplace_back( 10.f, 2.f, 0.f );
+
+    FaceBitSet largest;
+    int numSmallerComponents = -1;
+    ASSERT_NEAR( MeshComponents::getLargestComponentArea( mesh, MeshComponents::PerEdge, nullptr, &largest, &numSmallerComponents ), 2.0, 1e-6 );
+    ASSERT_EQ( numSmallerComponents, 1 );
+    ASSERT_EQ( largest.count(), 1 );
+    ASSERT_TRUE( largest.test( 1_f ) );
+
+    ASSERT_TRUE( MeshComponents::getLargestComponent( mesh, MeshComponents::PerEdge, nullptr, 1.0f, &numSmallerComponents ) == largest );
+    ASSERT_EQ( numSmallerComponents, 1 );
+    ASSERT_TRUE( MeshComponents::getLargestComponent( mesh, MeshComponents::PerEdge, nullptr, 3.0f, &numSmallerComponents ).none() );
+    ASSERT_EQ( numSmallerComponents, 2 ); // both components are smaller than requested
+
+    ASSERT_EQ( MeshComponents::getLargestComponentArea( Mesh{}, MeshComponents::PerEdge, nullptr, &largest, &numSmallerComponents ), 0 );
+    ASSERT_TRUE( largest.none() );
+    ASSERT_EQ( numSmallerComponents, 0 );
+}
+
 TEST(MRMesh, getLargestComponentVerts)
 {
     auto mesh = makeCube();


### PR DESCRIPTION
### New function

```cpp
[[nodiscard]] MRMESH_API double getLargestComponentArea( const MeshPart& meshPart,
    FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {}, FaceBitSet * largestComponent = nullptr,
    int * numSmallerComponents = nullptr );
```

It returns the area of the largest by surface area component (zero if there are no components at all), and optionally outputs the faces of that component and the number of the other components. Unlike `getLargestComponent`, it can be called with `largestComponent = nullptr`, and then no face bitset is allocated and filled.

`getLargestComponent` is now a thin wrapper over it: the `minArea` comparison `area < minArea` is exactly equivalent to the former `2*area < 2*minArea`, and `numSmallerComponents` keeps counting the largest component itself when the latter is too small to be returned.

### Existing usages

All places calling `getLargestComponent` were inspected; none of them benefits from the new function, so they are left as is:
* `getNLargeByAreaComponents` (`maxLargeComponents == 1` branch) and `MRUniteManyMeshes.cpp` need the faces only, not the area;
* `Mesh::deleteFaces` already skips the work for an empty argument, so knowing the number of components in advance saves nothing in `normalizeUniteMesh`.

A unit test for the new function is added.
