### PR TITLE
Precise predicates: lazy leading term of the polynomial difference instead of full products

### DIFF
--- a/source/MRMesh/MRPrecisePredicates2.cpp
+++ b/source/MRMesh/MRPrecisePredicates2.cpp
@@ -44,7 +44,7 @@ std::array<PointDegree, N> getPointDegrees( const std::array<PreciseVertCoords2,
 }
 
 // 64 bits are enough to store all coefficients of one ccw-polynomial (products of two coordinate differences),
-// while the coefficients of the products of two such polynomials need up to 128 bits, see mulAs<Int64Mul128> below
+// while the products of two such polynomials are computed in 128 bits, see signOfProductsDiff<Int64Mul128> below
 template<int M>
 using Poly = SparsePolynomial<std::int64_t, int, M>;
 
@@ -52,13 +52,44 @@ template<int M>
 Poly<M> ccwPoly( const PointDegree & a, const PointDegree & b, const PointDegree & c,
     int db ) // degree.x = degree.y * db
 {
-    const Poly<M> xx( a.pt.x - c.pt.x, a.d * db, 1, c.d * db, -1 );
-    const Poly<M> xy( a.pt.y - c.pt.y, a.d     , 1, c.d     , -1 );
-    const Poly<M> yx( b.pt.x - c.pt.x, b.d * db, 1, c.d * db, -1 );
-    const Poly<M> yy( b.pt.y - c.pt.y, b.d     , 1, c.d     , -1 );
-    auto det = xx * yy;
-    det -= xy * yx;
-    return det;
+    // every element of the matrix with the rows (a-c), (b-c) is a polynomial: delta + eps^degP - eps^degC,
+    // whose terms are stored below (skipping zero delta), the last term is always -eps^degC
+    struct Element
+    {
+        typename Poly<M>::Term terms[3];
+        int numTerms = 0;
+    };
+    Element m[2][2];
+    const PointDegree * rows[2] = { &a, &b };
+    const int w[2] = { db, 1 };
+    for ( int r = 0; r < 2; ++r )
+        for ( int col = 0; col < 2; ++col )
+        {
+            auto & e = m[r][col];
+            if ( const std::int64_t delta = std::int64_t( rows[r]->pt[col] ) - c.pt[col] )
+                e.terms[e.numTerms++] = { 0, delta };
+            e.terms[e.numTerms++] = { w[col] * rows[r]->d, 1 };
+            e.terms[e.numTerms++] = { w[col] * c.d, -1 };
+        }
+
+    // the determinant is m00*m11 - m01*m10, each product has up to 9 monomials;
+    // the product of the last terms of two elements (eps^((db+1)*degC) with the sign of the permutation) is excluded, since the two of them cancel one another
+    std::vector<typename Poly<M>::Term> terms;
+    terms.reserve( 2 * 8 );
+    for ( int perm = 0; perm < 2; ++perm )
+    {
+        const Element & e0 = m[0][perm];
+        const Element & e1 = m[1][1 - perm];
+        const std::int64_t sign = perm ? -1 : 1;
+        for ( int k0 = 0; k0 < e0.numTerms; ++k0 )
+        {
+            const int last1 = k0 + 1 == e0.numTerms ? e1.numTerms - 1 : e1.numTerms;
+            for ( int k1 = 0; k1 < last1; ++k1 )
+                if ( const auto deg = e0.terms[k0].first + e1.terms[k1].first; deg <= M )
+                    terms.emplace_back( deg, sign * e0.terms[k0].second * e1.terms[k1].second ); // all coefficients are within 2^32 by absolute value, so the product fits in int64
+        }
+    }
+    return Poly<M>::fromUnsortedTerms( std::move( terms ) );
 }
 
 std::int64_t area( const Vector2i & a, const Vector2i & b, const Vector2i & c )
@@ -362,7 +393,7 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords2, 6> & vs )
     const auto ds = getPointDegrees( vs );
 
     // 840 was found experimentally to be enough for all cases with 6 points having equal coordinates (but different ids);
-    // if it is not enough then we will get assert violation inside poly.isPositive(), and increase the value
+    // if it is not enough then we will get assert violation on nomSign below, and increase the value
     constexpr int MaxD = 840;
     const auto polySaOrg  = ccwPoly<MaxD>( ds[2], ds[3], ds[0], 3 );
     const auto polySaDest = ccwPoly<MaxD>( ds[2], ds[3], ds[1], 3 );
@@ -376,11 +407,10 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords2, 6> & vs )
     assert( polySbOrg.empty() || polySbDest.empty() || polySbOrg.isPositive() != polySbDest.isPositive() );
     const bool posSbOrg = polySbOrg.empty() ? !polySbDest.isPositive() : polySbOrg.isPositive();
 
-    // the coefficient of zero degree is nomSimple == 0, and it is automatically excluded from nom
-    auto nom = mulAs<Int64Mul128>( polySaOrg, polySbDest );
-    nom -= mulAs<Int64Mul128>( polySbOrg, polySaDest );
-
-    bool res = nom.isPositive();
+    // the sign of the leading term of nom = polySaOrg * polySbDest - polySbOrg * polySaDest, whose zero-degree coefficient is nomSimple == 0
+    const int nomSign = signOfProductsDiff<Int64Mul128>( polySaOrg, polySbDest, polySbOrg, polySaDest );
+    assert( nomSign != 0 );
+    bool res = nomSign > 0;
     if ( posSaOrg != posSbOrg ) // denominator is negative
         res = !res;
     return res;

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -26,12 +26,8 @@ struct PointDegree
     std::int64_t d = 0; // degree of epsilon for pt.z; pt.y gets 3*d, pt.x gets 9*d
 };
 
-// these values were found experimentally as the largest degree of a polynomial term that must be stored in the predicates
-// (the leading term of nom, or the leading term of at least one of two orient3d-polynomials for the segment's ends)
-// in the tests and in a random sweep of degenerate inputs; if it is not enough then we will get assert violation inside
-// poly.isPositive(), and increase the value; all polynomial terms of higher degrees are not stored to save computation time
-constexpr std::int64_t cMaxPolyDTriTri   = 15'943'959; // segmentIntersectionOrder
-constexpr std::int64_t cMaxPolyDTriPlane = 430'486'893; // segmentIntersectionTriPlaneOrder: it reaches the polynomial path with all three largest ids in the plane
+// the largest degree of a term in orient3d-polynomial: x, y and z perturbations of the vertex with the largest rank 7
+constexpr std::int64_t cMaxPolyD = ( 9 + 3 + 1 ) * 27LL * 27 * 27 * 27 * 27 * 27 * 27;
 
 std::array<PointDegree, 8> getPointDegrees( const std::array<PreciseVertCoords, 8> & vs )
 {
@@ -58,43 +54,54 @@ std::array<PointDegree, 8> getPointDegrees( const std::array<PreciseVertCoords, 
 }
 
 // 128 bits are enough to store all coefficients of one orient3d-polynomial (products of three coordinate differences),
-// while the coefficients of the products of two such polynomials need up to 256 bits, see mulAs<Int128Mul256> below
-template <std::int64_t M>
-using Poly = SparsePolynomial<FastInt128, std::int64_t, M>;
+// while the products of two such polynomials are computed in 256 bits, see signOfProductsDiff<Int128Mul256> below
+using Poly = SparsePolynomial<FastInt128, std::int64_t, cMaxPolyD>;
 
-template <std::int64_t M>
-Poly<M> orient3dPoly( const PointDegree & a, const PointDegree & b, const PointDegree & c, const PointDegree & d,
+Poly orient3dPoly( const PointDegree & a, const PointDegree & b, const PointDegree & c, const PointDegree & d,
     std::int64_t dy ) // degree.x = ( degree.y = degree.z * dy ) * dy
 {
-    const std::int64_t dx = dy * dy;
+    // every element of the matrix with the rows (a-d), (b-d), (c-d) is a polynomial: delta + eps^degP - eps^degD,
+    // whose terms are stored below (skipping zero delta), the last term is always -eps^degD
+    struct Element
+    {
+        Poly::Term terms[3];
+        int numTerms = 0;
+    };
+    Element m[3][3];
+    const PointDegree * rows[3] = { &a, &b, &c };
+    const std::int64_t w[3] = { dy * dy, dy, 1 };
+    for ( int r = 0; r < 3; ++r )
+        for ( int col = 0; col < 3; ++col )
+        {
+            auto & e = m[r][col];
+            if ( const std::int64_t delta = std::int64_t( rows[r]->pt[col] ) - d.pt[col] )
+                e.terms[e.numTerms++] = { 0, delta };
+            e.terms[e.numTerms++] = { w[col] * rows[r]->d, 1 };
+            e.terms[e.numTerms++] = { w[col] * d.d, -1 };
+        }
 
-    const Poly<M> xx( a.pt.x - d.pt.x, a.d * dx, 1, d.d * dx, -1 );
-    const Poly<M> xy( a.pt.y - d.pt.y, a.d * dy, 1, d.d * dy, -1 );
-    const Poly<M> xz( a.pt.z - d.pt.z, a.d     , 1, d.d     , -1 );
-
-    const Poly<M> yx( b.pt.x - d.pt.x, b.d * dx, 1, d.d * dx, -1 );
-    const Poly<M> yy( b.pt.y - d.pt.y, b.d * dy, 1, d.d * dy, -1 );
-    const Poly<M> yz( b.pt.z - d.pt.z, b.d     , 1, d.d     , -1 );
-
-    const Poly<M> zx( c.pt.x - d.pt.x, c.d * dx, 1, d.d * dx, -1 );
-    const Poly<M> zy( c.pt.y - d.pt.y, c.d * dy, 1, d.d * dy, -1 );
-    const Poly<M> zz( c.pt.z - d.pt.z, c.d     , 1, d.d     , -1 );
-
-    Poly<M> t;
-
-    t  = yy * zz;
-    t -= yz * zy;
-    Poly<M> det = xx * t;
-
-    t  = yx * zz;
-    t -= yz * zx;
-    det -= xy * t;
-
-    t  = yx * zy;
-    t -= yy * zx;
-    det += xz * t;
-
-    return det;
+    // the determinant is the sum over 6 permutations of the signed products of three elements, each product has up to 27 monomials;
+    // the product of the last terms of three elements (eps^(13*degD) with the sign of permutation) is excluded, since 6 of them cancel one another
+    constexpr int perms[6][4] = { { 0, 1, 2, 1 }, { 1, 2, 0, 1 }, { 2, 0, 1, 1 }, { 0, 2, 1, -1 }, { 2, 1, 0, -1 }, { 1, 0, 2, -1 } };
+    std::vector<Poly::Term> terms;
+    terms.reserve( 6 * 26 );
+    for ( const auto & p : perms )
+    {
+        const Element & e0 = m[0][p[0]];
+        const Element & e1 = m[1][p[1]];
+        const Element & e2 = m[2][p[2]];
+        for ( int k0 = 0; k0 < e0.numTerms; ++k0 )
+            for ( int k1 = 0; k1 < e1.numTerms; ++k1 )
+            {
+                // all coefficients are not larger than 2^32 by absolute value, so the product of two of them fits in int64
+                const std::int64_t c01 = p[3] * std::int64_t( e0.terms[k0].second ) * std::int64_t( e1.terms[k1].second );
+                const std::int64_t d01 = e0.terms[k0].first + e1.terms[k1].first;
+                const int last2 = k0 + 1 == e0.numTerms && k1 + 1 == e1.numTerms ? e2.numTerms - 1 : e2.numTerms;
+                for ( int k2 = 0; k2 < last2; ++k2 )
+                    terms.emplace_back( d01 + e2.terms[k2].first, Int64Mul128( c01 ) * Int64Mul128( std::int64_t( e2.terms[k2].second ) ) );
+            }
+    }
+    return Poly::fromUnsortedTerms( std::move( terms ) );
 }
 
 FastInt128 volume( const Vector3i & a, const Vector3i & b, const Vector3i & c, const Vector3i & d )
@@ -163,7 +170,6 @@ std::optional<bool> oneSideOfPlane( const std::array<PreciseVertCoords, 8> & vs,
 
 /// slow processing of the general case of segment intersection order, when both ta=234 and tb=567 are crossed by segment s=01,
 /// and neither triangle is on one side of the other's plane
-template <std::int64_t M>
 bool segmentIntersectionOrderGeneral( const std::array<PreciseVertCoords, 8> & vs )
 {
     // res = ( orient3d(ta,s[0])*orient3d(tb,s[1])   -   orient3d(tb,s[0])*orient3d(ta,s[1]) ) /
@@ -192,23 +198,22 @@ bool segmentIntersectionOrderGeneral( const std::array<PreciseVertCoords, 8> & v
 
     const auto ds = getPointDegrees( vs );
 
-    const auto polyTaOrg  = orient3dPoly<M>( ds[2], ds[3], ds[4], ds[0], 3 );
-    const auto polyTaDest = orient3dPoly<M>( ds[2], ds[3], ds[4], ds[1], 3 );
+    const auto polyTaOrg  = orient3dPoly( ds[2], ds[3], ds[4], ds[0], 3 );
+    const auto polyTaDest = orient3dPoly( ds[2], ds[3], ds[4], ds[1], 3 );
     assert( !polyTaOrg.empty() || !polyTaDest.empty() );
     assert( polyTaOrg.empty() || polyTaDest.empty() || polyTaOrg.isPositive() != polyTaDest.isPositive() );
     const bool posTaOrg = polyTaOrg.empty() ? !polyTaDest.isPositive() : polyTaOrg.isPositive();
 
-    const auto polyTbOrg  = orient3dPoly<M>( ds[5], ds[6], ds[7], ds[0], 3 );
-    const auto polyTbDest = orient3dPoly<M>( ds[5], ds[6], ds[7], ds[1], 3 );
+    const auto polyTbOrg  = orient3dPoly( ds[5], ds[6], ds[7], ds[0], 3 );
+    const auto polyTbDest = orient3dPoly( ds[5], ds[6], ds[7], ds[1], 3 );
     assert( !polyTbOrg.empty() || !polyTbDest.empty() );
     assert( polyTbOrg.empty() || polyTbDest.empty() || polyTbOrg.isPositive() != polyTbDest.isPositive() );
     const bool posTbOrg = polyTbOrg.empty() ? !polyTbDest.isPositive() : polyTbOrg.isPositive();
 
-    // the coefficient of zero degree is nomSimple == 0, and it is automatically excluded from nom
-    auto nom = mulAs<Int128Mul256>( polyTaOrg, polyTbDest );
-    nom -= mulAs<Int128Mul256>( polyTbOrg, polyTaDest );
-
-    bool res = nom.isPositive();
+    // the sign of the leading term of nom = polyTaOrg * polyTbDest - polyTbOrg * polyTaDest, whose zero-degree coefficient is nomSimple == 0
+    const int nomSign = signOfProductsDiff<Int128Mul256>( polyTaOrg, polyTbDest, polyTbOrg, polyTaDest );
+    assert( nomSign != 0 );
+    bool res = nomSign > 0;
     if ( posTaOrg != posTbOrg ) // denominator is negative
         res = !res;
     return res;
@@ -343,7 +348,7 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords, 8> & vs )
         return *sideB == orient3d( { vs[2], vs[3], vs[4], vs[1] } ); // tb is on one side of ta's plane
 
     // triangles ta and tb intersect one another
-    return segmentIntersectionOrderGeneral<cMaxPolyDTriTri>( vs );
+    return segmentIntersectionOrderGeneral( vs );
 }
 
 bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & vs )
@@ -363,8 +368,8 @@ bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & 
 
         // s is parallel to pb, and the perturbation of the points decides, which end of s is closer to pb
         const auto ds = getPointDegrees( vs );
-        auto diff = orient3dPoly<cMaxPolyDTriPlane>( ds[5], ds[6], ds[7], ds[0], 3 );
-        diff -= orient3dPoly<cMaxPolyDTriPlane>( ds[5], ds[6], ds[7], ds[1], 3 );
+        auto diff = orient3dPoly( ds[5], ds[6], ds[7], ds[0], 3 );
+        diff -= orient3dPoly( ds[5], ds[6], ds[7], ds[1], 3 );
         return diff.isPositive() == o0;
     }
 
@@ -374,7 +379,7 @@ bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & 
         return *sideA == o0; // ta is on one side of pb
 
     // pb is infinite, so even if all its three points are on one side of ta, pb can cross s on either side of s^ta
-    return segmentIntersectionOrderGeneral<cMaxPolyDTriPlane>( vs );
+    return segmentIntersectionOrderGeneral( vs );
 }
 
 ConvertToIntVector getToIntConverter( const Box3d& box )

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -26,8 +26,12 @@ struct PointDegree
     std::int64_t d = 0; // degree of epsilon for pt.z; pt.y gets 3*d, pt.x gets 9*d
 };
 
-// the largest degree of a term in orient3d-polynomial: x, y and z perturbations of the vertex with the largest rank 7
-constexpr std::int64_t cMaxPolyD = ( 9 + 3 + 1 ) * 27LL * 27 * 27 * 27 * 27 * 27 * 27;
+// these values were found experimentally as the largest degree of a polynomial term that must be considered in the predicates
+// (the leading term of nom, or the leading term of at least one of two orient3d-polynomials for the segment's ends)
+// in the tests and in a random sweep of degenerate inputs; the terms of higher degrees are not stored to save computation time,
+// and if it is not enough then signOfProductsDiff returns 0 with assert violation after it, increase the value in that case
+constexpr std::int64_t cMaxPolyDTriTri   = 15'943'959; // segmentIntersectionOrder
+constexpr std::int64_t cMaxPolyDTriPlane = 430'486'893; // segmentIntersectionTriPlaneOrder: it reaches the polynomial path with all three largest ids in the plane
 
 std::array<PointDegree, 8> getPointDegrees( const std::array<PreciseVertCoords, 8> & vs )
 {
@@ -55,16 +59,18 @@ std::array<PointDegree, 8> getPointDegrees( const std::array<PreciseVertCoords, 
 
 // 128 bits are enough to store all coefficients of one orient3d-polynomial (products of three coordinate differences),
 // while the products of two such polynomials are computed in 256 bits, see signOfProductsDiff<Int128Mul256> below
-using Poly = SparsePolynomial<FastInt128, std::int64_t, cMaxPolyD>;
+template <std::int64_t M>
+using Poly = SparsePolynomial<FastInt128, std::int64_t, M>;
 
-Poly orient3dPoly( const PointDegree & a, const PointDegree & b, const PointDegree & c, const PointDegree & d,
+template <std::int64_t M>
+Poly<M> orient3dPoly( const PointDegree & a, const PointDegree & b, const PointDegree & c, const PointDegree & d,
     std::int64_t dy ) // degree.x = ( degree.y = degree.z * dy ) * dy
 {
     // every element of the matrix with the rows (a-d), (b-d), (c-d) is a polynomial: delta + eps^degP - eps^degD,
     // whose terms are stored below (skipping zero delta), the last term is always -eps^degD
     struct Element
     {
-        Poly::Term terms[3];
+        typename Poly<M>::Term terms[3];
         int numTerms = 0;
     };
     Element m[3][3];
@@ -83,7 +89,7 @@ Poly orient3dPoly( const PointDegree & a, const PointDegree & b, const PointDegr
     // the determinant is the sum over 6 permutations of the signed products of three elements, each product has up to 27 monomials;
     // the product of the last terms of three elements (eps^(13*degD) with the sign of permutation) is excluded, since 6 of them cancel one another
     constexpr int perms[6][4] = { { 0, 1, 2, 1 }, { 1, 2, 0, 1 }, { 2, 0, 1, 1 }, { 0, 2, 1, -1 }, { 2, 1, 0, -1 }, { 1, 0, 2, -1 } };
-    std::vector<Poly::Term> terms;
+    std::vector<typename Poly<M>::Term> terms;
     terms.reserve( 6 * 26 );
     for ( const auto & p : perms )
     {
@@ -98,10 +104,11 @@ Poly orient3dPoly( const PointDegree & a, const PointDegree & b, const PointDegr
                 const std::int64_t d01 = e0.terms[k0].first + e1.terms[k1].first;
                 const int last2 = k0 + 1 == e0.numTerms && k1 + 1 == e1.numTerms ? e2.numTerms - 1 : e2.numTerms;
                 for ( int k2 = 0; k2 < last2; ++k2 )
-                    terms.emplace_back( d01 + e2.terms[k2].first, Int64Mul128( c01 ) * Int64Mul128( std::int64_t( e2.terms[k2].second ) ) );
+                    if ( const auto deg = d01 + e2.terms[k2].first; deg <= M )
+                        terms.emplace_back( deg, Int64Mul128( c01 ) * Int64Mul128( std::int64_t( e2.terms[k2].second ) ) );
             }
     }
-    return Poly::fromUnsortedTerms( std::move( terms ) );
+    return Poly<M>::fromUnsortedTerms( std::move( terms ) );
 }
 
 FastInt128 volume( const Vector3i & a, const Vector3i & b, const Vector3i & c, const Vector3i & d )
@@ -170,6 +177,7 @@ std::optional<bool> oneSideOfPlane( const std::array<PreciseVertCoords, 8> & vs,
 
 /// slow processing of the general case of segment intersection order, when both ta=234 and tb=567 are crossed by segment s=01,
 /// and neither triangle is on one side of the other's plane
+template <std::int64_t M>
 bool segmentIntersectionOrderGeneral( const std::array<PreciseVertCoords, 8> & vs )
 {
     // res = ( orient3d(ta,s[0])*orient3d(tb,s[1])   -   orient3d(tb,s[0])*orient3d(ta,s[1]) ) /
@@ -198,14 +206,14 @@ bool segmentIntersectionOrderGeneral( const std::array<PreciseVertCoords, 8> & v
 
     const auto ds = getPointDegrees( vs );
 
-    const auto polyTaOrg  = orient3dPoly( ds[2], ds[3], ds[4], ds[0], 3 );
-    const auto polyTaDest = orient3dPoly( ds[2], ds[3], ds[4], ds[1], 3 );
+    const auto polyTaOrg  = orient3dPoly<M>( ds[2], ds[3], ds[4], ds[0], 3 );
+    const auto polyTaDest = orient3dPoly<M>( ds[2], ds[3], ds[4], ds[1], 3 );
     assert( !polyTaOrg.empty() || !polyTaDest.empty() );
     assert( polyTaOrg.empty() || polyTaDest.empty() || polyTaOrg.isPositive() != polyTaDest.isPositive() );
     const bool posTaOrg = polyTaOrg.empty() ? !polyTaDest.isPositive() : polyTaOrg.isPositive();
 
-    const auto polyTbOrg  = orient3dPoly( ds[5], ds[6], ds[7], ds[0], 3 );
-    const auto polyTbDest = orient3dPoly( ds[5], ds[6], ds[7], ds[1], 3 );
+    const auto polyTbOrg  = orient3dPoly<M>( ds[5], ds[6], ds[7], ds[0], 3 );
+    const auto polyTbDest = orient3dPoly<M>( ds[5], ds[6], ds[7], ds[1], 3 );
     assert( !polyTbOrg.empty() || !polyTbDest.empty() );
     assert( polyTbOrg.empty() || polyTbDest.empty() || polyTbOrg.isPositive() != polyTbDest.isPositive() );
     const bool posTbOrg = polyTbOrg.empty() ? !polyTbDest.isPositive() : polyTbOrg.isPositive();
@@ -348,7 +356,7 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords, 8> & vs )
         return *sideB == orient3d( { vs[2], vs[3], vs[4], vs[1] } ); // tb is on one side of ta's plane
 
     // triangles ta and tb intersect one another
-    return segmentIntersectionOrderGeneral( vs );
+    return segmentIntersectionOrderGeneral<cMaxPolyDTriTri>( vs );
 }
 
 bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & vs )
@@ -368,8 +376,8 @@ bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & 
 
         // s is parallel to pb, and the perturbation of the points decides, which end of s is closer to pb
         const auto ds = getPointDegrees( vs );
-        auto diff = orient3dPoly( ds[5], ds[6], ds[7], ds[0], 3 );
-        diff -= orient3dPoly( ds[5], ds[6], ds[7], ds[1], 3 );
+        auto diff = orient3dPoly<cMaxPolyDTriPlane>( ds[5], ds[6], ds[7], ds[0], 3 );
+        diff -= orient3dPoly<cMaxPolyDTriPlane>( ds[5], ds[6], ds[7], ds[1], 3 );
         return diff.isPositive() == o0;
     }
 
@@ -379,7 +387,7 @@ bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & 
         return *sideA == o0; // ta is on one side of pb
 
     // pb is infinite, so even if all its three points are on one side of ta, pb can cross s on either side of s^ta
-    return segmentIntersectionOrderGeneral( vs );
+    return segmentIntersectionOrderGeneral<cMaxPolyDTriPlane>( vs );
 }
 
 ConvertToIntVector getToIntConverter( const Box3d& box )

--- a/source/MRMesh/MRSparsePolynomial.h
+++ b/source/MRMesh/MRSparsePolynomial.h
@@ -254,19 +254,18 @@ int signOfProductsDiff( const SparsePolynomial<C,D,M>& a, const SparsePolynomial
     auto greater = []( const RowTerm & x, const RowTerm & y ) { return x.deg > y.deg; };
     std::vector<RowTerm> heap;
     heap.reserve( a.get().size() + c.get().size() );
+    // the terms of degrees above M are never considered, and since the terms of every polynomial are sorted, the initialization stops at the first such row
     if ( !b.get().empty() )
-        for ( int i = 0; i < (int)a.get().size(); ++i )
+        for ( int i = 0; i < (int)a.get().size() && a.get()[i].first + b.get()[0].first <= M; ++i )
             heap.push_back( { a.get()[i].first + b.get()[0].first, i, 0, false } );
     if ( !d.get().empty() )
-        for ( int i = 0; i < (int)c.get().size(); ++i )
+        for ( int i = 0; i < (int)c.get().size() && c.get()[i].first + d.get()[0].first <= M; ++i )
             heap.push_back( { c.get()[i].first + d.get()[0].first, i, 0, true } );
     std::make_heap( heap.begin(), heap.end(), greater );
 
     while ( !heap.empty() )
     {
         const auto deg = heap.front().deg;
-        if ( deg > M )
-            break;
         decltype( std::declval<T>() * std::declval<T>() ) coeff{};
         do
         {
@@ -280,9 +279,8 @@ int signOfProductsDiff( const SparsePolynomial<C,D,M>& a, const SparsePolynomial
                 coeff -= prod;
             else
                 coeff += prod;
-            if ( ++r.j < (int)g.size() )
+            if ( ++r.j < (int)g.size() && ( r.deg = f[r.i].first + g[r.j].first ) <= M )
             {
-                r.deg = f[r.i].first + g[r.j].first;
                 heap.push_back( r );
                 std::push_heap( heap.begin(), heap.end(), greater );
             }

--- a/source/MRMesh/MRSparsePolynomial.h
+++ b/source/MRMesh/MRSparsePolynomial.h
@@ -24,6 +24,13 @@ SparsePolynomialProduct<T,D,M> mulAs( const SparsePolynomial<C,D,M>& a, const Sp
 template <typename C, typename D, D M>
 SparsePolynomial<C,D,M> operator *( const SparsePolynomial<C,D,M>& a, const SparsePolynomial<C,D,M>& b ) { return mulAs<C>( a, b ); }
 
+/// returns the sign of the polynomial ( a * b - c * d ) for infinitesimal positive argument, i.e. the sign of its lowest-degree not-zero coefficient,
+/// or 0 if the difference is zero polynomial; every coefficient is converted into type T before multiplication;
+/// the coefficients of the difference are computed in the order of increasing degree and only till the first not-zero one
+template <typename T, typename C, typename D, D M>
+[[nodiscard]] int signOfProductsDiff( const SparsePolynomial<C,D,M>& a, const SparsePolynomial<C,D,M>& b,
+    const SparsePolynomial<C,D,M>& c, const SparsePolynomial<C,D,M>& d );
+
 /// The class to store a polynomial with a large number of zero coefficients
 /// (only non-zeros are stored in a vector of terms sorted by ascending degree)
 /// \tparam C - type of coefficients
@@ -49,6 +56,9 @@ public:
 
     /// constructs polynomial c0 + c1*x^d1 + c2*x^d2
     SparsePolynomial( C c0, D d1, C c1, D d2, C c2 );
+
+    /// constructs polynomial from arbitrary terms: sorts them by degree, sums the coefficients of equal degrees, drops zero coefficients and the degrees above M
+    [[nodiscard]] static SparsePolynomial fromUnsortedTerms( std::vector<Term> && terms );
 
     /// sets coefficient for given degree to zero
     void setZeroCoeff( D d )
@@ -125,6 +135,18 @@ SparsePolynomial<C,D,M>::SparsePolynomial( C c0, D d1, C c1, D d2, C c2 )
         terms_.emplace_back( d1, c1 );
     if ( d2 <= M )
         terms_.emplace_back( d2, c2 );
+}
+
+template <typename C, typename D, D M>
+SparsePolynomial<C,D,M> SparsePolynomial<C,D,M>::fromUnsortedTerms( std::vector<Term> && terms )
+{
+    std::sort( terms.begin(), terms.end(), []( const Term & x, const Term & y ) { return x.first < y.first; } );
+    while ( !terms.empty() && terms.back().first > M )
+        terms.pop_back();
+    SparsePolynomial res;
+    res.terms_ = std::move( terms );
+    res.mergeTerms_();
+    return res;
 }
 
 template <typename C, typename D, D M>
@@ -214,12 +236,62 @@ template <typename T, typename C, typename D, D M>
             res.emplace_back( deg, T( cfA ) * T( cfB ) );
         }
     }
-    std::sort( res.begin(), res.end(),
-        []( const Term & x, const Term & y ) { return x.first < y.first; } );
-    Res r;
-    r.terms_ = std::move( res );
-    r.mergeTerms_();
-    return r;
+    return Res::fromUnsortedTerms( std::move( res ) );
+}
+
+template <typename T, typename C, typename D, D M>
+int signOfProductsDiff( const SparsePolynomial<C,D,M>& a, const SparsePolynomial<C,D,M>& b,
+    const SparsePolynomial<C,D,M>& c, const SparsePolynomial<C,D,M>& d )
+{
+    // the terms of a*b (and of c*d) form rows: the i-th term of a times all the terms of b in the order of increasing degree;
+    // the heap keeps the current term of every row, so all terms of both products are visited in the order of increasing degree
+    struct RowTerm
+    {
+        D deg;
+        int i, j; // indices of the terms in the two factors
+        bool neg; // true for the terms of c*d
+    };
+    auto greater = []( const RowTerm & x, const RowTerm & y ) { return x.deg > y.deg; };
+    std::vector<RowTerm> heap;
+    heap.reserve( a.get().size() + c.get().size() );
+    if ( !b.get().empty() )
+        for ( int i = 0; i < (int)a.get().size(); ++i )
+            heap.push_back( { a.get()[i].first + b.get()[0].first, i, 0, false } );
+    if ( !d.get().empty() )
+        for ( int i = 0; i < (int)c.get().size(); ++i )
+            heap.push_back( { c.get()[i].first + d.get()[0].first, i, 0, true } );
+    std::make_heap( heap.begin(), heap.end(), greater );
+
+    while ( !heap.empty() )
+    {
+        const auto deg = heap.front().deg;
+        decltype( std::declval<T>() * std::declval<T>() ) coeff{};
+        do
+        {
+            std::pop_heap( heap.begin(), heap.end(), greater );
+            auto r = heap.back();
+            heap.pop_back();
+            const auto & f = ( r.neg ? c : a ).get();
+            const auto & g = ( r.neg ? d : b ).get();
+            const auto prod = T( f[r.i].second ) * T( g[r.j].second );
+            if ( r.neg )
+                coeff -= prod;
+            else
+                coeff += prod;
+            if ( ++r.j < (int)g.size() )
+            {
+                r.deg = f[r.i].first + g[r.j].first;
+                heap.push_back( r );
+                std::push_heap( heap.begin(), heap.end(), greater );
+            }
+        }
+        while ( !heap.empty() && heap.front().deg == deg );
+        if ( coeff > 0 )
+            return 1;
+        if ( coeff < 0 )
+            return -1;
+    }
+    return 0;
 }
 
 } //namespace MR

--- a/source/MRMesh/MRSparsePolynomial.h
+++ b/source/MRMesh/MRSparsePolynomial.h
@@ -58,7 +58,7 @@ public:
     /// constructs polynomial c0 + c1*x^d1 + c2*x^d2
     SparsePolynomial( C c0, D d1, C c1, D d2, C c2 );
 
-    /// constructs polynomial from arbitrary terms: sorts them by degree, sums the coefficients of equal degrees, drops zero coefficients and the degrees above M
+    /// constructs polynomial from arbitrary terms with degrees not above M: sorts them by degree, sums the coefficients of equal degrees and drops zero coefficients
     [[nodiscard]] static SparsePolynomial fromUnsortedTerms( std::vector<Term> && terms );
 
     /// sets coefficient for given degree to zero
@@ -141,8 +141,8 @@ SparsePolynomial<C,D,M>::SparsePolynomial( C c0, D d1, C c1, D d2, C c2 )
 template <typename C, typename D, D M>
 SparsePolynomial<C,D,M> SparsePolynomial<C,D,M>::fromUnsortedTerms( std::vector<Term> && terms )
 {
-    terms.erase( std::remove_if( terms.begin(), terms.end(), []( const Term & t ) { return t.first > M; } ), terms.end() );
     std::sort( terms.begin(), terms.end(), []( const Term & x, const Term & y ) { return x.first < y.first; } );
+    assert( terms.empty() || terms.back().first <= M );
     SparsePolynomial res;
     res.terms_ = std::move( terms );
     res.mergeTerms_();

--- a/source/MRMesh/MRSparsePolynomial.h
+++ b/source/MRMesh/MRSparsePolynomial.h
@@ -25,7 +25,8 @@ template <typename C, typename D, D M>
 SparsePolynomial<C,D,M> operator *( const SparsePolynomial<C,D,M>& a, const SparsePolynomial<C,D,M>& b ) { return mulAs<C>( a, b ); }
 
 /// returns the sign of the polynomial ( a * b - c * d ) for infinitesimal positive argument, i.e. the sign of its lowest-degree not-zero coefficient,
-/// or 0 if the difference is zero polynomial; every coefficient is converted into type T before multiplication;
+/// or 0 if all its coefficients of degrees not above M are zeros (the terms of higher degrees are not considered, since the arguments store the terms of degrees not above M only);
+/// every coefficient is converted into type T before multiplication, and the coefficients of the products have the type of T*T;
 /// the coefficients of the difference are computed in the order of increasing degree and only till the first not-zero one
 template <typename T, typename C, typename D, D M>
 [[nodiscard]] int signOfProductsDiff( const SparsePolynomial<C,D,M>& a, const SparsePolynomial<C,D,M>& b,
@@ -140,9 +141,8 @@ SparsePolynomial<C,D,M>::SparsePolynomial( C c0, D d1, C c1, D d2, C c2 )
 template <typename C, typename D, D M>
 SparsePolynomial<C,D,M> SparsePolynomial<C,D,M>::fromUnsortedTerms( std::vector<Term> && terms )
 {
+    terms.erase( std::remove_if( terms.begin(), terms.end(), []( const Term & t ) { return t.first > M; } ), terms.end() );
     std::sort( terms.begin(), terms.end(), []( const Term & x, const Term & y ) { return x.first < y.first; } );
-    while ( !terms.empty() && terms.back().first > M )
-        terms.pop_back();
     SparsePolynomial res;
     res.terms_ = std::move( terms );
     res.mergeTerms_();
@@ -265,6 +265,8 @@ int signOfProductsDiff( const SparsePolynomial<C,D,M>& a, const SparsePolynomial
     while ( !heap.empty() )
     {
         const auto deg = heap.front().deg;
+        if ( deg > M )
+            break;
         decltype( std::declval<T>() * std::declval<T>() ) coeff{};
         do
         {

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -1201,7 +1201,7 @@ TEST( MRMesh, segmentIntersectionTriPlaneOrder )
         EXPECT_NE( r,  segmentIntersectionTriPlaneOrder( { vs[1], vs[0], vs[2], vs[3], vs[4], par[i], par[i+1], par[i+2] } ) );
     }
 
-    // 8 distinct ids with the three largest ones in pb: the leading term of nom has the degree ~27^6 here
+    // 8 distinct ids with the three largest ones in pb: the polynomials here have the largest degrees that must be considered (cMaxPolyDTriPlane)
     const std::array<PreciseVertCoords, 8> deg =
     {
         PreciseVertCoords{  9_v, Vector3i( 1, 1,-1 ) }, PreciseVertCoords{  0_v, Vector3i( 0,-1, 1 ) },

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -1,6 +1,7 @@
 #include <MRMesh/MRPrecisePredicates2.h>
 #include <MRMesh/MRPrecisePredicates3.h>
 #include <MRMesh/MRInSphere.h>
+#include <MRMesh/MRSparsePolynomial.h>
 #include <MRMesh/MRBox.h>
 #include <gtest/gtest.h>
 #include <algorithm>
@@ -1057,6 +1058,26 @@ TEST( MRMesh, segmentIntersectionOrder3c )
         PreciseVertCoords{  2_v, Vector3i( 1, 1,-1 ) }, PreciseVertCoords{  4_v, Vector3i(-1, 0, 1 ) }, PreciseVertCoords{ 14_v, Vector3i( 0, 0, 0 ) } }, false );
 }
 
+TEST( MRMesh, signOfProductsDiff )
+{
+    using P = SparsePolynomial<std::int64_t, int, 1000>;
+    const P one( std::vector<P::Term>{ { 0, 1 } } );
+    const P onePlusX( 1, 1, 1 );
+    const P oneMinusX( 1, 1, -1 );
+    const P a( 1, 1, 1, 2, 1 ); // 1 + x + x^2
+    const P b( 1, 1, 2, 2, 3 ); // 1 + 2x + 3x^2 = the first three terms of a*a
+
+    EXPECT_EQ( signOfProductsDiff<std::int64_t>( onePlusX, oneMinusX, one, one ), -1 ); // -x^2
+    EXPECT_EQ( signOfProductsDiff<std::int64_t>( one, one, onePlusX, oneMinusX ), 1 );
+    EXPECT_EQ( signOfProductsDiff<std::int64_t>( onePlusX, onePlusX, onePlusX, onePlusX ), 0 );
+    EXPECT_EQ( signOfProductsDiff<std::int64_t>( a, a, b, one ), 1 );  // 2x^3 + x^4
+    EXPECT_EQ( signOfProductsDiff<std::int64_t>( b, one, a, a ), -1 );
+    EXPECT_EQ( signOfProductsDiff<std::int64_t>( a, one, one, a ), 0 );
+    EXPECT_EQ( signOfProductsDiff<std::int64_t>( a, one, P{}, one ), 1 );
+    EXPECT_EQ( signOfProductsDiff<std::int64_t>( P{}, one, a, one ), -1 );
+    EXPECT_EQ( signOfProductsDiff<std::int64_t>( P{}, P{}, P{}, P{} ), 0 );
+}
+
 TEST( MRMesh, segmentIntersectionOrder3Scale )
 {
     // two triangles crossing the segment at the same point (x=0): ta is the plane x=0, tb is the plane y=x;
@@ -1180,7 +1201,7 @@ TEST( MRMesh, segmentIntersectionTriPlaneOrder )
         EXPECT_NE( r,  segmentIntersectionTriPlaneOrder( { vs[1], vs[0], vs[2], vs[3], vs[4], par[i], par[i+1], par[i+2] } ) );
     }
 
-    // 8 distinct ids with the three largest ones in pb: the polynomials here have the largest degrees that must be stored (cMaxPolyD)
+    // 8 distinct ids with the three largest ones in pb: the leading term of nom has the degree ~27^6 here
     const std::array<PreciseVertCoords, 8> deg =
     {
         PreciseVertCoords{  9_v, Vector3i( 1, 1,-1 ) }, PreciseVertCoords{  0_v, Vector3i( 0,-1, 1 ) },


### PR DESCRIPTION
The polynomial path of `segmentIntersectionOrder` / `segmentIntersectionTriPlaneOrder` (taken when `nomSimple` is exactly zero) computed the full products `polyTaOrg * polyTbDest` and `polyTbOrg * polyTaDest`, sorted and merged them, and read only the sign of the lowest-degree coefficient of their difference.

Now:
* `signOfProductsDiff<T>( a, b, c, d )` in `MRSparsePolynomial.h` returns the sign of `a*b - c*d` for infinitesimal argument. The terms of every factor are sorted by degree, so the terms of the products are visited in the order of increasing degree by a heap over the rows "one term of `a` times all terms of `b`" (and the same for `c*d`); the coefficients of equal degrees are summed, and the enumeration stops at the first not-zero sum. Measured: 1 heap pop per call on 8 coincident points, ~6 on full polynomials. `T` is the type the coefficients are converted into before multiplication (`Int128Mul256` here, giving `FastInt256` products, as in `mulAs`).
* `orient3dPoly` expands the 3x3 determinant directly into monomials (6 permutations x up to 27 selections of the term in every element, zero deltas skipped, the always-cancelling product of the three `-eps^degD` terms excluded, the degrees above the cap not generated), multiplies the coefficients in int64 and widens once via `Int64Mul128`, and builds the polynomial by the new `SparsePolynomial::fromUnsortedTerms` with one sort and one merge, instead of 6 intermediate products and 5 merges.
* the per-predicate caps `cMaxPolyDTriTri` / `cMaxPolyDTriPlane` stay with the same values and the same contract: the terms above the cap are not stored, `signOfProductsDiff` does not look above the cap either, so an insufficient cap gives `nomSign == 0` and the assert fires; lowering either constant by one fails exactly its predicate's test (Release) or asserts (Debug). Without the caps the same code is 2.5x slower on coincident points and 2x slower on full polynomials, since the determinants keep all their terms.
* the same for the 2D `segmentIntersectionOrder` in `MRPrecisePredicates2.cpp`: `signOfProductsDiff<Int64Mul128>` instead of the full products, and `ccwPoly` expands the 2x2 determinant directly (up to 2x8 monomials, `int64` coefficients); its caps `MaxD = 84 / 840` stay, and 839 asserts in the fully degenerate test as before;
* new test `signOfProductsDiff` on small integer polynomials; all existing tests (including the cap-defining inputs and the scale-invariance test) pass in Release and Debug.

Polynomial path timings (best of 10, `segmentIntersectionOrder`):

| inputs | master | this PR |
|---|---|---|
| 8 coincident points, 11'520 calls | 44.0 ms (3.8 us/call) | 14.7 ms (1.3 us/call) |
| two triangles crossing the segment at one point, all polynomials full, 40'320 calls | 2333 ms (58 us/call) | 293 ms (7.3 us/call) |

2D `segmentIntersectionOrder`:

| inputs | before | this PR |
|---|---|---|
| 6 coincident points, 9'600 calls | 5.6 ms | 2.1 ms |
| two segments crossing the third at one point, all polynomials full, 72'000 calls | 197 ms | 56 ms |
