### PR TITLE
Bracket the three phases of compressZip

### DIFF
--- a/source/MRMesh/MRZip.cpp
+++ b/source/MRMesh/MRZip.cpp
@@ -418,6 +418,8 @@ Expected<void> compressZip( const std::filesystem::path& zipFile, const std::fil
         }
     }
 
+    spdlog::info( "Compressing {} files into {}", files.size(), utf8string( zipFile ) );
+
     // pass #2: deflate each file in parallel, then hand libzip pre-deflated bytes via a source
     // callback — libzip's trust-source fast path copies them into the archive without recompressing.
     // level 0 (the settings-level "use default") normalizes to 6 — zlib's internal default is 6,
@@ -463,11 +465,14 @@ Expected<void> compressZip( const std::filesystem::path& zipFile, const std::fil
     if ( hadError.load() )
         return unexpected( std::move( firstError ) );
 
+    spdlog::info( "Deflated {} files, writing the archive", files.size() );
+
     // Phase B — serial hand-off to libzip; the AutoCloseZip keeps entries alive through zip_close
     if ( auto res = zip.addPreDeflatedEntries( std::move( entries ), files, level, settings.password ); !res )
         return res;
 
     auto closeRes = zip.close();
+    spdlog::info( "Compressed {} files into {}", files.size(), utf8string( zipFile ) );
 
     if ( !reportProgress( settings.cb, 1.0f ) )
         return unexpectedOperationCanceled();


### PR DESCRIPTION
Two of the seven wasm import stalls we have seen are inside `compressZip`, and unlike `decompressZip` since #6656 it writes nothing to the log -- so the 08-27 trace could only say the app went silent somewhere in there. `compressZip` reports progress only when handed a callback, and the STEP upload path passes default settings, so log lines are the only signal available.

Three lines split it into the phases that can each hang separately:

| last line | still to run |
|---|---|
| *(nothing)* | the `DirectoryRecursive` walk and the `zip_dir_add` calls |
| `Compressing N files into <zip>` | the parallel deflate -- one `ifstream` read per file, several threads in the filesystem at once |
| `Deflated N files, writing the archive` | the serial hand-off to libzip and `zip_close` |
| `Compressed N files into <zip>` | done |

That middle window is the interesting one: it is the only place in either zip direction where several threads touch the filesystem simultaneously, and the stalls have all been filesystem calls on worker threads (08-26 pinned two of them to the `ofstream` constructor and to `ofs.write`).

Three info lines per archive, on a path that runs once per scene save or STEP upload. `MRMesh` builds clean with MSVC `/Wall /WX`.
