### PR TITLE
DO NOT MERGE: MEMFS stress on 2 CPUs with a shared-log writer

### DIFF
--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -306,15 +306,15 @@ jobs:
   emscripten-test:
     if: ${{ !inputs.definitions_only }}
     needs: emscripten-build
-    timeout-minutes: 10
+    timeout-minutes: 25
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
         package_name:
-          - emscripten-singlethreaded
-          - emscripten-multithreaded
           - emscripten-multithreaded-64bit
+          - emscripten-multithreaded
+        shard: [1, 2, 3, 4]
 
     steps:
       - name: Download MRTest bundle
@@ -326,12 +326,12 @@ jobs:
           run-id: ${{ github.run_id }}
 
       - name: Unit Tests
-        timeout-minutes: 5
+        timeout-minutes: 20
         working-directory: mrtest-bundle
         run: |
-          python3 emrun.py \
+          taskset -c 0,1 python3 emrun.py \
             --browser=/usr/bin/firefox \
             --browser-args="--headless" \
             --safe-firefox-profile \
             --kill-exit \
-            ./MRTest.html
+            ./MRTest.html -- --gtest_filter=MRMesh.MemfsConcurrentStress

--- a/source/MRTest/MRMemfsStressTests.cpp
+++ b/source/MRTest/MRMemfsStressTests.cpp
@@ -1,0 +1,224 @@
+#include "MRMesh/MRUniqueTemporaryFolder.h"
+#include "MRPch/MRSpdlog.h"
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if defined( __EMSCRIPTEN__ ) && defined( __EMSCRIPTEN_PTHREADS__ )
+#include <emscripten/threading.h>
+#endif
+
+namespace MR
+{
+
+namespace
+{
+
+#ifdef __EMSCRIPTEN__
+constexpr int cSeconds = 480;
+#else
+// desktop CI runs this file too, and the target is a wasm-only suspicion there
+constexpr int cSeconds = 2;
+#endif
+
+/// entry sizes taken from the archives the app has stalled on
+constexpr size_t cSizes[] = { 195, 78603, 245796, 1021928 };
+
+/// one round of exactly what the zip paths ask of the filesystem: make sure the parent
+/// exists, write a file, read it back, drop it
+bool fileRound( const std::filesystem::path& dir, int tid, long long i, std::vector<char>& buf )
+{
+    std::error_code ec;
+    const auto sub = dir / ( "t" + std::to_string( tid ) );
+    if ( !std::filesystem::exists( sub, ec ) )
+        std::filesystem::create_directories( sub, ec );
+
+    const size_t size = cSizes[i % 4];
+    const auto path = sub / ( std::to_string( i % 4 ) + ".bin" );
+    buf.assign( size, char( i ) );
+
+    {
+        std::ofstream ofs( path, std::ios::binary );
+        if ( !ofs )
+            return false;
+        if ( !ofs.write( buf.data(), (std::streamsize)buf.size() ) )
+            return false;
+        ofs.close();
+    }
+    {
+        std::ifstream ifs( path, std::ios::binary );
+        if ( !ifs )
+            return false;
+        ifs.read( buf.data(), (std::streamsize)buf.size() );
+        if ( (size_t)ifs.gcount() != size )
+            return false;
+    }
+    std::filesystem::remove( path, ec );
+    return true;
+}
+
+#if !defined( __EMSCRIPTEN__ ) || defined( __EMSCRIPTEN_PTHREADS__ )
+
+constexpr int cStallSeconds = 60;
+
+/// mimics spdlog's rotating_file_sink_mt with flush_on( info ): one file, held open, one
+/// write plus flush per message, on a thread other than the one writing the zip entries.
+/// The app has exactly this pair and the singlethreaded build has neither.
+void appendForever( const std::filesystem::path& path, const std::atomic<bool>& stop,
+    std::atomic<long long>& lines )
+{
+    std::ofstream ofs( path, std::ios::binary | std::ios::app );
+    if ( !ofs )
+        return;
+    while ( !stop.load( std::memory_order_acquire ) )
+    {
+        ofs << "[info] a line of about the length the app writes, with a path in it" << char( 10 );
+        ofs.flush();
+        lines.fetch_add( 1, std::memory_order_relaxed );
+    }
+}
+
+/// PTHREAD_POOL_SIZE is navigator.hardwareConcurrency, and a thread past that one needs a
+/// Worker spawned on demand, which needs the main thread to reach the browser event loop --
+/// which this test's watchdog never does. Asking for more than the pool holds therefore
+/// deadlocks the test itself and says nothing about the filesystem. The appender takes one
+/// slot, so the file workers get the rest.
+int poolSizedThreadCount()
+{
+    const unsigned hc = std::thread::hardware_concurrency();
+    return std::max( 1, int( hc ? hc : 4 ) - 1 );
+}
+
+/// keeps this thread awake without parking it on a futex; on the emscripten main thread
+/// it also drains the proxying queue, which is what the app's UI thread does between frames
+void stayAwake( int ms )
+{
+#if defined( __EMSCRIPTEN__ ) && defined( __EMSCRIPTEN_PTHREADS__ )
+    emscripten_thread_sleep( ms );
+#else
+    std::this_thread::sleep_for( std::chrono::milliseconds( ms ) );
+#endif
+}
+
+/// a wedged thread cannot be joined, so the process has to leave without it
+[[noreturn]] void leaveNow( int code )
+{
+#ifdef __EMSCRIPTEN__
+    emscripten_force_exit( code );
+#endif
+    std::_Exit( code );
+}
+
+#endif
+
+} // namespace
+
+// Every stall seen in the field has been a filesystem call on a worker thread: twice inside
+// compressZip, whose ParallelFor puts several threads in the filesystem at once, and four
+// times inside decompressZip, once pinned to the ofstream constructor and once to ofs.write.
+// The singlethreaded build has never stalled. So this hammers MEMFS from more threads than
+// the runner has cores, with no zip and no scene code in the way: if it wedges, the
+// reproducer is small enough to hand upstream.
+TEST( MRMesh, MemfsConcurrentStress )
+{
+    UniqueTemporaryFolder folder;
+    ASSERT_TRUE( bool( folder ) );
+    const std::filesystem::path dir = folder;
+
+#if !defined( __EMSCRIPTEN__ ) || defined( __EMSCRIPTEN_PTHREADS__ )
+    std::atomic<long long> done{ 0 };
+    std::atomic<int> finished{ 0 };
+    std::atomic<bool> broken{ false };
+    const int cThreads = poolSizedThreadCount();
+    spdlog::info( "{} threads, {} s", cThreads, cSeconds );
+    std::vector<std::atomic<long long>> perThread( cThreads );
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds( cSeconds );
+    std::vector<std::thread> threads;
+    threads.reserve( size_t( cThreads ) );
+    for ( int tid = 0; tid < cThreads; ++tid )
+    {
+        threads.emplace_back( [&, tid]
+        {
+            std::vector<char> buf;
+            for ( long long i = 0; std::chrono::steady_clock::now() < deadline && !broken.load( std::memory_order_acquire ); ++i )
+            {
+                if ( !fileRound( dir, tid, i, buf ) )
+                {
+                    broken.store( true, std::memory_order_release );
+                    break;
+                }
+                perThread[tid].fetch_add( 1, std::memory_order_relaxed );
+                done.fetch_add( 1, std::memory_order_relaxed );
+            }
+            finished.fetch_add( 1, std::memory_order_release );
+        } );
+    }
+
+    std::atomic<bool> stopAppender{ false };
+    std::atomic<long long> logLines{ 0 };
+    std::thread appender( appendForever, dir / "shared.log", std::cref( stopAppender ), std::ref( logLines ) );
+
+    long long seen = 0;
+    int ticks = 0;
+    auto lastProgress = std::chrono::steady_clock::now();
+    while ( finished.load( std::memory_order_acquire ) < cThreads )
+    {
+        stayAwake( 250 );
+
+        const long long now = done.load( std::memory_order_relaxed );
+        if ( now != seen )
+        {
+            seen = now;
+            lastProgress = std::chrono::steady_clock::now();
+        }
+        else
+        {
+            const auto idle = std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - lastProgress ).count();
+            if ( idle >= cStallSeconds )
+            {
+                spdlog::error( "STALLED: no filesystem progress for {} s after {} rounds, {} log lines",
+                    idle, seen, logLines.load( std::memory_order_relaxed ) );
+                for ( int tid = 0; tid < cThreads; ++tid )
+                    spdlog::error( "  thread {}: {} rounds, finished {}", tid,
+                        perThread[tid].load( std::memory_order_relaxed ),
+                        finished.load( std::memory_order_relaxed ) );
+                leaveNow( 3 );
+            }
+        }
+
+        // once every five seconds, so a stalled log shows this thread alive next to silent workers
+        if ( ++ticks % 20 == 0 )
+            spdlog::info( "{} rounds across {} threads", seen, cThreads );
+    }
+
+    stopAppender.store( true, std::memory_order_release );
+    appender.join();
+    for ( auto& t : threads )
+        t.join();
+
+    ASSERT_FALSE( broken.load( std::memory_order_acquire ) ) << "a filesystem call failed";
+    spdlog::info( "done: {} rounds in {} s across {} threads, {} shared-log lines",
+        seen, cSeconds, cThreads, logLines.load( std::memory_order_relaxed ) );
+    EXPECT_GT( seen, 0 );
+#else
+    std::vector<char> buf;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds( cSeconds );
+    long long i = 0;
+    for ( ; std::chrono::steady_clock::now() < deadline; ++i )
+        ASSERT_TRUE( fileRound( dir, 0, i, buf ) ) << "round " << i;
+    spdlog::info( "done: {} single-threaded rounds", i );
+    EXPECT_GT( i, 0 );
+#endif
+}
+
+} // namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -8,6 +8,14 @@
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
@@ -36,6 +44,7 @@
     <ClCompile Include="MRGridSamplingTests.cpp" />
     <ClCompile Include="MRICPTests.cpp" />
     <ClCompile Include="MRLaplacianTests.cpp" />
+    <ClCompile Include="MRMemfsStressTests.cpp" />
     <ClCompile Include="MRMarchingCubesTests.cpp" />
     <ClCompile Include="MRMeshBooleanTests.cpp" />
     <ClCompile Include="MRMeshComponentsTests.cpp" />
@@ -43,8 +52,8 @@
     <ClCompile Include="MRMeshIntersectTests.cpp" />
     <ClCompile Include="MRMeshLoadSaveTest.cpp" />
     <ClCompile Include="MRMeshMeshDistanceTests.cpp" />
-    <ClCompile Include="MRMemfsStressTests.cpp" />
     <ClCompile Include="MRMeshTests.cpp" />
+    <ClCompile Include="MRMeshToPointCloudTests.cpp" />
     <ClCompile Include="MRMeshTopologyTests.cpp" />
     <ClCompile Include="MRMultiwayICPTests.cpp" />
     <ClCompile Include="MRNaNTest.cpp" />
@@ -116,6 +125,7 @@
     <ClCompile Include="MRPolylineSubdivideTests.cpp" />
     <ClCompile Include="MRPolylineTopologyTests.cpp" />
     <ClCompile Include="MRQuadraticFormTests.cpp" />
+    <ClCompile Include="MRRayBoxIntersectionTests.cpp" />
     <ClCompile Include="MRRectIndexerTests.cpp" />
     <ClCompile Include="MRRegionBoundaryTests.cpp" />
     <ClCompile Include="MRRegularGridMeshTests.cpp" />
@@ -163,12 +173,12 @@
     <RootNamespace>MRTest</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
@@ -180,16 +190,16 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)'=='Debug'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)'=='Release'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <Import Project="$(ProjectDir)\..\common.props" />
   <Import Project="$(ProjectDir)\..\MimallocRedirect.props" />
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Disabled</Optimization>
@@ -206,7 +216,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -8,14 +8,6 @@
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|ARM64">
-      <Configuration>Debug</Configuration>
-      <Platform>ARM64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM64">
-      <Configuration>Release</Configuration>
-      <Platform>ARM64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
@@ -51,8 +43,8 @@
     <ClCompile Include="MRMeshIntersectTests.cpp" />
     <ClCompile Include="MRMeshLoadSaveTest.cpp" />
     <ClCompile Include="MRMeshMeshDistanceTests.cpp" />
+    <ClCompile Include="MRMemfsStressTests.cpp" />
     <ClCompile Include="MRMeshTests.cpp" />
-    <ClCompile Include="MRMeshToPointCloudTests.cpp" />
     <ClCompile Include="MRMeshTopologyTests.cpp" />
     <ClCompile Include="MRMultiwayICPTests.cpp" />
     <ClCompile Include="MRNaNTest.cpp" />
@@ -124,7 +116,6 @@
     <ClCompile Include="MRPolylineSubdivideTests.cpp" />
     <ClCompile Include="MRPolylineTopologyTests.cpp" />
     <ClCompile Include="MRQuadraticFormTests.cpp" />
-    <ClCompile Include="MRRayBoxIntersectionTests.cpp" />
     <ClCompile Include="MRRectIndexerTests.cpp" />
     <ClCompile Include="MRRegionBoundaryTests.cpp" />
     <ClCompile Include="MRRegularGridMeshTests.cpp" />
@@ -172,12 +163,12 @@
     <RootNamespace>MRTest</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
@@ -189,16 +180,16 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)'=='Debug'">
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)'=='Release'">
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <Import Project="$(ProjectDir)\..\common.props" />
   <Import Project="$(ProjectDir)\..\MimallocRedirect.props" />
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Disabled</Optimization>
@@ -215,7 +206,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>


### PR DESCRIPTION
**Throwaway experiment -- do not merge, do not review.** Deleted once it has answered.

Fourth attempt at a reproducer for the wasm import stall, aimed at the two differences between the failing environment and every attempt that came back clean.

**Two CPUs.** Every stall has been on MIC's private `ubuntu-latest`, which is **2 cores**. #6659's 49,600 loads and #6701's ~890,000 filesystem rounds all ran on 4-core runners, so nothing has been tested at the contention the app actually sees. emrun now runs under `taskset -c 0,1`.

**A shared file, held open, flushed per line.** The app pairs one thread writing zip entries with another holding a log file open and flushing every message -- `setupLoggerByDefault` installs a `rotating_file_sink_mt` and calls `flush_on( minLevel )`. #6701 gave every thread its own files, so it never had that. There is now an appender thread doing exactly that against one shared file while the workers write their own.

Workers leave a pool slot for the appender: asking for more threads than `PTHREAD_POOL_SIZE` deadlocks the test itself, as the first run of #6701 demonstrated (threads past the pool need a Worker spawned on demand, which needs the main thread at the browser event loop, which the watchdog never allows).

480 s per shard, 4 shards on each multithreaded config. The watchdog exits 3 if the round counter stops for 60 s, printing every thread's tally and the log-line count.

Expectation: maybe one in four. If it comes back clean, the upstream report goes in with the two bracketed traces and an explicit "no minimal reproducer", listing what has been ruled out.

Refs MeshInspector/MeshInspectorCode#7724.
