### PR TITLE
Publish Windows arm64 developer distributives

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -335,16 +335,25 @@ jobs:
       - name: Rename Distributives
         run: |
           shopt -s nullglob
+          VERSION="${{ needs.config.outputs.app_version }}"
           for PKG_FILE in MeshLibDist*.zip ; do
-            case "$PKG_FILE" in
-              # Keep the historical layout for the iterator-debug archives:
-              # MeshLibDist-IteratorDebug[-PDB].zip -> MeshLibDist_<version>-IteratorDebug[-PDB].zip
-              *-IteratorDebug.zip|*-IteratorDebug-PDB.zip) mv "$PKG_FILE" "${PKG_FILE/Dist/Dist_${{ needs.config.outputs.app_version }}}" ;;
-              # Companion symbols archives: MeshLibDistVS19-PDB.zip -> MeshLibDistVS19_<version>-PDB.zip
-              *-PDB.zip) mv "$PKG_FILE" "${PKG_FILE%-PDB.zip}_${{ needs.config.outputs.app_version }}-PDB.zip" ;;
-              # Per-VS archives: MeshLibDistVS19.zip -> MeshLibDistVS19_<version>.zip
-              *) mv "$PKG_FILE" "${PKG_FILE%.zip}_${{ needs.config.outputs.app_version }}.zip" ;;
+            # An arm64 archive is named like its x64 sibling with `-arm64` appended
+            # last, so strip that suffix first and put it back at the end.
+            NAME="${PKG_FILE%.zip}"
+            ARCH_SUFFIX=""
+            case "$NAME" in
+              *-arm64) NAME="${NAME%-arm64}" ; ARCH_SUFFIX="-arm64" ;;
             esac
+            case "$NAME" in
+              # Keep the historical layout for the iterator-debug archives:
+              # MeshLibDist-IteratorDebug[-PDB] -> MeshLibDist_<version>-IteratorDebug[-PDB]
+              *-IteratorDebug|*-IteratorDebug-PDB) NAME="${NAME/Dist/Dist_${VERSION}}" ;;
+              # Companion symbols archives: MeshLibDistVS26-PDB -> MeshLibDistVS26_<version>-PDB
+              *-PDB) NAME="${NAME%-PDB}_${VERSION}-PDB" ;;
+              # Per-VS archives: MeshLibDistVS26 -> MeshLibDistVS26_<version>
+              *) NAME="${NAME}_${VERSION}" ;;
+            esac
+            mv "$PKG_FILE" "${NAME}${ARCH_SUFFIX}.zip"
           done
           for PKG_FILE in MeshLib*.nupkg ; do
             mv "$PKG_FILE" "${PKG_FILE/MeshLib/MeshLib_${{ needs.config.outputs.app_version }}}"

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -48,14 +48,15 @@ jobs:
       BUILD_C_SHARP: ${{ matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild' }}
       PYTEST_C_SHARP_ARGS: --run-c-sharp-samples --csharp-sample-dir=..\source\${{ matrix.arch || 'x64' }}\${{ matrix.config }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet || 'x64-windows-meshlib' }}
-      # Upload a developer distributive per Visual Studio toolchain so
-      # update-win-version can repackage each into MeshLibDistVS{19,22,26}.zip.
+      # Upload a developer distributive per Visual Studio toolchain and target
+      # architecture so update-win-version can repackage each into
+      # MeshLibDistVS{19,22,26}[-arm64].zip.
       # VS2019/VS2022 ship the CMake build; VS2026 ships the MSBuild build
       # (which also produces the C#/.NET components). VS_TAG keeps the archive
       # names distinct.
-      # arm64 is not distributed yet, and its VS_TAG would collide with the x64 archive
-      job_upload_artifact: ${{ inputs.upload_artifacts && matrix.arch != 'arm64' && ( matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild' || matrix.cxx_compiler != 'msvc-2026' && matrix.build_system == 'CMake' ) }}
-      VS_TAG: ${{ fromJSON('{"msvc-2019":"VS19","msvc-2022":"VS22"}')[matrix.cxx_compiler] || 'VS26' }}
+      job_upload_artifact: ${{ inputs.upload_artifacts && ( matrix.cxx_compiler == 'msvc-2026' && matrix.build_system == 'MSBuild' || matrix.cxx_compiler != 'msvc-2026' && matrix.build_system == 'CMake' ) }}
+      # Only VS2026 has an arm64 leg, so the suffix separates it from the x64 VS26 archive
+      VS_TAG: ${{ format('{0}{1}', fromJSON('{"msvc-2019":"VS19","msvc-2022":"VS22"}')[matrix.cxx_compiler] || 'VS26', matrix.arch == 'arm64' && '-arm64' || '') }}
       CUDA_VERSION: ${{ matrix.cuda_version }}
       VCVARS_VER: ${{ fromJSON('{"msvc-2019":"14.2","msvc-2022":"14.4"}')[matrix.cxx_compiler] || '14.5' }}
       PLATFORM_TOOLSET: ${{ fromJSON('{"msvc-2019":"v142","msvc-2022":"v143"}')[matrix.cxx_compiler] || 'v145' }}

--- a/.github/workflows/distro-release.yml
+++ b/.github/workflows/distro-release.yml
@@ -101,16 +101,25 @@ jobs:
       - name: Rename Distributives
         run: |
           shopt -s nullglob
+          VERSION="${{ needs.config.outputs.app_version }}"
           for PKG_FILE in MeshLibDist*.zip ; do
-            case "$PKG_FILE" in
-              # Keep the historical layout for the iterator-debug archives:
-              # MeshLibDist-IteratorDebug[-PDB].zip -> MeshLibDist_<version>-IteratorDebug[-PDB].zip
-              *-IteratorDebug.zip|*-IteratorDebug-PDB.zip) mv "$PKG_FILE" "${PKG_FILE/Dist/Dist_${{ needs.config.outputs.app_version }}}" ;;
-              # Companion symbols archives: MeshLibDistVS19-PDB.zip -> MeshLibDistVS19_<version>-PDB.zip
-              *-PDB.zip) mv "$PKG_FILE" "${PKG_FILE%-PDB.zip}_${{ needs.config.outputs.app_version }}-PDB.zip" ;;
-              # Per-VS archives: MeshLibDistVS19.zip -> MeshLibDistVS19_<version>.zip
-              *) mv "$PKG_FILE" "${PKG_FILE%.zip}_${{ needs.config.outputs.app_version }}.zip" ;;
+            # An arm64 archive is named like its x64 sibling with `-arm64` appended
+            # last, so strip that suffix first and put it back at the end.
+            NAME="${PKG_FILE%.zip}"
+            ARCH_SUFFIX=""
+            case "$NAME" in
+              *-arm64) NAME="${NAME%-arm64}" ; ARCH_SUFFIX="-arm64" ;;
             esac
+            case "$NAME" in
+              # Keep the historical layout for the iterator-debug archives:
+              # MeshLibDist-IteratorDebug[-PDB] -> MeshLibDist_<version>-IteratorDebug[-PDB]
+              *-IteratorDebug|*-IteratorDebug-PDB) NAME="${NAME/Dist/Dist_${VERSION}}" ;;
+              # Companion symbols archives: MeshLibDistVS26-PDB -> MeshLibDistVS26_<version>-PDB
+              *-PDB) NAME="${NAME%-PDB}_${VERSION}-PDB" ;;
+              # Per-VS archives: MeshLibDistVS26 -> MeshLibDistVS26_<version>
+              *) NAME="${NAME}_${VERSION}" ;;
+            esac
+            mv "$PKG_FILE" "${NAME}${ARCH_SUFFIX}.zip"
           done
 
       - name: Upload Distributives

--- a/.github/workflows/matrix/windows-finalize-release-config.json
+++ b/.github/workflows/matrix/windows-finalize-release-config.json
@@ -51,6 +51,22 @@
       "mrcuda_platform_toolset": "v143"
     },
     {
+      "cxx_compiler": "msvc-2026",
+      "config": "Release",
+      "build_system": "MSBuild",
+      "arch": "arm64",
+      "vcpkg_triplet": "arm64-windows-meshlib",
+      "runner": ["windows-11-vs2026-arm"]
+    },
+    {
+      "cxx_compiler": "msvc-2026",
+      "config": "Debug",
+      "build_system": "MSBuild",
+      "arch": "arm64",
+      "vcpkg_triplet": "arm64-windows-meshlib",
+      "runner": ["windows-11-vs2026-arm"]
+    },
+    {
       "cxx_compiler": "msvc-2019",
       "config": "Debug",
       "build_system": "CMake",

--- a/.github/workflows/matrix/windows-standard-config.json
+++ b/.github/workflows/matrix/windows-standard-config.json
@@ -17,6 +17,14 @@
       "runner": ["windows-11-vs2026-arm"]
     },
     {
+      "cxx_compiler": "msvc-2026",
+      "config": "Debug",
+      "build_system": "MSBuild",
+      "arch": "arm64",
+      "vcpkg_triplet": "arm64-windows-meshlib",
+      "runner": ["windows-11-vs2026-arm"]
+    },
+    {
       "cxx_compiler": "msvc-2019",
       "config": "Debug",
       "build_system": "CMake",

--- a/.github/workflows/update-win-version.yml
+++ b/.github/workflows/update-win-version.yml
@@ -17,13 +17,15 @@ on:
 jobs:
   update-win-version:
     timeout-minutes: 60
-    runs-on: windows-2025
+    # arm64 is packaged on an arm64 runner: it builds the example plugin against the
+    # freshly made install folder, which only a native toolchain can link and run.
+    runs-on: ${{ matrix.runner || 'windows-2025' }}
     strategy:
       fail-fast: false
       matrix:
-        # One developer distributive per Visual Studio toolchain. The MREDist_*
-        # inputs are produced by the matching VS CMake build in
-        # build-test-windows.yml (named via its VS_TAG).
+        # One developer distributive per Visual Studio toolchain and target
+        # architecture. The MREDist_* inputs are produced by the matching VS build
+        # in build-test-windows.yml (named via its VS_TAG).
         include:
           - vcpkg_triplet: x64-windows-vs2019-meshlib
             extract_release: MREDist_VS19_Release.zip
@@ -52,6 +54,19 @@ jobs:
             cxx_compiler: msvc-2026
             build_system: MSBuild
             build_config: Release
+          # The `-arm64` suffix comes last so upload-distributions can insert the
+          # version ahead of it: MeshLibDistVS26_<version>[-PDB]-arm64.zip.
+          - vcpkg_triplet: arm64-windows-meshlib
+            arch: arm64
+            runner: windows-11-vs2026-arm
+            extract_release: MREDist_VS26-arm64_Release.zip
+            extract_debug: MREDist_VS26-arm64_Debug.zip
+            output_zip: MeshLibDistVS26-arm64.zip
+            pdb_zip: MeshLibDistVS26-PDB-arm64.zip
+            artifact_name: DistributivesWin-VS26-arm64
+            cxx_compiler: msvc-2026
+            build_system: MSBuild
+            build_config: Release
           - vcpkg_triplet: x64-windows-meshlib-iterator-debug
             extract_debug: MREDist_VS19_Debug-IteratorDebug.zip
             output_zip: MeshLibDist-IteratorDebug.zip
@@ -75,7 +90,7 @@ jobs:
         uses: ./.github/actions/collect-runner-stats
         with:
           target_os: windows
-          target_arch: x64
+          target_arch: ${{ matrix.arch || 'x64' }}
           cxx_compiler: ${{ matrix.cxx_compiler }}
           build_config: ${{ matrix.build_config }}
           build_system: ${{ matrix.build_system }}
@@ -100,19 +115,25 @@ jobs:
           tar -xvzf ${{ matrix.extract_debug }}
           tar -xvzf MeshLibC2Headers.zip
 
+      # The install folder is assembled from source/<arch>/<config>, which
+      # make_install_folder.py derives from the triplet name.
       - name: Make Install Folder
-        run: py -3.10 scripts\make_install_folder.py ${{ inputs.app_version }} ${{ matrix.vcpkg_triplet }}
+        run: py -3 scripts\make_install_folder.py ${{ inputs.app_version }} ${{ matrix.vcpkg_triplet }}
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
+        with:
+          # see the same note in build-test-windows.yml: the default x86 MSBuild
+          # makes the VC props pick an x86 host compiler when targeting ARM64
+          msbuild-architecture: ${{ matrix.arch == 'arm64' && 'arm64' || 'x86' }}
 
       # The .pdb files are moved out of `install` first, so the main archive
       # carries none of them and each toolchain gets a companion symbols archive.
       - name: Archive Symbols
-        run: py -3.10 scripts\split_install_pdb.py install ${{ matrix.pdb_zip }}
+        run: py -3 scripts\split_install_pdb.py install ${{ matrix.pdb_zip }}
 
       - name: Archive Distribution
-        run: py -3.10 scripts\zip_distribution.py install example_plugin ${{ matrix.output_zip }}
+        run: py -3 scripts\zip_distribution.py install example_plugin ${{ matrix.output_zip }}
 
       - name: Collect artifact stats
         if: ${{ inputs.internal_build }}
@@ -127,9 +148,10 @@ jobs:
         env:
           IDL: ${{ matrix.vcpkg_triplet == 'x64-windows-meshlib-iterator-debug' && '2' || '0' }}
         run: |
-          msbuild -m example_plugin\example_plugin.sln -p:Configuration=Debug -p:MeshLibIteratorDebugLevel=$env:IDL
+          $platform = "${{ matrix.arch == 'arm64' && 'ARM64' || 'x64' }}"
+          msbuild -m example_plugin\example_plugin.sln -p:Configuration=Debug -p:Platform=$platform -p:MeshLibIteratorDebugLevel=$env:IDL
           if ("${{ matrix.extract_release }}") {
-            msbuild -m example_plugin\example_plugin.sln -p:Configuration=Release
+            msbuild -m example_plugin\example_plugin.sln -p:Configuration=Release -p:Platform=$platform
           }
 
       - name: Upload Windows Distribution

--- a/doxygen/common_files/CommonDistributionProperties.dox
+++ b/doxygen/common_files/CommonDistributionProperties.dox
@@ -1,6 +1,6 @@
   - Debug only:
     - **Debug Configuration: C/C++ → Preprocessor → Preprocessor Definitions**:
-    \n Add: `_ITERATOR_DEBUG_LEVEL=0;MR_ITERATOR_DEBUG_LEVEL=0` — for the per-Visual-Studio archives (`MeshLibDistVS19`, `MeshLibDistVS22`, `MeshLibDistVS26`).
+    \n Add: `_ITERATOR_DEBUG_LEVEL=0;MR_ITERATOR_DEBUG_LEVEL=0` — for the per-Visual-Studio archives (`MeshLibDistVS19`, `MeshLibDistVS22`, `MeshLibDistVS26`, `MeshLibDistVS26-arm64`).
     \n For the `MeshLibDist-IteratorDebug` archive add `_ITERATOR_DEBUG_LEVEL=2;MR_ITERATOR_DEBUG_LEVEL=2` instead. Both defines must carry the same value: MeshLib stops compilation with `#error _ITERATOR_DEBUG_LEVEL is inconsistent with MeshLib` when they disagree.
     \n Check whether your archive contains `install/include/MRMesh/config_dist.h`. If it does, that header already declares `MR_ITERATOR_DEBUG_LEVEL` for you, so only `_ITERATOR_DEBUG_LEVEL` is yours to set — and `IteratorDebug` then needs no define at all, MSVC's Debug default already being `2`. Setting `MR_ITERATOR_DEBUG_LEVEL` anyway is harmless as long as it matches the archive; a value that contradicts it is rejected at compile time.
   - For all configurations:

--- a/doxygen/general_pages/CppSetupGuide.dox
+++ b/doxygen/general_pages/CppSetupGuide.dox
@@ -12,16 +12,16 @@ When you are done, confirm the result with \ref CppSetupVerify "Verify your setu
 If a step fails, see \ref CppSetupTroubleshooting "Troubleshooting" at the end of this page.
 
 \subsection CppSetupWindows Windows
-\note MeshLib for Windows is distributed for **x64** only: set the platform of your project to `x64`.
+\note MeshLib for Windows is distributed for **x64** and **Arm64**: set the platform of your project to `x64` or `ARM64`.
 A 32-bit (`Win32`) build is not supported and fails while compiling `MRMesh/MRId.h` with
 `C2535: member function already defined or declared` and `C2995: function template has already been defined`
 (on 32-bit MSVC `size_t` and `unsigned int` are the same type, so two `MR::Id` constructors collapse into one).
 Visual Studio 2019 still defaults new C++ console projects to `Win32`.
-On Windows on Arm, use the x64 toolchain: no native Arm64 Windows build is published.
+On Windows on Arm, take the `-arm64` archive; it is built with Visual Studio 2026 and ships no `MRCuda`, there being no CUDA toolkit for that platform.
 
 There are two options: Download and Install release build or compile from sources:
 ### Installing the release build
-Every release publishes one Windows distributive per Visual Studio toolset, plus one for Debug builds that keep MSVC's iterator debugging on.
+Every release publishes one Windows distributive per Visual Studio toolset and target architecture, plus one for Debug builds that keep MSVC's iterator debugging on.
 Take the row matching the toolset your own project is built with, or an older one: MSVC keeps its `v140` to `v145` build tools (Visual Studio 2015 to 2026) [binary-compatible](https://learn.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017), so the `VS19` archive links into a Visual Studio 2022 or 2026 project as well — the link itself must be done by the newer toolset. The opposite direction does not work: older build tools accept a newer DLL only when its exports are `extern "C"`, and MeshLib exports C++.
 Matching your own toolset stays the tested configuration, though: MeshLib compiles with `/std:c++latest` (`source/common.props`), and MSVC's standard library excludes `/std:c++latest` features from that binary-compatibility promise.
 
@@ -30,14 +30,15 @@ Matching your own toolset stays the tested configuration, though: MeshLib compil
 | 2019 | `MeshLibDistVS19_<version>.zip` | `0` |
 | 2022 | `MeshLibDistVS22_<version>.zip` | `0` |
 | 2026 | `MeshLibDistVS26_<version>.zip` | `0` |
+| 2026, Windows on Arm | `MeshLibDistVS26_<version>-arm64.zip` | `0` |
 | 2019 (toolset `v142`), **Debug configuration only** | `MeshLibDist_<version>-IteratorDebug.zip` | `2` |
 
-The release description links the three per-Visual-Studio archives; `IteratorDebug` appears in the asset list only.
+The release description links the per-Visual-Studio archives; `IteratorDebug` appears in the asset list only.
 Take it if your project builds Debug with MSVC's default `_ITERATOR_DEBUG_LEVEL=2`: it ships `install/app/Debug` without `install/app/Release`, so it covers no Release build — but being a `v142` build it serves a newer Visual Studio too, under the rule above.
-Whichever archive you pick, step 2 must define `_ITERATOR_DEBUG_LEVEL` to the value in the table — `0` for the three per-Visual-Studio archives, `2` for `IteratorDebug`.
+Whichever archive you pick, step 2 must define `_ITERATOR_DEBUG_LEVEL` to the value in the table — `0` for the per-Visual-Studio archives, `2` for `IteratorDebug`.
 Archives predating `install/include/MRMesh/config_dist.h` need `MR_ITERATOR_DEBUG_LEVEL` set to the same value as well; newer ones declare it themselves in that header, which leaves `IteratorDebug` needing no define at all.
 
-Debug symbols ship separately: every archive above has a companion `-PDB.zip` (`MeshLibDistVS26_<version>-PDB.zip`, `MeshLibDist_<version>-IteratorDebug-PDB.zip`, ...) holding only the `.pdb` files.
+Debug symbols ship separately: every archive above has a companion `-PDB` archive (`MeshLibDistVS26_<version>-PDB.zip`, `MeshLibDistVS26_<version>-PDB-arm64.zip`, `MeshLibDist_<version>-IteratorDebug-PDB.zip`, ...) holding only the `.pdb` files.
 Extract it over the same directory to put them back under `install/lib`, where the debugger looks for them.
 They are needed for symbolized call stacks only: without them the archive still compiles, links and runs, and is a few hundred megabytes smaller.
 

--- a/example_plugin/example_plugin.sln
+++ b/example_plugin/example_plugin.sln
@@ -9,12 +9,18 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
 		Release|x64 = Release|x64
+		Debug|ARM64 = Debug|ARM64
+		Release|ARM64 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EB31768F-3B0D-4B68-AF4F-A7BA7ABF1996}.Debug|x64.ActiveCfg = Debug|x64
 		{EB31768F-3B0D-4B68-AF4F-A7BA7ABF1996}.Debug|x64.Build.0 = Debug|x64
 		{EB31768F-3B0D-4B68-AF4F-A7BA7ABF1996}.Release|x64.ActiveCfg = Release|x64
 		{EB31768F-3B0D-4B68-AF4F-A7BA7ABF1996}.Release|x64.Build.0 = Release|x64
+		{EB31768F-3B0D-4B68-AF4F-A7BA7ABF1996}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{EB31768F-3B0D-4B68-AF4F-A7BA7ABF1996}.Debug|ARM64.Build.0 = Debug|ARM64
+		{EB31768F-3B0D-4B68-AF4F-A7BA7ABF1996}.Release|ARM64.ActiveCfg = Release|ARM64
+		{EB31768F-3B0D-4B68-AF4F-A7BA7ABF1996}.Release|ARM64.Build.0 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/example_plugin/example_plugin.vcxproj
+++ b/example_plugin/example_plugin.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MyPlugin.cpp" />
@@ -32,13 +40,13 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
@@ -50,10 +58,7 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -62,13 +67,10 @@
   <PropertyGroup>
     <MeshLibIteratorDebugLevel Condition="'$(MeshLibIteratorDebugLevel)' == ''">0</MeshLibIteratorDebugLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+  <PropertyGroup>
     <IntDir>$(SolutionDir)TempOutput\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IntDir>$(SolutionDir)TempOutput\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
@@ -95,7 +97,7 @@
       </Command>
     </PreLinkEvent>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/scripts/devops/release_table.txt
+++ b/scripts/devops/release_table.txt
@@ -28,6 +28,13 @@
       </td>
     </tr>
     <tr>
+      <td align="center">Windows arm64 (Visual Studio 2026)</td>
+      <td align="center">
+        <a href="RELEASE_PATH/MeshLibDistVS26_SHORT_VERSION-arm64.zip">zip</a> /
+        <a href="RELEASE_PATH/MeshLibDistVS26_SHORT_VERSION-PDB-arm64.zip">pdb</a>
+      </td>
+    </tr>
+    <tr>
       <td align="center">Ubuntu 22 LTS x64</td>
       <td align="center">
         <a href="RELEASE_PATH/meshlib_SHORT_VERSION_ubuntu22-dev.deb">deb</a>

--- a/scripts/make_install_folder.py
+++ b/scripts/make_install_folder.py
@@ -25,6 +25,11 @@ def vcpkg_triplet_name():
 		return sys.argv[2]
 	return "x64-windows-meshlib"
 
+def target_arch():
+	# Every triplet leads with the target architecture: x64-windows-meshlib, arm64-windows-meshlib.
+	# It also names the build output folder, source/<arch>/<config>.
+	return vcpkg_triplet_name().split('-')[0]
+
 def vcpkg_dir():
 	vcpkg_triplet = vcpkg_triplet_name()
 	vcpkg_exe_dir = ""
@@ -46,7 +51,7 @@ def prepare_includes_list():
 	it.includes_src_dst.clear()
 	it.includes_src_dst_thirdparty.clear()
 	it.append_includes_list(os.path.join(vcpkg_directory,"include"), True)
-	it.append_includes_list(it.path_to_sources, skipped_dir_regexes = [re.compile('x64(/.*)?'), re.compile('TempOutput(/.*)?'), re.compile('MeshLibC2(/.*)?'), re.compile('MeshLibC2Cuda(/.*)?')])
+	it.append_includes_list(it.path_to_sources, skipped_dir_regexes = [re.compile(target_arch() + '(/.*)?'), re.compile('TempOutput(/.*)?'), re.compile('MeshLibC2(/.*)?'), re.compile('MeshLibC2Cuda(/.*)?')])
 	it.append_includes_list(os.path.join(it.path_to_sources, "MeshLibC2/include"))
 	it.append_includes_list(os.path.join(it.path_to_sources, "MeshLibC2Cuda/include"))
 	it.append_includes_list(path_to_phmap, True,'parallel_hashmap')
@@ -76,7 +81,7 @@ def copy_includes():
 	write_config_dist()
 
 def copy_app():
-	shutil.copytree(os.path.join(it.path_to_sources,'x64'),it.path_to_app,dirs_exist_ok=True)
+	shutil.copytree(os.path.join(it.path_to_sources,target_arch()),it.path_to_app,dirs_exist_ok=True)
 	folder = os.walk(it.path_to_app)
 	for address, dirs, files in folder:
 		for file in files:
@@ -84,12 +89,12 @@ def copy_app():
 				os.remove(os.path.join(address,file))
 
 def copy_lib():
-	shutil.copytree(os.path.join(it.path_to_sources,'x64'),it.path_to_libs,dirs_exist_ok=True)
+	shutil.copytree(os.path.join(it.path_to_sources,target_arch()),it.path_to_libs,dirs_exist_ok=True)
 	shutil.copytree(os.path.join(os.path.join(vcpkg_directory,'debug'),'lib'),os.path.join(it.path_to_libs,"Debug"),dirs_exist_ok=True)
 	shutil.copytree(os.path.join(vcpkg_directory,'lib'),os.path.join(it.path_to_libs,"Release"),dirs_exist_ok=True)
 
 	# Drop the debug-symbol cache that the .NET (C#) test run leaves under
-	# x64/<config>/sym (coreclr/ntdll/kernelbase PDBs, indexed by GUID). Its
+	# <arch>/<config>/sym (coreclr/ntdll/kernelbase PDBs, indexed by GUID). Its
 	# files end in .pdb so the prune below would otherwise keep them, bloating
 	# the package with system symbols that must not ship.
 	for sym_dir in glob.glob(os.path.join(it.path_to_libs, "*", "sym")):


### PR DESCRIPTION
Every release ships `MeshLibDistVS26_<version>.zip` and `MeshLibDistVS26_<version>-PDB.zip`, packed from the VS2026 MSBuild leg on x64. The arm64 MSBuild legs build, test and validate the very same components, but their output was discarded — a single `VS_TAG` named both archives, so `build-test-windows.yml` refused to upload the arm64 one.

This PR adds, next to each of those two assets, an arm64 sibling:

| existing | new |
|---|---|
| `MeshLibDistVS26_<version>.zip` | `MeshLibDistVS26_<version>-arm64.zip` |
| `MeshLibDistVS26_<version>-PDB.zip` | `MeshLibDistVS26_<version>-PDB-arm64.zip` |

`-arm64` comes last, after `-PDB`, matching how the release page already names the two `.pkg` files for macOS.

### What changed

* **`build-test-windows.yml`** — `VS_TAG` gains the architecture (`VS26-arm64`), which is what made the blanket `matrix.arch != 'arm64'` exclusion necessary; it is gone. Only the VS2026 MSBuild legs have an arm64 variant, so no other archive name moves.
* **`update-win-version.yml`** — a fifth matrix entry packs `MREDist_VS26-arm64_{Release,Debug}.zip`. It runs on `windows-11-vs2026-arm`: the job builds `example_plugin` against the install folder it has just assembled, which only a native toolchain can link. `py -3.10` becomes `py -3` — the three packaging scripts are stdlib-only, and the arm64 image ships no 3.10.
* **`make_install_folder.py`** — `copy_app()` / `copy_lib()` took `source/x64` literally. The architecture now comes off the triplet, which already leads with it (`arm64-windows-meshlib`), so no call site changes.
* **Rename step** in `upload-distributions` (both `build-test-distribute.yml` and `distro-release.yml`) — strips a trailing `-arm64`, inserts the version as before, appends it again.
* **Matrices** — `windows-standard-config.json` and `windows-finalize-release-config.json` gain the arm64 MSBuild **Debug** leg. A distributive needs both configurations; the full config already had it.
* **`example_plugin`** — an ARM64 configuration, so the packaging job's smoke build still runs there. Its per-configuration settings never depended on the platform, so they are conditioned on `$(Configuration)` alone rather than duplicated for a second platform.
* **Docs** — the C++ setup guide's archive table, and the release-body table.

### Notes

* The arm64 archive carries **no `MRCuda`**: there is no CUDA toolkit for Windows on Arm. Everything else — `MeshViewer`, `meshconv`, the C, C#/.NET and Python bindings — is the same set the x64 VS26 archive ships, and the arm64 legs already run the full test suite on it.
* `test-distribution.yml`'s `windows-test` still runs on `windows-2025` only, so the released arm64 archive is not smoke-tested from the release page yet. That wants its own matrix `runner` key and is left out of this PR deliberately.
* Cost: two extra `windows-11-vs2026-arm` jobs per release run (the arm64 Debug build, and the packaging job).
