### PR TITLE
Object: do not include MRBox.h

### DIFF
--- a/source/MRMesh/MRObject.cpp
+++ b/source/MRMesh/MRObject.cpp
@@ -3,6 +3,7 @@
 #include "MRObjectTagEventDispatcher.h"
 #include "MRSerializer.h"
 #include "MRStringConvert.h"
+#include "MRBox.h"
 #include "MRHeapBytes.h"
 #include "MRphmap.h"
 #include "MRPch/MRJson.h"
@@ -857,6 +858,11 @@ void Object::swap( Object& other )
     swapBase_( other );
     // swap signals second time to return in place
     swapSignals_( other );
+}
+
+Box3f Object::getWorldBox( ViewportId ) const
+{
+    return {}; // empty box
 }
 
 Box3f Object::getWorldTreeBox( ViewportId id ) const

--- a/source/MRMesh/MRObject.h
+++ b/source/MRMesh/MRObject.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "MRAffineXf3.h"
-#include "MRBox.h"
 #include "MRExpected.h"
 #include "MRProgressCallback.h"
 #include "MRSignal.h"
@@ -244,7 +243,7 @@ public:
     MRMESH_API void swap( Object& other );
 
     /// returns bounding box of this object in world coordinates for default or specific viewport
-    virtual Box3f getWorldBox( ViewportId = {} ) const { return {}; } ///empty box
+    MRMESH_API virtual Box3f getWorldBox( ViewportId = {} ) const;
     /// returns bounding box of this object and all children visible in given (or default) viewport in world coordinates
     MRMESH_API Box3f getWorldTreeBox( ViewportId = {} ) const;
 

--- a/source/MRMesh/MRVisualObject.h
+++ b/source/MRMesh/MRVisualObject.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MRObject.h"
+#include "MRBox.h"
 #include "MRMeshTexture.h"
 #include "MRVector.h"
 #include "MRColor.h"


### PR DESCRIPTION
`MRObject.h` no longer includes `MRBox.h`. The only thing in the header that needed `Box3f` complete was the inline `getWorldBox()` body, so that moves to the .cpp (`MRMESH_API virtual`, as the override declarations in the holders already are); `Box3f` in the two remaining declarations is satisfied by `MRMeshFwd.h`.

`MRVisualObject.h` now includes `MRBox.h` itself - it has an inline `computeBoundingBox_()` returning `Box3f()` and a `std::optional<Box3f>` member - which keeps every visual-object descendant supplied. `MRObject.cpp` includes it for `getWorldTreeBox()`.

Verified with a `cl /Zs` sweep of MRMesh, MRViewer, MRVoxels and MRSymbolMesh: failing-TU sets identical to the same sweep on master (4 known no-PCH artifacts in MRMesh, 82 in MRViewer, 0 elsewhere). An include-graph pass over the repo - traversing thirdparty and vcpkg headers this time, so std headers reached through `MRBox.h` (`<algorithm>`, `<cassert>`, `<iosfwd>`, `<limits>`, `<type_traits>`) are accounted for - leaves only `MRObjectTransformWidget.h`, whose `const Box3f&` parameters need no definition.

Note this overlaps #6274, which drops `MRBox.h` along with `MRAffineXf3.h`, `MRViewportProperty.h` and `<array>` and makes the same `getWorldBox()` and `MRVisualObject.h` changes; whichever lands second will need a trivial conflict resolution.
