### PR TITLE
2D segmentIntersectionOrder(): fix 64-bit overflow of polynomial coefficients on the degenerate path

### DIFF
--- a/source/MRMesh/MRPrecisePredicates2.cpp
+++ b/source/MRMesh/MRPrecisePredicates2.cpp
@@ -43,7 +43,8 @@ std::array<PointDegree, N> getPointDegrees( const std::array<PreciseVertCoords2,
     return res;
 }
 
-// std::int64_t is enough to store all coefficients in ( ccw(sa,s[0])*ccw(sb,s[1])   -   ccw(sb,s[0])*ccw(sa,s[1]) ) except for degree 0, which is computed separately.
+// 64 bits are enough to store all coefficients of one ccw-polynomial (products of two coordinate differences),
+// while the coefficients of the products of two such polynomials need up to 128 bits, see mulAs<Int64Mul128> below
 template<int M>
 using Poly = SparsePolynomial<std::int64_t, int, M>;
 
@@ -375,11 +376,9 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords2, 6> & vs )
     assert( polySbOrg.empty() || polySbDest.empty() || polySbOrg.isPositive() != polySbDest.isPositive() );
     const bool posSbOrg = polySbOrg.empty() ? !polySbDest.isPositive() : polySbOrg.isPositive();
 
-    auto nom = polySaOrg * polySbDest;
-    nom -= polySbOrg * polySaDest;
-
-    // nomSimple == 0 means that zero degree coefficient is zero, but it can be computed incorrectly due overflow errors in 64-bit arithmetic
-    nom.setZeroCoeff( 0 );
+    // the coefficient of zero degree is nomSimple == 0, and it is automatically excluded from nom
+    auto nom = mulAs<Int64Mul128>( polySaOrg, polySbDest );
+    nom -= mulAs<Int64Mul128>( polySbOrg, polySaDest );
 
     bool res = nom.isPositive();
     if ( posSaOrg != posSbOrg ) // denominator is negative

--- a/source/MRTest/MRPrecisePredicatesTests.cpp
+++ b/source/MRTest/MRPrecisePredicatesTests.cpp
@@ -694,6 +694,35 @@ TEST( MRMesh, sosInSphereDegenerate )
     EXPECT_EQ( tester( vc( 0_v, -1,2,-1 ) ), In );
 }
 
+TEST( MRMesh, segmentIntersectionOrder2Scale )
+{
+    // two segments crossing the third one at the same point (the origin): sa is the line x=0, sb is the line y=x;
+    // the answer of a simulation-of-simplicity predicate must not depend on the scale of the coordinates
+    // (and the coefficients of the polynomials at the large scale do not fit in 64 bits)
+    const Vector2i pts[6] = { { -1, 0 }, { 1, 0 }, { 0,-1 }, { 0, 1 }, { -1,-1 }, { 1, 1 } };
+    std::array<VertId, 6> ids;
+    for ( int i = 0; i < 6; ++i )
+        ids[i] = VertId( i );
+    int mismatches = 0;
+    do
+    {
+        int prev = -1;
+        for ( int scale : { 1, 1 << 29 } )
+        {
+            std::array<PreciseVertCoords2, 6> vs;
+            for ( int i = 0; i < 6; ++i )
+                vs[i] = { ids[i], pts[i] * scale };
+            if ( !doSegmentSegmentIntersect( { vs[2], vs[3], vs[0], vs[1] } ) || !doSegmentSegmentIntersect( { vs[4], vs[5], vs[0], vs[1] } ) )
+                break;
+            const int r = segmentIntersectionOrder( vs );
+            mismatches += prev >= 0 && prev != r;
+            prev = r;
+        }
+    }
+    while ( std::next_permutation( ids.begin(), ids.end() ) );
+    EXPECT_EQ( mismatches, 0 );
+}
+
 TEST( MRMesh, segmentIntersectionOrder2b )
 {
     PreciseVertCoords2 vs[6] =


### PR DESCRIPTION
The same overflow as fixed for 3D in #4832, now in the 2D `segmentIntersectionOrder`: on its polynomial path (exact `nomSimple == 0`) `nom = polySaOrg * polySbDest - polySbOrg * polySaDest` was computed with `int64` coefficients, but a positive-degree coefficient of `nom` is the product of a coefficient of one `ccw`-polynomial having one coordinate difference (~2^31) and the zero-degree coefficient of the other having two (~2^63), i.e. up to ~2^94. The 2D predicates take their integer coordinates from the same `getToIntConverter` as the 3D ones, so the differences do reach 0.99 * 2^31.

Fix: the two products are computed by `mulAs<Int64Mul128>`, i.e. in `FastInt128` coefficients; the zero-degree coefficient is then exactly `nomSimple == 0` and `setZeroCoeff( 0 )` is not needed. The degree cap `MaxD = 840` and everything else stay.

New test `segmentIntersectionOrder2Scale`: two segments crossing the third one at the origin (the lines `x=0` and `y=x`), at scales 1 and 2^29, must give the same answer for all 720 permutations of ids, since a simulation-of-simplicity answer is scale-invariant (every coefficient is a single product of coordinate differences); on master 360 permutations differ.
