### PR TITLE
Test the Python 3.9 wheel on Rocky Linux 9 instead of EOL Debian 11

### DIFF
--- a/.github/workflows/pip-build.yml
+++ b/.github/workflows/pip-build.yml
@@ -185,7 +185,7 @@ jobs:
                 - py-version: "3.8"
                   os: "rockylinux:8"
                 - py-version: "3.9"
-                  os: "debian:11-slim"
+                  os: "rockylinux:9"
                 - py-version: "3.10"
                   os: "ubuntu:22.04"
                 - py-version: "3.11"
@@ -795,16 +795,16 @@ jobs:
         with:
           ref: ${{ needs.setup.outputs.build_ref }}
 
-      - name: Rocky Linux system setup
+      - name: Rocky Linux 8 system setup
         if: ${{ matrix.os == 'rockylinux:8' }}
         run: dnf -y install python38-pip
 
-      - name: Debian/Ubuntu system setup
-        if: ${{ matrix.os == 'debian:11-slim' || matrix.os == 'ubuntu:22.04' || matrix.os == 'ubuntu:25.10' }}
+      - name: Ubuntu system setup
+        if: ${{ matrix.os == 'ubuntu:22.04' || matrix.os == 'ubuntu:25.10' }}
         run: apt -y update && apt -y install curl libssl-dev python3-pip python${{ matrix.py-version }}-venv
 
-      - name: Fedora system setup
-        if: ${{ matrix.os == 'fedora:37' || matrix.os == 'fedora:39' || matrix.os == 'fedora:42' }}
+      - name: Fedora / Rocky Linux 9 system setup
+        if: ${{ matrix.os == 'rockylinux:9' || matrix.os == 'fedora:37' || matrix.os == 'fedora:39' || matrix.os == 'fedora:42' }}
         run: dnf -y install python3-pip
 
       - name: Create virtualenv

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         config: [ "${{ inputs.index || 'prod' }}" ]
         platform: ["x86_64", "aarch64"]
-        os: ["ubuntu:20.04", "ubuntu:22.04", "debian:11-slim", "fedora:37"]
+        os: ["ubuntu:20.04", "ubuntu:22.04", "rockylinux:9", "fedora:37"]
         include:
           - config: prod
             pip-options: meshlib
@@ -62,7 +62,7 @@ jobs:
           - os: "ubuntu:22.04"
             py-version: "3.10"
             py-cmd: "python3.10"
-          - os: "debian:11-slim"
+          - os: "rockylinux:9"
             py-version: "3.9"
             py-cmd: "python3.9"
           - os: "fedora:37"
@@ -75,12 +75,12 @@ jobs:
           ref: ${{needs.setup.outputs.version_tag}}
 
       - name: Ubuntu system setup
-        if: ${{ matrix.os == 'ubuntu:20.04' || matrix.os == 'ubuntu:22.04' || matrix.os == 'debian:11-slim' }}
+        if: ${{ matrix.os == 'ubuntu:20.04' || matrix.os == 'ubuntu:22.04' }}
         run: apt -y update && apt -y upgrade && apt -y install curl libssl-dev python3-pip
 
-      - name: Fedora 37 system setup
-        if: ${{matrix.os == 'fedora:37'}}
-        run: dnf -y install python3 pip
+      - name: Fedora 37 / Rocky Linux 9 system setup
+        if: ${{ matrix.os == 'fedora:37' || matrix.os == 'rockylinux:9' }}
+        run: dnf -y install python3 python3-pip
 
       - name: Pip setup
         run: |


### PR DESCRIPTION
### Problem

Debian 11 (bullseye) reached **end of LTS on 2026-08-31**, and its packages are being drained from `deb.debian.org` right now. `apt -y install` in the Python 3.9 pip test therefore 404s on individual `.deb` files while `apt update`, two seconds earlier, still succeeds and the index still advertises those exact versions:

```
E: Failed to fetch .../libpython3.9-minimal_3.9.2-1+deb11u7_arm64.deb  404  Not Found
E: Failed to fetch .../gpgconf_2.2.27-2+deb11u3_arm64.deb              404  Not Found
E: Failed to fetch .../gnupg_2.2.27-2+deb11u3_all.deb                  404  Not Found
E: Failed to fetch .../libpython3.9-dev_3.9.2-1+deb11u7_arm64.deb      404  Not Found
E: Failed to fetch .../python3-pkg-resources_52.0.0-4+deb11u2_all.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
##[error]Process completed with exit code 100
```

(run [33938510856](https://github.com/MeshInspector/MeshLib/actions/runs/33938510856/job/101280394121))

The removal is still in progress rather than finished, so retrying only gets worse over time: `python3-setuptools_52.0.0-4+deb11u2` downloaded fine *during* that run and returns 404 *now*, while its same-version sibling `python3-pkg-resources` already 404'd then. And there is nowhere to repoint apt — `archive.debian.org/debian-security/dists/bullseye-security` is still 404, i.e. not populated yet.

### Fix

Test the Python 3.9 wheel on **Rocky Linux 9**, which ships Python 3.9 as its system interpreter and is supported until 2032. This keeps the 3.9 ABI covered — `debian:11-slim` was the only 3.9 leg in the matrix, so simply dropping it would have lost that coverage.

Verified against the live Rocky 9 repodata, on **both** `x86_64` and `aarch64`:

| needed | repo | version |
| --- | --- | --- |
| `python3` → `/usr/bin/python3.9` | BaseOS | 3.9.25 |
| `python3-pip` | AppStream | 21.3.1 |
| `python3-pip-wheel`, `python3-setuptools-wheel` (the ensurepip payload `python3.9 -m venv` needs) | BaseOS | 21.3.1 / 53.0.0 |

`arm64v8/rockylinux:9` and `rockylinux:9` both resolve on Docker Hub, same as the `rockylinux:8` images the 3.8 leg already uses.

### Changes

**`pip-build.yml`** (`manylinux-pip-test`)
- 3.9 leg: `debian:11-slim` → `rockylinux:9`
- `rockylinux:9` folded into the Fedora setup step — the command is byte-identical (`dnf -y install python3-pip`)
- *Rocky Linux system setup* → *Rocky Linux 8 system setup*, since it installs `python38-pip` and is Rocky-8-only
- *Debian/Ubuntu system setup* → *Ubuntu system setup*

**`release-tests.yml`** (`pip-test-linux`) — same swap, since the next release run would hit the identical 404
- `dnf -y install python3 pip` → `dnf -y install python3 python3-pip`; `pip` was a virtual provide of `python3-pip` on Fedora anyway, and the explicit name works on both distros

### Note for later

`release-tests.yml` also tests `ubuntu:20.04` (the 3.8 leg), EOL since April 2025. `archive.ubuntu.com` still serves focal today, but that is the next one to go the same way.
