### PR TITLE
CI: Introduce a separate dependency list for Ubuntu packages

### DIFF
--- a/requirements/ubuntu-package.txt
+++ b/requirements/ubuntu-package.txt
@@ -1,6 +1,6 @@
 build-essential
 cmake
-libblosc1
+libblosc-dev
 libboost-atomic-dev
 libboost-chrono-dev
 libboost-dev
@@ -13,7 +13,7 @@ libcurl4
 libeigen3-dev
 libexpected-dev
 libfmt-dev
-libfreetype6
+libfreetype-dev
 libgdcm3.0
 libglfw3-dev
 libglib2.0-0
@@ -35,4 +35,4 @@ libzip4 | libzip5
 occt-misc
 pkg-config
 python3-venv
-zlib1g
+zlib1g-dev

--- a/requirements/ubuntu-package.txt
+++ b/requirements/ubuntu-package.txt
@@ -1,0 +1,30 @@
+build-essential
+cmake
+libblosc1
+libboost-dev
+libboost-locale-dev
+libboost-program-options-dev
+libcurl4
+libeigen3-dev
+libexpected-dev
+libfmt-dev
+libfreetype6
+libgdcm3.0
+libglfw3-dev
+libgtk-3-0
+libhidapi-dev
+libhpdf-2.3.0
+libjsoncpp-dev
+libocct-data-exchange-7.5 | libocct-data-exchange-7.6 | libocct-data-exchange-7.9
+libpython3-dev
+libspdlog-dev
+libssl3
+libtbb-dev
+libtiff5 | libtiff6
+libtinyxml2-9 | libtinyxml2-10 | libtinyxml2-11
+libturbojpeg | libturbojpeg0
+libzip4 | libzip5
+libzstd1
+occt-misc
+pkg-config
+python3-venv

--- a/requirements/ubuntu-package.txt
+++ b/requirements/ubuntu-package.txt
@@ -1,9 +1,14 @@
 build-essential
 cmake
 libblosc1
+libboost-atomic-dev
+libboost-chrono-dev
 libboost-dev
+libboost-iostreams-dev
 libboost-locale-dev
 libboost-program-options-dev
+libboost-system-dev
+libboost-thread-dev
 libcurl4
 libeigen3-dev
 libexpected-dev
@@ -11,11 +16,13 @@ libfmt-dev
 libfreetype6
 libgdcm3.0
 libglfw3-dev
+libglib2.0-0
 libgtk-3-0
 libhidapi-dev
 libhpdf-2.3.0
 libjsoncpp-dev
 libocct-data-exchange-7.5 | libocct-data-exchange-7.6 | libocct-data-exchange-7.9
+libpng16-16
 libpython3-dev
 libspdlog-dev
 libssl3
@@ -23,8 +30,9 @@ libtbb-dev
 libtiff5 | libtiff6
 libtinyxml2-9 | libtinyxml2-10 | libtinyxml2-11
 libturbojpeg | libturbojpeg0
+libxcb1
 libzip4 | libzip5
-libzstd1
 occt-misc
 pkg-config
 python3-venv
+zlib1g

--- a/scripts/distribution.sh
+++ b/scripts/distribution.sh
@@ -54,7 +54,7 @@ fi
 echo ${MR_VERSION} > distr/meshlib-dev${MR_INSTALL_RES_DIR}/mr.version
 
 BASE_DIR=$(realpath $(dirname "$0")/..)
-REQUIREMENTS_FILE="${BASE_DIR}/requirements/ubuntu.txt"
+REQUIREMENTS_FILE="${BASE_DIR}/requirements/ubuntu-package.txt"
 # convert multi-line file to comma-separated string
 DEPENDS_LINE=$(cat ${REQUIREMENTS_FILE} | tr '\n' ',' | sed -e "s/,\s*$//" -e "s/,/, /g")
 


### PR DESCRIPTION
Ubuntu 26.04 has a kind of a issue: installing build-essential and libopenmpi-dev (an indirect dependency of libocct-data-exchange-dev) results in installing two versions of libstdc++, 15 and 16, which in turn causes building errors. The most simple solution (explicit installation of gfortran-15) can be applied to CI but is not suitable for end users. This change overcomes the libopenmpi-dev installation by replacing some development packages with runtime ones for end-user .deb packages.