### PR TITLE
Mark Historian constructor [[nodiscard]] to catch nameless temporaries

### DIFF
--- a/source/MRViewer/MRAppendHistory.h
+++ b/source/MRViewer/MRAppendHistory.h
@@ -34,7 +34,8 @@ void AppendHistory( Args&&... args )
 /// If the new state is already allocated, then AppendHistory with immediate-setting action constructor
 /// is a simpler alternative (no memory waste anyway, since such constructors keep the old state for undo via swap).
 /// Always create a named Historian variable and never a nameless temporary such as `Historian<ChangeMeshPointsAction>( "name", obj );`
-/// because a temporary is destroyed at the end of the same statement, calling setDirty before any data modification.
+/// because a temporary is destroyed at the end of the same statement, calling setDirty before any data modification;
+/// the constructor is marked [[nodiscard]] so a discarded temporary produces a compiler warning (an error with -Werror / /WX).
 template<class HistoryActionType>
 class Historian
 {
@@ -43,7 +44,7 @@ public:
     using Obj = typename HistoryActionType::Obj;
 
     template<typename... Args>
-    Historian( std::string name, std::shared_ptr<Obj> obj, Args&&... args ) : obj_( std::move( obj ) )
+    [[nodiscard]] Historian( std::string name, std::shared_ptr<Obj> obj, Args&&... args ) : obj_( std::move( obj ) )
     {
         if ( HistoryStore::getViewerInstance() )
             action_ = std::make_shared<HistoryActionType>( std::move( name ), obj_, std::forward<Args>( args )... );


### PR DESCRIPTION
Marks `Historian`'s constructor `[[nodiscard]]` (C++20, P1771R1 — whose motivating example was exactly this RAII-guard mistake), so a nameless temporary like

```cpp
Historian<ChangeMeshPointsAction>( "Apply Stamp", obj_ );
```

produces a compiler warning (an error on the -Werror / /WX CI legs), while named variables compile silently. Such a temporary is destroyed at the end of the statement, appending the action and calling setDirty before any data modification — a real bug of this kind was found at an "Apply Stamp" call site and fixed in MeshInspectorCode#7735.

Compilers ignore the attribute on constructors before GCC 10 / Clang 9 / VS2019 16.4, so it degrades gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
