### PR TITLE
RibbonSchemaHolder::findItem to look up a ribbon item by name

### DIFF
--- a/source/MRCommonPlugins/ViewerButtons/MRAddCustomTheme.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRAddCustomTheme.cpp
@@ -203,10 +203,9 @@ void AddCustomThemePlugin::updateThemeNames_()
         }
     }
 
-    auto itemId = RibbonSchemaHolder::schema().items.find( "Viewer settings" );
-    if ( itemId != RibbonSchemaHolder::schema().items.end() )
+    if ( const auto * itemInfo = RibbonSchemaHolder::findItem( "Viewer settings" ) )
     {
-        if ( auto viewerSettingsPlugin = std::dynamic_pointer_cast< ViewerSettingsPlugin >( itemId->second.item ) )
+        if ( auto viewerSettingsPlugin = std::dynamic_pointer_cast< ViewerSettingsPlugin >( itemInfo->item ) )
         {
             if ( viewerSettingsPlugin->isActive() )
                 viewerSettingsPlugin->updateThemes();

--- a/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
@@ -212,10 +212,9 @@ OpenFilesMenuItem::OpenFilesMenuItem() :
     // required to be deferred, resent items store to be initialized
     CommandLoop::appendCommand( [&] ()
     {
-        auto openDirIt = RibbonSchemaHolder::schema().items.find( "Open directory" );
-        if ( openDirIt != RibbonSchemaHolder::schema().items.end() )
+        if ( const auto * openDirInfo = RibbonSchemaHolder::findItem( "Open directory" ) )
         {
-            openDirectoryItem_ = std::dynamic_pointer_cast<OpenDirectoryMenuItem>( openDirIt->second.item );
+            openDirectoryItem_ = std::dynamic_pointer_cast<OpenDirectoryMenuItem>( openDirInfo->item );
         }
         else
         {

--- a/source/MRCommonPlugins/ViewerButtons/MRViewerSettingsPlugin.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRViewerSettingsPlugin.cpp
@@ -185,10 +185,10 @@ ViewerSettingsPlugin* ViewerSettingsPlugin::instance()
 {
     static ViewerSettingsPlugin* self = [&]()->ViewerSettingsPlugin*
     {
-      auto viewerSettingsIt = RibbonSchemaHolder::schema().items.find( "Viewer settings" );
-      if ( viewerSettingsIt == RibbonSchemaHolder::schema().items.end() )
+      const auto * viewerSettings = RibbonSchemaHolder::findItem( "Viewer settings" );
+      if ( !viewerSettings )
           return nullptr;
-      return dynamic_cast< ViewerSettingsPlugin* >( viewerSettingsIt->second.item.get() );
+      return dynamic_cast< ViewerSettingsPlugin* >( viewerSettings->item.get() );
       }();
     return self;
 }
@@ -997,17 +997,16 @@ void ViewerSettingsPlugin::drawThemeSelector_()
         }
         backgroundColor_ = Vector4f( ColorTheme::getViewportColor( ColorTheme::ViewportColorsType::Background ) );
     }
-    auto item = RibbonSchemaHolder::schema().items.find( "Add custom theme" );
-    if ( item != RibbonSchemaHolder::schema().items.end() )
+    if ( const auto * item = RibbonSchemaHolder::findItem( "Add custom theme" ) )
     {
         ImGui::SameLine( 300.0f * UI::scale() );
         if ( UI::button( _tr( "Add" ),
-            item->second.item->isAvailable( getAllObjectsInTree<const Object>( &SceneRoot::get(), ObjectSelectivityType::Selected ) ).empty(),
+            item->item->isAvailable( getAllObjectsInTree<const Object>( &SceneRoot::get(), ObjectSelectivityType::Selected ) ).empty(),
             Vector2f( 50.0f * UI::scale(), 0 ) ) )
         {
-            item->second.item->action();
+            item->item->action();
         }
-        UI::setTooltipIfHovered( _tr( item->second.tooltip.c_str(), item->second.localeDomainId ) );
+        UI::setTooltipIfHovered( _tr( item->tooltip.c_str(), item->localeDomainId ) );
     }
 }
 

--- a/source/MRViewer/MRRibbonLayoutConfig.cpp
+++ b/source/MRViewer/MRRibbonLayoutConfig.cpp
@@ -98,12 +98,12 @@ void applyRibbonConfig( const RibbonConfig& config )
                 {
                     const auto& item = items[i];
                     auto& itemName = item["Name"];
-                    auto findIt = RibbonSchemaHolder::schema().items.find( itemName.asString() );
-                    if ( findIt == RibbonSchemaHolder::schema().items.end() )
+                    auto * findIt = RibbonSchemaHolder::findItem( itemName.asString() );
+                    if ( !findIt )
                         continue;
-                    findIt->second.caption = "";
-                    findIt->second.helpLink = "";
-                    findIt->second.item->setDropItemsFromItemList( {} );
+                    findIt->caption = "";
+                    findIt->helpLink = "";
+                    findIt->item->setDropItemsFromItemList( {} );
                 }
                 readItemsJson_( root );
             }

--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -63,11 +63,10 @@ constexpr auto cTransformContextName = "TransformContextWindow";
 
 std::string getItemCaption( const std::string& name )
 {
-    auto it = RibbonSchemaHolder::schema().items.find( name );
-    if ( it == RibbonSchemaHolder::schema().items.end() )
+    const auto * item = RibbonSchemaHolder::findItem( name );
+    if ( !item )
         return name;
-    const auto& item = it->second;
-    return Locale::translate( item.getCaption().c_str(), item.localeDomainId );
+    return Locale::translate( item->getCaption().c_str(), item->localeDomainId );
 }
 
 } //anonymous namespace
@@ -226,11 +225,11 @@ void RibbonMenu::setSceneSize( const Vector2i& size )
 
 void RibbonMenu::updateItemStatus( const std::string& itemName )
 {
-    auto itemIt = RibbonSchemaHolder::schema().items.find( itemName );
-    if ( itemIt == RibbonSchemaHolder::schema().items.end() )
+    const auto * itemInfo = RibbonSchemaHolder::findItem( itemName );
+    if ( !itemInfo )
         return;
 
-    auto& item = itemIt->second.item;
+    const auto& item = itemInfo->item;
     assert( item );
     if ( item->isActive() )
     {
@@ -520,10 +519,10 @@ void RibbonMenu::drawHeaderQuickAccess_()
     int dropCount = 0;
     for ( const auto& item : RibbonSchemaHolder::schema().headerQuickAccessList )
     {
-        auto it = RibbonSchemaHolder::schema().items.find( item );
-        if ( it == RibbonSchemaHolder::schema().items.end() )
+        const auto * itemInfo = RibbonSchemaHolder::findItem( item );
+        if ( !itemInfo )
             continue;
-        if ( it->second.item && it->second.item->type() == RibbonItemType::ButtonWithDrop )
+        if ( itemInfo->item && itemInfo->item->type() == RibbonItemType::ButtonWithDrop )
             dropCount++;
     }
 
@@ -545,8 +544,8 @@ void RibbonMenu::drawHeaderQuickAccess_()
     UI::TestEngine::pushTree( "QuickAccess" );
     for ( const auto& item : RibbonSchemaHolder::schema().headerQuickAccessList )
     {
-        auto it = RibbonSchemaHolder::schema().items.find( item );
-        if ( it == RibbonSchemaHolder::schema().items.end() )
+        const auto * itemInfo = RibbonSchemaHolder::findItem( item );
+        if ( !itemInfo )
         {
 #ifndef __EMSCRIPTEN__
             spdlog::warn( "Plugin \"{}\" not found!", item );
@@ -554,7 +553,7 @@ void RibbonMenu::drawHeaderQuickAccess_()
             continue;
         }
 
-        buttonDrawer_.drawButtonItem( it->second, params );
+        buttonDrawer_.drawButtonItem( *itemInfo, params );
         ImGui::SameLine();
     }
     UI::TestEngine::popTree(); // "QuickAccess"
@@ -828,8 +827,7 @@ float RibbonMenu::drawHeaderHelpers_( float requiredTabSize )
 
 void RibbonMenu::drawActiveListButton_( float btnSize )
 {
-    auto activeListIt = RibbonSchemaHolder::schema().items.find( "Active Plugins List" );
-    if ( activeListIt != RibbonSchemaHolder::schema().items.end() )
+    if ( const auto * activeListInfo = RibbonSchemaHolder::findItem( "Active Plugins List" ) )
     {
         setActiveListPos( ImGui::GetCursorScreenPos() );
         CustomButtonParameters cParams;
@@ -854,7 +852,7 @@ void RibbonMenu::drawActiveListButton_( float btnSize )
         };
         const ImVec2 itemSize = { btnSize, btnSize };
         DrawButtonParams params{ DrawButtonParams::SizeType::Small, itemSize, cMiddleIconSize,DrawButtonParams::RootType::Toolbar };
-        buttonDrawer_.drawCustomButtonItem( activeListIt->second, cParams, params );
+        buttonDrawer_.drawCustomButtonItem( *activeListInfo, cParams, params );
     }
 }
 
@@ -1311,13 +1309,13 @@ void RibbonMenu::drawSmallButtonsSet_( const std::vector<std::string>& group, in
     auto type = withText ? DrawButtonParams::SizeType::SmallText : DrawButtonParams::SizeType::Small;
     for ( int i = setFrontIndex; i < setFrontIndex + setLength; ++i )
     {
-        auto it = RibbonSchemaHolder::schema().items.find( group[i] );
-        if ( it == RibbonSchemaHolder::schema().items.end() )
+        const auto * itemInfo = RibbonSchemaHolder::findItem( group[i] );
+        if ( !itemInfo )
             continue; // TODO: assert or log
 
-        widths[i - setFrontIndex] = buttonDrawer_.calcItemWidth( it->second, type );
+        widths[i - setFrontIndex] = buttonDrawer_.calcItemWidth( *itemInfo, type );
         auto sumWidth = widths[i - setFrontIndex].baseWidth + widths[i - setFrontIndex].additionalWidth;
-        items[i - setFrontIndex] = &it->second;
+        items[i - setFrontIndex] = itemInfo;
         if ( sumWidth > maxSetWidth )
             maxSetWidth = sumWidth;
     }
@@ -1370,12 +1368,12 @@ RibbonMenu::DrawTabConfig RibbonMenu::setupItemsGroupConfig_( const std::vector<
         {
             if ( config.numBig > 0 )
             {
-                auto itemIt = RibbonSchemaHolder::schema().items.find( items[i] );
+                const auto * itemInfo = RibbonSchemaHolder::findItem( items[i] );
                 ++i;
                 --config.numBig;
-                if ( itemIt == RibbonSchemaHolder::schema().items.end() )
+                if ( !itemInfo )
                     continue; // TODO: asserts or log
-                resWidth += buttonDrawer_.calcItemWidth( itemIt->second, DrawButtonParams::SizeType::Big ).baseWidth;
+                resWidth += buttonDrawer_.calcItemWidth( *itemInfo, DrawButtonParams::SizeType::Big ).baseWidth;
                 resWidth += style.ItemSpacing.x;
                 continue;
             }
@@ -1388,10 +1386,10 @@ RibbonMenu::DrawTabConfig RibbonMenu::setupItemsGroupConfig_( const std::vector<
                 float maxWidth = 0.0f;
                 for ( int j = i; j < i + n; ++j )
                 {
-                    auto itemIt = RibbonSchemaHolder::schema().items.find( items[j] );
-                    if ( itemIt == RibbonSchemaHolder::schema().items.end() )
+                    const auto * itemInfo = RibbonSchemaHolder::findItem( items[j] );
+                    if ( !itemInfo )
                         continue; // TODO: asserts or log
-                    auto width = buttonDrawer_.calcItemWidth( itemIt->second,
+                    auto width = buttonDrawer_.calcItemWidth( *itemInfo,
                                                               smallText ?
                                                               DrawButtonParams::SizeType::SmallText :
                                                               DrawButtonParams::SizeType::Small );
@@ -1497,8 +1495,8 @@ void RibbonMenu::drawItemsGroup_( const std::string& tabName, const std::string&
     for ( int i = 0; i < size; )
     {
         const auto& item = groupIt->second[i];
-        auto it = RibbonSchemaHolder::schema().items.find( item );
-        if ( it == RibbonSchemaHolder::schema().items.end() )
+        const auto * itemInfo = RibbonSchemaHolder::findItem( item );
+        if ( !itemInfo )
         {
             ++i;
             assert( false );
@@ -1508,7 +1506,7 @@ void RibbonMenu::drawItemsGroup_( const std::string& tabName, const std::string&
         ImGui::SetCursorPosY( defaultYPos - itemSpacing.y );
         if ( config.numBig > 0 )
         {
-            drawBigButtonItem_( it->second );
+            drawBigButtonItem_( *itemInfo );
             config.numBig--;
             i++;
             if ( i < size )
@@ -1566,11 +1564,11 @@ bool RibbonMenu::itemPressed_( const std::shared_ptr<RibbonMenuItem>& item, cons
             pushNotification( {
                 .onButtonClick = []
                 {
-                    auto viewerSettingsIt = RibbonSchemaHolder::schema().items.find( "Viewer settings" );
-                    if ( viewerSettingsIt == RibbonSchemaHolder::schema().items.end() )
+                    const auto * viewerSettings = RibbonSchemaHolder::findItem( "Viewer settings" );
+                    if ( !viewerSettings )
                         return;
-                    if ( viewerSettingsIt->second.item && !viewerSettingsIt->second.item->isActive() )
-                        viewerSettingsIt->second.item->action();
+                    if ( viewerSettings->item && !viewerSettings->item->isActive() )
+                        viewerSettings->item->action();
                 },
                 .buttonName = _tr( "Open Settings" ),
                 .text = _tr( "Unable to activate this tool because another blocking tool is already active.\nIt can be changed in the Settings." ),
@@ -1588,11 +1586,11 @@ bool RibbonMenu::itemPressed_( const std::shared_ptr<RibbonMenuItem>& item, cons
                 pushNotification( {
                 .onButtonClick = []
                 {
-                    auto viewerSettingsIt = RibbonSchemaHolder::schema().items.find( "Viewer settings" );
-                    if ( viewerSettingsIt == RibbonSchemaHolder::schema().items.end() )
+                    const auto * viewerSettings = RibbonSchemaHolder::findItem( "Viewer settings" );
+                    if ( !viewerSettings )
                         return;
-                    if ( viewerSettingsIt->second.item && !viewerSettingsIt->second.item->isActive() )
-                        viewerSettingsIt->second.item->action();
+                    if ( viewerSettings->item && !viewerSettings->item->isActive() )
+                        viewerSettings->item->action();
                 },
                 .buttonName = _tr( "Open Settings" ),
                 .text = _tr( "That tool was closed due to other tool start.\nIt can be changed in the Settings." ),
@@ -1662,8 +1660,8 @@ void RibbonMenu::drawSceneListButtons_()
     UI::TestEngine::pushTree( "RibbonSceneButtons" );
     for ( const auto& item : RibbonSchemaHolder::schema().sceneButtonsList )
     {
-        auto it = RibbonSchemaHolder::schema().items.find( item );
-        if ( it == RibbonSchemaHolder::schema().items.end() )
+        const auto * itemInfo = RibbonSchemaHolder::findItem( item );
+        if ( !itemInfo )
         {
 #ifndef __EMSCRIPTEN__
             spdlog::warn( "Plugin \"{}\" not found!", item ); // TODO don't flood same message
@@ -1671,7 +1669,7 @@ void RibbonMenu::drawSceneListButtons_()
             continue;
         }
 
-        buttonDrawer_.drawButtonItem( it->second, params );
+        buttonDrawer_.drawButtonItem( *itemInfo, params );
         ImGui::SameLine();
     }
     UI::TestEngine::popTree(); // "RibbonSceneButtons"
@@ -1950,10 +1948,9 @@ bool RibbonMenu::drawCollapsingHeaderTransform_()
         UI::setTooltipIfHovered( _tr( "Resets transform value to identity." ) );
         iconsFont.pushFont();
 
-        auto item = RibbonSchemaHolder::schema().items.find( "Apply Transform" );
-        bool drawApplyBtn = numButtons >=3.0f &&
-            item != RibbonSchemaHolder::schema().items.end() &&
-            item->second.item->isAvailable( SceneCache::getAllObjects<const Object, ObjectSelectivityType::Selected>() ).empty();
+        const auto * item = RibbonSchemaHolder::findItem( "Apply Transform" );
+        bool drawApplyBtn = numButtons >=3.0f && item &&
+            item->item->isAvailable( SceneCache::getAllObjects<const Object, ObjectSelectivityType::Selected>() ).empty();
 
         if ( drawApplyBtn )
         {
@@ -1961,7 +1958,7 @@ bool RibbonMenu::drawCollapsingHeaderTransform_()
             ImGui::SetCursorPos( contextBtnPos );
 
             if ( ImGui::Button( "\xef\x80\x8c", smallBtnSize ) ) // V(apply) icon for apply
-                item->second.item->action();
+                item->item->action();
             iconsFont.popFont();
             UI::setTooltipIfHovered( _tr( "Transforms object and resets transform value to identity." ) );
             iconsFont.pushFont();
@@ -2112,12 +2109,12 @@ bool RibbonMenu::drawTransformContextMenu_( const std::vector<std::shared_ptr<Ob
 
     if ( anyNonIdentity )
     {
-        auto item = RibbonSchemaHolder::schema().items.find( "Apply Transform" );
-        if ( item != RibbonSchemaHolder::schema().items.end() &&
-            item->second.item->isAvailable( SceneCache::getAllObjects<const Object, ObjectSelectivityType::Selected>() ).empty() &&
+        const auto * item = RibbonSchemaHolder::findItem( "Apply Transform" );
+        if ( item &&
+            item->item->isAvailable( SceneCache::getAllObjects<const Object, ObjectSelectivityType::Selected>() ).empty() &&
             UI::button( _tr( "Apply" ), Vector2f( buttonSize, 0 ) ) )
         {
-            item->second.item->action();
+            item->item->action();
             ImGui::CloseCurrentPopup();
         }
         UI::setTooltipIfHovered( _tr( "Transforms object and resets transform value to identity." ) );
@@ -2140,10 +2137,10 @@ void RibbonMenu::addRibbonItemShortcut( const std::string& itemName, const Short
         assert( false );
         return;
     }
-    auto itemIt = RibbonSchemaHolder::schema().items.find( itemName );
-    if ( itemIt != RibbonSchemaHolder::schema().items.end() )
+    const auto * itemInfo = RibbonSchemaHolder::findItem( itemName );
+    if ( itemInfo )
     {
-        shortcutManager_->setShortcut( shortcut, { itemIt->first, [item = itemIt->second.item, this]()
+        shortcutManager_->setShortcut( shortcut, { itemName, [item = itemInfo->item, this]()
         {
             itemPressed_( item, getRequirements_( item ) );
         } } );

--- a/source/MRViewer/MRRibbonSchema.cpp
+++ b/source/MRViewer/MRRibbonSchema.cpp
@@ -371,6 +371,13 @@ std::vector<RibbonSchemaHolder::SearchResult> RibbonSchemaHolder::search( const 
     return res;
 }
 
+MenuItemInfo * RibbonSchemaHolder::findItem( const std::string& name )
+{
+    auto& items = schema().items;
+    const auto it = items.find( name );
+    return it != items.end() ? &it->second : nullptr;
+}
+
 int RibbonSchemaHolder::findItemTab( const std::shared_ptr<RibbonMenuItem>& item )
 {
     if ( !item )
@@ -452,8 +459,7 @@ void RibbonSchemaLoader::readMenuItemsList( const Json::Value& root, MenuItemsLi
             assert( false );
             continue;
         }
-        auto findIt = RibbonSchemaHolder::schema().items.find( itemName.asString() );
-        if ( findIt == RibbonSchemaHolder::schema().items.end() )
+        if ( !RibbonSchemaHolder::findItem( itemName.asString() ) )
         {
             spdlog::warn( "Ribbon item \"{}\" is not registered", itemName.asString() );
             // do not assert here because item may have been saved (in user config) before MI version update
@@ -693,8 +699,8 @@ void RibbonSchemaLoader::readItemsJson_( const Json::Value& itemsStruct, const s
     {
         auto item = items[i];
         auto& itemName = item["Name"];
-        auto findIt = RibbonSchemaHolder::schema().items.find( itemName.asString() );
-        if ( findIt == RibbonSchemaHolder::schema().items.end() )
+        auto * findIt = RibbonSchemaHolder::findItem( itemName.asString() );
+        if ( !findIt )
         {
 #ifndef __EMSCRIPTEN__
             spdlog::warn( "Ribbon item \"{}\" is not registered", itemName.asString() );
@@ -702,7 +708,7 @@ void RibbonSchemaLoader::readItemsJson_( const Json::Value& itemsStruct, const s
 #endif
             continue;
         }
-        auto& [_, menuItem] = *findIt;
+        auto& menuItem = *findIt;
 
         menuItem.localeDomainId = domainId;
 

--- a/source/MRViewer/MRRibbonSchema.h
+++ b/source/MRViewer/MRRibbonSchema.h
@@ -108,6 +108,9 @@ public:
     /// returns false if item was not present
     MRVIEWER_API static bool delItem( const std::shared_ptr<RibbonMenuItem>& item );
 
+    /// returns the information about the item with given name, or nullptr if there is no such item
+    MRVIEWER_API static MenuItemInfo * findItem( const std::string& name );
+
     /// struct to hold information for search result presentation
     struct SearchResult
     {

--- a/source/MRViewer/MRStatePlugin.cpp
+++ b/source/MRViewer/MRStatePlugin.cpp
@@ -34,12 +34,11 @@ StateBasePlugin::StateBasePlugin( std::string name, StatePluginTabs tab ):
     {
         std::string name = this->name();
         LocaleDomainId localeDomainId;
-        auto item = RibbonSchemaHolder::schema().items.find( name );
-        if ( item != RibbonSchemaHolder::schema().items.end() )
+        if ( const auto * item = RibbonSchemaHolder::findItem( name ) )
         {
-            if ( !item->second.caption.empty() )
-                name = item->second.caption;
-            localeDomainId = item->second.localeDomainId;
+            if ( !item->caption.empty() )
+                name = item->caption;
+            localeDomainId = item->localeDomainId;
         }
         plugin_name = Locale::translate( name.c_str(), localeDomainId );
         plugin_name += UINameSuffix();
@@ -136,9 +135,9 @@ bool StateBasePlugin::ImGuiBeginWindow_( ImGui::CustomStatePluginWindowParameter
 
     if ( !params.helpBtnFn )
     {
-        auto it = RibbonSchemaHolder::schema().items.find( name() );
-        if ( it != RibbonSchemaHolder::schema().items.end() && !it->second.helpLink.empty() )
-            params.helpBtnFn = [&] () { OpenLink( it->second.helpLink ); };
+        const auto * it = RibbonSchemaHolder::findItem( name() );
+        if ( it && !it->helpLink.empty() )
+            params.helpBtnFn = [&] () { OpenLink( it->helpLink ); };
     }
 
     return BeginCustomStatePlugin( uiName().c_str(), &dialogIsOpen_, params );

--- a/source/MRViewer/MRToolbar.cpp
+++ b/source/MRViewer/MRToolbar.cpp
@@ -50,11 +50,11 @@ void Toolbar::drawToolbar()
     //TODO calc if list changes
     for ( const auto& item : itemsList_ )
     {
-        auto it = RibbonSchemaHolder::schema().items.find( item );
-        if ( it == RibbonSchemaHolder::schema().items.end() )
+        const auto * itemInfo = RibbonSchemaHolder::findItem( item );
+        if ( !itemInfo )
             continue;
         ++itemCount;
-        if ( it->second.item->type() == RibbonItemType::ButtonWithDrop )
+        if ( itemInfo->item->type() == RibbonItemType::ButtonWithDrop )
             ++droppedItemCount;
     }
 
@@ -103,8 +103,8 @@ void Toolbar::drawToolbar()
     UI::TestEngine::pushTree( "Toolbar" );
     for ( const auto& item : itemsList_ )
     {
-        auto it = RibbonSchemaHolder::schema().items.find( item );
-        if ( it == RibbonSchemaHolder::schema().items.end() )
+        const auto * itemInfo = RibbonSchemaHolder::findItem( item );
+        if ( !itemInfo )
         {
 #ifndef __EMSCRIPTEN__
             spdlog::warn( "Plugin \"{}\" not found!", item ); // TODO don't flood same message
@@ -112,12 +112,11 @@ void Toolbar::drawToolbar()
             continue;
         }
 
-        buttonDrawer.drawButtonItem( it->second, params );
+        buttonDrawer.drawButtonItem( *itemInfo, params );
         ImGui::SameLine();
     }
 
-    auto activeListIt = RibbonSchemaHolder::schema().items.find( "Active Plugins List" );
-    if ( activeListIt != RibbonSchemaHolder::schema().items.end() )
+    if ( const auto * activeListInfo = RibbonSchemaHolder::findItem( "Active Plugins List" ) )
     {
         ribbonMenu_->setActiveListPos( ImGui::GetCursorScreenPos() );
         CustomButtonParameters cParams;
@@ -140,7 +139,7 @@ void Toolbar::drawToolbar()
             }
             return 4;
         };
-        buttonDrawer.drawCustomButtonItem( activeListIt->second, cParams, params );
+        buttonDrawer.drawCustomButtonItem( *activeListInfo, cParams, params );
         ImGui::SameLine();
     }
 
@@ -273,8 +272,8 @@ void Toolbar::drawCustomizeModal_()
     for ( int i = 0; i < itemsListCustomize_.size(); ++i )
     {
         const auto& itemPreview = itemsListCustomize_[i];
-        auto iterItemPreview = RibbonSchemaHolder::schema().items.find( itemPreview );
-        if ( iterItemPreview == RibbonSchemaHolder::schema().items.end() )
+        const auto * iterItemPreview = RibbonSchemaHolder::findItem( itemPreview );
+        if ( !iterItemPreview )
         {
 #ifndef __EMSCRIPTEN__
             spdlog::warn( "Plugin \"{}\" not found!", itemPreview ); // TODO don't flood same message
@@ -302,14 +301,14 @@ void Toolbar::drawCustomizeModal_()
             ImGui::SetCursorPos( { 0, 0 } );
             ImGui::SetDragDropPayload( "ToolbarItemNumber", &i, sizeof( int ) );
             const auto& item = itemsList_[i];
-            auto iterItem = RibbonSchemaHolder::schema().items.find( item );
+            const auto * iterItem = RibbonSchemaHolder::findItem( item );
             ImGui::SetCursorPos( ImVec2( 1 * UI::scale(), 1 * UI::scale() ) );
             UI::button( "##ToolbarDragDropBtnHighlight", tooltipContourSize );
             ImGui::SetCursorPos( ImVec2( 2 * UI::scale(), 2 * UI::scale() ) );
             ImGui::Button( "##ToolbarDragDropBtn", params.itemSize);
             ImGui::SetCursorPos( ImVec2( 2 * UI::scale(), 2 * UI::scale() ) );
-            if ( iterItem != RibbonSchemaHolder::schema().items.end() )
-                buttonDrawer.drawButtonIcon( iterItem->second, params );
+            if ( iterItem )
+                buttonDrawer.drawButtonIcon( *iterItem, params );
             ImGui::EndDragDropSource();
             dragDrop_ = true;
         }
@@ -351,7 +350,7 @@ void Toolbar::drawCustomizeModal_()
         auto screenPos = Vector2f( ImGui::GetCursorScreenPos() );
         dashedRect_( screenPos, screenPos + Vector2f::diagonal( params.itemSize.x - 1 * UI::scale() ), 10.f, 0.5f,
             ColorTheme::getRibbonColor( ColorTheme::RibbonColorsType::Borders ) );
-        buttonDrawer.drawButtonIcon( iterItemPreview->second, params );
+        buttonDrawer.drawButtonIcon( *iterItemPreview, params );
 
         ImGui::SameLine( 0, childWindowPadding.x + 3 * UI::scale() );
     }
@@ -554,9 +553,9 @@ void Toolbar::drawCustomizeItemsList_()
         }
 
         bool checkboxChanged = false;
-        auto schemaItem = RibbonSchemaHolder::schema().items.find( item );
-        if ( schemaItem != RibbonSchemaHolder::schema().items.end() )
-            checkboxChanged = buttonDrawer.GradientCheckboxItem( schemaItem->second, &itemInQA );
+        const auto * schemaItem = RibbonSchemaHolder::findItem( item );
+        if ( schemaItem )
+            checkboxChanged = buttonDrawer.GradientCheckboxItem( *schemaItem, &itemInQA );
         else
             checkboxChanged = UI::checkbox( item.c_str(), &itemInQA );
 


### PR DESCRIPTION
`RibbonSchemaHolder` had `search()` and `findItemTab()` but no way to get one item by name, so every caller wrote the `schema().items.find( name )` + compare-to-`end()` pair by hand - 30 times in this repo, and more downstream.

```cpp
/// returns the information about the item with given name, or nullptr if there is no such item
MRVIEWER_API static MenuItemInfo * findItem( const std::string& name );
```

Non-const, like `schema()` itself, because three of the call sites write to the found item.

All 30 existing lookups now go through it. No behaviour change: each `it == end()` test becomes a null test and each `it->second` becomes the dereferenced pointer. One structured binding (`auto& [_, menuItem] = *findIt`) goes away with it, and `addRibbonItemShortcut` takes the name from its own argument rather than from the map key it just looked up by.

## Test plan

- The 8 changed translation units compile clean with the project's own flags, `/Wall /WX` included.
- The rest is CI: the change is a mechanical rewrite of lookups with no new branches.
