### PR TITLE
PlanarTriangulation: drop the timers inside the sweep

### DIFF
--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -3,7 +3,6 @@
 #include "MRVector.h"
 #include "MRVector2.h"
 #include "MRContour.h"
-#include "MRTimer.h"
 #include "MRRingIterator.h"
 #include "MRConstants.h"
 #include "MRRegionBoundary.h"
@@ -486,7 +485,6 @@ SweepLineQueue::SweepLineQueue( const MeshTopology& inTp, SweepLinePredicates pr
 
 std::optional<MR::Mesh> SweepLineQueue::run( IntersectionsMap* interMap )
 {
-    MR_TIMER;
     if ( !findIntersections() )
         return {};
     injectIntersections( interMap );
@@ -496,7 +494,6 @@ std::optional<MR::Mesh> SweepLineQueue::run( IntersectionsMap* interMap )
 
 bool SweepLineQueue::findIntersections()
 {
-    MR_TIMER;
     stage_ = Stage::Intersections;
     events_.clear();
     events_.reserve( tp_.numValidVerts() * 2 );
@@ -519,8 +516,6 @@ bool SweepLineQueue::findIntersections()
 
 void SweepLineQueue::injectIntersections( IntersectionsMap* interMap )
 {
-    MR_TIMER;
-
     if ( interMap )
         interMap->map.resize( intersections_.size() );
 
@@ -627,7 +622,6 @@ void SweepLineQueue::injectIntersections( IntersectionsMap* interMap )
 
 void SweepLineQueue::makeMonotone()
 {
-    MR_TIMER;
     stage_ = Stage::Monotonation;
     startVertIndex_ = 0;
     sortedVertIndex_ = 0;
@@ -643,7 +637,6 @@ void SweepLineQueue::makeMonotone()
 
 Mesh SweepLineQueue::triangulate()
 {
-    MR_TIMER;
     stage_ = Stage::Triangulation;
     if ( !params_.needOutline )
         reflexChainCache_.reserve( 256 ); // reserve once to have less allocations later
@@ -1081,7 +1074,6 @@ void SweepLineQueue::checkIntersection_( int i )
 
 void SweepLineQueue::initMeshByContours_( const std::vector<int>& contourSizes )
 {
-    MR_TIMER;
     for ( int contourId = 0; contourId < int( contourSizes.size() ); ++contourId )
     {
         if ( contourSizes[contourId] > 3 )
@@ -1116,7 +1108,6 @@ void SweepLineQueue::initMeshByContours_( const std::vector<int>& contourSizes )
 
 void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops& loops )
 {
-    MR_TIMER;
     //HashMap<>
     UndirectedEdgeHashMap in2p; // TODO: can be cached
     WholeEdgeMap p2inCache; // TODO: can be cached
@@ -1279,7 +1270,6 @@ void SweepLineQueue::initMeshByLoops_( const MeshTopology& inTp, const EdgeLoops
 
 void SweepLineQueue::mergeSamePoints_()
 {
-    MR_TIMER;
     sortedVerts_.reserve( tp_.vertSize() );
     for ( int i = 0; i < tp_.vertSize(); ++i )
         sortedVerts_.emplace_back( VertId( i ) );
@@ -1409,7 +1399,6 @@ void SweepLineQueue::mergeSinglePare_( VertId unique, VertId same )
 
 void SweepLineQueue::removeMultipleAfterMerge_()
 {
-    MR_TIMER;
     auto multiples = findMultipleEdges( tp_ ).value();
     for ( const auto& multiple : multiples )
     {
@@ -1456,7 +1445,6 @@ void SweepLineQueue::calculateWinding_()
 // https://www.cs.umd.edu/class/spring2020/cmsc754/Lects/lect05-triangulate.pdf
 void SweepLineQueue::triangulateMonotoneBlock_( EdgeId holeEdgeId )
 {
-    MR_TIMER;
     auto holeLoop = trackRightBoundaryLoop( tp_, holeEdgeId );
     auto lessPred = [&] ( EdgeId l, EdgeId r )
     {
@@ -1703,7 +1691,6 @@ std::optional<Mesh> triangulateDisjointContours( const Mesh& mesh, const EdgeLoo
 
 std::optional<HoleFillPlan> getMonotonePlan( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal )
 {
-    MR_TIMER;
     HoleFillPlan res;
     if ( loops.empty() )
         return res;

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -32,50 +32,69 @@ namespace PlanarTriangulation
 {
 
 // All coordinate-dependent operations of the sweep-line triangulation, factored out so a caller
-// can supply alternative geometry. The default implementation is precisePredicates() below, which
-// reproduces the historical exact-integer simulation-of-simplicity behavior.
+// can supply alternative geometry: precisePredicates() below for 2D contours, meshSpacePredicates()
+// for hole loops of a mesh. Both run the combinatorial predicates on the projected integer coordinates
+// `pts2`, reproducing the historical exact-integer simulation-of-simplicity behavior; the sweep calls
+// them on every comparison, so they are inline members rather than std::function
 struct SweepLinePredicates
 {
-    // strict order of vertices along the sweep direction (sweep advances toward the greater vertex)
-    std::function<bool( VertId l, VertId r )> less;
-    // whether two vertices share exactly the same position
-    std::function<bool( VertId l, VertId r )> samePos;
-    // orientation predicate, equivalent to MR::ccw( { a, b, c } )
-    std::function<bool( VertId a, VertId b, VertId c )> ccw;
-    // orientation of b around pivot relative to the direction the sweep arrives from
-    // (i.e. ccw with the first point placed far behind pivot, opposite to the sweep)
-    std::function<bool( VertId b, VertId pivot )> ccwFromBehind;
-    // store the position of input vertex v, identified by its (contourId, pointId) in the source contours
-    std::function<void( VertId v, int contourId, int pointId )> addInputPoint;
-    // compute and store the position of intersection vertex v of segments (a,b) and (c,d)
-    std::function<void( VertId v, VertId a, VertId b, VertId c, VertId d )> addIntersectionPoint;
-    // position of vertex v; tp is passed at call time because the queue's topology is moved into the output mesh
-    std::function<Vector3f( const MeshTopology& tp, VertId v )> point;
-};
+    // the projected integer position of every vertex, filled by addInputPoint/addIntersectionPoint;
+    // shared with the point() closure, which reads it after the queue's topology is moved out
+    std::shared_ptr<Vector<Vector2i, VertId>> pts2;
 
-// the sweep-line predicates that depend only on the projected integer coordinates `pts2`;
-// shared by precisePredicates (2D input) and meshSpacePredicates (3D mesh input projected on the dominant axis)
-static void setPts2Predicates( SweepLinePredicates& p, std::shared_ptr<Vector<Vector2i, VertId>> pts2 )
-{
-    p.less = [pts2] ( VertId l, VertId r )
+    // strict order of vertices along the sweep direction (sweep advances toward the greater vertex)
+    bool less( VertId l, VertId r ) const
     {
         return smaller( { .id = l, .pt = ( *pts2 )[l].x }, { .id = r, .pt = ( *pts2 )[r].x } );
-    };
-    p.samePos = [pts2] ( VertId l, VertId r )
+    }
+    // whether two vertices share exactly the same position
+    bool samePos( VertId l, VertId r ) const
     {
         return ( *pts2 )[l] == ( *pts2 )[r];
-    };
-    p.ccw = [pts2] ( VertId a, VertId b, VertId c )
+    }
+    // orientation predicate, equivalent to MR::ccw( { a, b, c } )
+    bool ccw( VertId a, VertId b, VertId c ) const
     {
         return MR::ccw( { PreciseVertCoords2{ a, ( *pts2 )[a] }, { b, ( *pts2 )[b] }, { c, ( *pts2 )[c] } } );
-    };
-    p.ccwFromBehind = [pts2] ( VertId b, VertId pivot )
+    }
+    // orientation of b around pivot relative to the direction the sweep arrives from
+    // (i.e. ccw with the first point placed far behind pivot, opposite to the sweep)
+    bool ccwFromBehind( VertId b, VertId pivot ) const
     {
         Vector2i base = ( *pts2 )[pivot];
         base.x -= 10000; // far behind pivot along -X (the sweep axis), matching the historical reference
         return MR::ccw( { PreciseVertCoords2{ VertId{}, base }, { b, ( *pts2 )[b] }, { pivot, ( *pts2 )[pivot] } } );
-    };
-}
+    }
+    // compute and store the position of intersection vertex v of segments (a,b) and (c,d)
+    void addIntersectionPoint( VertId v, VertId a, VertId b, VertId c, VertId d ) const
+    {
+        pts2->autoResizeSet( v, findSegmentSegmentIntersectionPrecise(
+            { PreciseVertCoords2{ a, ( *pts2 )[a] }, { b, ( *pts2 )[b] }, { c, ( *pts2 )[c] }, { d, ( *pts2 )[d] } } ) );
+    }
+
+    // where the input vertices come from, the only input-side difference between the two factories:
+    // either 2D contours, or hole loops of a mesh projected on the axes kx, ky; toInt maps to the exact grid
+    ConvertToIntVector toInt;
+    const Contours2f* srcContours = nullptr;
+    const Mesh* srcMesh = nullptr;
+    const EdgeLoops* srcLoops = nullptr;
+    int kx = 0, ky = 0;
+
+    // store the position of input vertex v, identified by its (contourId, pointId) in the source contours
+    void addInputPoint( VertId v, int contourId, int pointId ) const
+    {
+        if ( srcContours )
+        {
+            pts2->autoResizeSet( v, to2dim( toInt( to3dim( ( *srcContours )[contourId][pointId] ) ) ) );
+            return;
+        }
+        const Vector3i q = toInt( srcMesh->orgPnt( ( *srcLoops )[contourId][pointId] ) );
+        pts2->autoResizeSet( v, Vector2i( q[kx], q[ky] ) );
+    }
+
+    // position of vertex v; tp is passed at call time because the queue's topology is moved into the output mesh
+    std::function<Vector3f( const MeshTopology& tp, VertId v )> point;
+};
 
 // default predicates: exact integer arithmetic with simulation-of-simplicity (historical behavior)
 static SweepLinePredicates precisePredicates( const Contours2f& contours )
@@ -95,28 +114,17 @@ static SweepLinePredicates precisePredicates( const Contours2f& contours )
 
     auto pts = std::make_shared<Vector<Vector2i, VertId>>();
     pts->reserve( pointsSize );
-    auto toInt = [conv = getToIntConverter( Box3d( box ) )] ( const Vector2f& coord )
-    {
-        return to2dim( conv( to3dim( coord ) ) );
-    };
     auto toFloat = [conv = getToFloatConverter( Box3d( box ) )] ( const Vector2i& coord )
     {
         return to2dim( conv( to3dim( coord ) ) );
     };
 
     SweepLinePredicates p;
-    setPts2Predicates( p, pts );
-    // resolve an input vertex by (contourId, pointId); initMeshByContours_ drives the order, so
+    p.pts2 = pts;
+    p.toInt = getToIntConverter( Box3d( box ) );
+    // input vertices are resolved by (contourId, pointId); initMeshByContours_ drives the order, so
     // `contours` only needs to outlive construction (every caller passes its own input by reference)
-    p.addInputPoint = [&contours, pts, toInt] ( VertId v, int contourId, int pointId )
-    {
-        pts->autoResizeSet( v, toInt( contours[contourId][pointId] ) );
-    };
-    p.addIntersectionPoint = [pts] ( VertId v, VertId a, VertId b, VertId c, VertId d )
-    {
-        pts->autoResizeSet( v, findSegmentSegmentIntersectionPrecise(
-            { PreciseVertCoords2{ a, ( *pts )[a] }, { b, ( *pts )[b] }, { c, ( *pts )[c] }, { d, ( *pts )[d] } } ) );
-    };
+    p.srcContours = &contours;
     p.point = [pts, toFloat] ( const MeshTopology&, VertId v )
     {
         return to3dim( toFloat( ( *pts )[v] ) );
@@ -134,8 +142,8 @@ static std::vector<int> getContourSizes( const Contours2f& contours )
 }
 
 // mesh-space predicates: triangulate hole boundary loops of `mesh` in the mesh's own 3D coordinates,
-// orienting around `normal`. Combinatorics run on the dominant-axis projection (reusing the exact 2D
-// predicates via setPts2Predicates). point() restores each output vertex's exact original mesh position
+// orienting around `normal`. Combinatorics run on the dominant-axis projection (the exact 2D
+// predicates read pts2 directly). point() restores each output vertex's exact original mesh position
 // through `patchToInEdges`, the patch->input edge map (no separate coordinate copy, no projection round-trip).
 // `mesh`, `loops` and `patchToInEdges` only need to outlive the run; the map may be filled after construction.
 static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, const WholeEdgeMap& patchToInEdges )
@@ -163,20 +171,14 @@ static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoop
 
     auto pts2 = std::make_shared<Vector<Vector2i, VertId>>(); // dominant-axis projection, drives every predicate
     pts2->reserve( pointsSize );
-    auto toInt = getToIntConverter( Box3d( box ) ); // Vector3f -> Vector3i
 
     SweepLinePredicates p;
-    setPts2Predicates( p, pts2 );
-    p.addInputPoint = [&mesh, &loops, pts2, toInt, kx, ky] ( VertId v, int contourId, int pointId )
-    {
-        const Vector3i q = toInt( mesh.orgPnt( loops[contourId][pointId] ) );
-        pts2->autoResizeSet( v, Vector2i( q[kx], q[ky] ) );
-    };
-    p.addIntersectionPoint = [pts2] ( VertId v, VertId a, VertId b, VertId c, VertId d )
-    {
-        pts2->autoResizeSet( v, findSegmentSegmentIntersectionPrecise(
-            { PreciseVertCoords2{ a, ( *pts2 )[a] }, { b, ( *pts2 )[b] }, { c, ( *pts2 )[c] }, { d, ( *pts2 )[d] } } ) );
-    };
+    p.pts2 = pts2;
+    p.toInt = getToIntConverter( Box3d( box ) ); // Vector3f -> Vector3i
+    p.srcMesh = &mesh;
+    p.srcLoops = &loops;
+    p.kx = kx;
+    p.ky = ky;
     // every output vertex lies on a copied input edge (disjoint triangulation adds no intersection
     // vertices), so find one in its org ring, skipping the triangulation's own diagonals
     p.point = [&mesh, &patchToInEdges] ( const MeshTopology& patchTp, VertId v )

--- a/source/MRMesh/MR2DContoursTriangulation.cpp
+++ b/source/MRMesh/MR2DContoursTriangulation.cpp
@@ -32,69 +32,50 @@ namespace PlanarTriangulation
 {
 
 // All coordinate-dependent operations of the sweep-line triangulation, factored out so a caller
-// can supply alternative geometry: precisePredicates() below for 2D contours, meshSpacePredicates()
-// for hole loops of a mesh. Both run the combinatorial predicates on the projected integer coordinates
-// `pts2`, reproducing the historical exact-integer simulation-of-simplicity behavior; the sweep calls
-// them on every comparison, so they are inline members rather than std::function
+// can supply alternative geometry. The default implementation is precisePredicates() below, which
+// reproduces the historical exact-integer simulation-of-simplicity behavior.
 struct SweepLinePredicates
 {
-    // the projected integer position of every vertex, filled by addInputPoint/addIntersectionPoint;
-    // shared with the point() closure, which reads it after the queue's topology is moved out
-    std::shared_ptr<Vector<Vector2i, VertId>> pts2;
-
     // strict order of vertices along the sweep direction (sweep advances toward the greater vertex)
-    bool less( VertId l, VertId r ) const
-    {
-        return smaller( { .id = l, .pt = ( *pts2 )[l].x }, { .id = r, .pt = ( *pts2 )[r].x } );
-    }
+    std::function<bool( VertId l, VertId r )> less;
     // whether two vertices share exactly the same position
-    bool samePos( VertId l, VertId r ) const
-    {
-        return ( *pts2 )[l] == ( *pts2 )[r];
-    }
+    std::function<bool( VertId l, VertId r )> samePos;
     // orientation predicate, equivalent to MR::ccw( { a, b, c } )
-    bool ccw( VertId a, VertId b, VertId c ) const
-    {
-        return MR::ccw( { PreciseVertCoords2{ a, ( *pts2 )[a] }, { b, ( *pts2 )[b] }, { c, ( *pts2 )[c] } } );
-    }
+    std::function<bool( VertId a, VertId b, VertId c )> ccw;
     // orientation of b around pivot relative to the direction the sweep arrives from
     // (i.e. ccw with the first point placed far behind pivot, opposite to the sweep)
-    bool ccwFromBehind( VertId b, VertId pivot ) const
+    std::function<bool( VertId b, VertId pivot )> ccwFromBehind;
+    // store the position of input vertex v, identified by its (contourId, pointId) in the source contours
+    std::function<void( VertId v, int contourId, int pointId )> addInputPoint;
+    // compute and store the position of intersection vertex v of segments (a,b) and (c,d)
+    std::function<void( VertId v, VertId a, VertId b, VertId c, VertId d )> addIntersectionPoint;
+    // position of vertex v; tp is passed at call time because the queue's topology is moved into the output mesh
+    std::function<Vector3f( const MeshTopology& tp, VertId v )> point;
+};
+
+// the sweep-line predicates that depend only on the projected integer coordinates `pts2`;
+// shared by precisePredicates (2D input) and meshSpacePredicates (3D mesh input projected on the dominant axis)
+static void setPts2Predicates( SweepLinePredicates& p, std::shared_ptr<Vector<Vector2i, VertId>> pts2 )
+{
+    p.less = [pts2] ( VertId l, VertId r )
+    {
+        return smaller( { .id = l, .pt = ( *pts2 )[l].x }, { .id = r, .pt = ( *pts2 )[r].x } );
+    };
+    p.samePos = [pts2] ( VertId l, VertId r )
+    {
+        return ( *pts2 )[l] == ( *pts2 )[r];
+    };
+    p.ccw = [pts2] ( VertId a, VertId b, VertId c )
+    {
+        return MR::ccw( { PreciseVertCoords2{ a, ( *pts2 )[a] }, { b, ( *pts2 )[b] }, { c, ( *pts2 )[c] } } );
+    };
+    p.ccwFromBehind = [pts2] ( VertId b, VertId pivot )
     {
         Vector2i base = ( *pts2 )[pivot];
         base.x -= 10000; // far behind pivot along -X (the sweep axis), matching the historical reference
         return MR::ccw( { PreciseVertCoords2{ VertId{}, base }, { b, ( *pts2 )[b] }, { pivot, ( *pts2 )[pivot] } } );
-    }
-    // compute and store the position of intersection vertex v of segments (a,b) and (c,d)
-    void addIntersectionPoint( VertId v, VertId a, VertId b, VertId c, VertId d ) const
-    {
-        pts2->autoResizeSet( v, findSegmentSegmentIntersectionPrecise(
-            { PreciseVertCoords2{ a, ( *pts2 )[a] }, { b, ( *pts2 )[b] }, { c, ( *pts2 )[c] }, { d, ( *pts2 )[d] } } ) );
-    }
-
-    // where the input vertices come from, the only input-side difference between the two factories:
-    // either 2D contours, or hole loops of a mesh projected on the axes kx, ky; toInt maps to the exact grid
-    ConvertToIntVector toInt;
-    const Contours2f* srcContours = nullptr;
-    const Mesh* srcMesh = nullptr;
-    const EdgeLoops* srcLoops = nullptr;
-    int kx = 0, ky = 0;
-
-    // store the position of input vertex v, identified by its (contourId, pointId) in the source contours
-    void addInputPoint( VertId v, int contourId, int pointId ) const
-    {
-        if ( srcContours )
-        {
-            pts2->autoResizeSet( v, to2dim( toInt( to3dim( ( *srcContours )[contourId][pointId] ) ) ) );
-            return;
-        }
-        const Vector3i q = toInt( srcMesh->orgPnt( ( *srcLoops )[contourId][pointId] ) );
-        pts2->autoResizeSet( v, Vector2i( q[kx], q[ky] ) );
-    }
-
-    // position of vertex v; tp is passed at call time because the queue's topology is moved into the output mesh
-    std::function<Vector3f( const MeshTopology& tp, VertId v )> point;
-};
+    };
+}
 
 // default predicates: exact integer arithmetic with simulation-of-simplicity (historical behavior)
 static SweepLinePredicates precisePredicates( const Contours2f& contours )
@@ -114,17 +95,28 @@ static SweepLinePredicates precisePredicates( const Contours2f& contours )
 
     auto pts = std::make_shared<Vector<Vector2i, VertId>>();
     pts->reserve( pointsSize );
+    auto toInt = [conv = getToIntConverter( Box3d( box ) )] ( const Vector2f& coord )
+    {
+        return to2dim( conv( to3dim( coord ) ) );
+    };
     auto toFloat = [conv = getToFloatConverter( Box3d( box ) )] ( const Vector2i& coord )
     {
         return to2dim( conv( to3dim( coord ) ) );
     };
 
     SweepLinePredicates p;
-    p.pts2 = pts;
-    p.toInt = getToIntConverter( Box3d( box ) );
-    // input vertices are resolved by (contourId, pointId); initMeshByContours_ drives the order, so
+    setPts2Predicates( p, pts );
+    // resolve an input vertex by (contourId, pointId); initMeshByContours_ drives the order, so
     // `contours` only needs to outlive construction (every caller passes its own input by reference)
-    p.srcContours = &contours;
+    p.addInputPoint = [&contours, pts, toInt] ( VertId v, int contourId, int pointId )
+    {
+        pts->autoResizeSet( v, toInt( contours[contourId][pointId] ) );
+    };
+    p.addIntersectionPoint = [pts] ( VertId v, VertId a, VertId b, VertId c, VertId d )
+    {
+        pts->autoResizeSet( v, findSegmentSegmentIntersectionPrecise(
+            { PreciseVertCoords2{ a, ( *pts )[a] }, { b, ( *pts )[b] }, { c, ( *pts )[c] }, { d, ( *pts )[d] } } ) );
+    };
     p.point = [pts, toFloat] ( const MeshTopology&, VertId v )
     {
         return to3dim( toFloat( ( *pts )[v] ) );
@@ -142,8 +134,8 @@ static std::vector<int> getContourSizes( const Contours2f& contours )
 }
 
 // mesh-space predicates: triangulate hole boundary loops of `mesh` in the mesh's own 3D coordinates,
-// orienting around `normal`. Combinatorics run on the dominant-axis projection (the exact 2D
-// predicates read pts2 directly). point() restores each output vertex's exact original mesh position
+// orienting around `normal`. Combinatorics run on the dominant-axis projection (reusing the exact 2D
+// predicates via setPts2Predicates). point() restores each output vertex's exact original mesh position
 // through `patchToInEdges`, the patch->input edge map (no separate coordinate copy, no projection round-trip).
 // `mesh`, `loops` and `patchToInEdges` only need to outlive the run; the map may be filled after construction.
 static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoops& loops, const Vector3f& normal, const WholeEdgeMap& patchToInEdges )
@@ -171,14 +163,20 @@ static SweepLinePredicates meshSpacePredicates( const Mesh& mesh, const EdgeLoop
 
     auto pts2 = std::make_shared<Vector<Vector2i, VertId>>(); // dominant-axis projection, drives every predicate
     pts2->reserve( pointsSize );
+    auto toInt = getToIntConverter( Box3d( box ) ); // Vector3f -> Vector3i
 
     SweepLinePredicates p;
-    p.pts2 = pts2;
-    p.toInt = getToIntConverter( Box3d( box ) ); // Vector3f -> Vector3i
-    p.srcMesh = &mesh;
-    p.srcLoops = &loops;
-    p.kx = kx;
-    p.ky = ky;
+    setPts2Predicates( p, pts2 );
+    p.addInputPoint = [&mesh, &loops, pts2, toInt, kx, ky] ( VertId v, int contourId, int pointId )
+    {
+        const Vector3i q = toInt( mesh.orgPnt( loops[contourId][pointId] ) );
+        pts2->autoResizeSet( v, Vector2i( q[kx], q[ky] ) );
+    };
+    p.addIntersectionPoint = [pts2] ( VertId v, VertId a, VertId b, VertId c, VertId d )
+    {
+        pts2->autoResizeSet( v, findSegmentSegmentIntersectionPrecise(
+            { PreciseVertCoords2{ a, ( *pts2 )[a] }, { b, ( *pts2 )[b] }, { c, ( *pts2 )[c] }, { d, ( *pts2 )[d] } } ) );
+    };
     // every output vertex lies on a copied input edge (disjoint triangulation adds no intersection
     // vertices), so find one in its org ring, skipping the triangulation's own diagonals
     p.point = [&mesh, &patchToInEdges] ( const MeshTopology& patchTp, VertId v )


### PR DESCRIPTION
The `MR_TIMER`s inside `SweepLineQueue` (and the one in `getMonotonePlan`) are gone: on the main thread each of them builds a string and touches the timer tree, for stages that take microseconds on the hole patches the hole-fill planner feeds the sweep. The callers (`fillContours2D`, `getPlanarHoleFillPlans`, ...) keep their own timers, so the triangulation still shows up in their totals.

Measured with the planar hole-fill planner on master (this PR alone, medians): `getPlanarHoleFillPlan` x2000 serial on 16-vertex holes 21.2 → 20.2 ms (−5%); the parallel `getPlanarHoleFillPlans` batch is unchanged within noise, since on worker threads a timer is already nearly free.

Plan fingerprints on the test meshes are identical to master both at the default swept-hole threshold and with every hole routed through the sweep; MRTest boolean / hole-fill / planar-triangulation subset passes.

The predicate devirtualization (inline members instead of `std::function`) was in this PR first and is reverted here at review; it stays on a local branch for a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
