### PR TITLE
Better description of Historian class

### DIFF
--- a/source/MRViewer/MRAppendHistory.h
+++ b/source/MRViewer/MRAppendHistory.h
@@ -25,8 +25,12 @@ void AppendHistory( Args&&... args )
     AppendHistory( std::make_shared<HistoryActionType>( std::forward<Args>( args )... ) );
 }
 
-// if undo history is enabled, creates given action in the constructor;
-// and always mark the object as dirty in the destructor
+/// The main objective of this class is to save object's state in the constructor,
+/// then let the caller modify object's data in-place,
+/// and finally append the action in the history store and automatically call appropriate setDirty in the destructor.
+/// If HistoryStore::getViewerInstance() is missing, it does not allocate memory for undo (the action is not created at all).
+/// Always create a named Historian variable and never a nameless temporary such as `Historian<ChangeMeshPointsAction>( "name", obj );`
+/// because a temporary is destroyed at the end of the same statement, calling setDirty before any data modification.
 template<class HistoryActionType>
 class Historian
 {

--- a/source/MRViewer/MRAppendHistory.h
+++ b/source/MRViewer/MRAppendHistory.h
@@ -29,6 +29,10 @@ void AppendHistory( Args&&... args )
 /// then let the caller modify object's data in-place,
 /// and finally append the action in the history store and automatically call appropriate setDirty in the destructor.
 /// If HistoryStore::getViewerInstance() is missing, it does not allocate memory for undo (the action is not created at all).
+/// If the operation fails midway, call cancelAction() to revert the modifications made so far
+/// and to skip both appending in the history store and setDirty in the destructor.
+/// If the new state is already allocated, then AppendHistory with immediate-setting action constructor
+/// is a simpler alternative (no memory waste anyway, since such constructors keep the old state for undo via swap).
 /// Always create a named Historian variable and never a nameless temporary such as `Historian<ChangeMeshPointsAction>( "name", obj );`
 /// because a temporary is destroyed at the end of the same statement, calling setDirty before any data modification.
 template<class HistoryActionType>


### PR DESCRIPTION
Documentation-only: replaces the two-line comment on `Historian` with a description covering its actual contract:

1. its main objective is to save object's state in the constructor, then let the caller modify object's data in-place, and then automatically call appropriate setDirty in the destructor;
2. if `HistoryStore::getViewerInstance()` is missing, it does not allocate memory for undo (unlike `AppendHistory`, which always constructs the action);
3. `cancelAction()` reverts the modifications made so far and skips both the history append and setDirty — for operations that fail midway;
4. if the new state is already allocated, `AppendHistory` with an immediate-setting action constructor is a simpler alternative (no memory waste anyway, such constructors keep the old state for undo via swap);
5. always create a named `Historian` variable, never a nameless temporary — a temporary is destroyed at the end of the same statement, so setDirty fires before any data modification (this exact bug was found at an "Apply Stamp" call site, fixed in MeshInspectorCode#7735).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
