### PR TITLE
segmentIntersectionOrder(): fix for inputs with 7 or 8 distinct vertex ids reaching the polynomial path

### DIFF
--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -23,12 +23,14 @@ constexpr double cRangeIntMax = 0.99 * std::numeric_limits<int>::max(); // 0.99 
 struct PointDegree
 {
     Vector3i pt;
-    int d = 0; // degree of epsilon for pt.z
+    std::int64_t d = 0; // degree of epsilon for pt.z; pt.y gets 3*d, pt.x gets 9*d
 };
 
-// this value was found experimentally for segmentIntersectionOrder with all 8 points have equal coordinates (but different ids),
-// if it is not enough then we will get assert violation inside poly.isPositive(), and increase the value
-constexpr int cMaxPolyD = 14'941'836;
+// this value was found experimentally as the largest leading degree of the polynomials in segmentIntersectionOrder tests
+// (all 8 points have equal coordinates but different ids, and random degenerate inputs with 7 or 8 distinct ids),
+// if it is not enough then we will get assert violation inside poly.isPositive(), and increase the value;
+// all polynomial terms of higher degrees are not stored to save computation time
+constexpr std::int64_t cMaxPolyD = 430'467'210;
 
 std::array<PointDegree, 8> getPointDegrees( const std::array<PreciseVertCoords, 8> & vs )
 {
@@ -43,33 +45,25 @@ std::array<PointDegree, 8> getPointDegrees( const std::array<PreciseVertCoords, 
     std::sort( begin( as ), end( as ), []( const auto & a, const auto & b ) { return a.v < b.v; } );
 
     std::array<PointDegree, 8> res;
-    int d = 1;
-    constexpr int maxD = INT_MAX / 9;
-    static_assert( maxD > cMaxPolyD );
-    constexpr int preMaxD = maxD / 27;
+    std::int64_t d = 1;
     for ( int i = 0; i < 8; ++i )
     {
         const auto n = as[i].n;
         res[n] = { vs[n].pt, d };
         if ( i < 7 && as[i].v < as[i+1].v ) // skip to support triangles with shared vertices
-        {
-            if ( d <= preMaxD )
-                d *= 27; // normal power up
-            else if ( d <= maxD )
-                d = maxD; // to avoid integer overflow in orient3dPoly, assuming that such huge powers will never be necessary
-        }
+            d *= 27;
     }
     return res;
 }
 
 // 128 bits are enough to store all coefficients in ( orient3d(ta,s[0])*orient3d(tb,s[1]) - orient3d(tb,s[0])*orient3d(ta,s[1]) )
 // except for degree 0, which is computed separately.
-using Poly = SparsePolynomial<FastInt128, int, cMaxPolyD>;
+using Poly = SparsePolynomial<FastInt128, std::int64_t, cMaxPolyD>;
 
 Poly orient3dPoly( const PointDegree & a, const PointDegree & b, const PointDegree & c, const PointDegree & d,
-    int dy ) // degree.x = ( degree.y = degree.z * dy ) * dy
+    std::int64_t dy ) // degree.x = ( degree.y = degree.z * dy ) * dy
 {
-    const int dx = dy * dy;
+    const std::int64_t dx = dy * dy;
 
     const Poly xx( a.pt.x - d.pt.x, a.d * dx, 1, d.d * dx, -1 );
     const Poly xy( a.pt.y - d.pt.y, a.d * dy, 1, d.d * dy, -1 );

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -26,11 +26,11 @@ struct PointDegree
     std::int64_t d = 0; // degree of epsilon for pt.z; pt.y gets 3*d, pt.x gets 9*d
 };
 
-// this value was found experimentally as the largest leading degree of the polynomials in segmentIntersectionOrder tests
-// (all 8 points have equal coordinates but different ids, and random degenerate inputs with 7 or 8 distinct ids),
-// if it is not enough then we will get assert violation inside poly.isPositive(), and increase the value;
-// all polynomial terms of higher degrees are not stored to save computation time
-constexpr std::int64_t cMaxPolyD = 430'467'210;
+// this value was found experimentally as the largest degree of a polynomial term that must be stored in segmentIntersectionOrder
+// (the leading term of nom, or the leading term of at least one of two orient3d-polynomials for the segment's ends)
+// in the tests and in a random sweep of degenerate inputs; if it is not enough then we will get assert violation inside
+// poly.isPositive(), and increase the value; all polynomial terms of higher degrees are not stored to save computation time
+constexpr std::int64_t cMaxPolyD = 15'943'959;
 
 std::array<PointDegree, 8> getPointDegrees( const std::array<PreciseVertCoords, 8> & vs )
 {

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -1025,6 +1025,38 @@ TEST( MRMesh, segmentIntersectionOrder3b )
     EXPECT_FALSE( segmentIntersectionOrder( { vs[0], vs[1], vs[5], vs[6], vs[2], vs[2], vs[3], vs[4] } ) );
 }
 
+TEST( MRMesh, segmentIntersectionOrder3c )
+{
+    // degenerate inputs reaching the polynomial path with 7 or 8 distinct vertex ids,
+    // so the vertices with the largest ids must receive distinct (and huge) epsilon degrees
+    auto check = []( const std::array<PreciseVertCoords, 8> & vs, bool expected )
+    {
+        ASSERT_TRUE( doTriangleSegmentIntersect( { vs[2], vs[3], vs[4], vs[0], vs[1] } ) );
+        ASSERT_TRUE( doTriangleSegmentIntersect( { vs[5], vs[6], vs[7], vs[0], vs[1] } ) );
+        EXPECT_EQ( segmentIntersectionOrder( vs ), expected );
+        // swapped triangles
+        EXPECT_EQ( segmentIntersectionOrder( { vs[0], vs[1], vs[5], vs[6], vs[7], vs[2], vs[3], vs[4] } ), !expected );
+        // reversed segment
+        EXPECT_EQ( segmentIntersectionOrder( { vs[1], vs[0], vs[2], vs[3], vs[4], vs[5], vs[6], vs[7] } ), !expected );
+    };
+
+    // 8 distinct ids
+    check( {
+        PreciseVertCoords{ 12_v, Vector3i( 0,-1,-1 ) }, PreciseVertCoords{  1_v, Vector3i( 0, 1, 1 ) },
+        PreciseVertCoords{ 11_v, Vector3i( 1, 0, 0 ) }, PreciseVertCoords{  5_v, Vector3i(-1,-1,-1 ) }, PreciseVertCoords{ 0_v, Vector3i( 1, 0, 0 ) },
+        PreciseVertCoords{  4_v, Vector3i( 1, 0, 0 ) }, PreciseVertCoords{ 13_v, Vector3i(-1, 1, 1 ) }, PreciseVertCoords{ 6_v, Vector3i( 0,-1, 0 ) } }, true );
+
+    // 7 distinct ids: one shared vertex in ta and tb
+    check( {
+        PreciseVertCoords{  8_v, Vector3i( 1,-1, 0 ) }, PreciseVertCoords{ 10_v, Vector3i( 1,-1, 1 ) },
+        PreciseVertCoords{ 14_v, Vector3i( 1,-1, 1 ) }, PreciseVertCoords{  2_v, Vector3i( 0, 1, 0 ) }, PreciseVertCoords{ 4_v, Vector3i( 1, 1, 1 ) },
+        PreciseVertCoords{  5_v, Vector3i( 1, 1, 1 ) }, PreciseVertCoords{  0_v, Vector3i( 0, 1, 1 ) }, PreciseVertCoords{ 14_v, Vector3i( 1,-1, 1 ) } }, false );
+    check( {
+        PreciseVertCoords{ 12_v, Vector3i( 0, 0, 0 ) }, PreciseVertCoords{  8_v, Vector3i( 0, 0,-1 ) },
+        PreciseVertCoords{ 14_v, Vector3i( 0, 0, 0 ) }, PreciseVertCoords{  1_v, Vector3i( 0, 0,-1 ) }, PreciseVertCoords{ 0_v, Vector3i(-1, 1, 1 ) },
+        PreciseVertCoords{  2_v, Vector3i( 1, 1,-1 ) }, PreciseVertCoords{  4_v, Vector3i(-1, 0, 1 ) }, PreciseVertCoords{ 14_v, Vector3i( 0, 0, 0 ) } }, false );
+}
+
 TEST( MRMesh, getToIntConverter )
 {
     auto toInt = getToIntConverter( Box3d( {0,0,-1.0}, {0,0,1.0} ) );


### PR DESCRIPTION
`getPointDegrees` clamped the epsilon degrees to fit `int`: the vertices with the 7th and 8th smallest ids both received `maxD = INT_MAX/9`, and every polynomial term above `cMaxPolyD = 14'941'836` is dropped anyway. When the general (polynomial) path of `segmentIntersectionOrder` is reached with 7 or 8 distinct ids, this gives:
* in Debug: `assert( d1 != d2 )` in `SparsePolynomial` constructor, because two vertices got the same degree and one `orient3dPoly` contains both of them;
* in Release: silently inconsistent answers (e.g. swapping `ta` and `tb`, or reversing the segment, does not flip the result), because `cMaxPolyD` was smaller than the leading degree of `nom`, so `nom` lost all its terms and `isPositive()` returned `false` regardless of the input.

The fix:
* the degrees become `std::int64_t` and grow as `27^rank` for all 8 vertices, as `inSphere` does. This is not strictly necessary: `int` with distinct sentinel degrees above `cMaxPolyD` for the ranks 6 and 7 gives identical results, since every term of such a vertex is dropped anyway; `int64_t` was chosen only because it needs no clamping branch at all. Performance is the same: a polynomial term is `pair<degree, FastInt128>`, whose size does not depend on the degree type due to the alignment of `FastInt128`, and `PointDegree` itself is built once per call on the rare polynomial path only;
* `cMaxPolyD` remains an experimentally found cap of the stored degrees, but its meaning is refined. Dropping high-degree terms never changes lower coefficients, so a term must be stored only if it is the leading term of `nom`, or the leading term of at least one of the two `orient3d`-polynomials for the segment's ends (if one of them is dropped entirely, the code takes the negated sign of the other). The largest such degree over the tests and a random sweep of 30'000 degenerate inputs with coordinates in {-1,0,1} is 15'943'959, and it is attained by an input of the new test: with `cMaxPolyD = 15'943'958` the test asserts in Debug (`isPositive()` on an empty polynomial) and fails in Release. On the sweep the answers with the cap and without any cap are identical, and the old code disagrees only on the inputs where it is self-inconsistent.

The new test `segmentIntersectionOrder3c` holds three such inputs found by the sweep; on master it asserts in Debug and fails in Release.
