### PR TITLE
getLargestComponentVolume function

### DIFF
--- a/source/MRMesh/MRMeshComponents.cpp
+++ b/source/MRMesh/MRMeshComponents.cpp
@@ -124,8 +124,8 @@ FaceBitSet getLargestComponent( const MeshPart& meshPart, FaceIncidence incidenc
     return maxAreaComponent;
 }
 
-double getLargestComponentVolume( const MeshPart& meshPart, FaceIncidence incidence, const UndirectedEdgeBitSet * isCompBd,
-    FaceBitSet * largestComponent, int * numSmallerComponents )
+double getLargestComponentVolume( const MeshPart& meshPart, VolumeSelection selection, FaceIncidence incidence,
+    const UndirectedEdgeBitSet * isCompBd, FaceBitSet * largestComponent, int * numSmallerComponents )
 {
     MR_TIMER;
 
@@ -153,12 +153,41 @@ double getLargestComponentVolume( const MeshPart& meshPart, FaceIncidence incide
         sixVolumes[uniqueRootsMap[f]] += mixed( Vector3d( fp[0] ), Vector3d( fp[1] ), Vector3d( fp[2] ) );
     }
 
-    // unlike area, volume is not accumulated monotonically, so the largest one is found only here
-    int maxI = 0;
-    for ( int i = 1; i < k; ++i )
+    // unlike area, volume is not accumulated monotonically, so the component is selected only here
+    int maxI = -1;
+    double maxKey = 0; // the larger the key, the better the component
+    for ( int i = 0; i < k; ++i )
     {
-        if ( std::abs( sixVolumes[i] ) > std::abs( sixVolumes[maxI] ) )
+        double key = 0;
+        switch ( selection )
+        {
+        case VolumeSelection::Positive:
+            if ( sixVolumes[i] <= 0 )
+                continue;
+            key = sixVolumes[i];
+            break;
+        case VolumeSelection::Negative:
+            if ( sixVolumes[i] >= 0 )
+                continue;
+            key = -sixVolumes[i];
+            break;
+        default:
+            assert( selection == VolumeSelection::Abs );
+            key = std::abs( sixVolumes[i] );
+            break;
+        }
+        if ( maxI < 0 || key > maxKey )
+        {
             maxI = i;
+            maxKey = key;
+        }
+    }
+    if ( maxI < 0 )
+    {
+        // no component satisfies the selection rule, so all of them are counted as smaller ones
+        if ( numSmallerComponents )
+            *numSmallerComponents = k;
+        return 0;
     }
 
     if ( numSmallerComponents )

--- a/source/MRMesh/MRMeshComponents.cpp
+++ b/source/MRMesh/MRMeshComponents.cpp
@@ -155,7 +155,9 @@ double getLargestComponentVolume( const MeshPart& meshPart, VolumeSelection sele
 
     // unlike area, volume is not accumulated monotonically, so the component is selected only here
     int maxI = -1;
-    double maxKey = 0; // the larger the key, the better the component; not positive key means unsuitable component
+    // the larger the key, the better the component; not positive key means unsuitable component,
+    // and only Abs rule accepts a component of zero volume
+    double maxKey = selection == VolumeSelection::Abs ? -1.0 : 0.0;
     for ( int i = 0; i < k; ++i )
     {
         double key = 0;
@@ -180,7 +182,7 @@ double getLargestComponentVolume( const MeshPart& meshPart, VolumeSelection sele
     }
     if ( maxI < 0 )
     {
-        // no component with non-zero volume satisfies the selection rule, so all of them are counted as smaller ones
+        // no component satisfies the selection rule, so all of them are counted as smaller ones
         if ( numSmallerComponents )
             *numSmallerComponents = k;
         return 0;

--- a/source/MRMesh/MRMeshComponents.cpp
+++ b/source/MRMesh/MRMeshComponents.cpp
@@ -124,6 +124,59 @@ FaceBitSet getLargestComponent( const MeshPart& meshPart, FaceIncidence incidenc
     return maxAreaComponent;
 }
 
+double getLargestComponentVolume( const MeshPart& meshPart, FaceIncidence incidence, const UndirectedEdgeBitSet * isCompBd,
+    FaceBitSet * largestComponent, int * numSmallerComponents )
+{
+    MR_TIMER;
+
+    if ( largestComponent )
+        largestComponent->clear();
+
+    auto unionFindStruct = getUnionFindStructureFaces( meshPart, incidence, isCompBd );
+    const auto& mesh = meshPart.mesh;
+    const FaceBitSet& region = mesh.topology.getFaceIds( meshPart.region );
+
+    const auto& allRoots = unionFindStruct.roots();
+    auto [uniqueRootsMap, k] = getUniqueRootIds( allRoots, region );
+    if ( k <= 0 )
+    {
+        if ( numSmallerComponents )
+            *numSmallerComponents = 0;
+        return 0;
+    }
+
+    // six-fold volume of each component, valid if the component is closed
+    std::vector<double> sixVolumes( k, 0.0 );
+    for ( auto f : region )
+    {
+        const auto fp = mesh.getTriPoints( f );
+        sixVolumes[uniqueRootsMap[f]] += mixed( Vector3d( fp[0] ), Vector3d( fp[1] ), Vector3d( fp[2] ) );
+    }
+
+    // unlike area, volume is not accumulated monotonically, so the largest one is found only here
+    int maxI = 0;
+    for ( int i = 1; i < k; ++i )
+    {
+        if ( std::abs( sixVolumes[i] ) > std::abs( sixVolumes[maxI] ) )
+            maxI = i;
+    }
+
+    if ( numSmallerComponents )
+        *numSmallerComponents = k - 1;
+    if ( largestComponent )
+    {
+        largestComponent->resize( region.find_last() + 1 );
+        for ( auto f : region )
+        {
+            auto index = uniqueRootsMap[f];
+            if ( index != maxI )
+                continue;
+            largestComponent->set( f );
+        }
+    }
+    return sixVolumes[maxI] / 6.0;
+}
+
 VertBitSet getLargestComponentVerts( const Mesh& mesh, const VertBitSet* region /*= nullptr */ )
 {
     MR_TIMER;

--- a/source/MRMesh/MRMeshComponents.cpp
+++ b/source/MRMesh/MRMeshComponents.cpp
@@ -155,20 +155,16 @@ double getLargestComponentVolume( const MeshPart& meshPart, VolumeSelection sele
 
     // unlike area, volume is not accumulated monotonically, so the component is selected only here
     int maxI = -1;
-    double maxKey = 0; // the larger the key, the better the component
+    double maxKey = 0; // the larger the key, the better the component; not positive key means unsuitable component
     for ( int i = 0; i < k; ++i )
     {
         double key = 0;
         switch ( selection )
         {
         case VolumeSelection::Positive:
-            if ( sixVolumes[i] <= 0 )
-                continue;
             key = sixVolumes[i];
             break;
         case VolumeSelection::Negative:
-            if ( sixVolumes[i] >= 0 )
-                continue;
             key = -sixVolumes[i];
             break;
         default:
@@ -176,7 +172,7 @@ double getLargestComponentVolume( const MeshPart& meshPart, VolumeSelection sele
             key = std::abs( sixVolumes[i] );
             break;
         }
-        if ( maxI < 0 || key > maxKey )
+        if ( key > maxKey )
         {
             maxI = i;
             maxKey = key;
@@ -184,7 +180,7 @@ double getLargestComponentVolume( const MeshPart& meshPart, VolumeSelection sele
     }
     if ( maxI < 0 )
     {
-        // no component satisfies the selection rule, so all of them are counted as smaller ones
+        // no component with non-zero volume satisfies the selection rule, so all of them are counted as smaller ones
         if ( numSmallerComponents )
             *numSmallerComponents = k;
         return 0;

--- a/source/MRMesh/MRMeshComponents.h
+++ b/source/MRMesh/MRMeshComponents.h
@@ -55,7 +55,8 @@ enum class VolumeSelection
     Negative  ///< the component with the smallest negative volume (its normals look inside)
 };
 
-/// returns the signed volume of the component selected by given rule, and zero if no component with non-zero volume satisfies it;
+/// returns the signed volume of the component selected by given rule, and zero if no component satisfies it,
+/// which is possible for Positive and Negative rules only, since they never select a component of zero volume;
 /// the volume of each component is computed as if it were closed, so the result is correct
 /// only for a closed mesh part (or if the area of holes in it is almost zero)
 [[nodiscard]] MRMESH_API double getLargestComponentVolume( const MeshPart& meshPart, VolumeSelection selection = VolumeSelection::Abs,

--- a/source/MRMesh/MRMeshComponents.h
+++ b/source/MRMesh/MRMeshComponents.h
@@ -47,6 +47,13 @@ enum FaceIncidence
     FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {}, float minArea = 0,
     int * numSmallerComponents = nullptr ); ///< optional output: the number of components in addition to returned one
 
+/// returns the volume of the largest by absolute volume component, and zero if there are no components at all;
+/// the volume of each component is computed as if it were closed, so the result is correct
+/// only for a closed mesh part (or if the area of holes in it is almost zero)
+[[nodiscard]] MRMESH_API double getLargestComponentVolume( const MeshPart& meshPart,
+    FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {}, FaceBitSet * largestComponent = nullptr, ///< optional output with the faces of the largest by absolute volume component
+    int * numSmallerComponents = nullptr ); ///< optional output: the number of components in addition to returned one
+
 /// returns union of connected components, each of which contains at least one seed face
 [[nodiscard]] MRMESH_API FaceBitSet getComponents( const MeshPart& meshPart, const FaceBitSet & seeds,
     FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {} );

--- a/source/MRMesh/MRMeshComponents.h
+++ b/source/MRMesh/MRMeshComponents.h
@@ -47,12 +47,20 @@ enum FaceIncidence
     FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {}, float minArea = 0,
     int * numSmallerComponents = nullptr ); ///< optional output: the number of components in addition to returned one
 
-/// returns the volume of the largest by absolute volume component, and zero if there are no components at all;
+/// the rule of selecting one component by its signed volume
+enum class VolumeSelection
+{
+    Abs,      ///< the component with the largest absolute volume, whatever its sign is
+    Positive, ///< the component with the largest positive volume (its normals look outside)
+    Negative  ///< the component with the smallest negative volume (its normals look inside)
+};
+
+/// returns the signed volume of the component selected by given rule, and zero if no component satisfies it;
 /// the volume of each component is computed as if it were closed, so the result is correct
 /// only for a closed mesh part (or if the area of holes in it is almost zero)
-[[nodiscard]] MRMESH_API double getLargestComponentVolume( const MeshPart& meshPart,
-    FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {}, FaceBitSet * largestComponent = nullptr, ///< optional output with the faces of the largest by absolute volume component
-    int * numSmallerComponents = nullptr ); ///< optional output: the number of components in addition to returned one
+[[nodiscard]] MRMESH_API double getLargestComponentVolume( const MeshPart& meshPart, VolumeSelection selection = VolumeSelection::Abs,
+    FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {}, FaceBitSet * largestComponent = nullptr, ///< optional output with the faces of the selected component
+    int * numSmallerComponents = nullptr ); ///< optional output: the number of components in addition to returned one, so all components if none was selected
 
 /// returns union of connected components, each of which contains at least one seed face
 [[nodiscard]] MRMESH_API FaceBitSet getComponents( const MeshPart& meshPart, const FaceBitSet & seeds,

--- a/source/MRMesh/MRMeshComponents.h
+++ b/source/MRMesh/MRMeshComponents.h
@@ -55,7 +55,7 @@ enum class VolumeSelection
     Negative  ///< the component with the smallest negative volume (its normals look inside)
 };
 
-/// returns the signed volume of the component selected by given rule, and zero if no component satisfies it;
+/// returns the signed volume of the component selected by given rule, and zero if no component with non-zero volume satisfies it;
 /// the volume of each component is computed as if it were closed, so the result is correct
 /// only for a closed mesh part (or if the area of holes in it is almost zero)
 [[nodiscard]] MRMESH_API double getLargestComponentVolume( const MeshPart& meshPart, VolumeSelection selection = VolumeSelection::Abs,

--- a/source/MRTest/MRMeshComponentsTests.cpp
+++ b/source/MRTest/MRMeshComponentsTests.cpp
@@ -76,6 +76,28 @@ TEST(MRMesh, getLargestComponentArea)
     ASSERT_EQ( numSmallerComponents, 0 );
 }
 
+TEST(MRMesh, getLargestComponentVolume)
+{
+    auto mesh = makeCube( Vector3f::diagonal( 1 ), Vector3f::diagonal( 0 ) );
+    mesh.addMesh( makeCube( Vector3f::diagonal( 2 ), Vector3f::diagonal( 10 ) ) );
+
+    FaceBitSet largest;
+    int numSmallerComponents = -1;
+    ASSERT_NEAR( MeshComponents::getLargestComponentVolume( mesh, MeshComponents::PerEdge, nullptr, &largest, &numSmallerComponents ), 8.0, 1e-5 );
+    ASSERT_EQ( numSmallerComponents, 1 );
+    ASSERT_EQ( largest.count(), 12 );
+    ASSERT_NEAR( mesh.volume( &largest ), 8.0, 1e-5 );
+
+    // the components are selected by absolute volume, so the inverted mesh gives the same component with negative volume
+    mesh.topology.flipOrientation();
+    ASSERT_NEAR( MeshComponents::getLargestComponentVolume( mesh, MeshComponents::PerEdge, nullptr, &largest ), -8.0, 1e-5 );
+    ASSERT_EQ( largest.count(), 12 );
+
+    ASSERT_EQ( MeshComponents::getLargestComponentVolume( Mesh{}, MeshComponents::PerEdge, nullptr, &largest, &numSmallerComponents ), 0 );
+    ASSERT_TRUE( largest.none() );
+    ASSERT_EQ( numSmallerComponents, 0 );
+}
+
 TEST(MRMesh, getLargestComponentVerts)
 {
     auto mesh = makeCube();

--- a/source/MRTest/MRMeshComponentsTests.cpp
+++ b/source/MRTest/MRMeshComponentsTests.cpp
@@ -78,23 +78,48 @@ TEST(MRMesh, getLargestComponentArea)
 
 TEST(MRMesh, getLargestComponentVolume)
 {
+    using MeshComponents::VolumeSelection;
+    // the small cube has volume 1 and its normals look outside, the large one has volume -8 and its normals look inside
     auto mesh = makeCube( Vector3f::diagonal( 1 ), Vector3f::diagonal( 0 ) );
-    mesh.addMesh( makeCube( Vector3f::diagonal( 2 ), Vector3f::diagonal( 10 ) ) );
+    mesh.addMeshPart( makeCube( Vector3f::diagonal( 2 ), Vector3f::diagonal( 10 ) ), true );
+    FaceBitSet smallCube( 24 ), largeCube( 24 );
+    for ( FaceId f = 0_f; f < 12_f; ++f )
+        smallCube.set( f );
+    for ( FaceId f = 12_f; f < 24_f; ++f )
+        largeCube.set( f );
 
-    FaceBitSet largest;
+    FaceBitSet component;
     int numSmallerComponents = -1;
-    ASSERT_NEAR( MeshComponents::getLargestComponentVolume( mesh, MeshComponents::PerEdge, nullptr, &largest, &numSmallerComponents ), 8.0, 1e-5 );
+    ASSERT_NEAR( MeshComponents::getLargestComponentVolume( mesh, VolumeSelection::Abs, MeshComponents::PerEdge, nullptr, &component, &numSmallerComponents ), -8.0, 1e-5 );
+    ASSERT_TRUE( component == largeCube );
     ASSERT_EQ( numSmallerComponents, 1 );
-    ASSERT_EQ( largest.count(), 12 );
-    ASSERT_NEAR( mesh.volume( &largest ), 8.0, 1e-5 );
 
-    // the components are selected by absolute volume, so the inverted mesh gives the same component with negative volume
+    ASSERT_NEAR( MeshComponents::getLargestComponentVolume( mesh, VolumeSelection::Positive, MeshComponents::PerEdge, nullptr, &component, &numSmallerComponents ), 1.0, 1e-5 );
+    ASSERT_TRUE( component == smallCube );
+    ASSERT_EQ( numSmallerComponents, 1 );
+
+    ASSERT_NEAR( MeshComponents::getLargestComponentVolume( mesh, VolumeSelection::Negative, MeshComponents::PerEdge, nullptr, &component, &numSmallerComponents ), -8.0, 1e-5 );
+    ASSERT_TRUE( component == largeCube );
+    ASSERT_EQ( numSmallerComponents, 1 );
+
+    // flipping the whole mesh swaps the signs of both components
     mesh.topology.flipOrientation();
-    ASSERT_NEAR( MeshComponents::getLargestComponentVolume( mesh, MeshComponents::PerEdge, nullptr, &largest ), -8.0, 1e-5 );
-    ASSERT_EQ( largest.count(), 12 );
+    ASSERT_NEAR( MeshComponents::getLargestComponentVolume( mesh, VolumeSelection::Positive, MeshComponents::PerEdge, nullptr, &component ), 8.0, 1e-5 );
+    ASSERT_TRUE( component == largeCube );
+    ASSERT_NEAR( MeshComponents::getLargestComponentVolume( mesh, VolumeSelection::Negative, MeshComponents::PerEdge, nullptr, &component ), -1.0, 1e-5 );
+    ASSERT_TRUE( component == smallCube );
 
-    ASSERT_EQ( MeshComponents::getLargestComponentVolume( Mesh{}, MeshComponents::PerEdge, nullptr, &largest, &numSmallerComponents ), 0 );
-    ASSERT_TRUE( largest.none() );
+    // both cubes look outside, so there is no negative component at all
+    Mesh outward = makeCube( Vector3f::diagonal( 1 ), Vector3f::diagonal( 0 ) );
+    outward.addMesh( makeCube( Vector3f::diagonal( 2 ), Vector3f::diagonal( 10 ) ) );
+    ASSERT_NEAR( MeshComponents::getLargestComponentVolume( outward, VolumeSelection::Abs, MeshComponents::PerEdge, nullptr, &component ), 8.0, 1e-5 );
+    ASSERT_TRUE( component == largeCube );
+    ASSERT_EQ( MeshComponents::getLargestComponentVolume( outward, VolumeSelection::Negative, MeshComponents::PerEdge, nullptr, &component, &numSmallerComponents ), 0 );
+    ASSERT_TRUE( component.none() );
+    ASSERT_EQ( numSmallerComponents, 2 );
+
+    ASSERT_EQ( MeshComponents::getLargestComponentVolume( Mesh{}, VolumeSelection::Abs, MeshComponents::PerEdge, nullptr, &component, &numSmallerComponents ), 0 );
+    ASSERT_TRUE( component.none() );
     ASSERT_EQ( numSmallerComponents, 0 );
 }
 

--- a/source/MRTest/MRMeshComponentsTests.cpp
+++ b/source/MRTest/MRMeshComponentsTests.cpp
@@ -118,6 +118,15 @@ TEST(MRMesh, getLargestComponentVolume)
     ASSERT_TRUE( component.none() );
     ASSERT_EQ( numSmallerComponents, 2 );
 
+    // a degenerate component of zero volume is still returned by Abs rule, but never by the two others
+    const auto degenerate = makeCube( Vector3f::diagonal( 0 ), Vector3f::diagonal( 0 ) );
+    ASSERT_EQ( MeshComponents::getLargestComponentVolume( degenerate, VolumeSelection::Abs, MeshComponents::PerEdge, nullptr, &component, &numSmallerComponents ), 0 );
+    ASSERT_EQ( component.count(), 12 );
+    ASSERT_EQ( numSmallerComponents, 0 );
+    ASSERT_EQ( MeshComponents::getLargestComponentVolume( degenerate, VolumeSelection::Positive, MeshComponents::PerEdge, nullptr, &component, &numSmallerComponents ), 0 );
+    ASSERT_TRUE( component.none() );
+    ASSERT_EQ( numSmallerComponents, 1 );
+
     ASSERT_EQ( MeshComponents::getLargestComponentVolume( Mesh{}, VolumeSelection::Abs, MeshComponents::PerEdge, nullptr, &component, &numSmallerComponents ), 0 );
     ASSERT_TRUE( component.none() );
     ASSERT_EQ( numSmallerComponents, 0 );


### PR DESCRIPTION
### New function

```cpp
/// the rule of selecting one component by its signed volume
enum class VolumeSelection
{
    Abs,      ///< the component with the largest absolute volume, whatever its sign is
    Positive, ///< the component with the largest positive volume (its normals look outside)
    Negative  ///< the component with the smallest negative volume (its normals look inside)
};

[[nodiscard]] MRMESH_API double getLargestComponentVolume( const MeshPart& meshPart, VolumeSelection selection = VolumeSelection::Abs,
    FaceIncidence incidence = FaceIncidence::PerEdge, const UndirectedEdgeBitSet * isCompBd = {}, FaceBitSet * largestComponent = nullptr,
    int * numSmallerComponents = nullptr );
```

The volume counterpart of `getLargestComponentArea` (#6741), with the same optional outputs: passing `largestComponent = nullptr` skips allocating and filling the face bitset.

The volume of a component is the sum of the six-fold signed volumes of the tetrahedrons built on its faces and the origin, divided by 6 - the same expression as in `getLargeByVolumeComponents`. Holes are not capped, so the result is correct for a closed mesh part only, or if the area of the holes is almost zero. There is no closedness assert on purpose, to keep the second case usable.

The signed volume of the selected component is returned in all three modes, so `Negative` returns a negative number. Each rule is expressed as a key to maximize - `v`, `-v` and `abs( v )` respectively - and a not positive key means an unsuitable component; `Abs` starts the search from a negative key instead, so it still returns a component of exactly zero volume. If no component satisfies the rule (`Positive` on a fully inverted mesh, for example), zero is returned, the output component is empty, and `numSmallerComponents` reports all the components, following the convention of `getLargestComponent` with too large `minArea`.

Note that the largest component cannot be tracked inside the accumulation loop as it is done for the area, because a volume sum is not monotonic; it is found in a separate pass over the per-component volumes.

A unit test with two cubes of volume 1 and -8 covers all the three rules, both orientations, and the case with no suitable component.
