### PR TITLE
install-msys2-mrbind: add a repo-dir input

### DIFF
--- a/.github/actions/install-msys2-mrbind/action.yml
+++ b/.github/actions/install-msys2-mrbind/action.yml
@@ -13,6 +13,14 @@ inputs:
       Which pinned set to install: the `<suffix>` of
       `scripts/mrbind/msys2_package_hashes<suffix>.txt`. `_clang22` is the x86_64
       CLANG64 toolchain, `_clangarm64` the native aarch64 one.
+  repo-dir:
+    required: false
+    default: '.'
+    description: >
+      Path to this repository from the workspace root. The default suits a
+      workflow whose workspace is MeshLib itself; a downstream repo that has
+      MeshLib as a submodule passes the submodule path (e.g. `MeshLib`), since
+      every path below is resolved against the workspace, not the action.
 
 runs:
   using: composite
@@ -25,8 +33,8 @@ runs:
       uses: actions/cache@v5
       continue-on-error: true
       with:
-        path: scripts/mrbind/msys2_packages
-        key: msys2-mrbind${{ inputs.packages-suffix }}-${{ hashFiles(format('scripts/mrbind/msys2_package_hashes{0}.txt', inputs.packages-suffix)) }}
+        path: ${{ inputs.repo-dir }}/scripts/mrbind/msys2_packages
+        key: msys2-mrbind${{ inputs.packages-suffix }}-${{ hashFiles(format('{0}/scripts/mrbind/msys2_package_hashes{1}.txt', inputs.repo-dir, inputs.packages-suffix)) }}
 
     - name: Install MSYS2 itself when the image has none
       # Only the x64 runner images ship C:\msys64. MSYS2 publishes an x86_64 base
@@ -65,14 +73,14 @@ runs:
       run: |
         $attempts = 3
         foreach ($i in 1..$attempts) {
-          C:\msys64\msys2_shell.cmd -no-start -defterm -here -c "set -e && bash scripts/mrbind/msys2_download_packages.sh ${{ inputs.packages-suffix }} && bash scripts/mrbind/msys2_install_packages.sh ${{ inputs.packages-suffix }}"
+          C:\msys64\msys2_shell.cmd -no-start -defterm -here -c "set -e && bash ${{ inputs.repo-dir }}/scripts/mrbind/msys2_download_packages.sh ${{ inputs.packages-suffix }} && bash ${{ inputs.repo-dir }}/scripts/mrbind/msys2_install_packages.sh ${{ inputs.packages-suffix }}"
           $code = $LASTEXITCODE
           if ($code -eq 0) { break }
           # The msys2 shell dies without its console output reaching the
           # runner; recover what hit the disk instead.
           Write-Host "msys2_shell.cmd exited with code $code (attempt $i of $attempts)"
-          Write-Host '::group::scripts/mrbind/msys2_pacman_install.log'
-          $teeLog = 'scripts/mrbind/msys2_pacman_install.log'
+          Write-Host '::group::${{ inputs.repo-dir }}/scripts/mrbind/msys2_pacman_install.log'
+          $teeLog = '${{ inputs.repo-dir }}/scripts/mrbind/msys2_pacman_install.log'
           if (Test-Path $teeLog) { Get-Content $teeLog } else { Write-Host 'absent — died before pacman produced output' }
           Write-Host '::endgroup::'
           Write-Host '::group::C:\msys64\var\log\pacman.log (last 200 lines)'


### PR DESCRIPTION
`install-msys2-mrbind` is a composite action, so every path in it resolves against the **workspace**, not against the action's own directory. That is fine while the workspace is this repository, but it makes the action unusable from a downstream repository that consumes MeshLib as a git submodule: there `scripts/mrbind/...` points at the outer repo and nothing is found.

Four places were affected — the package cache `path`, its `hashFiles` key, the `msys2_download_packages.sh` / `msys2_install_packages.sh` invocation, and the tee-log path recovered on a failed attempt.

This adds a `repo-dir` input defaulting to `.`, so every existing caller is unchanged (`./scripts/...` resolves identically), and a submodule consumer can pass its submodule path instead:

```yaml
      - uses: ./MeshLib/.github/actions/install-msys2-mrbind
        with:
          packages-suffix: _clangarm64
          repo-dir: MeshLib
```

Without this, such a consumer has to duplicate the MSYS2 bootstrap — the x86_64 base install, the `pacman-key` re-init that works around the flaky first-launch populate, and the retry loop — which is exactly the hard-won logic that should stay in one place.

The Windows legs of this PR exercise the default path, including the arm64 ones that go through the full install rather than a cache hit.
