### PR TITLE
interpolateScalarsSmoothly(): EdgeWeights and VertexMass in params, overloads taking mesh points

### DIFF
--- a/source/MRMesh/MRPositionVertsSmoothly.cpp
+++ b/source/MRMesh/MRPositionVertsSmoothly.cpp
@@ -150,7 +150,12 @@ void positionVertsSmoothlySharpBd( const MeshTopology& topology, VertCoords& poi
     }
 }
 
-void interpolateScalarsSmoothly( const MeshTopology& topology, VertScalars& field, const InterpolateScalarsParams& params )
+void interpolateScalarsSmoothly( const Mesh& mesh, VertScalars& field, const InterpolateScalarsParams& params )
+{
+    interpolateScalarsSmoothly( mesh.topology, mesh.points, field, params );
+}
+
+void interpolateScalarsSmoothly( const MeshTopology& topology, const VertCoords& points, VertScalars& field, const InterpolateScalarsParams& params )
 {
     MR_TIMER;
     assert( params.stabilizer > 0 || params.vertStabilizers || ( params.region && !MeshComponents::hasFullySelectedComponent( topology, *params.region ) ) );
@@ -160,9 +165,23 @@ void interpolateScalarsSmoothly( const MeshTopology& topology, VertScalars& fiel
     if ( sz <= 0 )
         return;
 
+    UndirectedEdgeMetric edgeWeights = params.edgeWeightsMetric;
+    if ( !edgeWeights && params.edgeWeights == EdgeWeights::Cotan )
+        edgeWeights = [&topology, &points]( UndirectedEdgeId ue )
+        {
+            return std::clamp( cotan( topology, points, ue ), -1.0f, 10.0f ); // cotan() can be arbitrary high for degenerate edges
+        };
+
+    VertMetric vertStabilizers = params.vertStabilizers;
+    if ( params.vmass == VertexMass::NeiArea )
+        vertStabilizers = [&topology, &points, s = params.stabilizer, vs = params.vertStabilizers]( VertId v )
+        {
+            return ( vs ? vs( v ) : s ) * dblArea( topology, points, v );
+        };
+
     Eigen::VectorXd rhs( sz );
     Eigen::SimplicialLDLT<SparseMatrix> solver;
-    solver.compute( prepareLaplaceEquations( topology, verts, params.stabilizer, params.vertStabilizers, params.edgeWeights,
+    solver.compute( prepareLaplaceEquations( topology, verts, params.stabilizer, vertStabilizers, edgeWeights,
         [&]( VertId v ) { return double( field[v] ); },
         []( VertId ) { return 0.0; },
         [&]( int n, double r ) { rhs[n] = r; } ) );

--- a/source/MRMesh/MRPositionVertsSmoothly.cpp
+++ b/source/MRMesh/MRPositionVertsSmoothly.cpp
@@ -174,10 +174,18 @@ void interpolateScalarsSmoothly( const MeshTopology& topology, const VertCoords&
 
     VertMetric vertStabilizers = params.vertStabilizers;
     if ( params.vmass == VertexMass::NeiArea )
-        vertStabilizers = [&topology, &points, s = params.stabilizer, vs = params.vertStabilizers]( VertId v )
-        {
-            return ( vs ? vs( v ) : s ) * dblArea( topology, points, v );
-        };
+    {
+        if ( params.vertStabilizers )
+            vertStabilizers = [&topology, &points, &vs = params.vertStabilizers]( VertId v )
+            {
+                return vs( v ) * dblArea( topology, points, v );
+            };
+        else
+            vertStabilizers = [&topology, &points, s = params.stabilizer]( VertId v )
+            {
+                return s * dblArea( topology, points, v );
+            };
+    }
 
     Eigen::VectorXd rhs( sz );
     Eigen::SimplicialLDLT<SparseMatrix> solver;

--- a/source/MRMesh/MRPositionVertsSmoothly.cpp
+++ b/source/MRMesh/MRPositionVertsSmoothly.cpp
@@ -155,9 +155,40 @@ void interpolateScalarsSmoothly( const Mesh& mesh, VertScalars& field, const Int
     interpolateScalarsSmoothly( mesh.topology, mesh.points, field, params );
 }
 
-void interpolateScalarsSmoothly( const MeshTopology& topology, const VertCoords& points, VertScalars& field, const InterpolateScalarsParams& params )
+void interpolateScalarsSmoothly( const MeshTopology& topology, const VertCoords& points, VertScalars& field, const InterpolateScalarsParams& params0 )
 {
     MR_TIMER;
+    InterpolateScalarsParams params = params0;
+
+    if ( !params.edgeWeightsMetric && params.edgeWeights == EdgeWeights::Cotan )
+        params.edgeWeightsMetric = [&topology, &points]( UndirectedEdgeId ue )
+        {
+            return std::clamp( cotan( topology, points, ue ), -1.0f, 10.0f ); // cotan() can be arbitrary high for degenerate edges
+        };
+    params.edgeWeights = EdgeWeights::Unit;
+
+    if ( params.vmass == VertexMass::NeiArea )
+    {
+        if ( params0.vertStabilizers )
+            params.vertStabilizers = [&topology, &points, &vs = params0.vertStabilizers]( VertId v )
+            {
+                return vs( v ) * dblArea( topology, points, v );
+            };
+        else
+            params.vertStabilizers = [&topology, &points, s = params0.stabilizer]( VertId v )
+            {
+                return s * dblArea( topology, points, v );
+            };
+        params.vmass = VertexMass::Unit;
+    }
+
+    interpolateScalarsSmoothly( topology, field, params );
+}
+
+void interpolateScalarsSmoothly( const MeshTopology& topology, VertScalars& field, const InterpolateScalarsParams& params )
+{
+    MR_TIMER;
+    assert( params.edgeWeights == EdgeWeights::Unit && params.vmass == VertexMass::Unit ); // otherwise mesh points are required
     assert( params.stabilizer > 0 || params.vertStabilizers || ( params.region && !MeshComponents::hasFullySelectedComponent( topology, *params.region ) ) );
 
     const auto & verts = topology.getVertIds( params.region );
@@ -165,31 +196,9 @@ void interpolateScalarsSmoothly( const MeshTopology& topology, const VertCoords&
     if ( sz <= 0 )
         return;
 
-    UndirectedEdgeMetric edgeWeights = params.edgeWeightsMetric;
-    if ( !edgeWeights && params.edgeWeights == EdgeWeights::Cotan )
-        edgeWeights = [&topology, &points]( UndirectedEdgeId ue )
-        {
-            return std::clamp( cotan( topology, points, ue ), -1.0f, 10.0f ); // cotan() can be arbitrary high for degenerate edges
-        };
-
-    VertMetric vertStabilizers = params.vertStabilizers;
-    if ( params.vmass == VertexMass::NeiArea )
-    {
-        if ( params.vertStabilizers )
-            vertStabilizers = [&topology, &points, &vs = params.vertStabilizers]( VertId v )
-            {
-                return vs( v ) * dblArea( topology, points, v );
-            };
-        else
-            vertStabilizers = [&topology, &points, s = params.stabilizer]( VertId v )
-            {
-                return s * dblArea( topology, points, v );
-            };
-    }
-
     Eigen::VectorXd rhs( sz );
     Eigen::SimplicialLDLT<SparseMatrix> solver;
-    solver.compute( prepareLaplaceEquations( topology, verts, params.stabilizer, vertStabilizers, edgeWeights,
+    solver.compute( prepareLaplaceEquations( topology, verts, params.stabilizer, params.vertStabilizers, params.edgeWeightsMetric,
         [&]( VertId v ) { return double( field[v] ); },
         []( VertId ) { return 0.0; },
         [&]( int n, double r ) { rhs[n] = r; } ) );

--- a/source/MRMesh/MRPositionVertsSmoothly.h
+++ b/source/MRMesh/MRPositionVertsSmoothly.h
@@ -67,6 +67,8 @@ struct InterpolateScalarsParams
 /// with non-negative edge weights and zero stabilizers, the computed values never leave the range of the fixed values
 MRMESH_API void interpolateScalarsSmoothly( const Mesh& mesh, VertScalars& field, const InterpolateScalarsParams& params );
 MRMESH_API void interpolateScalarsSmoothly( const MeshTopology& topology, const VertCoords& points, VertScalars& field, const InterpolateScalarsParams& params );
+/// this overload has no access to mesh points, so it requires params.edgeWeights == EdgeWeights::Unit and params.vmass == VertexMass::Unit
+MRMESH_API void interpolateScalarsSmoothly( const MeshTopology& topology, VertScalars& field, const InterpolateScalarsParams& params );
 
 struct SpacingSettings
 {

--- a/source/MRMesh/MRPositionVertsSmoothly.h
+++ b/source/MRMesh/MRPositionVertsSmoothly.h
@@ -46,20 +46,27 @@ struct InterpolateScalarsParams
     /// it must not include all vertices of a mesh connected component unless stabilizer > 0
     const VertBitSet* region = nullptr;
 
+    /// weights of edges in the equations, used unless \p edgeWeightsMetric is specified
+    EdgeWeights edgeWeights = EdgeWeights::Unit;
+
+    /// the stabilizer of each vertex is multiplied on the mass of that vertex
+    VertexMass vmass = VertexMass::Unit;
+
     /// the more the value, the bigger attraction of each vertex to its original value
     float stabilizer = 0;
 
     /// if specified then it is used instead of \p stabilizer
     VertMetric vertStabilizers;
 
-    /// if specified then it is used for edge weights instead of default 1
-    UndirectedEdgeMetric edgeWeights;
+    /// if specified then it is used for edge weights instead of \p edgeWeights
+    UndirectedEdgeMetric edgeWeightsMetric;
 };
 
 /// Computes the values of scalar field in region vertices to make it harmonic there:
 /// each value becomes the weighted mean of the values in neighbor vertices, while the values in all other vertices remain fixed;
 /// with non-negative edge weights and zero stabilizers, the computed values never leave the range of the fixed values
-MRMESH_API void interpolateScalarsSmoothly( const MeshTopology& topology, VertScalars& field, const InterpolateScalarsParams& params );
+MRMESH_API void interpolateScalarsSmoothly( const Mesh& mesh, VertScalars& field, const InterpolateScalarsParams& params );
+MRMESH_API void interpolateScalarsSmoothly( const MeshTopology& topology, const VertCoords& points, VertScalars& field, const InterpolateScalarsParams& params );
 
 struct SpacingSettings
 {

--- a/source/MRTest/MRPositionVertsSmoothlyTests.cpp
+++ b/source/MRTest/MRPositionVertsSmoothlyTests.cpp
@@ -23,7 +23,7 @@ TEST( MRMesh, InterpolateScalarsSmoothly )
         else if ( z > 0 )
             field[v] = 1;
     }
-    interpolateScalarsSmoothly( sphere, field, { .region = &region } );
+    interpolateScalarsSmoothly( topology, field, { .region = &region } );
 
     for ( auto v : region )
     {

--- a/source/MRTest/MRPositionVertsSmoothlyTests.cpp
+++ b/source/MRTest/MRPositionVertsSmoothlyTests.cpp
@@ -23,7 +23,7 @@ TEST( MRMesh, InterpolateScalarsSmoothly )
         else if ( z > 0 )
             field[v] = 1;
     }
-    interpolateScalarsSmoothly( topology, field, { .region = &region } );
+    interpolateScalarsSmoothly( sphere, field, { .region = &region } );
 
     for ( auto v : region )
     {
@@ -43,6 +43,17 @@ TEST( MRMesh, InterpolateScalarsSmoothly )
     // by symmetry the values on the equator are in the middle
     for ( auto v : region )
     {
+        if ( std::abs( sphere.points[v].z ) >= 1e-5f )
+            continue;
+        EXPECT_NEAR( field[v], 0.5f, 1e-5f );
+    }
+
+    // cotangent weights are positive on a sphere, so the same properties hold
+    interpolateScalarsSmoothly( sphere, field, { .region = &region, .edgeWeights = EdgeWeights::Cotan } );
+    for ( auto v : region )
+    {
+        EXPECT_GE( field[v], 0 );
+        EXPECT_LE( field[v], 1 );
         if ( std::abs( sphere.points[v].z ) >= 1e-5f )
             continue;
         EXPECT_NEAR( field[v], 0.5f, 1e-5f );


### PR DESCRIPTION
Follow-up to #6763, which accepted edge weights only as a custom metric and had no notion of vertex mass.

**`InterpolateScalarsParams`**
- New `EdgeWeights edgeWeights = EdgeWeights::Unit`: `Cotan` uses the same clamped cotangent as `Laplacian::init`.
- New `VertexMass vmass = VertexMass::Unit`: the stabilizer of each vertex is multiplied on its mass, `NeiArea` = double area of the first-ring triangles (lumped-mass fidelity term). Without a stabilizer the mass changes nothing, because scaling a homogeneous equation does not change its solution.
- The custom metric `edgeWeights` is renamed to `edgeWeightsMetric`; when set, it still overrides the enum.

**Overloads**
- New `interpolateScalarsSmoothly( const Mesh& mesh, ... )` and `( const MeshTopology& topology, const VertCoords& points, ... )`: they turn `Cotan` and `NeiArea` into metrics (both need mesh points) and call the topology-only overload with the enums reset to `Unit`.
- The existing `( const MeshTopology& topology, ... )` overload is kept unchanged for callers and now asserts `edgeWeights == Unit && vmass == Unit`, since it cannot compute either without points. #6794 keeps compiling as is.

**Test**: `MRMesh.InterpolateScalarsSmoothly` additionally runs the cotangent variant on a sphere and checks that the values stay in the range of the fixed ones and equal 0.5 on the equator.
