### PR TITLE
Build C bindings in a separate step, after the main Build

### DIFF
--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -167,7 +167,7 @@ jobs:
             -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
             -DMR_PCH_USE_EXTRA_HEADERS=ON
             -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-11/root/usr/bin/g++
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
             -DMRVIEWER_NO_GTK=ON
             -DMRVIEWER_WITH_BUNDLED_CURL=ON
             -DCMAKE_CXX_FLAGS=${{ matrix.compiler == 'Clang' && format('--gcc-install-dir={0}', matrix.gcc-install-dir) || '' }}
@@ -194,13 +194,13 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # Reconfigure so the generated sources are globbed in; the targets are excluded from
-        # ALL, so they are built by name. MR_VERSION must repeat the Build step's value:
+        # C bindings sources are globbed at configure time, so they can only enter the build
+        # graph now, after the download. MR_VERSION must repeat the Build step's value:
         # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |
-          cmake -S . -B build/${{ matrix.config }}
+          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
           cmake --build build/${{ matrix.config }} -j $(nproc) --target MeshLibC2 MeshLibC2Cuda MRTestC2
 
       - name: MRMesh Exported Symbols

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -194,9 +194,6 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # C bindings sources are globbed at configure time, so they can only enter the build
-        # graph now, after the download. MR_VERSION must repeat the Build step's value:
-        # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -154,6 +154,24 @@ jobs:
       - name: Setup python requirements
         run: python3 -m pip install -r ./requirements/python/requirements.txt
 
+      - name: Build
+        run: ./scripts/build_source.sh
+        env:
+          MESHLIB_BUILD_RELEASE: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Release'] }}
+          MESHLIB_BUILD_DEBUG: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Debug'] }}
+          CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
+          MR_VERSION: ${{ inputs.app_version }}
+          # options to be passed to cmake
+          MR_CMAKE_OPTIONS: >
+            -DMR_PLATFORM=Linux_vcpkg
+            -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
+            -DMR_PCH_USE_EXTRA_HEADERS=ON
+            -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-11/root/usr/bin/g++
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
+            -DMRVIEWER_NO_GTK=ON
+            -DMRVIEWER_WITH_BUNDLED_CURL=ON
+            -DCMAKE_CXX_FLAGS=${{ matrix.compiler == 'Clang' && format('--gcc-install-dir={0}', matrix.gcc-install-dir) || '' }}
+
       - name: Wait for C bindings
         if: ${{ inputs.mrbind_c }}
         uses: ./.github/actions/wait-for-job
@@ -174,23 +192,16 @@ jobs:
           mv MeshLib/CbindingsTmp/MeshLibC2 source
           mv MeshLib/CbindingsTmp/MeshLibC2Cuda source
 
-      - name: Build
-        run: ./scripts/build_source.sh
+      - name: Build C bindings
+        if: ${{ inputs.mrbind_c }}
+        # C bindings sources are globbed at configure time, so they can only enter the build
+        # graph now, after the download. MR_VERSION must repeat the Build step's value:
+        # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
-          MESHLIB_BUILD_RELEASE: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Release'] }}
-          MESHLIB_BUILD_DEBUG: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Debug'] }}
-          CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
           MR_VERSION: ${{ inputs.app_version }}
-          # options to be passed to cmake
-          MR_CMAKE_OPTIONS: >
-            -DMR_PLATFORM=Linux_vcpkg
-            -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
-            -DMR_PCH_USE_EXTRA_HEADERS=ON
-            -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-11/root/usr/bin/g++
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
-            -DMRVIEWER_NO_GTK=ON
-            -DMRVIEWER_WITH_BUNDLED_CURL=ON
-            -DCMAKE_CXX_FLAGS=${{ matrix.compiler == 'Clang' && format('--gcc-install-dir={0}', matrix.gcc-install-dir) || '' }}
+        run: |
+          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
+          cmake --build build/${{ matrix.config }} -j $(nproc) --target MeshLibC2 MeshLibC2Cuda MRTestC2
 
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | llvm-cxxfilt

--- a/.github/workflows/build-test-linux-vcpkg.yml
+++ b/.github/workflows/build-test-linux-vcpkg.yml
@@ -167,7 +167,7 @@ jobs:
             -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
             -DMR_PCH_USE_EXTRA_HEADERS=ON
             -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-11/root/usr/bin/g++
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
             -DMRVIEWER_NO_GTK=ON
             -DMRVIEWER_WITH_BUNDLED_CURL=ON
             -DCMAKE_CXX_FLAGS=${{ matrix.compiler == 'Clang' && format('--gcc-install-dir={0}', matrix.gcc-install-dir) || '' }}
@@ -194,13 +194,13 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # C bindings sources are globbed at configure time, so they can only enter the build
-        # graph now, after the download. MR_VERSION must repeat the Build step's value:
+        # Reconfigure so the generated sources are globbed in; the targets are excluded from
+        # ALL, so they are built by name. MR_VERSION must repeat the Build step's value:
         # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |
-          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
+          cmake -S . -B build/${{ matrix.config }}
           cmake --build build/${{ matrix.config }} -j $(nproc) --target MeshLibC2 MeshLibC2Cuda MRTestC2
 
       - name: MRMesh Exported Symbols

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -166,7 +166,7 @@ jobs:
           MR_CMAKE_OPTIONS: >
             -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
             -DMR_CXX_STANDARD=23
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
             -DMR_PCH_USE_EXTRA_HEADERS=ON
 
       - name: Wait for C bindings
@@ -192,13 +192,13 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # Reconfigure so the generated sources are globbed in; the targets are excluded from
-        # ALL, so they are built by name. MR_VERSION must repeat the Build step's value:
+        # C bindings sources are globbed at configure time, so they can only enter the build
+        # graph now, after the download. MR_VERSION must repeat the Build step's value:
         # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |
-          cmake -S . -B build/${{ matrix.config }}
+          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
           cmake --build build/${{ matrix.config }} -j $(sysctl -n hw.logicalcpu) --target MeshLibC2 MeshLibC2Cuda MRTestC2
 
       - name: MRMesh Exported Symbols

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -156,6 +156,19 @@ jobs:
           python3 -m pip install -r ./requirements/python/requirements.txt
           python3 -m pip install pytest
 
+      - name: Build
+        run: ./scripts/build_source.sh
+        env:
+          MESHLIB_BUILD_RELEASE: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Release'] }}
+          MESHLIB_BUILD_DEBUG: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Debug'] }}
+          CMAKE_CXX_COMPILER: ${{ steps.thirdparty.outputs.cxx-compiler }}
+          MR_VERSION: ${{ inputs.app_version }}
+          MR_CMAKE_OPTIONS: >
+            -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
+            -DMR_CXX_STANDARD=23
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
+            -DMR_PCH_USE_EXTRA_HEADERS=ON
+
       - name: Wait for C bindings
         if: ${{ inputs.mrbind_c }}
         uses: ./.github/actions/wait-for-job
@@ -177,18 +190,16 @@ jobs:
           # Cuda placeholders:
           cp -R scripts/mrbind/cuda_placeholder_generated_c/{include,src} source/MeshLibC2Cuda
 
-      - name: Build
-        run: ./scripts/build_source.sh
+      - name: Build C bindings
+        if: ${{ inputs.mrbind_c }}
+        # C bindings sources are globbed at configure time, so they can only enter the build
+        # graph now, after the download. MR_VERSION must repeat the Build step's value:
+        # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
-          MESHLIB_BUILD_RELEASE: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Release'] }}
-          MESHLIB_BUILD_DEBUG: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Debug'] }}
-          CMAKE_CXX_COMPILER: ${{ steps.thirdparty.outputs.cxx-compiler }}
           MR_VERSION: ${{ inputs.app_version }}
-          MR_CMAKE_OPTIONS: >
-            -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
-            -DMR_CXX_STANDARD=23
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
-            -DMR_PCH_USE_EXTRA_HEADERS=ON
+        run: |
+          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
+          cmake --build build/${{ matrix.config }} -j $(sysctl -n hw.logicalcpu) --target MeshLibC2 MeshLibC2Cuda MRTestC2
 
       - name: MRMesh Exported Symbols
         run: |

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -192,9 +192,6 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # C bindings sources are globbed at configure time, so they can only enter the build
-        # graph now, after the download. MR_VERSION must repeat the Build step's value:
-        # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -166,7 +166,7 @@ jobs:
           MR_CMAKE_OPTIONS: >
             -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
             -DMR_CXX_STANDARD=23
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
             -DMR_PCH_USE_EXTRA_HEADERS=ON
 
       - name: Wait for C bindings
@@ -192,13 +192,13 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # C bindings sources are globbed at configure time, so they can only enter the build
-        # graph now, after the download. MR_VERSION must repeat the Build step's value:
+        # Reconfigure so the generated sources are globbed in; the targets are excluded from
+        # ALL, so they are built by name. MR_VERSION must repeat the Build step's value:
         # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |
-          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
+          cmake -S . -B build/${{ matrix.config }}
           cmake --build build/${{ matrix.config }} -j $(sysctl -n hw.logicalcpu) --target MeshLibC2 MeshLibC2Cuda MRTestC2
 
       - name: MRMesh Exported Symbols

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -116,6 +116,22 @@ jobs:
       - name: Setup python requirements
         run: python3 -m pip install -r ./requirements/python/requirements.txt
 
+      - name: Build
+        run: ./scripts/build_source.sh
+        env:
+          MESHLIB_BUILD_RELEASE: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Release'] }}
+          MESHLIB_BUILD_DEBUG: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Debug'] }}
+          CMAKE_C_COMPILER: ${{ matrix.c-compiler }}
+          CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
+          MR_VERSION: ${{ inputs.app_version }}
+          # options to be passed to cmake
+          MR_CMAKE_OPTIONS: >
+            -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
+            -DMR_PCH_USE_EXTRA_HEADERS=ON
+            -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
+            -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
+
       - name: Wait for C bindings
         if: ${{ inputs.mrbind_c }}
         uses: ./.github/actions/wait-for-job
@@ -136,6 +152,17 @@ jobs:
           mv MeshLib/CbindingsTmp/MeshLibC2 source
           mv MeshLib/CbindingsTmp/MeshLibC2Cuda source
 
+      - name: Build C bindings
+        if: ${{ inputs.mrbind_c }}
+        # C bindings sources are globbed at configure time, so they can only enter the build
+        # graph now, after the download. MR_VERSION must repeat the Build step's value:
+        # config_cmake.h is generated into the source tree, and a change rebuilds everything.
+        env:
+          MR_VERSION: ${{ inputs.app_version }}
+        run: |
+          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
+          cmake --build build/${{ matrix.config }} -j $(nproc) --target MeshLibC2 MeshLibC2Cuda MRTestC2
+
       - name: Generate C# bindings # generate only sources
         if: ${{ matrix.os == 'ubuntu22' && matrix.config == 'Release' && matrix.compiler == 'clang' }}
         run: make -f scripts/mrbind/generate.mk TARGET=csharp -B --trace generate
@@ -147,22 +174,6 @@ jobs:
           name: CsharpBindings
           path: ./source/MRDotNet2/src
           retention-days: 1
-
-      - name: Build
-        run: ./scripts/build_source.sh
-        env:
-          MESHLIB_BUILD_RELEASE: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Release'] }}
-          MESHLIB_BUILD_DEBUG: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Debug'] }}
-          CMAKE_C_COMPILER: ${{ matrix.c-compiler }}
-          CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
-          MR_VERSION: ${{ inputs.app_version }}
-          # options to be passed to cmake
-          MR_CMAKE_OPTIONS: >
-            -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
-            -DMR_PCH_USE_EXTRA_HEADERS=ON
-            -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
-            -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
 
       - name: MRMesh Exported Symbols
         run: objdump -T ./build/${{ matrix.config }}/bin/libMRMesh.so | c++filt

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -129,7 +129,7 @@ jobs:
             -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
             -DMR_PCH_USE_EXTRA_HEADERS=ON
             -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
             -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
 
       - name: Wait for C bindings
@@ -154,13 +154,13 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # Reconfigure so the generated sources are globbed in; the targets are excluded from
-        # ALL, so they are built by name. MR_VERSION must repeat the Build step's value:
+        # C bindings sources are globbed at configure time, so they can only enter the build
+        # graph now, after the download. MR_VERSION must repeat the Build step's value:
         # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |
-          cmake -S . -B build/${{ matrix.config }}
+          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
           cmake --build build/${{ matrix.config }} -j $(nproc) --target MeshLibC2 MeshLibC2Cuda MRTestC2
 
       - name: Generate C# bindings # generate only sources

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -129,7 +129,7 @@ jobs:
             -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
             -DMR_PCH_USE_EXTRA_HEADERS=ON
             -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
             -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
 
       - name: Wait for C bindings
@@ -154,13 +154,13 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # C bindings sources are globbed at configure time, so they can only enter the build
-        # graph now, after the download. MR_VERSION must repeat the Build step's value:
+        # Reconfigure so the generated sources are globbed in; the targets are excluded from
+        # ALL, so they are built by name. MR_VERSION must repeat the Build step's value:
         # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |
-          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
+          cmake -S . -B build/${{ matrix.config }}
           cmake --build build/${{ matrix.config }} -j $(nproc) --target MeshLibC2 MeshLibC2Cuda MRTestC2
 
       - name: Generate C# bindings # generate only sources

--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -154,9 +154,6 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # C bindings sources are globbed at configure time, so they can only enter the build
-        # graph now, after the download. MR_VERSION must repeat the Build step's value:
-        # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -119,7 +119,7 @@ jobs:
             -DMESHLIB_BUILD_MRCUDA=${{ matrix.build_mrcuda }}
             -DMR_PCH_USE_EXTRA_HEADERS=ON
             -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
             -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
 
       - name: Wait for C bindings
@@ -150,13 +150,13 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # Reconfigure so the generated sources are globbed in; the targets are excluded from
-        # ALL, so they are built by name. MR_VERSION must repeat the Build step's value:
+        # C bindings sources are globbed at configure time, so they can only enter the build
+        # graph now, after the download. MR_VERSION must repeat the Build step's value:
         # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |
-          cmake -S . -B build/${{ matrix.config }}
+          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
           cmake --build build/${{ matrix.config }} -j $(nproc) --target MeshLibC2 MeshLibC2Cuda MRTestC2
 
       - name: PCH size (diagnostic)

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -119,7 +119,7 @@ jobs:
             -DMESHLIB_BUILD_MRCUDA=${{ matrix.build_mrcuda }}
             -DMR_PCH_USE_EXTRA_HEADERS=ON
             -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
             -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
 
       - name: Wait for C bindings
@@ -150,13 +150,13 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # C bindings sources are globbed at configure time, so they can only enter the build
-        # graph now, after the download. MR_VERSION must repeat the Build step's value:
+        # Reconfigure so the generated sources are globbed in; the targets are excluded from
+        # ALL, so they are built by name. MR_VERSION must repeat the Build step's value:
         # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |
-          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
+          cmake -S . -B build/${{ matrix.config }}
           cmake --build build/${{ matrix.config }} -j $(nproc) --target MeshLibC2 MeshLibC2Cuda MRTestC2
 
       - name: PCH size (diagnostic)

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -150,9 +150,6 @@ jobs:
 
       - name: Build C bindings
         if: ${{ inputs.mrbind_c }}
-        # C bindings sources are globbed at configure time, so they can only enter the build
-        # graph now, after the download. MR_VERSION must repeat the Build step's value:
-        # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
           MR_VERSION: ${{ inputs.app_version }}
         run: |

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -105,6 +105,23 @@ jobs:
       - name: Setup python requirements
         run: python3 -m pip install -r ./requirements/python/requirements.txt
 
+      - name: Build
+        run: ./scripts/build_source.sh
+        env:
+          MESHLIB_BUILD_RELEASE: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Release'] }}
+          MESHLIB_BUILD_DEBUG: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Debug'] }}
+          CMAKE_C_COMPILER: ${{ matrix.c-compiler }}
+          CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
+          MR_VERSION: ${{ inputs.app_version }}
+          # options to be passed to cmake
+          MR_CMAKE_OPTIONS: >
+            -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
+            -DMESHLIB_BUILD_MRCUDA=${{ matrix.build_mrcuda }}
+            -DMR_PCH_USE_EXTRA_HEADERS=ON
+            -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
+            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF
+            -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
+
       - name: Wait for C bindings
         if: ${{ inputs.mrbind_c }}
         uses: ./.github/actions/wait-for-job
@@ -131,22 +148,16 @@ jobs:
             cp -r scripts/mrbind/cuda_placeholder_generated_c/{include,src} source/MeshLibC2Cuda
           fi
 
-      - name: Build
-        run: ./scripts/build_source.sh
+      - name: Build C bindings
+        if: ${{ inputs.mrbind_c }}
+        # C bindings sources are globbed at configure time, so they can only enter the build
+        # graph now, after the download. MR_VERSION must repeat the Build step's value:
+        # config_cmake.h is generated into the source tree, and a change rebuilds everything.
         env:
-          MESHLIB_BUILD_RELEASE: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Release'] }}
-          MESHLIB_BUILD_DEBUG: ${{ fromJSON('["OFF", "ON"]')[matrix.config == 'Debug'] }}
-          CMAKE_C_COMPILER: ${{ matrix.c-compiler }}
-          CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
           MR_VERSION: ${{ inputs.app_version }}
-          # options to be passed to cmake
-          MR_CMAKE_OPTIONS: >
-            -DMR_CXX_STANDARD=${{ matrix.cxx-standard }}
-            -DMESHLIB_BUILD_MRCUDA=${{ matrix.build_mrcuda }}
-            -DMR_PCH_USE_EXTRA_HEADERS=ON
-            -DMESHLIB_BUILD_MRMESH_PY_LEGACY=${{ fromJSON('["ON", "OFF"]')[inputs.mrbind] }}
-            -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }}
-            -DMRVIEWER_NO_XDG_DESKTOP_PORTAL=ON
+        run: |
+          cmake -S . -B build/${{ matrix.config }} -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
+          cmake --build build/${{ matrix.config }} -j $(nproc) --target MeshLibC2 MeshLibC2Cuda MRTestC2
 
       - name: PCH size (diagnostic)
         run: find ./build/${{ matrix.config }} -name 'cmake_pch.hxx.gch' -exec ls -lh {} +

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -168,52 +168,6 @@ jobs:
           extra-cache-key: ${{ hashFiles(format('scripts/mrbind/msys2_package_hashes{0}.txt', env.MSYS2_PKGS)) }}
           msys2-env: ${{ env.MSYS2_ENV }}
 
-      - name: Wait for C bindings
-        if: ${{ matrix.build_system == 'MSBuild' && ( inputs.mrbind_c || env.BUILD_C_SHARP == 'true' ) }}
-        uses: ./.github/actions/wait-for-job
-        with:
-          job-name: generate-c-bindings
-
-      - name: Download C bindings
-        if: ${{ matrix.build_system == 'MSBuild' && ( inputs.mrbind_c || env.BUILD_C_SHARP == 'true' ) }}
-        uses: actions/download-artifact@v8
-        with:
-          name: CBindings
-          path: MeshLib/CbindingsTmp
-
-      - name: Prepare C bindings folders
-        if: ${{ matrix.build_system == 'MSBuild' && ( inputs.mrbind_c || env.BUILD_C_SHARP == 'true' ) }}
-        run: |
-          rm -r -force source/MeshLibC2
-          move MeshLib/CbindingsTmp/MeshLibC2 source
-          if ( $env:CUDA_VERSION ) {
-            rm -r -force source/MeshLibC2Cuda
-            move MeshLib/CbindingsTmp/MeshLibC2Cuda source
-          } else {
-            # No Cuda toolkit, so MRCuda is not built and the generated Cuda bindings cannot
-            # link. Keep this project's CMakeLists and stub its sources, as macOS does; see
-            # scripts/mrbind/cuda_placeholder_generated_c/README.md
-            cp -R scripts/mrbind/cuda_placeholder_generated_c/include source/MeshLibC2Cuda
-            cp -R scripts/mrbind/cuda_placeholder_generated_c/src source/MeshLibC2Cuda
-          }
-
-        # This consumes the JSON created by generating the C bindings.
-      - name: Generate C# bindings
-        if: ${{ env.BUILD_C_SHARP == 'true' }}
-        shell: cmd
-        env:
-          MSYS2_DIR: C:\msys64
-        # Note that `\` doesn't work here as a line continuation, and will lead to weird errors.
-        # Note `|| exit /b 1` after each command: cmd.exe does not stop on a failed
-        #   command, so without these a generate_win.bat failure would be masked
-        #   by the following dotnet build (see the Build step's note below).
-        # `CSHARP_STATIC_DLLIMPORT=1` is used to build the version of the bindings that's suitable for use in Wasm in Unity.
-        run: |
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
-          call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}} || exit /b 1
-          call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}} CSHARP_STATIC_DLLIMPORT=1 || exit /b 1
-          dotnet build examples/c-sharp-examples -c ${{matrix.config}} -p:Platform=%MSBUILD_PLATFORM% -p:MeshLibArch=%MR_ARCH% || exit /b 1
-
       - name: Build
         shell: cmd
         env:
@@ -249,6 +203,55 @@ jobs:
         run: |
           & "$Env:GITHUB_WORKSPACE\scripts\diagnostics\windows-pch-sizes.ps1"
 
+      # Both build systems wait here rather than before the Build step, so the main build
+      # overlaps with generate-c-bindings: MeshLib.sln carries neither the C nor the C#
+      # bindings projects, and the CMake build configures its C bindings out until now.
+      - name: Wait for C bindings
+        if: ${{ inputs.mrbind_c || env.BUILD_C_SHARP == 'true' }}
+        uses: ./.github/actions/wait-for-job
+        with:
+          job-name: generate-c-bindings
+
+      - name: Download C bindings
+        if: ${{ inputs.mrbind_c || env.BUILD_C_SHARP == 'true' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: CBindings
+          path: MeshLib/CbindingsTmp
+
+      - name: Prepare C bindings folders
+        if: ${{ inputs.mrbind_c || env.BUILD_C_SHARP == 'true' }}
+        run: |
+          rm -r -force source/MeshLibC2
+          move MeshLib/CbindingsTmp/MeshLibC2 source
+          if ( $env:CUDA_VERSION ) {
+            rm -r -force source/MeshLibC2Cuda
+            move MeshLib/CbindingsTmp/MeshLibC2Cuda source
+          } else {
+            # No Cuda toolkit, so MRCuda is not built and the generated Cuda bindings cannot
+            # link. Keep this project's CMakeLists and stub its sources, as macOS does; see
+            # scripts/mrbind/cuda_placeholder_generated_c/README.md
+            cp -R scripts/mrbind/cuda_placeholder_generated_c/include source/MeshLibC2Cuda
+            cp -R scripts/mrbind/cuda_placeholder_generated_c/src source/MeshLibC2Cuda
+          }
+
+        # This consumes the JSON created by generating the C bindings.
+      - name: Generate C# bindings
+        if: ${{ env.BUILD_C_SHARP == 'true' }}
+        shell: cmd
+        env:
+          MSYS2_DIR: C:\msys64
+        # Note that `\` doesn't work here as a line continuation, and will lead to weird errors.
+        # Note `|| exit /b 1` after each command: cmd.exe does not stop on a failed
+        #   command, so without these a generate_win.bat failure would be masked
+        #   by the following dotnet build (see the Build step's note above).
+        # `CSHARP_STATIC_DLLIMPORT=1` is used to build the version of the bindings that's suitable for use in Wasm in Unity.
+        run: |
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}} || exit /b 1
+          call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}} CSHARP_STATIC_DLLIMPORT=1 || exit /b 1
+          dotnet build examples/c-sharp-examples -c ${{matrix.config}} -p:Platform=%MSBUILD_PLATFORM% -p:MeshLibArch=%MR_ARCH% || exit /b 1
+
       - name: Build C bindings with MSBuild
         if: ${{ inputs.mrbind_c && matrix.build_system == 'MSBuild' }}
         shell: cmd
@@ -266,38 +269,6 @@ jobs:
           VCPKG_ROOT: C:\vcpkg
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
         run: msbuild -m source\MeshLibC2Cuda\MeshLibC2Cuda.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=%MSBUILD_PLATFORM% -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }};MR_PCH_USE_EXTRA_HEADERS=ON
-
-      # The CMake legs wait here instead of before the Build step above, so that the main
-      # build overlaps with generate-c-bindings. The MSBuild legs cannot: MeshLib.sln
-      # compiles the C# bindings generated from this same artifact.
-      - name: Wait for C bindings
-        if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
-        uses: ./.github/actions/wait-for-job
-        with:
-          job-name: generate-c-bindings
-
-      - name: Download C bindings
-        if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
-        uses: actions/download-artifact@v8
-        with:
-          name: CBindings
-          path: MeshLib/CbindingsTmp
-
-      - name: Prepare C bindings folders
-        if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
-        run: |
-          rm -r -force source/MeshLibC2
-          move MeshLib/CbindingsTmp/MeshLibC2 source
-          if ( $env:CUDA_VERSION ) {
-            rm -r -force source/MeshLibC2Cuda
-            move MeshLib/CbindingsTmp/MeshLibC2Cuda source
-          } else {
-            # No Cuda toolkit, so MRCuda is not built and the generated Cuda bindings cannot
-            # link. Keep this project's CMakeLists and stub its sources, as macOS does; see
-            # scripts/mrbind/cuda_placeholder_generated_c/README.md
-            cp -R scripts/mrbind/cuda_placeholder_generated_c/include source/MeshLibC2Cuda
-            cp -R scripts/mrbind/cuda_placeholder_generated_c/src source/MeshLibC2Cuda
-          }
 
       - name: Build C bindings with CMake
         if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -183,7 +183,7 @@ jobs:
           if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
             call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
             cmake --version || exit /b 1
-            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DVCPKG_APPLOCAL_DEPS=OFF -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF -DMESHLIB_BUILD_MRCUDA=${{ env.CUDA_VERSION != '' && 'ON' || 'OFF' }} -DMR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
+            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DVCPKG_APPLOCAL_DEPS=OFF -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} -DMESHLIB_BUILD_MRCUDA=${{ env.CUDA_VERSION != '' && 'ON' || 'OFF' }} -DMR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
             cmake --build source\TempOutput -j || exit /b 1
             rem Deploy vcpkg DLLs in one serial pass here: with VCPKG_APPLOCAL_DEPS=ON (default)
             rem every parallel Ninja link edge runs its own z-applocal into the shared bin dir,
@@ -205,7 +205,7 @@ jobs:
 
       # Both build systems wait here rather than before the Build step, so the main build
       # overlaps with generate-c-bindings: MeshLib.sln carries neither the C nor the C#
-      # bindings projects, and the CMake build configures its C bindings out until now.
+      # bindings projects, and the CMake build keeps its C bindings targets out of ALL.
       - name: Wait for C bindings
         if: ${{ inputs.mrbind_c || env.BUILD_C_SHARP == 'true' }}
         uses: ./.github/actions/wait-for-job
@@ -259,16 +259,16 @@ jobs:
           GETTEXT_ROOT: C:\msys64\clang64
           VCPKG_ROOT: C:\vcpkg
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
-        # The CMake branch reconfigures the directory the Build step left behind: the C bindings
-        # sources are globbed at configure time, so they can only enter the build graph now that
-        # they are downloaded; every other cache entry survives the reconfigure.
+        # The CMake branch reconfigures the directory the Build step left behind, so that the
+        # generated sources are globbed in; the targets are excluded from ALL, so they are
+        # built by name. Every other cache entry survives the reconfigure.
         # cmd expands %VCPKG_ROOT% when it parses the parenthesized block, i.e. before
         # VsDevCmd.bat replaces it with the VS-bundled vcpkg, whose path has a space - the same
         # reason the Build step's own z-applocal loop works.
         run: |
           if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
             call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
-            cmake -S . -B source\TempOutput -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON || exit /b 1
+            cmake -S . -B source\TempOutput || exit /b 1
             cmake --build source\TempOutput -j %NUMBER_OF_PROCESSORS% --target MeshLibC2 MeshLibC2Cuda MRTestC2 || exit /b 1
             rem Only the new binaries need deploying; see the Build step's note on the serial pass.
             for %%b in (source\TempOutput\bin\MeshLibC2*.dll source\TempOutput\bin\MRTestC2.exe) do (

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -252,48 +252,39 @@ jobs:
           call ./scripts/mrbind/generate_win.bat -B --trace TARGET=csharp CSHARP_MODE=${{matrix.config}} CSHARP_STATIC_DLLIMPORT=1 || exit /b 1
           dotnet build examples/c-sharp-examples -c ${{matrix.config}} -p:Platform=%MSBUILD_PLATFORM% -p:MeshLibArch=%MR_ARCH% || exit /b 1
 
-      - name: Build C bindings with MSBuild
-        if: ${{ inputs.mrbind_c && matrix.build_system == 'MSBuild' }}
-        shell: cmd
-        env:
-          VCPKG_ROOT: C:\vcpkg
-          VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
-        run: msbuild -m source\MeshLibC2\MeshLibC2.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=%MSBUILD_PLATFORM% -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }};MR_PCH_USE_EXTRA_HEADERS=ON
-
-      - name: Build C CUDA bindings with MSBuild
-        # Needs a CUDA toolkit for its MRCuda ProjectReference, except on arm64, where no
-        # toolkit exists and the project builds the placeholder stubs instead.
-        if: ${{ inputs.mrbind_c && matrix.build_system == 'MSBuild' && ( env.CUDA_VERSION != '' || matrix.arch == 'arm64' ) }}
-        shell: cmd
-        env:
-          VCPKG_ROOT: C:\vcpkg
-          VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
-        run: msbuild -m source\MeshLibC2Cuda\MeshLibC2Cuda.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=%MSBUILD_PLATFORM% -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }};MR_PCH_USE_EXTRA_HEADERS=ON
-
-      - name: Build C bindings with CMake
-        if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
+      - name: Build C bindings
+        if: ${{ inputs.mrbind_c }}
         shell: cmd
         env:
           GETTEXT_ROOT: C:\msys64\clang64
           VCPKG_ROOT: C:\vcpkg
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
-        # The C bindings sources are globbed at configure time, so they can only enter the
-        # build graph now, once downloaded; every other cache entry survives the reconfigure.
+        # The CMake branch reconfigures the directory the Build step left behind: the C bindings
+        # sources are globbed at configure time, so they can only enter the build graph now that
+        # they are downloaded; every other cache entry survives the reconfigure.
+        # cmd expands %VCPKG_ROOT% when it parses the parenthesized block, i.e. before
+        # VsDevCmd.bat replaces it with the VS-bundled vcpkg, whose path has a space - the same
+        # reason the Build step's own z-applocal loop works.
         run: |
-          rem VsDevCmd.bat overrides VCPKG_ROOT with the VS-bundled vcpkg; preserve the step
-          rem env: value for the z-applocal loop below (the Build step's own loop is inside a
-          rem parenthesized IF block, so cmd expands it before VsDevCmd runs).
-          set "PROJ_VCPKG_ROOT=%VCPKG_ROOT%"
-          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
-          set "VCPKG_ROOT=%PROJ_VCPKG_ROOT%"
-          cmake -S . -B source\TempOutput -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON || exit /b 1
-          cmake --build source\TempOutput -j %NUMBER_OF_PROCESSORS% --target MeshLibC2 MeshLibC2Cuda MRTestC2 || exit /b 1
-          rem Only the new binaries need deploying; see the Build step's note on the serial pass.
-          for %%b in (source\TempOutput\bin\MeshLibC2*.dll source\TempOutput\bin\MRTestC2.exe) do (
-            %VCPKG_ROOT%\vcpkg.exe z-applocal --target-binary="%%b" --installed-bin-dir="%VCPKG_ROOT%\installed\%VCPKG_TARGET_TRIPLET%${{ matrix.config == 'Debug' && '\debug' || '' }}\bin" >nul || exit 1
+          if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
+            call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+            cmake -S . -B source\TempOutput -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON || exit /b 1
+            cmake --build source\TempOutput -j %NUMBER_OF_PROCESSORS% --target MeshLibC2 MeshLibC2Cuda MRTestC2 || exit /b 1
+            rem Only the new binaries need deploying; see the Build step's note on the serial pass.
+            for %%b in (source\TempOutput\bin\MeshLibC2*.dll source\TempOutput\bin\MRTestC2.exe) do (
+              %VCPKG_ROOT%\vcpkg.exe z-applocal --target-binary="%%b" --installed-bin-dir="%VCPKG_ROOT%\installed\%VCPKG_TARGET_TRIPLET%${{ matrix.config == 'Debug' && '\debug' || '' }}\bin" >nul || exit 1
+            )
+            xcopy source\TempOutput\bin\MeshLibC2*.* source\%MR_ARCH%\${{matrix.config}}\ /i /Y || exit /b 1
+            xcopy source\TempOutput\bin\MRTestC2*.* source\%MR_ARCH%\${{matrix.config}}\ /i /Y || exit /b 1
+          ) else (
+            msbuild -m source\MeshLibC2\MeshLibC2.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=%MSBUILD_PLATFORM% -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }};MR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
+            rem MeshLibC2Cuda needs a CUDA toolkit for its MRCuda ProjectReference, except on
+            rem arm64, where no toolkit exists and the project builds the placeholder stubs.
+            rem `exit 1` (no /b): cmd.exe drops the errorlevel of `exit /b` from this nested block.
+            if ${{ fromJSON('["1==0", "1==1"]')[env.CUDA_VERSION != '' || matrix.arch == 'arm64'] }} (
+              msbuild -m source\MeshLibC2Cuda\MeshLibC2Cuda.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=%MSBUILD_PLATFORM% -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }};MR_PCH_USE_EXTRA_HEADERS=ON || exit 1
+            )
           )
-          xcopy source\TempOutput\bin\MeshLibC2*.* source\%MR_ARCH%\${{matrix.config}}\ /i /Y || exit /b 1
-          xcopy source\TempOutput\bin\MRTestC2*.* source\%MR_ARCH%\${{matrix.config}}\ /i /Y || exit /b 1
 
       - name: Generate and build Python bindings
         if: ${{ inputs.mrbind && matrix.vcpkg_triplet != 'x64-windows-meshlib-iterator-debug' }}

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -309,7 +309,12 @@ jobs:
         # The C bindings sources are globbed at configure time, so they can only enter the
         # build graph now, once downloaded; every other cache entry survives the reconfigure.
         run: |
+          rem VsDevCmd.bat overrides VCPKG_ROOT with the VS-bundled vcpkg; preserve the step
+          rem env: value for the z-applocal loop below (the Build step's own loop is inside a
+          rem parenthesized IF block, so cmd expands it before VsDevCmd runs).
+          set "PROJ_VCPKG_ROOT=%VCPKG_ROOT%"
           call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          set "VCPKG_ROOT=%PROJ_VCPKG_ROOT%"
           cmake -S . -B source\TempOutput -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON || exit /b 1
           cmake --build source\TempOutput -j %NUMBER_OF_PROCESSORS% --target MeshLibC2 MeshLibC2Cuda MRTestC2 || exit /b 1
           rem Only the new binaries need deploying; see the Build step's note on the serial pass.

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -183,7 +183,7 @@ jobs:
           if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
             call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
             cmake --version || exit /b 1
-            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DVCPKG_APPLOCAL_DEPS=OFF -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} -DMESHLIB_BUILD_MRCUDA=${{ env.CUDA_VERSION != '' && 'ON' || 'OFF' }} -DMR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
+            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DVCPKG_APPLOCAL_DEPS=OFF -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF -DMESHLIB_BUILD_MRCUDA=${{ env.CUDA_VERSION != '' && 'ON' || 'OFF' }} -DMR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
             cmake --build source\TempOutput -j || exit /b 1
             rem Deploy vcpkg DLLs in one serial pass here: with VCPKG_APPLOCAL_DEPS=ON (default)
             rem every parallel Ninja link edge runs its own z-applocal into the shared bin dir,
@@ -205,7 +205,7 @@ jobs:
 
       # Both build systems wait here rather than before the Build step, so the main build
       # overlaps with generate-c-bindings: MeshLib.sln carries neither the C nor the C#
-      # bindings projects, and the CMake build keeps its C bindings targets out of ALL.
+      # bindings projects, and the CMake build configures its C bindings out until now.
       - name: Wait for C bindings
         if: ${{ inputs.mrbind_c || env.BUILD_C_SHARP == 'true' }}
         uses: ./.github/actions/wait-for-job
@@ -259,16 +259,16 @@ jobs:
           GETTEXT_ROOT: C:\msys64\clang64
           VCPKG_ROOT: C:\vcpkg
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
-        # The CMake branch reconfigures the directory the Build step left behind, so that the
-        # generated sources are globbed in; the targets are excluded from ALL, so they are
-        # built by name. Every other cache entry survives the reconfigure.
+        # The CMake branch reconfigures the directory the Build step left behind: the C bindings
+        # sources are globbed at configure time, so they can only enter the build graph now that
+        # they are downloaded; every other cache entry survives the reconfigure.
         # cmd expands %VCPKG_ROOT% when it parses the parenthesized block, i.e. before
         # VsDevCmd.bat replaces it with the VS-bundled vcpkg, whose path has a space - the same
         # reason the Build step's own z-applocal loop works.
         run: |
           if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
             call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
-            cmake -S . -B source\TempOutput || exit /b 1
+            cmake -S . -B source\TempOutput -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON || exit /b 1
             cmake --build source\TempOutput -j %NUMBER_OF_PROCESSORS% --target MeshLibC2 MeshLibC2Cuda MRTestC2 || exit /b 1
             rem Only the new binaries need deploying; see the Build step's note on the serial pass.
             for %%b in (source\TempOutput\bin\MeshLibC2*.dll source\TempOutput\bin\MRTestC2.exe) do (

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -169,20 +169,20 @@ jobs:
           msys2-env: ${{ env.MSYS2_ENV }}
 
       - name: Wait for C bindings
-        if: ${{ inputs.mrbind_c || env.BUILD_C_SHARP == 'true' }}
+        if: ${{ matrix.build_system == 'MSBuild' && ( inputs.mrbind_c || env.BUILD_C_SHARP == 'true' ) }}
         uses: ./.github/actions/wait-for-job
         with:
           job-name: generate-c-bindings
 
       - name: Download C bindings
-        if: ${{ inputs.mrbind_c || env.BUILD_C_SHARP == 'true' }}
+        if: ${{ matrix.build_system == 'MSBuild' && ( inputs.mrbind_c || env.BUILD_C_SHARP == 'true' ) }}
         uses: actions/download-artifact@v8
         with:
           name: CBindings
           path: MeshLib/CbindingsTmp
 
       - name: Prepare C bindings folders
-        if: ${{ inputs.mrbind_c || env.BUILD_C_SHARP == 'true' }}
+        if: ${{ matrix.build_system == 'MSBuild' && ( inputs.mrbind_c || env.BUILD_C_SHARP == 'true' ) }}
         run: |
           rm -r -force source/MeshLibC2
           move MeshLib/CbindingsTmp/MeshLibC2 source
@@ -229,7 +229,7 @@ jobs:
           if ${{ fromJSON('["1==0", "1==1"]')[matrix.build_system == 'CMake'] }} (
             call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
             cmake --version || exit /b 1
-            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DVCPKG_APPLOCAL_DEPS=OFF -DMESHLIB_BUILD_GENERATED_C_BINDINGS=${{ fromJSON('["OFF", "ON"]')[inputs.mrbind_c] }} -DMESHLIB_BUILD_MRCUDA=${{ env.CUDA_VERSION != '' && 'ON' || 'OFF' }} -DMR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
+            cmake -B source\TempOutput -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config}} -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DVCPKG_APPLOCAL_DEPS=OFF -DMESHLIB_BUILD_GENERATED_C_BINDINGS=OFF -DMESHLIB_BUILD_MRCUDA=${{ env.CUDA_VERSION != '' && 'ON' || 'OFF' }} -DMR_PCH_USE_EXTRA_HEADERS=ON || exit /b 1
             cmake --build source\TempOutput -j || exit /b 1
             rem Deploy vcpkg DLLs in one serial pass here: with VCPKG_APPLOCAL_DEPS=ON (default)
             rem every parallel Ninja link edge runs its own z-applocal into the shared bin dir,
@@ -266,6 +266,58 @@ jobs:
           VCPKG_ROOT: C:\vcpkg
           VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
         run: msbuild -m source\MeshLibC2Cuda\MeshLibC2Cuda.vcxproj -p:Configuration=${{ matrix.config }} -p:Platform=%MSBUILD_PLATFORM% -p:SolutionDir=%CD%\source\ -p:VcpkgTriplet=%VCPKG_TARGET_TRIPLET%;PlatformToolset=${{ env.PLATFORM_TOOLSET }};MRCudaPlatformToolset=${{ env.MRCUDA_PLATFORM_TOOLSET }};MR_PCH_USE_EXTRA_HEADERS=ON
+
+      # The CMake legs wait here instead of before the Build step above, so that the main
+      # build overlaps with generate-c-bindings. The MSBuild legs cannot: MeshLib.sln
+      # compiles the C# bindings generated from this same artifact.
+      - name: Wait for C bindings
+        if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
+        uses: ./.github/actions/wait-for-job
+        with:
+          job-name: generate-c-bindings
+
+      - name: Download C bindings
+        if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: CBindings
+          path: MeshLib/CbindingsTmp
+
+      - name: Prepare C bindings folders
+        if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
+        run: |
+          rm -r -force source/MeshLibC2
+          move MeshLib/CbindingsTmp/MeshLibC2 source
+          if ( $env:CUDA_VERSION ) {
+            rm -r -force source/MeshLibC2Cuda
+            move MeshLib/CbindingsTmp/MeshLibC2Cuda source
+          } else {
+            # No Cuda toolkit, so MRCuda is not built and the generated Cuda bindings cannot
+            # link. Keep this project's CMakeLists and stub its sources, as macOS does; see
+            # scripts/mrbind/cuda_placeholder_generated_c/README.md
+            cp -R scripts/mrbind/cuda_placeholder_generated_c/include source/MeshLibC2Cuda
+            cp -R scripts/mrbind/cuda_placeholder_generated_c/src source/MeshLibC2Cuda
+          }
+
+      - name: Build C bindings with CMake
+        if: ${{ inputs.mrbind_c && matrix.build_system == 'CMake' }}
+        shell: cmd
+        env:
+          GETTEXT_ROOT: C:\msys64\clang64
+          VCPKG_ROOT: C:\vcpkg
+          VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
+        # The C bindings sources are globbed at configure time, so they can only enter the
+        # build graph now, once downloaded; every other cache entry survives the reconfigure.
+        run: |
+          call "${{env.VC_PATH}}\Common7\Tools\VsDevCmd.bat" %VS_DEV_ARGS% -vcvars_ver=${{ env.VCVARS_VER }} || exit /b 1
+          cmake -S . -B source\TempOutput -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON || exit /b 1
+          cmake --build source\TempOutput -j %NUMBER_OF_PROCESSORS% --target MeshLibC2 MeshLibC2Cuda MRTestC2 || exit /b 1
+          rem Only the new binaries need deploying; see the Build step's note on the serial pass.
+          for %%b in (source\TempOutput\bin\MeshLibC2*.dll source\TempOutput\bin\MRTestC2.exe) do (
+            %VCPKG_ROOT%\vcpkg.exe z-applocal --target-binary="%%b" --installed-bin-dir="%VCPKG_ROOT%\installed\%VCPKG_TARGET_TRIPLET%${{ matrix.config == 'Debug' && '\debug' || '' }}\bin" >nul || exit 1
+          )
+          xcopy source\TempOutput\bin\MeshLibC2*.* source\%MR_ARCH%\${{matrix.config}}\ /i /Y || exit /b 1
+          xcopy source\TempOutput\bin\MRTestC2*.* source\%MR_ARCH%\${{matrix.config}}\ /i /Y || exit /b 1
 
       - name: Generate and build Python bindings
         if: ${{ inputs.mrbind && matrix.vcpkg_triplet != 'x64-windows-meshlib-iterator-debug' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ option(MESHLIB_BUILD_SYMBOLMESH "Build symbol-to-mesh library" ON)
 option(MESHLIB_BUILD_VOXELS "Build voxels library" ON)
 option(MESHLIB_BUILD_EXTRA_IO_FORMATS "Build extra IO format support library" ON)
 option(MESHLIB_BUILD_MCP "Enable MCP server" ON)
-option(MESHLIB_BUILD_GENERATED_C_BINDINGS "Configure the generated C bindings targets; they stay out of ALL and are built by name" OFF)
+option(MESHLIB_BUILD_GENERATED_C_BINDINGS "Build C bindings (assuming they are already generated)" OFF)
 option(MESHLIB_BUILD_WASM_MODULE "Build the headless WebAssembly module" OFF)
 option(MESHLIB_BUILD_WASM_DEFINITIONS_ONLY "Emit only the WebAssembly module's TypeScript definitions, leaving MeshLib unlinked" OFF)
 
@@ -259,29 +259,11 @@ ENDIF()
 
 IF(MESHLIB_BUILD_GENERATED_C_BINDINGS)
   option(MESHLIB_C_BINDINGS_UNITY_BUILD "Use unity build for C bindings" ON)
-  # These sources are generated (scripts/mrbind/generate.mk), and nothing but CMakeLists.txt
-  # is committed, so a configure legitimately precedes them: configure, generate, then
-  # reconfigure to pick the new files up.
-  # if(EXISTS) needs a full path, and PROJECT_SOURCE_DIR is the relative ./source here.
-  IF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_SOURCE_DIR}/MeshLibC2/src AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_SOURCE_DIR}/MeshLibC2Cuda/src)
-    add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2 ./MeshLibC2)
-    add_subdirectory(${PROJECT_SOURCE_DIR}/MRTestC2 ./MRTestC2)
+  add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2 ./MeshLibC2)
+  add_subdirectory(${PROJECT_SOURCE_DIR}/MRTestC2 ./MRTestC2)
 
-    # The Cuda is always enabled. Even if we don't want to actually build Cuda, we still need the stubs.
-    add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2Cuda ./MeshLibC2Cuda)
-
-    # Keep them out of the default build, so they are always built by name: the sources are
-    # only complete once generated. This is the target property, not add_subdirectory's
-    # EXCLUDE_FROM_ALL, which would drop these directories' install rules as well.
-    # Emscripten configures neither MRTestC2 nor MeshLibC2Cuda.
-    FOREACH(C_BINDINGS_TARGET MeshLibC2 MRTestC2 MeshLibC2Cuda)
-      IF(TARGET ${C_BINDINGS_TARGET})
-        set_target_properties(${C_BINDINGS_TARGET} PROPERTIES EXCLUDE_FROM_ALL ON)
-      ENDIF()
-    ENDFOREACH()
-  ELSE()
-    message(STATUS "C bindings are not generated yet: skipping MeshLibC2, MeshLibC2Cuda and MRTestC2")
-  ENDIF()
+  # The Cuda is always enabled. Even if we don't want to actually build Cuda, we still need the stubs.
+  add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2Cuda ./MeshLibC2Cuda)
 ENDIF()
 
 IF(MESHLIB_BUILD_SYMBOLMESH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,15 +261,24 @@ IF(MESHLIB_BUILD_GENERATED_C_BINDINGS)
   option(MESHLIB_C_BINDINGS_UNITY_BUILD "Use unity build for C bindings" ON)
   # These sources are generated (scripts/mrbind/generate.mk), and nothing but CMakeLists.txt
   # is committed, so a configure legitimately precedes them: configure, generate, then
-  # reconfigure to pick the new files up. EXCLUDE_FROM_ALL keeps them out of the default
-  # build once they are there, so they are always built by name.
+  # reconfigure to pick the new files up.
   # if(EXISTS) needs a full path, and PROJECT_SOURCE_DIR is the relative ./source here.
   IF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_SOURCE_DIR}/MeshLibC2/src AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_SOURCE_DIR}/MeshLibC2Cuda/src)
-    add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2 ./MeshLibC2 EXCLUDE_FROM_ALL)
-    add_subdirectory(${PROJECT_SOURCE_DIR}/MRTestC2 ./MRTestC2 EXCLUDE_FROM_ALL)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2 ./MeshLibC2)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/MRTestC2 ./MRTestC2)
 
     # The Cuda is always enabled. Even if we don't want to actually build Cuda, we still need the stubs.
-    add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2Cuda ./MeshLibC2Cuda EXCLUDE_FROM_ALL)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2Cuda ./MeshLibC2Cuda)
+
+    # Keep them out of the default build, so they are always built by name: the sources are
+    # only complete once generated. This is the target property, not add_subdirectory's
+    # EXCLUDE_FROM_ALL, which would drop these directories' install rules as well.
+    # Emscripten configures neither MRTestC2 nor MeshLibC2Cuda.
+    FOREACH(C_BINDINGS_TARGET MeshLibC2 MRTestC2 MeshLibC2Cuda)
+      IF(TARGET ${C_BINDINGS_TARGET})
+        set_target_properties(${C_BINDINGS_TARGET} PROPERTIES EXCLUDE_FROM_ALL ON)
+      ENDIF()
+    ENDFOREACH()
   ELSE()
     message(STATUS "C bindings are not generated yet: skipping MeshLibC2, MeshLibC2Cuda and MRTestC2")
   ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,8 @@ IF(MESHLIB_BUILD_GENERATED_C_BINDINGS)
   # is committed, so a configure legitimately precedes them: configure, generate, then
   # reconfigure to pick the new files up. EXCLUDE_FROM_ALL keeps them out of the default
   # build once they are there, so they are always built by name.
-  IF(EXISTS ${PROJECT_SOURCE_DIR}/MeshLibC2/src AND EXISTS ${PROJECT_SOURCE_DIR}/MeshLibC2Cuda/src)
+  # if(EXISTS) needs a full path, and PROJECT_SOURCE_DIR is the relative ./source here.
+  IF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_SOURCE_DIR}/MeshLibC2/src AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_SOURCE_DIR}/MeshLibC2Cuda/src)
     add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2 ./MeshLibC2 EXCLUDE_FROM_ALL)
     add_subdirectory(${PROJECT_SOURCE_DIR}/MRTestC2 ./MRTestC2 EXCLUDE_FROM_ALL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ option(MESHLIB_BUILD_SYMBOLMESH "Build symbol-to-mesh library" ON)
 option(MESHLIB_BUILD_VOXELS "Build voxels library" ON)
 option(MESHLIB_BUILD_EXTRA_IO_FORMATS "Build extra IO format support library" ON)
 option(MESHLIB_BUILD_MCP "Enable MCP server" ON)
-option(MESHLIB_BUILD_GENERATED_C_BINDINGS "Build C bindings (assuming they are already generated)" OFF)
+option(MESHLIB_BUILD_GENERATED_C_BINDINGS "Configure the generated C bindings targets; they stay out of ALL and are built by name" OFF)
 option(MESHLIB_BUILD_WASM_MODULE "Build the headless WebAssembly module" OFF)
 option(MESHLIB_BUILD_WASM_DEFINITIONS_ONLY "Emit only the WebAssembly module's TypeScript definitions, leaving MeshLib unlinked" OFF)
 
@@ -259,11 +259,19 @@ ENDIF()
 
 IF(MESHLIB_BUILD_GENERATED_C_BINDINGS)
   option(MESHLIB_C_BINDINGS_UNITY_BUILD "Use unity build for C bindings" ON)
-  add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2 ./MeshLibC2)
-  add_subdirectory(${PROJECT_SOURCE_DIR}/MRTestC2 ./MRTestC2)
+  # These sources are generated (scripts/mrbind/generate.mk), and nothing but CMakeLists.txt
+  # is committed, so a configure legitimately precedes them: configure, generate, then
+  # reconfigure to pick the new files up. EXCLUDE_FROM_ALL keeps them out of the default
+  # build once they are there, so they are always built by name.
+  IF(EXISTS ${PROJECT_SOURCE_DIR}/MeshLibC2/src AND EXISTS ${PROJECT_SOURCE_DIR}/MeshLibC2Cuda/src)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2 ./MeshLibC2 EXCLUDE_FROM_ALL)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/MRTestC2 ./MRTestC2 EXCLUDE_FROM_ALL)
 
-  # The Cuda is always enabled. Even if we don't want to actually build Cuda, we still need the stubs.
-  add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2Cuda ./MeshLibC2Cuda)
+    # The Cuda is always enabled. Even if we don't want to actually build Cuda, we still need the stubs.
+    add_subdirectory(${PROJECT_SOURCE_DIR}/MeshLibC2Cuda ./MeshLibC2Cuda EXCLUDE_FROM_ALL)
+  ELSE()
+    message(STATUS "C bindings are not generated yet: skipping MeshLibC2, MeshLibC2Cuda and MRTestC2")
+  ENDIF()
 ENDIF()
 
 IF(MESHLIB_BUILD_SYMBOLMESH)

--- a/cmake/Modules/ConfigureCuda.cmake
+++ b/cmake/Modules/ConfigureCuda.cmake
@@ -10,10 +10,6 @@ IF(NOT CUDAToolkit_FOUND AND NOT CUDA_FOUND)
 
       # For our VS2022 CI:
       # 20011: VS2026's <cmath> calls the __host__-only __copysignf intrinsic from __host__ __device__ copysign
-      # Seed the cache entry instead of shadowing it with a normal variable: the entry does
-      # not exist yet on the first configure, but enable_language(CUDA) creates it, so a
-      # second configure of the same build directory would append to a different base and
-      # change every .cu command line.
       set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler -diag-suppress 20011 -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" CACHE STRING "")
     ELSE()
       # https://cmake.org/cmake/help/latest/release/3.25.html#id2

--- a/cmake/Modules/ConfigureCuda.cmake
+++ b/cmake/Modules/ConfigureCuda.cmake
@@ -10,7 +10,11 @@ IF(NOT CUDAToolkit_FOUND AND NOT CUDA_FOUND)
 
       # For our VS2022 CI:
       # 20011: VS2026's <cmath> calls the __host__-only __copysignf intrinsic from __host__ __device__ copysign
-      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler -diag-suppress 20011 -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH")
+      # Seed the cache entry instead of shadowing it with a normal variable: the entry does
+      # not exist yet on the first configure, but enable_language(CUDA) creates it, so a
+      # second configure of the same build directory would append to a different base and
+      # change every .cu command line.
+      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler -diag-suppress 20011 -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" CACHE STRING "Flags used by the CUDA compiler during all build types")
     ELSE()
       # https://cmake.org/cmake/help/latest/release/3.25.html#id2
       IF(CMAKE_VERSION VERSION_LESS 3.25.2)

--- a/cmake/Modules/ConfigureCuda.cmake
+++ b/cmake/Modules/ConfigureCuda.cmake
@@ -14,7 +14,7 @@ IF(NOT CUDAToolkit_FOUND AND NOT CUDA_FOUND)
       # not exist yet on the first configure, but enable_language(CUDA) creates it, so a
       # second configure of the same build directory would append to a different base and
       # change every .cu command line.
-      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler -diag-suppress 20011 -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" CACHE STRING "Flags used by the CUDA compiler during all build types")
+      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler -diag-suppress 20011 -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH" CACHE STRING "")
     ELSE()
       # https://cmake.org/cmake/help/latest/release/3.25.html#id2
       IF(CMAKE_VERSION VERSION_LESS 3.25.2)


### PR DESCRIPTION
### What

The C bindings move out of the `Build` step into their own step, so that `Wait for C bindings` can sit *between* the two — on every leg, both build systems:

1. **Build** — builds everything except the C bindings.
2. **Wait for C bindings** → **Download** → **Prepare C bindings folders** — one shared trio.
3. **Build C bindings** — builds `MeshLibC2`, `MeshLibC2Cuda` and `MRTestC2` by name.

The main build now overlaps with `generate-c-bindings` instead of being gated on it.

Legs touched: ubuntu-x64, ubuntu-arm64, macos, linux-vcpkg, windows (CMake and MSBuild). The dedicated emscripten C-bindings leg is unchanged — it builds nothing else, so it still waits first.

### Why the step reconfigures, and why the option is toggled

`source/MeshLibC2` tracks only `CMakeLists.txt`, the `.vcxproj` and the config template: every source is generated by `scripts/mrbind/generate.mk`, and both `MeshLibC2/CMakeLists.txt` and `MeshLibC2Cuda/CMakeLists.txt` collect them with `file(GLOB_RECURSE SOURCES "src/*.cpp")` at *configure* time, under `IF(MESHLIB_BUILD_GENERATED_C_BINDINGS)`. So the sources must exist before `cmake` runs, which is why the wait used to precede the whole build; splitting the build alone is not possible, the configure has to be split too.

The `Build` step therefore configures with the option `OFF`, and `Build C bindings` reconfigures the same directory with it `ON` — which re-runs the globs over the downloaded sources — then builds `MeshLibC2 MeshLibC2Cuda MRTestC2` by name. The reconfigure reuses `CMakeCache.txt` (0.9 s on linux-vcpkg, 13-34 s on Windows/vcpkg) and rebuilds nothing else: 38 ninja edges, exactly the C bindings.

An earlier revision instead kept the three targets out of `ALL` permanently and held the option at one value; it is reverted here. For the record, two traps it hit, in case it is revisited: `add_subdirectory(... EXCLUDE_FROM_ALL)` also drops that directory's *install rules*, so the package lost `MeshLibC2Config.cmake` and `find_package(MeshLib)` failed in `Build C examples` (the `EXCLUDE_FROM_ALL` target property does not have that effect); and a `IF(EXISTS ${PROJECT_SOURCE_DIR}/...)` guard silently misfires, because `if(EXISTS)` needs a full path while `PROJECT_SOURCE_DIR` is overridden to the relative `./source`.

### Why the MSBuild legs can wait after `Build` too

`MeshLib.sln` contains neither `MeshLibC2` nor `MRDotNet2`, so nothing in it consumes the artifact. Only `Generate C# bindings` (which reads `source/MeshLibC2/temp/interop_desc.json`) and the C-bindings projects do, and moving the C# generation past `Build` puts all of them after the wait — hence a single trio for both build systems.

On Windows the three former steps (`Build C bindings with MSBuild`, `Build C CUDA bindings with MSBuild`, `Build C bindings with CMake`) are now one `Build C bindings` step that branches on `matrix.build_system` the way `Build` does, so every workflow names this work identically.

### Fallout found and fixed along the way

* **`ConfigureCuda.cmake` now seeds the `CMAKE_CUDA_FLAGS` cache entry** instead of appending to a normal variable. That variable is empty on a first configure but `enable_language(CUDA)` creates the cache entry, so the second configure appended to the cached MSVC init flags: every `.cu` command line changed and all 9 MRCuda objects rebuilt (~30 s). Seeding the cache keeps both configures identical and preserves what the first configure produces today.
* **`MR_VERSION` is repeated in the new step** on the unix legs. `MESHLIB_VERSION` comes from `$ENV{MR_VERSION}` and is baked into `source/MRMesh/config_cmake.h`, which `configure_file` writes *into the source tree*; a reconfigure without it would drop the version to `0.0.0` and rebuild the whole project. Windows passes no `MR_VERSION` in either configure.
* **Windows** repeats the `vcpkg z-applocal` deploy and the `xcopy` into `source/<arch>/<config>`, scoped to the new binaries, so `MRTestC2.exe` reaches the directory `C Unit Tests` and `Archive files` read. `%VCPKG_ROOT%` survives `VsDevCmd.bat` (which replaces it with the VS-bundled vcpkg, whose path has a space) because cmd expands the parenthesized block before running it — the same reason the `Build` step's own loop works.

### Effect on build time: none measurable

Summing `Build` + `Build C bindings` per leg, over the legs whose matrix entries match a master run:

| | n | master | PR |
|---|---|---|---|
| changed legs | 14–16 | 13 425 s / 13 842 s | 13 312 s (−0.8 % / −3.8 %) |
| untouched legs (control) | 7–9 | 3 893 s / 1 910 s | +3.7 % / +12.1 % |

The control group — legs this PR does not touch — moves as much as or more than the changed ones, and single legs swing ±30 % between two master runs. Waits were 2–54 s per leg in the last run, most of that the four emscripten C-bindings legs; `generate-c-bindings` takes ~100 s and normally finishes before any leg reaches its wait. So the gain is structural — a leg can no longer be blocked from starting its build by a slow or late-queued `generate-c-bindings` — rather than a speed-up. The cost is one CMake re-generate per CMake job, and a `generate-c-bindings` failure now fails these legs after the build instead of before it.

### Verification

Run 33847790954 is green with `full-ci` for this tree: 105 jobs, no failures. `Build C bindings` ran on 45 legs, `C Unit Tests` passed on 37, `Build C examples` on 37, and `Create Deb` / `Create Package` plus their extract-and-build-examples steps on all legs that run them — which is what proves the install rules survived.
