### PR TITLE
Replace Historian with AppendHistory where behavior is unchanged

### DIFF
--- a/source/MRMesh/MRChangePointCloudAction.h
+++ b/source/MRMesh/MRChangePointCloudAction.h
@@ -28,6 +28,18 @@ public:
         }
     }
 
+    /// use this constructor to remember object's point cloud and immediately set new point cloud
+    ChangePointCloudAction( std::string name, const std::shared_ptr<ObjectPoints>& obj, std::shared_ptr<PointCloud> newPointCloud ) :
+        objPoints_{ obj },
+        name_{ std::move( name ) }
+    {
+        if ( objPoints_ )
+        {
+            clonePointCloud_ = std::move( newPointCloud );
+            objPoints_->swapPointCloud( clonePointCloud_ );
+        }
+    }
+
     virtual std::string name() const override { return name_; }
 
     virtual void action( HistoryAction::Type ) override

--- a/source/MRMesh/MRChangeSelectionAction.h
+++ b/source/MRMesh/MRChangeSelectionAction.h
@@ -187,6 +187,17 @@ public:
         selection_ = objPoints_->getSelectedPoints();
     }
 
+    /// use this constructor to remember object's vertex selection and immediately set new selection
+    ChangePointPointSelectionAction( const std::string& name, const std::shared_ptr<ObjectPoints>& objPoints, VertBitSet&& newSelection ) :
+        name_{ name },
+        objPoints_{ objPoints }
+    {
+        if ( !objPoints_ )
+            return;
+        selection_ = objPoints_->getSelectedPoints();
+        objPoints_->selectPoints( std::move( newSelection ) );
+    }
+
     virtual std::string name() const override { return name_; }
 
     virtual void action( Type ) override

--- a/source/MRViewer/MRObjectMeshHistory.cpp
+++ b/source/MRViewer/MRObjectMeshHistory.cpp
@@ -35,10 +35,10 @@ void excludeAllEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh )
         return;
 
     // remove all edges from the selection
-    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh, {} );
+    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh, UndirectedEdgeBitSet{} );
 
     // remove all edges from creases
-    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh, {} );
+    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh, UndirectedEdgeBitSet{} );
 }
 
 void mapEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh, const WholeEdgeMap & emap )

--- a/source/MRViewer/MRObjectMeshHistory.cpp
+++ b/source/MRViewer/MRObjectMeshHistory.cpp
@@ -20,13 +20,13 @@ void excludeLoneEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh )
     // remove deleted edges from the selection
     auto selEdges = objMesh->getSelectedEdges();
     topology.excludeLoneEdges( selEdges );
-    Historian<ChangeMeshEdgeSelectionAction> hes( "edge selection", objMesh );
+    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh );
     objMesh->selectEdges( std::move( selEdges ) );
 
     // remove deleted edges from creases
     auto creases = objMesh->creases();
     topology.excludeLoneEdges( creases );
-    Historian<ChangeMeshCreasesAction> hcr( "creases", objMesh );
+    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh );
     objMesh->setCreases( std::move( creases ) );
 }
 
@@ -37,11 +37,11 @@ void excludeAllEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh )
         return;
 
     // remove all edges from the selection
-    Historian<ChangeMeshEdgeSelectionAction> hes( "edge selection", objMesh );
+    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh );
     objMesh->selectEdges( {} );
 
     // remove all edges from creases
-    Historian<ChangeMeshCreasesAction> hcr( "creases", objMesh );
+    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh );
     objMesh->setCreases( {} );
 }
 
@@ -53,12 +53,12 @@ void mapEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh, const Whol
 
     // update edges in the selection
     auto selEdges = mapEdges( emap, objMesh->getSelectedEdges() );
-    Historian<ChangeMeshEdgeSelectionAction> hes( "edge selection", objMesh );
+    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh );
     objMesh->selectEdges( std::move( selEdges ) );
 
     // update edges in the creases
     auto creases = mapEdges( emap, objMesh->creases() );
-    Historian<ChangeMeshCreasesAction> hcr( "creases", objMesh );
+    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh );
     objMesh->setCreases( std::move( creases ) );
 }
 
@@ -70,12 +70,12 @@ void mapEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh, const Whol
 
     // update edges in the selection
     auto selEdges = mapEdges( emap, objMesh->getSelectedEdges() );
-    Historian<ChangeMeshEdgeSelectionAction> hes( "edge selection", objMesh );
+    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh );
     objMesh->selectEdges( std::move( selEdges ) );
 
     // update edges in the creases
     auto creases = mapEdges( emap, objMesh->creases() );
-    Historian<ChangeMeshCreasesAction> hcr( "creases", objMesh );
+    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh );
     objMesh->setCreases( std::move( creases ) );
 }
 
@@ -87,12 +87,12 @@ void mapEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh, const Undi
 
     // update edges in the selection
     auto selEdges = mapEdges( emap, objMesh->getSelectedEdges() );
-    Historian<ChangeMeshEdgeSelectionAction> hes( "edge selection", objMesh );
+    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh );
     objMesh->selectEdges( std::move( selEdges ) );
 
     // update edges in the creases
     auto creases = mapEdges( emap, objMesh->creases() );
-    Historian<ChangeMeshCreasesAction> hcr( "creases", objMesh );
+    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh );
     objMesh->setCreases( std::move( creases ) );
 }
 

--- a/source/MRViewer/MRObjectMeshHistory.cpp
+++ b/source/MRViewer/MRObjectMeshHistory.cpp
@@ -20,14 +20,12 @@ void excludeLoneEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh )
     // remove deleted edges from the selection
     auto selEdges = objMesh->getSelectedEdges();
     topology.excludeLoneEdges( selEdges );
-    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh );
-    objMesh->selectEdges( std::move( selEdges ) );
+    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh, std::move( selEdges ) );
 
     // remove deleted edges from creases
     auto creases = objMesh->creases();
     topology.excludeLoneEdges( creases );
-    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh );
-    objMesh->setCreases( std::move( creases ) );
+    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh, std::move( creases ) );
 }
 
 void excludeAllEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh )
@@ -37,12 +35,10 @@ void excludeAllEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh )
         return;
 
     // remove all edges from the selection
-    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh );
-    objMesh->selectEdges( {} );
+    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh, {} );
 
     // remove all edges from creases
-    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh );
-    objMesh->setCreases( {} );
+    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh, {} );
 }
 
 void mapEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh, const WholeEdgeMap & emap )
@@ -53,13 +49,11 @@ void mapEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh, const Whol
 
     // update edges in the selection
     auto selEdges = mapEdges( emap, objMesh->getSelectedEdges() );
-    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh );
-    objMesh->selectEdges( std::move( selEdges ) );
+    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh, std::move( selEdges ) );
 
     // update edges in the creases
     auto creases = mapEdges( emap, objMesh->creases() );
-    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh );
-    objMesh->setCreases( std::move( creases ) );
+    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh, std::move( creases ) );
 }
 
 void mapEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh, const WholeEdgeHashMap & emap )
@@ -70,13 +64,11 @@ void mapEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh, const Whol
 
     // update edges in the selection
     auto selEdges = mapEdges( emap, objMesh->getSelectedEdges() );
-    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh );
-    objMesh->selectEdges( std::move( selEdges ) );
+    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh, std::move( selEdges ) );
 
     // update edges in the creases
     auto creases = mapEdges( emap, objMesh->creases() );
-    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh );
-    objMesh->setCreases( std::move( creases ) );
+    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh, std::move( creases ) );
 }
 
 void mapEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh, const UndirectedEdgeBMap & emap )
@@ -87,13 +79,11 @@ void mapEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh, const Undi
 
     // update edges in the selection
     auto selEdges = mapEdges( emap, objMesh->getSelectedEdges() );
-    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh );
-    objMesh->selectEdges( std::move( selEdges ) );
+    AppendHistory<ChangeMeshEdgeSelectionAction>( "edge selection", objMesh, std::move( selEdges ) );
 
     // update edges in the creases
     auto creases = mapEdges( emap, objMesh->creases() );
-    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh );
-    objMesh->setCreases( std::move( creases ) );
+    AppendHistory<ChangeMeshCreasesAction>( "creases", objMesh, std::move( creases ) );
 }
 
 } //namespace MR

--- a/source/MRViewer/MRObjectPointsHistory.cpp
+++ b/source/MRViewer/MRObjectPointsHistory.cpp
@@ -20,21 +20,21 @@ static void packPointsWithHistoryCore( const std::shared_ptr<ObjectPoints>& objP
     auto packed = pack( *objPoints, reorder, newValidVerts );
 
     {
-        Historian<ChangePointCloudAction> h( "set cloud", objPoints );
+        AppendHistory<ChangePointCloudAction>( "set cloud", objPoints );
         std::shared_ptr<PointCloud> tmp;
         packed->swapPointCloud( tmp );    // tmp := packed
         objPoints->swapPointCloud( tmp ); // objPoints := tmp
     }
 
     {
-        Historian<ChangeVertsColorMapAction<ObjectPoints>> hCM( "color map update", objPoints );
+        AppendHistory<ChangeVertsColorMapAction<ObjectPoints>>( "color map update", objPoints );
         VertColors tmp;
         packed->updateVertsColorMap( tmp );    // tmp := packed
         objPoints->updateVertsColorMap( tmp ); // objPoints := tmp
     }
 
     {
-        Historian<ChangePointPointSelectionAction> hs( "selection", objPoints );
+        AppendHistory<ChangePointPointSelectionAction>( "selection", objPoints );
         VertBitSet tmp;
         packed->updateSelectedPoints( tmp );    // tmp := packed
         objPoints->updateSelectedPoints( tmp ); // objPoints := tmp

--- a/source/MRViewer/MRObjectPointsHistory.cpp
+++ b/source/MRViewer/MRObjectPointsHistory.cpp
@@ -27,10 +27,9 @@ static void packPointsWithHistoryCore( const std::shared_ptr<ObjectPoints>& objP
     }
 
     {
-        AppendHistory<ChangeVertsColorMapAction<ObjectPoints>>( "color map update", objPoints );
         VertColors tmp;
         packed->updateVertsColorMap( tmp );    // tmp := packed
-        objPoints->updateVertsColorMap( tmp ); // objPoints := tmp
+        AppendHistory<ChangeVertsColorMapAction<ObjectPoints>>( "color map update", objPoints, std::move( tmp ) );
     }
 
     {

--- a/source/MRViewer/MRObjectPointsHistory.cpp
+++ b/source/MRViewer/MRObjectPointsHistory.cpp
@@ -20,10 +20,9 @@ static void packPointsWithHistoryCore( const std::shared_ptr<ObjectPoints>& objP
     auto packed = pack( *objPoints, reorder, newValidVerts );
 
     {
-        AppendHistory<ChangePointCloudAction>( "set cloud", objPoints );
         std::shared_ptr<PointCloud> tmp;
         packed->swapPointCloud( tmp );    // tmp := packed
-        objPoints->swapPointCloud( tmp ); // objPoints := tmp
+        AppendHistory<ChangePointCloudAction>( "set cloud", objPoints, std::move( tmp ) );
     }
 
     {
@@ -33,10 +32,9 @@ static void packPointsWithHistoryCore( const std::shared_ptr<ObjectPoints>& objP
     }
 
     {
-        AppendHistory<ChangePointPointSelectionAction>( "selection", objPoints );
         VertBitSet tmp;
         packed->updateSelectedPoints( tmp );    // tmp := packed
-        objPoints->updateSelectedPoints( tmp ); // objPoints := tmp
+        AppendHistory<ChangePointPointSelectionAction>( "selection", objPoints, std::move( tmp ) );
     }
 }
 


### PR DESCRIPTION
Replaces all 13 `Historian<Action>` usages (the only ones in the repo) with direct `AppendHistory<Action>` calls in `MRObjectMeshHistory.cpp` and `MRObjectPointsHistory.cpp`.

Why each site is behavior-preserving:
* The action is still constructed before the corresponding modification, so the captured undo state is identical.
* No site used `cancelAction()`.
* `setObjectDirty` from `Historian`'s destructor is not lost: it is a no-op for `ChangeMeshEdgeSelectionAction`, `ChangeMeshCreasesAction` and `ChangePointPointSelectionAction`, and for `ChangePointCloudAction` / `ChangeVertsColorMapAction` the setters called right after (`swapPointCloud`, `updateVertsColorMap`) already set exactly the same dirty flags. The only dropped effect is a duplicate `setDirtyFlags( DIRTY_ALL )` in `packPointsWithHistoryCore` that fired `pointsChangedSignal` a second time.

Follow-up commits: every `AppendHistory` call and the setter call after it are combined into one `AppendHistory<Action>( name, obj, newValue )` — the value-taking constructor captures the old state and applies the new value via the same setter, so behavior is identical (and the verts-color-map case saves one copy of the old map). `ChangePointCloudAction` and `ChangePointPointSelectionAction` had no value-taking constructors, so this PR adds them, mirroring `ChangeMeshAction` / `ChangeMeshEdgeSelectionAction`; note the new cloud constructor stores the object's old cloud pointer via `swapPointCloud` instead of deep-cloning it, like `ChangeMeshAction::updateMesh` does.

Two minor notes:
* In the mesh helpers, the two sibling actions are now appended in code order [selection, creases] instead of destructor order [creases, selection]. They touch independent fields and commute, so undoing both gives the identical state.
* `AppendHistory` constructs the action even when the global history store is absent (by design, per its comment in `MRAppendHistory.h`), while `Historian` skipped construction; for `ChangePointCloudAction` this means a point cloud clone that is immediately discarded if history is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
