### PR TITLE
CI: fix always-false CUDA test that hid the real generated C bindings on ubuntu-x64

### DIFF
--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -121,10 +121,12 @@ jobs:
       - name: Prepare C bindings folders
         if: ${{ inputs.mrbind_c }}
         shell: bash
+        env:
+          BUILD_MRCUDA: ${{ matrix.build_mrcuda }}
         run: |
           rm -rf source/MeshLibC2
           mv MeshLib/CbindingsTmp/MeshLibC2 source
-          if [[ $${matrix.build_mrcuda} == ON ]]; then
+          if [[ "${BUILD_MRCUDA}" == ON ]]; then
             rm -rf source/MeshLibC2Cuda
             mv MeshLib/CbindingsTmp/MeshLibC2Cuda source
           else


### PR DESCRIPTION
## The bug

`.github/workflows/build-test-ubuntu-x64.yml`, step **Prepare C bindings folders**, tested the CUDA matrix flag as

```bash
if [[ $${matrix.build_mrcuda} == ON ]]; then
```

`$${...}` is not a GitHub Actions expression — those are `${{ ... }}`. GHA therefore left the text alone and handed it to bash verbatim, where `$$` expanded to the shell's PID and `{matrix.build_mrcuda}` stayed literal. The test compared something like `1234{matrix.build_mrcuda}` against `ON`, so it was **always false**.

Every row consequently took the `else` branch:

```bash
cp -r scripts/mrbind/cuda_placeholder_generated_c/{include,src} source/MeshLibC2Cuda
```

i.e. the ubuntu-x64 leg installed the **placeholder** CUDA C bindings even on the rows that build MRCuda (`build_mrcuda: ON` — 3 of the 4 minimal-config rows: ubuntu22/gcc-12, ubuntu24/gcc-13, ubuntu26/gcc-15, and 12 of 14 full-config rows). The downloaded artifact's real `MeshLibC2Cuda` was silently discarded, so the real generated CUDA bindings have **never been compiled on this leg**.

The placeholder is one header plus one source (`MRCCuda/MRCudaBasic.{h,cpp}`, produced with `ENABLE_CUDA=0`); the real generated set covers all 16 MRCuda public headers. Nothing failed because `MeshLibC2Cuda`'s `CMakeLists.txt` globs `src/*.cpp`, so a smaller source set just builds a smaller library.

For comparison: `build-test-ubuntu-arm64.yml` unconditionally moves the real generated `MeshLibC2Cuda`, and `build-test-windows.yml` branches correctly on `$env:CUDA_VERSION`.

## The fix

Pass the flag through the step's `env:` rather than interpolating an expression into the shell body, and quote the expansion:

```yaml
        env:
          BUILD_MRCUDA: ${{ matrix.build_mrcuda }}
        run: |
          ...
          if [[ "${BUILD_MRCUDA}" == ON ]]; then
```

Line 127 was the only affected site in the file — the other two uses of `matrix.build_mrcuda` (the `-DMESHLIB_BUILD_MRCUDA=` cmake option and the `ENABLE_CUDA` env for the Python bindings) already used correct `${{ }}` syntax.

## Verification

The CUDA-enabled ubuntu-x64 rows now compile the real generated `MeshLibC2Cuda` for the first time, so this run is the actual test: it can surface genuine compile errors that the placeholder was hiding. Unaffected platforms are disabled for the first run; `generate-c-bindings` is not gated by those labels, so the CBindings artifact is still produced.

Found while reworking these workflows in #6770, which deliberately left this alone.
