### PR TITLE
splitOnSimpleLoops: keep vmap's storage between passes

### DIFF
--- a/source/MRMesh/MREdgePaths.cpp
+++ b/source/MRMesh/MREdgePaths.cpp
@@ -52,7 +52,7 @@ std::vector<EdgeLoop> splitOnSimpleLoops( const MeshTopology & topology, std::ve
                     break;
                 }
             }
-            vmap.clear();
+            vmap.erase( vmap.begin(), vmap.end() ); // unlike clear(), keeps the storage of a large table for the next pass
             if ( split )
                 continue;
             res.push_back( std::move( loop ) );


### PR DESCRIPTION
`splitOnSimpleLoops` reuses one `HashMap<VertId, int>` across every pass over every loop and empties it with `clear()`. phmap's `clear()` deallocates the table whenever its capacity exceeds 127 slots ([phmap.h:1274](https://github.com/MeshInspector/MeshLib/blob/master/thirdparty/parallel-hashmap/parallel_hashmap/phmap.h#L1274)), so for any loop longer than about 112 vertices - the normal case for the boolean's cut loops and for `findLeftBoundary` splitting - each pass freed the map and the next one allocated and re-grew it from scratch. `erase( begin(), end() )` walks the elements and keeps the array.

Same fix as `intersectionsMap_` / `in2p_` in #6784; a scan of every `clear()` on a phmap-typed container in `source/` found this as the only other reused one (`VertNeighbourhoodInspector::l_/r_` are also reused, but sized by vertex degree, so they stay below the threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
