### PR TITLE
Take the desktop picker id through a flat varying, not gl_PrimitiveID

### DIFF
--- a/source/MRViewer/MRGLStaticHolder.cpp
+++ b/source/MRViewer/MRGLStaticHolder.cpp
@@ -182,7 +182,14 @@ void GLStaticHolder::createShader_( ShaderType type )
   out vec3 world_pos;
   out float primitiveIdf0;
   out float primitiveIdf1;
-
+)"
+#ifndef __EMSCRIPTEN__
+            // desktop GL has integer varyings, so the id needs no float round-trip
+            R"(
+  flat out uint primitiveIdFlat;
+)"
+#endif
+            R"(
   void main()
   {
     world_pos = vec3(model*vec4 (position, 1.0));
@@ -190,6 +197,13 @@ void GLStaticHolder::createShader_( ShaderType type )
     uint primId = uint(gl_VertexID) / primBucketSize;
     primitiveIdf1 = float( uint( primId >> 20u ) ) + 0.5;
     primitiveIdf0 = float( primId % uint( 1u << 20u ) ) + 0.5;
+)"
+#ifndef __EMSCRIPTEN__
+            R"(
+    primitiveIdFlat = primId;
+)"
+#endif
+            R"(
     gl_PointSize = pointSize;
   }
 )";

--- a/source/MRViewer/MRShaderBlocks.cpp
+++ b/source/MRViewer/MRShaderBlocks.cpp
@@ -22,11 +22,18 @@ std::string getPickerFragmentShader( bool points, bool cornerMode )
   out highp uvec4 color;
 )";
 
+    // outside corner mode the id arrives in a flat integer varying: gl_PrimitiveID came back
+    // as garbage under llvmpipe 21.1.8 / Mesa 26.0.8. Declared only where read, so the pickers
+    // that stay in corner mode keep linking against vertex shaders without it.
     const std::string primId =
         cornerMode ? R"(
     uint primitiveId = ( uint(primitiveIdf1) << 20u ) + uint(primitiveIdf0);
 )" : R"(
-    uint primitiveId = uint(gl_PrimitiveID);
+    uint primitiveId = primitiveIdFlat;
+)";
+
+    const std::string idDecl = cornerMode ? "" : R"(
+  flat in uint primitiveIdFlat;
 )";
 
     const std::string tail = R"(
@@ -39,6 +46,7 @@ std::string getPickerFragmentShader( bool points, bool cornerMode )
 
     return
         head +
+        idDecl +
         getShaderMainBeginBlock( false ) +
         ( points ? getFragmentShaderPointSizeBlock() : R"()" ) +
         getFragmentShaderClippingBlock() +


### PR DESCRIPTION
Stacked on #6772 (the picked-point guard), so this PR's diff is the shader change alone. GitHub will retarget it to master once #6772 merges.

### What was wrong

The Ubuntu 26.04 UI test picked **face -1090332440 out of a 512-face mesh**, which is what #6772's new guard reports:

```
[warning] pointOnObjectToPickedPoint: not a valid mesh pick: face=-1090332440, faceSize=512
```

On desktop, `RenderMeshObject::renderPicker` uses `MeshDesktopPicker` ([MRRenderMeshObject.cpp:157](../blob/master/source/MRViewer/MRRenderMeshObject.cpp)), whose fragment shader took the primitive id from `uint(gl_PrimitiveID)`. That is the channel that came back wrong. The decisive detail is what came back *right*: `uniGeomId`, a plain uniform written into the neighbouring channel of the very same pick pixel, resolved to a real mesh object — otherwise the guard would never have reached the mesh branch. One channel of one fragment correct, the other garbage, points at `gl_PrimitiveID` itself rather than at the FBO, the read-back or the decode.

The read-back is not at fault: `GL_RGBA32UI` texture, `glClearBufferuiv` to `0xffffffff`, `glReadPixels(..., GL_RGBA_INTEGER, GL_UNSIGNED_INT, ...)` — internally consistent. Nor is the id arithmetic: every renderer that draws for picking sets `primBucketSize` (mesh 3 and 1, points 1, label 1; features delegate through `RenderObjectCombinator`), so there is no division by zero.

### What this does

The picker vertex shader already computes `uint primId = uint(gl_VertexID) / primBucketSize` for the corner-mode path. This passes that same value down a **flat integer varying** and reads it in place of `gl_PrimitiveID`:

- `flat out uint primitiveIdFlat;` / `primitiveIdFlat = primId;` in the picker vertex shader, desktop only.
- the non-corner-mode fragment path reads `primitiveIdFlat`.

Emscripten keeps `gl_PrimitiveID` untouched behind `#ifndef __EMSCRIPTEN__`, and the varying is declared only in the mode that reads it, so `LinesPicker`/`LinesJointPicker` keep linking against vertex shaders that do not provide it.

There is precedent for the platform split a few files over: `getMeshFragmentShaderColoringBlock()` already picks `gl_PrimitiveID` on desktop and the interpolated float pair on Emscripten.

### Evidence it works

Same MeshInspector UI suite, same ubuntu26 image, with this commit in the MeshLib gitlink:

| | before | after |
|---|---|---|
| guard warning | `face=-1090332440` | **none** |
| crashes | SIGSEGV in `toTriPoint`, then a second in `findVisibleFaces` | **0** |
| scenarios | died on the first pick of `create_feature_sphere` | features and select suites run to completion, **5 of 6 suites pass** |

The remaining failure is unrelated: the `text` scenario misses its mesh-similarity threshold by 0.0009 (0.9941 vs 0.995), which looks like a freetype/font difference on Resolute and is a baseline question, not a pick one.

`MRViewer.vcxproj` builds clean locally and `MeshViewer -hidden -noEventLoop -unloadPluginsAtEnd` exits 0 on Windows — though that only exercises the C++, since the picker shader is compiled lazily on the first pick.

### Note on scope

No `disable-build-*` labels: this changes shader generation shared by every desktop GL platform, so Windows, macOS and the vcpkg legs all want to run, and the Emscripten leg is what proves the untouched ES branch still compiles.
