### PR TITLE
addPartByMask: reject invalid stitching contours instead of only asserting

### DIFF
--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -167,7 +167,8 @@ Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepres
         return unexpected( std::move( v.error() ) );
 
     // patch vertices are the mesh's own, with the exact same coordinates, so no point fixup is needed
-    mesh.addMeshPart( *patch, false, paths, patchPaths );
+    if ( !mesh.addMeshPart( *patch, false, paths, patchPaths ) )
+        return unexpected( "Patch surface borders are incompatible with mesh borders" );
     return {};
 }
 

--- a/source/MRMesh/MRMesh.cpp
+++ b/source/MRMesh/MRMesh.cpp
@@ -371,7 +371,7 @@ void Mesh::addMeshPart( const MeshPart & from, const PartMapping & map, VacantEl
     addMeshPart( from, false, {}, {}, map, vacant );
 }
 
-void Mesh::addMeshPart( const MeshPart & from, bool flipOrientation,
+bool Mesh::addMeshPart( const MeshPart & from, bool flipOrientation,
     const std::vector<EdgePath> & thisContours,
     const std::vector<EdgePath> & fromContours,
     PartMapping map, VacantElements * vacant )
@@ -382,11 +382,13 @@ void Mesh::addMeshPart( const MeshPart & from, bool flipOrientation,
     auto localVmap = VertMapOrHashMap::createHashMap();
     if ( !map.src2tgtVerts )
         map.src2tgtVerts = &localVmap;
-    topology.addPartByMask( from.mesh.topology, from.region, flipOrientation, thisContours, fromContours, map, vacant );
+    if ( !topology.addPartByMask( from.mesh.topology, from.region, flipOrientation, thisContours, fromContours, map, vacant ) )
+        return false;
     VertId lastPointId = topology.lastValidVert();
     if ( points.size() < lastPointId + 1 )
         points.resize( lastPointId + 1 );
     map.src2tgtVerts->forEach( [&]( VertId fromVert, VertId thisVert ) { points[thisVert] = from.mesh.points[fromVert]; } );
+    return true;
 }
 
 Mesh Mesh::cloneRegion( const FaceBitSet & region, bool flipOrientation, const PartMapping & map ) const

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -404,7 +404,8 @@ struct [[nodiscard]] Mesh
     /// appends whole or part of another mesh to this joining added faces with existed ones along given contours
     /// \param flipOrientation true means that every (from) triangle is inverted before adding
     /// optional \param vacant can be passed to copy elements not at the end, but over given ones, which the user guaranties to be free/lone
-    MRMESH_API void addMeshPart( const MeshPart & from, bool flipOrientation = false,
+    /// \return false if the given contours cannot be stitched, and this mesh is left unmodified then
+    MRMESH_API bool addMeshPart( const MeshPart & from, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, // contours on this mesh that have to be stitched with
         const std::vector<EdgePath> & fromContours = {}, // contours on from mesh during addition
         // optionally returns mappings: from.id -> this.id

--- a/source/MRMesh/MRMesh.h
+++ b/source/MRMesh/MRMesh.h
@@ -405,6 +405,7 @@ struct [[nodiscard]] Mesh
     /// \param flipOrientation true means that every (from) triangle is inverted before adding
     /// optional \param vacant can be passed to copy elements not at the end, but over given ones, which the user guaranties to be free/lone
     /// \return false if the given contours cannot be stitched, and this mesh is left unmodified then
+    ///         (the src2tgt mappings in (map) argument can be partially filled nevertheless)
     MRMESH_API bool addMeshPart( const MeshPart & from, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, // contours on this mesh that have to be stitched with
         const std::vector<EdgePath> & fromContours = {}, // contours on from mesh during addition

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1859,65 +1859,6 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
     addPartByMask( from, fromFaces, false, {}, {}, map, vacant );
 }
 
-// checks the contours given to the stitching addPartByMask below: they must satisfy the conditions
-// the stitching code relies upon, otherwise it would produce an invalid topology
-static bool validStitchContours_( const MeshTopology & tgt, const MeshTopology & from, const FaceBitSet * fromFaces,
-    bool flipOrientation, const std::vector<EdgePath> & thisContours, const std::vector<EdgePath> & fromContours )
-{
-    if ( thisContours.size() != fromContours.size() )
-        return false;
-
-    UndirectedEdgeBitSet fromStitched( from.undirectedEdgeSize() );
-    EdgeBitSet thisStitched( tgt.edgeSize() );
-    VertHashMap from2this;
-    // the contours prescribe the image of every from-vertex on them, and it must be unique
-    auto sameImage = [&from2this]( VertId v, VertId v1 )
-    {
-        return from2this.try_emplace( v, v1 ).first->second == v1;
-    };
-    for ( int i = 0; i < int( thisContours.size() ); ++i )
-    {
-        const auto & thisContour = thisContours[i];
-        const auto & fromContour = fromContours[i];
-        if ( thisContour.size() != fromContour.size() )
-            return false;
-        if ( thisContour.empty() )
-            continue;
-        // either both contours are closed or both are open
-        if ( ( from.org( fromContour.front() ) == from.dest( fromContour.back() ) ) !=
-             ( tgt.org( thisContour.front() ) == tgt.dest( thisContour.back() ) ) )
-            return false;
-        for ( int j = 0; j < int( thisContour.size() ); ++j )
-        {
-            const EdgeId e = fromContour[j], e1 = thisContour[j];
-            if ( !e || !e1 || !from.hasEdge( e ) || !tgt.hasEdge( e1 ) )
-                return false;
-            if ( tgt.left( e1 ) )
-                return false; // the side of this edge to be stitched is occupied
-            if ( flipOrientation ? from.isLeftInRegion( e, fromFaces ) : from.isLeftInRegion( e.sym(), fromFaces ) )
-                return false; // the side of from edge to be stitched is occupied
-            if ( thisStitched.test_set( e1 ) || fromStitched.test_set( e.undirected() ) )
-                return false; // the same edge is stitched twice
-            if ( !sameImage( from.org( e ), tgt.org( e1 ) ) || !sameImage( from.dest( e ), tgt.dest( e1 ) ) )
-                return false;
-        }
-    }
-
-    // a stitched edge takes next/prev from its from-edge, so that neighbour must be added here as well
-    auto added = [&]( EdgeId e )
-    {
-        return fromStitched.test( e.undirected() ) ||
-            ( fromFaces ? from.isInnerOrBdEdge( e, fromFaces ) : !from.isLoneEdge( e ) );
-    };
-    for ( const auto & fromContour : fromContours )
-        for ( EdgeId e : fromContour )
-            if ( !added( flipOrientation ? from.prev( e ) : from.next( e ) ) ||
-                 !added( flipOrientation ? from.next( e.sym() ) : from.prev( e.sym() ) ) )
-                return false;
-
-    return true;
-}
-
 bool MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces0, bool flipOrientation,
     const std::vector<EdgePath> & thisContours,
     const std::vector<EdgePath> & fromContours,
@@ -1926,11 +1867,9 @@ bool MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
     )
 {
     MR_TIMER;
-    // the arguments are verified before anything here is modified, so a rejected call changes nothing
-    if ( !validStitchContours_( *this, from, fromFaces0, flipOrientation, thisContours, fromContours ) )
-        return false;
-
     const auto szContours = thisContours.size();
+    if ( szContours != fromContours.size() )
+        return false;
 
     const auto & fromFaces = from.getFaceIds( fromFaces0 );
     const auto fcount = fromFaces.count();
@@ -1946,6 +1885,22 @@ bool MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
     auto vmap = map.src2tgtVerts ? std::move( *map.src2tgtVerts ) : VertMapOrHashMap::createHashMap();
     vmap.resizeReserve( from.vertSize(), std::min( fcount, from.vertSize() ) ); // if whole connected component is copied then vcount=1/2*fcount; if unconnected triangles are copied then vcount=3*fcount
 
+    // gives the mappings taken from the caller back, whether filled or not
+    auto returnMaps = [&]()
+    {
+        if ( map.src2tgtFaces )
+            *map.src2tgtFaces = std::move( fmap );
+        if ( map.src2tgtVerts )
+            *map.src2tgtVerts = std::move( vmap );
+        if ( map.src2tgtEdges )
+            *map.src2tgtEdges = std::move( emap );
+    };
+    auto fail = [&]()
+    {
+        returnMaps();
+        return false;
+    };
+
     // maps: to index -> from index
     if ( map.tgt2srcEdges )
         map.tgt2srcEdges->resizeReserve( undirectedEdgeSize(), std::min( 2 * fcount, from.undirectedEdgeSize() ) );
@@ -1955,49 +1910,67 @@ bool MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
         map.tgt2srcFaces->resizeReserve( faceSize(), fcount );
 
     VertBitSet fromMappedVerts( from.vertSize() );
+    // remembers the image of a from-vertex, or returns false if the contours prescribe two different images for it
     auto setVmap = [&] ( VertId key, VertId val )
     {
         if ( !fromMappedVerts.test_set( key ) )
         {
             assert( !getAt( vmap, key ) );
             setAt( vmap, key, val );
+            return true;
         }
-#ifndef NDEBUG
-        else
-        {
-            assert( getAt( vmap, key ) == val );
-        }
-#endif
+        return getAt( vmap, key ) == val;
     };
 
     UndirectedEdgeBitSet fromMappedEdges( from.undirectedEdgeSize() ); //one of fromContours' edge
+    EdgeBitSet thisStitched( edgeSize() );
+    // verify the contours while recording their mappings: nothing in this topology is modified
+    // before all the checks pass, so a rejected call leaves it as it was
     for ( int i = 0; i < szContours; ++i )
     {
         const auto & thisContour = thisContours[i];
         const auto & fromContour = fromContours[i];
         const auto sz = thisContour.size();
-        assert( sz == fromContour.size() );
+        if ( sz != fromContour.size() )
+            return fail();
         if ( thisContour.empty() )
             continue;
         // either both contours are closed or both are open
-        [[maybe_unused]] auto s0 = from.org( fromContour.front() );
-        [[maybe_unused]] auto t0 = from.dest( fromContour.back() );
-        [[maybe_unused]] auto s1 = org( thisContour.front() );
-        [[maybe_unused]] auto t1 = dest( thisContour.back() );
-        assert( ( s0 == t0 && s1 == t1 ) || ( s0 != t0 && s1 != t1 ) );
+        if ( ( from.org( fromContour.front() ) == from.dest( fromContour.back() ) ) !=
+             ( org( thisContour.front() ) == dest( thisContour.back() ) ) )
+            return fail();
         for ( int j = 0; j < sz; ++j )
         {
             auto e = fromContour[j];
             auto e1 = thisContour[j];
-            assert( !left( e1 ) );
-            assert( ( flipOrientation && !from.isLeftInRegion( e, fromFaces0 ) ) || ( !flipOrientation && !from.isLeftInRegion( e.sym(), fromFaces0 ) ) );
-            setVmap( from.org( e ), org( e1 ) );
-            setVmap( from.dest( e ), dest( e1 ) );
-            assert( !getAt( emap, e.undirected() ) );
+            if ( !e || !e1 || !from.hasEdge( e ) || !hasEdge( e1 ) )
+                return fail();
+            if ( left( e1 ) )
+                return fail(); // the side of this edge to be stitched is occupied
+            if ( flipOrientation ? from.isLeftInRegion( e, fromFaces0 ) : from.isLeftInRegion( e.sym(), fromFaces0 ) )
+                return fail(); // the side of from edge to be stitched is occupied
+            if ( thisStitched.test_set( e1 ) )
+                return fail(); // this edge is stitched twice
+            if ( getAt( emap, e.undirected() ) )
+                return fail(); // from edge is stitched twice
+            if ( !setVmap( from.org( e ), org( e1 ) ) || !setVmap( from.dest( e ), dest( e1 ) ) )
+                return fail();
             setAt( emap, e.undirected(), e.even() ? e1 : e1.sym() );
             fromMappedEdges.set( e.undirected() );
         }
     }
+
+    // a stitched edge takes its next/prev from its from-edge, so that neighbour must be stitched or copied here as well
+    auto addedFrom = [&]( EdgeId e )
+    {
+        return fromMappedEdges.test( e.undirected() ) ||
+            ( fromFaces0 ? from.isInnerOrBdEdge( e, fromFaces0 ) : !from.isLoneEdge( e ) );
+    };
+    for ( const auto & fromContour : fromContours )
+        for ( EdgeId e : fromContour )
+            if ( !addedFrom( flipOrientation ? from.prev( e ) : from.next( e ) ) ||
+                 !addedFrom( flipOrientation ? from.next( e.sym() ) : from.prev( e.sym() ) ) )
+                return fail();
 
     // fill all maps
     VertBitSet fromCopiedVerts; // except for moved vertices
@@ -2284,12 +2257,7 @@ bool MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
             assert( m->size() == faceSize() );
 #endif
 
-    if ( map.src2tgtFaces )
-        *map.src2tgtFaces = std::move( fmap );
-    if ( map.src2tgtVerts )
-        *map.src2tgtVerts = std::move( vmap );
-    if ( map.src2tgtEdges )
-        *map.src2tgtEdges = std::move( emap );
+    returnMaps();
     return true;
 }
 

--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -1859,7 +1859,66 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
     addPartByMask( from, fromFaces, false, {}, {}, map, vacant );
 }
 
-void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces0, bool flipOrientation,
+// checks the contours given to the stitching addPartByMask below: they must satisfy the conditions
+// the stitching code relies upon, otherwise it would produce an invalid topology
+static bool validStitchContours_( const MeshTopology & tgt, const MeshTopology & from, const FaceBitSet * fromFaces,
+    bool flipOrientation, const std::vector<EdgePath> & thisContours, const std::vector<EdgePath> & fromContours )
+{
+    if ( thisContours.size() != fromContours.size() )
+        return false;
+
+    UndirectedEdgeBitSet fromStitched( from.undirectedEdgeSize() );
+    EdgeBitSet thisStitched( tgt.edgeSize() );
+    VertHashMap from2this;
+    // the contours prescribe the image of every from-vertex on them, and it must be unique
+    auto sameImage = [&from2this]( VertId v, VertId v1 )
+    {
+        return from2this.try_emplace( v, v1 ).first->second == v1;
+    };
+    for ( int i = 0; i < int( thisContours.size() ); ++i )
+    {
+        const auto & thisContour = thisContours[i];
+        const auto & fromContour = fromContours[i];
+        if ( thisContour.size() != fromContour.size() )
+            return false;
+        if ( thisContour.empty() )
+            continue;
+        // either both contours are closed or both are open
+        if ( ( from.org( fromContour.front() ) == from.dest( fromContour.back() ) ) !=
+             ( tgt.org( thisContour.front() ) == tgt.dest( thisContour.back() ) ) )
+            return false;
+        for ( int j = 0; j < int( thisContour.size() ); ++j )
+        {
+            const EdgeId e = fromContour[j], e1 = thisContour[j];
+            if ( !e || !e1 || !from.hasEdge( e ) || !tgt.hasEdge( e1 ) )
+                return false;
+            if ( tgt.left( e1 ) )
+                return false; // the side of this edge to be stitched is occupied
+            if ( flipOrientation ? from.isLeftInRegion( e, fromFaces ) : from.isLeftInRegion( e.sym(), fromFaces ) )
+                return false; // the side of from edge to be stitched is occupied
+            if ( thisStitched.test_set( e1 ) || fromStitched.test_set( e.undirected() ) )
+                return false; // the same edge is stitched twice
+            if ( !sameImage( from.org( e ), tgt.org( e1 ) ) || !sameImage( from.dest( e ), tgt.dest( e1 ) ) )
+                return false;
+        }
+    }
+
+    // a stitched edge takes next/prev from its from-edge, so that neighbour must be added here as well
+    auto added = [&]( EdgeId e )
+    {
+        return fromStitched.test( e.undirected() ) ||
+            ( fromFaces ? from.isInnerOrBdEdge( e, fromFaces ) : !from.isLoneEdge( e ) );
+    };
+    for ( const auto & fromContour : fromContours )
+        for ( EdgeId e : fromContour )
+            if ( !added( flipOrientation ? from.prev( e ) : from.next( e ) ) ||
+                 !added( flipOrientation ? from.next( e.sym() ) : from.prev( e.sym() ) ) )
+                return false;
+
+    return true;
+}
+
+bool MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces0, bool flipOrientation,
     const std::vector<EdgePath> & thisContours,
     const std::vector<EdgePath> & fromContours,
     const PartMapping & map,
@@ -1867,8 +1926,11 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
     )
 {
     MR_TIMER;
+    // the arguments are verified before anything here is modified, so a rejected call changes nothing
+    if ( !validStitchContours_( *this, from, fromFaces0, flipOrientation, thisContours, fromContours ) )
+        return false;
+
     const auto szContours = thisContours.size();
-    assert( szContours == fromContours.size() );
 
     const auto & fromFaces = from.getFaceIds( fromFaces0 );
     const auto fcount = fromFaces.count();
@@ -2228,6 +2290,7 @@ void MeshTopology::addPartByMask( const MeshTopology & from, const FaceBitSet * 
         *map.src2tgtVerts = std::move( vmap );
     if ( map.src2tgtEdges )
         *map.src2tgtEdges = std::move( emap );
+    return true;
 }
 
 void MeshTopology::rotateTriangles()

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -485,14 +485,15 @@ public:
     /// \param thisContours contours on this mesh (no left face) that have to be stitched with
     /// \param fromContours contours on from mesh during addition (no left face if flipOrientation otherwise no right face)
     /// optional \param vacant can be passed to copy elements not at the end, but over given ones, which the user guaranties to be free/lone
-    MRMESH_API void addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces, bool flipOrientation = false,
+    /// \return false if the given contours cannot be stitched (see the conditions on them above), and this topology is left unmodified then
+    MRMESH_API bool addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, const std::vector<EdgePath> & fromContours = {},
         const PartMapping & map = {}, VacantElements * vacant = {} );
 
     /// This is skipped in the bindings because it conflicts with the overload taking a pointer in C#. Since that overload is strictly more useful, we're keeping that one.
-    MR_BIND_IGNORE void addPartByMask( const MeshTopology & from, const FaceBitSet & fromFaces, bool flipOrientation = false,
+    MR_BIND_IGNORE bool addPartByMask( const MeshTopology & from, const FaceBitSet & fromFaces, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, const std::vector<EdgePath> & fromContours = {},
-        const PartMapping & map = {}, VacantElements * vacant = {} ) { addPartByMask( from, &fromFaces, flipOrientation, thisContours, fromContours, map, vacant ); }
+        const PartMapping & map = {}, VacantElements * vacant = {} ) { return addPartByMask( from, &fromFaces, flipOrientation, thisContours, fromContours, map, vacant ); }
 
     /// for each triangle selects edgeWithLeft with minimal origin vertex
     MRMESH_API void rotateTriangles();

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -486,6 +486,7 @@ public:
     /// \param fromContours contours on from mesh during addition (no left face if flipOrientation otherwise no right face)
     /// optional \param vacant can be passed to copy elements not at the end, but over given ones, which the user guaranties to be free/lone
     /// \return false if the given contours cannot be stitched (see the conditions on them above), and this topology is left unmodified then
+    ///         (the src2tgt mappings in (map) argument can be partially filled nevertheless)
     MRMESH_API bool addPartByMask( const MeshTopology & from, const FaceBitSet * fromFaces, bool flipOrientation = false,
         const std::vector<EdgePath> & thisContours = {}, const std::vector<EdgePath> & fromContours = {},
         const PartMapping & map = {}, VacantElements * vacant = {} );

--- a/source/MRTest/MRMeshTests.cpp
+++ b/source/MRTest/MRMeshTests.cpp
@@ -195,7 +195,7 @@ TEST(MRMesh, AddPartByMaskAndStitch)
     std::vector<EdgePath> c0 = { { topology0.findEdge( 1_v, 0_v ) } };
     std::vector<EdgePath> c1 = { { topology1.findEdge( 0_v, 1_v ) } };
     auto topologyRes = topology0;
-    topologyRes.addPartByMask( topology1, topology1.getValidFaces(), false, c0, c1 );
+    EXPECT_TRUE( topologyRes.addPartByMask( topology1, topology1.getValidFaces(), false, c0, c1 ) );
     EXPECT_TRUE( topologyRes.checkValidity() );
     EXPECT_EQ( topologyRes.numValidVerts(), 4 );
     EXPECT_EQ( topologyRes.numValidFaces(), 2 );
@@ -205,11 +205,42 @@ TEST(MRMesh, AddPartByMaskAndStitch)
     c0 = { { topology0.findEdge( 1_v, 0_v ) }, { topology0.findEdge( 0_v, 2_v ) }, { topology0.findEdge( 2_v, 1_v ) } };
     c1 = { { topology1.findEdge( 0_v, 1_v ) }, { topology1.findEdge( 1_v, 2_v ) }, { topology1.findEdge( 2_v, 0_v ) } };
     topologyRes = topology0;
-    topologyRes.addPartByMask( topology1, topology1.getValidFaces(), false, c0, c1 );
+    EXPECT_TRUE( topologyRes.addPartByMask( topology1, topology1.getValidFaces(), false, c0, c1 ) );
     EXPECT_TRUE( topologyRes.checkValidity() );
     EXPECT_EQ( topologyRes.numValidVerts(), 3 );
     EXPECT_EQ( topologyRes.numValidFaces(), 2 );
     EXPECT_EQ( topologyRes.lastNotLoneEdge(), 5_e ); // 3*2 = 6 half-edges in total
+}
+
+TEST(MRMesh, AddPartByMaskAndStitchBadInput)
+{
+    Triangulation t{ { 0_v, 1_v, 2_v } };
+    const auto topology0 = MeshBuilder::fromTriangles( t );
+    const auto topology1 = topology0;
+    const EdgePath good0 = { topology0.findEdge( 1_v, 0_v ) }; // no left face here
+    const EdgePath good1 = { topology1.findEdge( 0_v, 1_v ) }; // no right face here
+
+    auto topologyRes = topology0;
+    EXPECT_TRUE( topologyRes.addPartByMask( topology1, topology1.getValidFaces(), false, { good0 }, { good1 } ) );
+    EXPECT_TRUE( topologyRes.checkValidity() );
+
+    // each bad input must be rejected leaving the target topology intact
+    auto rejected = [&]( const std::vector<EdgePath> & c0, const std::vector<EdgePath> & c1, bool flipOrientation = false )
+    {
+        auto tgt = topology0;
+        const bool res = tgt.addPartByMask( topology1, topology1.getValidFaces(), flipOrientation, c0, c1 );
+        EXPECT_TRUE( tgt == topology0 );
+        EXPECT_TRUE( tgt.checkValidity() );
+        return res;
+    };
+
+    EXPECT_FALSE( rejected( { good0 }, {} ) );                                                    // different number of contours
+    EXPECT_FALSE( rejected( { good0 }, { { good1[0], topology1.findEdge( 1_v, 2_v ) } } ) );       // different contour sizes
+    EXPECT_FALSE( rejected( { { topology0.findEdge( 0_v, 1_v ) } }, { good1 } ) );                 // this edge has left face
+    EXPECT_FALSE( rejected( { good0 }, { good0 } ) );                                             // from edge is free on the stitched side
+    EXPECT_FALSE( rejected( { good0 }, { good1 }, true ) );                                       // flipOrientation swaps the sides required
+    EXPECT_FALSE( rejected( { good0, good0 }, { good1, { topology1.findEdge( 1_v, 2_v ) } } ) );   // this edge is stitched twice
+    EXPECT_FALSE( rejected( { good0, { topology0.findEdge( 0_v, 2_v ) } }, { good1, good1 } ) );   // from edge is stitched twice
 }
 
 TEST(MRMesh, AddMesh)


### PR DESCRIPTION
`MeshTopology::addPartByMask` (the overload that stitches along contours) used to only `assert` its arguments and then stitch anyway, so in a Release build bad contours silently produced a broken topology - no error, no way for the caller to notice. This PR verifies all of those conditions **before** anything in the target is modified and returns `false` instead, leaving the target intact and valid.

The verification happens in the same first contour loop that records the contour mappings, so no work is duplicated: the loop already built the vertex-image map (`vmap`) and the stitched-edge set (`fromMappedEdges`), and now its asserts are real checks. Verified, per contour pair:

- `thisContours.size() == fromContours.size()`, and the two contours of every pair have equal size;
- both contours of a pair are closed or both are open;
- every contour edge exists (not lone) and is free on the side to be stitched: no left face on a `thisContours` edge, and for the `fromContours` edge the side selected by `flipOrientation`;
- no edge is stitched twice (a `this` edge by direction, a `from` edge by undirected id, as the edge map keys it);
- the contours prescribe a single image for every `from` vertex on them;
- after the loop: every ring neighbour a stitched edge takes its `next`/`prev` from is stitched or copied too - otherwise the stitched edge would get an invalid `next`/`prev`.

API: the contour overloads of `MeshTopology::addPartByMask` and `Mesh::addMeshPart` now return `bool`; the overloads without contours stay `void`, they have nothing to check. Nothing is `[[nodiscard]]`, so existing callers compile unchanged. On a rejected call the src2tgt mappings can be partially filled (documented); the topology/mesh is never touched. `fillContours2D` now reports a refused stitch as an error rather than silently doing nothing.

Not addressed here, on purpose:

- a contour that passes the same vertex twice can still leave that vertex with two disjoint edge rings, when the patch is pinched at it as well. That is a property of the patch rather than of the contours (a disk patch across the pinch stitches perfectly validly), so it is not an argument check; see the disabled test in #6740.
- the three asserts on the open-contour seam fix-up (`prevNextEdges`) stay asserts: they check the derived rewiring after the copy phase, not the input.

Tests: new `MRMesh.AddPartByMaskAndStitchBadInput` runs seven bad inputs, each expecting `false` plus `tgt == topology0` and `checkValidity()`; the existing `AddPartByMaskAndStitch` now also checks that a good stitch returns `true`.

Verified locally (MSVC x64 Release): `MRMesh.vcxproj` builds clean in a fresh worktree, and a standalone program running the new test cases plus the sibling test's good stitches, the pinched sandclock (still accepted, still ends invalid - unchanged behaviour) and a rotated pinched contour (now rejected) reports all checks passed. `MRMeshTests.cpp` compiles; the gtest run itself is left to CI.

Generated with [Claude Code](https://claude.com/claude-code)
