### PR TITLE
Wasm package: namespace c-blosc's bundled lz4 and libjpeg-turbo to avoid clashing with Unity's copies

### DIFF
--- a/.github/workflows/build-test-emscripten-c-bindings.yml
+++ b/.github/workflows/build-test-emscripten-c-bindings.yml
@@ -138,6 +138,10 @@ jobs:
           #   bundles a zlib under the standard names, and renaming it would redirect every zlib call
           #   in the package to that copy. So the lz4 members are split into their own archive, which is
           #   then namespaced like the ports (libblosc.a ends up referencing mrml_LZ4_*).
+          # Unity's libjpeg leaks its internals the same way (`jcopy_block_row`, `jdiv_round_up`, `jinit_*`, ...),
+          #   which our libjpeg-turbo archives also define; that collides as soon as a game uses ImageConversion.
+          #   Both archives are namespaced together (they share the same internals), and the originals are dropped
+          #   from the package since libMRIOExtras.a is rewritten to reference mrml_tj*.
           AR=${EMSDK}/upstream/bin/llvm-ar
           mkdir -p lz4_split
           (cd lz4_split && ${AR} x ../${OUT_DIR}/libblosc.a lz4.c.o lz4hc.c.o && ${AR} qc liblz4.a lz4.c.o lz4hc.c.o)
@@ -150,7 +154,9 @@ jobs:
             --out-dir namespaced_deps \
             --lib libfreetype --lib libpng --private-lib libz=libzlib \
             --lib lz4_split/liblz4.a=liblz4 \
+            --lib ${OUT_DIR}/libjpeg.a=libjpeg --lib ${OUT_DIR}/libturbojpeg.a=libturbojpeg \
             ${{ matrix.config == 'Multithreaded' && '--pthread' || '' }}
+          rm ${OUT_DIR}/libjpeg.a ${OUT_DIR}/libturbojpeg.a
           cp namespaced_deps/*.a ${OUT_DIR}
 
       - name: Upload to Artifacts

--- a/.github/workflows/build-test-emscripten-c-bindings.yml
+++ b/.github/workflows/build-test-emscripten-c-bindings.yml
@@ -132,6 +132,16 @@ jobs:
           #   FT_*/png_* undefined). Ship them namespaced, because engines like Unity statically
           #   link their own trimmed freetype/libpng/zlib whose globals collide with vanilla copies;
           #   the package archives referencing them are rewritten in place to the new names.
+          # Unity also links its own lz4, and its renaming of that library leaks a few globals
+          #   (`read_long_length_no_check`, `LZ4_decompress_safe_partial_*`) that collide with the lz4
+          #   c-blosc bundles into libblosc.a. Only the lz4 objects may be renamed: libblosc.a also
+          #   bundles a zlib under the standard names, and renaming it would redirect every zlib call
+          #   in the package to that copy. So the lz4 members are split into their own archive, which is
+          #   then namespaced like the ports (libblosc.a ends up referencing mrml_LZ4_*).
+          AR=${EMSDK}/upstream/bin/llvm-ar
+          mkdir -p lz4_split
+          (cd lz4_split && ${AR} x ../${OUT_DIR}/libblosc.a lz4.c.o lz4hc.c.o && ${AR} qc liblz4.a lz4.c.o lz4hc.c.o)
+          ${AR} d ${OUT_DIR}/libblosc.a lz4.c.o lz4hc.c.o
           EMSDK_CACHE=$(${EMSDK}/upstream/emscripten/em-config CACHE)
           python3 scripts/nuget_patch/wasm_namespace_deps.py \
             --llvm-bin ${EMSDK}/upstream/bin \
@@ -139,6 +149,7 @@ jobs:
             --vanilla-libs ${EMSDK_CACHE}/sysroot/lib/wasm32-emscripten \
             --out-dir namespaced_deps \
             --lib libfreetype --lib libpng --private-lib libz=libzlib \
+            --lib lz4_split/liblz4.a=liblz4 \
             ${{ matrix.config == 'Multithreaded' && '--pthread' || '' }}
           cp namespaced_deps/*.a ${OUT_DIR}
 

--- a/docs/using_dotnet_wasm_bindings.md
+++ b/docs/using_dotnet_wasm_bindings.md
@@ -40,8 +40,6 @@ If you also have installed MeshLib in Nuget-for-Unity (which is a good idea to b
 
      * Click `Apply`.
 
-     Unity links some libraries of its own into the Wasm build (FreeType, libpng, zlib, lz4, libjpeg). The copies we ship are renamed (`*-mrml.a`, `mrml_` symbol prefix) so they don't conflict with Unity's, and no library needs to be unchecked.
-
   4. Uncheck the unused libraries:
 
      * If you used `.../singlethreaded/` libraries, then delete or disable the `.../multithreaded/` ones, or vice versa.

--- a/docs/using_dotnet_wasm_bindings.md
+++ b/docs/using_dotnet_wasm_bindings.md
@@ -40,15 +40,9 @@ If you also have installed MeshLib in Nuget-for-Unity (which is a good idea to b
 
      * Click `Apply`.
 
-  4. Uncheck specific libraries that conflcit with Unity:
+     Unity links some libraries of its own into the Wasm build (FreeType, libpng, zlib, lz4). The copies we ship are renamed (`*-mrml.a`, `mrml_` symbol prefix) so they don't conflict with Unity's, and no library needs to be unchecked.
 
-     * Select only `libblosc.a` and uncheck `WebGL`. Click `Apply`.
-
-     Unity links some libraries of its own into the Wasm build, which conflict with ours, and need to be disabled.
-
-     We still add them to the distribution for use outside of Unity.
-
-  5. Uncheck the unused libraries:
+  4. Uncheck the unused libraries:
 
      * If you used `.../singlethreaded/` libraries, then delete or disable the `.../multithreaded/` ones, or vice versa.
 

--- a/docs/using_dotnet_wasm_bindings.md
+++ b/docs/using_dotnet_wasm_bindings.md
@@ -40,7 +40,7 @@ If you also have installed MeshLib in Nuget-for-Unity (which is a good idea to b
 
      * Click `Apply`.
 
-     Unity links some libraries of its own into the Wasm build (FreeType, libpng, zlib, lz4). The copies we ship are renamed (`*-mrml.a`, `mrml_` symbol prefix) so they don't conflict with Unity's, and no library needs to be unchecked.
+     Unity links some libraries of its own into the Wasm build (FreeType, libpng, zlib, lz4, libjpeg). The copies we ship are renamed (`*-mrml.a`, `mrml_` symbol prefix) so they don't conflict with Unity's, and no library needs to be unchecked.
 
   4. Uncheck the unused libraries:
 

--- a/scripts/nuget_patch/wasm_namespace_deps.py
+++ b/scripts/nuget_patch/wasm_namespace_deps.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Namespace the Emscripten port libraries MeshLib links against (freetype,
-libpng, zlib) so the C# wasm package can ship them without colliding with a
-host engine's own copies of the same libraries.
+libpng, zlib), and the lz4 that c-blosc bundles, so the C# wasm package can
+ship them without colliding with a host engine's own copies of the same
+libraries.
 
-Unity's WebGL player statically links its own trimmed freetype, libpng and
-zlib whose leaked globals collide with full copies of the same libraries, and
-its frozen emsdk cache cannot build the ports on the consumer's machine.
+Unity's WebGL player statically links its own trimmed freetype, libpng, zlib
+and lz4 whose leaked globals collide with full copies of the same libraries,
+and its frozen emsdk cache cannot build the ports on the consumer's machine.
 
 Every symbol the listed libraries export is renamed with PREFIX, and the
 package archives' references to them are rewritten to match, so nothing

--- a/scripts/nuget_patch/wasm_namespace_deps.py
+++ b/scripts/nuget_patch/wasm_namespace_deps.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """Namespace the Emscripten port libraries MeshLib links against (freetype,
-libpng, zlib), and the lz4 that c-blosc bundles, so the C# wasm package can
-ship them without colliding with a host engine's own copies of the same
-libraries.
+libpng, zlib), the lz4 that c-blosc bundles, and our libjpeg-turbo archives,
+so the C# wasm package can ship them without colliding with a host engine's
+own copies of the same libraries.
 
-Unity's WebGL player statically links its own trimmed freetype, libpng, zlib
-and lz4 whose leaked globals collide with full copies of the same libraries,
-and its frozen emsdk cache cannot build the ports on the consumer's machine.
+Unity's WebGL player statically links its own trimmed freetype, libpng, zlib,
+lz4 and libjpeg whose leaked globals collide with full copies of the same
+libraries, and its frozen emsdk cache cannot build the ports on the
+consumer's machine.
 
 Every symbol the listed libraries export is renamed with PREFIX, and the
 package archives' references to them are rewritten to match, so nothing


### PR DESCRIPTION
## Problem

Unity's WebGL player statically links its own lz4 (`BuildTools/lib/modules/lz4.a`), renamed to `UNITY_LZ4_*` — except for three globals its rename list misses: `read_long_length_no_check`, `LZ4_decompress_safe_partial_forceExtDict`, `LZ4_decompress_safe_partial_usingDict`. The lz4 that c-blosc bundles into our `libblosc.a` exports the same three names, so a Unity WebGL build fails with `wasm-ld: error: duplicate symbol`. `docs/using_dotnet_wasm_bindings.md` told users to disable `libblosc.a`, which trades that for `undefined symbol: blosc_compress_ctx / blosc_decompress_ctx / blosc_cbuffer_sizes / blosc_init` from openvdb.

## Fix

Treat blosc's lz4 like the other libraries Unity also ships: in the emscripten C-bindings workflow, split the two lz4 objects (`lz4.c.o`, `lz4hc.c.o`) out of `libblosc.a` into a temporary `liblz4.a` and pass it to `wasm_namespace_deps.py` next to freetype/libpng/zlib. The package then ships `liblz4-mrml.a` (every export prefixed `mrml_`), `libblosc.a` references `mrml_LZ4_*`, and its `blosc_*` API stays untouched, so openvdb keeps working and nothing needs to be disabled in Unity.

Why not just `--lib libblosc.a`: blosc also bundles a full zlib under the standard names, so renaming the whole archive rewrites every zlib call in the package (`libgdcmzlib.a`, `libzip.a`, `libgdcmDSED.a`) onto blosc's copy while `libgdcmzlib.a` keeps defining the standard names — mixing two zlib copies inside one `z_stream`. Renaming only the lz4 members avoids that; the script's own check (`no standard name of the renamed libraries remains in the package`) still passes.

## libjpeg / libturbojpeg (second commit)

Unity's `libjpeg.a` leaks ~90 libjpeg internals (`jcopy_block_row`, `jdiv_round_up`, `jinit_*`, ...) the same way, and our `libjpeg.a`/`libturbojpeg.a` define the same names. Nothing collides until a game references `ImageConversion` (`Texture2D.LoadImage`, `EncodeToJPG`), which pulls Unity's jpeg objects in. Both archives are renamed in the same script invocation (they share the internals), `libMRIOExtras.a` is rewritten to `mrml_tj*`, and the plain copies are removed from the package (they were referenced only through turbojpeg). gdcm's own jpeg copies are already prefixed and are untouched.

## Verification (local, on the `meshlib_v1.0.0.5935_dotnet-wasm` package with Unity's own llvm tools)

- `liblz4-mrml.a`: 84 exports, all `mrml_`-prefixed including the three leaked helpers; imports are libc only.
- `libblosc.a`: no `LZ4_*` definitions left, references rewritten to `mrml_LZ4_compress_fast/decompress_safe/compress_HC`, `blosc_*` API unchanged; zero symbol overlap with Unity's `lz4.a`/`zlib.a`/`libjpeg.a`/`libpng.a`.
- Whole shipped package: 0 plain `LZ4_*` definitions or references; zlib users untouched.
- `libjpeg-mrml.a` (195 exports) and `libturbojpeg-mrml.a` (289 exports): all `mrml_`-prefixed; zero symbol overlap with Unity's `libjpeg.a`; zlib users untouched; script check passes.
- End-to-end in Unity 6000.3 WebGL, using this PR's `DotNetPatchArchiveWasm-3.1.38-singlethreaded` artifact (lz4 split) plus the jpeg renaming applied locally with the same script: the player links with 0 duplicate/undefined symbols and no hand patches, `libblosc.a` stays enabled, and the boolean test scene (Difference/Union/Intersection on kidney/tumor meshes) runs in the browser with no errors.

The docs step that disabled `libblosc.a` is removed; the script docstring mentions lz4. Draft until CI has produced the package with both changes; the local Unity test above already covers the lz4 split from CI and the jpeg renaming applied with the same script.

Unity's leak is also worth reporting upstream (those three should be in their `UNITY_` rename set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
