### PR TITLE
Precise predicates: exact answer first, simulation of simplicity only on exact ties

### DIFF
--- a/source/MRMesh/MRPrecisePredicates2.cpp
+++ b/source/MRMesh/MRPrecisePredicates2.cpp
@@ -131,8 +131,8 @@ std::optional<bool> segmentIntersectionOrderExact( const std::array<PreciseVertC
 }
 
 /// the order of intersections of segment s=01 with the lines of sa=23 and sb=45 when the intersection points coincide exactly,
-/// which is resolved by the perturbation of the points; the caller must have checked that neither segment is on one side of the other's line
-bool segmentIntersectionOrderPoly( const std::array<PreciseVertCoords2, 6> & vs )
+/// resolved by simulation-of-simplicity; the caller must have checked that neither segment is on one side of the other's line
+bool segmentIntersectionOrderDegenerate( const std::array<PreciseVertCoords2, 6> & vs )
 {
     const auto ds = getPointDegrees( vs );
 
@@ -443,7 +443,7 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords2, 6> & vs )
         // segments sa and sb intersect one another, process it as general case
     }
 
-    return segmentIntersectionOrderPoly( vs );
+    return segmentIntersectionOrderDegenerate( vs );
 }
 
 // intersection of segments (a,b) and (c,d) from the doubled areas abc = |area(a,b,c)| and

--- a/source/MRMesh/MRPrecisePredicates2.cpp
+++ b/source/MRMesh/MRPrecisePredicates2.cpp
@@ -165,12 +165,13 @@ bool segmentIntersectionOrderPoly( const std::array<PreciseVertCoords2, 6> & vs 
 // see https://arxiv.org/pdf/math/9410209 Table 4-i:
 // a=(pi_i,1, pi_i,2)
 // b=(pi_j,1, pi_j,2)
-bool ccw( const Vector2i & a, const Vector2i & b )
+namespace
 {
-    if ( auto v = cross( Vector2i64{ a }, Vector2i64{ b } ) )
-        return v > 0; // points are in general position
 
-    // points 0, a, b are on the same line
+/// ccw( a, b ) for the points 0, a, b known to be on the same line, resolved by simulation-of-simplicity
+bool ccwDegenerate( const Vector2i & a, const Vector2i & b )
+{
+    assert( cross( Vector2i64{ a }, Vector2i64{ b } ) == 0 );
 
     // permute points:
     // da.y >> da.x >> db.y >> db.x > 0
@@ -197,6 +198,15 @@ bool ccw( const Vector2i & a, const Vector2i & b )
     // the smallest permutation db.x does not change anything here, and
     // the rotation from a to b is always ccw independently on a.y sign
     return true;
+}
+
+} // anonymous namespace
+
+bool ccw( const Vector2i & a, const Vector2i & b )
+{
+    if ( auto v = cross( Vector2i64{ a }, Vector2i64{ b } ) )
+        return v > 0; // points are in general position
+    return ccwDegenerate( a, b );
 }
 
 bool smaller2( const std::array<PreciseVertCoords2, 4> & vs )
@@ -342,7 +352,7 @@ bool ccw( const PreciseVertCoords2* vs )
         }
     }
 
-    return odd != ccw( vs[order[0]].pt, vs[order[1]].pt, vs[order[2]].pt );
+    return odd != ccwDegenerate( vs[order[0]].pt - vs[order[2]].pt, vs[order[1]].pt - vs[order[2]].pt );
 }
 
 bool inCircle( const std::array<PreciseVertCoords2, 4>& vs )

--- a/source/MRMesh/MRPrecisePredicates2.cpp
+++ b/source/MRMesh/MRPrecisePredicates2.cpp
@@ -5,6 +5,7 @@
 #include "MRSparsePolynomial.h"
 #include "MRDivRound.h"
 #include "MRBox.h"
+#include <optional>
 
 namespace MR
 {
@@ -99,6 +100,64 @@ std::int64_t area( const Vector2i & a, const Vector2i & b, const Vector2i & c )
     const std::int64_t yx( b.x - c.x );
     const std::int64_t yy( b.y - c.y );
     return xx * yy - xy * yx;
+}
+
+/// the order of intersections of segment s=01 with the lines of sa=23 and sb=45 given by exact coordinates,
+/// or nullopt if the intersection points coincide exactly
+std::optional<bool> segmentIntersectionOrderExact( const std::array<PreciseVertCoords2, 6> & vs )
+{
+    // res = ( ccw(sa,s[0])*ccw(sb,s[1])   -   ccw(sb,s[0])*ccw(sa,s[1]) ) /
+    //       ( ccw(sa,s[0])-ccw(sa,s[1]) ) * ( ccw(sb,s[0])-ccw(sb,s[1]) )
+    const auto areaSaOrg  = area( vs[2].pt, vs[3].pt, vs[0].pt );
+    const auto areaSaDest = area( vs[2].pt, vs[3].pt, vs[1].pt );
+    assert( ( areaSaOrg <= 0 && areaSaDest >= 0 ) || ( areaSaOrg >= 0 && areaSaDest <= 0 ) );
+
+    const auto areaSbOrg  = area( vs[4].pt, vs[5].pt, vs[0].pt );
+    const auto areaSbDest = area( vs[4].pt, vs[5].pt, vs[1].pt );
+    assert( ( areaSbOrg <= 0 && areaSbDest >= 0 ) || ( areaSbOrg >= 0 && areaSbDest <= 0 ) );
+
+    const auto nomSimple = Int64Mul128( areaSaOrg ) * Int64Mul128( areaSbDest ) - Int64Mul128( areaSbOrg ) * Int64Mul128( areaSaDest );
+    if ( nomSimple == 0 )
+        return {};
+
+    bool res = nomSimple > 0;
+    assert( areaSaOrg || areaSaDest );
+    if ( areaSaOrg < areaSaDest )
+        res = !res;
+    assert( areaSbOrg || areaSbDest );
+    if ( areaSbOrg < areaSbDest )
+        res = !res;
+    return res;
+}
+
+/// the order of intersections of segment s=01 with the lines of sa=23 and sb=45 when the intersection points coincide exactly,
+/// which is resolved by the perturbation of the points; the caller must have checked that neither segment is on one side of the other's line
+bool segmentIntersectionOrderPoly( const std::array<PreciseVertCoords2, 6> & vs )
+{
+    const auto ds = getPointDegrees( vs );
+
+    // 840 was found experimentally to be enough for all cases with 6 points having equal coordinates (but different ids);
+    // if it is not enough then we will get assert violation on nomSign below, and increase the value
+    constexpr int MaxD = 840;
+    const auto polySaOrg  = ccwPoly<MaxD>( ds[2], ds[3], ds[0], 3 );
+    const auto polySaDest = ccwPoly<MaxD>( ds[2], ds[3], ds[1], 3 );
+    assert( !polySaOrg.empty() || !polySaDest.empty() );
+    assert( polySaOrg.empty() || polySaDest.empty() || polySaOrg.isPositive() != polySaDest.isPositive() );
+    const bool posSaOrg = polySaOrg.empty() ? !polySaDest.isPositive() : polySaOrg.isPositive();
+
+    const auto polySbOrg  = ccwPoly<MaxD>( ds[4], ds[5], ds[0], 3 );
+    const auto polySbDest = ccwPoly<MaxD>( ds[4], ds[5], ds[1], 3 );
+    assert( !polySbOrg.empty() || !polySbDest.empty() );
+    assert( polySbOrg.empty() || polySbDest.empty() || polySbOrg.isPositive() != polySbDest.isPositive() );
+    const bool posSbOrg = polySbOrg.empty() ? !polySbDest.isPositive() : polySbOrg.isPositive();
+
+    // the sign of the leading term of nom = polySaOrg * polySbDest - polySbOrg * polySaDest, whose zero-degree coefficient is nomSimple == 0
+    const int nomSign = signOfProductsDiff<Int64Mul128>( polySaOrg, polySbDest, polySbOrg, polySaDest );
+    assert( nomSign != 0 );
+    bool res = nomSign > 0;
+    if ( posSaOrg != posSbOrg ) // denominator is negative
+        res = !res;
+    return res;
 }
 
 } // anonymous namespace
@@ -263,6 +322,10 @@ bool ccw( const std::array<PreciseVertCoords2, 3> & vs )
 
 bool ccw( const PreciseVertCoords2* vs )
 {
+    // the exact answer first, the perturbation of the points is necessary only if all three points are exactly collinear
+    if ( const auto a = area( vs[0].pt, vs[1].pt, vs[2].pt ); a != 0 )
+        return a > 0;
+
     bool odd = false;
     std::array<int, 3> order = {0, 1, 2};
 
@@ -327,6 +390,10 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords2, 6> & vs )
     assert( doSegmentSegmentIntersect( { vs[0], vs[1], vs[2], vs[3] } ) );
     assert( doSegmentSegmentIntersect( { vs[0], vs[1], vs[4], vs[5] } ) );
 
+    if ( auto res = segmentIntersectionOrderExact( vs ) )
+        return *res;
+
+    // the intersection points coincide exactly, and the perturbation of the points decides;
     // if sa and sb have a shared point
     PreciseVertCoords2 sharedPoint;
     for ( auto va : { vs[2], vs[3] } )
@@ -366,54 +433,7 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords2, 6> & vs )
         // segments sa and sb intersect one another, process it as general case
     }
 
-    // res = ( ccw(sa,s[0])*ccw(sb,s[1])   -   ccw(sb,s[0])*ccw(sa,s[1]) ) /
-    //       ( ccw(sa,s[0])-ccw(sa,s[1]) ) * ( ccw(sb,s[0])-ccw(sb,s[1]) )
-    const auto areaSaOrg  = area( vs[2].pt, vs[3].pt, vs[0].pt );
-    const auto areaSaDest = area( vs[2].pt, vs[3].pt, vs[1].pt );
-    assert( ( areaSaOrg <= 0 && areaSaDest >= 0 ) || ( areaSaOrg >= 0 && areaSaDest <= 0 ) );
-
-    const auto areaSbOrg  = area( vs[4].pt, vs[5].pt, vs[0].pt );
-    const auto areaSbDest = area( vs[4].pt, vs[5].pt, vs[1].pt );
-    assert( ( areaSbOrg <= 0 && areaSbDest >= 0 ) || ( areaSbOrg >= 0 && areaSbDest <= 0 ) );
-
-    const auto nomSimple = Int64Mul128( areaSaOrg ) * Int64Mul128( areaSbDest ) - Int64Mul128( areaSbOrg ) * Int64Mul128( areaSaDest );
-    if ( nomSimple != 0 )
-    {
-        // happy not-degenerated path
-        bool res = nomSimple > 0;
-        assert( areaSaOrg || areaSaDest );
-        if ( areaSaOrg < areaSaDest )
-            res = !res;
-        assert( areaSbOrg || areaSbDest );
-        if ( areaSbOrg < areaSbDest )
-            res = !res;
-        return res;
-    }
-
-    const auto ds = getPointDegrees( vs );
-
-    // 840 was found experimentally to be enough for all cases with 6 points having equal coordinates (but different ids);
-    // if it is not enough then we will get assert violation on nomSign below, and increase the value
-    constexpr int MaxD = 840;
-    const auto polySaOrg  = ccwPoly<MaxD>( ds[2], ds[3], ds[0], 3 );
-    const auto polySaDest = ccwPoly<MaxD>( ds[2], ds[3], ds[1], 3 );
-    assert( !polySaOrg.empty() || !polySaDest.empty() );
-    assert( polySaOrg.empty() || polySaDest.empty() || polySaOrg.isPositive() != polySaDest.isPositive() );
-    const bool posSaOrg = polySaOrg.empty() ? !polySaDest.isPositive() : polySaOrg.isPositive();
-
-    const auto polySbOrg  = ccwPoly<MaxD>( ds[4], ds[5], ds[0], 3 );
-    const auto polySbDest = ccwPoly<MaxD>( ds[4], ds[5], ds[1], 3 );
-    assert( !polySbOrg.empty() || !polySbDest.empty() );
-    assert( polySbOrg.empty() || polySbDest.empty() || polySbOrg.isPositive() != polySbDest.isPositive() );
-    const bool posSbOrg = polySbOrg.empty() ? !polySbDest.isPositive() : polySbOrg.isPositive();
-
-    // the sign of the leading term of nom = polySaOrg * polySbDest - polySbOrg * polySaDest, whose zero-degree coefficient is nomSimple == 0
-    const int nomSign = signOfProductsDiff<Int64Mul128>( polySaOrg, polySbDest, polySbOrg, polySaDest );
-    assert( nomSign != 0 );
-    bool res = nomSign > 0;
-    if ( posSaOrg != posSbOrg ) // denominator is negative
-        res = !res;
-    return res;
+    return segmentIntersectionOrderPoly( vs );
 }
 
 // intersection of segments (a,b) and (c,d) from the doubled areas abc = |area(a,b,c)| and

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -175,10 +175,9 @@ std::optional<bool> oneSideOfPlane( const std::array<PreciseVertCoords, 8> & vs,
     return side;
 }
 
-/// slow processing of the general case of segment intersection order, when both ta=234 and tb=567 are crossed by segment s=01,
-/// and neither triangle is on one side of the other's plane
-template <std::int64_t M>
-bool segmentIntersectionOrderGeneral( const std::array<PreciseVertCoords, 8> & vs )
+/// the order of intersections of segment s=01 with the planes of ta=234 and tb=567 given by exact coordinates,
+/// or nullopt if the intersection points coincide exactly
+std::optional<bool> segmentIntersectionOrderExact( const std::array<PreciseVertCoords, 8> & vs )
 {
     // res = ( orient3d(ta,s[0])*orient3d(tb,s[1])   -   orient3d(tb,s[0])*orient3d(ta,s[1]) ) /
     //       ( orient3d(ta,s[0])-orient3d(ta,s[1]) ) * ( orient3d(tb,s[0])-orient3d(tb,s[1]) )
@@ -191,21 +190,25 @@ bool segmentIntersectionOrderGeneral( const std::array<PreciseVertCoords, 8> & v
     assert( ( volumeTbOrg <= 0 && volumeTbDest >= 0 ) || ( volumeTbOrg >= 0 && volumeTbDest <= 0 ) );
 
     const auto nomSimple = Int128Mul256( volumeTaOrg ) * Int128Mul256( volumeTbDest ) - Int128Mul256( volumeTbOrg ) * Int128Mul256( volumeTaDest );
-    if ( nomSimple != 0 )
-    {
-        // happy not-degenerated path
-        bool res = nomSimple > 0;
-        assert( volumeTaOrg || volumeTaDest );
-        if ( volumeTaOrg < volumeTaDest )
-            res = !res;
-        assert( volumeTbOrg || volumeTbDest );
-        if ( volumeTbOrg < volumeTbDest )
-            res = !res;
-        return res;
-    }
+    if ( nomSimple == 0 )
+        return {};
 
+    bool res = nomSimple > 0;
+    assert( volumeTaOrg || volumeTaDest );
+    if ( volumeTaOrg < volumeTaDest )
+        res = !res;
+    assert( volumeTbOrg || volumeTbDest );
+    if ( volumeTbOrg < volumeTbDest )
+        res = !res;
+    return res;
+}
+
+/// the order of intersections of segment s=01 with the planes of ta=234 and tb=567 when the intersection points coincide exactly,
+/// which is resolved by the perturbation of the points; the caller must have checked that neither triangle is on one side of the other's plane
+template <std::int64_t M>
+bool segmentIntersectionOrderPoly( const std::array<PreciseVertCoords, 8> & vs )
+{
     const auto ds = getPointDegrees( vs );
-
     const auto polyTaOrg  = orient3dPoly<M>( ds[2], ds[3], ds[4], ds[0], 3 );
     const auto polyTaDest = orient3dPoly<M>( ds[2], ds[3], ds[4], ds[1], 3 );
     assert( !polyTaOrg.empty() || !polyTaDest.empty() );
@@ -275,6 +278,10 @@ bool orient3d( const Vector3i & a, const Vector3i& b, const Vector3i& c )
 
 bool orient3d( const PreciseVertCoords* vs )
 {
+    // the exact answer first, the perturbation of the points is necessary only if all four points are exactly coplanar
+    if ( const auto v = volume( vs[0].pt, vs[1].pt, vs[2].pt, vs[3].pt ); v != 0 )
+        return v > 0;
+
     bool odd = false;
     std::array<int, 4> order = { 0, 1, 2, 3 };
 
@@ -348,6 +355,10 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords, 8> & vs )
     assert( doTriangleSegmentIntersect( { vs[2], vs[3], vs[4], vs[0], vs[1] } ) );
     assert( doTriangleSegmentIntersect( { vs[5], vs[6], vs[7], vs[0], vs[1] } ) );
 
+    if ( auto res = segmentIntersectionOrderExact( vs ) )
+        return *res;
+
+    // the intersection points coincide exactly, and the perturbation of the points decides;
     // shared vertices are on both planes, so only not-shared vertices define the side of a triangle
     const auto sp = findSharedPoints( vs );
     if ( auto sideA = oneSideOfPlane( vs, 5, 6, 7, sp.otherA, 3 - sp.numShared ) )
@@ -356,7 +367,7 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords, 8> & vs )
         return *sideB == orient3d( { vs[2], vs[3], vs[4], vs[1] } ); // tb is on one side of ta's plane
 
     // triangles ta and tb intersect one another
-    return segmentIntersectionOrderGeneral<cMaxPolyDTriTri>( vs );
+    return segmentIntersectionOrderPoly<cMaxPolyDTriTri>( vs );
 }
 
 bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & vs )
@@ -382,12 +393,16 @@ bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & 
     }
 
     // segment s crosses plane pb
+    if ( auto res = segmentIntersectionOrderExact( vs ) )
+        return *res;
+
+    // the intersection points coincide exactly, and the perturbation of the points decides
     const auto sp = findSharedPoints( vs );
     if ( auto sideA = oneSideOfPlane( vs, 5, 6, 7, sp.otherA, 3 - sp.numShared ) )
         return *sideA == o0; // ta is on one side of pb
 
     // pb is infinite, so even if all its three points are on one side of ta, pb can cross s on either side of s^ta
-    return segmentIntersectionOrderGeneral<cMaxPolyDTriPlane>( vs );
+    return segmentIntersectionOrderPoly<cMaxPolyDTriPlane>( vs );
 }
 
 ConvertToIntVector getToIntConverter( const Box3d& box )

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -175,13 +175,6 @@ std::optional<bool> oneSideOfPlane( const std::array<PreciseVertCoords, 8> & vs,
     return side;
 }
 
-/// orient3d( vs ) given the exact volume of the same tetrahedron computed before
-bool orient3d( FastInt128 exactVolume, const std::array<PreciseVertCoords, 4> & vs )
-{
-    assert( exactVolume == volume( vs[0].pt, vs[1].pt, vs[2].pt, vs[3].pt ) );
-    return exactVolume != 0 ? exactVolume > 0 : orient3d( vs );
-}
-
 /// the volumes of the tetrahedra formed by two triangles ta, tb (or planes) and the ends of segment s
 struct SegmentVolumes
 {
@@ -287,20 +280,10 @@ bool orient3dDegenerate( const Vector3i & a, const Vector3i& b, const Vector3i& 
     return true;
 }
 
-} // anonymous namespace
-
-bool orient3d( const Vector3i & a, const Vector3i& b, const Vector3i& c )
+/// orient3d( vs ) for four points known to be exactly coplanar, resolved by simulation-of-simplicity
+bool orient3dDegenerate( const std::array<PreciseVertCoords, 4> & vs )
 {
-    auto vhp = dot( Vector3i64mul{ a }, Vector3i64mul{ cross( Vector3i64{ b }, Vector3i64{ c } ) } );
-    if ( vhp ) return vhp > 0;
-    return orient3dDegenerate( a, b, c );
-}
-
-bool orient3d( const PreciseVertCoords* vs )
-{
-    // the exact answer first, the perturbation of the points is necessary only if all four points are exactly coplanar
-    if ( const auto v = volume( vs[0].pt, vs[1].pt, vs[2].pt, vs[3].pt ); v != 0 )
-        return v > 0;
+    assert( volume( vs[0].pt, vs[1].pt, vs[2].pt, vs[3].pt ) == 0 );
 
     bool odd = false;
     std::array<int, 4> order = { 0, 1, 2, 3 };
@@ -320,6 +303,23 @@ bool orient3d( const PreciseVertCoords* vs )
 
     const auto & d = vs[order[3]].pt;
     return odd != orient3dDegenerate( vs[order[0]].pt - d, vs[order[1]].pt - d, vs[order[2]].pt - d );
+}
+
+} // anonymous namespace
+
+bool orient3d( const Vector3i & a, const Vector3i& b, const Vector3i& c )
+{
+    auto vhp = dot( Vector3i64mul{ a }, Vector3i64mul{ cross( Vector3i64{ b }, Vector3i64{ c } ) } );
+    if ( vhp ) return vhp > 0;
+    return orient3dDegenerate( a, b, c );
+}
+
+bool orient3d( const PreciseVertCoords* vs )
+{
+    // the exact answer first, the perturbation of the points is necessary only if all four points are exactly coplanar
+    if ( const auto v = volume( vs[0].pt, vs[1].pt, vs[2].pt, vs[3].pt ); v != 0 )
+        return v > 0;
+    return orient3dDegenerate( { vs[0], vs[1], vs[2], vs[3] } );
 }
 
 bool ccwAroundLine( const PreciseVertCoords* vs )
@@ -390,9 +390,9 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords, 8> & vs )
     // shared vertices are on both planes, so only not-shared vertices define the side of a triangle
     const auto sp = findSharedPoints( vs );
     if ( auto sideA = oneSideOfPlane( vs, 5, 6, 7, sp.otherA, 3 - sp.numShared ) )
-        return *sideA == orient3d( v.tbOrg, { vs[5], vs[6], vs[7], vs[0] } ); // ta is on one side of tb's plane
+        return *sideA == ( v.tbOrg != 0 ? v.tbOrg > 0 : orient3dDegenerate( { vs[5], vs[6], vs[7], vs[0] } ) ); // ta is on one side of tb's plane
     if ( auto sideB = oneSideOfPlane( vs, 2, 3, 4, sp.otherB, 3 - sp.numShared ) )
-        return *sideB == orient3d( v.taDest, { vs[2], vs[3], vs[4], vs[1] } ); // tb is on one side of ta's plane
+        return *sideB == ( v.taDest != 0 ? v.taDest > 0 : orient3dDegenerate( { vs[2], vs[3], vs[4], vs[1] } ) ); // tb is on one side of ta's plane
 
     // triangles ta and tb intersect one another
     return segmentIntersectionOrderPoly<cMaxPolyDTriTri>( vs );
@@ -405,8 +405,9 @@ bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & 
 
     const auto volumeOrg  = volume( vs[5].pt, vs[6].pt, vs[7].pt, vs[0].pt );
     const auto volumeDest = volume( vs[5].pt, vs[6].pt, vs[7].pt, vs[1].pt );
-    const bool o0 = orient3d( volumeOrg, { vs[5], vs[6], vs[7], vs[0] } );
-    if ( o0 == orient3d( volumeDest, { vs[5], vs[6], vs[7], vs[1] } ) )
+    const bool o0 = volumeOrg  != 0 ? volumeOrg  > 0 : orient3dDegenerate( { vs[5], vs[6], vs[7], vs[0] } );
+    const bool o1 = volumeDest != 0 ? volumeDest > 0 : orient3dDegenerate( { vs[5], vs[6], vs[7], vs[1] } );
+    if ( o0 == o1 )
     {
         // entire segment s is on one side of plane pb, so the line of s crosses pb either before s[0] or after s[1];
         // it is after s[1] iff s[1] is closer to pb than s[0]

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -205,9 +205,9 @@ std::optional<bool> segmentIntersectionOrderExact( const SegmentVolumes & v )
 }
 
 /// the order of intersections of segment s=01 with the planes of ta=234 and tb=567 when the intersection points coincide exactly,
-/// which is resolved by the perturbation of the points; the caller must have checked that neither triangle is on one side of the other's plane
+/// resolved by simulation-of-simplicity; the caller must have checked that neither triangle is on one side of the other's plane
 template <std::int64_t M>
-bool segmentIntersectionOrderPoly( const std::array<PreciseVertCoords, 8> & vs )
+bool segmentIntersectionOrderDegenerate( const std::array<PreciseVertCoords, 8> & vs )
 {
     const auto ds = getPointDegrees( vs );
     const auto polyTaOrg  = orient3dPoly<M>( ds[2], ds[3], ds[4], ds[0], 3 );
@@ -395,7 +395,7 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords, 8> & vs )
         return *sideB == ( v.taDest != 0 ? v.taDest > 0 : orient3dDegenerate( { vs[2], vs[3], vs[4], vs[1] } ) ); // tb is on one side of ta's plane
 
     // triangles ta and tb intersect one another
-    return segmentIntersectionOrderPoly<cMaxPolyDTriTri>( vs );
+    return segmentIntersectionOrderDegenerate<cMaxPolyDTriTri>( vs );
 }
 
 bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & vs )
@@ -438,7 +438,7 @@ bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & 
         return *sideA == o0; // ta is on one side of pb
 
     // pb is infinite, so even if all its three points are on one side of ta, pb can cross s on either side of s^ta
-    return segmentIntersectionOrderPoly<cMaxPolyDTriPlane>( vs );
+    return segmentIntersectionOrderDegenerate<cMaxPolyDTriPlane>( vs );
 }
 
 ConvertToIntVector getToIntConverter( const Box3d& box )

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -175,30 +175,38 @@ std::optional<bool> oneSideOfPlane( const std::array<PreciseVertCoords, 8> & vs,
     return side;
 }
 
+/// orient3d( vs ) given the exact volume of the same tetrahedron computed before
+bool orient3d( FastInt128 exactVolume, const std::array<PreciseVertCoords, 4> & vs )
+{
+    assert( exactVolume == volume( vs[0].pt, vs[1].pt, vs[2].pt, vs[3].pt ) );
+    return exactVolume != 0 ? exactVolume > 0 : orient3d( vs );
+}
+
+/// the volumes of the tetrahedra formed by two triangles ta, tb (or planes) and the ends of segment s
+struct SegmentVolumes
+{
+    FastInt128 taOrg, taDest, tbOrg, tbDest;
+};
+
 /// the order of intersections of segment s=01 with the planes of ta=234 and tb=567 given by exact coordinates,
 /// or nullopt if the intersection points coincide exactly
-std::optional<bool> segmentIntersectionOrderExact( const std::array<PreciseVertCoords, 8> & vs )
+std::optional<bool> segmentIntersectionOrderExact( const SegmentVolumes & v )
 {
     // res = ( orient3d(ta,s[0])*orient3d(tb,s[1])   -   orient3d(tb,s[0])*orient3d(ta,s[1]) ) /
     //       ( orient3d(ta,s[0])-orient3d(ta,s[1]) ) * ( orient3d(tb,s[0])-orient3d(tb,s[1]) )
-    const auto volumeTaOrg  = volume( vs[2].pt, vs[3].pt, vs[4].pt, vs[0].pt );
-    const auto volumeTaDest = volume( vs[2].pt, vs[3].pt, vs[4].pt, vs[1].pt );
-    assert( ( volumeTaOrg <= 0 && volumeTaDest >= 0 ) || ( volumeTaOrg >= 0 && volumeTaDest <= 0 ) );
+    assert( ( v.taOrg <= 0 && v.taDest >= 0 ) || ( v.taOrg >= 0 && v.taDest <= 0 ) );
+    assert( ( v.tbOrg <= 0 && v.tbDest >= 0 ) || ( v.tbOrg >= 0 && v.tbDest <= 0 ) );
 
-    const auto volumeTbOrg  = volume( vs[5].pt, vs[6].pt, vs[7].pt, vs[0].pt );
-    const auto volumeTbDest = volume( vs[5].pt, vs[6].pt, vs[7].pt, vs[1].pt );
-    assert( ( volumeTbOrg <= 0 && volumeTbDest >= 0 ) || ( volumeTbOrg >= 0 && volumeTbDest <= 0 ) );
-
-    const auto nomSimple = Int128Mul256( volumeTaOrg ) * Int128Mul256( volumeTbDest ) - Int128Mul256( volumeTbOrg ) * Int128Mul256( volumeTaDest );
+    const auto nomSimple = Int128Mul256( v.taOrg ) * Int128Mul256( v.tbDest ) - Int128Mul256( v.tbOrg ) * Int128Mul256( v.taDest );
     if ( nomSimple == 0 )
         return {};
 
     bool res = nomSimple > 0;
-    assert( volumeTaOrg || volumeTaDest );
-    if ( volumeTaOrg < volumeTaDest )
+    assert( v.taOrg || v.taDest );
+    if ( v.taOrg < v.taDest )
         res = !res;
-    assert( volumeTbOrg || volumeTbDest );
-    if ( volumeTbOrg < volumeTbDest )
+    assert( v.tbOrg || v.tbDest );
+    if ( v.tbOrg < v.tbDest )
         res = !res;
     return res;
 }
@@ -368,16 +376,23 @@ bool segmentIntersectionOrder( const std::array<PreciseVertCoords, 8> & vs )
     assert( doTriangleSegmentIntersect( { vs[2], vs[3], vs[4], vs[0], vs[1] } ) );
     assert( doTriangleSegmentIntersect( { vs[5], vs[6], vs[7], vs[0], vs[1] } ) );
 
-    if ( auto res = segmentIntersectionOrderExact( vs ) )
+    const SegmentVolumes v
+    {
+        .taOrg  = volume( vs[2].pt, vs[3].pt, vs[4].pt, vs[0].pt ),
+        .taDest = volume( vs[2].pt, vs[3].pt, vs[4].pt, vs[1].pt ),
+        .tbOrg  = volume( vs[5].pt, vs[6].pt, vs[7].pt, vs[0].pt ),
+        .tbDest = volume( vs[5].pt, vs[6].pt, vs[7].pt, vs[1].pt )
+    };
+    if ( auto res = segmentIntersectionOrderExact( v ) )
         return *res;
 
     // the intersection points coincide exactly, and the perturbation of the points decides;
     // shared vertices are on both planes, so only not-shared vertices define the side of a triangle
     const auto sp = findSharedPoints( vs );
     if ( auto sideA = oneSideOfPlane( vs, 5, 6, 7, sp.otherA, 3 - sp.numShared ) )
-        return *sideA == orient3d( { vs[5], vs[6], vs[7], vs[0] } ); // ta is on one side of tb's plane
+        return *sideA == orient3d( v.tbOrg, { vs[5], vs[6], vs[7], vs[0] } ); // ta is on one side of tb's plane
     if ( auto sideB = oneSideOfPlane( vs, 2, 3, 4, sp.otherB, 3 - sp.numShared ) )
-        return *sideB == orient3d( { vs[2], vs[3], vs[4], vs[1] } ); // tb is on one side of ta's plane
+        return *sideB == orient3d( v.taDest, { vs[2], vs[3], vs[4], vs[1] } ); // tb is on one side of ta's plane
 
     // triangles ta and tb intersect one another
     return segmentIntersectionOrderPoly<cMaxPolyDTriTri>( vs );
@@ -388,13 +403,13 @@ bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & 
     // s=01, ta=234, pb=567
     assert( doTriangleSegmentIntersect( { vs[2], vs[3], vs[4], vs[0], vs[1] } ) );
 
-    const bool o0 = orient3d( { vs[5], vs[6], vs[7], vs[0] } );
-    if ( o0 == orient3d( { vs[5], vs[6], vs[7], vs[1] } ) )
+    const auto volumeOrg  = volume( vs[5].pt, vs[6].pt, vs[7].pt, vs[0].pt );
+    const auto volumeDest = volume( vs[5].pt, vs[6].pt, vs[7].pt, vs[1].pt );
+    const bool o0 = orient3d( volumeOrg, { vs[5], vs[6], vs[7], vs[0] } );
+    if ( o0 == orient3d( volumeDest, { vs[5], vs[6], vs[7], vs[1] } ) )
     {
         // entire segment s is on one side of plane pb, so the line of s crosses pb either before s[0] or after s[1];
         // it is after s[1] iff s[1] is closer to pb than s[0]
-        const auto volumeOrg  = volume( vs[5].pt, vs[6].pt, vs[7].pt, vs[0].pt );
-        const auto volumeDest = volume( vs[5].pt, vs[6].pt, vs[7].pt, vs[1].pt );
         if ( volumeOrg != volumeDest )
             return ( volumeOrg > volumeDest ) == o0;
 
@@ -406,7 +421,14 @@ bool segmentIntersectionTriPlaneOrder( const std::array<PreciseVertCoords, 8> & 
     }
 
     // segment s crosses plane pb
-    if ( auto res = segmentIntersectionOrderExact( vs ) )
+    const SegmentVolumes v
+    {
+        .taOrg  = volume( vs[2].pt, vs[3].pt, vs[4].pt, vs[0].pt ),
+        .taDest = volume( vs[2].pt, vs[3].pt, vs[4].pt, vs[1].pt ),
+        .tbOrg  = volumeOrg,
+        .tbDest = volumeDest
+    };
+    if ( auto res = segmentIntersectionOrderExact( v ) )
         return *res;
 
     // the intersection points coincide exactly, and the perturbation of the points decides

--- a/source/MRMesh/MRPrecisePredicates3.cpp
+++ b/source/MRMesh/MRPrecisePredicates3.cpp
@@ -232,10 +232,13 @@ bool segmentIntersectionOrderPoly( const std::array<PreciseVertCoords, 8> & vs )
 
 } // anonymous namespace
 
-bool orient3d( const Vector3i & a, const Vector3i& b, const Vector3i& c )
+namespace
 {
-    auto vhp = dot( Vector3i64mul{ a }, Vector3i64mul{ cross( Vector3i64{ b }, Vector3i64{ c } ) } );
-    if ( vhp ) return vhp > 0;
+
+/// orient3d( a, b, c ) for the points 0, a, b, c known to be on the same plane, resolved by simulation-of-simplicity
+bool orient3dDegenerate( const Vector3i & a, const Vector3i& b, const Vector3i& c )
+{
+    assert( dot( Vector3i64mul{ a }, Vector3i64mul{ cross( Vector3i64{ b }, Vector3i64{ c } ) } ) == 0 );
 
     auto v = cross( Vector2i64{ b.x, b.y }, Vector2i64{ c.x, c.y } );
     if ( v ) return v > 0;
@@ -276,6 +279,15 @@ bool orient3d( const Vector3i & a, const Vector3i& b, const Vector3i& c )
     return true;
 }
 
+} // anonymous namespace
+
+bool orient3d( const Vector3i & a, const Vector3i& b, const Vector3i& c )
+{
+    auto vhp = dot( Vector3i64mul{ a }, Vector3i64mul{ cross( Vector3i64{ b }, Vector3i64{ c } ) } );
+    if ( vhp ) return vhp > 0;
+    return orient3dDegenerate( a, b, c );
+}
+
 bool orient3d( const PreciseVertCoords* vs )
 {
     // the exact answer first, the perturbation of the points is necessary only if all four points are exactly coplanar
@@ -298,7 +310,8 @@ bool orient3d( const PreciseVertCoords* vs )
         }
     }
 
-    return odd != orient3d( vs[order[0]].pt, vs[order[1]].pt, vs[order[2]].pt, vs[order[3]].pt );
+    const auto & d = vs[order[3]].pt;
+    return odd != orient3dDegenerate( vs[order[0]].pt - d, vs[order[1]].pt - d, vs[order[2]].pt - d );
 }
 
 bool ccwAroundLine( const PreciseVertCoords* vs )


### PR DESCRIPTION
The precise predicates spent most of their time on the non-degenerate inputs in preparations for simulation of simplicity that are needed only on exact ties:
* `orient3d( const PreciseVertCoords* )` and `ccw( const PreciseVertCoords2* )` sorted the vertices by ids (with the parity of the permutation) before every evaluation, although the sorting affects only the perturbation-based tie-break: when the exact determinant is not zero, its sign is the answer for any order of vertices. Now the exact determinant is computed first, and the id-sorted perturbation chain runs only when it is zero. The chains themselves are the new `orient3dDegenerate` / `ccwDegenerate` functions taking the exact zero as given (asserted), so it is not recomputed on the tie path; the public `orient3d( a, b, c )` / `ccw( a, b )` are the exact check followed by the chain. `doTriangleSegmentIntersect`, `doSegmentSegmentIntersect`, `ccwAroundLine`, `inCircle` etc. get the speedup for free.
* `segmentIntersectionOrder` (3D and 2D) and `segmentIntersectionTriPlaneOrder` first searched for shared vertices and checked whether one triangle (segment) is on one side of the other's plane (line) with up to 6 `orient3d` calls, and only then computed the four volumes and `nomSimple`, which give the exact answer whenever `nomSimple != 0`. Now the caller computes the four volumes once (`SegmentVolumes`) and the exact formula goes first (`segmentIntersectionOrderExact`); the shortcuts and the polynomial part (`segmentIntersectionOrderDegenerate`) run only on the exact tie, and the shortcuts reuse the volumes instead of calling `orient3d` again. The former `segmentIntersectionOrderGeneral` is split into these two functions. Both paths are correct predicates on the same exact configuration, so they agree whenever the exact formula is decisive. `segmentIntersectionTriPlaneOrder` also stops recomputing the two volumes of the segment ends against the plane, which it evaluated up to three times before (one-side check, one-side branch, exact formula).

Naming: `<predicate>Exact` returns the answer from exact arithmetic or `nullopt`, `<predicate>Degenerate` is the perturbation-based answer for an exactly degenerate input.

No behavior change on any input: the existing tests (fully degenerate permutations, cap-defining inputs, scale-invariance tests, boolean tests) pass in Release and Debug, and on 20'000 random non-degenerate inputs the old and the new code agree on every call.

Timings per call, 20'000 random non-degenerate inputs (coordinates up to +-2^28, random ids), best of 10 passes:

| predicate | before | after |
|---|---|---|
| `orient3d( 4 PreciseVertCoords )` | 36 ns | 10 ns |
| `doTriangleSegmentIntersect` | 132 ns | 52 ns |
| `segmentIntersectionOrder` (3D) | 222 ns | 79 ns |
