### PR TITLE
Cancel a PR's superseded Build Test Distribute runs

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -14,7 +14,7 @@ on:
     - cron: '0 2 * * *'  # Run every day at 2 AM UTC
 
 # Supersede a PR's previous run instead of racing it (two live runs of one branch
-# collided pushing the same new Docker Hub repo). Push/schedule/dispatch get a
+# collided pushing the same new Docker Hub repo, #6738). Push/schedule/dispatch get
 # unique group, so a release run is never cancelled and never queues behind one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -13,6 +13,13 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Run every day at 2 AM UTC
 
+# Supersede a PR's previous run instead of racing it (two live runs of one branch
+# collided pushing the same new Docker Hub repo). Push/schedule/dispatch get a
+# unique group, so a release run is never cancelled and never queues behind one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   id-token: write
   contents: write


### PR DESCRIPTION
### Why

`build-test-distribute.yml` has no `concurrency:` group, so pushing to a PR branch leaves the previous run alive alongside the new one. On #6738 that turned into a real failure rather than just wasted minutes.

Two runs of `fedr/ubuntu26-target` were live at once — my commit, then a second push two minutes later — and both reached the point of pushing the brand-new `meshlib/meshlib-ubuntu26` image:

| | winner (run 33490915399) | loser (run 33491107890) |
|---|---|---|
| push starts | 09:24:44 | 09:25:36 |
| first blob | `Pushed` @ 09:24:46 | `Retrying in 5 seconds` @ 09:25:36 |
| retries / auth errors | 0 | 3 rounds, then `unauthorized` @ 09:25:51 |
| manifest | pushed 09:28:39 | never |

The loser was denied on its very first blob POST, 52 s after the winner started and while the winner was still uploading. The token is not the problem — the winner *created* that repository from nothing with zero retries, and as a control both runs pushed the identical tag `source-checksum-f4e25eb26edf59ef` to the **existing** `meshlib-ubuntu24` repo over overlapping windows (09:22:01→09:24:22 and 09:24:01→09:26:22) and both succeeded. Existing repo plus concurrent same-tag push is fine; a repository that does not exist yet is created as part of the first push, and a second session asking for push scope on that same path while creation is in flight gets `unauthorized`. `docker push` retries only ~15 s, so the loser dies.

### What

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Only `pull_request` runs share a group, and only they are cancellable. Every other event (`push` to master, `schedule`, `workflow_dispatch`) keys the group on `github.run_id`, which is unique per run — so a release run is never cancelled by the next push, and equally never sits queued behind the previous one. Keying those on `github.ref` instead would have serialized consecutive master pushes behind a 1–2 h pipeline, which is worse than the race it fixes.

Cancelling mid-image-push is safe: the manifest is written last, so a cancelled push leaves only orphan blobs and the next run re-pushes the tag.

### Verification

I will push a second commit to this branch on purpose and confirm the first run ends up `cancelled` rather than racing — that is the only way to exercise this end to end, and I will report the result in a comment.

### Notes

Labels disable the platforms this cannot affect; no `upload-binaries`, since nothing here needs a published release.
