### PR TITLE
install-msys2-mrbind: add an msys2-dir input

### DIFF
--- a/.github/actions/install-msys2-mrbind/action.yml
+++ b/.github/actions/install-msys2-mrbind/action.yml
@@ -2,7 +2,7 @@ name: Install MSYS2 for MRBind
 description: >
   Restore (or download) the pinned MSYS2 toolchain listed in
   `scripts/mrbind/msys2_package_hashes<packages-suffix>.txt`, sha256-verify it,
-  and `pacman -U` into `C:\msys64`, installing MSYS2 first when the runner
+  and `pacman -U` into `msys2-dir`, installing MSYS2 first when the runner
   image ships none (the arm64 images do not).
 
 inputs:
@@ -21,6 +21,14 @@ inputs:
       workflow whose workspace is MeshLib itself; a downstream repo that has
       MeshLib as a submodule passes the submodule path (e.g. `MeshLib`), since
       every path below is resolved against the workspace, not the action.
+  msys2-dir:
+    required: false
+    default: 'C:\msys64'
+    description: >
+      Where MSYS2 lives, or should be installed. Defaults to `C:\msys64`, the
+      path the runner images use. Override to match a runner whose image (or
+      whose downstream repo) puts it elsewhere, and pass the same value to
+      `build-mrbind`.
 
 runs:
   using: composite
@@ -41,23 +49,27 @@ runs:
       # only; on arm64 its runtime runs under emulation while the CLANGARM64
       # packages installed below are native (https://www.msys2.org/docs/arm64/).
       shell: pwsh
+      env:
+        MSYS2_DIR: ${{ inputs.msys2-dir }}
       run: |
-        if (Test-Path 'C:\msys64\msys2_shell.cmd') {
+        if (Test-Path "$env:MSYS2_DIR\msys2_shell.cmd") {
           Write-Host 'MSYS2 already present.'
           exit 0
         }
         $sfx = Join-Path $Env:RUNNER_TEMP 'msys2-base.sfx.exe'
         $url = 'https://github.com/msys2/msys2-installer/releases/latest/download/msys2-base-x86_64-latest.sfx.exe'
         Invoke-WebRequest $url -OutFile $sfx
-        # the archive contains a top-level msys64/, so -oC:\ yields C:\msys64
-        & $sfx -y '-oC:\'
-        if (-not (Test-Path 'C:\msys64\msys2_shell.cmd')) { throw 'MSYS2 extraction failed' }
+        # the archive has a fixed top-level msys64/, so unpack it aside and move
+        # it to where the caller asked
+        & $sfx -y "-o$Env:RUNNER_TEMP"
+        if (-not (Test-Path "$Env:RUNNER_TEMP\msys64\msys2_shell.cmd")) { throw 'MSYS2 extraction failed' }
+        Move-Item "$Env:RUNNER_TEMP\msys64" $env:MSYS2_DIR
         # first launch generates /etc and the user skeleton; pacman needs them
-        & 'C:\msys64\msys2_shell.cmd' -no-start -defterm -here -c 'true'
+        & "$env:MSYS2_DIR\msys2_shell.cmd" -no-start -defterm -here -c 'true'
         # that init runs `pacman-key --populate msys2 || true` and intermittently
         # dies before signing the keys, leaving every repo database at "unknown
         # trust"; redo it here, plus the wget msys2-base lacks
-        & 'C:\msys64\msys2_shell.cmd' -no-start -defterm -here -c 'pacman-key --init && pacman-key --populate msys2 && pacman-key --updatedb && pacman -Sy --noconfirm --needed wget'
+        & "$env:MSYS2_DIR\msys2_shell.cmd" -no-start -defterm -here -c 'pacman-key --init && pacman-key --populate msys2 && pacman-key --updatedb && pacman -Sy --noconfirm --needed wget'
         if ($LASTEXITCODE -ne 0) { throw "MSYS2 keyring setup exited with code $LASTEXITCODE" }
 
     - name: Install MSYS2 for MRBind
@@ -70,10 +82,12 @@ runs:
       # Everything here is idempotent: `wget -nc` skips present files and
       # `pacman -U --needed` skips already-installed packages.
       shell: pwsh
+      env:
+        MSYS2_DIR: ${{ inputs.msys2-dir }}
       run: |
         $attempts = 3
         foreach ($i in 1..$attempts) {
-          C:\msys64\msys2_shell.cmd -no-start -defterm -here -c "set -e && bash ${{ inputs.repo-dir }}/scripts/mrbind/msys2_download_packages.sh ${{ inputs.packages-suffix }} && bash ${{ inputs.repo-dir }}/scripts/mrbind/msys2_install_packages.sh ${{ inputs.packages-suffix }}"
+          & "$env:MSYS2_DIR\msys2_shell.cmd" -no-start -defterm -here -c "set -e && bash ${{ inputs.repo-dir }}/scripts/mrbind/msys2_download_packages.sh ${{ inputs.packages-suffix }} && bash ${{ inputs.repo-dir }}/scripts/mrbind/msys2_install_packages.sh ${{ inputs.packages-suffix }}"
           $code = $LASTEXITCODE
           if ($code -eq 0) { break }
           # The msys2 shell dies without its console output reaching the
@@ -83,13 +97,13 @@ runs:
           $teeLog = '${{ inputs.repo-dir }}/scripts/mrbind/msys2_pacman_install.log'
           if (Test-Path $teeLog) { Get-Content $teeLog } else { Write-Host 'absent — died before pacman produced output' }
           Write-Host '::endgroup::'
-          Write-Host '::group::C:\msys64\var\log\pacman.log (last 200 lines)'
-          $pacLog = 'C:\msys64\var\log\pacman.log'
+          Write-Host "::group::$env:MSYS2_DIR\var\log\pacman.log (last 200 lines)"
+          $pacLog = "$env:MSYS2_DIR\var\log\pacman.log"
           if (Test-Path $pacLog) { Get-Content $pacLog -Tail 200 } else { Write-Host 'absent — pacman never started a transaction' }
           Write-Host '::endgroup::'
           if ($i -lt $attempts) {
             # A pacman killed mid-transaction leaves a stale db lock behind.
-            Remove-Item 'C:\msys64\var\lib\pacman\db.lck' -Force -ErrorAction SilentlyContinue
+            Remove-Item "$env:MSYS2_DIR\var\lib\pacman\db.lck" -Force -ErrorAction SilentlyContinue
             Remove-Item $teeLog -Force -ErrorAction SilentlyContinue
             Start-Sleep -Seconds 10
           }


### PR DESCRIPTION
`.github/actions/install-msys2-mrbind` hardcoded `C:\msys64`, which is the one thing about it that is not portable. Its sibling `build-mrbind` already takes an `msys2-dir` input with the same `C:\msys64` default, so the two could not be pointed at the same non-default location.

That gap is why MeshInspector could not reuse this action for its new Windows ARM leg and duplicated it inline instead: MeshInspector's self-hosted Windows AMI installs MSYS2 at `C:\msys64_meshlib_mrbind`, and the ARM leg installs it there too so the path needs no arch conditional. The inline copy is a fork of this file with the retry loop and the pacman-log dump dropped - exactly the parts that exist because the msys2 runtime intermittently dies spawning pacman.

## Change

- New `msys2-dir` input, default `C:\msys64`, threaded into both PowerShell steps as `MSYS2_DIR` (same shape `build-mrbind` uses).
- The msys2 shell invocations, the `pacman.log` tail and the stale-`db.lck` cleanup all read it.
- Extraction had to change shape: the sfx archive has a fixed top-level `msys64/`, so `-oC:\` can only ever produce `C:\msys64`. It now unpacks into `RUNNER_TEMP` and moves the tree to the requested path.

Together with `repo-dir` (#6762) the action is now fully usable from a repo that has MeshLib as a submodule.

## Coverage

No behaviour change at the default - both callers here (`build-test-windows.yml`, `pip-build.yml`) omit the input, so they still resolve to `C:\msys64`.

The rewritten extraction is not dead code on this PR: it runs whenever the image ships no MSYS2, which is the arm64 Windows images, and `windows-minimal-config.json` carries both arm64 legs with `mrbind` defaulting to true. So a plain PR run exercises it.

Non-Windows platforms are disabled by label.
