### PR TITLE
Pin the Python test requirements to the versions CI installs

### DIFF
--- a/requirements/python/requirements.txt
+++ b/requirements/python/requirements.txt
@@ -1,3 +1,5 @@
-numpy>=1.19.0
-pytest>=7.1.2
+numpy==2.5.2; python_version >= "3.12"
+numpy>=1.19.0; python_version < "3.12"
+pytest==9.1.1; python_version >= "3.10"
+pytest>=7.1.2; python_version < "3.10"
 pytest-check==2.3.1


### PR DESCRIPTION
`requirements/python/requirements.txt` left numpy and pytest unbounded, so every CI run resolved to whatever was newest that day. This pins them to what CI currently installs - numpy 2.5.2 and pytest 9.1.1, exactly the versions the latest Windows runs report - so a pip release cannot silently change what the tests execute against.

A flat pin is not possible here: this file is installed on Python 3.8 through 3.14 (the wheel matrix in `pip-build.yml`, the Ubuntu/macOS legs, `install_apt_requirements.sh`, docs and test-distribution all read it), while

```
numpy 2.5.2      requires_python >=3.12
pytest 9.1.1     requires_python >=3.10
pytest-check 2.3.1  requires_python >=3.7
```

Pinning them unconditionally would make the 3.8-3.11 environments unsatisfiable. So each pin is gated by an environment marker, and the old lower bound stays for older interpreters:

```
numpy==2.5.2; python_version >= "3.12"
numpy>=1.19.0; python_version < "3.12"
pytest==9.1.1; python_version >= "3.10"
pytest>=7.1.2; python_version < "3.10"
pytest-check==2.3.1
```

Resolution is unambiguous - exactly one requirement per package per interpreter:

```
py 3.8   -> numpy>=1.19.0, pytest>=7.1.2, pytest-check==2.3.1
py 3.10  -> numpy>=1.19.0, pytest==9.1.1, pytest-check==2.3.1
py 3.12  -> numpy==2.5.2,  pytest==9.1.1, pytest-check==2.3.1
py 3.14  -> numpy==2.5.2,  pytest==9.1.1, pytest-check==2.3.1
```

Nothing changes for a leg that is already on 3.12+; it just stops drifting. Legs on older interpreters keep exactly today's behaviour.

Note this file is part of `scripts/devops/docker_image_source_checksum.sh`, so the Linux images rebuild once.
