### PR TITLE
Ship namespaced freetype/libpng/zlib in the C# wasm package

### DIFF
--- a/.github/workflows/build-test-emscripten-c-bindings.yml
+++ b/.github/workflows/build-test-emscripten-c-bindings.yml
@@ -131,12 +131,13 @@ jobs:
           #   ports themselves (Unity's WebGL emsdk has FROZEN_CACHE and ships none of them, leaving
           #   FT_*/png_* undefined). Ship them namespaced, because engines like Unity statically
           #   link their own trimmed freetype/libpng/zlib whose globals collide with vanilla copies.
-          EM_CACHE=$(${EMSDK}/upstream/emscripten/em-config CACHE)
-          python3 scripts/wasm_namespace_deps.py \
+          EMSDK_CACHE=$(${EMSDK}/upstream/emscripten/em-config CACHE)
+          python3 scripts/nuget_patch/wasm_namespace_deps.py \
             --llvm-bin ${EMSDK}/upstream/bin \
             --package-dir ${OUT_DIR} \
-            --vanilla-libs ${EM_CACHE}/sysroot/lib/wasm32-emscripten \
+            --vanilla-libs ${EMSDK_CACHE}/sysroot/lib/wasm32-emscripten \
             --out-dir namespaced_deps \
+            --lib libfreetype --lib libpng --private-lib libz=libzlib \
             ${{ matrix.config == 'Multithreaded' && '--pthread' || '' }}
           cp namespaced_deps/*.a ${OUT_DIR}
 

--- a/.github/workflows/build-test-emscripten-c-bindings.yml
+++ b/.github/workflows/build-test-emscripten-c-bindings.yml
@@ -130,7 +130,8 @@ jobs:
           #   our build tree, so the globs above miss them and consumers cannot always build the
           #   ports themselves (Unity's WebGL emsdk has FROZEN_CACHE and ships none of them, leaving
           #   FT_*/png_* undefined). Ship them namespaced, because engines like Unity statically
-          #   link their own trimmed freetype/libpng/zlib whose globals collide with vanilla copies.
+          #   link their own trimmed freetype/libpng/zlib whose globals collide with vanilla copies;
+          #   the package archives referencing them are rewritten in place to the new names.
           EMSDK_CACHE=$(${EMSDK}/upstream/emscripten/em-config CACHE)
           python3 scripts/nuget_patch/wasm_namespace_deps.py \
             --llvm-bin ${EMSDK}/upstream/bin \

--- a/.github/workflows/build-test-emscripten-c-bindings.yml
+++ b/.github/workflows/build-test-emscripten-c-bindings.yml
@@ -133,9 +133,8 @@ jobs:
           #   link their own trimmed freetype/libpng/zlib whose globals collide with vanilla copies.
           EM_CACHE=$(${EMSDK}/upstream/emscripten/em-config CACHE)
           python3 scripts/wasm_namespace_deps.py \
-            --emscripten ${EMSDK}/upstream/emscripten \
+            --llvm-bin ${EMSDK}/upstream/bin \
             --package-dir ${OUT_DIR} \
-            --ports-dir ${EM_CACHE}/ports \
             --vanilla-libs ${EM_CACHE}/sysroot/lib/wasm32-emscripten \
             --out-dir namespaced_deps \
             ${{ matrix.config == 'Multithreaded' && '--pthread' || '' }}

--- a/.github/workflows/build-test-emscripten-c-bindings.yml
+++ b/.github/workflows/build-test-emscripten-c-bindings.yml
@@ -122,9 +122,24 @@ jobs:
       - name: Prepare output files
         shell: bash
         run: |
-          mkdir -p wasm_files/emsdk-${{matrix.emsdk_ver}}/${{matrix.short_name}}
-          cp build/Release/bin/*.a wasm_files/emsdk-${{matrix.emsdk_ver}}/${{matrix.short_name}}
-          cp lib/*.a wasm_files/emsdk-${{matrix.emsdk_ver}}/${{matrix.short_name}}
+          OUT_DIR=wasm_files/emsdk-${{matrix.emsdk_ver}}/${{matrix.short_name}}
+          mkdir -p ${OUT_DIR}
+          cp build/Release/bin/*.a ${OUT_DIR}
+          cp lib/*.a ${OUT_DIR}
+          # The freetype/libpng/zlib the -sUSE_* flags link against live in the emsdk cache, not in
+          #   our build tree, so the globs above miss them and consumers cannot always build the
+          #   ports themselves (Unity's WebGL emsdk has FROZEN_CACHE and ships none of them, leaving
+          #   FT_*/png_* undefined). Ship them namespaced, because engines like Unity statically
+          #   link their own trimmed freetype/libpng/zlib whose globals collide with vanilla copies.
+          EM_CACHE=$(${EMSDK}/upstream/emscripten/em-config CACHE)
+          python3 scripts/wasm_namespace_deps.py \
+            --emscripten ${EMSDK}/upstream/emscripten \
+            --package-dir ${OUT_DIR} \
+            --ports-dir ${EM_CACHE}/ports \
+            --vanilla-libs ${EM_CACHE}/sysroot/lib/wasm32-emscripten \
+            --out-dir namespaced_deps \
+            ${{ matrix.config == 'Multithreaded' && '--pthread' || '' }}
+          cp namespaced_deps/*.a ${OUT_DIR}
 
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v7

--- a/scripts/nuget_patch/wasm_namespace_deps.py
+++ b/scripts/nuget_patch/wasm_namespace_deps.py
@@ -7,11 +7,14 @@ Unity's WebGL player statically links its own trimmed freetype, libpng and
 zlib whose leaked globals collide with full copies of the same libraries, and
 its frozen emsdk cache cannot build the ports on the consumer's machine.
 
-Every symbol the port libraries export is renamed with PREFIX, except the
+Every symbol the listed libraries export is renamed with PREFIX, except the
 exact set the MeshLib package archives reference (computed with llvm-nm), so
 the already-compiled MeshLib objects link against these libraries unchanged.
-zlib is treated as private to libpng: MeshLib's own zlib references keep
-resolving to the archives that provide them today, never to this copy.
+All libraries of one package must be renamed by a single invocation: they
+share one rename map, so references between them (libpng calls zlib) are
+renamed consistently. A --private-lib is renamed in full even where the
+package references its symbols - used for zlib, whose standard names the
+package already resolves elsewhere (libgdcmzlib.a ships them).
 
 The renaming rewrites the wasm object files of the archives the MeshLib build
 already produced, so the shipped code is bit-identical to what was built and
@@ -244,10 +247,17 @@ def main():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument('--llvm-bin', default='', help='directory with llvm-nm and llvm-ar (default: from PATH)')
     p.add_argument('--package-dir', required=True, help='directory with the MeshLib .a files being shipped')
-    p.add_argument('--vanilla-libs', required=True, help='dir with the port builds to rename (libfreetype*.a, libpng*.a, libz*.a)')
+    p.add_argument('--vanilla-libs', required=True, help='dir where library stems are looked up (the emsdk cache lib dir for ports)')
     p.add_argument('--out-dir', required=True)
     p.add_argument('--pthread', action='store_true', help='prefer the -mt port variants (multithreaded package)')
+    p.add_argument('--lib', action='append', default=[], metavar='STEM[=OUT]',
+                   help='library to rename, as a stem globbed in --vanilla-libs (or a path to an archive); '
+                        'written to OUT-mrml.a (default: STEM-mrml.a); repeatable')
+    p.add_argument('--private-lib', action='append', default=[], metavar='STEM[=OUT]',
+                   help='like --lib, but renamed in full: none of its symbols join the kept API set')
     args = p.parse_args()
+    if not args.lib and not args.private_lib:
+        p.error('at least one --lib/--private-lib is required')
 
     bindir = Path(args.llvm_bin) if args.llvm_bin else None
 
@@ -274,26 +284,34 @@ def main():
             sys.exit(f'no {stem}*.a in {vanilla}; the MeshLib build should have built the ports')
         return cands[0]
 
-    src_libs = {
-        'libfreetype-mrml.a': vanilla_lib('libfreetype'),
-        'libpng-mrml.a': vanilla_lib('libpng'),
-        'libzlib-mrml.a': vanilla_lib('libz'),
-    }
+    def resolve(spec):
+        stem, _, out = spec.partition('=')
+        path = Path(stem)
+        src = path if path.suffix == '.a' and path.exists() else vanilla_lib(stem)
+        return (out or stem) + '-mrml.a', src
 
-    d_ft = nm_symbols(nm, src_libs['libfreetype-mrml.a'], '--defined-only')
-    d_png = nm_symbols(nm, src_libs['libpng-mrml.a'], '--defined-only')
-    d_z = nm_symbols(nm, src_libs['libzlib-mrml.a'], '--defined-only')
+    src_libs = {}
+    d_keepable = set()
+    d_all = set()
+    for spec in args.lib + args.private_lib:
+        name, src = resolve(spec)
+        src_libs[name] = src
+        defined = nm_symbols(nm, src, '--defined-only')
+        d_all |= defined
+        if spec in args.lib:
+            d_keepable |= defined
 
     u_pkg = set()
+    renamed_srcs = {s.resolve() for s in src_libs.values()}
     for a in sorted(Path(args.package_dir).glob('*.a')):
-        if a.name.endswith('-mrml.a'):
-            continue  # a previous run's own outputs
+        if a.name.endswith('-mrml.a') or a.resolve() in renamed_srcs:
+            continue  # our own outputs, or a library being renamed
         u_pkg |= nm_symbols(nm, a, '--undefined-only')
 
-    # The unrenamed surface: exactly what the package references from freetype
-    # and libpng. zlib stays fully renamed - it exists only to serve libpng.
-    s_api = u_pkg & (d_ft | d_png)
-    rename = (d_ft | d_png | d_z) - s_api
+    # The unrenamed surface: exactly what the package references from the
+    # non-private libraries.
+    s_api = u_pkg & d_keepable
+    rename = d_all - s_api
 
     (out / 'renamed_symbols.txt').write_text(''.join(s + '\n' for s in sorted(rename)))
     print(f'kept unrenamed (referenced by the package): {len(s_api)}')

--- a/scripts/nuget_patch/wasm_namespace_deps.py
+++ b/scripts/nuget_patch/wasm_namespace_deps.py
@@ -1,29 +1,29 @@
 #!/usr/bin/env python3
-"""Ship namespaced (symbol-prefixed) copies of the Emscripten port libraries
-MeshLib links against (freetype, libpng, zlib) in the C# wasm package, so
-they cannot collide with a host engine's own copies of the same libraries.
+"""Namespace the Emscripten port libraries MeshLib links against (freetype,
+libpng, zlib) so the C# wasm package can ship them without colliding with a
+host engine's own copies of the same libraries.
 
 Unity's WebGL player statically links its own trimmed freetype, libpng and
 zlib whose leaked globals collide with full copies of the same libraries, and
 its frozen emsdk cache cannot build the ports on the consumer's machine.
 
-Every symbol the listed libraries export is renamed with PREFIX, except the
-exact set the MeshLib package archives reference (computed with llvm-nm), so
-the already-compiled MeshLib objects link against these libraries unchanged.
-All libraries of one package must be renamed by a single invocation: they
-share one rename map, so references between them (libpng calls zlib) are
-renamed consistently. A --private-lib is renamed in full even where the
-package references its symbols - used for zlib, whose standard names the
-package already resolves elsewhere (libgdcmzlib.a ships them).
+Every symbol the listed libraries export is renamed with PREFIX, and the
+package archives' references to them are rewritten to match, so nothing
+about these libraries stays visible under a standard name. All libraries of
+one package must be renamed by a single invocation: they share one rename
+map, so references between them (libpng calls zlib) stay consistent. The
+package's references to a --private-lib are left alone: that library serves
+only the other renamed ones - used for zlib, whose standard names the package
+already resolves elsewhere (libgdcmzlib.a ships them).
 
-The renaming rewrites the wasm object files of the archives the MeshLib build
-already produced, so the shipped code is bit-identical to what was built and
-tested, and nothing needs to know the ports' source layout or compile flags.
-llvm-objcopy does not support symbol renaming for wasm objects, but the
-format makes renaming exact: symbol names live only in the `linking` custom
-section's symbol table and in the import entries' field names, while
-relocations reference symbols by index, so rewriting the name strings is
-complete and safe.
+The renaming rewrites the wasm object files inside the archives the MeshLib
+build already produced, so the shipped code is bit-identical to what was
+built and tested, and nothing needs to know the ports' source layout or
+compile flags. llvm-objcopy does not support symbol renaming for wasm
+objects, but the format makes renaming exact: symbol names live only in the
+`linking` custom section's symbol table and in the import entries' field
+names, while relocations reference symbols by index, so rewriting the name
+strings is complete and safe.
 """
 
 import argparse
@@ -107,7 +107,7 @@ class Reader:
             self.leb()
 
 
-def splice(payload, spans, rename):
+def splice(payload, spans):
     out = bytearray()
     last = 0
     for start, end, old in spans:
@@ -146,7 +146,7 @@ def rewrite_imports(payload, rename):
             spans.append((start, end, field))
     if r.pos != len(payload):
         sys.exit('trailing bytes in the import section')
-    return splice(payload, spans, rename)
+    return splice(payload, spans)
 
 
 def rewrite_symtab(payload, rename):
@@ -177,7 +177,7 @@ def rewrite_symtab(payload, rename):
             sys.exit(f'unknown symbol kind {kind}')
     if r.pos != len(payload):
         sys.exit('trailing bytes in the symbol table')
-    return splice(payload, spans, rename)
+    return splice(payload, spans)
 
 
 def rewrite_linking(content, rename):
@@ -227,34 +227,78 @@ def rewrite_object(data, rename):
     return bytes(out)
 
 
+def ar_members(path):
+    """(name, data) of each object in an ar archive, duplicates included.
+
+    The symbol index is dropped (llvm-ar rebuilds it); GNU long-name table
+    entries and BSD inline long names are both resolved."""
+    data = path.read_bytes()
+    if data[:8] != b'!<arch>\n':
+        sys.exit(f'{path.name}: not an ar archive')
+    pos = 8
+    longnames = b''
+    members = []
+    while pos + 60 <= len(data):
+        hdr = data[pos:pos + 60]
+        if hdr[58:60] != b'`\n':
+            sys.exit(f'{path.name}: bad ar member header at offset {pos}')
+        raw = hdr[:16].rstrip()
+        size = int(hdr[48:58])
+        body = data[pos + 60:pos + 60 + size]
+        pos += 60 + size + (size & 1)
+        if raw in (b'/', b'/SYM64/', b'__.SYMDEF', b'__.SYMDEF SORTED'):
+            continue
+        if raw == b'//':
+            longnames = body
+            continue
+        if raw.startswith(b'#1/'):
+            n = int(raw[3:])
+            name, body = body[:n].rstrip(b'\0'), body[n:]
+        elif raw.startswith(b'/'):
+            off = int(raw[1:])
+            name = longnames[off:longnames.index(b'/\n', off)]
+        else:
+            name = raw.rstrip(b'/')
+        members.append((name.decode(), body))
+    return members
+
+
 def rewrite_archive(ar, src, dst, rename, workdir):
-    members = [m for m in run([ar, 't', str(src)]).splitlines() if m]
-    if len(set(members)) != len(members):
-        sys.exit(f'{src.name}: duplicate member names, flat extraction would clobber')
     workdir.mkdir(parents=True, exist_ok=True)
-    run([ar, 'x', str(src)], cwd=workdir)
-    for m in members:
-        p = workdir / m
-        rewritten = rewrite_object(p.read_bytes(), rename)
+    paths = []
+    for i, (name, data) in enumerate(ar_members(src)):
+        # one directory per member keeps duplicate member names apart;
+        # llvm-ar stores basenames, so the archive keeps the original names
+        sub = workdir / f'{i:05d}'
+        sub.mkdir(exist_ok=True)
+        rewritten = rewrite_object(data, rename)
         rewrite_object(rewritten, set())  # self-check: the output must re-parse
-        p.write_bytes(rewritten)
-    if dst.exists():
-        dst.unlink()
-    run([ar, 'qc', str(dst)] + members, cwd=workdir)
+        (sub / name).write_bytes(rewritten)
+        paths.append(f'{sub.name}/{name}')
+    rsp = workdir / 'members.rsp'
+    rsp.write_text(''.join(p + '\n' for p in paths))
+    tmp = workdir / 'out.a'
+    if tmp.exists():
+        tmp.unlink()
+    run([ar, 'qc', str(tmp), '@' + rsp.name], cwd=workdir)
+    tmp.replace(dst)
 
 
 def main():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument('--llvm-bin', default='', help='directory with llvm-nm and llvm-ar (default: from PATH)')
-    p.add_argument('--package-dir', required=True, help='directory with the MeshLib .a files being shipped')
+    p.add_argument('--package-dir', required=True,
+                   help='directory with the MeshLib .a files being shipped; archives referencing the '
+                        'renamed libraries are rewritten in place')
     p.add_argument('--vanilla-libs', required=True, help='dir where library stems are looked up (the emsdk cache lib dir for ports)')
     p.add_argument('--out-dir', required=True)
     p.add_argument('--pthread', action='store_true', help='prefer the -mt port variants (multithreaded package)')
     p.add_argument('--lib', action='append', default=[], metavar='STEM[=OUT]',
                    help='library to rename, as a stem globbed in --vanilla-libs (or a path to an archive); '
-                        'written to OUT-mrml.a (default: STEM-mrml.a); repeatable')
+                        'written to OUT-mrml.a (default: STEM-mrml.a); the package references are rewritten; repeatable')
     p.add_argument('--private-lib', action='append', default=[], metavar='STEM[=OUT]',
-                   help='like --lib, but renamed in full: none of its symbols join the kept API set')
+                   help='like --lib, but the package references to it are left alone: it serves only the '
+                        'other renamed libraries')
     args = p.parse_args()
     if not args.lib and not args.private_lib:
         p.error('at least one --lib/--private-lib is required')
@@ -285,13 +329,13 @@ def main():
         return cands[0]
 
     def resolve(spec):
-        stem, _, out = spec.partition('=')
+        stem, _, out_name = spec.partition('=')
         path = Path(stem)
         src = path if path.suffix == '.a' and path.exists() else vanilla_lib(stem)
-        return (out or stem) + '-mrml.a', src
+        return (out_name or stem) + '-mrml.a', src
 
     src_libs = {}
-    d_keepable = set()
+    d_public = set()  # exports whose package references get rewritten
     d_all = set()
     for spec in args.lib + args.private_lib:
         name, src = resolve(spec)
@@ -299,46 +343,53 @@ def main():
         defined = nm_symbols(nm, src, '--defined-only')
         d_all |= defined
         if spec in args.lib:
-            d_keepable |= defined
+            d_public |= defined
 
-    u_pkg = set()
     renamed_srcs = {s.resolve() for s in src_libs.values()}
-    for a in sorted(Path(args.package_dir).glob('*.a')):
-        if a.name.endswith('-mrml.a') or a.resolve() in renamed_srcs:
-            continue  # our own outputs, or a library being renamed
-        u_pkg |= nm_symbols(nm, a, '--undefined-only')
+    package = [a for a in sorted(Path(args.package_dir).glob('*.a'))
+               if not a.name.endswith('-mrml.a') and a.resolve() not in renamed_srcs]
+    consumers = []
+    refs = set()
+    for a in package:
+        used = (nm_symbols(nm, a, '--undefined-only') | nm_symbols(nm, a, '--defined-only')) & d_public
+        if used:
+            consumers.append(a)
+            refs |= used
 
-    # The unrenamed surface: exactly what the package references from the
-    # non-private libraries.
-    s_api = u_pkg & d_keepable
-    rename = d_all - s_api
-
-    (out / 'renamed_symbols.txt').write_text(''.join(s + '\n' for s in sorted(rename)))
-    print(f'kept unrenamed (referenced by the package): {len(s_api)}')
-    for s in sorted(s_api):
+    (out / 'renamed_symbols.txt').write_text(''.join(s + '\n' for s in sorted(d_all)))
+    print(f'renamed: {len(d_all)} symbols of {len(src_libs)} libraries')
+    print(f'package references rewritten: {len(refs)} symbols in {len(consumers)} archives')
+    for s in sorted(refs):
         print(f'  {s}')
-    print(f'renamed: {len(rename)}')
 
     for name, src in src_libs.items():
         print(f'{src.name} -> {name}')
-        rewrite_archive(ar, src, out / name, rename, out / ('members-' + name[:-2]))
+        rewrite_archive(ar, src, out / name, d_all, out / ('members-' + name[:-2]))
+    for a in consumers:
+        print(f'{a.name}: rewriting references in place')
+        rewrite_archive(ar, a, a, refs, out / ('members-' + a.stem))
 
-    # Verify with an independent tool: no library may export a name outside
-    # PREFIX except the s_api set, and nothing may still reference a renamed
-    # symbol by its old name.
+    # Verify with an independent tool: the renamed libraries export nothing
+    # outside PREFIX and reference no renamed symbol by its old name, and the
+    # package no longer uses any standard name of the public libraries.
     ok = True
     for lib in src_libs:
-        bad = {s for s in nm_symbols(nm, out / lib, '--defined-only') if not s.startswith(PREFIX)} - s_api
+        bad = {s for s in nm_symbols(nm, out / lib, '--defined-only') if not s.startswith(PREFIX)}
         if bad:
             ok = False
             print(f'ERROR: {lib} exports unrenamed symbols: {sorted(bad)}')
-        leaked = nm_symbols(nm, out / lib, '--undefined-only') & rename
+        leaked = nm_symbols(nm, out / lib, '--undefined-only') & d_all
         if leaked:
             ok = False
             print(f'ERROR: {lib} references renamed symbols by their old names: {sorted(leaked)}')
+    for a in consumers:
+        leaked = (nm_symbols(nm, a, '--undefined-only') | nm_symbols(nm, a, '--defined-only')) & d_public
+        if leaked:
+            ok = False
+            print(f'ERROR: {a.name} still uses standard names: {sorted(leaked)}')
     if not ok:
         sys.exit(1)
-    print('verified: only the package-referenced API is exported unrenamed')
+    print('verified: no standard name of the renamed libraries remains in the package')
 
 
 if __name__ == '__main__':

--- a/scripts/wasm_namespace_deps.py
+++ b/scripts/wasm_namespace_deps.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Build namespaced (symbol-prefixed) static libraries of the Emscripten ports
+MeshLib links against (freetype, libpng, zlib) so they can be shipped in the
+C# wasm package without colliding with a host engine's own copies.
+
+Unity's WebGL player statically links its own trimmed freetype, libpng and
+zlib whose leaked globals collide with full copies of the same libraries, and
+its frozen emsdk cache cannot build ports on the consumer's machine. Renaming
+is done at compile time (a generated header of #define lines) because
+llvm-objcopy does not support symbol renaming for wasm objects.
+
+Every symbol a dependency exports is renamed with PREFIX, except the exact
+set the MeshLib package archives reference (computed with llvm-nm), so the
+already-compiled MeshLib objects link against these libraries unchanged.
+zlib is treated as private to libpng: MeshLib's own zlib references keep
+resolving to the archives that provide them today, never to this copy.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PREFIX = 'mrml_'
+
+FREETYPE_SRCS = [
+    'src/autofit/autofit.c', 'src/base/ftadvanc.c', 'src/base/ftbbox.c',
+    'src/base/ftbdf.c', 'src/base/ftbitmap.c', 'src/base/ftcalc.c',
+    'src/base/ftcid.c', 'src/base/ftdbgmem.c', 'src/base/ftdebug.c',
+    'src/base/ftfntfmt.c', 'src/base/ftfstype.c', 'src/base/ftgasp.c',
+    'src/base/ftgloadr.c', 'src/base/ftglyph.c', 'src/base/ftgxval.c',
+    'src/base/ftinit.c', 'src/base/ftlcdfil.c', 'src/base/ftmm.c',
+    'src/base/ftobjs.c', 'src/base/ftotval.c', 'src/base/ftoutln.c',
+    'src/base/ftpatent.c', 'src/base/ftpfr.c', 'src/base/ftrfork.c',
+    'src/base/ftsnames.c', 'src/base/ftstream.c', 'src/base/ftstroke.c',
+    'src/base/ftsynth.c', 'src/base/ftsystem.c', 'src/base/fttrigon.c',
+    'src/base/fttype1.c', 'src/base/ftutil.c', 'src/base/ftwinfnt.c',
+    'src/bdf/bdf.c', 'src/bzip2/ftbzip2.c', 'src/cache/ftcache.c',
+    'src/cff/cff.c', 'src/cid/type1cid.c', 'src/gzip/ftgzip.c',
+    'src/lzw/ftlzw.c', 'src/pcf/pcf.c', 'src/pfr/pfr.c',
+    'src/psaux/psaux.c', 'src/pshinter/pshinter.c', 'src/psnames/psmodule.c',
+    'src/raster/raster.c', 'src/sfnt/sfnt.c', 'src/smooth/smooth.c',
+    'src/truetype/truetype.c', 'src/type1/type1.c', 'src/type42/type42.c',
+    'src/winfonts/winfnt.c',
+]
+
+ZLIB_SRCS = [
+    'adler32.c', 'compress.c', 'crc32.c', 'deflate.c', 'gzclose.c',
+    'gzlib.c', 'gzread.c', 'gzwrite.c', 'infback.c', 'inffast.c',
+    'inflate.c', 'inftrees.c', 'trees.c', 'uncompr.c', 'zutil.c',
+]
+
+IDENT = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+# Definition sites the rename header cannot reach: libpng defines these with
+# the parenthesized "(PNGAPI name)" idiom that defeats macro expansion, and
+# zlib #undef's gzgetc right before defining it. Patched in source copies.
+PATCHES = {
+    'pngrutil.c': [
+        ('png_get_uint_32)(png_const_bytep buf)', f'{PREFIX}png_get_uint_32)(png_const_bytep buf)'),
+        ('png_get_int_32)(png_const_bytep buf)', f'{PREFIX}png_get_int_32)(png_const_bytep buf)'),
+        ('png_get_uint_16)(png_const_bytep buf)', f'{PREFIX}png_get_uint_16)(png_const_bytep buf)'),
+    ],
+    'gzread.c': [
+        ('int ZEXPORT gzgetc(file)', f'int ZEXPORT {PREFIX}gzgetc(file)'),
+        ('    return gzgetc(file);', f'    return {PREFIX}gzgetc(file);'),
+    ],
+}
+
+
+def run(cmd, **kw):
+    r = subprocess.run(cmd, capture_output=True, text=True, **kw)
+    if r.returncode != 0:
+        sys.exit(f'FAILED ({r.returncode}): {" ".join(map(str, cmd))}\n{r.stdout}\n{r.stderr}')
+    return r.stdout
+
+
+def nm_symbols(nm, archive, mode):
+    out = run([nm, mode, '--extern-only', str(archive)])
+    syms = set()
+    for line in out.splitlines():
+        parts = line.split()
+        if parts and IDENT.match(parts[-1]):
+            syms.add(parts[-1])
+    return syms
+
+
+def compile_lib(emcc, ar, srcs, src_root, out_lib, extra_flags, jobs_dir):
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+    objs = []
+    for src in srcs:
+        path = src_root / src
+        name = Path(src).name
+        if name in PATCHES:
+            text = path.read_text()
+            for old, new in PATCHES[name]:
+                assert text.count(old) == 1, f'{name}: pattern not found once: {old}'
+                text = text.replace(old, new)
+            path = jobs_dir / name
+            path.write_text(text)
+        obj = jobs_dir / (src.replace('/', '_') + '.o')
+        run([emcc, '-c', str(path), '-o', str(obj), '-O2', '-I' + str(src_root)] + extra_flags)
+        objs.append(str(obj))
+    if out_lib.exists():
+        out_lib.unlink()
+    run([ar, 'qc', str(out_lib)] + objs)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--emscripten', required=True, help='emscripten root (contains emcc, cache/)')
+    p.add_argument('--package-dir', required=True, help='directory with the MeshLib .a files being shipped')
+    p.add_argument('--ports-dir', required=True, help='emsdk cache ports dir with unpacked freetype/libpng/zlib sources')
+    p.add_argument('--vanilla-libs', required=True, help='dir with unrenamed port builds (libfreetype.a, libpng.a, libz.a) used to enumerate their exports')
+    p.add_argument('--out-dir', required=True)
+    p.add_argument('--pthread', action='store_true', help='build with -pthread (multithreaded package variant)')
+    args = p.parse_args()
+
+    em = Path(args.emscripten)
+    llvm = em.parent / 'llvm'
+    nm = str(llvm / 'llvm-nm.exe') if (llvm / 'llvm-nm.exe').exists() else 'llvm-nm'
+    ar = str(llvm / 'llvm-ar.exe') if (llvm / 'llvm-ar.exe').exists() else 'llvm-ar'
+    emcc = str(em / ('emcc.bat' if os.name == 'nt' else 'emcc'))
+    out = Path(args.out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    vanilla = Path(args.vanilla_libs)
+    ports = Path(args.ports_dir)
+
+    def vanilla_lib(stem):
+        # port builds may carry variant suffixes (-mt, -wasm-sjlj, ...);
+        # any variant works here since only symbol names are read
+        cands = sorted(vanilla.glob(stem + '*.a'), key=lambda c: len(c.name))
+        if not cands:
+            sys.exit(f'no {stem}*.a in {vanilla}; build the ports first (embuilder build freetype libpng zlib)')
+        return cands[0]
+
+    d_ft = nm_symbols(nm, vanilla_lib('libfreetype'), '--defined-only')
+    d_png = nm_symbols(nm, vanilla_lib('libpng'), '--defined-only')
+    d_z = nm_symbols(nm, vanilla_lib('libz'), '--defined-only')
+
+    u_pkg = set()
+    for a in sorted(Path(args.package_dir).glob('*.a')):
+        u_pkg |= nm_symbols(nm, a, '--undefined-only')
+
+    # The unrenamed surface: exactly what the package references from freetype
+    # and libpng. zlib stays fully renamed - it exists only to serve libpng.
+    s_api = u_pkg & (d_ft | d_png)
+    rename = (d_ft | d_png | d_z) - s_api
+
+    hdr = out / 'mrml_rename.h'
+    with open(hdr, 'w', newline='\n') as f:
+        f.write('/* generated by wasm_namespace_deps.py - do not edit */\n')
+        f.write('#pragma once\n')
+        for s in sorted(rename):
+            f.write(f'#define {s} {PREFIX}{s}\n')
+
+    print(f'kept unrenamed (referenced by the package): {len(s_api)}')
+    for s in sorted(s_api):
+        print(f'  {s}')
+    print(f'renamed: {len(rename)}')
+
+    ft_src = next(ports.glob('freetype/FreeType-*'))
+    png_src = next(ports.glob('libpng/libpng-*'))
+    z_src = next(ports.glob('zlib/zlib-*'))
+    missing = [f for f in FREETYPE_SRCS if not (ft_src / f).exists()]
+    if missing:
+        sys.exit(f'freetype port layout changed ({ft_src.name}); update FREETYPE_SRCS: {missing}')
+
+    inc = ['-include', str(hdr)]
+    if args.pthread:
+        inc.append('-pthread')
+    compile_lib(emcc, ar, ZLIB_SRCS, z_src, out / 'libzlib-mrml.a',
+                inc + ['-Wno-deprecated-non-prototype'], out / 'obj-z')
+    png_srcs = sorted(f.name for f in png_src.glob('*.c') if f.name != 'pngtest.c')
+    compile_lib(emcc, ar, png_srcs, png_src, out / 'libpng-mrml.a',
+                inc + ['-I' + str(z_src)], out / 'obj-png')
+    compile_lib(emcc, ar, FREETYPE_SRCS, ft_src, out / 'libfreetype-mrml.a',
+                inc + ['-DFT2_BUILD_LIBRARY', '-I' + str(ft_src / 'include')], out / 'obj-ft')
+
+    # Verify: no library may export a name outside PREFIX except the s_api set.
+    ok = True
+    for lib in ('libfreetype-mrml.a', 'libpng-mrml.a', 'libzlib-mrml.a'):
+        exported = nm_symbols(nm, out / lib, '--defined-only')
+        bad = {s for s in exported if not s.startswith(PREFIX)} - s_api
+        if bad:
+            ok = False
+            print(f'ERROR: {lib} exports unrenamed symbols: {sorted(bad)}')
+    # And libpng's zlib references must all be renamed (private zlib).
+    png_undef = nm_symbols(nm, out / 'libpng-mrml.a', '--undefined-only')
+    leaked = png_undef & d_z
+    if leaked:
+        ok = False
+        print(f'ERROR: libpng-mrml still references unrenamed zlib: {sorted(leaked)}')
+    if not ok:
+        sys.exit(1)
+    print('verified: only the package-referenced API is exported unrenamed')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/wasm_namespace_deps.py
+++ b/scripts/wasm_namespace_deps.py
@@ -1,23 +1,29 @@
 #!/usr/bin/env python3
-"""Build namespaced (symbol-prefixed) static libraries of the Emscripten ports
-MeshLib links against (freetype, libpng, zlib) so they can be shipped in the
-C# wasm package without colliding with a host engine's own copies.
+"""Ship namespaced (symbol-prefixed) copies of the Emscripten port libraries
+MeshLib links against (freetype, libpng, zlib) in the C# wasm package, so
+they cannot collide with a host engine's own copies of the same libraries.
 
 Unity's WebGL player statically links its own trimmed freetype, libpng and
 zlib whose leaked globals collide with full copies of the same libraries, and
-its frozen emsdk cache cannot build ports on the consumer's machine. Renaming
-is done at compile time (a generated header of #define lines) because
-llvm-objcopy does not support symbol renaming for wasm objects.
+its frozen emsdk cache cannot build the ports on the consumer's machine.
 
-Every symbol a dependency exports is renamed with PREFIX, except the exact
-set the MeshLib package archives reference (computed with llvm-nm), so the
-already-compiled MeshLib objects link against these libraries unchanged.
+Every symbol the port libraries export is renamed with PREFIX, except the
+exact set the MeshLib package archives reference (computed with llvm-nm), so
+the already-compiled MeshLib objects link against these libraries unchanged.
 zlib is treated as private to libpng: MeshLib's own zlib references keep
 resolving to the archives that provide them today, never to this copy.
+
+The renaming rewrites the wasm object files of the archives the MeshLib build
+already produced, so the shipped code is bit-identical to what was built and
+tested, and nothing needs to know the ports' source layout or compile flags.
+llvm-objcopy does not support symbol renaming for wasm objects, but the
+format makes renaming exact: symbol names live only in the `linking` custom
+section's symbol table and in the import entries' field names, while
+relocations reference symbols by index, so rewriting the name strings is
+complete and safe.
 """
 
 import argparse
-import os
 import re
 import subprocess
 import sys
@@ -25,49 +31,12 @@ from pathlib import Path
 
 PREFIX = 'mrml_'
 
-FREETYPE_SRCS = [
-    'src/autofit/autofit.c', 'src/base/ftadvanc.c', 'src/base/ftbbox.c',
-    'src/base/ftbdf.c', 'src/base/ftbitmap.c', 'src/base/ftcalc.c',
-    'src/base/ftcid.c', 'src/base/ftdbgmem.c', 'src/base/ftdebug.c',
-    'src/base/ftfntfmt.c', 'src/base/ftfstype.c', 'src/base/ftgasp.c',
-    'src/base/ftgloadr.c', 'src/base/ftglyph.c', 'src/base/ftgxval.c',
-    'src/base/ftinit.c', 'src/base/ftlcdfil.c', 'src/base/ftmm.c',
-    'src/base/ftobjs.c', 'src/base/ftotval.c', 'src/base/ftoutln.c',
-    'src/base/ftpatent.c', 'src/base/ftpfr.c', 'src/base/ftrfork.c',
-    'src/base/ftsnames.c', 'src/base/ftstream.c', 'src/base/ftstroke.c',
-    'src/base/ftsynth.c', 'src/base/ftsystem.c', 'src/base/fttrigon.c',
-    'src/base/fttype1.c', 'src/base/ftutil.c', 'src/base/ftwinfnt.c',
-    'src/bdf/bdf.c', 'src/bzip2/ftbzip2.c', 'src/cache/ftcache.c',
-    'src/cff/cff.c', 'src/cid/type1cid.c', 'src/gzip/ftgzip.c',
-    'src/lzw/ftlzw.c', 'src/pcf/pcf.c', 'src/pfr/pfr.c',
-    'src/psaux/psaux.c', 'src/pshinter/pshinter.c', 'src/psnames/psmodule.c',
-    'src/raster/raster.c', 'src/sfnt/sfnt.c', 'src/smooth/smooth.c',
-    'src/truetype/truetype.c', 'src/type1/type1.c', 'src/type42/type42.c',
-    'src/winfonts/winfnt.c',
-]
-
-ZLIB_SRCS = [
-    'adler32.c', 'compress.c', 'crc32.c', 'deflate.c', 'gzclose.c',
-    'gzlib.c', 'gzread.c', 'gzwrite.c', 'infback.c', 'inffast.c',
-    'inflate.c', 'inftrees.c', 'trees.c', 'uncompr.c', 'zutil.c',
-]
-
 IDENT = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
 
-# Definition sites the rename header cannot reach: libpng defines these with
-# the parenthesized "(PNGAPI name)" idiom that defeats macro expansion, and
-# zlib #undef's gzgetc right before defining it. Patched in source copies.
-PATCHES = {
-    'pngrutil.c': [
-        ('png_get_uint_32)(png_const_bytep buf)', f'{PREFIX}png_get_uint_32)(png_const_bytep buf)'),
-        ('png_get_int_32)(png_const_bytep buf)', f'{PREFIX}png_get_int_32)(png_const_bytep buf)'),
-        ('png_get_uint_16)(png_const_bytep buf)', f'{PREFIX}png_get_uint_16)(png_const_bytep buf)'),
-    ],
-    'gzread.c': [
-        ('int ZEXPORT gzgetc(file)', f'int ZEXPORT {PREFIX}gzgetc(file)'),
-        ('    return gzgetc(file);', f'    return {PREFIX}gzgetc(file);'),
-    ],
-}
+# Wasm object file conventions: see tool-conventions/Linking.md.
+WASM_SYM_UNDEFINED = 0x10
+WASM_SYM_EXPLICIT_NAME = 0x40
+KIND_FUNCTION, KIND_DATA, KIND_GLOBAL, KIND_SECTION, KIND_TAG, KIND_TABLE = range(6)
 
 
 def run(cmd, **kw):
@@ -87,61 +56,238 @@ def nm_symbols(nm, archive, mode):
     return syms
 
 
-def compile_lib(emcc, ar, srcs, src_root, out_lib, extra_flags, jobs_dir):
-    jobs_dir.mkdir(parents=True, exist_ok=True)
-    objs = []
-    for src in srcs:
-        path = src_root / src
-        name = Path(src).name
-        if name in PATCHES:
-            text = path.read_text()
-            for old, new in PATCHES[name]:
-                assert text.count(old) == 1, f'{name}: pattern not found once: {old}'
-                text = text.replace(old, new)
-            path = jobs_dir / name
-            path.write_text(text)
-        obj = jobs_dir / (src.replace('/', '_') + '.o')
-        run([emcc, '-c', str(path), '-o', str(obj), '-O2', '-I' + str(src_root)] + extra_flags)
-        objs.append(str(obj))
-    if out_lib.exists():
-        out_lib.unlink()
-    run([ar, 'qc', str(out_lib)] + objs)
+def enc_leb(value):
+    out = bytearray()
+    while True:
+        b = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(b | 0x80)
+        else:
+            out.append(b)
+            return bytes(out)
+
+
+class Reader:
+    def __init__(self, buf):
+        self.buf = buf
+        self.pos = 0
+
+    def u8(self):
+        b = self.buf[self.pos]
+        self.pos += 1
+        return b
+
+    def leb(self):
+        result = 0
+        shift = 0
+        while True:
+            b = self.u8()
+            result |= (b & 0x7F) << shift
+            if not (b & 0x80):
+                return result
+            shift += 7
+
+    def str_span(self):
+        # returns (text, start, end) where [start, end) covers the
+        # length-prefixed string, so it can be spliced out
+        start = self.pos
+        n = self.leb()
+        s = self.buf[self.pos:self.pos + n].decode()
+        self.pos += n
+        return s, start, self.pos
+
+    def limits(self):
+        flags = self.leb()
+        self.leb()
+        if flags & 1:
+            self.leb()
+
+
+def splice(payload, spans, rename):
+    out = bytearray()
+    last = 0
+    for start, end, old in spans:
+        new = (PREFIX + old).encode()
+        out += payload[last:start]
+        out += enc_leb(len(new)) + new
+        last = end
+    out += payload[last:]
+    return bytes(out)
+
+
+def rewrite_imports(payload, rename):
+    # undefined symbols carry their name as the import entry's field name
+    r = Reader(payload)
+    spans = []
+    for _ in range(r.leb()):
+        r.str_span()  # module
+        field, start, end = r.str_span()
+        kind = r.u8()
+        if kind == 0x00:
+            r.leb()  # function: type index
+        elif kind == 0x01:
+            r.u8()
+            r.limits()  # table: reftype, limits
+        elif kind == 0x02:
+            r.limits()  # memory
+        elif kind == 0x03:
+            r.u8()
+            r.u8()  # global: valtype, mutability
+        elif kind == 0x04:
+            r.u8()
+            r.leb()  # tag: attribute, type index
+        else:
+            sys.exit(f'unknown import kind {kind}')
+        if field in rename:
+            spans.append((start, end, field))
+    if r.pos != len(payload):
+        sys.exit('trailing bytes in the import section')
+    return splice(payload, spans, rename)
+
+
+def rewrite_symtab(payload, rename):
+    r = Reader(payload)
+    spans = []
+    for _ in range(r.leb()):
+        kind = r.u8()
+        flags = r.leb()
+        if kind in (KIND_FUNCTION, KIND_GLOBAL, KIND_TAG, KIND_TABLE):
+            r.leb()  # index into the kind's index space
+            # an undefined symbol's name lives in its import entry instead,
+            # unless an explicit one is stored here
+            if not (flags & WASM_SYM_UNDEFINED) or (flags & WASM_SYM_EXPLICIT_NAME):
+                name, start, end = r.str_span()
+                if name in rename:
+                    spans.append((start, end, name))
+        elif kind == KIND_DATA:
+            name, start, end = r.str_span()
+            if name in rename:
+                spans.append((start, end, name))
+            if not (flags & WASM_SYM_UNDEFINED):
+                r.leb()
+                r.leb()
+                r.leb()  # segment, offset, size
+        elif kind == KIND_SECTION:
+            r.leb()
+        else:
+            sys.exit(f'unknown symbol kind {kind}')
+    if r.pos != len(payload):
+        sys.exit('trailing bytes in the symbol table')
+    return splice(payload, spans, rename)
+
+
+def rewrite_linking(content, rename):
+    r = Reader(content)
+    version = r.leb()
+    if version != 2:
+        sys.exit(f'unsupported linking section version {version}')
+    out = bytearray(content[:r.pos])
+    while r.pos < len(content):
+        sub_type = r.u8()
+        size = r.leb()
+        payload = content[r.pos:r.pos + size]
+        r.pos += size
+        if sub_type == 8:  # WASM_SYMBOL_TABLE
+            payload = rewrite_symtab(payload, rename)
+        out.append(sub_type)
+        out += enc_leb(len(payload))
+        out += payload
+    return bytes(out)
+
+
+def rewrite_object(data, rename):
+    if data[:8] != b'\0asm\x01\0\0\0':
+        sys.exit('not a wasm object file (LTO bitcode members are not supported)')
+    out = bytearray(data[:8])
+    pos = 8
+    while pos < len(data):
+        sec_id = data[pos]
+        r = Reader(data)
+        r.pos = pos + 1
+        size = r.leb()
+        payload = data[r.pos:r.pos + size]
+        pos = r.pos + size
+        if sec_id == 2:
+            payload = rewrite_imports(payload, rename)
+        elif sec_id == 0:
+            pr = Reader(payload)
+            name, _, hdr_end = pr.str_span()
+            if name == 'linking':
+                payload = payload[:hdr_end] + rewrite_linking(payload[hdr_end:], rename)
+            # relocation sections reference symbols by index and the `name`
+            # section is debug info, so neither needs a fixup; section count
+            # and order are preserved, keeping cross-section indices valid
+        out.append(sec_id)
+        out += enc_leb(len(payload))
+        out += payload
+    return bytes(out)
+
+
+def rewrite_archive(ar, src, dst, rename, workdir):
+    members = [m for m in run([ar, 't', str(src)]).splitlines() if m]
+    if len(set(members)) != len(members):
+        sys.exit(f'{src.name}: duplicate member names, flat extraction would clobber')
+    workdir.mkdir(parents=True, exist_ok=True)
+    run([ar, 'x', str(src)], cwd=workdir)
+    for m in members:
+        p = workdir / m
+        rewritten = rewrite_object(p.read_bytes(), rename)
+        rewrite_object(rewritten, set())  # self-check: the output must re-parse
+        p.write_bytes(rewritten)
+    if dst.exists():
+        dst.unlink()
+    run([ar, 'qc', str(dst)] + members, cwd=workdir)
 
 
 def main():
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument('--emscripten', required=True, help='emscripten root (contains emcc, cache/)')
+    p.add_argument('--llvm-bin', default='', help='directory with llvm-nm and llvm-ar (default: from PATH)')
     p.add_argument('--package-dir', required=True, help='directory with the MeshLib .a files being shipped')
-    p.add_argument('--ports-dir', required=True, help='emsdk cache ports dir with unpacked freetype/libpng/zlib sources')
-    p.add_argument('--vanilla-libs', required=True, help='dir with unrenamed port builds (libfreetype.a, libpng.a, libz.a) used to enumerate their exports')
+    p.add_argument('--vanilla-libs', required=True, help='dir with the port builds to rename (libfreetype*.a, libpng*.a, libz*.a)')
     p.add_argument('--out-dir', required=True)
-    p.add_argument('--pthread', action='store_true', help='build with -pthread (multithreaded package variant)')
+    p.add_argument('--pthread', action='store_true', help='prefer the -mt port variants (multithreaded package)')
     args = p.parse_args()
 
-    em = Path(args.emscripten)
-    llvm = em.parent / 'llvm'
-    nm = str(llvm / 'llvm-nm.exe') if (llvm / 'llvm-nm.exe').exists() else 'llvm-nm'
-    ar = str(llvm / 'llvm-ar.exe') if (llvm / 'llvm-ar.exe').exists() else 'llvm-ar'
-    emcc = str(em / ('emcc.bat' if os.name == 'nt' else 'emcc'))
-    out = Path(args.out_dir)
+    bindir = Path(args.llvm_bin) if args.llvm_bin else None
+
+    def tool(name):
+        if not bindir:
+            return name
+        for cand in (bindir / name, bindir / (name + '.exe')):
+            if cand.exists():
+                return str(cand)
+        sys.exit(f'{name} not found in {bindir}')
+
+    nm = tool('llvm-nm')
+    ar = tool('llvm-ar')
+    out = Path(args.out_dir).resolve()
     out.mkdir(parents=True, exist_ok=True)
     vanilla = Path(args.vanilla_libs)
-    ports = Path(args.ports_dir)
 
     def vanilla_lib(stem):
-        # port builds may carry variant suffixes (-mt, -wasm-sjlj, ...);
-        # any variant works here since only symbol names are read
-        cands = sorted(vanilla.glob(stem + '*.a'), key=lambda c: len(c.name))
+        # prefer the variant matching the threading mode; port builds may
+        # carry suffixes (-mt, -wasm-sjlj, ...) or none at all
+        cands = sorted(vanilla.glob(stem + '*.a'),
+                       key=lambda c: (('-mt' in c.name) != args.pthread, len(c.name)))
         if not cands:
-            sys.exit(f'no {stem}*.a in {vanilla}; build the ports first (embuilder build freetype libpng zlib)')
+            sys.exit(f'no {stem}*.a in {vanilla}; the MeshLib build should have built the ports')
         return cands[0]
 
-    d_ft = nm_symbols(nm, vanilla_lib('libfreetype'), '--defined-only')
-    d_png = nm_symbols(nm, vanilla_lib('libpng'), '--defined-only')
-    d_z = nm_symbols(nm, vanilla_lib('libz'), '--defined-only')
+    src_libs = {
+        'libfreetype-mrml.a': vanilla_lib('libfreetype'),
+        'libpng-mrml.a': vanilla_lib('libpng'),
+        'libzlib-mrml.a': vanilla_lib('libz'),
+    }
+
+    d_ft = nm_symbols(nm, src_libs['libfreetype-mrml.a'], '--defined-only')
+    d_png = nm_symbols(nm, src_libs['libpng-mrml.a'], '--defined-only')
+    d_z = nm_symbols(nm, src_libs['libzlib-mrml.a'], '--defined-only')
 
     u_pkg = set()
     for a in sorted(Path(args.package_dir).glob('*.a')):
+        if a.name.endswith('-mrml.a'):
+            continue  # a previous run's own outputs
         u_pkg |= nm_symbols(nm, a, '--undefined-only')
 
     # The unrenamed surface: exactly what the package references from freetype
@@ -149,50 +295,29 @@ def main():
     s_api = u_pkg & (d_ft | d_png)
     rename = (d_ft | d_png | d_z) - s_api
 
-    hdr = out / 'mrml_rename.h'
-    with open(hdr, 'w', newline='\n') as f:
-        f.write('/* generated by wasm_namespace_deps.py - do not edit */\n')
-        f.write('#pragma once\n')
-        for s in sorted(rename):
-            f.write(f'#define {s} {PREFIX}{s}\n')
-
+    (out / 'renamed_symbols.txt').write_text(''.join(s + '\n' for s in sorted(rename)))
     print(f'kept unrenamed (referenced by the package): {len(s_api)}')
     for s in sorted(s_api):
         print(f'  {s}')
     print(f'renamed: {len(rename)}')
 
-    ft_src = next(ports.glob('freetype/FreeType-*'))
-    png_src = next(ports.glob('libpng/libpng-*'))
-    z_src = next(ports.glob('zlib/zlib-*'))
-    missing = [f for f in FREETYPE_SRCS if not (ft_src / f).exists()]
-    if missing:
-        sys.exit(f'freetype port layout changed ({ft_src.name}); update FREETYPE_SRCS: {missing}')
+    for name, src in src_libs.items():
+        print(f'{src.name} -> {name}')
+        rewrite_archive(ar, src, out / name, rename, out / ('members-' + name[:-2]))
 
-    inc = ['-include', str(hdr)]
-    if args.pthread:
-        inc.append('-pthread')
-    compile_lib(emcc, ar, ZLIB_SRCS, z_src, out / 'libzlib-mrml.a',
-                inc + ['-Wno-deprecated-non-prototype'], out / 'obj-z')
-    png_srcs = sorted(f.name for f in png_src.glob('*.c') if f.name != 'pngtest.c')
-    compile_lib(emcc, ar, png_srcs, png_src, out / 'libpng-mrml.a',
-                inc + ['-I' + str(z_src)], out / 'obj-png')
-    compile_lib(emcc, ar, FREETYPE_SRCS, ft_src, out / 'libfreetype-mrml.a',
-                inc + ['-DFT2_BUILD_LIBRARY', '-I' + str(ft_src / 'include')], out / 'obj-ft')
-
-    # Verify: no library may export a name outside PREFIX except the s_api set.
+    # Verify with an independent tool: no library may export a name outside
+    # PREFIX except the s_api set, and nothing may still reference a renamed
+    # symbol by its old name.
     ok = True
-    for lib in ('libfreetype-mrml.a', 'libpng-mrml.a', 'libzlib-mrml.a'):
-        exported = nm_symbols(nm, out / lib, '--defined-only')
-        bad = {s for s in exported if not s.startswith(PREFIX)} - s_api
+    for lib in src_libs:
+        bad = {s for s in nm_symbols(nm, out / lib, '--defined-only') if not s.startswith(PREFIX)} - s_api
         if bad:
             ok = False
             print(f'ERROR: {lib} exports unrenamed symbols: {sorted(bad)}')
-    # And libpng's zlib references must all be renamed (private zlib).
-    png_undef = nm_symbols(nm, out / 'libpng-mrml.a', '--undefined-only')
-    leaked = png_undef & d_z
-    if leaked:
-        ok = False
-        print(f'ERROR: libpng-mrml still references unrenamed zlib: {sorted(leaked)}')
+        leaked = nm_symbols(nm, out / lib, '--undefined-only') & rename
+        if leaked:
+            ok = False
+            print(f'ERROR: {lib} references renamed symbols by their old names: {sorted(leaked)}')
     if not ok:
         sys.exit(1)
     print('verified: only the package-referenced API is exported unrenamed')


### PR DESCRIPTION
The `-sUSE_FREETYPE/-sUSE_LIBPNG/-sUSE_ZLIB` port libraries live in the emsdk cache rather than in our build tree, so the packaging globs never included them, and consumers cannot always build the ports themselves: Unity's WebGL emsdk has `FROZEN_CACHE` and ships none of them, leaving `FT_*`/`png_*` undefined when linking the package. Vanilla copies cannot be shipped either, because Unity statically links its own trimmed freetype/libpng/zlib whose leaked globals (`ft_grays_raster`, `png_get_uint_32`, …) collide with full builds and cross-wire the two library versions at symbol resolution.

`scripts/nuget_patch/wasm_namespace_deps.py` takes the port archives the MeshLib build already produced, renames every exported symbol to `mrml_*` (930 symbols), and rewrites the package archives that reference them (`libimgui.a`, `libMRIOExtras.a`, `libMRSymbolMesh.a` — 40 names) in place to the new names, so the dependencies export nothing under a standard name and cannot collide with any host engine or third-party plugin. The renaming rewrites the wasm object files directly: symbol names live only in the `linking` section's symbol table and in import field names, and relocations reference symbols by index, so the shipped code is bit-identical to what was built and tested, and nothing needs to know the ports' source layout or compile flags (llvm-objcopy does not support symbol renaming for wasm objects, hence the small hand-rolled rewriter). zlib is renamed as a private dependency of libpng: the package's own zlib references keep resolving to `libgdcmzlib.a` as today. The packaging step ships `libfreetype-mrml.a`, `libpng-mrml.a`, `libzlib-mrml.a` next to the MeshLib archives.

Verified against Unity 6000.3.6f1 by replaying its exact Bee/emcc link of the dotnet-wasm package (zero errors, identical wasm) and by a full Editor WebGL build of a consumer project with the CI-built artifact. After this change the whole package shares no names with Unity's 6153 exports except three libc++ COMDAT instantiations that are meant to be shared.

Labels trim CI to the emscripten legs, which exercise the new packaging step in both emsdk × thread-variant combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)