### PR TITLE
Object: do not include MRBitSet.h

### DIFF
--- a/source/MRMesh/MRObject.cpp
+++ b/source/MRMesh/MRObject.cpp
@@ -4,6 +4,7 @@
 #include "MRSerializer.h"
 #include "MRStringConvert.h"
 #include "MRHeapBytes.h"
+#include "MRphmap.h"
 #include "MRPch/MRJson.h"
 #include "MRPch/MRSpdlog.h"
 

--- a/source/MRMesh/MRObject.h
+++ b/source/MRMesh/MRObject.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "MRAffineXf3.h"
-#include "MRBitSet.h"
 #include "MRBox.h"
 #include "MRExpected.h"
 #include "MRProgressCallback.h"

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MRPch/MRBindingMacros.h"
+#include "MRBitSet.h"
 #include "MRVisualObject.h"
 #include "MRXfBasedCache.h"
 #include "MRPointCloudPart.h"

--- a/source/MRMesh/MRVisualObject.h
+++ b/source/MRMesh/MRVisualObject.h
@@ -8,6 +8,8 @@
 #include "MRUniquePtr.h"
 #include "MREnums.h"
 
+#include <optional>
+
 namespace MR
 {
 

--- a/source/MRViewer/MRViewportGL.cpp
+++ b/source/MRViewer/MRViewportGL.cpp
@@ -3,6 +3,7 @@
 #include "MRGLStaticHolder.h"
 #include "MRViewer.h"
 #include "MRGladGlfw.h"
+#include "MRMesh/MRBitSet.h"
 #include "MRMesh/MRParallelFor.h"
 #include "MRMesh/MRVisualObject.h"
 #include "MRMesh/MRMatrix4.h"


### PR DESCRIPTION
`MRObject.h` does not use any bitset type, so it no longer includes `MRBitSet.h`.

Three files were relying on that transitive include and now include what they use:

- `MRObject.cpp` - `HashMap` (`MRphmap.h`)
- `MRObjectPointsHolder.h` - `VertBitSet` member
- `MRViewer/MRViewportGL.cpp` - `BitSet` locals

Verified locally with a `cl /Zs` syntax sweep of MRMesh (305 TUs), MRViewer, MRVoxels and MRSymbolMesh: no new failures vs. the same sweep on master. An include-graph script over the whole repo (checking every user of `MRObject.h` for the types `MRBitSet.h` was providing - bitsets, `Id`, `Vector`, `HashMap`, `resizeNoInit`, `<iterator>`) reports only declaration-only uses that `MRMeshFwd.h` satisfies.
