### PR TITLE
Do not call CUDA through CudaAccessor when CUDA is not available

### DIFF
--- a/source/MRCuda/MRCudaBasic.cpp
+++ b/source/MRCuda/MRCudaBasic.cpp
@@ -13,31 +13,6 @@ namespace MR
 namespace Cuda
 {
 
-namespace {
-
-std::string cudaVersionString( int version )
-{
-    return fmt::format( "{}.{}", version / 1000, ( version % 1000 ) / 10 );
-}
-
-/// CUDA reports a missing driver and an outdated one alike, both as
-/// cudaErrorInsufficientDriver whose message speaks only of an insufficient version
-std::string driverDetails( cudaError_t code )
-{
-    if ( code != cudaErrorInsufficientDriver )
-        return {};
-
-    int driverVersion = 0, runtimeVersion = 0;
-    cudaDriverGetVersion( &driverVersion ); // zero if no driver is installed
-    cudaRuntimeGetVersion( &runtimeVersion );
-    if ( driverVersion <= 0 )
-        return fmt::format( " (no NVIDIA driver installed, CUDA runtime {})", cudaVersionString( runtimeVersion ) );
-    return fmt::format( " (NVIDIA driver supports CUDA {}, older than the runtime {})",
-        cudaVersionString( driverVersion ), cudaVersionString( runtimeVersion ) );
-}
-
-} // anonymous namespace
-
 Expected<DeviceInfo> getDeviceInfo()
 {
     DeviceInfo res;
@@ -51,7 +26,7 @@ Expected<DeviceInfo> getDeviceInfo()
         if ( code != cudaSuccess || n <= 0 )
         {
             auto err = ( code != cudaSuccess ) ? MR::Cuda::getError( code ) : "NVIDIA GPU error: no capable device found";
-            err += fmt::format( ", CUDA driver {}", cudaVersionString( res.driverVersion ) );
+            err += fmt::format( ", CUDA driver {}.{}", res.driverVersion / 1000, ( res.driverVersion % 1000 ) / 10 );
             return MR::unexpected( err );
         }
     }
@@ -133,7 +108,7 @@ size_t maxBufferSizeAlignedByBlock( size_t availableBytes, const Vector3i& block
 
 std::string getError( cudaError_t code )
 {
-    return fmt::format( "NVIDIA GPU error: {}{}", cudaGetErrorString( code ), driverDetails( code ) );
+    return fmt::format( "NVIDIA GPU error: {}", cudaGetErrorString( code ) );
 }
 
 cudaError_t logError( cudaError_t code, const char * file, int line )
@@ -143,12 +118,12 @@ cudaError_t logError( cudaError_t code, const char * file, int line )
 
     if ( file )
     {
-        spdlog::error("CUDA error {}: {}{}. In file: {} Line: {}", 
-            cudaGetErrorName( code ), cudaGetErrorString( code ), driverDetails( code ), file, line );
+        spdlog::error("CUDA error {}: {}. In file: {} Line: {}", 
+            cudaGetErrorName( code ), cudaGetErrorString( code ), file, line );
     }
     else
     {
-        spdlog::error( "CUDA error {}: {}{}", cudaGetErrorName( code ), cudaGetErrorString( code ), driverDetails( code ) );
+        spdlog::error( "CUDA error {}: {}", cudaGetErrorName( code ), cudaGetErrorString( code ) );
     }
     return code;
 }

--- a/source/MRCuda/MRCudaBasic.cpp
+++ b/source/MRCuda/MRCudaBasic.cpp
@@ -13,6 +13,31 @@ namespace MR
 namespace Cuda
 {
 
+namespace {
+
+std::string cudaVersionString( int version )
+{
+    return fmt::format( "{}.{}", version / 1000, ( version % 1000 ) / 10 );
+}
+
+/// CUDA reports a missing driver and an outdated one alike, both as
+/// cudaErrorInsufficientDriver whose message speaks only of an insufficient version
+std::string driverDetails( cudaError_t code )
+{
+    if ( code != cudaErrorInsufficientDriver )
+        return {};
+
+    int driverVersion = 0, runtimeVersion = 0;
+    cudaDriverGetVersion( &driverVersion ); // zero if no driver is installed
+    cudaRuntimeGetVersion( &runtimeVersion );
+    if ( driverVersion <= 0 )
+        return fmt::format( " (no NVIDIA driver installed, CUDA runtime {})", cudaVersionString( runtimeVersion ) );
+    return fmt::format( " (NVIDIA driver supports CUDA {}, older than the runtime {})",
+        cudaVersionString( driverVersion ), cudaVersionString( runtimeVersion ) );
+}
+
+} // anonymous namespace
+
 Expected<DeviceInfo> getDeviceInfo()
 {
     DeviceInfo res;
@@ -26,7 +51,7 @@ Expected<DeviceInfo> getDeviceInfo()
         if ( code != cudaSuccess || n <= 0 )
         {
             auto err = ( code != cudaSuccess ) ? MR::Cuda::getError( code ) : "NVIDIA GPU error: no capable device found";
-            err += fmt::format( ", CUDA driver {}.{}", res.driverVersion / 1000, ( res.driverVersion % 1000 ) / 10 );
+            err += fmt::format( ", CUDA driver {}", cudaVersionString( res.driverVersion ) );
             return MR::unexpected( err );
         }
     }
@@ -108,7 +133,7 @@ size_t maxBufferSizeAlignedByBlock( size_t availableBytes, const Vector3i& block
 
 std::string getError( cudaError_t code )
 {
-    return fmt::format( "NVIDIA GPU error: {}", cudaGetErrorString( code ) );
+    return fmt::format( "NVIDIA GPU error: {}{}", cudaGetErrorString( code ), driverDetails( code ) );
 }
 
 cudaError_t logError( cudaError_t code, const char * file, int line )
@@ -118,12 +143,12 @@ cudaError_t logError( cudaError_t code, const char * file, int line )
 
     if ( file )
     {
-        spdlog::error("CUDA error {}: {}. In file: {} Line: {}", 
-            cudaGetErrorName( code ), cudaGetErrorString( code ), file, line );
+        spdlog::error("CUDA error {}: {}{}. In file: {} Line: {}", 
+            cudaGetErrorName( code ), cudaGetErrorString( code ), driverDetails( code ), file, line );
     }
     else
     {
-        spdlog::error( "CUDA error {}: {}", cudaGetErrorName( code ), cudaGetErrorString( code ) );
+        spdlog::error( "CUDA error {}: {}{}", cudaGetErrorName( code ), cudaGetErrorString( code ), driverDetails( code ) );
     }
     return code;
 }

--- a/source/MRViewer/MRCudaAccessor.cpp
+++ b/source/MRViewer/MRCudaAccessor.cpp
@@ -98,10 +98,13 @@ int CudaAccessor::getComputeCapabilityMinor()
     return instance_().computeMinor_;
 }
 
+// The CUDA functors below are registered whether or not CUDA turned out to be usable, so every
+// getter checks availability itself: otherwise the plugins' capability checks call into CUDA on a
+// machine with no driver, and each call logs an error that reads as an outdated driver.
 size_t CudaAccessor::getCudaFreeMemory()
 {
     auto& inst = instance_();
-    if ( !inst.freeMemFunc_ )
+    if ( !inst.isCudaAvailable_ || !inst.freeMemFunc_ )
         return 0;
     return inst.freeMemFunc_();
 }
@@ -109,7 +112,7 @@ size_t CudaAccessor::getCudaFreeMemory()
 std::unique_ptr<IFastWindingNumber> CudaAccessor::getCudaFastWindingNumber( const Mesh& mesh )
 {
     auto& inst = instance_();
-    if ( !inst.fwnCtor_ )
+    if ( !inst.isCudaAvailable_ || !inst.fwnCtor_ )
         return {};
     return inst.fwnCtor_( mesh );
 }
@@ -117,7 +120,7 @@ std::unique_ptr<IFastWindingNumber> CudaAccessor::getCudaFastWindingNumber( cons
 std::unique_ptr<IPointsToMeshProjector> CudaAccessor::getCudaPointsToMeshProjector()
 {
     auto& inst = instance_();
-    if ( !inst.mpCtor_ )
+    if ( !inst.isCudaAvailable_ || !inst.mpCtor_ )
         return {};
     return inst.mpCtor_();
 }
@@ -125,7 +128,7 @@ std::unique_ptr<IPointsToMeshProjector> CudaAccessor::getCudaPointsToMeshProject
 std::unique_ptr<MR::IPointsProjector> CudaAccessor::getCudaPointsProjector()
 {
     auto& inst = instance_();
-    if ( !inst.ppCtor_ )
+    if ( !inst.isCudaAvailable_ || !inst.ppCtor_ )
         return {};
     return inst.ppCtor_();
 }
@@ -134,7 +137,7 @@ std::unique_ptr<MR::IPointsProjector> CudaAccessor::getCudaPointsProjector()
 CudaAccessor::CudaPointsToDistanceVolumeCallback CudaAccessor::getCudaPointsToDistanceVolumeCallback()
 {
     auto& inst = instance_();
-    if ( !inst.pointsToDistanceVolumeCallback_ )
+    if ( !inst.isCudaAvailable_ || !inst.pointsToDistanceVolumeCallback_ )
         return {};
 
     return inst.pointsToDistanceVolumeCallback_;
@@ -143,7 +146,7 @@ CudaAccessor::CudaPointsToDistanceVolumeCallback CudaAccessor::getCudaPointsToDi
 CudaAccessor::CudaPointsToDistanceVolumeByPartsCallback CudaAccessor::getCudaPointsToDistanceVolumeByPartsCallback()
 {
     auto& inst = instance_();
-    if ( !inst.pointsToDistanceVolumeByPartsCallback_ )
+    if ( !inst.isCudaAvailable_ || !inst.pointsToDistanceVolumeByPartsCallback_ )
         return {};
 
     return inst.pointsToDistanceVolumeByPartsCallback_;
@@ -152,7 +155,7 @@ CudaAccessor::CudaPointsToDistanceVolumeByPartsCallback CudaAccessor::getCudaPoi
 std::unique_ptr<IComputeToolDistance> CudaAccessor::getCudaComputeToolDistance()
 {
     auto& inst = instance_();
-    if ( !inst.ctdCtor_ )
+    if ( !inst.isCudaAvailable_ || !inst.ctdCtor_ )
         return {};
 
     return inst.ctdCtor_();


### PR DESCRIPTION
### Why

Our CI machines have no NVIDIA driver, and every run logs this seven times per Ubuntu leg:

```
CUDA error cudaErrorInsufficientDriver: CUDA driver version is insufficient for CUDA runtime version.
In file: MeshLib/source/MRCuda/MRCudaBasic.cpp Line: 77
```

Two things are wrong with that. The message describes an outdated driver, while the actual situation is that there is no driver at all — the runtime cannot load `libcuda.so.1` and reports the same code. And the calls should not be happening in the first place: `getDeviceInfo()` already failed at startup and `setCudaAvailable( false, … )` was already called.

The reason they happen: the CUDA functors are registered **unconditionally** by the downstream setup code, after the `if/else` that decides availability, and the `CudaAccessor` getters only checked that a functor exists:

```cpp
size_t CudaAccessor::getCudaFreeMemory()
{
    auto& inst = instance_();
    if ( !inst.freeMemFunc_ )       // registered even when CUDA is unusable
        return 0;
    return inst.freeMemFunc_();     // -> cudaSetDevice(0) -> logs error 35
}
```

So the plugins' ordinary "can I use CUDA?" checks call into CUDA on machines that have none. Several of them — `MROffsetPlugin`, `MRRebuildMeshPlugin`, `MRMeshInspectorPlugin`, `MRPointsFusionPlugin`, `MRBaseDistanceComparePlugin` — call `getCudaFreeMemory()` without an `isCudaAvailable()` guard of their own, which is where the seven lines come from.

### What

Every `CudaAccessor` getter that reaches CUDA now checks availability alongside the functor, returning the same empty result it already returns when no functor is registered: `getCudaFreeMemory`, `getCudaFastWindingNumber`, `getCudaPointsToMeshProjector`, `getCudaPointsProjector`, `getCudaPointsToDistanceVolumeCallback`, `getCudaPointsToDistanceVolumeByPartsCallback`, `getCudaComputeToolDistance`.

No call site changes. Callers already treat zero free memory and a null implementation as "cannot use CUDA", which is the conclusion they reached anyway — via a CUDA error instead of a check. The pure size estimators (`fastWindingNumberMeshMemory`, `fromGridMemory`, `fromVectorMemory`, `selfIntersectionsMemory`, `pointsToDistanceVolumeMemory`) are arithmetic only and stay as they are: they answer "how much would this need", which is a fair question with or without a GPU.

### On the first version of this PR

It decorated the error text instead, appending "no NVIDIA driver installed" or "driver supports CUDA X, older than the runtime Y" by consulting `cudaDriverGetVersion()`, which returns 0 when nothing is installed. That is reverted here — annotating a call that should not happen is the wrong layer, and `getDeviceInfo()` has distinguished the two cases correctly since 2024 (`"NVIDIA GPU error: no CUDA driver found"`). Its error simply never reaches the log, because the only consumer passes it to telemetry; that is worth fixing too, but separately.

### Verification

`MRViewer` and `MRCuda` build clean (Release x64, 0 warnings) and `MRTestCuda` passes.

The guards do not trigger on my machine — it reports driver 12.7 against runtime 12.0, so CUDA is available and every getter behaves exactly as before. The change is visible on a machine without a driver, which is what CI is: those seven lines per leg should disappear from the next run's logs, and that absence is the check worth making after merge.
