### PR TITLE
DO NOT MERGE: test a MultiSSL libcurl (curl[openssl]) on Windows arm64

### DIFF
--- a/.github/workflows/arm64-msvc-prologue.yml
+++ b/.github/workflows/arm64-msvc-prologue.yml
@@ -39,3 +39,38 @@ jobs:
             dumpbin /nologo /disasm:nobytes repro.obj > repro.asm || exit /b 1
             python scripts/arm64_prologue_report.py repro.asm || exit /b 1
           )
+
+      - name: Check for a reducer on the image
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          foreach ( $t in "creduce", "cvise", "clang-format", "llvm-reduce" )
+          {
+            $c = Get-Command $t -ErrorAction SilentlyContinue
+            if ( $null -ne $c ) { Write-Host "  $t : $($c.Source)" } else { Write-Host "  $t : absent" }
+          }
+
+      - name: Delta-debug the reproducer down
+        shell: cmd
+        timeout-minutes: 30
+        run: |
+          call "%VC_PATH%/Common7/Tools/VsDevCmd.bat" -arch=arm64 -host_arch=arm64 -vcvars_ver=14.5 || exit /b 1
+          py -3 scripts/arm64_reduce.py scripts/arm64_reduce_input.c 800
+
+      - name: Show the reduced file's prologue
+        shell: cmd
+        continue-on-error: true
+        run: |
+          call "%VC_PATH%/Common7/Tools/VsDevCmd.bat" -arch=arm64 -host_arch=arm64 -vcvars_ver=14.5 || exit /b 1
+          cl /nologo /c /O2 /Gs0 /Fo:reduced.obj reduced.c || exit /b 1
+          dumpbin /nologo /disasm:nobytes reduced.obj > reduced.asm || exit /b 1
+          py -3 scripts/arm64_prologue_report.py reduced.asm
+
+      - name: Upload the reduced source
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: reduced-c
+          path: reduced.c
+          if-no-files-found: warn

--- a/.github/workflows/arm64-msvc-prologue.yml
+++ b/.github/workflows/arm64-msvc-prologue.yml
@@ -1,0 +1,41 @@
+name: arm64 MSVC prologue reduction
+
+# Throwaway diagnostic workflow (branch ci/arm64-curl-openssl-repro): compiles
+# scripts/arm64_prologue_repro.c for ARM64 at several optimization settings and
+# prints each function's prologue, to find the smallest shape where MSVC emits
+# `bl __chkstk` before storing x30. Compile-only, so it takes seconds.
+on:
+  push:
+    branches:
+      - ci/arm64-curl-openssl-repro
+  workflow_dispatch:
+
+jobs:
+  prologues:
+    runs-on: windows-11-vs2026-arm
+    timeout-minutes: 15
+    steps:
+      - name: Checkout the reproducer only
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            .github/actions
+            scripts
+
+      - name: Locate Visual Studio
+        uses: ./.github/actions/locate-visual-studio
+
+      - name: Compile at /O2 /Gs0, /O2, /O1, /Od and dump every prologue
+        shell: cmd
+        run: |
+          call "%VC_PATH%/Common7/Tools/VsDevCmd.bat" -arch=arm64 -host_arch=arm64 -vcvars_ver=14.5 || exit /b 1
+          cl 2>&1 | findstr /C:"Version"
+          for %%F in ("/O2 /Gs0" "/O2" "/O1 /Gs0" "/Od /Gs0") do (
+            echo.
+            echo ================================================================
+            echo ==== flags: %%~F
+            echo ================================================================
+            cl /nologo /c %%~F /Fo:repro.obj scripts/arm64_prologue_repro.c || exit /b 1
+            dumpbin /nologo /disasm:nobytes repro.obj > repro.asm || exit /b 1
+            python scripts/arm64_prologue_report.py repro.asm || exit /b 1
+          )

--- a/.github/workflows/arm64-openssl-mre.yml
+++ b/.github/workflows/arm64-openssl-mre.yml
@@ -68,7 +68,7 @@ jobs:
           # saved, so every unwinder follows a clobbered LR. Break on entry instead, where
           # LR still holds the real return address. `bu` defers resolution until libssl is
           # loaded, and no -g so the loader breakpoint is honoured first.
-          $cmd = '.lines; bu libssl_3_arm64!tls_parse_all_extensions ".if (\x0==1) {.echo CAUGHT_BAD_CALL; r; ln \lr; kp; ub \lr L10; q} .else {.echo ok-call x0=; r \x0; gc}"; g; q'
+          $cmd = '.lines; bu libssl_3_arm64!tls_parse_all_extensions ".if (@x0==1) {.echo CAUGHT_BAD_CALL; r; ln @lr; kp; ub @lr L10; q} .else {.echo ok-call x0=; r @x0; gc}"; g; q'
           $out = & $cdb.FullName -G -lines -y "$pwd" -c $cmd mre.exe 2>&1
           $out | ForEach-Object { Write-Host $_ }
 

--- a/.github/workflows/arm64-openssl-mre.yml
+++ b/.github/workflows/arm64-openssl-mre.yml
@@ -45,15 +45,37 @@ jobs:
           $crt += Get-ChildItem "C:/Program Files (x86)/Windows Kits/10/bin/*/arm64/ucrt/ucrtbased.dll" -ErrorAction SilentlyContinue
           foreach ( $f in $crt ) { Copy-Item $f.FullName . -Force; Write-Host "  $($f.Name)" }
 
-      - name: Build the MRE, run it against release then debug OpenSSL
+      - name: Build the MRE and run it against the release OpenSSL
         shell: cmd
+        continue-on-error: true
         run: |
           call "%VC_PATH%\Common7\Tools\VsDevCmd.bat" -arch=arm64 -host_arch=arm64 -vcvars_ver=14.5 || exit /b 1
           cl /nologo /O2 /MD /W3 scripts\arm64_openssl_mre.c /I ossl\include /Fe:mre.exe /link /LIBPATH:ossl\lib libssl.lib libcrypto.lib ws2_32.lib crypt32.lib || exit /b 1
           copy ossl\bin\*.dll . >nul || exit /b 1
+          copy ossl\bin\*.pdb . >nul
           echo ==== MRE against RELEASE OpenSSL
           mre.exe
           echo MRE exit code: %errorlevel%
+
+      - name: Catch the bad call at function entry, where LR is still valid
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $cdb = Get-ChildItem "C:/Program Files (x86)/Windows Kits/10/Debuggers/arm64/cdb.exe" -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+          if ( $null -eq $cdb ) { Write-Host "cdb.exe not on this image"; exit 0 }
+          # Unwinding from the fault is hopeless: it happens in the prologue before x30 is
+          # saved, so every unwinder follows a clobbered LR. Break on entry instead, where
+          # LR still holds the real return address. `bu` defers resolution until libssl is
+          # loaded, and no -g so the loader breakpoint is honoured first.
+          $cmd = '.lines; bu libssl_3_arm64!tls_parse_all_extensions ".if (\x0==1) {.echo CAUGHT_BAD_CALL; r; ln \lr; kp; ub \lr L10; q} .else {.echo ok-call x0=; r \x0; gc}"; g; q'
+          $out = & $cdb.FullName -G -lines -y "$pwd" -c $cmd mre.exe 2>&1
+          $out | ForEach-Object { Write-Host $_ }
+
+      - name: Now run it against the debug OpenSSL
+        shell: cmd
+        continue-on-error: true
+        run: |
           copy ossl\debug\bin\libssl-3-arm64.dll . >nul || exit /b 1
           copy ossl\debug\bin\libcrypto-3-arm64.dll . >nul || exit /b 1
           echo ==== MRE against DEBUG OpenSSL

--- a/.github/workflows/arm64-openssl-mre.yml
+++ b/.github/workflows/arm64-openssl-mre.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Gather the debug CRT that the debug OpenSSL needs
         shell: pwsh
         run: |
-          $crt = \()
+          $crt = @()
           $crt += Get-ChildItem "C:/Program Files/Microsoft Visual Studio/*/*/VC/Redist/MSVC/*/debug_nonredist/arm64/Microsoft.VC*.DebugCRT/*.dll" -ErrorAction SilentlyContinue
           $crt += Get-ChildItem "C:/Program Files (x86)/Windows Kits/10/bin/*/arm64/ucrt/ucrtbased.dll" -ErrorAction SilentlyContinue
           foreach ( $f in $crt ) { Copy-Item $f.FullName . -Force; Write-Host "  $($f.Name)" }

--- a/.github/workflows/arm64-openssl-mre.yml
+++ b/.github/workflows/arm64-openssl-mre.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout the reproducer only
-        uses: actions/checkout\v7
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             .github/actions

--- a/.github/workflows/arm64-openssl-mre.yml
+++ b/.github/workflows/arm64-openssl-mre.yml
@@ -1,0 +1,61 @@
+name: arm64 OpenSSL MRE
+
+# Throwaway diagnostic workflow (branch ci/arm64-curl-openssl-repro): builds and
+# runs scripts/arm64_openssl_mre.c on a Windows ARM64 runner against the prebuilt
+# vcpkg OpenSSL 3.6.3 - release DLLs first, debug DLLs second. It needs headers,
+# import libs and DLLs only, so there is no vcpkg install, no submodule checkout
+# and no MeshLib build: ~2 minutes instead of ~25.
+on:
+  push:
+    branches:
+      - ci/arm64-curl-openssl-repro
+  workflow_dispatch:
+
+jobs:
+  mre:
+    runs-on: windows-11-vs2026-arm
+    timeout-minutes: 15
+    steps:
+      - name: Checkout the reproducer only
+        uses: actions/checkout\v7
+        with:
+          sparse-checkout: |
+            .github/actions
+            scripts
+
+      - name: Locate Visual Studio
+        uses: ./.github/actions/locate-visual-studio
+
+      - name: Fetch the prebuilt arm64 OpenSSL from the vcpkg binary cache
+        shell: pwsh
+        run: |
+          # The bucket allows unsigned reads. The path is <vcpkg tag>/<triplet>/<abi hash>.zip;
+          # the hash comes from any build log line "buildtrees\openssl_<64 hex>".
+          $u = 'https://vcpkg-export.s3.amazonaws.com/2026.07.29/arm64-windows-meshlib/f4d729b10c924de5eb6d339769ba73b05aef3d87bea5c04932b568778f14313f.zip'
+          Invoke-WebRequest -Uri $u -OutFile openssl.zip
+          Expand-Archive openssl.zip -DestinationPath ossl -Force
+          Get-ChildItem ossl/bin, ossl/debug/bin -Filter *-arm64.dll |
+            ForEach-Object { Write-Host "  $($_.Directory.Name)/$($_.Name)  $($_.Length) bytes" }
+
+      - name: Gather the debug CRT that the debug OpenSSL needs
+        shell: pwsh
+        run: |
+          $crt = \()
+          $crt += Get-ChildItem "C:/Program Files/Microsoft Visual Studio/*/*/VC/Redist/MSVC/*/debug_nonredist/arm64/Microsoft.VC*.DebugCRT/*.dll" -ErrorAction SilentlyContinue
+          $crt += Get-ChildItem "C:/Program Files (x86)/Windows Kits/10/bin/*/arm64/ucrt/ucrtbased.dll" -ErrorAction SilentlyContinue
+          foreach ( $f in $crt ) { Copy-Item $f.FullName . -Force; Write-Host "  $($f.Name)" }
+
+      - name: Build the MRE, run it against release then debug OpenSSL
+        shell: cmd
+        run: |
+          call "%VC_PATH%\Common7\Tools\VsDevCmd.bat" -arch=arm64 -host_arch=arm64 -vcvars_ver=14.5 || exit /b 1
+          cl /nologo /O2 /MD /W3 scripts\arm64_openssl_mre.c /I ossl\include /Fe:mre.exe /link /LIBPATH:ossl\lib libssl.lib libcrypto.lib ws2_32.lib crypt32.lib || exit /b 1
+          copy ossl\bin\*.dll . >nul || exit /b 1
+          echo ==== MRE against RELEASE OpenSSL
+          mre.exe
+          echo MRE exit code: %errorlevel%
+          copy ossl\debug\bin\libssl-3-arm64.dll . >nul || exit /b 1
+          copy ossl\debug\bin\libcrypto-3-arm64.dll . >nul || exit /b 1
+          echo ==== MRE against DEBUG OpenSSL
+          mre.exe
+          echo MRE exit code: %errorlevel%

--- a/.github/workflows/arm64-openssl-mre.yml
+++ b/.github/workflows/arm64-openssl-mre.yml
@@ -68,8 +68,9 @@ jobs:
           # saved, so every unwinder follows a clobbered LR. Break on entry instead, where
           # LR still holds the real return address. `bu` defers resolution until libssl is
           # loaded, and no -g so the loader breakpoint is honoured first.
-          $cmd = '.lines; bu libssl_3_arm64!tls_parse_all_extensions ".if (@x0==1) {.echo CAUGHT_BAD_CALL; r; ln @lr; kp; ub @lr L10; q} .else {.echo ok-call x0=; r @x0; gc}"; g; q'
-          $out = & $cdb.FullName -G -lines -y "$pwd" -c $cmd mre.exe 2>&1
+          # commands live in a script file: nested quoting through YAML, pwsh and
+          # cdb is not worth debugging twice
+          $out = & $cdb.FullName -G -lines -y "$pwd" -cf scripts/arm64_cdb_cmds.txt mre.exe 2>&1
           $out | ForEach-Object { Write-Host $_ }
 
       - name: Now run it against the debug OpenSSL

--- a/.github/workflows/arm64-openssl-source-build.yml
+++ b/.github/workflows/arm64-openssl-source-build.yml
@@ -2,9 +2,11 @@ name: arm64 OpenSSL from-source check
 
 # Throwaway diagnostic workflow (branch ci/arm64-curl-openssl-repro): builds
 # OpenSSL 3.6.3 from the release tarball with `perl Configure VC-WIN64-ARM`,
-# release in one leg and debug in the other, then runs
-# scripts/arm64_openssl_mre.c against each. This removes vcpkg (and its port
-# patches) from the picture before the crash is reported upstream.
+# then runs scripts/arm64_openssl_mre.c against it, under cdb.
+#
+# The legs separate optimization from everything else `--debug` also changes
+# (CRT, NDEBUG, OpenSSL's own debug code): release-Od and release-O1 keep every
+# release setting and vary only the optimization level.
 on:
   push:
     branches:
@@ -16,9 +18,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - release
-          - debug
+        include:
+          - name: release
+            opts: --release
+          - name: debug
+            opts: --debug
+          - name: release-Od
+            opts: --release -Od
+          - name: release-O1
+            opts: --release -O1
+    name: ${{ matrix.name }}
     runs-on: windows-11-vs2026-arm
     timeout-minutes: 120
     steps:
@@ -45,7 +54,6 @@ jobs:
           else
           {
             Write-Host "perl: $($perl.Source)"
-            & $perl.Source -v
           }
 
       - name: Gather the debug CRT that a debug OpenSSL needs
@@ -63,10 +71,8 @@ jobs:
           Invoke-WebRequest -Uri $u -OutFile openssl.tar.gz
           Write-Host "sha256: $((Get-FileHash openssl.tar.gz -Algorithm SHA256).Hash)"
           tar -xzf openssl.tar.gz
-          Write-Host "extracted:"
-          Get-ChildItem openssl-3.6.3 -Filter "Configure" | ForEach-Object { Write-Host "  $($_.Name)" }
 
-      - name: Configure and build OpenSSL (VC-WIN64-ARM, ${{ matrix.config }})
+      - name: Configure and build OpenSSL (VC-WIN64-ARM, ${{ matrix.name }})
         shell: cmd
         working-directory: openssl-3.6.3
         run: |
@@ -74,51 +80,53 @@ jobs:
           cl 2>&1 | findstr /C:"Version"
           rem no-apps/no-docs/no-tests only skip artefacts we do not use; they do not
           rem change how libssl and libcrypto themselves are compiled.
-          perl Configure VC-WIN64-ARM shared no-apps no-docs no-tests --${{ matrix.config }} || exit /b 1
-          perl configdata.pm --dump || exit /b 1
+          perl Configure VC-WIN64-ARM shared no-apps no-docs no-tests ${{ matrix.opts }} || exit /b 1
+          perl configdata.pm --dump | findstr /C:"CFLAGS" /C:"CPPDEFINES" /C:"LFLAGS"
           nmake || exit /b 1
           dir /b *.dll *.lib
 
-      - name: Symbolize the fault on this very build
+      - name: Stage the built OpenSSL next to the reproducer
+        shell: pwsh
+        run: |
+          Copy-Item openssl-3.6.3/*.dll . -Force
+          Copy-Item openssl-3.6.3/*.pdb . -Force -ErrorAction SilentlyContinue
+          Get-ChildItem *-arm64.dll | ForEach-Object { Write-Host "  $($_.Name)  $($_.Length) bytes" }
+
+      - name: Build the MRE and run it against this OpenSSL
+        shell: cmd
+        continue-on-error: true
+        run: |
+          call "%VC_PATH%/Common7/Tools/VsDevCmd.bat" -arch=arm64 -host_arch=arm64 -vcvars_ver=14.5 || exit /b 1
+          rem the reproducer itself is always /O2 /MD, so only OpenSSL's configuration varies
+          cl /nologo /O2 /MD /W3 scripts/arm64_openssl_mre.c /I openssl-3.6.3/include /Fe:mre.exe /link /LIBPATH:openssl-3.6.3 libssl.lib libcrypto.lib ws2_32.lib crypt32.lib || exit /b 1
+          echo ==== MRE against a from-source ${{ matrix.name }} VC-WIN64-ARM OpenSSL
+          mre.exe
+          echo MRE exit code: %errorlevel%
+
+      - name: Name the faulting frame and its caller under cdb
         if: ${{ always() }}
         continue-on-error: true
         shell: pwsh
         run: |
-          # Debugging Tools for Windows, when the image carries them, name the
-          # faulting function without leaving the runner.
           $cdb = Get-ChildItem "C:/Program Files (x86)/Windows Kits/10/Debuggers/arm64/cdb.exe" -ErrorAction SilentlyContinue |
             Select-Object -First 1
-          if ( $null -ne $cdb )
-          {
-            Write-Host "cdb: $($cdb.FullName)"
-            & $cdb.FullName -g -G -c '.lines; g; kp; ln @pc; r; q' mre.exe 2>&1 | Select-Object -Last 120
-          }
-          else
-          {
-            Write-Host "cdb.exe not on this image; rely on the uploaded pdb instead"
-          }
+          if ( $null -eq $cdb ) { Write-Host "cdb.exe not on this image"; exit 0 }
+          if ( -not ( Test-Path mre.exe ) ) { Write-Host "mre.exe was not built"; exit 0 }
+          Write-Host "cdb: $($cdb.FullName)"
+          # kp prints the stack WITH argument values, so the caller is observed rather
+          # than inferred; ln @pc names the faulting symbol; ub @pc disassembles back.
+          $out = & $cdb.FullName -g -G -lines -y "$pwd" -c '.lines; g; kp; ln @pc; r; ub @pc L8; q' mre.exe 2>&1
+          $out | Select-Object -Last 160 | ForEach-Object { Write-Host $_ }
 
       - name: Upload the built libssl and its pdb for offline symbolization
         if: ${{ always() }}
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
-          name: openssl-${{ matrix.config }}-arm64
+          name: openssl-${{ matrix.name }}-arm64
           path: |
             openssl-3.6.3/libssl-3-arm64.dll
             openssl-3.6.3/libssl-3-arm64.pdb
             openssl-3.6.3/libcrypto-3-arm64.dll
             openssl-3.6.3/libcrypto-3-arm64.pdb
-            openssl-3.6.3/configdata.pm
           if-no-files-found: warn
-
-      - name: Build the MRE and run it against the from-source OpenSSL
-        shell: cmd
-        run: |
-          call "%VC_PATH%/Common7/Tools/VsDevCmd.bat" -arch=arm64 -host_arch=arm64 -vcvars_ver=14.5 || exit /b 1
-          rem the reproducer itself is always /O2 /MD, so only OpenSSL's configuration varies
-          cl /nologo /O2 /MD /W3 scripts/arm64_openssl_mre.c /I openssl-3.6.3/include /Fe:mre.exe /link /LIBPATH:openssl-3.6.3 libssl.lib libcrypto.lib ws2_32.lib crypt32.lib || exit /b 1
-          copy openssl-3.6.3\*.dll . >nul || exit /b 1
-          echo ==== MRE against a from-source ${{ matrix.config }} VC-WIN64-ARM OpenSSL
-          mre.exe
-          echo MRE exit code: %errorlevel%

--- a/.github/workflows/arm64-openssl-source-build.yml
+++ b/.github/workflows/arm64-openssl-source-build.yml
@@ -79,6 +79,39 @@ jobs:
           nmake || exit /b 1
           dir /b *.dll *.lib
 
+      - name: Symbolize the fault on this very build
+        if: ${{ always() }}
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          # Debugging Tools for Windows, when the image carries them, name the
+          # faulting function without leaving the runner.
+          $cdb = Get-ChildItem "C:/Program Files (x86)/Windows Kits/10/Debuggers/arm64/cdb.exe" -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+          if ( $null -ne $cdb )
+          {
+            Write-Host "cdb: $($cdb.FullName)"
+            & $cdb.FullName -g -G -c '.lines; g; kp; ln @pc; r; q' mre.exe 2>&1 | Select-Object -Last 120
+          }
+          else
+          {
+            Write-Host "cdb.exe not on this image; rely on the uploaded pdb instead"
+          }
+
+      - name: Upload the built libssl and its pdb for offline symbolization
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: openssl-${{ matrix.config }}-arm64
+          path: |
+            openssl-3.6.3/libssl-3-arm64.dll
+            openssl-3.6.3/libssl-3-arm64.pdb
+            openssl-3.6.3/libcrypto-3-arm64.dll
+            openssl-3.6.3/libcrypto-3-arm64.pdb
+            openssl-3.6.3/configdata.pm
+          if-no-files-found: warn
+
       - name: Build the MRE and run it against the from-source OpenSSL
         shell: cmd
         run: |

--- a/.github/workflows/arm64-openssl-source-build.yml
+++ b/.github/workflows/arm64-openssl-source-build.yml
@@ -21,12 +21,6 @@ jobs:
         include:
           - name: release
             opts: --release
-          - name: debug
-            opts: --debug
-          - name: release-Od
-            opts: --release -Od
-          - name: release-O1
-            opts: --release -O1
     name: ${{ matrix.name }}
     runs-on: windows-11-vs2026-arm
     timeout-minutes: 120
@@ -103,7 +97,7 @@ jobs:
           mre.exe
           echo MRE exit code: %errorlevel%
 
-      - name: Name the faulting frame and its caller under cdb
+      - name: Catch the bad call at function entry, where LR is still valid
         if: ${{ always() }}
         continue-on-error: true
         shell: pwsh
@@ -112,11 +106,13 @@ jobs:
             Select-Object -First 1
           if ( $null -eq $cdb ) { Write-Host "cdb.exe not on this image"; exit 0 }
           if ( -not ( Test-Path mre.exe ) ) { Write-Host "mre.exe was not built"; exit 0 }
-          Write-Host "cdb: $($cdb.FullName)"
-          # kp prints the stack WITH argument values, so the caller is observed rather
-          # than inferred; ln @pc names the faulting symbol; ub @pc disassembles back.
-          $out = & $cdb.FullName -g -G -lines -y "$pwd" -c '.lines; g; kp; ln @pc; r; ub @pc L8; q' mre.exe 2>&1
-          $out | Select-Object -Last 160 | ForEach-Object { Write-Host $_ }
+          # Unwinding from the fault is hopeless: it happens in the prologue before x30
+          # is saved, so every unwinder follows a clobbered LR. Breaking on entry instead
+          # catches the moment when LR still holds the real return address. The condition
+          # skips any well-formed call and stops only on the bad one.
+          $cmd = '.lines; bp libssl_3_arm64!tls_parse_all_extensions ".if (@x0==1) {.echo CAUGHT_BAD_CALL; r; ln @lr; kp; ub @lr L10; q} .else {.echo ok-call; gc}"; g; q'
+          $out = & $cdb.FullName -g -G -lines -y "$pwd" -c $cmd mre.exe 2>&1
+          $out | Select-Object -Last 120 | ForEach-Object { Write-Host $_ }
 
       - name: Upload the built libssl and its pdb for offline symbolization
         if: ${{ always() }}

--- a/.github/workflows/arm64-openssl-source-build.yml
+++ b/.github/workflows/arm64-openssl-source-build.yml
@@ -1,0 +1,91 @@
+name: arm64 OpenSSL from-source check
+
+# Throwaway diagnostic workflow (branch ci/arm64-curl-openssl-repro): builds
+# OpenSSL 3.6.3 from the release tarball with `perl Configure VC-WIN64-ARM`,
+# release in one leg and debug in the other, then runs
+# scripts/arm64_openssl_mre.c against each. This removes vcpkg (and its port
+# patches) from the picture before the crash is reported upstream.
+on:
+  push:
+    branches:
+      - ci/arm64-curl-openssl-repro
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - release
+          - debug
+    runs-on: windows-11-vs2026-arm
+    timeout-minutes: 120
+    steps:
+      - name: Checkout the reproducer only
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            .github/actions
+            scripts
+
+      - name: Locate Visual Studio
+        uses: ./.github/actions/locate-visual-studio
+
+      - name: Ensure perl
+        shell: pwsh
+        run: |
+          $perl = Get-Command perl -ErrorAction SilentlyContinue
+          if ( $null -eq $perl )
+          {
+            Write-Host "perl not found, installing Strawberry Perl"
+            choco install strawberryperl -y --no-progress
+            "C:/Strawberry/perl/bin" | Out-File -Append -Encoding utf8 $env:GITHUB_PATH
+          }
+          else
+          {
+            Write-Host "perl: $($perl.Source)"
+            & $perl.Source -v
+          }
+
+      - name: Gather the debug CRT that a debug OpenSSL needs
+        shell: pwsh
+        run: |
+          $crt = @()
+          $crt += Get-ChildItem "C:/Program Files/Microsoft Visual Studio/*/*/VC/Redist/MSVC/*/debug_nonredist/arm64/Microsoft.VC*.DebugCRT/*.dll" -ErrorAction SilentlyContinue
+          $crt += Get-ChildItem "C:/Program Files (x86)/Windows Kits/10/bin/*/arm64/ucrt/ucrtbased.dll" -ErrorAction SilentlyContinue
+          foreach ( $f in $crt ) { Copy-Item $f.FullName . -Force; Write-Host "  $($f.Name)" }
+
+      - name: Download the OpenSSL 3.6.3 release tarball
+        shell: pwsh
+        run: |
+          $u = 'https://github.com/openssl/openssl/releases/download/openssl-3.6.3/openssl-3.6.3.tar.gz'
+          Invoke-WebRequest -Uri $u -OutFile openssl.tar.gz
+          Write-Host "sha256: $((Get-FileHash openssl.tar.gz -Algorithm SHA256).Hash)"
+          tar -xzf openssl.tar.gz
+          Write-Host "extracted:"
+          Get-ChildItem openssl-3.6.3 -Filter "Configure" | ForEach-Object { Write-Host "  $($_.Name)" }
+
+      - name: Configure and build OpenSSL (VC-WIN64-ARM, ${{ matrix.config }})
+        shell: cmd
+        working-directory: openssl-3.6.3
+        run: |
+          call "%VC_PATH%/Common7/Tools/VsDevCmd.bat" -arch=arm64 -host_arch=arm64 -vcvars_ver=14.5 || exit /b 1
+          cl 2>&1 | findstr /C:"Version"
+          rem no-apps/no-docs/no-tests only skip artefacts we do not use; they do not
+          rem change how libssl and libcrypto themselves are compiled.
+          perl Configure VC-WIN64-ARM shared no-apps no-docs no-tests --${{ matrix.config }} || exit /b 1
+          perl configdata.pm --dump || exit /b 1
+          nmake || exit /b 1
+          dir /b *.dll *.lib
+
+      - name: Build the MRE and run it against the from-source OpenSSL
+        shell: cmd
+        run: |
+          call "%VC_PATH%/Common7/Tools/VsDevCmd.bat" -arch=arm64 -host_arch=arm64 -vcvars_ver=14.5 || exit /b 1
+          rem the reproducer itself is always /O2 /MD, so only OpenSSL's configuration varies
+          cl /nologo /O2 /MD /W3 scripts/arm64_openssl_mre.c /I openssl-3.6.3/include /Fe:mre.exe /link /LIBPATH:openssl-3.6.3 libssl.lib libcrypto.lib ws2_32.lib crypt32.lib || exit /b 1
+          copy openssl-3.6.3\*.dll . >nul || exit /b 1
+          echo ==== MRE against a from-source ${{ matrix.config }} VC-WIN64-ARM OpenSSL
+          mre.exe
+          echo MRE exit code: %errorlevel%

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -315,11 +315,48 @@ jobs:
         with:
           build-bin-dir: source\${{ env.MR_ARCH }}\${{ matrix.config }}
 
+      # ---- DEBUG (throwaway branch): locate the arm64 MultiSSL libcurl crash ----
+      - name: DEBUG copy vcpkg PDBs next to the binaries
+        continue-on-error: true
+        run: |
+          $vcpkgDir = Split-Path (Get-Command vcpkg).Source
+          $src = Join-Path $vcpkgDir "installed/$env:VCPKG_DEFAULT_TRIPLET/bin"
+          Write-Host "PDB source dir: $src"
+          Get-ChildItem $src -Filter *.pdb -ErrorAction SilentlyContinue |
+            ForEach-Object { Write-Host "  available: $($_.Name)" }
+          Copy-Item (Join-Path $src "*.pdb") "source/${{ env.MR_ARCH }}/${{ matrix.config }}" -Force -ErrorAction SilentlyContinue
+          Get-ChildItem "source/${{ env.MR_ARCH }}/${{ matrix.config }}/*.pdb" -ErrorAction SilentlyContinue |
+            ForEach-Object { Write-Host "  copied: $($_.Name)" }
+
+      - name: DEBUG raw libcurl, default backend
+        continue-on-error: true
+        timeout-minutes: 3
+        run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CPRSslBackends:MRViewer.CurlRawGet
+
+      - name: DEBUG raw libcurl, CURL_SSL_BACKEND=schannel
+        continue-on-error: true
+        timeout-minutes: 3
+        env:
+          CURL_SSL_BACKEND: schannel
+        run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CPRSslBackends:MRViewer.CurlRawGet
+
+      - name: DEBUG cpr verbose, default backend
+        continue-on-error: true
+        timeout-minutes: 3
+        run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CPRTestGetVerbose
+
+      - name: DEBUG cpr verbose, CURL_SSL_BACKEND=schannel
+        continue-on-error: true
+        timeout-minutes: 3
+        env:
+          CURL_SSL_BACKEND: schannel
+        run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CPRTestGetVerbose
+
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'
         timeout-minutes: 10
-        run: source\${{ env.MR_ARCH }}\${{ matrix.config }}\MRTest.exe
+        run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CPRTest*
 
       - name: C Unit Tests
         if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -362,6 +362,33 @@ jobs:
         timeout-minutes: 3
         run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CPRSslBackends
 
+      - name: DEBUG 7 raw libcurl against the DEBUG OpenSSL DLLs
+        continue-on-error: true
+        timeout-minutes: 6
+        run: |
+          $bin = "source/${{ env.MR_ARCH }}/${{ matrix.config }}"
+          $vcpkgDir = Split-Path (Get-Command vcpkg).Source
+          $dbg = Join-Path $vcpkgDir "installed/$env:VCPKG_DEFAULT_TRIPLET/debug/bin"
+          Write-Host "debug bin: $dbg"
+          # The debug OpenSSL links the debug CRT, which is not on PATH by default.
+          $crt = @()
+          $crt += Get-ChildItem "C:/Program Files/Microsoft Visual Studio/*/*/VC/Redist/MSVC/*/debug_nonredist/arm64/Microsoft.VC*.DebugCRT/*.dll" -ErrorAction SilentlyContinue
+          $crt += Get-ChildItem "C:/Program Files (x86)/Windows Kits/10/bin/*/arm64/ucrt/ucrtbased.dll" -ErrorAction SilentlyContinue
+          foreach ( $f in $crt ) { Copy-Item $f.FullName $bin -Force; Write-Host "  crt: $($f.Name)" }
+          New-Item -ItemType Directory -Force relbak | Out-Null
+          $swap = @( "libssl-3-arm64.dll", "libcrypto-3-arm64.dll" )
+          foreach ( $f in $swap )
+          {
+            Copy-Item "$bin/$f" "relbak/$f" -Force
+            Copy-Item "$dbg/$f" "$bin/$f" -Force
+            Copy-Item "$dbg/$($f -replace '.dll$','.pdb')" $bin -Force -ErrorAction SilentlyContinue
+            Write-Host "  swapped in debug $f"
+          }
+          & "$bin/MRTest.exe" --gtest_filter=MRViewer.CurlRawGet
+          Write-Host "MRTest exit code with debug OpenSSL: $LASTEXITCODE"
+          foreach ( $f in $swap ) { Copy-Item "relbak/$f" "$bin/$f" -Force }
+          Write-Host "release DLLs restored"
+
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -328,29 +328,39 @@ jobs:
           Get-ChildItem "source/${{ env.MR_ARCH }}/${{ matrix.config }}/*.pdb" -ErrorAction SilentlyContinue |
             ForEach-Object { Write-Host "  copied: $($_.Name)" }
 
-      - name: DEBUG raw libcurl, default backend
+      - name: DEBUG 1 raw libcurl, no options
         continue-on-error: true
         timeout-minutes: 3
-        run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CPRSslBackends:MRViewer.CurlRawGet
+        run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CurlRawGet
 
-      - name: DEBUG raw libcurl, CURL_SSL_BACKEND=schannel
+      - name: DEBUG 2 raw libcurl, CURLSSLOPT_NATIVE_CA
+        continue-on-error: true
+        timeout-minutes: 3
+        run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CurlRawGetNativeCa
+
+      - name: DEBUG 3 raw libcurl, NATIVE_CA + CURL_SSL_BACKEND=schannel
         continue-on-error: true
         timeout-minutes: 3
         env:
           CURL_SSL_BACKEND: schannel
-        run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CPRSslBackends:MRViewer.CurlRawGet
+        run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CurlRawGetNativeCa
 
-      - name: DEBUG cpr verbose, default backend
+      - name: DEBUG 4 cpr verbose session
         continue-on-error: true
         timeout-minutes: 3
         run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CPRTestGetVerbose
 
-      - name: DEBUG cpr verbose, CURL_SSL_BACKEND=schannel
+      - name: DEBUG 5 cpr verbose session, CURL_SSL_BACKEND=schannel
         continue-on-error: true
         timeout-minutes: 3
         env:
           CURL_SSL_BACKEND: schannel
         run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CPRTestGetVerbose
+
+      - name: DEBUG 6 backend diagnostics
+        continue-on-error: true
+        timeout-minutes: 3
+        run: source/${{ env.MR_ARCH }}/${{ matrix.config }}/MRTest.exe --gtest_filter=MRViewer.CPRSslBackends
 
       - name: Unit Tests
         env:

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -389,28 +389,6 @@ jobs:
           foreach ( $f in $swap ) { Copy-Item "relbak/$f" "$bin/$f" -Force }
           Write-Host "release DLLs restored"
 
-      - name: DEBUG 8 standalone OpenSSL-only MRE, release then debug DLLs
-        shell: cmd
-        continue-on-error: true
-        timeout-minutes: 6
-        run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
-          set INST=C:\vcpkg\installed\%VCPKG_DEFAULT_TRIPLET%
-          if not exist mre mkdir mre
-          cl /nologo /O2 /MD /W3 scripts\arm64_openssl_mre.c /I %INST%\include /Fo:mre\ /Fe:mre\mre.exe /link /LIBPATH:%INST%\lib libssl.lib libcrypto.lib ws2_32.lib crypt32.lib || exit /b 1
-          rem the debug OpenSSL needs the debug CRT, already gathered by the previous step
-          copy source\%MR_ARCH%\${{ matrix.config }}\*d.dll mre\ >nul 2>nul
-          copy %INST%\bin\libssl-3-arm64.dll mre\ >nul || exit /b 1
-          copy %INST%\bin\libcrypto-3-arm64.dll mre\ >nul || exit /b 1
-          echo ==== MRE against RELEASE OpenSSL
-          mre\mre.exe
-          echo MRE exit code: %errorlevel%
-          copy %INST%\debug\bin\libssl-3-arm64.dll mre\ >nul || exit /b 1
-          copy %INST%\debug\bin\libcrypto-3-arm64.dll mre\ >nul || exit /b 1
-          echo ==== MRE against DEBUG OpenSSL
-          mre\mre.exe
-          echo MRE exit code: %errorlevel%
-
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -389,6 +389,28 @@ jobs:
           foreach ( $f in $swap ) { Copy-Item "relbak/$f" "$bin/$f" -Force }
           Write-Host "release DLLs restored"
 
+      - name: DEBUG 8 standalone OpenSSL-only MRE, release then debug DLLs
+        shell: cmd
+        continue-on-error: true
+        timeout-minutes: 6
+        run: |
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          set INST=C:\vcpkg\installed\%VCPKG_DEFAULT_TRIPLET%
+          if not exist mre mkdir mre
+          cl /nologo /O2 /MD /W3 scripts\arm64_openssl_mre.c /I %INST%\include /Fo:mre\ /Fe:mre\mre.exe /link /LIBPATH:%INST%\lib libssl.lib libcrypto.lib ws2_32.lib crypt32.lib || exit /b 1
+          rem the debug OpenSSL needs the debug CRT, already gathered by the previous step
+          copy source\%MR_ARCH%\${{ matrix.config }}\*d.dll mre\ >nul 2>nul
+          copy %INST%\bin\libssl-3-arm64.dll mre\ >nul || exit /b 1
+          copy %INST%\bin\libcrypto-3-arm64.dll mre\ >nul || exit /b 1
+          echo ==== MRE against RELEASE OpenSSL
+          mre\mre.exe
+          echo MRE exit code: %errorlevel%
+          copy %INST%\debug\bin\libssl-3-arm64.dll mre\ >nul || exit /b 1
+          copy %INST%\debug\bin\libcrypto-3-arm64.dll mre\ >nul || exit /b 1
+          echo ==== MRE against DEBUG OpenSSL
+          mre\mre.exe
+          echo MRE exit code: %errorlevel%
+
       - name: Unit Tests
         env:
           GTEST_OUTPUT: 'xml:unit_tests_report_gtest.xml'

--- a/.github/workflows/matrix/windows-minimal-config.json
+++ b/.github/workflows/matrix/windows-minimal-config.json
@@ -15,40 +15,6 @@
       "arch": "arm64",
       "vcpkg_triplet": "arm64-windows-meshlib",
       "runner": ["windows-11-vs2026-arm"]
-    },
-    {
-      "cxx_compiler": "msvc-2019",
-      "config": "Release",
-      "build_system": "CMake",
-      "vcpkg_triplet": "x64-windows-vs2019-meshlib",
-      "runner": ["windows-2022"],
-      "cuda_version": "11.4.2"
-    },
-    {
-      "cxx_compiler": "msvc-2019",
-      "config": "Debug",
-      "build_system": "CMake",
-      "vcpkg_triplet": "x64-windows-meshlib-iterator-debug",
-      "upload_name": "Debug-IteratorDebug",
-      "runner": ["windows-2022"],
-      "cuda_version": "11.4.2"
-    },
-    {
-      "cxx_compiler": "msvc-2026",
-      "config": "Release",
-      "build_system": "MSBuild",
-      "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2025"],
-      "cuda_version": "12.0.1",
-      "mrcuda_platform_toolset": "v143"
-    },
-    {
-      "cxx_compiler": "msvc-2026",
-      "config": "Debug",
-      "build_system": "CMake",
-      "vcpkg_triplet": "x64-windows-meshlib",
-      "runner": ["windows-2025"],
-      "cuda_version": "13.2.0"
     }
   ]
 }

--- a/.github/workflows/matrix/windows-minimal-config.json
+++ b/.github/workflows/matrix/windows-minimal-config.json
@@ -6,15 +6,9 @@
       "build_system": "CMake",
       "arch": "arm64",
       "vcpkg_triplet": "arm64-windows-meshlib",
-      "runner": ["windows-11-vs2026-arm"]
-    },
-    {
-      "cxx_compiler": "msvc-2026",
-      "config": "Release",
-      "build_system": "MSBuild",
-      "arch": "arm64",
-      "vcpkg_triplet": "arm64-windows-meshlib",
-      "runner": ["windows-11-vs2026-arm"]
+      "runner": [
+        "windows-11-vs2026-arm"
+      ]
     }
   ]
 }

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -12,6 +12,7 @@ boost-stacktrace
 boost-url
 libjpeg-turbo
 cpr
+curl[openssl]
 eigen3
 fastmcpp
 freetype

--- a/scripts/arm64_cdb_cmds.txt
+++ b/scripts/arm64_cdb_cmds.txt
@@ -1,23 +1,25 @@
 $$ cdb script for the arm64 OpenSSL TLS 1.3 fault (throwaway diagnostic).
-$$ Log every entry to the suspect function with its argument and real return
-$$ address, then, when the access violation stops the debugger, dump the
-$$ faulting context and every thread's stack.
+$$ The fault is a corrupted stack pointer, not a bad argument: at the AV, sp is
+$$ outside the thread's stack and x15 no longer holds the 1 its own prologue put
+$$ there. So walk down the handshake call chain printing sp at each entry, to find
+$$ the frame where sp first leaves the legal range printed by !teb.
 .lines
+.echo ==== legal stack range for this thread
+!teb
 .echo ==== breakpoints
-bu libssl_3_arm64!tls_parse_all_extensions ".echo ==ENTRY==; r @x0; r @lr; ln @lr; ~.; gc"
+bu libssl_3_arm64!read_state_machine ".echo == read_state_machine; r @sp; gc"
+bu libssl_3_arm64!ossl_statem_client_process_message ".echo == process_message; r @sp; gc"
+bu libssl_3_arm64!tls_process_server_hello ".echo == server_hello; r @sp; gc"
+bu libssl_3_arm64!tls_collect_extensions ".echo == collect_extensions; r @sp; gc"
+bu libssl_3_arm64!tls_parse_all_extensions ".echo == parse_all_extensions; r @sp; r @x0; r @x15; gc"
 bl
 .echo ==== running
 g
 .echo ==== STOPPED
-.echo ---- faulting thread and registers
-~.
 r
+.echo ---- stack bounds again
+!teb
 .echo ---- faulting instruction
-ln @pc
 u @pc-0x10 L8
-.echo ---- exception record
-.exr -1
-.echo ---- all thread stacks
-~*kp
 .echo ==== done
 q

--- a/scripts/arm64_cdb_cmds.txt
+++ b/scripts/arm64_cdb_cmds.txt
@@ -1,22 +1,55 @@
 $$ cdb script for the arm64 OpenSSL TLS 1.3 fault (throwaway diagnostic).
 $$
-$$ Established so far: sp is valid at every frame down to tls_parse_all_extensions
-$$ entry, and four instructions later sp is outside the thread stack and x15 holds
-$$ garbage instead of the 1 its own prologue just set. Those four instructions are
-$$   sub sp,sp,#0x60 / mov x15,#1 / bl __chkstk / sub sp,sp,x15,lsl #4
-$$ so this script single-steps them, dumping sp/x15/x0 after each, and steps
-$$ through __chkstk itself. If the corruption does not reproduce while stepping,
-$$ that points at an asynchronous cause rather than these instructions.
+$$ Established: sp is valid at every frame down to tls_parse_all_extensions entry
+$$ and after its own `sub sp,sp,#0x60`; four instructions later sp is outside the
+$$ thread stack and x15 holds garbage instead of the 1 just set. The only callee
+$$ in that window is __chkstk (_alloca_probe), which provably writes x16/x17 only.
+$$
+$$ So single-step the prologue and through __chkstk. Stepping must happen at top
+$$ level: `t` inside a breakpoint command block makes cdb skip the rest of the list.
 .lines
-!teb
-.echo ==== breakpoint on the suspect prologue
-bu libssl_3_arm64!tls_parse_all_extensions ".echo ==ENTRY==; r; .echo -- step 1: sub sp,sp,#0x60; t; r @sp; .echo -- step 2: mov x15,#1; t; r @sp; r @x15; .echo -- step 3: into __chkstk; t; r @sp; r @x15; .echo -- stepping through __chkstk; t; r; t; r; t; r; t; r; t; r; t; r; .echo -- back in caller?; r; k; .echo -- continue to the fault; g"
-bl
-.echo ==== running
+.echo ==== breakpoint
+bu libssl_3_arm64!tls_parse_all_extensions
+g
+.echo ==== AT ENTRY
+~.
+r
+.echo -- t1: sub sp,sp,#0x60
+t
+r @sp
+.echo -- t2: mov x15,#1
+t
+r @sp
+r @x15
+.echo -- t3: bl __chkstk, stepping in
+t
+r @pc
+r @sp
+r @x15
+.echo -- inside __chkstk, one instruction at a time
+t
+r
+t
+r
+t
+r
+t
+r
+t
+r
+t
+r
+t
+r
+t
+r
+.echo ==== where are we now
+r
+k
+.echo ==== run to the fault
 g
 .echo ==== STOPPED
 r
-!teb
 u @pc-0x10 L8
 .echo ==== done
 q

--- a/scripts/arm64_cdb_cmds.txt
+++ b/scripts/arm64_cdb_cmds.txt
@@ -1,55 +1,34 @@
 $$ cdb script for the arm64 OpenSSL TLS 1.3 fault (throwaway diagnostic).
 $$
-$$ Established: sp is valid at every frame down to tls_parse_all_extensions entry
-$$ and after its own `sub sp,sp,#0x60`; four instructions later sp is outside the
-$$ thread stack and x15 holds garbage instead of the 1 just set. The only callee
-$$ in that window is __chkstk (_alloca_probe), which provably writes x16/x17 only.
+$$ Established: this is a WILD RETURN, not a bad argument.
+$$   1. tls_parse_all_extensions is called once, legitimately, and returns fine.
+$$   2. Later, execution arrives at tls_parse_all_extensions+0xc WITHOUT passing
+$$      its entry: some function executes `ret` while x30 still holds the stale
+$$      +0xc left by that function's own `bl __chkstk`.
+$$   3. +0xc is `sub sp,sp,x15,lsl #4`, so that function's garbage x15 wrecks sp.
+$$   4. +0x10 then reads [x0+0x878] with x0 = that function's return value (1),
+$$      which is the 0x879 access violation.
+$$ x13/x14 hold high-entropy values at that point, so the culprit is likely one of
+$$ libcrypto's hand-written aarch64 assembly routines returning without a valid
+$$ link register.
 $$
-$$ So single-step the prologue and through __chkstk. Stepping must happen at top
-$$ level: `t` inside a breakpoint command block makes cdb skip the rest of the list.
+$$ A hardware execute breakpoint at +0xc catches the instant of the wild transfer,
+$$ while sp still belongs to the culprit, so its frame and return chain are intact.
 .lines
-.echo ==== breakpoint
-bu libssl_3_arm64!tls_parse_all_extensions
+.echo ==== hardware breakpoint on the wild-jump landing site
+ba e1 libssl_3_arm64!tls_parse_all_extensions+0xc
+bl
+.echo ==== running
 g
-.echo ==== AT ENTRY
-~.
+.echo ==== CAUGHT THE WILD TRANSFER
 r
-.echo -- t1: sub sp,sp,#0x60
-t
-r @sp
-.echo -- t2: mov x15,#1
-t
-r @sp
-r @x15
-.echo -- t3: bl __chkstk, stepping in
-t
-r @pc
-r @sp
-r @x15
-.echo -- inside __chkstk, one instruction at a time
-t
-r
-t
-r
-t
-r
-t
-r
-t
-r
-t
-r
-t
-r
-t
-r
-.echo ==== where are we now
-r
+.echo ---- who owns this stack pointer
+!address @sp
+.echo ---- stack contents: return addresses of the culprit chain
+dps @sp L40
+.echo ---- unwind attempt
 k
-.echo ==== run to the fault
-g
-.echo ==== STOPPED
-r
-u @pc-0x10 L8
+.echo ---- and the same for every thread
+~*k
 .echo ==== done
 q

--- a/scripts/arm64_cdb_cmds.txt
+++ b/scripts/arm64_cdb_cmds.txt
@@ -1,0 +1,23 @@
+$$ cdb script for the arm64 OpenSSL TLS 1.3 fault (throwaway diagnostic).
+$$ Log every entry to the suspect function with its argument and real return
+$$ address, then, when the access violation stops the debugger, dump the
+$$ faulting context and every thread's stack.
+.lines
+.echo ==== breakpoints
+bu libssl_3_arm64!tls_parse_all_extensions ".echo ==ENTRY==; r @x0; r @lr; ln @lr; ~.; gc"
+bl
+.echo ==== running
+g
+.echo ==== STOPPED
+.echo ---- faulting thread and registers
+~.
+r
+.echo ---- faulting instruction
+ln @pc
+u @pc-0x10 L8
+.echo ---- exception record
+.exr -1
+.echo ---- all thread stacks
+~*kp
+.echo ==== done
+q

--- a/scripts/arm64_cdb_cmds.txt
+++ b/scripts/arm64_cdb_cmds.txt
@@ -1,25 +1,22 @@
 $$ cdb script for the arm64 OpenSSL TLS 1.3 fault (throwaway diagnostic).
-$$ The fault is a corrupted stack pointer, not a bad argument: at the AV, sp is
-$$ outside the thread's stack and x15 no longer holds the 1 its own prologue put
-$$ there. So walk down the handshake call chain printing sp at each entry, to find
-$$ the frame where sp first leaves the legal range printed by !teb.
+$$
+$$ Established so far: sp is valid at every frame down to tls_parse_all_extensions
+$$ entry, and four instructions later sp is outside the thread stack and x15 holds
+$$ garbage instead of the 1 its own prologue just set. Those four instructions are
+$$   sub sp,sp,#0x60 / mov x15,#1 / bl __chkstk / sub sp,sp,x15,lsl #4
+$$ so this script single-steps them, dumping sp/x15/x0 after each, and steps
+$$ through __chkstk itself. If the corruption does not reproduce while stepping,
+$$ that points at an asynchronous cause rather than these instructions.
 .lines
-.echo ==== legal stack range for this thread
 !teb
-.echo ==== breakpoints
-bu libssl_3_arm64!read_state_machine ".echo == read_state_machine; r @sp; gc"
-bu libssl_3_arm64!ossl_statem_client_process_message ".echo == process_message; r @sp; gc"
-bu libssl_3_arm64!tls_process_server_hello ".echo == server_hello; r @sp; gc"
-bu libssl_3_arm64!tls_collect_extensions ".echo == collect_extensions; r @sp; gc"
-bu libssl_3_arm64!tls_parse_all_extensions ".echo == parse_all_extensions; r @sp; r @x0; r @x15; gc"
+.echo ==== breakpoint on the suspect prologue
+bu libssl_3_arm64!tls_parse_all_extensions ".echo ==ENTRY==; r; .echo -- step 1: sub sp,sp,#0x60; t; r @sp; .echo -- step 2: mov x15,#1; t; r @sp; r @x15; .echo -- step 3: into __chkstk; t; r @sp; r @x15; .echo -- stepping through __chkstk; t; r; t; r; t; r; t; r; t; r; t; r; .echo -- back in caller?; r; k; .echo -- continue to the fault; g"
 bl
 .echo ==== running
 g
 .echo ==== STOPPED
 r
-.echo ---- stack bounds again
 !teb
-.echo ---- faulting instruction
 u @pc-0x10 L8
 .echo ==== done
 q

--- a/scripts/arm64_openssl_mre.c
+++ b/scripts/arm64_openssl_mre.c
@@ -1,0 +1,121 @@
+/*
+ * Minimal reproducer: OpenSSL 3.6.3 built for arm64-windows with optimization
+ * crashes while parsing a TLS 1.3 ServerHello.
+ *
+ * No curl, no cpr, no C++: only libssl/libcrypto.
+ *
+ * Build (native ARM64 developer prompt, vcpkg openssl):
+ *   cl /O2 /MD arm64_openssl_mre.c /I %VCPKG%\installed\arm64-windows\include ^
+ *      /link /LIBPATH:%VCPKG%\installed\arm64-windows\lib ^
+ *      libssl.lib libcrypto.lib ws2_32.lib crypt32.lib
+ *
+ * Run:
+ *   arm64_openssl_mre.exe [host] [port]      (default postman-echo.com 443)
+ *
+ * Expected: "handshake OK".
+ * Actual, arm64 + Release OpenSSL DLLs:
+ *   access violation reading 0x00000879 in
+ *   libssl-3-arm64.dll!tls_parse_all_extensions (ssl/statem/extensions.c:747)
+ *   at `ldr x8, [x0, #0x878]`, i.e. `s->cert` where the SSL_CONNECTION *s
+ *   argument is 1 instead of a pointer (0x879 == 1 + offsetof(cert)).
+ * The very same DLLs built without optimization complete the handshake, so the
+ * fault is optimization-dependent. x64 is unaffected; so is Schannel.
+ *
+ * Certificate verification is deliberately left off: the crash happens while
+ * parsing the ServerHello, long before any certificate is checked, so the
+ * reproducer needs no CA store.
+ */
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef _WIN32
+#include <windows.h>
+
+/* Reports the faulting instruction as module+RVA, so the crash can be located
+ * in a disassembly without a debugger. Not part of the reproduction itself. */
+static LONG NTAPI reportFault( EXCEPTION_POINTERS * info )
+{
+    const EXCEPTION_RECORD * er = info->ExceptionRecord;
+    HMODULE mod = NULL;
+    char path[MAX_PATH] = { 0 };
+
+    if ( er->ExceptionCode != EXCEPTION_ACCESS_VIOLATION )
+        return EXCEPTION_CONTINUE_SEARCH;
+
+    if ( GetModuleHandleExA( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                 GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+             (LPCSTR)er->ExceptionAddress, &mod ) &&
+        mod != NULL )
+        GetModuleFileNameA( mod, path, MAX_PATH );
+
+    printf( "\nACCESS VIOLATION %s address 0x%llx\n"
+            "  faulting pc 0x%llx = %s + 0x%llx\n",
+        er->ExceptionInformation[0] == 0 ? "reading" : "writing",
+        (unsigned long long)er->ExceptionInformation[1],
+        (unsigned long long)(uintptr_t)er->ExceptionAddress,
+        path[0] != '\0' ? path : "<unknown module>",
+        (unsigned long long)( (uintptr_t)er->ExceptionAddress - (uintptr_t)mod ) );
+#if defined( _M_ARM64 )
+    printf( "  x0 = 0x%llx (the SSL_CONNECTION* argument; expected a pointer)\n",
+        (unsigned long long)info->ContextRecord->X0 );
+#endif
+    fflush( stdout );
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+#endif
+
+int main( int argc, char ** argv )
+{
+    const char * host = argc > 1 ? argv[1] : "postman-echo.com";
+    const char * port = argc > 2 ? argv[2] : "443";
+    SSL_CTX * ctx = NULL;
+    BIO * bio = NULL;
+    SSL * ssl = NULL;
+
+#ifdef _WIN32
+    AddVectoredExceptionHandler( 1, reportFault );
+#endif
+
+    printf( "OpenSSL: %s\n", OpenSSL_version( OPENSSL_VERSION_STRING ) );
+    printf( "target : %s:%s (TLS 1.3 only)\n", host, port );
+
+    ctx = SSL_CTX_new( TLS_client_method() );
+    if ( ctx == NULL )
+    {
+        ERR_print_errors_fp( stderr );
+        return 1;
+    }
+    /* The crash is on the TLS 1.3 ServerHello path (SSL_EXT_TLS1_3_SERVER_HELLO). */
+    SSL_CTX_set_min_proto_version( ctx, TLS1_3_VERSION );
+    SSL_CTX_set_verify( ctx, SSL_VERIFY_NONE, NULL );
+
+    bio = BIO_new_ssl_connect( ctx );
+    if ( bio == NULL )
+    {
+        ERR_print_errors_fp( stderr );
+        return 1;
+    }
+    BIO_get_ssl( bio, &ssl );
+    SSL_set_tlsext_host_name( ssl, host ); /* SNI */
+    BIO_set_conn_hostname( bio, host );
+    BIO_set_conn_port( bio, port );
+
+    printf( "connecting and handshaking...\n" );
+    fflush( stdout );
+
+    if ( BIO_do_connect( bio ) <= 0 )
+    {
+        printf( "BIO_do_connect failed (no crash)\n" );
+        ERR_print_errors_fp( stderr );
+        BIO_free_all( bio );
+        SSL_CTX_free( ctx );
+        return 2;
+    }
+
+    printf( "handshake OK: %s / %s\n", SSL_get_version( ssl ), SSL_get_cipher( ssl ) );
+    BIO_free_all( bio );
+    SSL_CTX_free( ctx );
+    return 0;
+}

--- a/scripts/arm64_prologue_report.py
+++ b/scripts/arm64_prologue_report.py
@@ -52,8 +52,6 @@ def analyse(body):
 def main():
     lines = open(sys.argv[1], encoding="utf-8", errors="replace").read().splitlines()
     for name, body in functions(lines):
-        if not re.match(r"^v\d+$", name):
-            continue
         state, frame, chkstk_at, lr_save_at = analyse(body)
         print(
             "  %-4s %-32s frame=%-6s chkstk@%s lr-save@%s"

--- a/scripts/arm64_prologue_report.py
+++ b/scripts/arm64_prologue_report.py
@@ -1,0 +1,50 @@
+"""Print each function's prologue from a dumpbin /disasm listing and flag the
+defect: `bl __chkstk` reached before x30 is stored.
+
+Usage: python arm64_prologue_report.py repro.asm
+"""
+
+import re
+import sys
+
+
+def functions(lines):
+    name, body = None, []
+    for line in lines:
+        m = re.match(r"^([A-Za-z_$?][\w$?@]*):$", line.strip())
+        if m:
+            if name:
+                yield name, body
+            name, body = m.group(1), []
+        elif name is not None:
+            body.append(line.rstrip())
+    if name:
+        yield name, body
+
+
+def verdict(body):
+    """Walk the prologue; report which of __chkstk / x30-store comes first."""
+    for line in body[:40]:
+        low = line.lower()
+        if "chkstk" in low or "alloca_probe" in low:
+            return "BAD  - bl __chkstk before x30 is saved"
+        if re.search(r"\b(str|stp)\b.*\bx30\b", low):
+            return "ok   - x30 saved first"
+    return "n/a  - neither in the first 40 instructions"
+
+
+def main():
+    lines = open(sys.argv[1], encoding="utf-8", errors="replace").read().splitlines()
+    for name, body in functions(lines):
+        if not re.match(r"^v\d+$", name):
+            continue
+        print("  %-4s %s" % (name, verdict(body)))
+        for line in body[:8]:
+            text = line.strip()
+            if text:
+                print("         " + text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/arm64_prologue_report.py
+++ b/scripts/arm64_prologue_report.py
@@ -1,11 +1,17 @@
-"""Print each function's prologue from a dumpbin /disasm listing and flag the
-defect: `bl __chkstk` reached before x30 is stored.
+"""Print each candidate's prologue from a dumpbin /disasm listing and flag the
+defect: `bl __chkstk` reached before the link register is saved.
+
+dumpbin prints the fp/lr aliases, not x29/x30, so match both spellings.
 
 Usage: python arm64_prologue_report.py repro.asm
 """
 
 import re
 import sys
+
+LR_SAVE = re.compile(r"\b(str|stp)\b.*\b(x30|lr)\b")
+LR_LOAD = re.compile(r"\b(ldr|ldp)\b.*\b(x30|lr)\b")
+CHKSTK = re.compile(r"chkstk|alloca_probe")
 
 
 def functions(lines):
@@ -22,15 +28,25 @@ def functions(lines):
         yield name, body
 
 
-def verdict(body):
-    """Walk the prologue; report which of __chkstk / x30-store comes first."""
-    for line in body[:40]:
+def analyse(body):
+    frame = ""
+    chkstk_at = lr_save_at = None
+    for i, line in enumerate(body):
         low = line.lower()
-        if "chkstk" in low or "alloca_probe" in low:
-            return "BAD  - bl __chkstk before x30 is saved"
-        if re.search(r"\b(str|stp)\b.*\bx30\b", low):
-            return "ok   - x30 saved first"
-    return "n/a  - neither in the first 40 instructions"
+        m = re.search(r"sub\s+sp,sp,#(0x[0-9a-f]+)", low)
+        if m and not frame:
+            frame = m.group(1)
+        if chkstk_at is None and CHKSTK.search(low):
+            chkstk_at = i
+        if lr_save_at is None and LR_SAVE.search(low):
+            lr_save_at = i
+    if chkstk_at is None:
+        return "no-probe", frame, chkstk_at, lr_save_at
+    if lr_save_at is None:
+        return "BAD (lr never saved)", frame, chkstk_at, lr_save_at
+    if chkstk_at < lr_save_at:
+        return "BAD (chkstk destroys lr first)", frame, chkstk_at, lr_save_at
+    return "ok", frame, chkstk_at, lr_save_at
 
 
 def main():
@@ -38,11 +54,19 @@ def main():
     for name, body in functions(lines):
         if not re.match(r"^v\d+$", name):
             continue
-        print("  %-4s %s" % (name, verdict(body)))
-        for line in body[:8]:
-            text = line.strip()
-            if text:
-                print("         " + text)
+        state, frame, chkstk_at, lr_save_at = analyse(body)
+        print(
+            "  %-4s %-32s frame=%-6s chkstk@%s lr-save@%s"
+            % (name, state, frame or "-", chkstk_at, lr_save_at)
+        )
+        if state.startswith("BAD"):
+            for i, line in enumerate(body):
+                text = line.strip()
+                keep = i < 6 or CHKSTK.search(text.lower()) or LR_SAVE.search(
+                    text.lower()
+                ) or LR_LOAD.search(text.lower()) or "ret" in text.lower()
+                if text and keep:
+                    print("         " + text)
     return 0
 
 

--- a/scripts/arm64_prologue_repro.c
+++ b/scripts/arm64_prologue_repro.c
@@ -200,3 +200,135 @@ int v18( unsigned long long n, unsigned long long a, unsigned long long b, unsig
     sink( &local );
     return ( int )local;
 }
+
+/* ---- second reduction round: exactly one change from v7 each --------------
+ * v11..v17 all failed to emit a probe because they allocate the frame with a
+ * pre-indexed `stp ...,[sp,#-N]!`, which saves registers as part of frame setup.
+ * The defect needs the split form (bare `sub sp,sp,#0x60`, saves deferred), so
+ * these vary one ingredient at a time to find which one produces it.
+ * ------------------------------------------------------------------------- */
+
+/* v19: v7 without the trailing function-pointer loop. */
+int v19( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29 + s->cert->meths_count;
+    unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
+    unsigned long long c = chainidx, d = ( unsigned long long )context;
+    unsigned long long e = ( unsigned long long )fin, f = numexts, g = 0, h = 0;
+
+    for ( i = 0; i < numexts; i++ )
+    {
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+        g += a + b + c + d + e + f;
+        h ^= g + i;
+    }
+    return ( int )( ( g ^ h ) & 1 );
+}
+
+/* v20: v7 with a one-field struct instead of the padded double dereference. */
+typedef struct Def2
+{
+    int context;
+    int ( *final )( Count *, int, int );
+} Def2;
+
+extern const Def2 defs2[29];
+
+int v20( Count *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29 + s->n;
+    unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
+    unsigned long long c = chainidx, d = ( unsigned long long )context;
+    unsigned long long e = ( unsigned long long )fin, f = numexts, g = 0, h = 0;
+    const Def2 *dd;
+
+    for ( i = 0; i < numexts; i++ )
+    {
+        if ( !call1( i ) )
+            return 0;
+        g += a + b + c + d + e + f;
+        h ^= g + i;
+    }
+    if ( fin )
+    {
+        for ( i = 0, dd = defs2; i < 29; i++, dd++ )
+            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
+                return 0;
+    }
+    return ( int )( ( g ^ h ) & 1 );
+}
+
+/* v21: v7 with a one-argument callee in the first loop. */
+int v21( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29 + s->cert->meths_count;
+    unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
+    unsigned long long c = chainidx, d = ( unsigned long long )context;
+    unsigned long long e = ( unsigned long long )fin, f = numexts, g = 0, h = 0;
+    const Def *dd;
+
+    for ( i = 0; i < numexts; i++ )
+    {
+        if ( !call1( i ) )
+            return 0;
+        g += a + b + c + d + e + f;
+        h ^= g + i;
+    }
+    if ( fin )
+    {
+        for ( i = 0, dd = defs; i < 29; i++, dd++ )
+            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
+                return 0;
+    }
+    return ( int )( ( g ^ h ) & 1 );
+}
+
+/* v22: v7 with one fewer value live across the calls. */
+int v22( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29 + s->cert->meths_count;
+    unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
+    unsigned long long c = chainidx, d = ( unsigned long long )context;
+    unsigned long long e = ( unsigned long long )fin, g = 0, h = 0;
+    const Def *dd;
+
+    for ( i = 0; i < numexts; i++ )
+    {
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+        g += a + b + c + d + e;
+        h ^= g + i;
+    }
+    if ( fin )
+    {
+        for ( i = 0, dd = defs; i < 29; i++, dd++ )
+            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
+                return 0;
+    }
+    return ( int )( ( g ^ h ) & 1 );
+}
+
+/* v23: v7 without the second accumulator h. */
+int v23( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29 + s->cert->meths_count;
+    unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
+    unsigned long long c = chainidx, d = ( unsigned long long )context;
+    unsigned long long e = ( unsigned long long )fin, f = numexts, g = 0;
+    const Def *dd;
+
+    for ( i = 0; i < numexts; i++ )
+    {
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+        g += a + b + c + d + e + f + i;
+    }
+    if ( fin )
+    {
+        for ( i = 0, dd = defs; i < 29; i++, dd++ )
+            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
+                return 0;
+    }
+    return ( int )( g & 1 );
+}

--- a/scripts/arm64_prologue_repro.c
+++ b/scripts/arm64_prologue_repro.c
@@ -1,0 +1,146 @@
+/*
+ * Candidate shapes for the MSVC ARM64 /O2 /Gs0 prologue defect:
+ * `bl __chkstk` is emitted before `str x30`, so the return address is destroyed
+ * before it is spilled.
+ *
+ *   cl /c /O2 /Gs0 arm64_prologue_repro.c
+ *   dumpbin /disasm:nobytes arm64_prologue_repro.obj
+ *
+ * A function is BAD when its prologue shows `bl __chkstk` ahead of the
+ * instruction that stores x30. v1 mirrors OpenSSL's tls_parse_all_extensions;
+ * the others strip one ingredient each, to find which are required.
+ */
+
+typedef struct Cert
+{
+    char pad[0x88];
+    unsigned long long meths_count;
+} Cert;
+
+typedef struct Conn
+{
+    char pad[0x878];
+    Cert *cert;
+} Conn;
+
+typedef struct Def
+{
+    int context;
+    int ( *final )( Conn *, int, int );
+} Def;
+
+extern const Def defs[29];
+
+extern int parse_one( Conn *s, unsigned long long i, int ctx, void *exts, void *x, unsigned long long idx );
+
+/* v1: same shape as tls_parse_all_extensions - six parameters, a count read
+ * through a two-level dereference of the first one, a loop of calls, then a
+ * second loop calling through a table of function pointers. */
+int v1( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29;
+    const Def *d;
+
+    numexts += s->cert->meths_count;
+
+    for ( i = 0; i < numexts; i++ )
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+
+    if ( fin )
+    {
+        for ( i = 0, d = defs; i < 29; i++, d++ )
+            if ( ( d->context & context ) != 0 && d->final != 0 && !d->final( s, context, 1 ) )
+                return 0;
+    }
+    return 1;
+}
+
+/* v2: v1 without the function-pointer loop. */
+int v2( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29;
+
+    numexts += s->cert->meths_count;
+    ( void )fin;
+
+    for ( i = 0; i < numexts; i++ )
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+    return 1;
+}
+
+/* v3: v1 without the dereference that produces the loop bound, so no early-exit
+ * test can be hoisted ahead of the register saves. */
+int v3( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i;
+    const Def *d;
+
+    for ( i = 0; i < 29; i++ )
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+
+    if ( fin )
+    {
+        for ( i = 0, d = defs; i < 29; i++, d++ )
+            if ( ( d->context & context ) != 0 && d->final != 0 && !d->final( s, context, 1 ) )
+                return 0;
+    }
+    return 1;
+}
+
+/* v4: v1 with fewer parameters. */
+int v4( Conn *s, int context, int fin )
+{
+    unsigned long long i, numexts = 29;
+    const Def *d;
+
+    numexts += s->cert->meths_count;
+
+    for ( i = 0; i < numexts; i++ )
+        if ( !parse_one( s, i, context, 0, 0, 0 ) )
+            return 0;
+
+    if ( fin )
+    {
+        for ( i = 0, d = defs; i < 29; i++, d++ )
+            if ( ( d->context & context ) != 0 && d->final != 0 && !d->final( s, context, 1 ) )
+                return 0;
+    }
+    return 1;
+}
+
+/* v5: the early-exit alone - a count of zero skips everything, which is the test
+ * `cbz x7` that /O2 hoists above the register saves in the real function. */
+int v5( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = s->cert->meths_count;
+    const Def *d;
+
+    if ( numexts == 0 )
+        return 1;
+
+    for ( i = 0; i < numexts; i++ )
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+
+    if ( fin )
+    {
+        for ( i = 0, d = defs; i < 29; i++, d++ )
+            if ( ( d->context & context ) != 0 && d->final != 0 && !d->final( s, context, 1 ) )
+                return 0;
+    }
+    return 1;
+}
+
+/* v6: no calls at all, so nothing needs x30 saved. Control shape only. */
+int v6( Conn *s, int context )
+{
+    unsigned long long i, numexts = 29, acc = 0;
+
+    numexts += s->cert->meths_count;
+    for ( i = 0; i < numexts; i++ )
+        acc += ( unsigned long long )( defs[i % 29].context & context );
+    return ( int )acc;
+}

--- a/scripts/arm64_prologue_repro.c
+++ b/scripts/arm64_prologue_repro.c
@@ -144,3 +144,129 @@ int v6( Conn *s, int context )
         acc += ( unsigned long long )( defs[i % 29].context & context );
     return ( int )acc;
 }
+
+/* ---------------------------------------------------------------------------
+ * The real function's frame is 0x70, split by MSVC into `sub sp,sp,#0x60` for
+ * eleven callee-saved registers plus a probed 0x10 for locals - and it is that
+ * probed tail which pulls in `bl __chkstk`. v1..v6 above only reach a 0x50
+ * frame and get no probe at all, so the variants below add register pressure
+ * (many values live across the calls) and an address-taken local.
+ * ------------------------------------------------------------------------- */
+
+extern void sink( unsigned long long *p );
+
+/* v7: v1 plus eight extra values kept live across every call. */
+int v7( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29 + s->cert->meths_count;
+    unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
+    unsigned long long c = chainidx, d = ( unsigned long long )context;
+    unsigned long long e = ( unsigned long long )fin, f = numexts, g = 0, h = 0;
+    const Def *dd;
+
+    for ( i = 0; i < numexts; i++ )
+    {
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+        g += a + b + c + d + e + f;
+        h ^= g + i;
+    }
+    if ( fin )
+    {
+        for ( i = 0, dd = defs; i < 29; i++, dd++ )
+            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
+                return 0;
+    }
+    return ( int )( ( g ^ h ) & 1 );
+}
+
+/* v8: v7 plus an address-taken local, so the frame needs a locals area on top
+ * of the register saves. */
+int v8( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29 + s->cert->meths_count;
+    unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
+    unsigned long long c = chainidx, d = ( unsigned long long )context;
+    unsigned long long e = ( unsigned long long )fin, f = numexts, g = 0, h = 0;
+    unsigned long long local;
+    const Def *dd;
+
+    for ( i = 0; i < numexts; i++ )
+    {
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+        g += a + b + c + d + e + f;
+        h ^= g + i;
+    }
+    local = g ^ h;
+    sink( &local );
+    if ( fin )
+    {
+        for ( i = 0, dd = defs; i < 29; i++, dd++ )
+            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
+                return 0;
+    }
+    return ( int )( local & 1 );
+}
+
+/* v9: v8 with a two-element local array, pushing the locals area to 0x10. */
+int v9( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29 + s->cert->meths_count;
+    unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
+    unsigned long long c = chainidx, d = ( unsigned long long )context;
+    unsigned long long e = ( unsigned long long )fin, f = numexts, g = 0, h = 0;
+    unsigned long long local[2];
+    const Def *dd;
+
+    for ( i = 0; i < numexts; i++ )
+    {
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+        g += a + b + c + d + e + f;
+        h ^= g + i;
+    }
+    local[0] = g;
+    local[1] = h;
+    sink( local );
+    if ( fin )
+    {
+        for ( i = 0, dd = defs; i < 29; i++, dd++ )
+            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
+                return 0;
+    }
+    return ( int )( local[0] & 1 );
+}
+
+/* v10: v9 with the early-exit test written explicitly, which is the shape /O2
+ * hoists above the register saves in the real function. */
+int v10( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29 + s->cert->meths_count;
+    unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
+    unsigned long long c = chainidx, d = ( unsigned long long )context;
+    unsigned long long e = ( unsigned long long )fin, f = numexts, g = 0, h = 0;
+    unsigned long long local[2];
+    const Def *dd;
+
+    if ( numexts == 0 )
+        return 1;
+
+    for ( i = 0; i < numexts; i++ )
+    {
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+        g += a + b + c + d + e + f;
+        h ^= g + i;
+    }
+    local[0] = g;
+    local[1] = h;
+    sink( local );
+    if ( fin )
+    {
+        for ( i = 0, dd = defs; i < 29; i++, dd++ )
+            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
+                return 0;
+    }
+    return ( int )( local[0] & 1 );
+}

--- a/scripts/arm64_prologue_repro.c
+++ b/scripts/arm64_prologue_repro.c
@@ -1,15 +1,18 @@
 /*
- * Candidate shapes for the MSVC ARM64 /O2 /Gs0 prologue defect:
- * `bl __chkstk` is emitted before `str x30`, so the return address is destroyed
- * before it is spilled.
+ * Reducing the MSVC ARM64 /O2 /Gs0 prologue defect: `bl __chkstk` is emitted in
+ * the leading part of the prologue while the callee-saved spills - including lr -
+ * are deferred past an early-exit test, so the call destroys the return address
+ * before it is saved.
  *
  *   cl /c /O2 /Gs0 arm64_prologue_repro.c
  *   dumpbin /disasm:nobytes arm64_prologue_repro.obj
+ *   python arm64_prologue_report.py <listing>
  *
- * A function is BAD when its prologue shows `bl __chkstk` ahead of the
- * instruction that stores x30. v1 mirrors OpenSSL's tls_parse_all_extensions;
- * the others strip one ingredient each, to find which are required.
+ * v7 is the known-bad control (mirrors OpenSSL's tls_parse_all_extensions).
+ * v11..v18 strip one thing at a time to find the smallest form that reproduces.
  */
+
+/* ---- scaffolding used by the v7 control only ------------------------------- */
 
 typedef struct Cert
 {
@@ -30,132 +33,9 @@ typedef struct Def
 } Def;
 
 extern const Def defs[29];
-
 extern int parse_one( Conn *s, unsigned long long i, int ctx, void *exts, void *x, unsigned long long idx );
 
-/* v1: same shape as tls_parse_all_extensions - six parameters, a count read
- * through a two-level dereference of the first one, a loop of calls, then a
- * second loop calling through a table of function pointers. */
-int v1( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
-{
-    unsigned long long i, numexts = 29;
-    const Def *d;
-
-    numexts += s->cert->meths_count;
-
-    for ( i = 0; i < numexts; i++ )
-        if ( !parse_one( s, i, context, exts, x, chainidx ) )
-            return 0;
-
-    if ( fin )
-    {
-        for ( i = 0, d = defs; i < 29; i++, d++ )
-            if ( ( d->context & context ) != 0 && d->final != 0 && !d->final( s, context, 1 ) )
-                return 0;
-    }
-    return 1;
-}
-
-/* v2: v1 without the function-pointer loop. */
-int v2( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
-{
-    unsigned long long i, numexts = 29;
-
-    numexts += s->cert->meths_count;
-    ( void )fin;
-
-    for ( i = 0; i < numexts; i++ )
-        if ( !parse_one( s, i, context, exts, x, chainidx ) )
-            return 0;
-    return 1;
-}
-
-/* v3: v1 without the dereference that produces the loop bound, so no early-exit
- * test can be hoisted ahead of the register saves. */
-int v3( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
-{
-    unsigned long long i;
-    const Def *d;
-
-    for ( i = 0; i < 29; i++ )
-        if ( !parse_one( s, i, context, exts, x, chainidx ) )
-            return 0;
-
-    if ( fin )
-    {
-        for ( i = 0, d = defs; i < 29; i++, d++ )
-            if ( ( d->context & context ) != 0 && d->final != 0 && !d->final( s, context, 1 ) )
-                return 0;
-    }
-    return 1;
-}
-
-/* v4: v1 with fewer parameters. */
-int v4( Conn *s, int context, int fin )
-{
-    unsigned long long i, numexts = 29;
-    const Def *d;
-
-    numexts += s->cert->meths_count;
-
-    for ( i = 0; i < numexts; i++ )
-        if ( !parse_one( s, i, context, 0, 0, 0 ) )
-            return 0;
-
-    if ( fin )
-    {
-        for ( i = 0, d = defs; i < 29; i++, d++ )
-            if ( ( d->context & context ) != 0 && d->final != 0 && !d->final( s, context, 1 ) )
-                return 0;
-    }
-    return 1;
-}
-
-/* v5: the early-exit alone - a count of zero skips everything, which is the test
- * `cbz x7` that /O2 hoists above the register saves in the real function. */
-int v5( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
-{
-    unsigned long long i, numexts = s->cert->meths_count;
-    const Def *d;
-
-    if ( numexts == 0 )
-        return 1;
-
-    for ( i = 0; i < numexts; i++ )
-        if ( !parse_one( s, i, context, exts, x, chainidx ) )
-            return 0;
-
-    if ( fin )
-    {
-        for ( i = 0, d = defs; i < 29; i++, d++ )
-            if ( ( d->context & context ) != 0 && d->final != 0 && !d->final( s, context, 1 ) )
-                return 0;
-    }
-    return 1;
-}
-
-/* v6: no calls at all, so nothing needs x30 saved. Control shape only. */
-int v6( Conn *s, int context )
-{
-    unsigned long long i, numexts = 29, acc = 0;
-
-    numexts += s->cert->meths_count;
-    for ( i = 0; i < numexts; i++ )
-        acc += ( unsigned long long )( defs[i % 29].context & context );
-    return ( int )acc;
-}
-
-/* ---------------------------------------------------------------------------
- * The real function's frame is 0x70, split by MSVC into `sub sp,sp,#0x60` for
- * eleven callee-saved registers plus a probed 0x10 for locals - and it is that
- * probed tail which pulls in `bl __chkstk`. v1..v6 above only reach a 0x50
- * frame and get no probe at all, so the variants below add register pressure
- * (many values live across the calls) and an address-taken local.
- * ------------------------------------------------------------------------- */
-
-extern void sink( unsigned long long *p );
-
-/* v7: v1 plus eight extra values kept live across every call. */
+/* v7: control - known BAD at /O2 /Gs0. */
 int v7( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
 {
     unsigned long long i, numexts = 29 + s->cert->meths_count;
@@ -180,93 +60,143 @@ int v7( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, 
     return ( int )( ( g ^ h ) & 1 );
 }
 
-/* v8: v7 plus an address-taken local, so the frame needs a locals area on top
- * of the register saves. */
-int v8( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+/* ---- reduction candidates -------------------------------------------------- */
+
+extern int call1( unsigned long long i );
+extern void sink( unsigned long long *p );
+
+typedef struct Count
 {
-    unsigned long long i, numexts = 29 + s->cert->meths_count;
+    unsigned long long n;
+} Count;
+
+/* v11: v7 with a plain one-field struct instead of the padded double dereference,
+ * and a one-argument callee. */
+int v11( Count *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i, numexts = 29 + s->n;
     unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
     unsigned long long c = chainidx, d = ( unsigned long long )context;
     unsigned long long e = ( unsigned long long )fin, f = numexts, g = 0, h = 0;
-    unsigned long long local;
-    const Def *dd;
 
     for ( i = 0; i < numexts; i++ )
     {
-        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+        if ( !call1( i ) )
             return 0;
         g += a + b + c + d + e + f;
         h ^= g + i;
     }
-    local = g ^ h;
-    sink( &local );
-    if ( fin )
-    {
-        for ( i = 0, dd = defs; i < 29; i++, dd++ )
-            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
-                return 0;
-    }
-    return ( int )( local & 1 );
+    return ( int )( ( g ^ h ) & 1 );
 }
 
-/* v9: v8 with a two-element local array, pushing the locals area to 0x10. */
-int v9( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+/* v12: loop bound straight from a parameter - no struct, no dereference. */
+int v12( unsigned long long n, unsigned long long a, unsigned long long b, unsigned long long c,
+    unsigned long long d, unsigned long long e, unsigned long long f, unsigned long long h )
 {
-    unsigned long long i, numexts = 29 + s->cert->meths_count;
-    unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
-    unsigned long long c = chainidx, d = ( unsigned long long )context;
-    unsigned long long e = ( unsigned long long )fin, f = numexts, g = 0, h = 0;
-    unsigned long long local[2];
-    const Def *dd;
+    unsigned long long i, g = 0, k = 0;
 
-    for ( i = 0; i < numexts; i++ )
+    for ( i = 0; i < n; i++ )
     {
-        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+        if ( !call1( i ) )
             return 0;
-        g += a + b + c + d + e + f;
-        h ^= g + i;
+        g += a + b + c + d + e + f + h;
+        k ^= g + i;
     }
-    local[0] = g;
-    local[1] = h;
-    sink( local );
-    if ( fin )
-    {
-        for ( i = 0, dd = defs; i < 29; i++, dd++ )
-            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
-                return 0;
-    }
-    return ( int )( local[0] & 1 );
+    return ( int )( ( g ^ k ) & 1 );
 }
 
-/* v10: v9 with the early-exit test written explicitly, which is the shape /O2
- * hoists above the register saves in the real function. */
-int v10( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+/* v13: v12 without the second accumulator. */
+int v13( unsigned long long n, unsigned long long a, unsigned long long b, unsigned long long c,
+    unsigned long long d, unsigned long long e, unsigned long long f, unsigned long long h )
 {
-    unsigned long long i, numexts = 29 + s->cert->meths_count;
-    unsigned long long a = ( unsigned long long )exts, b = ( unsigned long long )x;
-    unsigned long long c = chainidx, d = ( unsigned long long )context;
-    unsigned long long e = ( unsigned long long )fin, f = numexts, g = 0, h = 0;
-    unsigned long long local[2];
-    const Def *dd;
+    unsigned long long i, g = 0;
 
-    if ( numexts == 0 )
+    for ( i = 0; i < n; i++ )
+    {
+        if ( !call1( i ) )
+            return 0;
+        g += a + b + c + d + e + f + h + i;
+    }
+    return ( int )g;
+}
+
+/* v14: v13 with six parameters instead of eight. */
+int v14( unsigned long long n, unsigned long long a, unsigned long long b, unsigned long long c,
+    unsigned long long d, unsigned long long e )
+{
+    unsigned long long i, g = 0;
+
+    for ( i = 0; i < n; i++ )
+    {
+        if ( !call1( i ) )
+            return 0;
+        g += a + b + c + d + e + i;
+    }
+    return ( int )g;
+}
+
+/* v15: v13 with the sum hoisted out of the loop, so fewer values stay live. */
+int v15( unsigned long long n, unsigned long long a, unsigned long long b, unsigned long long c,
+    unsigned long long d, unsigned long long e, unsigned long long f, unsigned long long h )
+{
+    unsigned long long i, g = 0, s = a + b + c + d + e + f + h;
+
+    for ( i = 0; i < n; i++ )
+    {
+        if ( !call1( i ) )
+            return 0;
+        g += s + i;
+    }
+    return ( int )g;
+}
+
+/* v16: v13 with the early exit written explicitly rather than left to the loop. */
+int v16( unsigned long long n, unsigned long long a, unsigned long long b, unsigned long long c,
+    unsigned long long d, unsigned long long e, unsigned long long f, unsigned long long h )
+{
+    unsigned long long i, g = 0;
+
+    if ( n == 0 )
         return 1;
 
-    for ( i = 0; i < numexts; i++ )
+    for ( i = 0; i < n; i++ )
     {
-        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+        if ( !call1( i ) )
             return 0;
-        g += a + b + c + d + e + f;
-        h ^= g + i;
+        g += a + b + c + d + e + f + h + i;
     }
-    local[0] = g;
-    local[1] = h;
-    sink( local );
-    if ( fin )
+    return ( int )g;
+}
+
+/* v17: v13 with no early exit at all - the loop body always runs once. */
+int v17( unsigned long long n, unsigned long long a, unsigned long long b, unsigned long long c,
+    unsigned long long d, unsigned long long e, unsigned long long f, unsigned long long h )
+{
+    unsigned long long i, g = 0;
+
+    for ( i = 0; i <= n; i++ )
     {
-        for ( i = 0, dd = defs; i < 29; i++, dd++ )
-            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
-                return 0;
+        if ( !call1( i ) )
+            return 0;
+        g += a + b + c + d + e + f + h + i;
     }
-    return ( int )( local[0] & 1 );
+    return ( int )g;
+}
+
+/* v18: v13 plus an address-taken local, which made the prologue correct at v7's
+ * size - included to confirm that still holds in the reduced form. */
+int v18( unsigned long long n, unsigned long long a, unsigned long long b, unsigned long long c,
+    unsigned long long d, unsigned long long e, unsigned long long f, unsigned long long h )
+{
+    unsigned long long i, g = 0, local;
+
+    for ( i = 0; i < n; i++ )
+    {
+        if ( !call1( i ) )
+            return 0;
+        g += a + b + c + d + e + f + h + i;
+    }
+    local = g;
+    sink( &local );
+    return ( int )local;
 }

--- a/scripts/arm64_reduce.py
+++ b/scripts/arm64_reduce.py
@@ -46,7 +46,7 @@ def interesting(text):
     for line in r.stdout.decode("utf-8", "replace").splitlines():
         m = FUNC.match(line.strip())
         if m:
-            if name and chk is not None and (lrs is None or chk < lrs):
+            if name and chk is not None and lrs is not None and chk < lrs:
                 return True
             name, chk, lrs = m.group(1), None, None
             idx = 0
@@ -59,7 +59,7 @@ def interesting(text):
         if LR_SAVE.search(low) and lrs is None:
             lrs = idx
         idx += 1
-    return bool(name and chk is not None and (lrs is None or chk < lrs))
+    return bool(name and chk is not None and lrs is not None and chk < lrs)
 
 
 def ddmin(lines):

--- a/scripts/arm64_reduce.py
+++ b/scripts/arm64_reduce.py
@@ -1,0 +1,120 @@
+"""Delta-debug a C file down to the smallest form that still makes MSVC ARM64
+emit `bl __chkstk` ahead of the link-register spill at /O2 /Gs0.
+
+llvm-reduce operates on LLVM IR for a clang pipeline, so it cannot drive MSVC's
+code generator; C-Reduce and cvise are not available on Windows ARM64. This is
+the same idea with `cl` + `dumpbin` as the interestingness test: ddmin over
+lines, then a numeric-shrink pass, then ddmin again.
+
+Usage: python arm64_reduce.py input.c [max_tests]
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+CHKSTK = re.compile(r"chkstk|alloca_probe")
+LR_SAVE = re.compile(r"\b(str|stp)\b.*\b(x30|lr)\b")
+FUNC = re.compile(r"^([A-Za-z_$?][\w$?@]*):$")
+
+tests = 0
+max_tests = 800
+
+
+def interesting(text):
+    """True when the file compiles and some function spills lr after a chkstk call."""
+    global tests
+    tests += 1
+    with open("cand.c", "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(text)
+    for stale in ("cand.obj", "cand.asm"):
+        if os.path.exists(stale):
+            os.remove(stale)
+    r = subprocess.run(
+        ["cl", "/nologo", "/c", "/O2", "/Gs0", "/Fo:cand.obj", "cand.c"],
+        capture_output=True,
+    )
+    if r.returncode != 0 or not os.path.exists("cand.obj"):
+        return False
+    r = subprocess.run(
+        ["dumpbin", "/nologo", "/disasm:nobytes", "cand.obj"], capture_output=True
+    )
+    if r.returncode != 0:
+        return False
+    name, chk, lrs = None, None, None
+    for line in r.stdout.decode("utf-8", "replace").splitlines():
+        m = FUNC.match(line.strip())
+        if m:
+            if name and chk is not None and (lrs is None or chk < lrs):
+                return True
+            name, chk, lrs = m.group(1), None, None
+            idx = 0
+            continue
+        if name is None:
+            continue
+        low = line.lower()
+        if CHKSTK.search(low) and chk is None:
+            chk = idx
+        if LR_SAVE.search(low) and lrs is None:
+            lrs = idx
+        idx += 1
+    return bool(name and chk is not None and (lrs is None or chk < lrs))
+
+
+def ddmin(lines):
+    """Classic ddmin over lines: drop chunks, keep whatever stays interesting."""
+    n = max(len(lines) // 2, 1)
+    while n >= 1:
+        i = 0
+        while i < len(lines):
+            trial = lines[:i] + lines[i + n :]
+            if tests < max_tests and trial and interesting("".join(trial)):
+                lines = trial
+                print("    -%d lines -> %d left" % (n, len(lines)), flush=True)
+            else:
+                i += n
+        if n == 1:
+            break
+        n = max(n // 2, 1)
+    return lines
+
+
+def shrink_numbers(text):
+    """Try smaller values for every literal; frame layout may not need the big ones."""
+    for lit in sorted(set(re.findall(r"0x[0-9a-fA-F]+|\b\d{2,}\b", text)), key=len, reverse=True):
+        for repl in ("0x8", "2", "1"):
+            if lit == repl or tests >= max_tests:
+                continue
+            trial = text.replace(lit, repl)
+            if trial != text and interesting(trial):
+                print("    %s -> %s" % (lit, repl), flush=True)
+                text = trial
+                break
+    return text
+
+
+def main():
+    src = open(sys.argv[1], encoding="utf-8").read()
+    global max_tests
+    if len(sys.argv) > 2:
+        max_tests = int(sys.argv[2])
+
+    if not interesting(src):
+        print("input is NOT interesting - nothing to reduce", flush=True)
+        return 1
+    print("input reproduces; reducing (budget %d compiles)" % max_tests, flush=True)
+
+    lines = ddmin(src.splitlines(keepends=True))
+    text = shrink_numbers("".join(lines))
+    text = "".join(ddmin(text.splitlines(keepends=True)))
+
+    print("\n==== compiles used: %d" % tests, flush=True)
+    print("==== reduced source ====", flush=True)
+    print(text, flush=True)
+    open("reduced.c", "w", encoding="utf-8", newline="\n").write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/arm64_reduce_input.c
+++ b/scripts/arm64_reduce_input.c
@@ -1,0 +1,33 @@
+typedef struct Cert { char pad[0x88]; unsigned long long meths_count; } Cert;
+typedef struct Conn { char pad[0x878]; Cert *cert; } Conn;
+typedef struct Def { int context; int ( *final )( Conn *, int, int ); } Def;
+extern const Def defs[29];
+extern int parse_one( Conn *s, unsigned long long i, int ctx, void *exts, void *x, unsigned long long idx );
+int repro( Conn *s, int context, void *exts, void *x, unsigned long long chainidx, int fin )
+{
+    unsigned long long i;
+    unsigned long long numexts = 29 + s->cert->meths_count;
+    unsigned long long a = ( unsigned long long )exts;
+    unsigned long long b = ( unsigned long long )x;
+    unsigned long long c = chainidx;
+    unsigned long long d = ( unsigned long long )context;
+    unsigned long long e = ( unsigned long long )fin;
+    unsigned long long f = numexts;
+    unsigned long long g = 0;
+    unsigned long long h = 0;
+    const Def *dd;
+    for ( i = 0; i < numexts; i++ )
+    {
+        if ( !parse_one( s, i, context, exts, x, chainidx ) )
+            return 0;
+        g += a + b + c + d + e + f;
+        h ^= g + i;
+    }
+    if ( fin )
+    {
+        for ( i = 0, dd = defs; i < 29; i++, dd++ )
+            if ( ( dd->context & context ) != 0 && dd->final != 0 && !dd->final( s, context, 1 ) )
+                return 0;
+    }
+    return ( int )( ( g ^ h ) & 1 );
+}

--- a/source/MRTest/MRCPRTests.cpp
+++ b/source/MRTest/MRCPRTests.cpp
@@ -5,6 +5,7 @@
 #include <curl/curl.h>
 #include "MRPch/MRSpdlog.h"
 #include <gtest/gtest.h>
+#include <string_view>
 
 constexpr int MAX_RETRIES = 10;
 constexpr std::chrono::seconds COOLDOWN_PERIOD { 10 };
@@ -44,6 +45,74 @@ TEST( MRViewer, CPRSslBackends )
     {
         spdlog::info( "libcurl reports a single SSL backend (no list available)" );
     }
+}
+
+namespace
+{
+
+size_t discardBody( char *, size_t size, size_t nmemb, void * )
+{
+    return size * nmemb;
+}
+
+int curlTrace( CURL *, curl_infotype type, char * data, size_t size, void * )
+{
+    if ( type == CURLINFO_TEXT )
+        spdlog::info( "curl: {}", std::string_view( data, size ) );
+    return 0;
+}
+
+} // namespace
+
+// Raw libcurl request without cpr: tells a cpr bug from a libcurl one.
+// Every step is logged so a crash points at the exact call that faulted.
+TEST( MRViewer, CurlRawGet )
+{
+    const char * backendEnv = std::getenv( "CURL_SSL_BACKEND" );
+    spdlog::info( "raw: env CURL_SSL_BACKEND={}", backendEnv ? backendEnv : "<unset>" );
+
+    spdlog::info( "raw: curl_global_init..." );
+    const auto initRes = curl_global_init( CURL_GLOBAL_ALL );
+    spdlog::info( "raw: curl_global_init -> {}", (int)initRes );
+    ASSERT_EQ( initRes, CURLE_OK );
+
+    spdlog::info( "raw: libcurl now reports: {}", curl_version() );
+
+    spdlog::info( "raw: curl_easy_init..." );
+    CURL * h = curl_easy_init();
+    spdlog::info( "raw: curl_easy_init -> {}", (const void *)h );
+    ASSERT_NE( h, nullptr );
+
+    curl_easy_setopt( h, CURLOPT_URL, "https://postman-echo.com/get" );
+    curl_easy_setopt( h, CURLOPT_TIMEOUT_MS, 8000L );
+    curl_easy_setopt( h, CURLOPT_WRITEFUNCTION, &discardBody );
+    curl_easy_setopt( h, CURLOPT_VERBOSE, 1L );
+    curl_easy_setopt( h, CURLOPT_DEBUGFUNCTION, &curlTrace );
+    spdlog::info( "raw: options set" );
+
+    spdlog::info( "raw: curl_easy_perform..." );
+    const auto res = curl_easy_perform( h );
+    spdlog::info( "raw: curl_easy_perform -> {} ({})", (int)res, curl_easy_strerror( res ) );
+
+    long code = 0;
+    curl_easy_getinfo( h, CURLINFO_RESPONSE_CODE, &code );
+    spdlog::info( "raw: response code {}", code );
+    curl_easy_cleanup( h );
+    EXPECT_EQ( res, CURLE_OK );
+}
+
+// CPRTestGet with curl's verbose trace, to see how far the request gets.
+TEST( MRViewer, CPRTestGetVerbose )
+{
+    spdlog::info( "cpr verbose: constructing session" );
+    cpr::Session session;
+    session.SetUrl( cpr::Url{ "https://postman-echo.com/get" } );
+    session.SetTimeout( cpr::Timeout{ 8000 } );
+    session.SetVerbose( cpr::Verbose{ true } );
+    spdlog::info( "cpr verbose: session ready, calling Get" );
+    const auto resp = session.Get();
+    spdlog::info( "cpr verbose: status {}, curl error {} ({})", resp.status_code,
+        (int32_t)resp.error.code, resp.error.message );
 }
 
 TEST( MRViewer, CPRTestGet )

--- a/source/MRTest/MRCPRTests.cpp
+++ b/source/MRTest/MRCPRTests.cpp
@@ -86,6 +86,20 @@ LONG NTAPI logFaultPc( EXCEPTION_POINTERS * info )
     for ( int i = 0; i < 29; ++i )
         regs += fmt::format( "x{}={:#x} ", i, (uintptr_t)c->X[i] );
     spdlog::critical( "FAULT regs {}", regs );
+    // Fingerprint the code that actually ran, so the disassembly can be matched offline.
+    if ( mod )
+    {
+        const auto * dos = (const IMAGE_DOS_HEADER *)mod;
+        const auto * nt = (const IMAGE_NT_HEADERS64 *)( (const char *)mod + dos->e_lfanew );
+        spdlog::critical( "FAULT module stamp={:#x} sizeOfImage={:#x} checksum={:#x}",
+            (unsigned)nt->FileHeader.TimeDateStamp, (unsigned)nt->OptionalHeader.SizeOfImage,
+            (unsigned)nt->OptionalHeader.CheckSum );
+    }
+    std::string code;
+    const auto * words = (const unsigned int *)( pc - 16 );
+    for ( int i = 0; i < 9; ++i )
+        code += fmt::format( "{}{:08x} ", i == 4 ? "[pc]" : "", words[i] );
+    spdlog::critical( "FAULT code {}", code );
     // Return addresses live on the stack; a raw scan beats a broken unwinder.
     std::string cands;
     const auto * stack = (const uintptr_t *)c->Sp;

--- a/source/MRTest/MRCPRTests.cpp
+++ b/source/MRTest/MRCPRTests.cpp
@@ -5,7 +5,12 @@
 #include <curl/curl.h>
 #include "MRPch/MRSpdlog.h"
 #include <gtest/gtest.h>
+#include <string>
 #include <string_view>
+#include "MRPch/MRFmt.h"
+#ifdef _WIN32
+#include "MRPch/MRWinapi.h"
+#endif
 
 constexpr int MAX_RETRIES = 10;
 constexpr std::chrono::seconds COOLDOWN_PERIOD { 10 };
@@ -50,6 +55,69 @@ TEST( MRViewer, CPRSslBackends )
 namespace
 {
 
+#ifdef _WIN32
+// The default handler logs only the faulting DATA address; the faulting PC (and the
+// register that held the bad value) is what identifies the instruction. Unwinding
+// through OpenSSL's arm64 assembly fails, so the stacktrace alone is useless here.
+LONG NTAPI logFaultPc( EXCEPTION_POINTERS * info )
+{
+    const auto * er = info->ExceptionRecord;
+    if ( er->ExceptionCode != EXCEPTION_ACCESS_VIOLATION )
+        return EXCEPTION_CONTINUE_SEARCH;
+
+    const auto pc = (uintptr_t)er->ExceptionAddress;
+    HMODULE mod = nullptr;
+    char path[MAX_PATH] = {};
+    uintptr_t rva = 0;
+    if ( GetModuleHandleExA( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+             (LPCSTR)pc, &mod ) && mod )
+    {
+        GetModuleFileNameA( mod, path, MAX_PATH );
+        rva = pc - (uintptr_t)mod;
+    }
+    spdlog::critical( "FAULT pc={:#x} module={} base={:#x} rva={:#x} access={} addr={:#x}",
+        pc, path[0] ? path : "<unknown>", (uintptr_t)mod, rva,
+        (size_t)er->ExceptionInformation[0], (size_t)er->ExceptionInformation[1] );
+#if defined( _M_ARM64 )
+    const auto * c = info->ContextRecord;
+    spdlog::critical( "FAULT arm64 pc={:#x} lr={:#x} sp={:#x} fp={:#x}",
+        (uintptr_t)c->Pc, (uintptr_t)c->Lr, (uintptr_t)c->Sp, (uintptr_t)c->Fp );
+    std::string regs;
+    for ( int i = 0; i < 29; ++i )
+        regs += fmt::format( "x{}={:#x} ", i, (uintptr_t)c->X[i] );
+    spdlog::critical( "FAULT regs {}", regs );
+    // Return addresses live on the stack; a raw scan beats a broken unwinder.
+    std::string cands;
+    const auto * stack = (const uintptr_t *)c->Sp;
+    for ( int i = 0; i < 64; ++i )
+    {
+        const auto v = stack[i];
+        HMODULE m = nullptr;
+        char p2[MAX_PATH] = {};
+        if ( v > 0x10000 && GetModuleHandleExA( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                 (LPCSTR)v, &m ) && m )
+        {
+            GetModuleFileNameA( m, p2, MAX_PATH );
+            const std::string_view sv( p2 );
+            const auto slash = sv.find_last_of( "/" );
+            cands += fmt::format( "[sp+{:#x}] {}+{:#x}  ", i * 8,
+                slash == std::string_view::npos ? sv : sv.substr( slash + 1 ), v - (uintptr_t)m );
+        }
+    }
+    spdlog::critical( "FAULT stack return-address candidates: {}", cands );
+#endif
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+const struct FaultPcLoggerInstaller
+{
+    FaultPcLoggerInstaller()
+    {
+        AddVectoredExceptionHandler( 1, logFaultPc );
+    }
+} faultPcLoggerInstaller;
+#endif
+
 size_t discardBody( char *, size_t size, size_t nmemb, void * )
 {
     return size * nmemb;
@@ -66,7 +134,9 @@ int curlTrace( CURL *, curl_infotype type, char * data, size_t size, void * )
 
 // Raw libcurl request without cpr: tells a cpr bug from a libcurl one.
 // Every step is logged so a crash points at the exact call that faulted.
-TEST( MRViewer, CurlRawGet )
+// nativeCa mirrors what cpr::SslOptions{} does (CURLSSLOPT_NATIVE_CA), which is
+// a no-op for Schannel but makes OpenSSL import the Windows certificate store.
+static void rawGet( bool nativeCa )
 {
     const char * backendEnv = std::getenv( "CURL_SSL_BACKEND" );
     spdlog::info( "raw: env CURL_SSL_BACKEND={}", backendEnv ? backendEnv : "<unset>" );
@@ -88,7 +158,12 @@ TEST( MRViewer, CurlRawGet )
     curl_easy_setopt( h, CURLOPT_WRITEFUNCTION, &discardBody );
     curl_easy_setopt( h, CURLOPT_VERBOSE, 1L );
     curl_easy_setopt( h, CURLOPT_DEBUGFUNCTION, &curlTrace );
-    spdlog::info( "raw: options set" );
+    if ( nativeCa )
+    {
+        spdlog::info( "raw: setting CURLSSLOPT_NATIVE_CA" );
+        curl_easy_setopt( h, CURLOPT_SSL_OPTIONS, (long)CURLSSLOPT_NATIVE_CA );
+    }
+    spdlog::info( "raw: options set (nativeCa={})", nativeCa );
 
     spdlog::info( "raw: curl_easy_perform..." );
     const auto res = curl_easy_perform( h );
@@ -99,6 +174,16 @@ TEST( MRViewer, CurlRawGet )
     spdlog::info( "raw: response code {}", code );
     curl_easy_cleanup( h );
     EXPECT_EQ( res, CURLE_OK );
+}
+
+TEST( MRViewer, CurlRawGet )
+{
+    rawGet( false );
+}
+
+TEST( MRViewer, CurlRawGetNativeCa )
+{
+    rawGet( true );
 }
 
 // CPRTestGet with curl's verbose trace, to see how far the request gets.


### PR DESCRIPTION
**Throwaway CI experiment — do not merge.**

MeshLib's Windows arm64 legs run `MRViewer.CPRTestGet`/`CPRTestPost` on every PR and they pass, because plain `cpr` gets a **Schannel-only** libcurl:

```
[info] libcurl version: libcurl/8.21.0 Schannel zlib/1.3.2
[info] libcurl SSL backend [0]: schannel (id=8)
[  OK  ] MRViewer.CPRTestGet (241 ms)
```

A downstream Windows app appends `curl[openssl]` to the same requirements file, which makes vcpkg build a **MultiSSL** libcurl (`OpenSSL/3.6.3 (Schannel)`, backends `openssl` + `schannel`). With that build, arm64 crashes with an access violation reading `0x879` inside `cpr::Session::Get` on the first HTTPS request; the identical x64 build is fine, and forcing the Schannel backend at runtime does not help — so the suspect is the MultiSSL backend dispatch on arm64 rather than OpenSSL's TLS code.

This branch adds `curl[openssl]` to `requirements/windows.txt` to see whether the crash follows the MultiSSL libcurl into MeshLib's own arm64 MRTest.

Scope trimming (throwaway, so the leg is cheap):
- Windows minimal matrix reduced to the two arm64 vs2026 legs.
- `skip-image-rebuild` so the `requirements/windows.txt` change does not fire the four-triplet `windows-vcpkg-build-upload` prepare job; the build jobs install their own deps with `--write-s3`.
- All non-Windows platforms disabled by label.

Expected outcome: `MRViewer.CPRTestGet` crashes/fails on arm64 → confirms MultiSSL libcurl as the cause and makes MeshLib the minimal reproducer. If it passes, something outside libcurl's feature set is at fault.
