### PR TITLE
interpolateScalarsSmoothly(): harmonic interpolation of a scalar field with fixed values

### DIFF
--- a/source/MRMesh/MRPositionVertsSmoothly.cpp
+++ b/source/MRMesh/MRPositionVertsSmoothly.cpp
@@ -11,6 +11,7 @@
 #include "MRTimer.h"
 #include <MRPch/MREigenSparseCore.h>
 #include <Eigen/SparseCholesky>
+#include <array>
 
 namespace MR
 {
@@ -41,12 +42,18 @@ void positionVertsSmoothlySharpBd( Mesh& mesh, const PositionVertsSmoothlyParams
     positionVertsSmoothlySharpBd( mesh.topology, mesh.points, params );
 }
 
-void positionVertsSmoothlySharpBd( const MeshTopology& topology, VertCoords& points, const PositionVertsSmoothlyParams& params )
+namespace
+{
+
+/// finds N scalar fields on region vertices, where each value is the weighted mean of the values in neighbor vertices;
+/// getVal(v) returns the fixed values of not-region vertex or the original values of region vertex (for stabilization),
+/// getShift(v) returns additional shifts of the equation of region vertex v, setVal(v, vals) stores the solution
+template<size_t N, class GetVal, class GetShift, class SetVal>
+void solveLaplaceEquations( const MeshTopology& topology, const VertBitSet& verts,
+    float stabilizer, const VertMetric& vertStabilizers, const UndirectedEdgeMetric& edgeWeights,
+    GetVal getVal, GetShift getShift, SetVal setVal )
 {
     MR_TIMER;
-    assert( params.stabilizer > 0 || params.vertStabilizers || ( params.region && !MeshComponents::hasFullySelectedComponent( topology, *params.region ) ) );
-
-    const auto & verts = topology.getVertIds( params.region );
     const auto sz = verts.count();
     if ( sz <= 0 )
         return;
@@ -54,18 +61,24 @@ void positionVertsSmoothlySharpBd( const MeshTopology& topology, VertCoords& poi
     // vertex id -> position in the matrix
     HashMap<VertId, int> vertToMatPos = makeHashMapWithSeqNums( verts );
 
+    using Vals = std::array<double, N>;
     std::vector< Eigen::Triplet<double> > mTriplets;
-    Eigen::VectorXd rhs[3];
-    for ( int i = 0; i < 3; ++i )
-        rhs[i].resize( sz );
+    Eigen::VectorXd rhs[N];
+    for ( auto & r : rhs )
+        r.resize( sz );
     int n = 0;
     for ( auto v : verts )
     {
         double sumW = 0;
-        Vector3d sumFixed;
+        Vals sumFixed{};
+        auto addFixed = [&sumFixed]( double w, const Vals & vals )
+        {
+            for ( size_t i = 0; i < N; ++i )
+                sumFixed[i] += w * vals[i];
+        };
         for ( auto e : orgRing( topology, v ) )
         {
-            const double edgeW = params.edgeWeights ? params.edgeWeights( e ) : 1;
+            const double edgeW = edgeWeights ? edgeWeights( e ) : 1;
             sumW += edgeW;
             auto d = topology.dest( e );
             if ( auto it = vertToMatPos.find( d ); it != vertToMatPos.end() )
@@ -78,26 +91,23 @@ void positionVertsSmoothlySharpBd( const MeshTopology& topology, VertCoords& poi
             else
             {
                 // fixed neighbor
-                sumFixed += edgeW * Vector3d( points[d] );
+                addFixed( edgeW, getVal( d ) );
             }
         }
-        if ( params.vertShifts )
-            sumFixed += sumW * Vector3d( (*params.vertShifts)[v] );
-        if ( params.vertStabilizers )
+        addFixed( sumW, getShift( v ) );
+        double s = stabilizer; //for VertexMass::Unit only
+        if ( vertStabilizers )
         {
-            const auto s = params.vertStabilizers( v ); //for VertexMass::Unit only
+            s = vertStabilizers( v );
             assert( s >= 0 );
-            sumW += s;
-            sumFixed += Vector3d( s * points[v] );
         }
-        else if ( params.stabilizer != 0 )
+        if ( s != 0 )
         {
-            const auto s = params.stabilizer; //for VertexMass::Unit only
             sumW += s;
-            sumFixed += Vector3d( s * points[v] );
+            addFixed( s, getVal( v ) );
         }
         mTriplets.emplace_back( n, n, sumW );
-        for ( int i = 0; i < 3; ++i )
+        for ( size_t i = 0; i < N; ++i )
             rhs[i][n] = sumFixed[i];
         ++n;
     }
@@ -109,22 +119,54 @@ void positionVertsSmoothlySharpBd( const MeshTopology& topology, VertCoords& poi
     Eigen::SimplicialLDLT<SparseMatrix> solver;
     solver.compute( A );
 
-    Eigen::VectorXd sol[3];
-    ParallelFor( 0, 3, [&]( int i )
+    Eigen::VectorXd sol[N];
+    ParallelFor( 0, (int)N, [&]( int i )
     {
         sol[i] = solver.solve( rhs[i] );
     } );
 
-    // copy solution back into mesh points
     n = 0;
     for ( auto v : verts )
     {
-        auto & pt = points[v];
-        pt.x = (float) sol[0][n];
-        pt.y = (float) sol[1][n];
-        pt.z = (float) sol[2][n];
+        Vals vals;
+        for ( size_t i = 0; i < N; ++i )
+            vals[i] = sol[i][n];
+        setVal( v, vals );
         ++n;
     }
+}
+
+} // anonymous namespace
+
+void positionVertsSmoothlySharpBd( const MeshTopology& topology, VertCoords& points, const PositionVertsSmoothlyParams& params )
+{
+    MR_TIMER;
+    assert( params.stabilizer > 0 || params.vertStabilizers || ( params.region && !MeshComponents::hasFullySelectedComponent( topology, *params.region ) ) );
+
+    solveLaplaceEquations<3>( topology, topology.getVertIds( params.region ), params.stabilizer, params.vertStabilizers, params.edgeWeights,
+        [&points]( VertId v ) { const auto & p = points[v]; return std::array<double, 3>{ p.x, p.y, p.z }; },
+        [&params]( VertId v )
+        {
+            std::array<double, 3> res{};
+            if ( params.vertShifts )
+            {
+                const auto & p = (*params.vertShifts)[v];
+                res = { p.x, p.y, p.z };
+            }
+            return res;
+        },
+        [&points]( VertId v, const std::array<double, 3> & vals ) { points[v] = Vector3f( (float)vals[0], (float)vals[1], (float)vals[2] ); } );
+}
+
+void interpolateScalarsSmoothly( const MeshTopology& topology, VertScalars& field, const InterpolateScalarsParams& params )
+{
+    MR_TIMER;
+    assert( params.stabilizer > 0 || params.vertStabilizers || ( params.region && !MeshComponents::hasFullySelectedComponent( topology, *params.region ) ) );
+
+    solveLaplaceEquations<1>( topology, topology.getVertIds( params.region ), params.stabilizer, params.vertStabilizers, params.edgeWeights,
+        [&field]( VertId v ) { return std::array<double, 1>{ field[v] }; },
+        []( VertId ) { return std::array<double, 1>{}; },
+        [&field]( VertId v, const std::array<double, 1> & vals ) { field[v] = (float)vals[0]; } );
 }
 
 void positionVertsWithSpacing( Mesh& mesh, const SpacingSettings & settings )

--- a/source/MRMesh/MRPositionVertsSmoothly.cpp
+++ b/source/MRMesh/MRPositionVertsSmoothly.cpp
@@ -11,7 +11,6 @@
 #include "MRTimer.h"
 #include <MRPch/MREigenSparseCore.h>
 #include <Eigen/SparseCholesky>
-#include <array>
 
 namespace MR
 {
@@ -45,37 +44,27 @@ void positionVertsSmoothlySharpBd( Mesh& mesh, const PositionVertsSmoothlyParams
 namespace
 {
 
-/// finds N scalar fields on region vertices, where each value is the weighted mean of the values in neighbor vertices;
-/// getVal(v) returns the fixed values of not-region vertex or the original values of region vertex (for stabilization),
-/// getShift(v) returns additional shifts of the equation of region vertex v, setVal(v, vals) stores the solution
-template<size_t N, class GetVal, class GetShift, class SetVal>
-void solveLaplaceEquations( const MeshTopology& topology, const VertBitSet& verts,
-    float stabilizer, const VertMetric& vertStabilizers, const UndirectedEdgeMetric& edgeWeights,
-    GetVal getVal, GetShift getShift, SetVal setVal )
+using SparseMatrix = Eigen::SparseMatrix<double,Eigen::RowMajor>;
+
+/// prepares the matrix of Laplace equations, where each vertex from \p verts is the weighted mean of its neighbors;
+/// g(v) returns the value in fixed vertex v, or the original value in free vertex v (used with stabilizers),
+/// shift(v) returns additional shift of the equation of free vertex v, s(n, r) stores the right hand side r of n-th equation
+template <typename G, typename Sh, typename S>
+SparseMatrix prepareLaplaceEquations( const MeshTopology& topology, const VertBitSet& verts,
+    float stabilizer, const VertMetric& vertStabilizers, const UndirectedEdgeMetric& edgeWeights, G && g, Sh && shift, S && s )
 {
     MR_TIMER;
     const auto sz = verts.count();
-    if ( sz <= 0 )
-        return;
 
     // vertex id -> position in the matrix
     HashMap<VertId, int> vertToMatPos = makeHashMapWithSeqNums( verts );
 
-    using Vals = std::array<double, N>;
     std::vector< Eigen::Triplet<double> > mTriplets;
-    Eigen::VectorXd rhs[N];
-    for ( auto & r : rhs )
-        r.resize( sz );
     int n = 0;
     for ( auto v : verts )
     {
         double sumW = 0;
-        Vals sumFixed{};
-        auto addFixed = [&sumFixed]( double w, const Vals & vals )
-        {
-            for ( size_t i = 0; i < N; ++i )
-                sumFixed[i] += w * vals[i];
-        };
+        decltype( g( v ) ) sumFixed{};
         for ( auto e : orgRing( topology, v ) )
         {
             const double edgeW = edgeWeights ? edgeWeights( e ) : 1;
@@ -91,49 +80,30 @@ void solveLaplaceEquations( const MeshTopology& topology, const VertBitSet& vert
             else
             {
                 // fixed neighbor
-                addFixed( edgeW, getVal( d ) );
+                sumFixed += edgeW * g( d );
             }
         }
-        addFixed( sumW, getShift( v ) );
-        double s = stabilizer; //for VertexMass::Unit only
+        sumFixed += sumW * shift( v );
+        double st = stabilizer; //for VertexMass::Unit only
         if ( vertStabilizers )
         {
-            s = vertStabilizers( v );
-            assert( s >= 0 );
+            st = vertStabilizers( v );
+            assert( st >= 0 );
         }
-        if ( s != 0 )
+        if ( st != 0 )
         {
-            sumW += s;
-            addFixed( s, getVal( v ) );
+            sumW += st;
+            sumFixed += st * g( v );
         }
         mTriplets.emplace_back( n, n, sumW );
-        for ( size_t i = 0; i < N; ++i )
-            rhs[i][n] = sumFixed[i];
+        s( n, sumFixed );
         ++n;
     }
 
-    using SparseMatrix = Eigen::SparseMatrix<double,Eigen::RowMajor>;
     SparseMatrix A;
     A.resize( sz, sz );
     A.setFromTriplets( mTriplets.begin(), mTriplets.end() );
-    Eigen::SimplicialLDLT<SparseMatrix> solver;
-    solver.compute( A );
-
-    Eigen::VectorXd sol[N];
-    ParallelFor( 0, (int)N, [&]( int i )
-    {
-        sol[i] = solver.solve( rhs[i] );
-    } );
-
-    n = 0;
-    for ( auto v : verts )
-    {
-        Vals vals;
-        for ( size_t i = 0; i < N; ++i )
-            vals[i] = sol[i][n];
-        setVal( v, vals );
-        ++n;
-    }
+    return A;
 }
 
 } // anonymous namespace
@@ -143,19 +113,41 @@ void positionVertsSmoothlySharpBd( const MeshTopology& topology, VertCoords& poi
     MR_TIMER;
     assert( params.stabilizer > 0 || params.vertStabilizers || ( params.region && !MeshComponents::hasFullySelectedComponent( topology, *params.region ) ) );
 
-    solveLaplaceEquations<3>( topology, topology.getVertIds( params.region ), params.stabilizer, params.vertStabilizers, params.edgeWeights,
-        [&points]( VertId v ) { const auto & p = points[v]; return std::array<double, 3>{ p.x, p.y, p.z }; },
-        [&params]( VertId v )
+    const auto & verts = topology.getVertIds( params.region );
+    const auto sz = verts.count();
+    if ( sz <= 0 )
+        return;
+
+    Eigen::VectorXd rhs[3];
+    for ( int i = 0; i < 3; ++i )
+        rhs[i].resize( sz );
+
+    Eigen::SimplicialLDLT<SparseMatrix> solver;
+    solver.compute( prepareLaplaceEquations( topology, verts, params.stabilizer, params.vertStabilizers, params.edgeWeights,
+        [&]( VertId v ) { return Vector3d( points[v] ); },
+        [&]( VertId v ) { return params.vertShifts ? Vector3d( (*params.vertShifts)[v] ) : Vector3d{}; },
+        [&]( int n, const Vector3d & r )
         {
-            std::array<double, 3> res{};
-            if ( params.vertShifts )
-            {
-                const auto & p = (*params.vertShifts)[v];
-                res = { p.x, p.y, p.z };
-            }
-            return res;
-        },
-        [&points]( VertId v, const std::array<double, 3> & vals ) { points[v] = Vector3f( (float)vals[0], (float)vals[1], (float)vals[2] ); } );
+            for ( int i = 0; i < 3; ++i )
+                rhs[i][n] = r[i];
+        } ) );
+
+    Eigen::VectorXd sol[3];
+    ParallelFor( 0, 3, [&]( int i )
+    {
+        sol[i] = solver.solve( rhs[i] );
+    } );
+
+    // copy solution back into mesh points
+    int n = 0;
+    for ( auto v : verts )
+    {
+        auto & pt = points[v];
+        pt.x = (float) sol[0][n];
+        pt.y = (float) sol[1][n];
+        pt.z = (float) sol[2][n];
+        ++n;
+    }
 }
 
 void interpolateScalarsSmoothly( const MeshTopology& topology, VertScalars& field, const InterpolateScalarsParams& params )
@@ -163,10 +155,22 @@ void interpolateScalarsSmoothly( const MeshTopology& topology, VertScalars& fiel
     MR_TIMER;
     assert( params.stabilizer > 0 || params.vertStabilizers || ( params.region && !MeshComponents::hasFullySelectedComponent( topology, *params.region ) ) );
 
-    solveLaplaceEquations<1>( topology, topology.getVertIds( params.region ), params.stabilizer, params.vertStabilizers, params.edgeWeights,
-        [&field]( VertId v ) { return std::array<double, 1>{ field[v] }; },
-        []( VertId ) { return std::array<double, 1>{}; },
-        [&field]( VertId v, const std::array<double, 1> & vals ) { field[v] = (float)vals[0]; } );
+    const auto & verts = topology.getVertIds( params.region );
+    const auto sz = verts.count();
+    if ( sz <= 0 )
+        return;
+
+    Eigen::VectorXd rhs( sz );
+    Eigen::SimplicialLDLT<SparseMatrix> solver;
+    solver.compute( prepareLaplaceEquations( topology, verts, params.stabilizer, params.vertStabilizers, params.edgeWeights,
+        [&]( VertId v ) { return double( field[v] ); },
+        []( VertId ) { return 0.0; },
+        [&]( int n, double r ) { rhs[n] = r; } ) );
+
+    Eigen::VectorXd sol = solver.solve( rhs );
+    int n = 0;
+    for ( auto v : verts )
+        field[v] = float( sol[n++] );
 }
 
 void positionVertsWithSpacing( Mesh& mesh, const SpacingSettings & settings )

--- a/source/MRMesh/MRPositionVertsSmoothly.h
+++ b/source/MRMesh/MRPositionVertsSmoothly.h
@@ -40,6 +40,27 @@ MRMESH_API void positionVertsSmoothlySharpBd( Mesh& mesh, const PositionVertsSmo
 MRMESH_API void positionVertsSmoothlySharpBd( const MeshTopology& topology, VertCoords& points, const PositionVertsSmoothlyParams& params );
 [[deprecated]] MRMESH_API void positionVertsSmoothlySharpBd( Mesh& mesh, const VertBitSet& verts );
 
+struct InterpolateScalarsParams
+{
+    /// vertices where the field values are computed, nullptr means all vertices;
+    /// it must not include all vertices of a mesh connected component unless stabilizer > 0
+    const VertBitSet* region = nullptr;
+
+    /// the more the value, the bigger attraction of each vertex to its original value
+    float stabilizer = 0;
+
+    /// if specified then it is used instead of \p stabilizer
+    VertMetric vertStabilizers;
+
+    /// if specified then it is used for edge weights instead of default 1
+    UndirectedEdgeMetric edgeWeights;
+};
+
+/// Computes the values of scalar field in region vertices to make it harmonic there:
+/// each value becomes the weighted mean of the values in neighbor vertices, while the values in all other vertices remain fixed;
+/// with non-negative edge weights and zero stabilizers, the computed values never leave the range of the fixed values
+MRMESH_API void interpolateScalarsSmoothly( const MeshTopology& topology, VertScalars& field, const InterpolateScalarsParams& params );
+
 struct SpacingSettings
 {
     /// vertices to be moved by the algorithm, nullptr means all valid vertices

--- a/source/MRTest/MRPositionVertsSmoothlyTests.cpp
+++ b/source/MRTest/MRPositionVertsSmoothlyTests.cpp
@@ -42,8 +42,10 @@ TEST( MRMesh, InterpolateScalarsSmoothly )
 
     // by symmetry the values on the equator are in the middle
     for ( auto v : region )
+    {
         if ( std::abs( sphere.points[v].z ) < 1e-5f )
             EXPECT_NEAR( field[v], 0.5f, 1e-5f );
+    }
 }
 
 } //namespace MR

--- a/source/MRTest/MRPositionVertsSmoothlyTests.cpp
+++ b/source/MRTest/MRPositionVertsSmoothlyTests.cpp
@@ -43,8 +43,9 @@ TEST( MRMesh, InterpolateScalarsSmoothly )
     // by symmetry the values on the equator are in the middle
     for ( auto v : region )
     {
-        if ( std::abs( sphere.points[v].z ) < 1e-5f )
-            EXPECT_NEAR( field[v], 0.5f, 1e-5f );
+        if ( std::abs( sphere.points[v].z ) >= 1e-5f )
+            continue;
+        EXPECT_NEAR( field[v], 0.5f, 1e-5f );
     }
 }
 

--- a/source/MRTest/MRPositionVertsSmoothlyTests.cpp
+++ b/source/MRTest/MRPositionVertsSmoothlyTests.cpp
@@ -1,0 +1,49 @@
+#include <MRMesh/MRPositionVertsSmoothly.h>
+#include <MRMesh/MRMakeSphereMesh.h>
+#include <MRMesh/MRMesh.h>
+#include <MRMesh/MRRingIterator.h>
+#include <gtest/gtest.h>
+
+namespace MR
+{
+
+TEST( MRMesh, InterpolateScalarsSmoothly )
+{
+    const Mesh sphere = makeUVSphere( 1, 16, 16 );
+    const auto & topology = sphere.topology;
+
+    // values are fixed near the poles (1 at the top, 0 at the bottom) and interpolated in the middle band
+    VertBitSet region( topology.vertSize() );
+    VertScalars field( topology.vertSize(), 0 );
+    for ( auto v : topology.getValidVerts() )
+    {
+        const auto z = sphere.points[v].z;
+        if ( std::abs( z ) < 0.5f )
+            region.set( v );
+        else if ( z > 0 )
+            field[v] = 1;
+    }
+    interpolateScalarsSmoothly( topology, field, { .region = &region } );
+
+    for ( auto v : region )
+    {
+        // every free value is exactly the mean of its neighbors, so it never leaves the range of fixed values
+        double sum = 0;
+        int cnt = 0;
+        for ( auto e : orgRing( topology, v ) )
+        {
+            sum += field[topology.dest( e )];
+            ++cnt;
+        }
+        EXPECT_NEAR( field[v], sum / cnt, 1e-5f );
+        EXPECT_GE( field[v], 0 );
+        EXPECT_LE( field[v], 1 );
+    }
+
+    // by symmetry the values on the equator are in the middle
+    for ( auto v : region )
+        if ( std::abs( sphere.points[v].z ) < 1e-5f )
+            EXPECT_NEAR( field[v], 0.5f, 1e-5f );
+}
+
+} //namespace MR

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -123,6 +123,7 @@
     <ClCompile Include="MRPolylineDecimateTests.cpp" />
     <ClCompile Include="MRPolylineSubdivideTests.cpp" />
     <ClCompile Include="MRPolylineTopologyTests.cpp" />
+    <ClCompile Include="MRPositionVertsSmoothlyTests.cpp" />
     <ClCompile Include="MRQuadraticFormTests.cpp" />
     <ClCompile Include="MRRayBoxIntersectionTests.cpp" />
     <ClCompile Include="MRRectIndexerTests.cpp" />


### PR DESCRIPTION
New function `interpolateScalarsSmoothly( topology, field, params )`: given values in some vertices, it computes the values in the region vertices so that each of them is the weighted mean of its neighbors (harmonic interpolation with Dirichlet boundary conditions). With non-negative edge weights and no stabilizer the result never leaves the range of the fixed values.

This is the scalar counterpart of `positionVertsSmoothlySharpBd`, and both now share one internal solver templated on the number of scalar fields, so the position function is unchanged in behavior.

Motivation: a customer asked for a "dynamic dilation" of a cranioplasty implant where the thickness is given on a few groups of boundary vertices and has to vary smoothly across the surface. The interpolated thickness then feeds `WeightedShell::meshShell`. The only existing option, `Laplacian::applyToScalar`, minimizes the squared Laplacian in the least-squares sense over the free vertices plus their first fixed ring, so it overshoots the given values (4.00..8.00 mm requested, 3.92..8.14 mm obtained on the customer's mesh) and does not fit this task without clamping.

A unit test checks the mean-of-neighbors property, the range and the symmetry of the solution on a sphere.
