### PR TITLE
Build the Cuda C-binding stubs for Wasm too

### DIFF
--- a/.github/workflows/build-test-emscripten-c-bindings.yml
+++ b/.github/workflows/build-test-emscripten-c-bindings.yml
@@ -116,7 +116,7 @@ jobs:
             -DMR_PCH_USE_EXTRA_HEADERS=ON
             -DMESHLIB_BUILD_GENERATED_C_BINDINGS=ON
           MR_CMAKE_BUILD_OPTIONS: >
-            --target MeshLibC2
+            --target MeshLibC2 MeshLibC2Cuda
         run: ./scripts/build_source.sh
 
       - name: Prepare output files

--- a/source/MeshLibC2Cuda/CMakeLists.txt
+++ b/source/MeshLibC2Cuda/CMakeLists.txt
@@ -4,7 +4,9 @@
 
 project(MeshLibC2Cuda CXX)
 
-IF(NOT EMSCRIPTEN)
+# This is also built for Emscripten, even though Cuda itself never is. The C# bindings always
+#   declare `MR_Cuda_isCudaAvailable()`, and its dummy implementation (always returning false)
+#   lives here, so skipping this project leaves that symbol undefined for wasm consumers.
 
 IF(MSVC)
   # Disabling following warnings:
@@ -86,5 +88,3 @@ install(
   NAMESPACE MeshLib::
   DESTINATION ${MR_CONFIG_DIR}
 )
-
-ENDIF() # NOT EMSCRIPTEN


### PR DESCRIPTION
The `meshlib_vX_dotnet-wasm` package ships one C API declaration with no definition, so a Unity WebGL consumer cannot link it:

```
wasm-ld: error: GameAssembly.a(...): undefined symbol: MR_Cuda_isCudaAvailable
```

### Why

`generate.mk` deliberately keeps `isCudaAvailable()` in the bindings when Cuda is off — [`generate.mk:547`](https://github.com/MeshInspector/MeshLib/blob/master/scripts/mrbind/generate.mk#L547): *"Even if this is false, we emit a dummy `isCudaAvailable()` that always returns false. That's what we use wherever there is no Cuda toolkit: Macs, Windows Arm, Wasm."* Since #6798 that also covers wasm, so `MRDotNet2Static.dll` still P/Invokes it.

Its dummy implementation lives in `MeshLibC2Cuda` (`scripts/mrbind/cuda_placeholder_generated_c/src/MRCCuda/MRCudaBasic.cpp`, which CI copies into `source/MeshLibC2Cuda`), but that whole project was wrapped in `IF(NOT EMSCRIPTEN)` — added by #6271 when nothing consumed the C bindings on wasm yet. The root `CMakeLists.txt` already states the opposite intent: *"The Cuda is always enabled. Even if we don't want to actually build Cuda, we still need the stubs."* So the declaration shipped and the definition did not.

### Fix

- drop the `IF(NOT EMSCRIPTEN)` guard in `source/MeshLibC2Cuda/CMakeLists.txt` (MRCuda linkage is already behind `MESHLIB_BUILD_MRCUDA`, which the root `CMakeLists.txt` forces off for Emscripten, so only the placeholder is compiled)
- build the target in the wasm C-bindings job, so `libMeshLibC2Cuda.a` reaches the package

The package grows by one archive holding one function. No consumer-side change: `docs/using_dotnet_wasm_bindings.md` already says to enable all `.a` files in the chosen `emsdk-*/<threads>` directory, and `Prepare output files` globs `build/Release/bin/*.a`.

### Verification

Tested locally against `meshlib_v3.1.3.674_dotnet-wasm.zip` (Unity 6000.3.6f1, `emsdk-3.1.38/singlethreaded`, WebGL player), comparing the DLL's P/Invoke entry points against every symbol defined in the package:

| | 3.1.3.661 | 3.1.3.674 | 674 + this fix, emulated locally |
|---|---|---|---|
| declared but undefined | 162 | 1 | 0 |
| duplicate symbols | 0 | 0 | 0 |
| `function signature mismatch` | 0 | 0 | 0 |

With 3.1.3.674 as shipped the WebGL build fails on that one symbol. Substituting a local stand-in with the placeholder's exact semantics (zero the four `int32_t*` outputs, return false) gives `result=Succeeded errors=0 warnings=0`, zero `wasm-ld` diagnostics of any kind, and the boolean test scene runs correctly (Difference 35 ms, Union 16 ms, Intersection 7 ms).

Please re-test the wasm zip from this PR's draft release — no CI leg builds a Unity WebGL player, so this path is only covered manually. `unity-nuget-test.yml` uses the desktop `.nupkg` and does not build for WebGL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
