### PR TITLE
makeDeloneEdgeFlips: reusable buffers and a serial worklist for small meshes

### DIFF
--- a/source/MRMesh/MRMeshDelone.cpp
+++ b/source/MRMesh/MRMeshDelone.cpp
@@ -209,11 +209,8 @@ int makeDeloneEdgeFlips( Mesh & mesh, const DeloneSettings& settings, int numIte
 // and a flip re-queues only the four edges around it, so unlike the parallel passes there is no rescan
 // of the whole candidate set and no second check before a flip; the flips come in another order though,
 // so where the result is not unique (cocircular vertices, or the constraints in settings) it can differ
-static int makeDeloneEdgeFlipsSerial( MeshTopology& topology, const VertCoords& points, const DeloneSettings& settings, int numIters,
-    const ProgressCallback& progressCallback, DeloneFlipsCache& cache )
+static int makeDeloneEdgeFlipsSerial( MeshTopology& topology, const VertCoords& points, const DeloneSettings& settings, int numIters, DeloneFlipsCache& cache )
 {
-    if ( progressCallback && !progressCallback( 0.0f ) )
-        return 0;
     const auto ueSize = topology.undirectedEdgeSize();
     auto& queued = cache.nextFlipCandidates; // the edges currently waiting in the worklist
     queued.clear();
@@ -253,10 +250,11 @@ int makeDeloneEdgeFlips( MeshTopology& topology, const VertCoords& points, const
     DeloneFlipsCache& cache = settings.cache ? *settings.cache : localCache;
 
     // below this size the passes spend more on entering the task arena and rescanning the candidate
-    // sets than on the checks themselves (and such a call is over too soon for the timer to matter)
+    // sets than on the checks themselves; such a call is also over too soon for the timer or the
+    // progress callback to matter
     constexpr size_t cMinParallelEdges = 256;
     if ( topology.undirectedEdgeSize() < cMinParallelEdges )
-        return makeDeloneEdgeFlipsSerial( topology, points, settings, numIters, progressCallback, cache );
+        return makeDeloneEdgeFlipsSerial( topology, points, settings, numIters, cache );
     MR_TIMER;
 
     auto& flipCandidates = cache.flipCandidates;

--- a/source/MRMesh/MRMeshDelone.cpp
+++ b/source/MRMesh/MRMeshDelone.cpp
@@ -9,6 +9,7 @@
 #include "MRReducePath.h"
 #include "MRTwoLineSegmDist.h"
 #include "MREdgeLengthMesh.h"
+#include <algorithm>
 
 namespace MR
 {
@@ -205,36 +206,41 @@ int makeDeloneEdgeFlips( Mesh & mesh, const DeloneSettings& settings, int numIte
     return flipsDone;
 }
 
-// serial Delone flipping of a small mesh: every edge is checked once when popped from the worklist,
-// and a flip re-queues only the four edges around it, so unlike the parallel passes there is no rescan
-// of the whole candidate set and no second check before a flip; the flips come in another order though,
-// so where the result is not unique (cocircular vertices, or the constraints in settings) it can differ
+// serial Delone flipping of a small mesh in the same rounds as the parallel passes below: round 1 checks every
+// edge in id order, round r+1 the edges around the flips of round r; but the candidates are kept in a list
+// instead of rescanning bitsets, and each is checked once right before its flip, so an edge made non-Delone
+// by an earlier flip of the same round is flipped at once rather than a round later
 static int makeDeloneEdgeFlipsSerial( MeshTopology& topology, const VertCoords& points, const DeloneSettings& settings, int numIters, DeloneFlipsCache& cache )
 {
     const auto ueSize = topology.undirectedEdgeSize();
-    auto& queued = cache.nextFlipCandidates; // the edges currently waiting in the worklist
+    auto& queued = cache.nextFlipCandidates; // the edges already in the next round
     queued.clear();
-    queued.resize( ueSize, true );
-    auto& work = cache.worklist;
-    work.clear();
-    work.reserve( ueSize );
-    for ( int i = int( ueSize ) - 1; i >= 0; --i ) // popped from the back: the first round goes in id order like a pass
-        work.push_back( UndirectedEdgeId( i ) );
-    // the passes check at most numIters * ueSize edges; the same budget guards against endless flipping
-    const size_t maxPops = size_t( numIters ) * ueSize;
+    queued.resize( ueSize );
+    auto& cur = cache.worklist;
+    auto& next = cache.nextWorklist;
+    cur.clear();
+    cur.reserve( ueSize );
+    for ( int i = 0; i < int( ueSize ); ++i )
+        cur.push_back( UndirectedEdgeId( i ) );
     int flipsDone = 0;
-    for ( size_t pops = 0; !work.empty() && pops < maxPops; ++pops )
+    for ( int iter = 0; iter < numIters; ++iter )
     {
-        const auto e = work.back();
-        work.pop_back();
-        queued.reset( e );
-        if ( checkDeloneQuadrangleInMesh( topology, points, e, settings ) )
-            continue;
-        topology.flipEdge( e );
-        ++flipsDone;
-        for ( EdgeId ne : { topology.next( EdgeId( e ) ), topology.prev( EdgeId( e ) ), topology.next( EdgeId( e ).sym() ), topology.prev( EdgeId( e ).sym() ) } )
-            if ( !queued.test_set( ne.undirected() ) )
-                work.push_back( ne.undirected() );
+        next.clear();
+        for ( UndirectedEdgeId e : cur )
+        {
+            if ( checkDeloneQuadrangleInMesh( topology, points, e, settings ) )
+                continue;
+            topology.flipEdge( e );
+            ++flipsDone;
+            for ( EdgeId ne : { topology.next( EdgeId( e ) ), topology.prev( EdgeId( e ) ), topology.next( EdgeId( e ).sym() ), topology.prev( EdgeId( e ).sym() ) } )
+                if ( !queued.test_set( ne.undirected() ) )
+                    next.push_back( ne.undirected() );
+        }
+        if ( next.empty() )
+            break;
+        queued.reset(); // a few words for such a mesh
+        std::sort( next.begin(), next.end() ); // id order within a round, like the passes
+        std::swap( cur, next );
     }
     return flipsDone;
 }

--- a/source/MRMesh/MRMeshDelone.cpp
+++ b/source/MRMesh/MRMeshDelone.cpp
@@ -205,16 +205,60 @@ int makeDeloneEdgeFlips( Mesh & mesh, const DeloneSettings& settings, int numIte
     return flipsDone;
 }
 
+// serial Delone flipping of a small mesh: every edge is checked once when popped from the worklist,
+// and a flip re-queues only the four edges around it, so unlike the parallel passes there is no rescan
+// of the whole candidate set and no second check before a flip; the flips come in another order though,
+// so where the result is not unique (cocircular vertices, or the constraints in settings) it can differ
+static int makeDeloneEdgeFlipsSerial( MeshTopology& topology, const VertCoords& points, const DeloneSettings& settings, int numIters,
+    const ProgressCallback& progressCallback, DeloneFlipsCache& cache )
+{
+    if ( progressCallback && !progressCallback( 0.0f ) )
+        return 0;
+    const auto ueSize = topology.undirectedEdgeSize();
+    auto& queued = cache.nextFlipCandidates; // the edges currently waiting in the worklist
+    queued.clear();
+    queued.resize( ueSize, true );
+    auto& work = cache.worklist;
+    work.clear();
+    work.reserve( ueSize );
+    for ( int i = int( ueSize ) - 1; i >= 0; --i ) // popped from the back: the first round goes in id order like a pass
+        work.push_back( UndirectedEdgeId( i ) );
+    // the passes check at most numIters * ueSize edges; the same budget guards against endless flipping
+    const size_t maxPops = size_t( numIters ) * ueSize;
+    int flipsDone = 0;
+    for ( size_t pops = 0; !work.empty() && pops < maxPops; ++pops )
+    {
+        const auto e = work.back();
+        work.pop_back();
+        queued.reset( e );
+        if ( checkDeloneQuadrangleInMesh( topology, points, e, settings ) )
+            continue;
+        topology.flipEdge( e );
+        ++flipsDone;
+        for ( EdgeId ne : { topology.next( EdgeId( e ) ), topology.prev( EdgeId( e ) ), topology.next( EdgeId( e ).sym() ), topology.prev( EdgeId( e ).sym() ) } )
+            if ( !queued.test_set( ne.undirected() ) )
+                work.push_back( ne.undirected() );
+    }
+    return flipsDone;
+}
+
 int makeDeloneEdgeFlips( MeshTopology& topology, const VertCoords& points, const DeloneSettings& settings, int numIters, const ProgressCallback& progressCallback )
 {
     if ( numIters <= 0 )
         return 0;
-    MR_TIMER;
 
     // the candidate sets come from the caller's cache when it has one (keeping their capacity),
     // so a caller flipping many small meshes one by one does not allocate them every time
     DeloneFlipsCache localCache;
     DeloneFlipsCache& cache = settings.cache ? *settings.cache : localCache;
+
+    // below this size the passes spend more on entering the task arena and rescanning the candidate
+    // sets than on the checks themselves (and such a call is over too soon for the timer to matter)
+    constexpr size_t cMinParallelEdges = 256;
+    if ( topology.undirectedEdgeSize() < cMinParallelEdges )
+        return makeDeloneEdgeFlipsSerial( topology, points, settings, numIters, progressCallback, cache );
+    MR_TIMER;
+
     auto& flipCandidates = cache.flipCandidates;
     auto& nextFlipCandidates = cache.nextFlipCandidates;
     flipCandidates.clear();

--- a/source/MRMesh/MRMeshDelone.cpp
+++ b/source/MRMesh/MRMeshDelone.cpp
@@ -211,8 +211,16 @@ int makeDeloneEdgeFlips( MeshTopology& topology, const VertCoords& points, const
         return 0;
     MR_TIMER;
 
-    UndirectedEdgeBitSet flipCandidates( topology.undirectedEdgeSize() );
-    UndirectedEdgeBitSet nextFlipCandidates( topology.undirectedEdgeSize(), true );
+    // the candidate sets come from the caller's cache when it has one (keeping their capacity),
+    // so a caller flipping many small meshes one by one does not allocate them every time
+    DeloneFlipsCache localCache;
+    DeloneFlipsCache& cache = settings.cache ? *settings.cache : localCache;
+    auto& flipCandidates = cache.flipCandidates;
+    auto& nextFlipCandidates = cache.nextFlipCandidates;
+    flipCandidates.clear();
+    flipCandidates.resize( topology.undirectedEdgeSize() );
+    nextFlipCandidates.clear();
+    nextFlipCandidates.resize( topology.undirectedEdgeSize(), true );
 
     int flipsDone = 0;
     for ( int iter = 0; iter < numIters; ++iter )

--- a/source/MRMesh/MRMeshDelone.cpp
+++ b/source/MRMesh/MRMeshDelone.cpp
@@ -213,11 +213,11 @@ int makeDeloneEdgeFlips( Mesh & mesh, const DeloneSettings& settings, int numIte
 static int makeDeloneEdgeFlipsSerial( MeshTopology& topology, const VertCoords& points, const DeloneSettings& settings, int numIters, DeloneFlipsCache& cache )
 {
     const auto ueSize = topology.undirectedEdgeSize();
-    auto& queued = cache.nextFlipCandidates; // the edges already in the next round
+    auto& queued = cache.queuedEdges;
     queued.clear();
     queued.resize( ueSize );
-    auto& cur = cache.worklist;
-    auto& next = cache.nextWorklist;
+    auto& cur = cache.roundEdges;
+    auto& next = cache.nextRoundEdges;
     cur.clear();
     cur.reserve( ueSize );
     for ( int i = 0; i < int( ueSize ); ++i )
@@ -238,7 +238,7 @@ static int makeDeloneEdgeFlipsSerial( MeshTopology& topology, const VertCoords& 
         }
         if ( next.empty() )
             break;
-        queued.reset(); // a few words for such a mesh
+        queued.reset(); // a few 64-bit words on a mesh this small
         std::sort( next.begin(), next.end() ); // id order within a round, like the passes
         std::swap( cur, next );
     }

--- a/source/MRMesh/MRMeshDelone.h
+++ b/source/MRMesh/MRMeshDelone.h
@@ -9,12 +9,16 @@ namespace MR
 {
 
 /// the buffers makeDeloneEdgeFlips grows on every call; a caller running it many times on small meshes
-/// (e.g. one hole patch after another) keeps one instance between the calls to allocate them just once
+/// (e.g. one hole patch after another) keeps one instance between the calls to allocate them just once;
+/// one cache must not be used by several threads at once
 struct DeloneFlipsCache
 {
-    UndirectedEdgeBitSet flipCandidates;
-    UndirectedEdgeBitSet nextFlipCandidates;
-    std::vector<UndirectedEdgeId> worklist, nextWorklist; ///< the current and the next round of the serial small-mesh path
+    /// of the parallel passes (a mesh of 256 undirected edges or more)
+    UndirectedEdgeBitSet flipCandidates, nextFlipCandidates;
+
+    /// of the serial rounds (a smaller mesh): the edges already queued for the next round, and the two rounds
+    UndirectedEdgeBitSet queuedEdges;
+    std::vector<UndirectedEdgeId> roundEdges, nextRoundEdges;
 };
 
 struct DeloneSettings
@@ -38,7 +42,8 @@ struct DeloneSettings
     /// Only edges with origin or destination in this set before or after flip can be flipped
     const VertBitSet* vertRegion = nullptr;
 
-    /// optional buffers reused between calls, see DeloneFlipsCache
+    /// optional buffers reused between calls, see DeloneFlipsCache;
+    /// flipping several meshes in parallel, give every thread its own cache
     DeloneFlipsCache* cache = nullptr;
 };
 

--- a/source/MRMesh/MRMeshDelone.h
+++ b/source/MRMesh/MRMeshDelone.h
@@ -14,7 +14,7 @@ struct DeloneFlipsCache
 {
     UndirectedEdgeBitSet flipCandidates;
     UndirectedEdgeBitSet nextFlipCandidates;
-    std::vector<UndirectedEdgeId> worklist; ///< of the serial small-mesh path
+    std::vector<UndirectedEdgeId> worklist, nextWorklist; ///< the current and the next round of the serial small-mesh path
 };
 
 struct DeloneSettings

--- a/source/MRMesh/MRMeshDelone.h
+++ b/source/MRMesh/MRMeshDelone.h
@@ -14,6 +14,7 @@ struct DeloneFlipsCache
 {
     UndirectedEdgeBitSet flipCandidates;
     UndirectedEdgeBitSet nextFlipCandidates;
+    std::vector<UndirectedEdgeId> worklist; ///< of the serial small-mesh path
 };
 
 struct DeloneSettings

--- a/source/MRMesh/MRMeshDelone.h
+++ b/source/MRMesh/MRMeshDelone.h
@@ -1,11 +1,20 @@
 #pragma once
 
 #include "MRMeshFwd.h"
+#include "MRBitSet.h"
 #include "MRProgressCallback.h"
 #include <cfloat>
 
 namespace MR
 {
+
+/// the buffers makeDeloneEdgeFlips grows on every call; a caller running it many times on small meshes
+/// (e.g. one hole patch after another) keeps one instance between the calls to allocate them just once
+struct DeloneFlipsCache
+{
+    UndirectedEdgeBitSet flipCandidates;
+    UndirectedEdgeBitSet nextFlipCandidates;
+};
 
 struct DeloneSettings
 {
@@ -27,6 +36,9 @@ struct DeloneSettings
 
     /// Only edges with origin or destination in this set before or after flip can be flipped
     const VertBitSet* vertRegion = nullptr;
+
+    /// optional buffers reused between calls, see DeloneFlipsCache
+    DeloneFlipsCache* cache = nullptr;
 };
 
 /// \defgroup MeshDeloneGroup Mesh Delone

--- a/source/MRTest/MRDeloneTests.cpp
+++ b/source/MRTest/MRDeloneTests.cpp
@@ -1,4 +1,5 @@
 #include "MRMesh/MRMeshDelone.h"
+#include "MRMesh/MRMesh.h"
 #include "MRMesh/MRVector3.h"
 #include <gtest/gtest.h>
 
@@ -13,6 +14,29 @@ TEST( MRMesh, checkDeloneQuadrangle )
     Vector3d d( 1.1, 0, 0 );
     // ABCD quadrangle has zero area
     EXPECT_FALSE( checkDeloneQuadrangle( a, b, c, d, 10 ) );
+}
+
+TEST( MRMesh, DeloneFlipsSmallMeshOneIter )
+{
+    // several separate thin rhombi, each triangulated across its long diagonal (not Delone); the sides are
+    // boundary edges, so one iteration must flip exactly one edge per rhombus whatever the edge order is
+    constexpr int cNumRhombi = 4;
+    VertCoords points;
+    Triangulation t;
+    for ( int i = 0; i < cNumRhombi; ++i )
+    {
+        const float x = 10.0f * i;
+        const VertId v0( int( points.size() ) );
+        points.push_back( Vector3f( x - 1, 0, 0 ) );
+        points.push_back( Vector3f( x, -0.2f, 0 ) );
+        points.push_back( Vector3f( x + 1, 0, 0 ) );
+        points.push_back( Vector3f( x, 0.2f, 0 ) );
+        t.push_back( ThreeVertIds{ v0, v0 + 1, v0 + 2 } );
+        t.push_back( ThreeVertIds{ v0, v0 + 2, v0 + 3 } );
+    }
+    Mesh mesh = Mesh::fromTriangles( std::move( points ), t );
+    EXPECT_EQ( makeDeloneEdgeFlips( mesh, {}, 1 ), cNumRhombi );
+    EXPECT_EQ( makeDeloneEdgeFlips( mesh, {}, 1 ), 0 ); // everything is Delone now
 }
 
 } //namespace MR


### PR DESCRIPTION
`makeDeloneEdgeFlips( topology, points, ... )` runs once per hole patch inside the sweep-line triangulation, where the patch has a few dozen edges. There it spent more on allocating its two candidate bitsets, entering the TBB arena and rescanning the candidate sets than on the Delone checks themselves (a third to a half of a hole-fill plan's time in a profile).

- `DeloneFlipsCache` + `DeloneSettings::cache`: a caller running the function many times keeps the candidate sets (and the round lists below) between the calls, so they are allocated once. Without a cache nothing changes; the sweep-line planner will pass its cache in a follow-up PR.
- Meshes under 256 undirected edges take a serial path in the same rounds as the parallel passes: round 1 checks every edge in id order, round r+1 the edges around the flips of round r, `numIters` bounds the rounds. The candidates live in a list instead of rescanned bitsets, each is checked once right before its flip, and there is no timer or progress callback for a call that is over in microseconds. The one semantic difference from the passes: an edge made non-Delone by an earlier flip of the same round is flipped at once instead of a round later, so where the result is not unique (cocircular vertices, or constrained by the settings) it can differ; on the hole-fill test meshes it is bit-identical.

Review history: the first serial version was a LIFO worklist with a `numIters * edges` pop budget, which let re-queued neighbours displace never-examined initial edges when `numIters` is small (default 1). `MRMesh.DeloneFlipsSmallMeshOneIter` pins that case (4 separate non-Delone rhombi, one iteration, exactly 4 flips); it fails on the LIFO version and passes now.

Measured with the planar hole-fill planner on master (this PR alone, interleaved runs, medians):

| workload | master | this PR |
|---|---|---|
| `getPlanarHoleFillPlans`, 2000 holes of 16 vertices | 1.44 ms | 1.33 ms (−8%) |
| `getPlanarHoleFillPlan` x2000 serial, same holes | 21.7 ms | 19.0 ms (−12%) |

Plan fingerprints on the test meshes are identical to master both at the default swept-hole threshold and with every hole routed through the sweep; MRTest boolean / hole-fill / planar-triangulation / Delone subset passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
