### PR TITLE
Emit a monotone split plan from PlanarTriangulation

### DIFF
--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -11,6 +11,7 @@
 #include "MREdgeIterator.h"
 #include "MRMeshMetrics.h"
 #include "MRMeshFillHole.h"
+#include "MRMapEdge.h"
 #include "MRMeshDelone.h"
 #include "MRMeshCollidePrecise.h"
 #include "MRBox.h"
@@ -307,7 +308,9 @@ struct SweepLineParams
     /// optional map of patch topology edges->input topology edges
     WholeEdgeMap* outPatchMap{ nullptr };
 
-    /// if set, makeMonotone() records here every edge it adds, in creation order
+    /// optional output: the chords makeMonotone() adds, in creation order. Because makeEdge() only
+    /// appends, chord k is the undirected edge patchToInEdges.size() + k - but only while nothing is
+    /// injected between the loop edges and the chords (i.e. findIntersections() found no intersection)
     std::vector<MonotoneChord>* outChords{ nullptr };
 };
 
@@ -320,7 +323,6 @@ public:
     SweepLineQueue( const MeshTopology& inTp, SweepLinePredicates predicates, const EdgeLoops& holes, const SweepLineParams& params );
 
     size_t vertSize() const { return tp_.vertSize(); }
-    size_t undirectedEdgeSize() const { return tp_.undirectedEdgeSize(); }
     std::optional<Mesh> run( IntersectionsMap* interMap = nullptr );
 
     bool findIntersections();
@@ -446,6 +448,9 @@ private:
     void updateStartRightGoingCache_();
     void processStartEvent_( int index );
     void processDestenationEvent_( int index );
+    // adds one monotonation chord org( anchor1 ) -> org( anchor2 ) with the parity of refEdge (which
+    // also sources its winding), records it for outChords, and returns the created edge
+    EdgeId addChord_( EdgeId anchor1, EdgeId anchor2, EdgeId refEdge );
     void processIntersectionEvent_( int index );
 
     struct IntersectionInfo
@@ -844,6 +849,19 @@ void SweepLineQueue::updateStartRightGoingCache_()
     std::rotate( rightGoingCache_.begin(), rightGoingCache_.begin() + pos, rightGoingCache_.end() );
 }
 
+EdgeId SweepLineQueue::addChord_( EdgeId anchor1, EdgeId anchor2, EdgeId refEdge )
+{
+    auto newEdge = tp_.makeEdge();
+    if ( refEdge.odd() )
+        newEdge = newEdge.sym();
+    tp_.splice( anchor1, newEdge );
+    tp_.splice( anchor2, newEdge.sym() );
+    if ( params_.outChords )
+        params_.outChords->push_back( { anchor1, anchor2, newEdge } );
+    windingInfo_.autoResizeSet( newEdge.undirected(), windingInfo_[refEdge.undirected()] );
+    return newEdge;
+}
+
 void SweepLineQueue::processStartEvent_( int index )
 {
     updateStartRightGoingCache_();
@@ -879,15 +897,7 @@ void SweepLineQueue::processStartEvent_( int index )
         }
         assert( helperId );
 
-        auto newEdge = tp_.makeEdge();
-        if ( activeSweepEdges_[index - 1].edgeId.odd() )
-            newEdge = newEdge.sym();
-        tp_.splice( helperId, newEdge );
-        tp_.splice( rightGoingCache_.back().edgeId, newEdge.sym() );
-        if ( params_.outChords )
-            params_.outChords->push_back( { helperId, rightGoingCache_.back().edgeId, newEdge } );
-
-        windingInfo_.autoResizeSet( newEdge.undirected(), windingInfo_[activeSweepEdges_[index - 1].edgeId.undirected()] );
+        addChord_( helperId, rightGoingCache_.back().edgeId, activeSweepEdges_[index - 1].edgeId );
     }
 
     activeSweepEdges_.insert( activeSweepEdges_.begin() + index, rightGoingCache_.begin(), rightGoingCache_.end() );
@@ -939,17 +949,10 @@ void SweepLineQueue::processDestenationEvent_( int index )
             else
                 connectorEdgeId = tp_.prev( activeSweepEdges_[i].edgeId.sym() );
 
-            auto newEdge = tp_.makeEdge();
-            if ( activeSweepEdges_[i].edgeId.odd() )
-                newEdge = newEdge.sym();
-            tp_.splice( lowerLone, newEdge );
-            tp_.splice( connectorEdgeId, newEdge.sym() );
-            if ( params_.outChords )
-                params_.outChords->push_back( { lowerLone, connectorEdgeId, newEdge } );
+            const EdgeId newEdge = addChord_( lowerLone, connectorEdgeId, activeSweepEdges_[i].edgeId );
 
             lowerLone = upperLone = {};
 
-            windingInfo_.autoResizeSet( newEdge.undirected(), windingInfo_[activeSweepEdges_[i].edgeId.undirected()] );
             if ( i == minIndex - 1 )
                 lowestLeft = newEdge;
         }
@@ -1692,11 +1695,7 @@ std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoo
     // copy the boundary sub-topology from the mesh: shared vertices and slit edges arrive already shared
     WholeEdgeMap localMap;
     WholeEdgeMap& patchToInEdges = outPatchMap ? *outPatchMap : localMap;
-    patchToInEdges.clear();
-    size_t numLoopEdges = 0;
-    for ( const auto& loop : loops )
-        numLoopEdges += loop.size();
-    patchToInEdges.reserve( numLoopEdges );
+    patchToInEdges.clear(); // initMeshByLoops_ reserves it from the loop sizes
     SweepLineQueue triangulator( mesh.topology, meshSpacePredicates( mesh, loops, normal, patchToInEdges ), loops,
         { .abortWhenIntersect = true, .outPatchMap = &patchToInEdges } );
     return triangulator.run();
@@ -1708,16 +1707,11 @@ std::optional<HoleFillPlan> getMonotonePlan( const Mesh& mesh, const EdgeLoops& 
     HoleFillPlan res;
     if ( loops.empty() )
         return res;
-    size_t numLoopEdges = 0;
     for ( const auto& loop : loops )
-    {
         if ( loop.size() < 3 )
             return {}; // the sweep skips such loops entirely, so their holes would stay unaddressed
-        numLoopEdges += loop.size();
-    }
 
-    WholeEdgeMap patchToInEdges;
-    patchToInEdges.reserve( numLoopEdges );
+    WholeEdgeMap patchToInEdges; // initMeshByLoops_ reserves it from the loop sizes
     std::vector<MonotoneChord> chords;
     SweepLineQueue triangulator( mesh.topology, meshSpacePredicates( mesh, loops, normal, patchToInEdges ), loops,
         { .abortWhenIntersect = true, .outPatchMap = &patchToInEdges, .outChords = &chords } );
@@ -1727,16 +1721,15 @@ std::optional<HoleFillPlan> getMonotonePlan( const Mesh& mesh, const EdgeLoops& 
     // once; and it is where to stop - monotone parts are what the caller fills
     triangulator.makeMonotone();
 
-    // the anchors are patch edges: the loop edges copied from the mesh (patchToInEdges maps them
-    // back), and past them the chords in creation order, because makeEdge() only appends
-    assert( triangulator.undirectedEdgeSize() == patchToInEdges.size() + chords.size() );
+    // an anchor is a patch edge: either a loop edge copied from the mesh (patchToInEdges maps it back),
+    // or, past those, a chord referenced by the item that will create it
     auto codeOf = [&] ( EdgeId patch )
     {
         if ( patch.undirected() < patchToInEdges.size() )
         {
-            const EdgeId inE = patchToInEdges[patch.undirected()];
+            const EdgeId inE = mapEdge( patchToInEdges, patch );
             assert( inE );
-            return int( patch.odd() ? inE.sym() : inE );
+            return int( inE );
         }
         // a chord: the item of the same index, reversed if directed against the recorded edge
         const int k = int( patch.undirected() ) - int( patchToInEdges.size() );
@@ -1746,6 +1739,8 @@ std::optional<HoleFillPlan> getMonotonePlan( const Mesh& mesh, const EdgeLoops& 
     res.items.resize( chords.size() );
     for ( int k = 0; k < int( chords.size() ); ++k )
     {
+        // makeEdge() only appends and nothing was injected, so chord k is the k-th edge past the loops
+        assert( chords[k].edge.undirected() == patchToInEdges.size() + k );
         const int code1 = codeOf( chords[k].anchor1 );
         const int code2 = codeOf( chords[k].anchor2 );
         // the chord is spliced right after each of its anchors, so it lands in the wedge left( anchor );
@@ -1755,6 +1750,9 @@ std::optional<HoleFillPlan> getMonotonePlan( const Mesh& mesh, const EdgeLoops& 
                 return {};
         res.items[k] = { code1, code2 };
     }
+    // a chord could still duplicate an off-loop mesh edge already joining its two endpoints (e.g. a
+    // folded or coplanar patch); the caller runs isFillingMultipleEdgeFree() before committing the plan,
+    // exactly as it does for getPlanarHoleFillPlans() output
     return res;
 }
 

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -279,6 +279,14 @@ int findClosestToFront( const MeshTopology& tp, const SweepLinePredicates& predi
     return findClosestToFront( tp, predicates, edges, left, baseId );
 }
 
+/// one edge added by makeMonotone() to split the region in monotone parts:
+/// it was created as `splice( anchor1, edge ); splice( anchor2, edge.sym() )`, so it connects
+/// org( anchor1 ) with org( anchor2 ) exactly like makeNewEdge( topology, anchor1, anchor2 ) does
+struct MonotoneChord
+{
+    EdgeId anchor1, anchor2, edge;
+};
+
 struct SweepLineParams
 {
     /// if not set - adds new vertices at intersection points
@@ -298,6 +306,9 @@ struct SweepLineParams
 
     /// optional map of patch topology edges->input topology edges
     WholeEdgeMap* outPatchMap{ nullptr };
+
+    /// if set, makeMonotone() records here every edge it adds, in creation order
+    std::vector<MonotoneChord>* outChords{ nullptr };
 };
 
 class SweepLineQueue
@@ -309,6 +320,7 @@ public:
     SweepLineQueue( const MeshTopology& inTp, SweepLinePredicates predicates, const EdgeLoops& holes, const SweepLineParams& params );
 
     size_t vertSize() const { return tp_.vertSize(); }
+    size_t undirectedEdgeSize() const { return tp_.undirectedEdgeSize(); }
     std::optional<Mesh> run( IntersectionsMap* interMap = nullptr );
 
     bool findIntersections();
@@ -872,6 +884,8 @@ void SweepLineQueue::processStartEvent_( int index )
             newEdge = newEdge.sym();
         tp_.splice( helperId, newEdge );
         tp_.splice( rightGoingCache_.back().edgeId, newEdge.sym() );
+        if ( params_.outChords )
+            params_.outChords->push_back( { helperId, rightGoingCache_.back().edgeId, newEdge } );
 
         windingInfo_.autoResizeSet( newEdge.undirected(), windingInfo_[activeSweepEdges_[index - 1].edgeId.undirected()] );
     }
@@ -930,6 +944,8 @@ void SweepLineQueue::processDestenationEvent_( int index )
                 newEdge = newEdge.sym();
             tp_.splice( lowerLone, newEdge );
             tp_.splice( connectorEdgeId, newEdge.sym() );
+            if ( params_.outChords )
+                params_.outChords->push_back( { lowerLone, connectorEdgeId, newEdge } );
 
             lowerLone = upperLone = {};
 
@@ -1684,6 +1700,62 @@ std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoo
     SweepLineQueue triangulator( mesh.topology, meshSpacePredicates( mesh, loops, normal, patchToInEdges ), loops,
         { .abortWhenIntersect = true, .outPatchMap = &patchToInEdges } );
     return triangulator.run();
+}
+
+std::optional<HoleFillPlan> getMonotonePlan( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal )
+{
+    MR_TIMER;
+    HoleFillPlan res;
+    if ( loops.empty() )
+        return res;
+    size_t numLoopEdges = 0;
+    for ( const auto& loop : loops )
+    {
+        if ( loop.size() < 3 )
+            return {}; // the sweep skips such loops entirely, so their holes would stay unaddressed
+        numLoopEdges += loop.size();
+    }
+
+    WholeEdgeMap patchToInEdges;
+    patchToInEdges.reserve( numLoopEdges );
+    std::vector<MonotoneChord> chords;
+    SweepLineQueue triangulator( mesh.topology, meshSpacePredicates( mesh, loops, normal, patchToInEdges ), loops,
+        { .abortWhenIntersect = true, .outPatchMap = &patchToInEdges, .outChords = &chords } );
+    if ( !triangulator.findIntersections() )
+        return {};
+    // passing findIntersections here means there is nothing to inject, so monotonation can run at
+    // once; and it is where to stop - monotone parts are what the caller fills
+    triangulator.makeMonotone();
+
+    // the anchors are patch edges: the loop edges copied from the mesh (patchToInEdges maps them
+    // back), and past them the chords in creation order, because makeEdge() only appends
+    assert( triangulator.undirectedEdgeSize() == patchToInEdges.size() + chords.size() );
+    auto codeOf = [&] ( EdgeId patch )
+    {
+        if ( patch.undirected() < patchToInEdges.size() )
+        {
+            const EdgeId inE = patchToInEdges[patch.undirected()];
+            assert( inE );
+            return int( patch.odd() ? inE.sym() : inE );
+        }
+        // a chord: the item of the same index, reversed if directed against the recorded edge
+        const int k = int( patch.undirected() ) - int( patchToInEdges.size() );
+        return FillHoleItemEdge{ .item = k, .sym = patch.odd() != chords[k].edge.odd() }.encode();
+    };
+
+    res.items.resize( chords.size() );
+    for ( int k = 0; k < int( chords.size() ); ++k )
+    {
+        const int code1 = codeOf( chords[k].anchor1 );
+        const int code2 = codeOf( chords[k].anchor2 );
+        // the chord is spliced right after each of its anchors, so it lands in the wedge left( anchor );
+        // that wedge must be a hole of the mesh, otherwise the loops do not bound a region of this mesh
+        for ( const int code : { code1, code2 } )
+            if ( code >= 0 && mesh.topology.left( EdgeId( code ) ) )
+                return {};
+        res.items[k] = { code1, code2 };
+    }
+    return res;
 }
 
 }

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -1750,9 +1750,6 @@ std::optional<HoleFillPlan> getMonotonePlan( const Mesh& mesh, const EdgeLoops& 
                 return {};
         res.items[k] = { code1, code2 };
     }
-    // a chord could still duplicate an off-loop mesh edge already joining its two endpoints (e.g. a
-    // folded or coplanar patch); the caller runs isFillingMultipleEdgeFree() before committing the plan,
-    // exactly as it does for getPlanarHoleFillPlans() output
     return res;
 }
 

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -109,24 +109,15 @@ MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& co
 MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, WholeEdgeMap* outPatchMap = nullptr );
 
 /**
- * @brief splits the planar region bounded by \p loops in monotone parts, without triangulating them
- * this is the sweep-line triangulation stopped after monotonation: the returned plan lists the edges
- * to add to \p mesh to realize the split, each connecting the origins of two already existing edges
- * @param loops one closed EdgeLoop per boundary of one region (as produced by trackRightBoundaryLoop
- *        on a hole edge); each loop must have at least 3 edges. Which way round a loop runs does not
- *        matter: the region is taken from the winding number of the loops, not from their direction.
- *        The loops are expected to bound real holes of \p mesh (faces on their far side) lying close to
- *        one plane; on a strongly non-planar region sharing a vertex between two loops a chord may be
- *        placed into the wrong wedge, as in \ref triangulateDisjointContours
+ * @brief splits the near-planar region bounded by \p loops in monotone parts, without triangulating them
+ * this is the sweep-line triangulation stopped right after monotonation
+ * @param loops one closed EdgeLoop of at least 3 edges per boundary of one region, bounding holes of
+ *        \p mesh as trackRightBoundaryLoop returns them; which way round a loop runs does not matter
  * @param normal the orientation the region is monotone around, see \ref triangulateDisjointContours
- * @return std::nullopt if the loops intersect, or if realizing the split would place a chord into a
- *         face of \p mesh instead of a hole (so the loops do not bound a region of it), so that the
- *         caller can fall back on filling every loop separately. A region that needs no chord always
- *         returns a valued plan, even should the loops not bound a hole. Otherwise a plan with
- *         numTris == 0, to run with \ref executeHoleFillPlan, which then only adds edges and creates no
- *         faces (an empty plan, returned when the region is already monotone, is a valid no-op).
- *         A chord may still duplicate an off-loop mesh edge, so validate the plan with
- *         \ref isFillingMultipleEdgeFree before executing it
+ * @return std::nullopt if the loops intersect or a chord would land in a face instead of a hole, so that
+ *         the caller can fall back on filling every loop separately; otherwise a plan with numTris == 0
+ *         for \ref executeHoleFillPlan, which then only adds edges (empty if already monotone, a no-op).
+ *         Validate it with \ref isFillingMultipleEdgeFree: a chord may duplicate an off-loop mesh edge
  */
 MRMESH_API std::optional<HoleFillPlan> getMonotonePlan( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal );
 

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -114,13 +114,17 @@ MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, co
  * to add to \p mesh to realize the split, each connecting the origins of two already existing edges
  * @param loops one closed EdgeLoop per boundary of one region (as produced by trackRightBoundaryLoop
  *        on a hole edge); each loop must have at least 3 edges. Which way round a loop runs does not
- *        matter: the region is taken from the winding number of the loops, not from their direction
+ *        matter: the region is taken from the winding number of the loops, not from their direction.
+ *        The loops are expected to bound real holes of \p mesh (faces on their far side) lying close to
+ *        one plane; on a strongly non-planar region sharing a vertex between two loops a chord may be
+ *        placed into the wrong wedge, as in \ref triangulateDisjointContours
  * @param normal the orientation the region is monotone around, see \ref triangulateDisjointContours
  * @return std::nullopt if the loops intersect or do not bound holes of \p mesh, so that the caller can
  *         fall back on filling every loop separately; otherwise a plan with numTris == 0, to run with
- *         \ref executeHoleFillPlan which then only adds edges and creates no faces.
- *         The plan is empty if the region is a single already monotone loop; an empty plan must not be
- *         executed, there is nothing to add
+ *         \ref executeHoleFillPlan, which then only adds edges and creates no faces (an empty plan,
+ *         returned when the region is already monotone, is a valid no-op).
+ *         A chord may still duplicate an off-loop mesh edge, so validate the plan with
+ *         \ref isFillingMultipleEdgeFree before executing it
  */
 MRMESH_API std::optional<HoleFillPlan> getMonotonePlan( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal );
 

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -119,10 +119,12 @@ MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, co
  *        one plane; on a strongly non-planar region sharing a vertex between two loops a chord may be
  *        placed into the wrong wedge, as in \ref triangulateDisjointContours
  * @param normal the orientation the region is monotone around, see \ref triangulateDisjointContours
- * @return std::nullopt if the loops intersect or do not bound holes of \p mesh, so that the caller can
- *         fall back on filling every loop separately; otherwise a plan with numTris == 0, to run with
- *         \ref executeHoleFillPlan, which then only adds edges and creates no faces (an empty plan,
- *         returned when the region is already monotone, is a valid no-op).
+ * @return std::nullopt if the loops intersect, or if realizing the split would place a chord into a
+ *         face of \p mesh instead of a hole (so the loops do not bound a region of it), so that the
+ *         caller can fall back on filling every loop separately. A region that needs no chord always
+ *         returns a valued plan, even should the loops not bound a hole. Otherwise a plan with
+ *         numTris == 0, to run with \ref executeHoleFillPlan, which then only adds edges and creates no
+ *         faces (an empty plan, returned when the region is already monotone, is a valid no-op).
  *         A chord may still duplicate an off-loop mesh edge, so validate the plan with
  *         \ref isFillingMultipleEdgeFree before executing it
  */

--- a/source/MRMesh/MR2DContoursTriangulation.h
+++ b/source/MRMesh/MR2DContoursTriangulation.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "MRMeshFwd.h"
 #include "MRId.h"
+#include "MRHoleFillPlan.h"
 #include <optional>
 
 namespace MR
@@ -106,6 +107,22 @@ MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Contours2f& co
  * @return std::nullopt if the loops self-intersect, otherwise the patch mesh
  */
 MRMESH_API std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, WholeEdgeMap* outPatchMap = nullptr );
+
+/**
+ * @brief splits the planar region bounded by \p loops in monotone parts, without triangulating them
+ * this is the sweep-line triangulation stopped after monotonation: the returned plan lists the edges
+ * to add to \p mesh to realize the split, each connecting the origins of two already existing edges
+ * @param loops one closed EdgeLoop per boundary of one region (as produced by trackRightBoundaryLoop
+ *        on a hole edge); each loop must have at least 3 edges. Which way round a loop runs does not
+ *        matter: the region is taken from the winding number of the loops, not from their direction
+ * @param normal the orientation the region is monotone around, see \ref triangulateDisjointContours
+ * @return std::nullopt if the loops intersect or do not bound holes of \p mesh, so that the caller can
+ *         fall back on filling every loop separately; otherwise a plan with numTris == 0, to run with
+ *         \ref executeHoleFillPlan which then only adds edges and creates no faces.
+ *         The plan is empty if the region is a single already monotone loop; an empty plan must not be
+ *         executed, there is nothing to add
+ */
+MRMESH_API std::optional<HoleFillPlan> getMonotonePlan( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal );
 
 }
 }

--- a/source/MRMesh/MRMeshFillHole.cpp
+++ b/source/MRMesh/MRMeshFillHole.cpp
@@ -539,10 +539,10 @@ inline EdgeId executedPlanEdge( const HoleFillPlan & plan, int code )
     return sym ? e.sym() : e;
 }
 
-// adds the edges of the plan without creating any face
+// adds the edges of the plan without creating any face; an empty plan is a valid no-op (e.g. a region
+// getMonotonePlan() found already monotone)
 void executeEdgesOnlyPlan( MeshTopology & topology, HoleFillPlan & plan )
 {
-    assert( !plan.items.empty() ); // nothing to add, most likely a default-constructed plan
     for ( int i = 0; i < plan.items.size(); ++i )
     {
         EdgeId a = executedPlanEdge( plan, plan.items[i].edgeCode1 );

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -339,26 +339,21 @@ float sweepCoord( const Vector3f& p, const Vector3f& normal )
 }
 
 // a loop is monotone when it is two chains that both advance with the sweep, so walking it the sweep
-// coordinate turns around exactly twice; edges perpendicular to the sweep do not turn it around, the
-// sweep resolves those by an infinitesimal perturbation
+// coordinate turns around exactly twice; edges across the sweep do not turn it around, the sweep
+// resolves those by an infinitesimal perturbation
 bool isMonotoneHole( const Mesh& mesh, EdgeId e0, const Vector3f& normal )
 {
-    const EdgeLoop loop = trackRightBoundaryLoop( mesh.topology, e0 );
-    const int n = int( loop.size() );
-    if ( n < 3 )
-        return false;
     std::vector<int> dirs;
-    for ( int i = 0; i < n; ++i )
+    for ( EdgeId e : trackRightBoundaryLoop( mesh.topology, e0 ) )
     {
-        const float a = sweepCoord( mesh.orgPnt( loop[i] ), normal );
-        const float b = sweepCoord( mesh.orgPnt( loop[( i + 1 ) % n] ), normal );
+        const float a = sweepCoord( mesh.orgPnt( e ), normal );
+        const float b = sweepCoord( mesh.destPnt( e ), normal );
         if ( a != b )
             dirs.push_back( a < b ? 1 : -1 );
     }
     int turns = 0;
-    for ( int i = 0; i < int( dirs.size() ); ++i )
-        if ( dirs[i] != dirs[( i + 1 ) % dirs.size()] )
-            ++turns;
+    for ( size_t i = 0; i < dirs.size(); ++i )
+        turns += dirs[i] != dirs[( i + 1 ) % dirs.size()];
     return turns == 2;
 }
 
@@ -369,12 +364,8 @@ std::vector<EdgeId> collectParts( const MeshTopology& tp, const EdgeLoops& loops
     std::vector<EdgeId> starts;
     for ( const auto& loop : loops )
         starts.insert( starts.end(), loop.begin(), loop.end() );
-    for ( const auto& item : executedPlan.items )
-    {
-        const EdgeId e( item.edgeCode1 ); // execution replaced the code with the created edge
-        starts.push_back( e );
-        starts.push_back( e.sym() );
-    }
+    for ( const auto& item : executedPlan.items ) // execution replaced the code with the created edge
+        starts.insert( starts.end(), { EdgeId( item.edgeCode1 ), EdgeId( item.edgeCode1 ).sym() } );
     std::vector<EdgeId> res;
     EdgeBitSet visited( tp.edgeSize() );
     for ( EdgeId s : starts )
@@ -388,68 +379,39 @@ std::vector<EdgeId> collectParts( const MeshTopology& tp, const EdgeLoops& loops
     return res;
 }
 
-std::vector<Vector3f> to3d( const std::vector<Vector2f>& pts )
+// vertex (i,j) of a grid on the plane through the origin with the given normal, sheared a little so
+// that no two vertices share a sweep coordinate along either axis: then the cut the sweep makes does
+// not depend on how it breaks ties between equally placed vertices, which is by vertex number
+Vector3f gridPnt( int i, int j, const Vector3f& normal = Vector3f::plusZ() )
 {
-    std::vector<Vector3f> res;
-    res.reserve( pts.size() );
-    for ( const auto& p : pts )
-        res.push_back( to3dim( p ) );
-    return res;
-}
-
-// the boundary loop through e0 that has the polygon interior on its left
-EdgeLoop interiorLoop( const Mesh& mesh, EdgeId e0, const Vector3f& normal )
-{
-    EdgeLoop loop = trackRightBoundaryLoop( mesh.topology, e0 );
-    Vector3f doubleArea;
-    for ( EdgeId e : loop )
-        doubleArea += cross( mesh.orgPnt( e ), mesh.destPnt( e ) );
-    if ( dot( doubleArea, normal ) < 0 ) // the interior is on the left of the loop running ccw around +normal
-        loop = trackRightBoundaryLoop( mesh.topology, e0.sym() );
-    return loop;
-}
-
-// a mesh that is nothing but one closed edge loop, with that loop taken as above
-std::pair<Mesh, EdgeLoop> makeFreeLoop( const std::vector<Vector3f>& poly, const Vector3f& normal )
-{
-    Mesh mesh;
-    const EdgeId e0 = mesh.addSeparateEdgeLoop( poly );
-    EdgeLoop loop = interiorLoop( mesh, e0, normal );
-    return { std::move( mesh ), std::move( loop ) };
-}
-
-// the grid below is sheared a little, so that no two of its vertices share a sweep coordinate along
-// either axis: then the cut the sweep makes does not depend on how it breaks ties between equally
-// placed vertices, which is by vertex number and so by where the caller's loop happens to start
-Vector3f gridPnt( int i, int j )
-{
-    return { float( i ) + 0.05f * float( j ), float( j ) + 0.05f * float( i ), 0.f };
+    const float x = float( i ) + 0.05f * float( j );
+    const float y = float( j ) + 0.05f * float( i );
+    return { x, y, -( normal.x * x + normal.y * y ) / normal.z };
 }
 
 // a grid of n x n quads with the cells `isHole` marks left out: the region to fill is then a real
 // mesh hole with faces around it, and every coordinate stays exact
-Mesh makeGridWithHoles( int n, const std::function<bool( int, int )>& isHole )
+Mesh makeGridWithHoles( int n, const Vector3f& normal, const std::function<bool( int, int )>& isHole )
 {
-    std::vector<Vector3f> pts;
-    pts.reserve( ( n + 1 ) * ( n + 1 ) );
+    VertCoords pts;
     for ( int j = 0; j <= n; ++j )
         for ( int i = 0; i <= n; ++i )
-            pts.push_back( gridPnt( i, j ) );
+            pts.push_back( gridPnt( i, j, normal ) );
     auto vid = [n] ( int i, int j ) { return VertId( j * ( n + 1 ) + i ); };
     Triangulation t;
     for ( int j = 0; j < n; ++j )
         for ( int i = 0; i < n; ++i )
         {
             if ( isHole( i, j ) )
-                continue; // the cell's two triangles and their shared diagonal are all left out
+                continue;
             t.push_back( { vid( i, j ), vid( i + 1, j ), vid( i + 1, j + 1 ) } );
             t.push_back( { vid( i, j ), vid( i + 1, j + 1 ), vid( i, j + 1 ) } );
         }
-    return Mesh::fromTriangles( VertCoords( std::move( pts ) ), t );
+    return Mesh::fromTriangles( std::move( pts ), t );
 }
 
-// the hole loop of `mesh` running from `from` to `to`, so with that hole on its left; an edge tells
-// two holes apart even where they meet in one vertex, which a point alone would not
+// the hole loop of `mesh` running from grid vertex `from` to `to`, so with that hole on its left;
+// an edge tells two holes apart even where they meet in one vertex, which a point alone would not
 EdgeLoop findHoleByEdge( const Mesh& mesh, const Vector3f& from, const Vector3f& to )
 {
     for ( EdgeId e : mesh.topology.findHoleRepresentiveEdges() )
@@ -459,30 +421,13 @@ EdgeLoop findHoleByEdge( const Mesh& mesh, const Vector3f& from, const Vector3f&
     return {};
 }
 
-// the cells of a C, its notch opening toward +x, so that it splits a sweep along x
-bool cCell( int i, int j )
-{
-    return ( j == 1 && i >= 1 && i <= 3 ) || ( i == 1 && j == 2 ) || ( j == 3 && i >= 1 && i <= 3 );
-}
-
-// the same shape turned a quarter, so that it splits a sweep along y instead
-bool uCell( int i, int j )
-{
-    return ( j == 1 && i >= 1 && i <= 3 ) || ( i == 1 && j >= 2 && j <= 3 ) || ( i == 3 && j >= 2 && j <= 3 );
-}
-
-// a ring of cells around one kept in the middle: the kept cell touches nothing, so it is an island
-// floating inside the region, and the ring is not monotone along either axis
-bool ringCell( int i, int j )
-{
-    return i >= 1 && i <= 3 && j >= 1 && j <= 3 && !( i == 2 && j == 2 );
-}
-
 // executes the monotone plan and checks that the parts it leaves are monotone holes, and that
-// filling them reproduces what the full sweep line triangulation of the same region produces
+// filling them reproduces what the full sweep-line triangulation of the same region produces
 // \param expectedChords the number of edges the plan must add, or -1 not to check it
 void checkMonotonePlan( Mesh mesh, const EdgeLoops& loops, const Vector3f& normal, int expectedChords )
 {
+    for ( const auto& loop : loops )
+        ASSERT_GE( loop.size(), size_t( 3 ) ); // the fixture lookup found its hole
     const auto refPatch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, normal );
     ASSERT_TRUE( refPatch.has_value() );
 
@@ -502,112 +447,84 @@ void checkMonotonePlan( Mesh mesh, const EdgeLoops& loops, const Vector3f& norma
     const auto numFaces0 = mesh.topology.numValidFaces();
     const double area0 = mesh.area();
     auto fillPlans = getPlanarHoleFillPlans( mesh, parts );
-    ASSERT_EQ( fillPlans.size(), parts.size() );
     for ( int i = 0; i < int( parts.size() ); ++i )
         executeHoleFillPlan( mesh, parts[i], fillPlans[i] );
-
     // a triangulation of the region that uses only its boundary vertices always has the same number
     // of triangles, whatever the diagonals are
     EXPECT_EQ( mesh.topology.numValidFaces() - numFaces0, refPatch->topology.numValidFaces() );
     EXPECT_NEAR( mesh.area() - area0, refPatch->area(), 1e-4 * refPatch->area() );
 }
 
-// a C opening toward +x: its notch splits the region in two arms as the sweep passes x = 1
-const std::vector<Vector2f> cShapeCcw =
-    { { 0.f, 0.f }, { 4.f, 0.f }, { 4.f, 1.f }, { 1.f, 1.f }, { 1.f, 3.f }, { 4.f, 3.f }, { 4.f, 4.f }, { 0.f, 4.f } };
-
-// three arms on a spine, of increasing length so that they also end in sweep order: each of the two
-// notches between them splits the region once
-const std::vector<Vector2f> combCcw =
-    { { 0.f, 0.f }, { 4.f, 0.f }, { 4.f, 1.f }, { 1.f, 1.f }, { 1.f, 2.f }, { 6.f, 2.f }, { 6.f, 3.f },
-      { 1.f, 3.f }, { 1.f, 4.f }, { 8.f, 4.f }, { 8.f, 5.f }, { 0.f, 5.f } };
+// hole cells of the grid fixtures; the region to fill is their union
+bool cCell( int i, int j ) // a C opening toward +x: its notch splits a sweep along x once
+{
+    return ( j == 1 || j == 3 ) ? i >= 1 && i <= 3 : ( j == 2 && i == 1 );
+}
+bool uCell( int i, int j ) // the same shape turned a quarter, so that it splits a sweep along y instead
+{
+    return j == 1 ? i >= 1 && i <= 3 : ( ( i == 1 || i == 3 ) && j >= 2 && j <= 3 );
+}
+bool ringCell( int i, int j ) // a ring around one kept cell, which touches nothing: an island in the region
+{
+    return i >= 1 && i <= 3 && j >= 1 && j <= 3 && !( i == 2 && j == 2 );
+}
+bool combCell( int i, int j ) // three arms of increasing length on a spine: two notches, so two splits
+{
+    return i == 1 ? j >= 1 && j <= 5 : i >= 2 && ( ( j == 1 && i <= 3 ) || ( j == 3 && i <= 5 ) || ( j == 5 && i <= 6 ) );
+}
 
 } // anonymous namespace
 
-TEST( MRMesh, PlanarTriangulationMonotonePlanFreeLoops )
+TEST( MRMesh, PlanarTriangulationMonotonePlan )
 {
     const Vector3f normal = Vector3f::plusZ();
+    auto hole = [] ( const Mesh& mesh, int i0, int j0, int i1, int j1, const Vector3f& n = Vector3f::plusZ() )
+    {
+        return findHoleByEdge( mesh, gridPnt( i0, j0, n ), gridPnt( i1, j1, n ) );
+    };
 
-    { // one split vertex, so one chord
-        const auto [mesh, loop] = makeFreeLoop( to3d( cShapeCcw ), normal );
-        checkMonotonePlan( mesh, { loop }, normal, 1 );
-    }
-
-    { // one chord per notch, where the region splits off another arm
-        const auto [mesh, loop] = makeFreeLoop( to3d( combCcw ), normal );
-        checkMonotonePlan( mesh, { loop }, normal, 2 );
-    }
-
-    { // a convex loop is already monotone: an empty plan, not a failure
-        const auto [mesh, loop] = makeFreeLoop( to3d( { { 0.f, 0.f }, { 4.f, 0.f }, { 4.f, 4.f }, { 0.f, 4.f } } ), normal );
-        const auto plan = PlanarTriangulation::getMonotonePlan( mesh, { loop }, normal );
-        ASSERT_TRUE( plan.has_value() );
-        EXPECT_TRUE( plan->items.empty() );
-        checkMonotonePlan( mesh, { loop }, normal, 0 );
-    }
-
-    { // the same C shape carried onto a plane tilted off all axes, in the mesh's own 3d space:
-      // its z is whatever the plane dictates, so only the projection the sweep runs on is the C
-        const Vector3f tilted = Vector3f( 1.f, 2.f, 3.f ).normalized();
-        const Vector3f center( 10.f, -5.f, 2.f );
-        std::vector<Vector3f> poly;
-        for ( const auto& p : cShapeCcw )
-        {
-            const float z = center.z - ( tilted.x * ( p.x - center.x ) + tilted.y * ( p.y - center.y ) ) / tilted.z;
-            poly.push_back( { p.x, p.y, z } );
-        }
-        const auto [mesh, loop] = makeFreeLoop( poly, tilted );
-        checkMonotonePlan( mesh, { loop }, tilted, 1 );
-    }
-}
-
-TEST( MRMesh, PlanarTriangulationMonotonePlanInMesh )
-{
-    const Vector3f normal = Vector3f::plusZ();
-
-    { // the anchors are now real mesh hole edges, so the wedge guard has something to check
-        const Mesh mesh = makeGridWithHoles( 5, cCell );
-        const EdgeLoop loop = findHoleByEdge( mesh, gridPnt( 1, 1 ), gridPnt( 2, 1 ) );
-        ASSERT_EQ( loop.size(), size_t( 16 ) );
+    { // the notch of the C splits the region in two arms as the sweep passes it: one chord, anchored
+      // on real mesh hole edges, so the wedge guard has something to check
+        const Mesh mesh = makeGridWithHoles( 5, normal, cCell );
+        const EdgeLoop loop = hole( mesh, 1, 1, 2, 1 );
         checkMonotonePlan( mesh, { loop }, normal, 1 );
 
-        // which way round the loops run is not part of the input: the sweep takes the region from the
-        // winding number, and the anchors translate back to the same mesh edges either way. It may
-        // still cut the region differently, because reversing the loop renumbers the vertices and the
-        // sweep breaks ties between equally placed ones by their number
+        // which way round the loop runs is not part of the input: the sweep takes the region from the
+        // winding number, and the anchors translate back to the same mesh edges either way; it may
+        // still cut differently, since reversing renumbers the vertices the sweep breaks ties by
         EdgeLoop backwards;
         for ( auto it = loop.rbegin(); it != loop.rend(); ++it )
             backwards.push_back( it->sym() );
         checkMonotonePlan( mesh, { backwards }, normal, -1 );
     }
-
-    { // two holes pinched together at one vertex, which then has two hole sectors in the mesh ring;
-      // each of them is monotone on its own, so a correct plan adds nothing at all here
-        const Mesh mesh = makeGridWithHoles( 4, [] ( int i, int j ) { return ( i == 1 && j == 1 ) || ( i == 2 && j == 2 ); } );
-        const EdgeLoop l1 = findHoleByEdge( mesh, gridPnt( 1, 1 ), gridPnt( 2, 1 ) );
-        const EdgeLoop l2 = findHoleByEdge( mesh, gridPnt( 2, 2 ), gridPnt( 3, 2 ) );
-        ASSERT_EQ( l1.size(), size_t( 4 ) );
-        ASSERT_EQ( l2.size(), size_t( 4 ) );
-        checkMonotonePlan( mesh, { l1, l2 }, normal, 0 );
+    { // one chord per notch between the arms
+        const Mesh mesh = makeGridWithHoles( 8, normal, combCell );
+        checkMonotonePlan( mesh, { hole( mesh, 1, 1, 2, 1 ) }, normal, 2 );
     }
-
+    { // a single cell is already monotone: an empty plan, not a failure
+        const Mesh mesh = makeGridWithHoles( 3, normal, [] ( int i, int j ) { return i == 1 && j == 1; } );
+        checkMonotonePlan( mesh, { hole( mesh, 1, 1, 2, 1 ) }, normal, 0 );
+    }
+    { // the C on a plane tilted off all axes: the sweep runs on the projection along the dominant axis
+        const Vector3f tilted = Vector3f( 1.f, 2.f, 3.f ).normalized();
+        const Mesh mesh = makeGridWithHoles( 5, tilted, cCell );
+        checkMonotonePlan( mesh, { hole( mesh, 1, 1, 2, 1, tilted ) }, tilted, 1 );
+    }
+    { // two holes pinched together at one vertex, which then has two hole sectors in the mesh ring;
+      // each of them is monotone on its own, so a correct plan adds nothing at all
+        const Mesh mesh = makeGridWithHoles( 4, normal, [] ( int i, int j ) { return ( i == 1 && j == 1 ) || ( i == 2 && j == 2 ); } );
+        checkMonotonePlan( mesh, { hole( mesh, 1, 1, 2, 1 ), hole( mesh, 2, 2, 3, 2 ) }, normal, 0 );
+    }
     { // an annulus: the island touches nothing, so only a chord can bridge it to the outer loop -
       // one where the sweep splits the region around it, and one where it closes back up
-        const Mesh mesh = makeGridWithHoles( 5, ringCell );
-        const EdgeLoop lRing = findHoleByEdge( mesh, gridPnt( 1, 1 ), gridPnt( 2, 1 ) );
-        const EdgeLoop lIsland = findHoleByEdge( mesh, gridPnt( 3, 2 ), gridPnt( 2, 2 ) );
-        ASSERT_EQ( lRing.size(), size_t( 12 ) );
-        ASSERT_EQ( lIsland.size(), size_t( 4 ) );
-        checkMonotonePlan( mesh, { lRing, lIsland }, normal, 2 );
+        const Mesh mesh = makeGridWithHoles( 5, normal, ringCell );
+        checkMonotonePlan( mesh, { hole( mesh, 1, 1, 2, 1 ), hole( mesh, 3, 2, 2, 2 ) }, normal, 2 );
     }
-
     { // a mesh oriented the other way round, swept around -normal: that swaps the two kept axes, so
-      // the sweep now runs along y and the region has to be notched the other way to need a chord
-        Mesh mesh = makeGridWithHoles( 5, uCell );
+      // the sweep runs along y and the region has to be notched the other way to need a chord
+        Mesh mesh = makeGridWithHoles( 5, normal, uCell );
         mesh.topology.flipOrientation();
-        const EdgeLoop loop = findHoleByEdge( mesh, gridPnt( 2, 1 ), gridPnt( 1, 1 ) );
-        ASSERT_EQ( loop.size(), size_t( 16 ) );
-        checkMonotonePlan( mesh, { loop }, -normal, 1 );
+        checkMonotonePlan( mesh, { hole( mesh, 2, 1, 1, 1 ) }, -normal, 1 );
     }
 }
 
@@ -615,27 +532,22 @@ TEST( MRMesh, PlanarTriangulationMonotonePlanRejects )
 {
     const Vector3f normal = Vector3f::plusZ();
     // an annulus is not monotone along either axis, so it needs chords whichever way it is swept
-    const Mesh mesh = makeGridWithHoles( 5, ringCell );
-    const EdgeLoop lRing = findHoleByEdge( mesh, gridPnt( 1, 1 ), gridPnt( 2, 1 ) );
-    const EdgeLoop lIsland = findHoleByEdge( mesh, gridPnt( 3, 2 ), gridPnt( 2, 2 ) );
-    ASSERT_EQ( lRing.size(), size_t( 12 ) );
-    ASSERT_EQ( lIsland.size(), size_t( 4 ) );
+    const Mesh mesh = makeGridWithHoles( 5, normal, ringCell );
+    const EdgeLoops loops = { findHoleByEdge( mesh, gridPnt( 1, 1 ), gridPnt( 2, 1 ) ), findHoleByEdge( mesh, gridPnt( 3, 2 ), gridPnt( 2, 2 ) ) };
+    ASSERT_EQ( loops[1].size(), size_t( 4 ) );
 
-    // asking for the region around the opposite normal swaps the two kept axes, which mirrors the
-    // plane the sweep works in: every chord would then be spliced in a wedge that mesh faces occupy,
-    // and the wedge guard rejects the plan instead of corrupting the mesh
-    EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( mesh, { lRing, lIsland }, -normal ).has_value() );
-
+    // the opposite normal swaps the two kept axes, which mirrors the plane the sweep works in: every
+    // chord would then be spliced in a wedge that mesh faces occupy, and the wedge guard rejects the plan
+    EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( mesh, loops, -normal ).has_value() );
     // a loop of less than 3 edges is not a contour the sweep can take
-    EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( mesh, { EdgeLoop{ lIsland[0], lIsland[1] } }, normal ).has_value() );
+    EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( mesh, { EdgeLoop{ loops[1][0], loops[1][1] } }, normal ).has_value() );
 
-    { // intersecting loops: there is no region to decompose, the caller keeps its per loop path
-        Mesh two;
-        const EdgeId a0 = two.addSeparateEdgeLoop( to3d( { { 0.f, 0.f }, { 4.f, 0.f }, { 4.f, 4.f }, { 0.f, 4.f } } ) );
-        const EdgeId b0 = two.addSeparateEdgeLoop( to3d( { { 2.f, 2.f }, { 6.f, 2.f }, { 6.f, 6.f }, { 2.f, 6.f } } ) );
-        const EdgeLoops crossing = { interiorLoop( two, a0, normal ), interiorLoop( two, b0, normal ) };
-        EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( two, crossing, normal ).has_value() );
-    }
+    // intersecting loops: there is no region to decompose, the caller keeps its per loop path
+    Mesh two;
+    const EdgeId a0 = two.addSeparateEdgeLoop( { { 0.f, 0.f, 0.f }, { 4.f, 0.f, 0.f }, { 4.f, 4.f, 0.f }, { 0.f, 4.f, 0.f } } );
+    const EdgeId b0 = two.addSeparateEdgeLoop( { { 2.f, 2.f, 0.f }, { 6.f, 2.f, 0.f }, { 6.f, 6.f, 0.f }, { 2.f, 6.f, 0.f } } );
+    EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( two,
+        { trackRightBoundaryLoop( two.topology, a0 ), trackRightBoundaryLoop( two.topology, b0 ) }, normal ).has_value() );
 }
 
 namespace

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -348,11 +348,9 @@ TEST( MRMesh, PlanarTriangulationMonotonePlan )
 
     // the hole loops of the gap: the disk's boundary and the ring's inner boundary,
     // as opposed to the ring's outer boundary at radius 3
-    auto inGap = [&mesh] ( EdgeId e ) { return mesh.orgPnt( e ).lengthSq() < 5.f; };
-    EdgeLoops loops;
-    for ( EdgeId e : mesh.topology.findHoleRepresentiveEdges() )
-        if ( inGap( e ) )
-            loops.push_back( trackRightBoundaryLoop( mesh.topology, e ) );
+    auto inGap = [&mesh] ( const EdgeLoop& l ) { return mesh.orgPnt( l.front() ).lengthSq() < 5.f; };
+    EdgeLoops loops = findRightBoundary( mesh.topology );
+    std::erase_if( loops, [&] ( const EdgeLoop& l ) { return !inGap( l ); } );
     ASSERT_EQ( loops.size(), size_t( 2 ) );
 
     const Vector3f normal = Vector3f::plusZ();
@@ -368,20 +366,17 @@ TEST( MRMesh, PlanarTriangulationMonotonePlan )
     executeHoleFillPlan( mesh, loops[0][0], *plan );
 
     // each of the two holes the chords left is monotone along x: walking it, x turns around twice
-    int numParts = 0;
-    for ( EdgeId e0 : mesh.topology.findHoleRepresentiveEdges() )
+    EdgeLoops parts = findRightBoundary( mesh.topology );
+    std::erase_if( parts, [&] ( const EdgeLoop& l ) { return !inGap( l ); } );
+    for ( const EdgeLoop& loop : parts )
     {
-        if ( !inGap( e0 ) )
-            continue;
-        ++numParts;
-        const EdgeLoop loop = trackRightBoundaryLoop( mesh.topology, e0 );
         auto rightGoing = [&] ( size_t i ) { return mesh.orgPnt( loop[i] ).x < mesh.destPnt( loop[i] ).x; };
         int turns = 0;
         for ( size_t i = 0; i < loop.size(); ++i )
             turns += rightGoing( i ) != rightGoing( ( i + 1 ) % loop.size() );
         EXPECT_EQ( turns, 2 );
     }
-    EXPECT_EQ( numParts, 2 );
+    EXPECT_EQ( parts.size(), size_t( 2 ) );
 }
 
 namespace

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -8,7 +8,6 @@
 #include <MRMesh/MRExtractIsolines.h>
 #include <MRMesh/MRAffineXf3.h>
 #include <MRMesh/MRRegionBoundary.h>
-#include <MRMesh/MRRingIterator.h>
 #include <MRMesh/MRMeshFillHole.h>
 #include <MRMesh/MR2to3.h>
 #include <MRSymbolMesh/MRSymbolMesh.h>
@@ -324,230 +323,65 @@ TEST( MRMesh, PlanarTriangulationChainedActiveEdges3 )
     EXPECT_GE( mesh.topology.numValidFaces(), 0 ); // completing without the assert is the test
 }
 
-namespace
+TEST( MRMesh, PlanarTriangulationMonotonePlan )
 {
-
-// the sweep orders vertices by this coordinate alone: the axis most aligned with the normal is
-// dropped, and of the two kept axes the first one is the sweep direction (they swap with the normal)
-float sweepCoord( const Vector3f& p, const Vector3f& normal )
-{
-    int dropAx = 0;
-    for ( int i = 1; i < 3; ++i )
-        if ( normal[i] * normal[i] > normal[dropAx] * normal[dropAx] )
-            dropAx = i;
-    return p[( dropAx + ( normal[dropAx] < 0 ? 2 : 1 ) ) % 3];
-}
-
-// a loop is monotone when it is two chains that both advance with the sweep, so walking it the sweep
-// coordinate turns around exactly twice; edges across the sweep do not turn it around, the sweep
-// resolves those by an infinitesimal perturbation
-bool isMonotoneHole( const Mesh& mesh, EdgeId e0, const Vector3f& normal )
-{
-    std::vector<int> dirs;
-    for ( EdgeId e : trackRightBoundaryLoop( mesh.topology, e0 ) )
-    {
-        const float a = sweepCoord( mesh.orgPnt( e ), normal );
-        const float b = sweepCoord( mesh.destPnt( e ), normal );
-        if ( a != b )
-            dirs.push_back( a < b ? 1 : -1 );
-    }
-    int turns = 0;
-    for ( size_t i = 0; i < dirs.size(); ++i )
-        turns += dirs[i] != dirs[( i + 1 ) % dirs.size()];
-    return turns == 2;
-}
-
-// one representative edge per hole an executed monotone plan left behind: every part is incident to
-// an original loop edge or to an added edge, so the left rings of those cover all the parts
-std::vector<EdgeId> collectParts( const MeshTopology& tp, const EdgeLoops& loops, const HoleFillPlan& executedPlan )
-{
-    std::vector<EdgeId> starts;
-    for ( const auto& loop : loops )
-        starts.insert( starts.end(), loop.begin(), loop.end() );
-    for ( const auto& item : executedPlan.items ) // execution replaced the code with the created edge
-        starts.insert( starts.end(), { EdgeId( item.edgeCode1 ), EdgeId( item.edgeCode1 ).sym() } );
-    std::vector<EdgeId> res;
-    EdgeBitSet visited( tp.edgeSize() );
-    for ( EdgeId s : starts )
-    {
-        if ( visited.test( s ) || tp.left( s ) )
-            continue;
-        res.push_back( s );
-        for ( EdgeId e : leftRing( tp, s ) )
-            visited.set( e );
-    }
-    return res;
-}
-
-// vertex (i,j) of a grid on the plane through the origin with the given normal, sheared a little so
-// that no two vertices share a sweep coordinate along either axis: then the cut the sweep makes does
-// not depend on how it breaks ties between equally placed vertices, which is by vertex number
-Vector3f gridPnt( int i, int j, const Vector3f& normal = Vector3f::plusZ() )
-{
-    const float x = float( i ) + 0.05f * float( j );
-    const float y = float( j ) + 0.05f * float( i );
-    return { x, y, -( normal.x * x + normal.y * y ) / normal.z };
-}
-
-// a grid of n x n quads with the cells `isHole` marks left out: the region to fill is then a real
-// mesh hole with faces around it, and every coordinate stays exact
-Mesh makeGridWithHoles( int n, const Vector3f& normal, const std::function<bool( int, int )>& isHole )
-{
+    // a flat disk inside a flat ring: the gap between them is bounded by two concentric circles, and
+    // the disk touches nothing, so only chords can join its loop to the ring's
+    constexpr int n = 8;
     VertCoords pts;
-    for ( int j = 0; j <= n; ++j )
-        for ( int i = 0; i <= n; ++i )
-            pts.push_back( gridPnt( i, j, normal ) );
-    auto vid = [n] ( int i, int j ) { return VertId( j * ( n + 1 ) + i ); };
-    Triangulation t;
-    for ( int j = 0; j < n; ++j )
+    pts.push_back( Vector3f() ); // disk center
+    for ( int ring = 0; ring < 3; ++ring ) // circles of radius 1 (the disk), 2 and 3 (the ring)
         for ( int i = 0; i < n; ++i )
         {
-            if ( isHole( i, j ) )
-                continue;
-            t.push_back( { vid( i, j ), vid( i + 1, j ), vid( i + 1, j + 1 ) } );
-            t.push_back( { vid( i, j ), vid( i + 1, j + 1 ), vid( i, j + 1 ) } );
+            const float a = 2 * PI_F * i / n + 0.3f; // off the axes, so no two vertices share an x
+            pts.push_back( Vector3f( ( ring + 1 ) * std::cos( a ), ( ring + 1 ) * std::sin( a ), 0.f ) );
         }
-    return Mesh::fromTriangles( std::move( pts ), t );
-}
+    auto v = [] ( int ring, int i ) { return VertId( 1 + ring * n + i % n ); };
+    Triangulation t;
+    for ( int i = 0; i < n; ++i )
+    {
+        t.push_back( { VertId( 0 ), v( 0, i ), v( 0, i + 1 ) } );
+        t.push_back( { v( 1, i ), v( 2, i ), v( 2, i + 1 ) } );
+        t.push_back( { v( 1, i ), v( 2, i + 1 ), v( 1, i + 1 ) } );
+    }
+    Mesh mesh = Mesh::fromTriangles( std::move( pts ), t );
 
-// the hole loop of `mesh` running from grid vertex `from` to `to`, so with that hole on its left;
-// an edge tells two holes apart even where they meet in one vertex, which a point alone would not
-EdgeLoop findHoleByEdge( const Mesh& mesh, const Vector3f& from, const Vector3f& to )
-{
+    // the hole loops of the gap: the disk's boundary and the ring's inner boundary,
+    // as opposed to the ring's outer boundary at radius 3
+    auto inGap = [&mesh] ( EdgeId e ) { return mesh.orgPnt( e ).lengthSq() < 5.f; };
+    EdgeLoops loops;
     for ( EdgeId e : mesh.topology.findHoleRepresentiveEdges() )
-        for ( EdgeId le : trackRightBoundaryLoop( mesh.topology, e ) )
-            if ( mesh.orgPnt( le ) == from && mesh.destPnt( le ) == to )
-                return trackRightBoundaryLoop( mesh.topology, le );
-    return {};
-}
+        if ( inGap( e ) )
+            loops.push_back( trackRightBoundaryLoop( mesh.topology, e ) );
+    ASSERT_EQ( loops.size(), size_t( 2 ) );
 
-// executes the monotone plan and checks that the parts it leaves are monotone holes, and that
-// filling them reproduces what the full sweep-line triangulation of the same region produces
-// \param expectedChords the number of edges the plan must add, or -1 not to check it
-void checkMonotonePlan( Mesh mesh, const EdgeLoops& loops, const Vector3f& normal, int expectedChords )
-{
-    for ( const auto& loop : loops )
-        ASSERT_GE( loop.size(), size_t( 3 ) ); // the fixture lookup found its hole
-    const auto refPatch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, normal );
-    ASSERT_TRUE( refPatch.has_value() );
+    const Vector3f normal = Vector3f::plusZ();
+    // around the opposite normal the sweep works in a mirrored plane, so every chord would land in a
+    // wedge that faces occupy: the plan is rejected instead
+    EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( mesh, loops, -normal ).has_value() );
 
     auto plan = PlanarTriangulation::getMonotonePlan( mesh, loops, normal );
     ASSERT_TRUE( plan.has_value() );
     EXPECT_EQ( plan->numTris, 0 ); // the plan only adds edges
-    if ( expectedChords >= 0 )
-        EXPECT_EQ( int( plan->items.size() ), expectedChords );
-    if ( !plan->items.empty() )
-        executeHoleFillPlan( mesh, loops[0][0], *plan );
+    // the sweep splits the gap where it reaches the disk and closes it back up where it leaves it
+    ASSERT_EQ( plan->items.size(), size_t( 2 ) );
+    executeHoleFillPlan( mesh, loops[0][0], *plan );
 
-    const auto parts = collectParts( mesh.topology, loops, *plan );
-    EXPECT_FALSE( parts.empty() );
-    for ( EdgeId e : parts )
-        EXPECT_TRUE( isMonotoneHole( mesh, e, normal ) );
-
-    const auto numFaces0 = mesh.topology.numValidFaces();
-    const double area0 = mesh.area();
-    auto fillPlans = getPlanarHoleFillPlans( mesh, parts );
-    for ( int i = 0; i < int( parts.size() ); ++i )
-        executeHoleFillPlan( mesh, parts[i], fillPlans[i] );
-    // a triangulation of the region that uses only its boundary vertices always has the same number
-    // of triangles, whatever the diagonals are
-    EXPECT_EQ( mesh.topology.numValidFaces() - numFaces0, refPatch->topology.numValidFaces() );
-    EXPECT_NEAR( mesh.area() - area0, refPatch->area(), 1e-4 * refPatch->area() );
-}
-
-// hole cells of the grid fixtures; the region to fill is their union
-bool cCell( int i, int j ) // a C opening toward +x: its notch splits a sweep along x once
-{
-    return ( j == 1 || j == 3 ) ? i >= 1 && i <= 3 : ( j == 2 && i == 1 );
-}
-bool uCell( int i, int j ) // the same shape turned a quarter, so that it splits a sweep along y instead
-{
-    return j == 1 ? i >= 1 && i <= 3 : ( ( i == 1 || i == 3 ) && j >= 2 && j <= 3 );
-}
-bool ringCell( int i, int j ) // a ring around one kept cell, which touches nothing: an island in the region
-{
-    return i >= 1 && i <= 3 && j >= 1 && j <= 3 && !( i == 2 && j == 2 );
-}
-bool combCell( int i, int j ) // three arms of increasing length on a spine: two notches, so two splits
-{
-    return i == 1 ? j >= 1 && j <= 5 : i >= 2 && ( ( j == 1 && i <= 3 ) || ( j == 3 && i <= 5 ) || ( j == 5 && i <= 6 ) );
-}
-
-} // anonymous namespace
-
-TEST( MRMesh, PlanarTriangulationMonotonePlan )
-{
-    const Vector3f normal = Vector3f::plusZ();
-    auto hole = [] ( const Mesh& mesh, int i0, int j0, int i1, int j1, const Vector3f& n = Vector3f::plusZ() )
+    // each of the two holes the chords left is monotone along x: walking it, x turns around twice
+    int numParts = 0;
+    for ( EdgeId e0 : mesh.topology.findHoleRepresentiveEdges() )
     {
-        return findHoleByEdge( mesh, gridPnt( i0, j0, n ), gridPnt( i1, j1, n ) );
-    };
-
-    { // the notch of the C splits the region in two arms as the sweep passes it: one chord, anchored
-      // on real mesh hole edges, so the wedge guard has something to check
-        const Mesh mesh = makeGridWithHoles( 5, normal, cCell );
-        const EdgeLoop loop = hole( mesh, 1, 1, 2, 1 );
-        checkMonotonePlan( mesh, { loop }, normal, 1 );
-
-        // which way round the loop runs is not part of the input: the sweep takes the region from the
-        // winding number, and the anchors translate back to the same mesh edges either way; it may
-        // still cut differently, since reversing renumbers the vertices the sweep breaks ties by
-        EdgeLoop backwards;
-        for ( auto it = loop.rbegin(); it != loop.rend(); ++it )
-            backwards.push_back( it->sym() );
-        checkMonotonePlan( mesh, { backwards }, normal, -1 );
+        if ( !inGap( e0 ) )
+            continue;
+        ++numParts;
+        const EdgeLoop loop = trackRightBoundaryLoop( mesh.topology, e0 );
+        auto rightGoing = [&] ( size_t i ) { return mesh.orgPnt( loop[i] ).x < mesh.destPnt( loop[i] ).x; };
+        int turns = 0;
+        for ( size_t i = 0; i < loop.size(); ++i )
+            turns += rightGoing( i ) != rightGoing( ( i + 1 ) % loop.size() );
+        EXPECT_EQ( turns, 2 );
     }
-    { // one chord per notch between the arms
-        const Mesh mesh = makeGridWithHoles( 8, normal, combCell );
-        checkMonotonePlan( mesh, { hole( mesh, 1, 1, 2, 1 ) }, normal, 2 );
-    }
-    { // a single cell is already monotone: an empty plan, not a failure
-        const Mesh mesh = makeGridWithHoles( 3, normal, [] ( int i, int j ) { return i == 1 && j == 1; } );
-        checkMonotonePlan( mesh, { hole( mesh, 1, 1, 2, 1 ) }, normal, 0 );
-    }
-    { // the C on a plane tilted off all axes: the sweep runs on the projection along the dominant axis
-        const Vector3f tilted = Vector3f( 1.f, 2.f, 3.f ).normalized();
-        const Mesh mesh = makeGridWithHoles( 5, tilted, cCell );
-        checkMonotonePlan( mesh, { hole( mesh, 1, 1, 2, 1, tilted ) }, tilted, 1 );
-    }
-    { // two holes pinched together at one vertex, which then has two hole sectors in the mesh ring;
-      // each of them is monotone on its own, so a correct plan adds nothing at all
-        const Mesh mesh = makeGridWithHoles( 4, normal, [] ( int i, int j ) { return ( i == 1 && j == 1 ) || ( i == 2 && j == 2 ); } );
-        checkMonotonePlan( mesh, { hole( mesh, 1, 1, 2, 1 ), hole( mesh, 2, 2, 3, 2 ) }, normal, 0 );
-    }
-    { // an annulus: the island touches nothing, so only a chord can bridge it to the outer loop -
-      // one where the sweep splits the region around it, and one where it closes back up
-        const Mesh mesh = makeGridWithHoles( 5, normal, ringCell );
-        checkMonotonePlan( mesh, { hole( mesh, 1, 1, 2, 1 ), hole( mesh, 3, 2, 2, 2 ) }, normal, 2 );
-    }
-    { // a mesh oriented the other way round, swept around -normal: that swaps the two kept axes, so
-      // the sweep runs along y and the region has to be notched the other way to need a chord
-        Mesh mesh = makeGridWithHoles( 5, normal, uCell );
-        mesh.topology.flipOrientation();
-        checkMonotonePlan( mesh, { hole( mesh, 2, 1, 1, 1 ) }, -normal, 1 );
-    }
-}
-
-TEST( MRMesh, PlanarTriangulationMonotonePlanRejects )
-{
-    const Vector3f normal = Vector3f::plusZ();
-    // an annulus is not monotone along either axis, so it needs chords whichever way it is swept
-    const Mesh mesh = makeGridWithHoles( 5, normal, ringCell );
-    const EdgeLoops loops = { findHoleByEdge( mesh, gridPnt( 1, 1 ), gridPnt( 2, 1 ) ), findHoleByEdge( mesh, gridPnt( 3, 2 ), gridPnt( 2, 2 ) ) };
-    ASSERT_EQ( loops[1].size(), size_t( 4 ) );
-
-    // the opposite normal swaps the two kept axes, which mirrors the plane the sweep works in: every
-    // chord would then be spliced in a wedge that mesh faces occupy, and the wedge guard rejects the plan
-    EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( mesh, loops, -normal ).has_value() );
-    // a loop of less than 3 edges is not a contour the sweep can take
-    EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( mesh, { EdgeLoop{ loops[1][0], loops[1][1] } }, normal ).has_value() );
-
-    // intersecting loops: there is no region to decompose, the caller keeps its per loop path
-    Mesh two;
-    const EdgeId a0 = two.addSeparateEdgeLoop( { { 0.f, 0.f, 0.f }, { 4.f, 0.f, 0.f }, { 4.f, 4.f, 0.f }, { 0.f, 4.f, 0.f } } );
-    const EdgeId b0 = two.addSeparateEdgeLoop( { { 2.f, 2.f, 0.f }, { 6.f, 2.f, 0.f }, { 6.f, 6.f, 0.f }, { 2.f, 6.f, 0.f } } );
-    EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( two,
-        { trackRightBoundaryLoop( two.topology, a0 ), trackRightBoundaryLoop( two.topology, b0 ) }, normal ).has_value() );
+    EXPECT_EQ( numParts, 2 );
 }
 
 namespace

--- a/source/MRTest/MR2DContoursTriangulationTests.cpp
+++ b/source/MRTest/MR2DContoursTriangulationTests.cpp
@@ -8,6 +8,8 @@
 #include <MRMesh/MRExtractIsolines.h>
 #include <MRMesh/MRAffineXf3.h>
 #include <MRMesh/MRRegionBoundary.h>
+#include <MRMesh/MRRingIterator.h>
+#include <MRMesh/MRMeshFillHole.h>
 #include <MRMesh/MR2to3.h>
 #include <MRSymbolMesh/MRSymbolMesh.h>
 #include <gtest/gtest.h>
@@ -320,6 +322,320 @@ TEST( MRMesh, PlanarTriangulationChainedActiveEdges3 )
     cont.push_back( cont.front() );
     Mesh mesh = PlanarTriangulation::triangulateContours( { cont } );
     EXPECT_GE( mesh.topology.numValidFaces(), 0 ); // completing without the assert is the test
+}
+
+namespace
+{
+
+// the sweep orders vertices by this coordinate alone: the axis most aligned with the normal is
+// dropped, and of the two kept axes the first one is the sweep direction (they swap with the normal)
+float sweepCoord( const Vector3f& p, const Vector3f& normal )
+{
+    int dropAx = 0;
+    for ( int i = 1; i < 3; ++i )
+        if ( normal[i] * normal[i] > normal[dropAx] * normal[dropAx] )
+            dropAx = i;
+    return p[( dropAx + ( normal[dropAx] < 0 ? 2 : 1 ) ) % 3];
+}
+
+// a loop is monotone when it is two chains that both advance with the sweep, so walking it the sweep
+// coordinate turns around exactly twice; edges perpendicular to the sweep do not turn it around, the
+// sweep resolves those by an infinitesimal perturbation
+bool isMonotoneHole( const Mesh& mesh, EdgeId e0, const Vector3f& normal )
+{
+    const EdgeLoop loop = trackRightBoundaryLoop( mesh.topology, e0 );
+    const int n = int( loop.size() );
+    if ( n < 3 )
+        return false;
+    std::vector<int> dirs;
+    for ( int i = 0; i < n; ++i )
+    {
+        const float a = sweepCoord( mesh.orgPnt( loop[i] ), normal );
+        const float b = sweepCoord( mesh.orgPnt( loop[( i + 1 ) % n] ), normal );
+        if ( a != b )
+            dirs.push_back( a < b ? 1 : -1 );
+    }
+    int turns = 0;
+    for ( int i = 0; i < int( dirs.size() ); ++i )
+        if ( dirs[i] != dirs[( i + 1 ) % dirs.size()] )
+            ++turns;
+    return turns == 2;
+}
+
+// one representative edge per hole an executed monotone plan left behind: every part is incident to
+// an original loop edge or to an added edge, so the left rings of those cover all the parts
+std::vector<EdgeId> collectParts( const MeshTopology& tp, const EdgeLoops& loops, const HoleFillPlan& executedPlan )
+{
+    std::vector<EdgeId> starts;
+    for ( const auto& loop : loops )
+        starts.insert( starts.end(), loop.begin(), loop.end() );
+    for ( const auto& item : executedPlan.items )
+    {
+        const EdgeId e( item.edgeCode1 ); // execution replaced the code with the created edge
+        starts.push_back( e );
+        starts.push_back( e.sym() );
+    }
+    std::vector<EdgeId> res;
+    EdgeBitSet visited( tp.edgeSize() );
+    for ( EdgeId s : starts )
+    {
+        if ( visited.test( s ) || tp.left( s ) )
+            continue;
+        res.push_back( s );
+        for ( EdgeId e : leftRing( tp, s ) )
+            visited.set( e );
+    }
+    return res;
+}
+
+std::vector<Vector3f> to3d( const std::vector<Vector2f>& pts )
+{
+    std::vector<Vector3f> res;
+    res.reserve( pts.size() );
+    for ( const auto& p : pts )
+        res.push_back( to3dim( p ) );
+    return res;
+}
+
+// the boundary loop through e0 that has the polygon interior on its left
+EdgeLoop interiorLoop( const Mesh& mesh, EdgeId e0, const Vector3f& normal )
+{
+    EdgeLoop loop = trackRightBoundaryLoop( mesh.topology, e0 );
+    Vector3f doubleArea;
+    for ( EdgeId e : loop )
+        doubleArea += cross( mesh.orgPnt( e ), mesh.destPnt( e ) );
+    if ( dot( doubleArea, normal ) < 0 ) // the interior is on the left of the loop running ccw around +normal
+        loop = trackRightBoundaryLoop( mesh.topology, e0.sym() );
+    return loop;
+}
+
+// a mesh that is nothing but one closed edge loop, with that loop taken as above
+std::pair<Mesh, EdgeLoop> makeFreeLoop( const std::vector<Vector3f>& poly, const Vector3f& normal )
+{
+    Mesh mesh;
+    const EdgeId e0 = mesh.addSeparateEdgeLoop( poly );
+    EdgeLoop loop = interiorLoop( mesh, e0, normal );
+    return { std::move( mesh ), std::move( loop ) };
+}
+
+// the grid below is sheared a little, so that no two of its vertices share a sweep coordinate along
+// either axis: then the cut the sweep makes does not depend on how it breaks ties between equally
+// placed vertices, which is by vertex number and so by where the caller's loop happens to start
+Vector3f gridPnt( int i, int j )
+{
+    return { float( i ) + 0.05f * float( j ), float( j ) + 0.05f * float( i ), 0.f };
+}
+
+// a grid of n x n quads with the cells `isHole` marks left out: the region to fill is then a real
+// mesh hole with faces around it, and every coordinate stays exact
+Mesh makeGridWithHoles( int n, const std::function<bool( int, int )>& isHole )
+{
+    std::vector<Vector3f> pts;
+    pts.reserve( ( n + 1 ) * ( n + 1 ) );
+    for ( int j = 0; j <= n; ++j )
+        for ( int i = 0; i <= n; ++i )
+            pts.push_back( gridPnt( i, j ) );
+    auto vid = [n] ( int i, int j ) { return VertId( j * ( n + 1 ) + i ); };
+    Triangulation t;
+    for ( int j = 0; j < n; ++j )
+        for ( int i = 0; i < n; ++i )
+        {
+            if ( isHole( i, j ) )
+                continue; // the cell's two triangles and their shared diagonal are all left out
+            t.push_back( { vid( i, j ), vid( i + 1, j ), vid( i + 1, j + 1 ) } );
+            t.push_back( { vid( i, j ), vid( i + 1, j + 1 ), vid( i, j + 1 ) } );
+        }
+    return Mesh::fromTriangles( VertCoords( std::move( pts ) ), t );
+}
+
+// the hole loop of `mesh` running from `from` to `to`, so with that hole on its left; an edge tells
+// two holes apart even where they meet in one vertex, which a point alone would not
+EdgeLoop findHoleByEdge( const Mesh& mesh, const Vector3f& from, const Vector3f& to )
+{
+    for ( EdgeId e : mesh.topology.findHoleRepresentiveEdges() )
+        for ( EdgeId le : trackRightBoundaryLoop( mesh.topology, e ) )
+            if ( mesh.orgPnt( le ) == from && mesh.destPnt( le ) == to )
+                return trackRightBoundaryLoop( mesh.topology, le );
+    return {};
+}
+
+// the cells of a C, its notch opening toward +x, so that it splits a sweep along x
+bool cCell( int i, int j )
+{
+    return ( j == 1 && i >= 1 && i <= 3 ) || ( i == 1 && j == 2 ) || ( j == 3 && i >= 1 && i <= 3 );
+}
+
+// the same shape turned a quarter, so that it splits a sweep along y instead
+bool uCell( int i, int j )
+{
+    return ( j == 1 && i >= 1 && i <= 3 ) || ( i == 1 && j >= 2 && j <= 3 ) || ( i == 3 && j >= 2 && j <= 3 );
+}
+
+// a ring of cells around one kept in the middle: the kept cell touches nothing, so it is an island
+// floating inside the region, and the ring is not monotone along either axis
+bool ringCell( int i, int j )
+{
+    return i >= 1 && i <= 3 && j >= 1 && j <= 3 && !( i == 2 && j == 2 );
+}
+
+// executes the monotone plan and checks that the parts it leaves are monotone holes, and that
+// filling them reproduces what the full sweep line triangulation of the same region produces
+// \param expectedChords the number of edges the plan must add, or -1 not to check it
+void checkMonotonePlan( Mesh mesh, const EdgeLoops& loops, const Vector3f& normal, int expectedChords )
+{
+    const auto refPatch = PlanarTriangulation::triangulateDisjointContours( mesh, loops, normal );
+    ASSERT_TRUE( refPatch.has_value() );
+
+    auto plan = PlanarTriangulation::getMonotonePlan( mesh, loops, normal );
+    ASSERT_TRUE( plan.has_value() );
+    EXPECT_EQ( plan->numTris, 0 ); // the plan only adds edges
+    if ( expectedChords >= 0 )
+        EXPECT_EQ( int( plan->items.size() ), expectedChords );
+    if ( !plan->items.empty() )
+        executeHoleFillPlan( mesh, loops[0][0], *plan );
+
+    const auto parts = collectParts( mesh.topology, loops, *plan );
+    EXPECT_FALSE( parts.empty() );
+    for ( EdgeId e : parts )
+        EXPECT_TRUE( isMonotoneHole( mesh, e, normal ) );
+
+    const auto numFaces0 = mesh.topology.numValidFaces();
+    const double area0 = mesh.area();
+    auto fillPlans = getPlanarHoleFillPlans( mesh, parts );
+    ASSERT_EQ( fillPlans.size(), parts.size() );
+    for ( int i = 0; i < int( parts.size() ); ++i )
+        executeHoleFillPlan( mesh, parts[i], fillPlans[i] );
+
+    // a triangulation of the region that uses only its boundary vertices always has the same number
+    // of triangles, whatever the diagonals are
+    EXPECT_EQ( mesh.topology.numValidFaces() - numFaces0, refPatch->topology.numValidFaces() );
+    EXPECT_NEAR( mesh.area() - area0, refPatch->area(), 1e-4 * refPatch->area() );
+}
+
+// a C opening toward +x: its notch splits the region in two arms as the sweep passes x = 1
+const std::vector<Vector2f> cShapeCcw =
+    { { 0.f, 0.f }, { 4.f, 0.f }, { 4.f, 1.f }, { 1.f, 1.f }, { 1.f, 3.f }, { 4.f, 3.f }, { 4.f, 4.f }, { 0.f, 4.f } };
+
+// three arms on a spine, of increasing length so that they also end in sweep order: each of the two
+// notches between them splits the region once
+const std::vector<Vector2f> combCcw =
+    { { 0.f, 0.f }, { 4.f, 0.f }, { 4.f, 1.f }, { 1.f, 1.f }, { 1.f, 2.f }, { 6.f, 2.f }, { 6.f, 3.f },
+      { 1.f, 3.f }, { 1.f, 4.f }, { 8.f, 4.f }, { 8.f, 5.f }, { 0.f, 5.f } };
+
+} // anonymous namespace
+
+TEST( MRMesh, PlanarTriangulationMonotonePlanFreeLoops )
+{
+    const Vector3f normal = Vector3f::plusZ();
+
+    { // one split vertex, so one chord
+        const auto [mesh, loop] = makeFreeLoop( to3d( cShapeCcw ), normal );
+        checkMonotonePlan( mesh, { loop }, normal, 1 );
+    }
+
+    { // one chord per notch, where the region splits off another arm
+        const auto [mesh, loop] = makeFreeLoop( to3d( combCcw ), normal );
+        checkMonotonePlan( mesh, { loop }, normal, 2 );
+    }
+
+    { // a convex loop is already monotone: an empty plan, not a failure
+        const auto [mesh, loop] = makeFreeLoop( to3d( { { 0.f, 0.f }, { 4.f, 0.f }, { 4.f, 4.f }, { 0.f, 4.f } } ), normal );
+        const auto plan = PlanarTriangulation::getMonotonePlan( mesh, { loop }, normal );
+        ASSERT_TRUE( plan.has_value() );
+        EXPECT_TRUE( plan->items.empty() );
+        checkMonotonePlan( mesh, { loop }, normal, 0 );
+    }
+
+    { // the same C shape carried onto a plane tilted off all axes, in the mesh's own 3d space:
+      // its z is whatever the plane dictates, so only the projection the sweep runs on is the C
+        const Vector3f tilted = Vector3f( 1.f, 2.f, 3.f ).normalized();
+        const Vector3f center( 10.f, -5.f, 2.f );
+        std::vector<Vector3f> poly;
+        for ( const auto& p : cShapeCcw )
+        {
+            const float z = center.z - ( tilted.x * ( p.x - center.x ) + tilted.y * ( p.y - center.y ) ) / tilted.z;
+            poly.push_back( { p.x, p.y, z } );
+        }
+        const auto [mesh, loop] = makeFreeLoop( poly, tilted );
+        checkMonotonePlan( mesh, { loop }, tilted, 1 );
+    }
+}
+
+TEST( MRMesh, PlanarTriangulationMonotonePlanInMesh )
+{
+    const Vector3f normal = Vector3f::plusZ();
+
+    { // the anchors are now real mesh hole edges, so the wedge guard has something to check
+        const Mesh mesh = makeGridWithHoles( 5, cCell );
+        const EdgeLoop loop = findHoleByEdge( mesh, gridPnt( 1, 1 ), gridPnt( 2, 1 ) );
+        ASSERT_EQ( loop.size(), size_t( 16 ) );
+        checkMonotonePlan( mesh, { loop }, normal, 1 );
+
+        // which way round the loops run is not part of the input: the sweep takes the region from the
+        // winding number, and the anchors translate back to the same mesh edges either way. It may
+        // still cut the region differently, because reversing the loop renumbers the vertices and the
+        // sweep breaks ties between equally placed ones by their number
+        EdgeLoop backwards;
+        for ( auto it = loop.rbegin(); it != loop.rend(); ++it )
+            backwards.push_back( it->sym() );
+        checkMonotonePlan( mesh, { backwards }, normal, -1 );
+    }
+
+    { // two holes pinched together at one vertex, which then has two hole sectors in the mesh ring;
+      // each of them is monotone on its own, so a correct plan adds nothing at all here
+        const Mesh mesh = makeGridWithHoles( 4, [] ( int i, int j ) { return ( i == 1 && j == 1 ) || ( i == 2 && j == 2 ); } );
+        const EdgeLoop l1 = findHoleByEdge( mesh, gridPnt( 1, 1 ), gridPnt( 2, 1 ) );
+        const EdgeLoop l2 = findHoleByEdge( mesh, gridPnt( 2, 2 ), gridPnt( 3, 2 ) );
+        ASSERT_EQ( l1.size(), size_t( 4 ) );
+        ASSERT_EQ( l2.size(), size_t( 4 ) );
+        checkMonotonePlan( mesh, { l1, l2 }, normal, 0 );
+    }
+
+    { // an annulus: the island touches nothing, so only a chord can bridge it to the outer loop -
+      // one where the sweep splits the region around it, and one where it closes back up
+        const Mesh mesh = makeGridWithHoles( 5, ringCell );
+        const EdgeLoop lRing = findHoleByEdge( mesh, gridPnt( 1, 1 ), gridPnt( 2, 1 ) );
+        const EdgeLoop lIsland = findHoleByEdge( mesh, gridPnt( 3, 2 ), gridPnt( 2, 2 ) );
+        ASSERT_EQ( lRing.size(), size_t( 12 ) );
+        ASSERT_EQ( lIsland.size(), size_t( 4 ) );
+        checkMonotonePlan( mesh, { lRing, lIsland }, normal, 2 );
+    }
+
+    { // a mesh oriented the other way round, swept around -normal: that swaps the two kept axes, so
+      // the sweep now runs along y and the region has to be notched the other way to need a chord
+        Mesh mesh = makeGridWithHoles( 5, uCell );
+        mesh.topology.flipOrientation();
+        const EdgeLoop loop = findHoleByEdge( mesh, gridPnt( 2, 1 ), gridPnt( 1, 1 ) );
+        ASSERT_EQ( loop.size(), size_t( 16 ) );
+        checkMonotonePlan( mesh, { loop }, -normal, 1 );
+    }
+}
+
+TEST( MRMesh, PlanarTriangulationMonotonePlanRejects )
+{
+    const Vector3f normal = Vector3f::plusZ();
+    // an annulus is not monotone along either axis, so it needs chords whichever way it is swept
+    const Mesh mesh = makeGridWithHoles( 5, ringCell );
+    const EdgeLoop lRing = findHoleByEdge( mesh, gridPnt( 1, 1 ), gridPnt( 2, 1 ) );
+    const EdgeLoop lIsland = findHoleByEdge( mesh, gridPnt( 3, 2 ), gridPnt( 2, 2 ) );
+    ASSERT_EQ( lRing.size(), size_t( 12 ) );
+    ASSERT_EQ( lIsland.size(), size_t( 4 ) );
+
+    // asking for the region around the opposite normal swaps the two kept axes, which mirrors the
+    // plane the sweep works in: every chord would then be spliced in a wedge that mesh faces occupy,
+    // and the wedge guard rejects the plan instead of corrupting the mesh
+    EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( mesh, { lRing, lIsland }, -normal ).has_value() );
+
+    // a loop of less than 3 edges is not a contour the sweep can take
+    EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( mesh, { EdgeLoop{ lIsland[0], lIsland[1] } }, normal ).has_value() );
+
+    { // intersecting loops: there is no region to decompose, the caller keeps its per loop path
+        Mesh two;
+        const EdgeId a0 = two.addSeparateEdgeLoop( to3d( { { 0.f, 0.f }, { 4.f, 0.f }, { 4.f, 4.f }, { 0.f, 4.f } } ) );
+        const EdgeId b0 = two.addSeparateEdgeLoop( to3d( { { 2.f, 2.f }, { 6.f, 2.f }, { 6.f, 6.f }, { 2.f, 6.f } } ) );
+        const EdgeLoops crossing = { interiorLoop( two, a0, normal ), interiorLoop( two, b0, normal ) };
+        EXPECT_FALSE( PlanarTriangulation::getMonotonePlan( two, crossing, normal ).has_value() );
+    }
 }
 
 namespace


### PR DESCRIPTION
`PlanarTriangulation::getMonotonePlan( mesh, loops, normal )` — the mesh-space sweep-line triangulation stopped after monotonation. It returns the chords `makeMonotone()` adds as a `HoleFillPlan` with `numTris == 0` (the edges-only mode from #6576), so a caller can execute them on its own mesh and then fill the resulting monotone parts exactly as it fills holes today. This is the primitive for filling all holes of one cut face jointly in `cutMesh`; that consumer is not in this PR.

### Design

* **The plan is a recording, not a reconstruction.** Both chord sites already create their edge as `makeEdge(); splice( a, e ); splice( b, e.sym() )` — which is exactly `makeNewEdge( a, b )`, the primitive the plan executor replays. A guarded `outChords` sink records `{ a, b, e }` at each site, in creation order. Anchors have to be recorded at creation: a later chord spliced at the same anchor displaces the earlier one in the ring, so they cannot be derived afterwards.
* **Translation is arithmetic.** On this path there is nothing to inject (`abortWhenIntersect`), so the patch edges are the loop edges copied from the mesh — mapped back by the `patchToInEdges` map the loop-copying init already maintains — followed by the chords in creation order, since `makeEdge()` only appends. Anchors on earlier chords become negative codes with the sym bit.
* **Wedge guard.** `splice( a, e )` puts the chord in the wedge `left( a )`, so every mesh-side anchor must satisfy `!mesh.topology.left( anchor )`; otherwise the plan is rejected (`nullopt`) rather than corrupting the mesh. This catches a mirrored projection (normal against the mesh orientation). Loop direction, by contrast, is not part of the contract: the region comes from the winding number, and the translation is direction-preserving.
* The default triangulation path is untouched: two null-pointer checks inside the chord sites and one added params field.

### Test

A flat disk inside a flat ring: the gap between them is bounded by two concentric circular hole loops, and the disk touches nothing, so only chords can join the loops. The plan must add exactly two (where the sweep reaches the disk and where it leaves it), and each of the two holes they leave must be monotone along the sweep. The opposite normal must be rejected.

### Verification

* `MRTest --no-python-tests`: **389/389**, Release and Debug (Debug runs the topology asserts along the new path).
* Geometric digest (boolean sweep of 128 transform combinations, big booleans, inner-contour-on-face, self-boolean — verts/faces/holes/area/volume) **byte-identical** against a `master` build from the same base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
