### PR TITLE
Remove the dead HolesVertIds/outBoundaries machinery

### DIFF
--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -38,8 +38,6 @@ struct SweepLinePredicates
 {
     // strict order of vertices along the sweep direction (sweep advances toward the greater vertex)
     std::function<bool( VertId l, VertId r )> less;
-    // strict lexicographic order of positions; used only to group coincident vertices before merging
-    std::function<bool( VertId l, VertId r )> less2d;
     // whether two vertices share exactly the same position
     std::function<bool( VertId l, VertId r )> samePos;
     // orientation predicate, equivalent to MR::ccw( { a, b, c } )
@@ -62,10 +60,6 @@ static void setPts2Predicates( SweepLinePredicates& p, std::shared_ptr<Vector<Ve
     p.less = [pts2] ( VertId l, VertId r )
     {
         return smaller( { .id = l, .pt = ( *pts2 )[l].x }, { .id = r, .pt = ( *pts2 )[r].x } );
-    };
-    p.less2d = [pts2] ( VertId l, VertId r )
-    {
-        return std::tuple( ( *pts2 )[l].x, ( *pts2 )[l].y ) < std::tuple( ( *pts2 )[r].x, ( *pts2 )[r].y );
     };
     p.samePos = [pts2] ( VertId l, VertId r )
     {
@@ -287,10 +281,6 @@ int findClosestToFront( const MeshTopology& tp, const SweepLinePredicates& predi
 
 struct SweepLineParams
 {
-    /// if holesVertId is null - merge all vertices with same coordinates
-    /// otherwise only merge the ones with same initial vertId
-    const HolesVertIds* holesVertId{ nullptr };
-
     /// if not set - adds new vertices at intersection points
     /// otherwise aborts
     bool abortWhenIntersect{ false };
@@ -303,9 +293,6 @@ struct SweepLineParams
     /// one can disable merge for identical vertices, merge is useful on symbol contours
     bool allowMerge{ true };
 
-    /// optional out EdgePaths that corresponds to initial contours
-    std::vector<EdgePath>* outBoundaries{ nullptr };
-
     /// optional out per-face winding numbers
     Vector<int, FaceId>* outFaceWinding{ nullptr };
 
@@ -317,8 +304,6 @@ class SweepLineQueue
 {
 public:
     // constructor makes initial mesh which simply contain input contours as edges
-    // if holesVertId is null - merge all vertices with same coordinates
-    // otherwise only merge the ones with same initial vertId
     SweepLineQueue( SweepLinePredicates predicates, std::vector<int> contourSizes, const SweepLineParams& params );
 
     SweepLineQueue( const MeshTopology& inTp, SweepLinePredicates predicates, const EdgeLoops& holes, const SweepLineParams& params );
@@ -341,7 +326,7 @@ private:
     void initMeshByContours_( const std::vector<int>& contourSizes );
     void initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops& loops );
     // merge same points on base mesh
-    void mergeSamePoints_( const HolesVertIds* holesVertId );
+    void mergeSamePoints_();
     void mergeSinglePare_( VertId unique, VertId same );
 
     // merging same vertices can make multiple edges, so clear it and update winding modifiers for merged edges
@@ -470,7 +455,7 @@ SweepLineQueue::SweepLineQueue( SweepLinePredicates predicates, std::vector<int>
     params_{ params }
 {
     initMeshByContours_( contourSizes );
-    mergeSamePoints_( params.holesVertId );
+    mergeSamePoints_();
     setupStartVertices_();
 }
 
@@ -1090,28 +1075,18 @@ void SweepLineQueue::initMeshByContours_( const std::vector<int>& contourSizes )
         }
     }
 
-    int boundId = -1;
-    if ( params_.outBoundaries )
-        params_.outBoundaries->resize( contourSizes.size() );
-
     int firstVert = 0;
     for ( int contSize : contourSizes )
     {
-        ++boundId;
         if ( contSize <= 3 )
             continue;
 
         int size = contSize - 1;
 
-        if ( params_.outBoundaries )
-            ( *params_.outBoundaries )[boundId].resize( size );
-
         for ( int i = 0; i < size; ++i )
         {
             auto newEdgeId = tp_.makeEdge();
             tp_.setOrg( newEdgeId, VertId( firstVert + i ) );
-            if ( params_.outBoundaries )
-                ( *params_.outBoundaries )[boundId][i] = newEdgeId;
         }
         const auto& edgePerVert = tp_.edgePerVertex();
         for ( int i = 0; i < size; ++i )
@@ -1283,35 +1258,13 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
     } );
 }
 
-void SweepLineQueue::mergeSamePoints_( const HolesVertIds* holesVertId )
+void SweepLineQueue::mergeSamePoints_()
 {
     MR_TIMER;
-    auto findRealVertId = [&] ( VertId patchId )
-    {
-        int holeId = 0;
-        while ( patchId >= ( *holesVertId )[holeId].size() )
-        {
-            patchId -= int( ( *holesVertId )[holeId].size() );
-            ++holeId;
-        }
-        return ( *holesVertId )[holeId][patchId];
-    };
     sortedVerts_.reserve( tp_.vertSize() );
     for ( int i = 0; i < tp_.vertSize(); ++i )
         sortedVerts_.emplace_back( VertId( i ) );
-    if ( !holesVertId )
-        tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r ) { return predicates_.less( l, r ); } );
-    else
-    {
-        tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r )
-        {
-            if ( predicates_.less2d( l, r ) )
-                return true;
-            if ( predicates_.less2d( r, l ) )
-                return false;
-            return findRealVertId( l ) < findRealVertId( r );
-        } );
-    }
+    tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r ) { return predicates_.less( l, r ); } );
 
     if ( !params_.allowMerge )
     {
@@ -1328,17 +1281,11 @@ void SweepLineQueue::mergeSamePoints_( const HolesVertIds* holesVertId )
             prevUnique = i;
             continue;
         }
-        // if same coords
-        if ( !holesVertId || findRealVertId( sortedVerts_[prevUnique] ) == findRealVertId( sortedVerts_[i] ) )
-            mergeSinglePare_( sortedVerts_[prevUnique], sortedVerts_[i] );
+        mergeSinglePare_( sortedVerts_[prevUnique], sortedVerts_[i] );
     }
 
-    if ( holesVertId ) // sort with correct indices in case of other way sort before
-        tbb::parallel_sort( sortedVerts_.begin(), sortedVerts_.end(), [&] ( VertId l, VertId r ) { return predicates_.less( l, r ); } );
-
     windingInfo_.resize( tp_.undirectedEdgeSize() );
-    if ( !params_.abortWhenIntersect || !holesVertId )
-        removeMultipleAfterMerge_();
+    removeMultipleAfterMerge_();
 }
 
 void SweepLineQueue::mergeSinglePare_( VertId unique, VertId same )
@@ -1454,31 +1401,6 @@ void SweepLineQueue::removeMultipleAfterMerge_()
                 multiplesFromThis.push_back( e );
         }
         assert( multiplesFromThis.size() > 1 );
-
-        if ( params_.outBoundaries )
-        {
-            auto& bounds = *params_.outBoundaries;
-            auto getBoundId = [&bounds] ( EdgeId e )->std::pair<int, int>
-            {
-                int i0 = 0;
-                auto i1 = int( e.undirected() );
-                while ( i1 >= bounds[i0].size() )
-                {
-                    ++i0;
-                    i1 -= int( bounds[i0].size() );
-                }
-                assert( e.undirected() == bounds[i0][i1].undirected() );
-                return { i0,i1 };
-            };
-            auto [bf0, bf1] = getBoundId( multiplesFromThis.front() );
-            auto bf = bounds[bf0][bf1];
-            for ( int i = 1; i < multiplesFromThis.size(); ++i )
-            {
-                auto [bi0, bi1] = getBoundId( multiplesFromThis[i] );
-                auto& bi = bounds[bi0][bi1];
-                bi = multiplesFromThis[i] == bi ? bf : bf.sym();
-            }
-        }
 
         auto& edgeInfo = windingInfo_[multiplesFromThis.front().undirected()];
         edgeInfo.windingModifier = 1;
@@ -1641,26 +1563,10 @@ void SweepLineQueue::triangulateMonotoneBlock_( EdgeId holeEdgeId )
     }
 }
 
-HolesVertIds findHoleVertIdsByHoleEdges( const MeshTopology& tp, const std::vector<EdgePath>& holePaths )
-{
-    HolesVertIds res;
-    res.reserve( holePaths.size() );
-    for ( const auto& path : holePaths )
-    {
-        if ( path.size() < 3 )
-            continue;
-        res.emplace_back();
-        auto& holeIds = res.back();
-        holeIds.reserve( path.size() );
-        for ( const auto& e : path )
-            holeIds.emplace_back( tp.org( e ) );
-    }
-    return res;
-}
-
 Mesh getOutlineMesh( const Contours2f& conts, IntersectionsMap* interMap /*= nullptr */, const BaseOutlineParameters& params )
 {
-    SweepLineQueue triangulator( precisePredicates( conts ), getContourSizes( conts ), { nullptr, false, params.innerType, true, params.allowMerge } );
+    SweepLineQueue triangulator( precisePredicates( conts ), getContourSizes( conts ),
+        { .windingMode = params.innerType, .needOutline = true, .allowMerge = params.allowMerge } );
 
     if ( interMap )
         interMap->shift = triangulator.vertSize();
@@ -1732,7 +1638,7 @@ Mesh triangulateContours( const Contours2f& contours, const TriangulationParamet
     if ( contours.empty() )
         return {};
     SweepLineQueue triangulator( precisePredicates( contours ), getContourSizes( contours ),
-        { params.holeVertsIds, false, WindingMode::NonZero, false, true, nullptr, params.outFaceWinding } );
+        { .outFaceWinding = params.outFaceWinding } );
     if ( params.outInterMap )
         params.outInterMap->shift = triangulator.vertSize();
     auto res = triangulator.run( params.outInterMap );
@@ -1749,63 +1655,34 @@ Mesh triangulateContours( const Contours2d& contours, const TriangulationParamet
     return triangulateContours( contsf, params );
 }
 
-Mesh triangulateContours( const Contours2d& contours, const HolesVertIds* holeVertsIds )
-{
-    return triangulateContours( contours, { .holeVertsIds = holeVertsIds } );
-}
-
-Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVertsIds )
-{
-    return triangulateContours( contours, { .holeVertsIds = holeVertsIds } );
-}
-
-std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours, const HolesVertIds* holeVertsIds /*= nullptr*/, std::vector<EdgePath>* outBoundaries /*= nullptr*/ )
+std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours )
 {
     if ( contours.empty() )
         return Mesh();
-    SweepLineQueue triangulator( precisePredicates( contours ), getContourSizes( contours ), { holeVertsIds, true, WindingMode::NonZero, false, true, outBoundaries } );
+    SweepLineQueue triangulator( precisePredicates( contours ), getContourSizes( contours ), { .abortWhenIntersect = true } );
     return triangulator.run();
 }
 
-std::optional<Mesh> triangulateDisjointContours( const Contours2d& contours, const HolesVertIds* holeVertsIds /*= nullptr*/, std::vector<EdgePath>* outBoundaries /*= nullptr*/ )
+std::optional<Mesh> triangulateDisjointContours( const Contours2d& contours )
 {
     const auto contsf = convertContours<Contours2f>( contours );
-    return triangulateDisjointContours( contsf, holeVertsIds, outBoundaries );
+    return triangulateDisjointContours( contsf );
 }
 
-std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, std::vector<EdgePath>* outBoundaries /*= nullptr*/, WholeEdgeMap* outPatchMap /*= nullptr*/ )
+std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, WholeEdgeMap* outPatchMap /*= nullptr*/ )
 {
     if ( loops.empty() )
         return Mesh();
-    if ( !outBoundaries )
-    {
-        // copy the boundary sub-topology from the mesh: shared vertices and slit edges arrive already shared
-        WholeEdgeMap localMap;
-        WholeEdgeMap& patchToInEdges = outPatchMap ? *outPatchMap : localMap;
-        patchToInEdges.clear();
-        size_t numLoopEdges = 0;
-        for ( const auto& loop : loops )
-            numLoopEdges += loop.size();
-        patchToInEdges.reserve( numLoopEdges );
-        SweepLineQueue triangulator( mesh.topology, meshSpacePredicates( mesh, loops, normal, patchToInEdges ), loops,
-            { .abortWhenIntersect = true, .outPatchMap = &patchToInEdges } );
-        return triangulator.run();
-    }
-    // outBoundaries consumers (fillContours2D) still need the rebuild-from-contours path
-    const HolesVertIds holeVertIds = findHoleVertIdsByHoleEdges( mesh.topology, loops );
-    // initMeshByContours_ creates edges sequentially per non-degenerate contour and merging never
-    // collapses edges, so the patch->input map here is positional
-    WholeEdgeMap patchToInEdges;
-    std::vector<int> sizes( loops.size() );
-    for ( int i = 0; i < int( loops.size() ); ++i )
-    {
-        sizes[i] = int( loops[i].size() ) + 1; // +1 matches the queue's closed-contour convention (it allocates size-1 verts)
-        if ( loops[i].size() >= 3 )
-            for ( EdgeId e : loops[i] )
-                patchToInEdges.push_back( e );
-    }
-    SweepLineQueue triangulator( meshSpacePredicates( mesh, loops, normal, patchToInEdges ), std::move( sizes ),
-        { &holeVertIds, true, WindingMode::NonZero, false, true, outBoundaries } );
+    // copy the boundary sub-topology from the mesh: shared vertices and slit edges arrive already shared
+    WholeEdgeMap localMap;
+    WholeEdgeMap& patchToInEdges = outPatchMap ? *outPatchMap : localMap;
+    patchToInEdges.clear();
+    size_t numLoopEdges = 0;
+    for ( const auto& loop : loops )
+        numLoopEdges += loop.size();
+    patchToInEdges.reserve( numLoopEdges );
+    SweepLineQueue triangulator( mesh.topology, meshSpacePredicates( mesh, loops, normal, patchToInEdges ), loops,
+        { .abortWhenIntersect = true, .outPatchMap = &patchToInEdges } );
     return triangulator.run();
 }
 

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -17,12 +17,6 @@ enum class WindingMode
     Negative
 };
 
-using HoleVertIds = std::vector<VertId>;
-using HolesVertIds = std::vector<HoleVertIds>;
-
-/// return vertices of holes that correspond internal contours representation of PlanarTriangulation
-MRMESH_API HolesVertIds findHoleVertIdsByHoleEdges( const MeshTopology& tp, const std::vector<EdgePath>& holePaths );
-
 /// Info about intersection point for mapping
 struct IntersectionInfo
 {
@@ -77,9 +71,6 @@ MRMESH_API Contours2f getOutline( const Contours2d& contours, const OutlineParam
 
 struct TriangulationParameters
 {
-    /// if set merge only points with same vertex id, otherwise merge all points with same coordinates
-    const HolesVertIds* holeVertsIds{ nullptr };
-
     /// optional output: winding number of the region each face belongs to;
     /// when set, Delone flips after triangulation are skipped, so each face stays strictly inside one winding region
     Vector<int, FaceId>* outFaceWinding{ nullptr };
@@ -97,21 +88,13 @@ struct TriangulationParameters
 MRMESH_API Mesh triangulateContours( const Contours2d& contours, const TriangulationParameters& params = {} );
 MRMESH_API Mesh triangulateContours( const Contours2f& contours, const TriangulationParameters& params = {} );
 
-/// triangulate 2d contours, C++-only overload for backward compatibility;
-/// hidden from generated bindings to keep their triangulateContours signatures unique
-/// \param holeVertsIds if set merge only points with same vertex id, otherwise merge all points with same coordinates
-MR_BIND_IGNORE MRMESH_API Mesh triangulateContours( const Contours2d& contours, const HolesVertIds* holeVertsIds );
-MR_BIND_IGNORE MRMESH_API Mesh triangulateContours( const Contours2f& contours, const HolesVertIds* holeVertsIds );
-
 /**
  * @brief triangulate 2d contours
  * only closed contours are allowed (first point of each contour should be the same as last point of the contour)
- * @param holeVertsIds if set merge only points with same vertex id, otherwise merge all points with same coordinates
- * @param outBoundaries optional output EdgePaths that correspond to initial contours
  * @return std::optional<Mesh> : if some contours intersect return false, otherwise return created mesh
  */
-MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2d& contours, const HolesVertIds* holeVertsIds = nullptr, std::vector<EdgePath>* outBoundaries = nullptr );
-MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours, const HolesVertIds* holeVertsIds = nullptr, std::vector<EdgePath>* outBoundaries = nullptr );
+MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2d& contours );
+MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& contours );
 
 /**
  * @brief triangulate hole boundary loops of \p mesh in the mesh's own 3d space, orienting faces around \p normal
@@ -119,10 +102,10 @@ MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& co
  * (no projection round-trip), and loops sharing a mesh vertex are merged by identity.
  * @param loops one closed EdgeLoop per contour (as produced by trackRightBoundaryLoop on each hole edge)
  * @param outPatchMap optional output: for each patch boundary edge (by undirected id) the mesh edge it copies,
- *        directed along it; edges past its size are the triangulation's own. Not produced with \p outBoundaries
+ *        directed along it; edges past its size are the triangulation's own
  * @return std::nullopt if the loops self-intersect, otherwise the patch mesh
  */
-MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, std::vector<EdgePath>* outBoundaries = nullptr, WholeEdgeMap* outPatchMap = nullptr );
+MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, WholeEdgeMap* outPatchMap = nullptr );
 
 }
 }

--- a/source/MRMesh/MRFillContours2D.cpp
+++ b/source/MRMesh/MRFillContours2D.cpp
@@ -134,7 +134,7 @@ Expected<void> fillContours2D( Mesh& mesh, const std::vector<EdgeId>& holeRepres
 
     // the holes wind counterclockwise around this direction, same as around the fitted plane's normal it replaces
     WholeEdgeMap patch2mesh;
-    auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, paths, Vector3f( sumCross.normalized() ), nullptr, &patch2mesh );
+    auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, paths, Vector3f( sumCross.normalized() ), &patch2mesh );
     if ( !patch )
         return unexpected( "Cannot triangulate contours with self-intersections" );
     // one patch edge per loop edge; fewer means the loops traverse a mesh edge twice, and that edge
@@ -202,7 +202,7 @@ Expected<HoleFillPlan> fillContours2DPlan( const Mesh& mesh, EdgeId holeEdgeId )
 
     // patch boundary edge (by undirected id) -> the mesh edge it copies; the peel anchors through it
     WholeEdgeMap bd2mesh;
-    auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f( sumCross.normalized() ), nullptr, &bd2mesh );
+    auto patch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, Vector3f( sumCross.normalized() ), &bd2mesh );
     if ( !patch )
         return unexpected( "Cannot triangulate contours with self-intersections" );
 

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -107,9 +107,6 @@ TEST( MRMesh, PlanarTriangulationWindingAndIntersections )
         }
 
         checkWinding( conts, mesh, faceWinding, 6.0, 1.0 ); // union 7 = 6 + the [1,2]^2 overlap
-
-        // the holeVertsIds overload stays available and resolves without ambiguity
-        EXPECT_EQ( PlanarTriangulation::triangulateContours( conts, nullptr ).topology.numValidFaces(), mesh.topology.numValidFaces() );
     }
 
     {


### PR DESCRIPTION
Since #6739 moved `fillContours2D` into mesh space, nothing in the repo constructs a `HolesVertIds` or asks for `outBoundaries` any more, so the identity-merge and rebuild-from-contours paths they fed became unreachable. This removes them.

### Removed

- `HoleVertIds` / `HolesVertIds` and `findHoleVertIdsByHoleEdges`
- `TriangulationParameters::holeVertsIds`
- the two `MR_BIND_IGNORE Mesh triangulateContours( contours, const HolesVertIds* )` shims
- `SweepLineParams::holesVertId` and `SweepLineParams::outBoundaries`, with their writes in `initMeshByContours_` and the boundary fixup in `removeMultipleAfterMerge_`
- the `holeVertsIds` / `outBoundaries` parameters of every `triangulateDisjointContours`

The mesh overload is now `triangulateDisjointContours( mesh, loops, normal, outPatchMap = nullptr )` with only its copy-the-boundary-sub-topology path; both in-repo callers already passed `nullptr` for `outBoundaries`.

### Knock-on simplifications

- `mergeSamePoints_()` becomes a pure positional weld: one sort by the sweep order, no identity guard, no corrective re-sort, and `removeMultipleAfterMerge_()` unconditional — its guard `!abortWhenIntersect || !holesVertId` was only ever false on the deleted rebuild path.
- `SweepLinePredicates::less2d` was consumed solely by the identity-merge sort and is removed with it.

The three surviving `SweepLineParams` call sites move to designated initializers; each now names one or two non-default fields.

### API break

`TriangulationParameters::holeVertsIds` and the `holeVertsIds` / `outBoundaries` parameters of the bound `triangulateDisjointContours( Contours2f/d, … )` are gone, so those generated binding signatures change. The `MR_BIND_IGNORE` overloads were never bound, and no example, Python test, or MeshInspectorCode caller passes any of the removed parameters.

### Verification

- MRMesh Release plus MRTest Release and Debug build clean, no new warnings.
- MRTest passes 384/384 in both configurations; the Debug run raises no asserts.
- The `spheres-digest` end-to-end fill harness against the new DLL is byte-identical to the pre-change baseline, as a dead-branch deletion should be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
