### PR TITLE
Recognize Azure Cobalt 200, AWS Graviton5 (Neoverse-V3) and Microsoft's ARM implementer on Linux arm64

### DIFF
--- a/scripts/devops/collect_runner_sys_stats.py
+++ b/scripts/devops/collect_runner_sys_stats.py
@@ -58,6 +58,7 @@ BRANDED_ARM_CPUS = {
     ("Amazon EC2",            0x41, 0xd0c): "AWS Graviton2",
     ("Amazon EC2",            0x41, 0xd40): "AWS Graviton3",
     ("Amazon EC2",            0x41, 0xd4f): "AWS Graviton4",
+    ("Amazon EC2",            0x41, 0xd84): "AWS Graviton5",
 }
 
 def read_arm_midr():

--- a/scripts/devops/collect_runner_sys_stats.py
+++ b/scripts/devops/collect_runner_sys_stats.py
@@ -31,9 +31,10 @@ ARM_CPU_NAMES = {
     (0x41, 0xd0d): "Cortex-A77",     (0x41, 0xd40): "Neoverse-V1",
     (0x41, 0xd41): "Cortex-A78",     (0x41, 0xd44): "Cortex-X1",
     (0x41, 0xd49): "Neoverse-N2",    (0x41, 0xd4f): "Neoverse-V2",
+    (0x41, 0xd84): "Neoverse-V3",    (0x41, 0xd8e): "Neoverse-N3",
     (0xc0, 0xac3): "Ampere-1",       (0xc0, 0xac4): "Ampere-1a",
     (0x43, 0x0af): "ThunderX2-99xx", (0x46, 0x001): "A64FX",
-    (0x51, 0xc01): "Saphira",
+    (0x51, 0xc01): "Saphira",        (0x6d, 0xd49): "Azure-Cobalt-100",
 }
 
 ARM_VENDORS = {
@@ -41,13 +42,18 @@ ARM_VENDORS = {
     0x43: "Cavium",  0x48: "HiSilicon",
     0x4e: "NVIDIA",  0x51: "Qualcomm",
     0x53: "Samsung", 0x56: "Marvell",
-    0x70: "Phytium", 0xc0: "Ampere",
+    0x6d: "Microsoft", 0x70: "Phytium",
+    0xc0: "Ampere",
 }
 
 # the real name of a cloud CPU lives in SMBIOS type 4, which is root-only, so brand
 # the known ones by DMI vendor + MIDR pair: Cobalt and Graviton are stock ARM cores
+# (bare-metal Cobalt uses Microsoft's own implementer 0x6d, Azure VMs show 0x41)
 BRANDED_ARM_CPUS = {
     ("Microsoft Corporation", 0x41, 0xd49): "Cobalt 100",
+    ("Microsoft Corporation", 0x41, 0xd84): "Cobalt 200",
+    ("Microsoft Corporation", 0x6d, 0xd49): "Cobalt 100",
+    ("Microsoft Corporation", 0x6d, 0xd84): "Cobalt 200",
     ("Amazon EC2",            0x41, 0xd08): "AWS Graviton",
     ("Amazon EC2",            0x41, 0xd0c): "AWS Graviton2",
     ("Amazon EC2",            0x41, 0xd40): "AWS Graviton3",

--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -436,6 +436,7 @@ std::string GetCpuId()
         { "Amazon EC2",            0x41, 0xd0c, "AWS Graviton2" },
         { "Amazon EC2",            0x41, 0xd40, "AWS Graviton3" },
         { "Amazon EC2",            0x41, 0xd4f, "AWS Graviton4" },
+        { "Amazon EC2",            0x41, 0xd84, "AWS Graviton5" },
     };
     {
         std::ifstream sysVendor( "/sys/class/dmi/id/sys_vendor" );

--- a/source/MRMesh/MRSystem.cpp
+++ b/source/MRMesh/MRSystem.cpp
@@ -425,9 +425,13 @@ std::string GetCpuId()
 
     // a cloud CPU's real name is only in SMBIOS, which needs root, so brand the known
     // ones by DMI vendor: Cobalt and Graviton both report as stock ARM cores
+    // (bare-metal Cobalt uses Microsoft's own implementer 0x6d, Azure VMs show 0x41)
     struct BrandedArmCpu { const char* vendor; int implementer, part; const char* name; };
     static constexpr BrandedArmCpu brandedArmCpus[] = {
         { "Microsoft Corporation", 0x41, 0xd49, "Cobalt 100" },
+        { "Microsoft Corporation", 0x41, 0xd84, "Cobalt 200" },
+        { "Microsoft Corporation", 0x6d, 0xd49, "Cobalt 100" },
+        { "Microsoft Corporation", 0x6d, 0xd84, "Cobalt 200" },
         { "Amazon EC2",            0x41, 0xd08, "AWS Graviton" },
         { "Amazon EC2",            0x41, 0xd0c, "AWS Graviton2" },
         { "Amazon EC2",            0x41, 0xd40, "AWS Graviton3" },
@@ -451,9 +455,10 @@ std::string GetCpuId()
         { 0x41, 0xd0d, "ARM Cortex-A77" },   { 0x41, 0xd40, "ARM Neoverse-V1" },
         { 0x41, 0xd41, "ARM Cortex-A78" },   { 0x41, 0xd44, "ARM Cortex-X1" },
         { 0x41, 0xd49, "ARM Neoverse-N2" },  { 0x41, 0xd4f, "ARM Neoverse-V2" },
+        { 0x41, 0xd84, "ARM Neoverse-V3" },  { 0x41, 0xd8e, "ARM Neoverse-N3" },
         { 0xc0, 0xac3, "Ampere-1" },         { 0xc0, 0xac4, "Ampere-1a" },
         { 0x43, 0x0af, "Marvell ThunderX2" },{ 0x46, 0x001, "Fujitsu A64FX" },
-        { 0x51, 0xc01, "Qualcomm Kryo" },
+        { 0x51, 0xc01, "Qualcomm Kryo" },      { 0x6d, 0xd49, "Azure Cobalt 100" },
     };
     for ( const auto& c : armCpuNames )
         if ( c.implementer == implementer && c.part == part )
@@ -467,7 +472,8 @@ std::string GetCpuId()
     case 0x43: vendor = "Cavium";    break;  case 0x48: vendor = "HiSilicon"; break;
     case 0x4e: vendor = "NVIDIA";    break;  case 0x51: vendor = "Qualcomm";  break;
     case 0x53: vendor = "Samsung";   break;  case 0x56: vendor = "Marvell";   break;
-    case 0x70: vendor = "Phytium";   break;  case 0xc0: vendor = "Ampere";    break;
+    case 0x6d: vendor = "Microsoft"; break;  case 0x70: vendor = "Phytium";   break;
+    case 0xc0: vendor = "Ampere";    break;
     }
     if ( vendor && part >= 0 )
         return fmt::format( "{} ARM CPU (part {:#x})", vendor, part );


### PR DESCRIPTION
### Problem

Azure Cobalt 200 VMs (Dpsv7 / Dplsv7 / Epsv7, in preview, GA expected later in 2026) are built on Arm Neoverse CSS V3, and GitHub has announced it will move its arm64 hosted runners to Cobalt 200. Neither `GetCpuId()` nor `scripts/devops/collect_runner_sys_stats.py` knows the V3 MIDR part, so on such a VM both would fall through to the implementer-only fallback and report

```
ARM ARM CPU (part 0xd84)
```

instead of a name, and the CI stats rows for those runners would not group with anything.

### Fix

Follow-up to #6712, same two tables in both files:

| implementer | part | `GetCpuId()` | stats script (lscpu name) | branded on Azure as |
| --- | --- | --- | --- | --- |
| `0x41` ARM | `0xd84` | `ARM Neoverse-V3` | `Neoverse-V3` | `Cobalt 200` on Azure, `AWS Graviton5` on EC2 |
| `0x41` ARM | `0xd8e` | `ARM Neoverse-N3` | `Neoverse-N3` | - |
| `0x6d` Microsoft | `0xd49` | `Azure Cobalt 100` | `Azure-Cobalt-100` | `Cobalt 100` |
| `0x6d` Microsoft | `0xd84` | `Microsoft ARM CPU (part 0xd84)` | `Microsoft ARM CPU (part 0xd84)` | `Cobalt 200` |

Part numbers are from util-linux `lscpu-arm.c`, whose names the stats script mirrors on purpose.

The `0x6d` rows: bare-metal Cobalt 100 does not report ARM's implementer at all but Microsoft's own `0x6d` with part `0xd49` (Linux `arch/arm64/include/asm/cputype.h` `MICROSOFT_CPU_PART_AZURE_COBALT_100`, and lscpu since 2.40). The `ubuntu-24.04-arm` hosted runner measured in #6712 showed `0x41`, so the hypervisor currently presents the stock ARM identity, but the physical one is documented and cheap to accept. The `0x6d`/`0xd84` Cobalt 200 row assumes the same convention (Microsoft implementer, part equal to the underlying Arm core); it is a guess until a Cobalt 200 VM can be measured, and it is harmless if wrong.

Graviton5 (M9g, GA June 2026) is also a Neoverse-V3: `CPU implementer 0x41`, `CPU part 0xd84`, MIDR `0x410fd841`, DMI vendor `Amazon EC2`, per an [lscpu/dmidecode dump from an m9g.medium](https://dev.classmethod.jp/en/articles/ec2-m9g-graviton5-instance-launch/). Same part as Cobalt 200, so the DMI vendor is what tells them apart, exactly the split #6712 introduced.

No behaviour change on x86, macOS or Windows (Windows reads `ProcessorNameString` from the registry).
