### PR TITLE
smoothCameraMeshDepth(): depth denoising of a camera-points mesh via interpolateScalarsSmoothly

### DIFF
--- a/source/MRMesh/MRCameraPointsTriangulation.cpp
+++ b/source/MRMesh/MRCameraPointsTriangulation.cpp
@@ -81,31 +81,37 @@ Expected<Mesh> triangulateCameraPoints( const VertCoords & points, const CameraP
 
 void smoothCameraMeshDepth( Mesh & mesh, const SmoothCameraMeshDepthSettings & settings )
 {
+    mesh.invalidateCaches();
+    smoothCameraMeshDepth( mesh.topology, mesh.points, settings );
+}
+
+void smoothCameraMeshDepth( const MeshTopology & topology, VertCoords & points, const SmoothCameraMeshDepthSettings & settings )
+{
     MR_TIMER;
-    const auto & verts = mesh.topology.getVertIds( settings.region );
-    VertScalars depth( mesh.points.size() );
+    const auto & verts = topology.getVertIds( settings.region );
+    VertScalars depth( points.size() );
     // the mesh projected in the image plane (normalized coordinates), where edge weights and vertex areas are computed
-    VertCoords projected( mesh.points.size() );
-    BitSetParallelFor( mesh.topology.getValidVerts(), [&]( VertId v )
+    VertCoords projected( points.size() );
+    BitSetParallelFor( topology.getValidVerts(), [&]( VertId v )
     {
-        const auto & p = mesh.points[v];
+        const auto & p = points[v];
         depth[v] = p.z;
         projected[v] = Vector3f( p.x / p.z, -p.y / p.z, 1 );
     } );
 
-    VertScalars stabilizers( mesh.points.size(), settings.innerStabilizer );
+    VertScalars stabilizers( points.size(), settings.innerStabilizer );
     if ( settings.innerStabilizerType != AreaStabilizer::Uniform )
     {
         BitSetParallelFor( verts, [&]( VertId v )
         {
-            const auto a = dblArea( mesh.topology, projected, v );
+            const auto a = dblArea( topology, projected, v );
             stabilizers[v] = settings.innerStabilizerType == AreaStabilizer::Area ? a : sqr( a );
         } );
         double sum = 0;
         int n = 0;
         for ( auto v : verts )
         {
-            if ( mesh.topology.isBdVertex( v ) )
+            if ( topology.isBdVertex( v ) )
                 continue;
             sum += stabilizers[v];
             ++n;
@@ -117,7 +123,7 @@ void smoothCameraMeshDepth( Mesh & mesh, const SmoothCameraMeshDepthSettings & s
         } );
     }
     for ( auto v : verts )
-        if ( mesh.topology.isBdVertex( v ) )
+        if ( topology.isBdVertex( v ) )
             stabilizers[v] = settings.bdStabilizer;
 
     InterpolateScalarsParams params
@@ -126,14 +132,13 @@ void smoothCameraMeshDepth( Mesh & mesh, const SmoothCameraMeshDepthSettings & s
         .edgeWeights = settings.edgeWeights,
         .vertStabilizers = [&stabilizers]( VertId v ) { return stabilizers[v]; }
     };
-    interpolateScalarsSmoothly( mesh.topology, projected, depth, params );
+    interpolateScalarsSmoothly( topology, projected, depth, params );
     BitSetParallelFor( verts, [&]( VertId v )
     {
-        auto & p = mesh.points[v];
+        auto & p = points[v];
         if ( p.z > 0 && depth[v] > 0 )
             p *= depth[v] / p.z;
     } );
-    mesh.invalidateCaches();
 }
 
 Expected<Mesh> triangulateCameraPoints( const PointCloud & cloud, const CameraPointsTriangulationSettings & settings, const ProgressCallback & cb )

--- a/source/MRMesh/MRCameraPointsTriangulation.cpp
+++ b/source/MRMesh/MRCameraPointsTriangulation.cpp
@@ -3,6 +3,7 @@
 #include "MRPointCloud.h"
 #include "MRDelaunayTriangulationXY.h"
 #include "MRCloseVertices.h"
+#include "MRMeshMath.h"
 #include "MRBitSetParallelFor.h"
 #include "MRTimer.h"
 
@@ -78,12 +79,12 @@ Expected<Mesh> triangulateCameraPoints( const VertCoords & points, const CameraP
     return triangulateCameraPoints( points, nullptr, settings, cb );
 }
 
-void smoothCameraMeshDepth( Mesh & mesh, const InterpolateScalarsParams & params )
+void smoothCameraMeshDepth( Mesh & mesh, const SmoothCameraMeshDepthSettings & settings )
 {
     MR_TIMER;
-    const auto & verts = mesh.topology.getVertIds( params.region );
+    const auto & verts = mesh.topology.getVertIds( settings.region );
     VertScalars depth( mesh.points.size() );
-    // the mesh projected in the image plane (normalized coordinates), where edge weights and vertex masses are computed
+    // the mesh projected in the image plane (normalized coordinates), where edge weights and vertex areas are computed
     VertCoords projected( mesh.points.size() );
     BitSetParallelFor( mesh.topology.getValidVerts(), [&]( VertId v )
     {
@@ -91,6 +92,40 @@ void smoothCameraMeshDepth( Mesh & mesh, const InterpolateScalarsParams & params
         depth[v] = p.z;
         projected[v] = Vector3f( p.x / p.z, -p.y / p.z, 1 );
     } );
+
+    VertScalars stabilizers( mesh.points.size(), settings.innerStabilizer );
+    if ( settings.innerStabilizerType != AreaStabilizer::Uniform )
+    {
+        BitSetParallelFor( verts, [&]( VertId v )
+        {
+            const auto a = dblArea( mesh.topology, projected, v );
+            stabilizers[v] = settings.innerStabilizerType == AreaStabilizer::Area ? a : sqr( a );
+        } );
+        double sum = 0;
+        int n = 0;
+        for ( auto v : verts )
+        {
+            if ( mesh.topology.isBdVertex( v ) )
+                continue;
+            sum += stabilizers[v];
+            ++n;
+        }
+        const float k = sum > 0 ? float( settings.innerStabilizer * n / sum ) : 0;
+        BitSetParallelFor( verts, [&]( VertId v )
+        {
+            stabilizers[v] *= k;
+        } );
+    }
+    for ( auto v : verts )
+        if ( mesh.topology.isBdVertex( v ) )
+            stabilizers[v] = settings.bdStabilizer;
+
+    InterpolateScalarsParams params
+    {
+        .region = settings.region,
+        .edgeWeights = settings.edgeWeights,
+        .vertStabilizers = [&stabilizers]( VertId v ) { return stabilizers[v]; }
+    };
     interpolateScalarsSmoothly( mesh.topology, projected, depth, params );
     BitSetParallelFor( verts, [&]( VertId v )
     {

--- a/source/MRMesh/MRCameraPointsTriangulation.cpp
+++ b/source/MRMesh/MRCameraPointsTriangulation.cpp
@@ -78,6 +78,25 @@ Expected<Mesh> triangulateCameraPoints( const VertCoords & points, const CameraP
     return triangulateCameraPoints( points, nullptr, settings, cb );
 }
 
+void smoothCameraMeshDepth( Mesh & mesh, const InterpolateScalarsParams & params )
+{
+    MR_TIMER;
+    const auto & verts = mesh.topology.getVertIds( params.region );
+    VertScalars depth( mesh.points.size() );
+    BitSetParallelFor( verts, [&]( VertId v )
+    {
+        depth[v] = mesh.points[v].z;
+    } );
+    interpolateScalarsSmoothly( mesh.topology, depth, params );
+    BitSetParallelFor( verts, [&]( VertId v )
+    {
+        auto & p = mesh.points[v];
+        if ( p.z > 0 && depth[v] > 0 )
+            p *= depth[v] / p.z;
+    } );
+    mesh.invalidateCaches();
+}
+
 Expected<Mesh> triangulateCameraPoints( const PointCloud & cloud, const CameraPointsTriangulationSettings & settings, const ProgressCallback & cb )
 {
     return triangulateCameraPoints( cloud.points, &cloud.validPoints, settings, cb );

--- a/source/MRMesh/MRCameraPointsTriangulation.cpp
+++ b/source/MRMesh/MRCameraPointsTriangulation.cpp
@@ -83,11 +83,15 @@ void smoothCameraMeshDepth( Mesh & mesh, const InterpolateScalarsParams & params
     MR_TIMER;
     const auto & verts = mesh.topology.getVertIds( params.region );
     VertScalars depth( mesh.points.size() );
-    BitSetParallelFor( verts, [&]( VertId v )
+    // the mesh projected in the image plane (normalized coordinates), where edge weights and vertex masses are computed
+    VertCoords projected( mesh.points.size() );
+    BitSetParallelFor( mesh.topology.getValidVerts(), [&]( VertId v )
     {
-        depth[v] = mesh.points[v].z;
+        const auto & p = mesh.points[v];
+        depth[v] = p.z;
+        projected[v] = Vector3f( p.x / p.z, -p.y / p.z, 1 );
     } );
-    interpolateScalarsSmoothly( mesh.topology, depth, params );
+    interpolateScalarsSmoothly( mesh.topology, projected, depth, params );
     BitSetParallelFor( verts, [&]( VertId v )
     {
         auto & p = mesh.points[v];

--- a/source/MRMesh/MRCameraPointsTriangulation.h
+++ b/source/MRMesh/MRCameraPointsTriangulation.h
@@ -44,7 +44,8 @@ struct CameraPointsTriangulationSettings
 
 /// Reduces the depth noise of a mesh produced by triangulateCameraPoints (camera at the origin looking along +Z):
 /// the depth (z) field is made smooth by interpolateScalarsSmoothly with given parameters (params.stabilizer > 0 keeps
-/// every vertex attracted to its measured depth), and every vertex is moved along its viewing ray to the new depth,
+/// every vertex attracted to its measured depth; params.edgeWeights and params.vmass are computed on the mesh projected
+/// in the image plane), and every vertex is moved along its viewing ray to the new depth,
 /// so the projection of the mesh in the image plane and its absence of self-intersections are preserved
 MRMESH_API void smoothCameraMeshDepth( Mesh & mesh, const InterpolateScalarsParams & params );
 

--- a/source/MRMesh/MRCameraPointsTriangulation.h
+++ b/source/MRMesh/MRCameraPointsTriangulation.h
@@ -73,5 +73,6 @@ struct SmoothCameraMeshDepthSettings
 /// (computed on the mesh projected in the image plane), and every vertex is moved along its viewing ray to the new depth,
 /// so the projection of the mesh in the image plane and its absence of self-intersections are preserved
 MRMESH_API void smoothCameraMeshDepth( Mesh & mesh, const SmoothCameraMeshDepthSettings & settings = {} );
+MRMESH_API void smoothCameraMeshDepth( const MeshTopology & topology, VertCoords & points, const SmoothCameraMeshDepthSettings & settings = {} );
 
 } //namespace MR

--- a/source/MRMesh/MRCameraPointsTriangulation.h
+++ b/source/MRMesh/MRCameraPointsTriangulation.h
@@ -42,11 +42,36 @@ struct CameraPointsTriangulationSettings
 /// same as above, but moves cloud points into the resulting mesh instead of copying them
 [[nodiscard]] MRMESH_API Expected<Mesh> triangulateCameraPoints( PointCloud && cloud, const CameraPointsTriangulationSettings & settings, const ProgressCallback & cb = {} );
 
+/// how the stabilizer of an inner vertex depends on the area of its neighborhood in the image plane
+enum class AreaStabilizer
+{
+    Uniform,  ///< all inner vertices have the same stabilizer
+    Area,     ///< proportional to the neighborhood area (dense regions are smoothed the same as sparse ones)
+    AreaSq    ///< proportional to the squared neighborhood area (dense regions are smoothed more than sparse ones)
+};
+
+struct SmoothCameraMeshDepthSettings
+{
+    /// vertices where the depth is smoothed, nullptr means all vertices
+    const VertBitSet * region = nullptr;
+
+    /// weights of edges in the equations, computed on the mesh projected in the image plane
+    EdgeWeights edgeWeights = EdgeWeights::Cotan;
+
+    /// stabilizer of every boundary vertex of the mesh: the more the value, the bigger attraction of the vertex to its measured depth
+    float bdStabilizer = 10;
+
+    /// average stabilizer of inner vertices
+    float innerStabilizer = 1;
+
+    /// distribution of innerStabilizer among inner vertices
+    AreaStabilizer innerStabilizerType = AreaStabilizer::AreaSq;
+};
+
 /// Reduces the depth noise of a mesh produced by triangulateCameraPoints (camera at the origin looking along +Z):
-/// the depth (z) field is made smooth by interpolateScalarsSmoothly with given parameters (params.stabilizer > 0 keeps
-/// every vertex attracted to its measured depth; params.edgeWeights and params.vmass are computed on the mesh projected
-/// in the image plane), and every vertex is moved along its viewing ray to the new depth,
+/// the depth (z) field is made smooth by interpolateScalarsSmoothly with the stabilizers and edge weights given above
+/// (computed on the mesh projected in the image plane), and every vertex is moved along its viewing ray to the new depth,
 /// so the projection of the mesh in the image plane and its absence of self-intersections are preserved
-MRMESH_API void smoothCameraMeshDepth( Mesh & mesh, const InterpolateScalarsParams & params );
+MRMESH_API void smoothCameraMeshDepth( Mesh & mesh, const SmoothCameraMeshDepthSettings & settings = {} );
 
 } //namespace MR

--- a/source/MRMesh/MRCameraPointsTriangulation.h
+++ b/source/MRMesh/MRCameraPointsTriangulation.h
@@ -4,6 +4,7 @@
 #include "MRMatrix3.h"
 #include "MRExpected.h"
 #include "MRProgressCallback.h"
+#include "MRPositionVertsSmoothly.h"
 
 namespace MR
 {
@@ -40,5 +41,11 @@ struct CameraPointsTriangulationSettings
 
 /// same as above, but moves cloud points into the resulting mesh instead of copying them
 [[nodiscard]] MRMESH_API Expected<Mesh> triangulateCameraPoints( PointCloud && cloud, const CameraPointsTriangulationSettings & settings, const ProgressCallback & cb = {} );
+
+/// Reduces the depth noise of a mesh produced by triangulateCameraPoints (camera at the origin looking along +Z):
+/// the depth (z) field is made smooth by interpolateScalarsSmoothly with given parameters (params.stabilizer > 0 keeps
+/// every vertex attracted to its measured depth), and every vertex is moved along its viewing ray to the new depth,
+/// so the projection of the mesh in the image plane and its absence of self-intersections are preserved
+MRMESH_API void smoothCameraMeshDepth( Mesh & mesh, const InterpolateScalarsParams & params );
 
 } //namespace MR

--- a/source/MRTest/MRCameraPointsTriangulationTests.cpp
+++ b/source/MRTest/MRCameraPointsTriangulationTests.cpp
@@ -3,7 +3,9 @@
 #include "MRMesh/MREdgeIterator.h"
 #include "MRMesh/MRMeshFixer.h"
 #include "MRMesh/MRPointCloud.h"
+#include "MRMesh/MRVector2.h"
 #include <gtest/gtest.h>
+#include <cmath>
 
 namespace MR
 {
@@ -100,6 +102,48 @@ TEST( MRMesh, TriangulateCameraPoints )
     EXPECT_LT( open.topology.numValidFaces(), bridged->topology.numValidFaces() );
     for ( UndirectedEdgeId ue : undirectedEdges( open.topology ) )
         EXPECT_LE( open.edgeLength( ue ), 1.5f );
+}
+
+TEST( MRMesh, SmoothCameraMeshDepth )
+{
+    // tilted plane (a harmonic depth field) sampled on a grid with a deterministic depth noise;
+    // the smoothing must bring the vertices closer to the plane while keeping their projections;
+    // the error is measured away from the boundary, where the one-sided neighborhoods bend the harmonic field
+    constexpr int cHalf = 10;
+    VertCoords exact, noisy;
+    VertBitSet interior;
+    for ( int i = -cHalf; i <= cHalf; ++i )
+        for ( int j = -cHalf; j <= cHalf; ++j )
+        {
+            const float z = 100 + 0.05f * i + 0.02f * j;
+            interior.autoResizeSet( VertId( int( exact.size() ) ), std::abs( i ) <= cHalf - 3 && std::abs( j ) <= cHalf - 3 );
+            exact.emplace_back( float( i ), float( j ), z );
+            const float noise = 0.1f * ( ( ( i * 7 + j * 13 ) % 5 + 5 ) % 5 - 2 ); // in [-0.2, 0.2]
+            noisy.push_back( exact.back() * ( ( z + noise ) / z ) );      // along the viewing ray
+        }
+    CameraPointsTriangulationSettings settings;
+    settings.intrinsics = Matrix3f( { 1000, 0, 500 }, { 0, 1000, 500 }, { 0, 0, 1 } );
+    settings.weldPixels = 0;
+    auto mesh = triangulateCameraPoints( noisy, settings );
+    ASSERT_TRUE( mesh.has_value() );
+    ASSERT_EQ( mesh->points.size(), exact.size() );
+
+    auto rmsError = [&]( const VertCoords & pts )
+    {
+        double sum = 0;
+        for ( VertId v : interior )
+            sum += sqr( pts[v].z - exact[v].z );
+        return std::sqrt( sum / interior.count() );
+    };
+    const auto errBefore = rmsError( mesh->points );
+    smoothCameraMeshDepth( *mesh, { .stabilizer = 0.1f } );
+    const auto errAfter = rmsError( mesh->points );
+    EXPECT_LT( errAfter, 0.5 * errBefore );
+    for ( VertId v( 0 ); v < exact.size(); ++v )
+    {
+        const auto & p = mesh->points[v];
+        EXPECT_LT( ( Vector2f( p.x / p.z, p.y / p.z ) - Vector2f( exact[v].x / exact[v].z, exact[v].y / exact[v].z ) ).length(), 1e-6f );
+    }
 }
 
 } //namespace MR

--- a/source/MRTest/MRCameraPointsTriangulationTests.cpp
+++ b/source/MRTest/MRCameraPointsTriangulationTests.cpp
@@ -106,17 +106,14 @@ TEST( MRMesh, TriangulateCameraPoints )
 
 TEST( MRMesh, SmoothCameraMeshDepth )
 {
-    // tilted plane (a harmonic depth field) sampled on a grid with a deterministic depth noise;
-    // the smoothing must bring the vertices closer to the plane while keeping their projections;
-    // the error is measured away from the boundary, where the one-sided neighborhoods bend the harmonic field
+    // constant depth (a harmonic field even at the grid boundary) sampled on a grid with a deterministic depth noise;
+    // the smoothing must bring the vertices closer to the plane while keeping their projections
     constexpr int cHalf = 10;
     VertCoords exact, noisy;
-    VertBitSet interior;
     for ( int i = -cHalf; i <= cHalf; ++i )
         for ( int j = -cHalf; j <= cHalf; ++j )
         {
-            const float z = 100 + 0.05f * i + 0.02f * j;
-            interior.autoResizeSet( VertId( int( exact.size() ) ), std::abs( i ) <= cHalf - 3 && std::abs( j ) <= cHalf - 3 );
+            const float z = 100;
             exact.emplace_back( float( i ), float( j ), z );
             const float noise = 0.1f * ( ( ( i * 7 + j * 13 ) % 5 + 5 ) % 5 - 2 ); // in [-0.2, 0.2]
             noisy.push_back( exact.back() * ( ( z + noise ) / z ) );      // along the viewing ray
@@ -131,9 +128,9 @@ TEST( MRMesh, SmoothCameraMeshDepth )
     auto rmsError = [&]( const VertCoords & pts )
     {
         double sum = 0;
-        for ( VertId v : interior )
+        for ( VertId v( 0 ); v < pts.size(); ++v )
             sum += sqr( pts[v].z - exact[v].z );
-        return std::sqrt( sum / interior.count() );
+        return std::sqrt( sum / pts.size() );
     };
     const auto errBefore = rmsError( mesh->points );
     smoothCameraMeshDepth( *mesh, { .stabilizer = 0.1f } );

--- a/source/MRTest/MRCameraPointsTriangulationTests.cpp
+++ b/source/MRTest/MRCameraPointsTriangulationTests.cpp
@@ -133,13 +133,16 @@ TEST( MRMesh, SmoothCameraMeshDepth )
         return std::sqrt( sum / pts.size() );
     };
     const auto errBefore = rmsError( mesh->points );
-    smoothCameraMeshDepth( *mesh, { .stabilizer = 0.1f } );
-    const auto errAfter = rmsError( mesh->points );
-    EXPECT_LT( errAfter, 0.5 * errBefore );
-    for ( VertId v( 0 ); v < exact.size(); ++v )
+    for ( auto edgeWeights : { EdgeWeights::Unit, EdgeWeights::Cotan } )
     {
-        const auto & p = mesh->points[v];
-        EXPECT_LT( ( Vector2f( p.x / p.z, p.y / p.z ) - Vector2f( exact[v].x / exact[v].z, exact[v].y / exact[v].z ) ).length(), 1e-6f );
+        Mesh smoothed = *mesh;
+        smoothCameraMeshDepth( smoothed, { .edgeWeights = edgeWeights, .stabilizer = 0.1f } );
+        EXPECT_LT( rmsError( smoothed.points ), 0.5 * errBefore );
+        for ( VertId v( 0 ); v < exact.size(); ++v )
+        {
+            const auto & p = smoothed.points[v];
+            EXPECT_LT( ( Vector2f( p.x / p.z, p.y / p.z ) - Vector2f( exact[v].x / exact[v].z, exact[v].y / exact[v].z ) ).length(), 1e-6f );
+        }
     }
 }
 

--- a/source/MRTest/MRCameraPointsTriangulationTests.cpp
+++ b/source/MRTest/MRCameraPointsTriangulationTests.cpp
@@ -134,16 +134,38 @@ TEST( MRMesh, SmoothCameraMeshDepth )
     };
     const auto errBefore = rmsError( mesh->points );
     for ( auto edgeWeights : { EdgeWeights::Unit, EdgeWeights::Cotan } )
-    {
-        Mesh smoothed = *mesh;
-        smoothCameraMeshDepth( smoothed, { .edgeWeights = edgeWeights, .stabilizer = 0.1f } );
-        EXPECT_LT( rmsError( smoothed.points ), 0.5 * errBefore );
-        for ( VertId v( 0 ); v < exact.size(); ++v )
+        for ( auto type : { AreaStabilizer::Uniform, AreaStabilizer::Area, AreaStabilizer::AreaSq } )
         {
-            const auto & p = smoothed.points[v];
-            EXPECT_LT( ( Vector2f( p.x / p.z, p.y / p.z ) - Vector2f( exact[v].x / exact[v].z, exact[v].y / exact[v].z ) ).length(), 1e-6f );
+            Mesh smoothed = *mesh;
+            smoothCameraMeshDepth( smoothed, { .edgeWeights = edgeWeights, .bdStabilizer = 0.1f, .innerStabilizer = 0.1f, .innerStabilizerType = type } );
+            EXPECT_LT( rmsError( smoothed.points ), 0.5 * errBefore );
+            for ( VertId v( 0 ); v < exact.size(); ++v )
+            {
+                const auto & p = smoothed.points[v];
+                EXPECT_LT( ( Vector2f( p.x / p.z, p.y / p.z ) - Vector2f( exact[v].x / exact[v].z, exact[v].y / exact[v].z ) ).length(), 1e-6f );
+            }
+        }
+
+    // with the default settings the boundary vertices are attracted to their noisy depths much stronger than inner ones
+    Mesh smoothed = *mesh;
+    smoothCameraMeshDepth( smoothed );
+    double bdMove = 0, innerMove = 0;
+    int nBd = 0, nInner = 0;
+    for ( VertId v( 0 ); v < exact.size(); ++v )
+    {
+        const auto move = std::abs( smoothed.points[v].z - mesh->points[v].z );
+        if ( smoothed.topology.isBdVertex( v ) )
+        {
+            bdMove += move;
+            ++nBd;
+        }
+        else
+        {
+            innerMove += move;
+            ++nInner;
         }
     }
+    EXPECT_LT( bdMove / nBd, 0.5 * innerMove / nInner );
 }
 
 } //namespace MR

--- a/source/MRTest/MRCameraPointsTriangulationTests.cpp
+++ b/source/MRTest/MRCameraPointsTriangulationTests.cpp
@@ -149,6 +149,9 @@ TEST( MRMesh, SmoothCameraMeshDepth )
     // with the default settings the boundary vertices are attracted to their noisy depths much stronger than inner ones
     Mesh smoothed = *mesh;
     smoothCameraMeshDepth( smoothed );
+    VertCoords points2 = mesh->points;
+    smoothCameraMeshDepth( mesh->topology, points2 );
+    EXPECT_EQ( points2, smoothed.points );
     double bdMove = 0, innerMove = 0;
     int nBd = 0, nInner = 0;
     for ( VertId v( 0 ); v < exact.size(); ++v )


### PR DESCRIPTION
New `smoothCameraMeshDepth( Mesh&, const SmoothCameraMeshDepthSettings& = {} )` and `smoothCameraMeshDepth( const MeshTopology&, VertCoords&, ... )` in `MRMesh/MRCameraPointsTriangulation.h`: a depth denoiser for meshes produced by `triangulateCameraPoints` (#6787).

The z coordinate of every vertex (in `region`, default all) is taken as a scalar field and smoothed by `interpolateScalarsSmoothly`, with edge weights (`edgeWeights`, default Cotan) and vertex neighbourhood areas computed on the mesh **projected in the image plane** (normalized coordinates `( x/z, -y/z, 1 )`), i.e. on the planar domain of the height field. Then every vertex is moved **along its viewing ray** to the new depth (`p *= zNew / zOld`), so the projection of the mesh is unchanged and it stays a height field without self-intersections.

Stabilizers (attraction of a vertex to its measured depth):
- `bdStabilizer = 10` for every boundary vertex of the mesh;
- `innerStabilizer = 1` is the **mean** over inner vertices, distributed by `innerStabilizerType`: `Uniform`, `Area` (proportional to the projected neighbourhood area, i.e. a lumped mass matrix: dense and sparse regions are smoothed equally), or `AreaSq` (default; proportional to the squared area: dense regions are smoothed more, sparse ones less).

Measured on a real intra-oral frame (17,455 vertices, cotan weights, boundary 10), mean (p90) dihedral angle between adjacent faces as roughness, 33.9° (77.4°) before smoothing:

| inner stabilizer mean | Uniform | Area | AreaSq |
|---|---|---|---|
| 1 | 6.55° (13.85°), move 0.074 mm | 5.99° (13.10°), 0.075 mm | 5.20° (12.09°), 0.084 mm |
| 0.1 | 3.22° (6.95°), 0.123 mm | 3.14° (7.01°), 0.127 mm | 3.12° (7.33°), 0.145 mm |

Why area weighting helps: with cotan weights the Laplacian term is the integrated one, `A_i · Δz`, so a uniform stabilizer gives the effective data weight `s / A_i`, strongest where the mesh is dense; `s_i ∝ A_i` makes it uniform, and `s_i ∝ A_i²` shifts stiffness from the dense regions (most edges, the same noise) to the isolated vertices (least reliable). Stabilizers proportional to `1/A` or `1/sqrt(A)` were measured worse than uniform. Cotan vs unit edge weights at the same stabilizer: 2.7° vs 8.6° at 0.1, 6.4° vs 11.3° at 1 (free boundary).

The unit test smooths a grid at constant depth with a deterministic noise (a constant is harmonic even at the grid boundary, where one-sided neighbourhoods bend a tilted plane) for both edge weights and all three stabilizer types, checks that the RMS error at least halves and that every projection is preserved to 1e-6, and that with the default settings the boundary vertices move less than half as much as the inner ones.
