### PR TITLE
appendRightBoundaryLoop and MeshTopology::clear(): buffer-reusing helpers

### DIFF
--- a/source/MRMesh/MRMeshTopology.cpp
+++ b/source/MRMesh/MRMeshTopology.cpp
@@ -160,6 +160,18 @@ void MeshTopology::shrinkToFit()
     validFaces_.shrink_to_fit();
 }
 
+void MeshTopology::clear()
+{
+    edges_.clear();
+    edgePerVertex_.clear();
+    validVerts_.clear();
+    edgePerFace_.clear();
+    validFaces_.clear();
+    numValidVerts_ = 0;
+    numValidFaces_ = 0;
+    updateValids_ = true;
+}
+
 void MeshTopology::splice( EdgeId a, EdgeId b )
 {
     assert( a.valid() && b.valid() );

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -71,6 +71,9 @@ public:
     /// requests the removal of unused capacity
     MRMESH_API void shrinkToFit();
 
+    /// removes all vertices, edges and faces, keeping the buffers' capacity for reuse
+    MRMESH_API void clear();
+
 
     /// given two half edges do either of two:
     /// 1) if a and b were from distinct rings, puts them in one ring;

--- a/source/MRMesh/MRMeshTopology.h
+++ b/source/MRMesh/MRMeshTopology.h
@@ -71,7 +71,7 @@ public:
     /// requests the removal of unused capacity
     MRMESH_API void shrinkToFit();
 
-    /// removes all vertices, edges and faces, keeping the buffers' capacity for reuse
+    /// resets to the default-constructed state (including resuming valids updating), keeping the buffers' capacity for reuse
     MRMESH_API void clear();
 
 

--- a/source/MRMesh/MRRegionBoundary.cpp
+++ b/source/MRMesh/MRRegionBoundary.cpp
@@ -12,33 +12,33 @@
 namespace MR
 {
 
-static EdgeLoop trackBoundaryLoop( const MeshTopology& topology, EdgeId e0, const FaceBitSet* region /*= nullptr */, bool left, Turn turn )
+static void appendBoundaryLoop( EdgeLoop& res, const MeshTopology& topology, EdgeId e0, const FaceBitSet* region, bool left, Turn turn )
 {
-    std::function<EdgeId( EdgeId )> next;
-    if ( left )
-        next = [&] ( EdgeId e ) { return topology.nextLeftBd( e, region, turn ); };
-    else
-        next = [&] ( EdgeId e ) { return topology.prevLeftBd( e.sym(), region, turn ).sym(); };
-
-    EdgeLoop res;
     auto e = e0;
     do
     {
         res.push_back( e );
-        e = next( e );
+        e = left ? topology.nextLeftBd( e, region, turn ) : topology.prevLeftBd( e.sym(), region, turn ).sym();
     } while ( e != e0 );
-
-    return res;
 }
 
 EdgeLoop trackLeftBoundaryLoop( const MeshTopology& topology, EdgeId e0, const FaceBitSet* region, Turn turn )
 {
-    return trackBoundaryLoop( topology, e0, region, true, turn );
+    EdgeLoop res;
+    appendBoundaryLoop( res, topology, e0, region, true, turn );
+    return res;
 }
 
 EdgeLoop trackRightBoundaryLoop( const MeshTopology& topology, EdgeId e0, const FaceBitSet* region, Turn turn )
 {
-    return trackBoundaryLoop( topology, e0, region, false, turn );
+    EdgeLoop res;
+    appendBoundaryLoop( res, topology, e0, region, false, turn );
+    return res;
+}
+
+void appendRightBoundaryLoop( EdgeLoop& res, const MeshTopology& topology, EdgeId e0, const FaceBitSet* region, Turn turn )
+{
+    appendBoundaryLoop( res, topology, e0, region, false, turn );
 }
 
 EdgeId extractPath( const MeshTopology& topology, EdgeId e, EdgeBitSet& edges, EdgePath* outPath, Turn turn )

--- a/source/MRMesh/MRRegionBoundary.cpp
+++ b/source/MRMesh/MRRegionBoundary.cpp
@@ -12,33 +12,39 @@
 namespace MR
 {
 
-static void appendBoundaryLoop( EdgeLoop& res, const MeshTopology& topology, EdgeId e0, const FaceBitSet* region, bool left, Turn turn )
+static void trackBoundaryLoop( const MeshTopology& topology, EdgeId e0, EdgeLoop& outLoop, const FaceBitSet* region, bool left, Turn turn )
 {
+    outLoop.clear();
     auto e = e0;
     do
     {
-        res.push_back( e );
+        outLoop.push_back( e );
         e = left ? topology.nextLeftBd( e, region, turn ) : topology.prevLeftBd( e.sym(), region, turn ).sym();
     } while ( e != e0 );
+}
+
+void trackLeftBoundaryLoop( const MeshTopology& topology, EdgeId e0, EdgeLoop& outLoop, const FaceBitSet* region, Turn turn )
+{
+    trackBoundaryLoop( topology, e0, outLoop, region, true, turn );
 }
 
 EdgeLoop trackLeftBoundaryLoop( const MeshTopology& topology, EdgeId e0, const FaceBitSet* region, Turn turn )
 {
     EdgeLoop res;
-    appendBoundaryLoop( res, topology, e0, region, true, turn );
+    trackLeftBoundaryLoop( topology, e0, res, region, turn );
     return res;
+}
+
+void trackRightBoundaryLoop( const MeshTopology& topology, EdgeId e0, EdgeLoop& outLoop, const FaceBitSet* region, Turn turn )
+{
+    trackBoundaryLoop( topology, e0, outLoop, region, false, turn );
 }
 
 EdgeLoop trackRightBoundaryLoop( const MeshTopology& topology, EdgeId e0, const FaceBitSet* region, Turn turn )
 {
     EdgeLoop res;
-    appendBoundaryLoop( res, topology, e0, region, false, turn );
+    trackRightBoundaryLoop( topology, e0, res, region, turn );
     return res;
-}
-
-void appendRightBoundaryLoop( EdgeLoop& res, const MeshTopology& topology, EdgeId e0, const FaceBitSet* region, Turn turn )
-{
-    appendBoundaryLoop( res, topology, e0, region, false, turn );
 }
 
 EdgeId extractPath( const MeshTopology& topology, EdgeId e, EdgeBitSet& edges, EdgePath* outPath, Turn turn )
@@ -177,38 +183,26 @@ static std::vector<EdgeLoop> findRegionBoundary( const MeshTopology& topology, c
 
     std::vector<EdgeLoop> res;
     HashSet<EdgeId> reportedBdEdges;
-
-    std::function<bool( EdgeId )> insert;
-    std::function<EdgeLoop( EdgeId )> track;
-    if ( left )
-    {
-        insert = [&] ( EdgeId e ) { return reportedBdEdges.insert( e ).second; };
-        track = [&] ( EdgeId e ) { return trackLeftBoundaryLoop( topology, e, region, turn ); };
-    }
-    else
-    {
-        insert = [&] ( EdgeId e ) { return reportedBdEdges.insert( e.sym() ).second; };
-        track = [&] ( EdgeId e ) { return trackRightBoundaryLoop( topology, e.sym(), region, turn ); };
-    }
+    // a left boundary loop starts from the left-boundary edge itself, a right one from its opposite
+    auto loopEdge = [left] ( EdgeId e ) { return left ? e : e.sym(); };
 
     EdgeBitSet bdEdges = findAllLeftBdEdges( topology, region );
 
     for ( auto e : bdEdges )
     {
         assert ( topology.isLeftBdEdge( e, region ) );
-        if ( !insert( e ) )
+        if ( !reportedBdEdges.insert( loopEdge( e ) ).second )
             continue;
-        auto loop = track( e );
+        auto & loop = res.emplace_back();
+        trackBoundaryLoop( topology, loopEdge( e ), loop, region, left, turn );
         for ( int i = 1; i < loop.size(); ++i )
         {
             [[maybe_unused]] bool inserted = reportedBdEdges.insert( loop[i] ).second;
             assert( inserted );
         }
-        res.push_back( std::move( loop ) );
     }
 
     return res;
-
 }
 
 std::vector<EdgeLoop> findLeftBoundary( const MeshTopology& topology, const FaceBitSet* region, Turn turn )

--- a/source/MRMesh/MRRegionBoundary.h
+++ b/source/MRMesh/MRRegionBoundary.h
@@ -21,6 +21,9 @@ namespace MR
 // This is skipped in the bindings to avoid complex function names for the overloads in C.
 [[nodiscard]] MR_BIND_IGNORE inline EdgeLoop trackRightBoundaryLoop( const MeshTopology & topology, const FaceBitSet & region, EdgeId e0, Turn turn = Turn::Rightmost )
     { return trackRightBoundaryLoop( topology, e0, &region, turn ); }
+/// same as trackRightBoundaryLoop, but appends the loop to given container,
+/// which allows a caller tracking many loops to reuse its capacity
+MRMESH_API void appendRightBoundaryLoop( EdgeLoop & res, const MeshTopology & topology, EdgeId e0, const FaceBitSet * region = nullptr, Turn turn = Turn::Rightmost );
 
 /// tracks the path of edges with set bits in (edges) starting from (e0);
 /// \return the last edge of the path or invalid edge if e0's bit in (edge) was reset;

--- a/source/MRMesh/MRRegionBoundary.h
+++ b/source/MRMesh/MRRegionBoundary.h
@@ -14,6 +14,8 @@ namespace MR
 // This is skipped in the bindings to avoid complex function names for the overloads in C.
 [[nodiscard]] MR_BIND_IGNORE inline EdgeLoop trackLeftBoundaryLoop( const MeshTopology & topology, const FaceBitSet & region, EdgeId e0, Turn turn = Turn::Rightmost )
     { return trackLeftBoundaryLoop( topology, e0, &region, turn ); }
+/// same as above, but writes the loop in \p outLoop (cleared first), so a caller tracking many loops one by one reuses its capacity
+MR_BIND_IGNORE MRMESH_API void trackLeftBoundaryLoop( const MeshTopology & topology, EdgeId e0, EdgeLoop & outLoop, const FaceBitSet * region = nullptr, Turn turn = Turn::Rightmost );
 
 /// returns closed loop of region boundary starting from given region boundary edge (region faces on the right, and not-region faces or holes on the left);
 /// if more than two boundary edges connect in one vertex, then the function makes the most abrupt turn to left
@@ -21,9 +23,8 @@ namespace MR
 // This is skipped in the bindings to avoid complex function names for the overloads in C.
 [[nodiscard]] MR_BIND_IGNORE inline EdgeLoop trackRightBoundaryLoop( const MeshTopology & topology, const FaceBitSet & region, EdgeId e0, Turn turn = Turn::Rightmost )
     { return trackRightBoundaryLoop( topology, e0, &region, turn ); }
-/// same as trackRightBoundaryLoop, but appends the loop to given container,
-/// which allows a caller tracking many loops to reuse its capacity
-MRMESH_API void appendRightBoundaryLoop( EdgeLoop & res, const MeshTopology & topology, EdgeId e0, const FaceBitSet * region = nullptr, Turn turn = Turn::Rightmost );
+/// same as above, but writes the loop in \p outLoop (cleared first), so a caller tracking many loops one by one reuses its capacity
+MR_BIND_IGNORE MRMESH_API void trackRightBoundaryLoop( const MeshTopology & topology, EdgeId e0, EdgeLoop & outLoop, const FaceBitSet * region = nullptr, Turn turn = Turn::Rightmost );
 
 /// tracks the path of edges with set bits in (edges) starting from (e0);
 /// \return the last edge of the path or invalid edge if e0's bit in (edge) was reset;


### PR DESCRIPTION
Two small helpers for a caller that repeats an operation many times and wants to keep its buffers between the runs. The first such caller will be the sweep-line hole-fill planner (`fillContours2DPlan` / `getPlanarHoleFillPlans`), in a follow-up PR that reuses one triangulation cache across the holes.

- `trackLeftBoundaryLoop` / `trackRightBoundaryLoop` get an overload writing the loop into a caller's `EdgeLoop` (cleared first), so a caller tracking many loops one by one reuses its capacity. C++-only (`MR_BIND_IGNORE`, like the other overloads here). The shared helper lost its `std::function` step, and `findRegionBoundary` now calls it directly instead of going through its own two `std::function`s and a temporary loop per boundary; results are unchanged.
- `MeshTopology::clear()` resets to the default-constructed state (including resuming valids updating) while keeping the buffers' capacity, like `std::vector::clear()`.

Verified locally: the MRTest boolean / hole-fill / planar-triangulation subset passes, and the planar hole-fill plans on the test meshes are bit-identical to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
