### PR TITLE
telemetrySaveMesh() and telemetrySavePoints(): telemetry for every written mesh/point cloud, none inside .mru

### DIFF
--- a/source/MRMesh/MRMeshSave.cpp
+++ b/source/MRMesh/MRMeshSave.cpp
@@ -11,6 +11,7 @@
 #include "MRMeshTexture.h"
 #include "MRImageSave.h"
 #include "MRSerializer.h"
+#include "MRTelemetry.h"
 #include <fstream>
 
 namespace MR
@@ -586,6 +587,50 @@ Expected<void> toPly( const TriMesh & mesh, std::ostream & out, const SaveSettin
     return toPlyImpl( mesh, out, settings );
 }
 
+static void telemetryLogSize( const Mesh& mesh )
+{
+    if ( int logFaces = intLog2( mesh.topology.numValidFaces() ) )
+        TelemetrySignal( "Save Mesh Log Tris " + std::to_string( logFaces ) );
+    else if ( int logPoints = intLog2( mesh.points.size() ) ) // if saved mesh contains no triangles but only points
+        TelemetrySignal( "Save Mesh Log Pnts " + std::to_string( logPoints ) );
+}
+
+static void telemetrySaveMesh( const std::string& ext, const Mesh& mesh, const SaveSettings& settings )
+{
+    std::string signalString = "Save " + ext;
+
+    if ( auto lv = mesh.points.size() ) // not lv = mesh.topology.lastValidVert(), since topology can be empty
+    {
+        signalString += " VP";
+        if ( settings.colors && settings.colors->size() >= lv )
+            signalString += 'C';
+        if ( settings.uvMap && settings.uvMap->size() >= lv )
+            signalString += "UV";
+    }
+
+    if ( auto lf = mesh.topology.lastValidFace() )
+    {
+        signalString += " TRI";
+        if ( settings.primitiveColors && settings.primitiveColors->size() >= lf )
+            signalString += 'C';
+    }
+
+    if ( settings.texture && !settings.texture->pixels.empty() )
+        signalString += " TEX";
+
+    if ( settings.solidColor )
+        signalString += " SOLIDC";
+
+    if ( settings.lengthUnit )
+        signalString += " UNITS";
+
+    if ( settings.xf && *settings.xf != AffineXf3d{} )
+        signalString += " XF";
+
+    TelemetrySignal( signalString );
+    telemetryLogSize( mesh );
+}
+
 Expected<void> toAnySupportedFormat( const Mesh& mesh, const std::filesystem::path& file, const SaveSettings & settings )
 {
     auto ext = utf8string( file.extension() );
@@ -597,7 +642,10 @@ Expected<void> toAnySupportedFormat( const Mesh& mesh, const std::filesystem::pa
     if ( !saver.fileSave )
         return unexpectedUnsupportedFileExtension();
 
-    return saver.fileSave( mesh, file, settings );
+    auto res = saver.fileSave( mesh, file, settings );
+    if ( res )
+        telemetrySaveMesh( ext, mesh, settings );
+    return res;
 }
 
 Expected<void> toAnySupportedFormat( const Mesh& mesh, const std::string& extension, std::ostream& out, const SaveSettings & settings )
@@ -610,7 +658,10 @@ Expected<void> toAnySupportedFormat( const Mesh& mesh, const std::string& extens
     if ( !saver.streamSave )
         return unexpected( std::string( "unsupported stream extension" ) );
 
-    return saver.streamSave( mesh, out, settings );
+    auto res = saver.streamSave( mesh, out, settings );
+    if ( res )
+        telemetrySaveMesh( ext, mesh, settings );
+    return res;
 }
 
 /// One can call this function from VS interpreter window during debuging

--- a/source/MRMesh/MRMeshSave.cpp
+++ b/source/MRMesh/MRMeshSave.cpp
@@ -597,6 +597,9 @@ static void telemetryLogSize( const Mesh& mesh )
 
 static void telemetrySaveMesh( const std::string& ext, const Mesh& mesh, const SaveSettings& settings )
 {
+    if ( !settings.telemetrySignal )
+        return;
+
     std::string signalString = "Save " + ext;
 
     if ( auto lv = mesh.points.size() ) // not lv = mesh.topology.lastValidVert(), since topology can be empty

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -56,6 +56,7 @@ Expected<std::future<Expected<void>>> ObjectMeshHolder::serializeModel_( const s
     SaveSettings saveSettings;
     saveSettings.onlyValidPoints = false;
     saveSettings.packPrimitives = false;
+    saveSettings.telemetrySignal = false;
     if ( !data_.vertColors.empty() )
         saveSettings.colors = &data_.vertColors;
     auto save = [mesh = data_.mesh, serializeFormat = std::string( actualSerializeFormat() ), path, saveSettings]() -> Expected<void>

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -298,6 +298,7 @@ Expected<std::future<Expected<void>>> ObjectPointsHolder::serializeModel_( const
     SaveSettings saveSettings;
     saveSettings.onlyValidPoints = false;
     saveSettings.packPrimitives = false;
+    saveSettings.telemetrySignal = false;
     if ( !vertsColorMap_.empty() )
         saveSettings.colors = &vertsColorMap_;
     auto save = [points = points_, serializeFormat = serializeFormat_ ? serializeFormat_ : defaultSerializePointsFormat(), path, saveSettings]()

--- a/source/MRMesh/MRPointsSave.cpp
+++ b/source/MRMesh/MRPointsSave.cpp
@@ -5,6 +5,7 @@
 #include "MRIOFormatsRegistry.h"
 #include "MRStringConvert.h"
 #include "MRProgressReadWrite.h"
+#include "MRTelemetry.h"
 #include "MRPch/MRFmt.h"
 #include <fstream>
 
@@ -204,6 +205,40 @@ Expected<void> toPly( const PointCloud& cloud, std::ostream& out, const SaveSett
     return {};
 }
 
+static void telemetryLogSize( const PointCloud& cloud )
+{
+    TelemetrySignal( "Save Pnts Log Pnts " + std::to_string( intLog2( cloud.calcNumValidPoints() ) ) );
+}
+
+static void telemetrySavePoints( const std::string& ext, const PointCloud& cloud, const SaveSettings& settings )
+{
+    if ( !settings.telemetrySignal )
+        return;
+
+    std::string signalString = "Save " + ext;
+
+    if ( cloud.validPoints.any() )
+    {
+        signalString += " VP";
+        if ( cloud.hasNormals() )
+            signalString += 'N';
+        if ( settings.colors && settings.colors->size() >= cloud.points.size() )
+            signalString += 'C';
+    }
+
+    if ( settings.solidColor )
+        signalString += " SOLIDC";
+
+    if ( settings.lengthUnit )
+        signalString += " UNITS";
+
+    if ( settings.xf && *settings.xf != AffineXf3d{} )
+        signalString += " XF";
+
+    TelemetrySignal( signalString );
+    telemetryLogSize( cloud );
+}
+
 Expected<void> toAnySupportedFormat( const PointCloud& points, const std::filesystem::path& file, const SaveSettings& settings )
 {
     auto ext = utf8string( file.extension() );
@@ -215,7 +250,10 @@ Expected<void> toAnySupportedFormat( const PointCloud& points, const std::filesy
     if ( !saver.fileSave )
         return unexpectedUnsupportedFileExtension();
 
-    return saver.fileSave( points, file, settings );
+    auto res = saver.fileSave( points, file, settings );
+    if ( res )
+        telemetrySavePoints( ext, points, settings );
+    return res;
 }
 Expected<void> toAnySupportedFormat( const PointCloud& points, const std::string& extension, std::ostream& out, const SaveSettings& settings )
 {
@@ -227,7 +265,10 @@ Expected<void> toAnySupportedFormat( const PointCloud& points, const std::string
     if ( !saver.streamSave )
         return unexpected( std::string( "unsupported stream extension" ) );
 
-    return saver.streamSave( points, out, settings );
+    auto res = saver.streamSave( points, out, settings );
+    if ( res )
+        telemetrySavePoints( ext, points, settings );
+    return res;
 }
 
 MR_ADD_POINTS_SAVER( IOFilter( "XYZ (.xyz)", "*.xyz" ), toXyz )

--- a/source/MRMesh/MRSaveSettings.h
+++ b/source/MRMesh/MRSaveSettings.h
@@ -54,6 +54,9 @@ struct SaveSettings
     /// the color of whole object
     std::optional<Color> solidColor;
 
+    /// permit telemetry signal about saving
+    bool telemetrySignal = true;
+
     /// to report save progress and cancel saving if user desires
     ProgressCallback progress;
 };

--- a/source/MRTest/MRSerializeTests.cpp
+++ b/source/MRTest/MRSerializeTests.cpp
@@ -3,8 +3,13 @@
 #include "MRMesh/MRObjectSave.h"
 #include "MRMesh/MRObjectLoad.h"
 #include "MRMesh/MRObjectMesh.h"
+#include "MRMesh/MRObjectPoints.h"
 #include "MRMesh/MRCube.h"
 #include "MRMesh/MRMesh.h"
+#include "MRMesh/MRMeshSave.h"
+#include "MRMesh/MRMeshToPointCloud.h"
+#include "MRMesh/MRPointsSave.h"
+#include "MRMesh/MRTelemetry.h"
 #include <gtest/gtest.h>
 
 namespace MR
@@ -56,6 +61,46 @@ TEST( MRMesh, SerializeObjectMesh )
     // meshes are equal but not shared
     EXPECT_EQ( *m0->mesh(), *m1->mesh() );
     EXPECT_NE( m0->mesh(), m1->mesh() );
+}
+
+// writing a scene in .mru file must not report any telemetry about the models saved inside it
+TEST( MRMesh, SerializeNoTelemetry )
+{
+    Object o;
+    o.setName( "root" );
+    auto om = std::make_shared<ObjectMesh>();
+    om->setName( "mesh" );
+    om->setMesh( std::make_shared<Mesh>( makeCube() ) );
+    o.addChild( om );
+    auto cloud = std::make_shared<PointCloud>( meshToPointCloud( *om->mesh() ) );
+    auto op = std::make_shared<ObjectPoints>();
+    op->setName( "points" );
+    op->setPointCloud( cloud );
+    o.addChild( op );
+    auto op1 = std::make_shared<ObjectPoints>();
+    op1->setName( "points1" );
+    op1->setPointCloud( cloud );
+    op1->setSerializeFormat( ".unknown" ); // the only way to reach PointsSave::toAnySupportedFormat from here
+    o.addChild( op1 );
+
+    std::vector<std::string> signals;
+    boost::signals2::scoped_connection con = TelemetrySignal.connect(
+        [&signals]( const std::string& s ) { signals.push_back( s ); } );
+
+    UniqueTemporaryFolder f;
+    auto s = serializeObjectTree( o, f / "noTelemetry.mru" );
+    EXPECT_TRUE( s.has_value() ) << ( s.has_value() ? "" : s.error() );
+    for ( const auto & signal : signals )
+        ADD_FAILURE() << "unexpected telemetry during .mru saving: " << signal;
+
+    // in contrast, ordinary saving of the same models is reported
+    signals.clear();
+    EXPECT_TRUE( MeshSave::toAnySupportedFormat( *om->mesh(), f / "cube.ply" ).has_value() );
+    EXPECT_EQ( signals, std::vector<std::string>( { "Save *.ply VP TRI", "Save Mesh Log Tris 4" } ) );
+
+    signals.clear();
+    EXPECT_TRUE( PointsSave::toAnySupportedFormat( *cloud, f / "cube.xyz" ).has_value() );
+    EXPECT_EQ( signals, std::vector<std::string>( { "Save *.xyz VPN", "Save Pnts Log Pnts 4" } ) );
 }
 
 // Zendesk #1121: the name is cut to 12 characters, and the cut used to end with a space


### PR DESCRIPTION
Adds `telemetrySaveMesh()` in `MRMeshSave.cpp` and `telemetrySavePoints()` in `MRPointsSave.cpp`, direct counterparts of `telemetryOpenMesh()` / `telemetryOpenPoints()` on the loading side. Both `toAnySupportedFormat()` overloads (file and stream) of each namespace emit the signal after a successful save.

**No save event is reported for the models written inside a .mru file.** `SaveSettings` gets a `telemetrySignal` flag, as all three loading settings structs already have, and both `serializeModel_()` implementations that write a mesh or a point cloud clear it. `ObjectPointsHolder::serializeModel_()` needs it: it falls back to `PointsSave::toAnySupportedFormat()` when the serialization format has no registered saver. `ObjectMeshHolder::serializeModel_()` invokes `getMeshSaver().fileSave` directly and so reports nothing today either way, but it is cleared there too to keep the rule uniform. `ObjectLinesHolder` has no `serializeModel_()` at all, and no other object type writes a mesh or a point cloud.

`MRMesh.SerializeNoTelemetry` in `MRSerializeTests.cpp` locks that in. Its scene holds an `ObjectMesh`, an `ObjectPoints`, and an `ObjectPoints` with an unregistered serialization format (the only way .mru writing can reach `PointsSave::toAnySupportedFormat()`); it also checks that ordinary saving of the same two models *is* reported, so the test cannot pass vacuously. Verified in both directions locally - commenting out the flag in `ObjectPointsHolder::serializeModel_()` makes it fail with `Save *.ply VPN` and `Save Pnts Log Pnts 4`.

The signal string starts with `Save ` + the extension and then lists what was actually written:

| token | mesh | point cloud |
|---|---|---|
| `VP` | vertex positions, `+C` for `SaveSettings::colors`, `+UV` for `SaveSettings::uvMap` | points, `+N` if the cloud has normals, `+C` for `SaveSettings::colors` |
| `TRI` | triangles, `+C` for `SaveSettings::primitiveColors` | - |
| `TEX` | non-empty `SaveSettings::texture` | - |
| `SOLIDC` | `SaveSettings::solidColor` | same |
| `UNITS` | `SaveSettings::lengthUnit` | same |
| `XF` | non-identity `SaveSettings::xf` | same |

e.g. `Save *.ply VPC TRI XF` or `Save *.ply VPNC`.

A second signal reports the size on the same binary-logarithm scale as the loading side: `Save Mesh Log Tris <n>` (or `Save Mesh Log Pnts <n>` for a mesh with no triangles) and `Save Pnts Log Pnts <n>`.

Telemetry is reported only for a successful save, as on the loading side.
