### PR TITLE
Add value-taking constructor to ChangePolylinePointsAction

### DIFF
--- a/source/MRMesh/MRChangePolylineAction.h
+++ b/source/MRMesh/MRChangePolylineAction.h
@@ -86,6 +86,15 @@ public:
             clonePoints_ = p->points;
     }
 
+    /// use this constructor to remember object's lines points and immediate set new value
+    ChangePolylinePointsAction( std::string name, const std::shared_ptr<ObjectLines>& obj, VertCoords && newPoints ) :
+        objLines_{ obj },
+        clonePoints_{ std::move( newPoints ) },
+        name_{ std::move( name ) }
+    {
+        action( HistoryAction::Type::Redo );
+    }
+
     virtual std::string name() const override
     {
         return name_;


### PR DESCRIPTION
Adds the value-taking constructor to ChangePolylinePointsAction, mirroring ChangePointCloudPointsAction: it stores the new points, then action( Redo ) swaps them into the polyline and sets DIRTY_POSITION.

Lets MeshInspectorCode#7735 convert the last in-place polyline-points site (ApplyTransform) to the one-line AppendHistory form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
