### PR TITLE
setup-vcpkg-windows: add repo-dir and extra-cache-key inputs

### DIFF
--- a/.github/actions/setup-vcpkg-windows/action.yml
+++ b/.github/actions/setup-vcpkg-windows/action.yml
@@ -21,22 +21,53 @@ inputs:
     description: 'String boolean ("true" or "false"). Set it in jobs whose only purpose is to populate the cache and that never build against the restored tree. On a cache hit such a job has nothing left to do, so the restore (and the MSBuild integration that follows it) is skipped instead of downloading a tree no step in this job reads.'
     required: false
     default: 'false'
+  repo-dir:
+    description: >
+      Path to this repository from the workspace root. The default suits a
+      workflow whose workspace is MeshLib itself; a downstream repo that has
+      MeshLib as a submodule passes the submodule path (e.g. `MeshLib`).
+      It locates the ports, the triplet file and the diagnostic script.
+      `thirdparty\install.bat` is deliberately NOT covered: it is run from the
+      workspace root, so a downstream repo runs its own wrapper.
+    required: false
+    default: '.'
+  extra-cache-key:
+    description: >
+      Extra text folded into the cache key. A downstream repo whose own files
+      change the installed tree passes their hash, e.g.
+      `${{ hashFiles('requirements/windows*.txt', 'thirdparty/install.bat') }}`.
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
   steps:
+    - name: Resolve repo prefix
+      shell: bash
+      run: |
+        d='${{ inputs.repo-dir }}'
+        if [ -z "$d" ] || [ "$d" = "." ]; then
+          echo "REPO_PREFIX=" >> "$GITHUB_ENV"
+        else
+          echo "REPO_PREFIX=${d%/}/" >> "$GITHUB_ENV"
+        fi
+
     - name: Compute Vcpkg Cache Key
       # Bust the cache when overlay ports, the active triplet, the package
       # list, or install.bat change. The VS2019 overlay glob is empty for
       # other triplets so it doesn't invalidate their caches.
       shell: bash
       env:
-        VS19_PORTS_GLOB: ${{ (inputs.vcpkg-triplet == 'x64-windows-vs2019-meshlib' || inputs.vcpkg-triplet == 'x64-windows-meshlib-iterator-debug') && 'thirdparty/vcpkg/ports-vs19/**' || '' }}
+        VS19_PORTS_GLOB: ${{ (inputs.vcpkg-triplet == 'x64-windows-vs2019-meshlib' || inputs.vcpkg-triplet == 'x64-windows-meshlib-iterator-debug') && format('{0}thirdparty/vcpkg/ports-vs19/**', env.REPO_PREFIX) || '' }}
       run: |
-        triplet_file="thirdparty/vcpkg/triplets/${{ inputs.vcpkg-triplet }}.cmake"
+        triplet_file="${REPO_PREFIX}thirdparty/vcpkg/triplets/${{ inputs.vcpkg-triplet }}.cmake"
         echo "Triplet file: $triplet_file"
         test -f "$triplet_file" || { echo "::error::Triplet file not found: $triplet_file"; exit 1; }
-        echo "VCPKG_CACHE_KEY=vcpkg-cache-${{ inputs.vcpkg-version }}-${{ inputs.vcpkg-triplet }}-${{ hashFiles('thirdparty/vcpkg/ports/**', env.VS19_PORTS_GLOB, format('thirdparty/vcpkg/triplets/{0}.cmake', inputs.vcpkg-triplet), 'requirements/windows.txt', 'thirdparty/install.bat') }}-slim2" >> "$GITHUB_ENV"
+        files_hash='${{ hashFiles(format('{0}thirdparty/vcpkg/ports/**', env.REPO_PREFIX), env.VS19_PORTS_GLOB, format('{0}thirdparty/vcpkg/triplets/{1}.cmake', env.REPO_PREFIX, inputs.vcpkg-triplet), format('{0}requirements/windows.txt', env.REPO_PREFIX), format('{0}thirdparty/install.bat', env.REPO_PREFIX)) }}'
+        # An empty hash means every pattern matched nothing, which would pin the
+        # key to a constant and never bust it again. Fail instead.
+        test -n "$files_hash" || { echo "::error::cache key inputs matched no files under '${REPO_PREFIX:-<workspace>}'"; exit 1; }
+        echo "VCPKG_CACHE_KEY=vcpkg-cache-${{ inputs.vcpkg-version }}-${{ inputs.vcpkg-triplet }}-${files_hash}${{ inputs.extra-cache-key && format('-{0}', inputs.extra-cache-key) || '' }}-slim2" >> "$GITHUB_ENV"
 
     - name: Look up Vcpkg Cache
       id: lookup
@@ -154,6 +185,8 @@ runs:
       if: ${{ env.VCPKG_CACHE_HIT != 'true' }}
       shell: pwsh
       run: |
+        # Workspace-relative on purpose, not repo-dir-relative: a downstream
+        # repo's own install.bat wraps MeshLib's and adds its requirements.
         ./thirdparty/install.bat ${{ inputs.install-flags }}
 
         Write-Host "=== C:\vcpkg subfolder sizes (pre-trim) ==="
@@ -202,4 +235,4 @@ runs:
       if: ${{ always() && env.VCPKG_RESTORE_SKIPPED != 'true' }}
       shell: pwsh
       continue-on-error: true
-      run: ./scripts/diagnostics/windows-vcpkg-tree.ps1 -Triplet "${{ inputs.vcpkg-triplet }}"
+      run: ./${{ env.REPO_PREFIX }}scripts/diagnostics/windows-vcpkg-tree.ps1 -Triplet "${{ inputs.vcpkg-triplet }}"

--- a/.github/actions/setup-vcpkg-windows/action.yml
+++ b/.github/actions/setup-vcpkg-windows/action.yml
@@ -34,8 +34,8 @@ inputs:
   extra-cache-key:
     description: >
       Extra text folded into the cache key. A downstream repo whose own files
-      change the installed tree passes their hash, e.g.
-      `${{ hashFiles('requirements/windows*.txt', 'thirdparty/install.bat') }}`.
+      change the installed tree passes their hash, computed by the caller with
+      hashFiles over e.g. requirements/windows*.txt and thirdparty/install.bat.
     required: false
     default: ''
 


### PR DESCRIPTION
`setup-vcpkg-windows` resolves every path in its cache key against the workspace root, so it only works in a workflow whose workspace *is* MeshLib. MeshInspector has MeshLib as a submodule and cannot call it: the ports and triplets are under `MeshLib/`, the triplet-file check `exit 1`s rather than degrading, and `scripts/diagnostics/windows-vcpkg-tree.ps1` does not exist there at all.

That matters because of what MeshInspector pays without it. On its Windows ARM leg (the same hosted `windows-11-vs2026-arm` image this repo uses), `Update thirdparty` takes **10m20s** — and nothing builds from source: `Restored 142 package(s) from AWS in 9.2 min`, i.e. 142 sequential S3 fetches. The same step here, via this action on a cache hit, is **1m27s**. One tarball instead of 142.

## Change

- **`repo-dir`** (default `.`) prefixes the ports glob, the VS2019 overlay glob, the triplet file, MeshLib's `requirements/windows.txt`, MeshLib's `thirdparty/install.bat`, and the diagnostic script.
- **`extra-cache-key`** (default empty) is appended to the key, so a downstream repo can fold in the hash of its own files. MeshInspector needs this: its `requirements/windows.txt` / `windows-x64.txt` and the `install.bat` wrapper that chooses between them both change the installed tree.

`thirdparty\install.bat` is deliberately *not* prefixed - it keeps running from the workspace root, because downstream that is the wrapper and it calls MeshLib's. So the executed script and the hashed script are different files by design, and the input's description says so.

## Two non-obvious bits

**The prefix is resolved in its own step**, not as an expression in the key step's `env:` block. GitHub treats the empty string as falsy, so `inputs.repo-dir == '.' && '' || format(...)` evaluates to the `format(...)` branch in exactly the default case - the ternary cannot yield `''`.

**`hashFiles` stays inside `run:`.** `VS19_PORTS_GLOB` is set in that step's own `env:` block, and sibling entries in one `env:` mapping cannot see each other. Hoisting the hash up next to it would have read an undefined `env.VS19_PORTS_GLOB` as empty and silently dropped the VS2019 overlay ports from the key for `x64-windows-vs2019-meshlib` and `x64-windows-meshlib-iterator-debug`. (`REPO_PREFIX` is fine there - it comes from the previous step.)

While in here: an empty `hashFiles` result is now a hard error. Previously a typo in a glob would have pinned the key to a constant that never busts again, which fails in the worst possible way - silently, and only once someone changes a port.

## Coverage

Keys are byte-identical at the defaults - prefix `""`, no extra key - so all four callers (`build-test-windows.yml`, `pip-build.yml`, `prepare-images.yml`, `update-win-version.yml`) keep hitting their existing cache entries. A cache miss on this PR would be visible as a ~10 min `Update vcpkg packages` in the Windows legs.

Non-Windows platforms are disabled by label.
