### PR TITLE
Show primitive mapping in the Mesh Boolean examples

### DIFF
--- a/doxygen/examples/MeshBoolean.dox
+++ b/doxygen/examples/MeshBoolean.dox
@@ -3,8 +3,9 @@
 
 Example of boolean operation
 
-The optional \ref MR::BooleanResultMapper "BooleanResultMapper" passed to the operation maps
-faces, vertices and edges of the input meshes to the primitives of the result mesh.
+The optional \ref MR::BooleanResultMapper "BooleanResultMapper" passed to the operation maps faces,
+vertices and edges of the input meshes to the primitives of the result mesh, and its
+\ref MR::BooleanResultMapper::getNew2OldFaceMap "getNew2OldFaceMap" maps the faces back.
 
 <div class="tabbed">
  

--- a/doxygen/examples/MeshBoolean.dox
+++ b/doxygen/examples/MeshBoolean.dox
@@ -3,6 +3,9 @@
 
 Example of boolean operation
 
+The optional \ref MR::BooleanResultMapper "BooleanResultMapper" passed to the operation maps
+faces, vertices and edges of the input meshes to the primitives of the result mesh.
+
 <div class="tabbed">
  
 - <b class="tab-title">C++</b>

--- a/examples/c-examples/MeshBoolean.dox.c
+++ b/examples/c-examples/MeshBoolean.dox.c
@@ -1,11 +1,13 @@
 #include <MRCMesh/MRAffineXf.h>
 #include <MRCMesh/MRBitSet.h>
 #include <MRCMesh/MRBooleanOperation.h>
+#include <MRCMesh/MRId.h>
 #include <MRCMesh/MRMakeSphereMesh.h>
 #include <MRCMesh/MRMesh.h>
 #include <MRCMesh/MRMeshBoolean.h>
 #include <MRCMesh/MRMeshSave.h>
 #include <MRCMesh/MRMeshTopology.h>
+#include <MRCMesh/MRVector.h>
 #include <MRCMesh/MRVector3.h>
 #include <MRCMisc/expected_void_std_string.h>
 #include <MRCMisc/std_string.h>
@@ -59,6 +61,25 @@ int main( void )
     MR_FaceBitSet_Destroy( newFaces );
     MR_FaceBitSet_Destroy( facesOfSphere2 );
     MR_FaceBitSet_Destroy( facesOfSphere1 );
+
+    // Map one particular face of sphere1 forward: the cut can split it in several faces of the
+    // result, or drop it completely if that part of sphere1 is not in the result.
+    MR_FaceId faceOfSphere1 = { 793 };
+    MR_FaceBitSet* oneFace = MR_FaceBitSet_DefaultConstruct();
+    MR_FaceBitSet_autoResizeSet_2( oneFace, faceOfSphere1, NULL );
+    MR_FaceBitSet* producedFaces = MR_BooleanResultMapper_map_MR_FaceBitSet( mapper, oneFace, MR_BooleanResultMapper_MapObject_A );
+    printf( "face %d of sphere1 produced %zu faces of the result\n", faceOfSphere1.id_, MR_FaceBitSet_count( producedFaces ) );
+
+    // And backward: the face of sphere1 each face of the result came from
+    // (invalid id for the faces that came from sphere2).
+    MR_FaceMap* new2OldFaces = MR_BooleanResultMapper_getNew2OldFaceMap( mapper, MR_BooleanResultMapper_MapObject_A );
+    MR_FaceId resultFace = MR_FaceBitSet_find_first( producedFaces );
+    printf( "face %d of the result came from face %d of sphere1\n",
+        resultFace.id_, MR_FaceMap_index( new2OldFaces, resultFace )->id_ );
+
+    MR_FaceMap_Destroy( new2OldFaces );
+    MR_FaceBitSet_Destroy( producedFaces );
+    MR_FaceBitSet_Destroy( oneFace );
 
     // Save result to an STL file.
     MR_expected_void_std_string* saveEx = MR_MeshSave_toAnySupportedFormat_3( MR_BooleanResult_Get_mesh( result ), "out_boolean.stl", NULL, NULL);

--- a/examples/c-examples/MeshBoolean.dox.c
+++ b/examples/c-examples/MeshBoolean.dox.c
@@ -1,8 +1,11 @@
 #include <MRCMesh/MRAffineXf.h>
+#include <MRCMesh/MRBitSet.h>
+#include <MRCMesh/MRBooleanOperation.h>
 #include <MRCMesh/MRMakeSphereMesh.h>
 #include <MRCMesh/MRMesh.h>
 #include <MRCMesh/MRMeshBoolean.h>
 #include <MRCMesh/MRMeshSave.h>
+#include <MRCMesh/MRMeshTopology.h>
 #include <MRCMesh/MRVector3.h>
 #include <MRCMisc/expected_void_std_string.h>
 #include <MRCMisc/std_string.h>
@@ -28,13 +31,34 @@ int main( void )
     MR_AffineXf3f xf = MR_AffineXf3f_translation( &xfTranslation );
     MR_Mesh_transform( sphere2, &xf, NULL );
 
+    // Ask for an optional mapper relating the primitives of the input meshes to the primitives of the result.
+    MR_BooleanResultMapper* mapper = MR_BooleanResultMapper_DefaultConstruct();
+    MR_BooleanParameters* params = MR_BooleanParameters_DefaultConstruct();
+    MR_BooleanParameters_Set_mapper( params, mapper );
+
     // Perform the boolean operation.
-    MR_BooleanResult* result = MR_boolean_4_const_MR_Mesh_ref( sphere1, sphere2, MR_BooleanOperation_Intersection, NULL );
+    MR_BooleanResult* result = MR_boolean_4_const_MR_Mesh_ref( sphere1, sphere2, MR_BooleanOperation_Intersection, params );
+    MR_BooleanParameters_Destroy( params );
     if ( !MR_BooleanResult_valid( result ) )
     {
         fprintf( stderr, "Failed to perform boolean: %s\n", MR_std_string_data( MR_BooleanResult_Get_errorString( result ) ) );
         goto fail;
     }
+
+    // Find the faces of the result produced by each input sphere, and the faces the cut created.
+    MR_FaceBitSet* facesOfSphere1 = MR_BooleanResultMapper_map_MR_FaceBitSet(
+        mapper, MR_MeshTopology_getValidFaces( MR_Mesh_Get_topology( sphere1 ) ), MR_BooleanResultMapper_MapObject_A );
+    MR_FaceBitSet* facesOfSphere2 = MR_BooleanResultMapper_map_MR_FaceBitSet(
+        mapper, MR_MeshTopology_getValidFaces( MR_Mesh_Get_topology( sphere2 ) ), MR_BooleanResultMapper_MapObject_B );
+    MR_FaceBitSet* newFaces = MR_BooleanResultMapper_newFaces( mapper );
+
+    printf( "faces from sphere1: %zu\n", MR_FaceBitSet_count( facesOfSphere1 ) );
+    printf( "faces from sphere2: %zu\n", MR_FaceBitSet_count( facesOfSphere2 ) );
+    printf( "faces created by the cut: %zu\n", MR_FaceBitSet_count( newFaces ) );
+
+    MR_FaceBitSet_Destroy( newFaces );
+    MR_FaceBitSet_Destroy( facesOfSphere2 );
+    MR_FaceBitSet_Destroy( facesOfSphere1 );
 
     // Save result to an STL file.
     MR_expected_void_std_string* saveEx = MR_MeshSave_toAnySupportedFormat_3( MR_BooleanResult_Get_mesh( result ), "out_boolean.stl", NULL, NULL);
@@ -47,6 +71,7 @@ int main( void )
     rc = EXIT_SUCCESS;
 fail:
     MR_BooleanResult_Destroy( result );
+    MR_BooleanResultMapper_Destroy( mapper );
     MR_Mesh_Destroy( sphere2 );
     MR_Mesh_Destroy( sphere1 );
     return rc;

--- a/examples/c-sharp-examples/MeshBoolean.dox.cs
+++ b/examples/c-sharp-examples/MeshBoolean.dox.cs
@@ -19,13 +19,26 @@ public class MeshBooleanExample
                 mesh_b.transform(MR.AffineXf3f.translation(new MR.Vector3f(0.7f, 0.0f, 0.0f)));
             }
 
+            // optional mapper relating the primitives of the input meshes to the primitives of the result
+            var mapper = new MR.BooleanResultMapper();
+            var parameters = new MR.BooleanParameters();
+            parameters.mapper = mapper;
+
             // perform boolean operation
-            MR.BooleanResult res = MR.boolean(mesh_a, mesh_b, MR.BooleanOperation.Intersection);
+            MR.BooleanResult res = MR.boolean(mesh_a, mesh_b, MR.BooleanOperation.Intersection, parameters);
             if (!res.valid())
             {
                 Console.WriteLine("Error: {0}", res.errorString);
                 return;
             }
+
+            // find the faces of the result produced by each input mesh, and the faces the cut created
+            var facesOfA = mapper.map(mesh_a.topology.getValidFaces(), MR.BooleanResultMapper.MapObject.A);
+            var facesOfB = mapper.map(mesh_b.topology.getValidFaces(), MR.BooleanResultMapper.MapObject.B);
+            var newFaces = mapper.newFaces();
+            Console.WriteLine("faces from mesh A: {0}", facesOfA.count());
+            Console.WriteLine("faces from mesh B: {0}", facesOfB.count());
+            Console.WriteLine("faces created by the cut: {0}", newFaces.count());
 
             // save result to STL file
             MR.MeshSave.toAnySupportedFormat(res.mesh, "out_boolean.stl");

--- a/examples/c-sharp-examples/MeshBoolean.dox.cs
+++ b/examples/c-sharp-examples/MeshBoolean.dox.cs
@@ -50,12 +50,15 @@ public class MeshBooleanExample
 
             // and backward: the face of mesh A each face of the result came from
             // (invalid id for the faces that came from mesh B)
-            if (producedFaces.count() > 0)
+            var new2OldFaces = mapper.getNew2OldFaceMap(MR.BooleanResultMapper.MapObject.A);
+            for (int f = 0; f < (int)new2OldFaces.size(); ++f)
             {
-                var new2OldFaces = mapper.getNew2OldFaceMap(MR.BooleanResultMapper.MapObject.A);
-                var resultFace = producedFaces.find_first();
+                var resultFace = new MR.FaceId(f);
+                if (!producedFaces.test(resultFace))
+                    continue;
                 Console.WriteLine("face {0} of the result came from face {1} of mesh A",
-                    resultFace.id, new2OldFaces[resultFace].id);
+                    f, new2OldFaces[resultFace].id);
+                break;
             }
 
             // save result to STL file

--- a/examples/c-sharp-examples/MeshBoolean.dox.cs
+++ b/examples/c-sharp-examples/MeshBoolean.dox.cs
@@ -40,6 +40,24 @@ public class MeshBooleanExample
             Console.WriteLine("faces from mesh B: {0}", facesOfB.count());
             Console.WriteLine("faces created by the cut: {0}", newFaces.count());
 
+            // map one particular face of mesh A forward: the cut can split it in several faces of
+            // the result, or drop it completely if that part of mesh A is not in the result
+            var faceOfA = new MR.FaceId(793);
+            var oneFace = new MR.FaceBitSet(794);
+            oneFace.set(faceOfA);
+            var producedFaces = mapper.map(oneFace, MR.BooleanResultMapper.MapObject.A);
+            Console.WriteLine("face {0} of mesh A produced {1} faces of the result", faceOfA.id, producedFaces.count());
+
+            // and backward: the face of mesh A each face of the result came from
+            // (invalid id for the faces that came from mesh B)
+            if (producedFaces.count() > 0)
+            {
+                var new2OldFaces = mapper.getNew2OldFaceMap(MR.BooleanResultMapper.MapObject.A);
+                var resultFace = producedFaces.find_first();
+                Console.WriteLine("face {0} of the result came from face {1} of mesh A",
+                    resultFace.id, new2OldFaces[resultFace].id);
+            }
+
             // save result to STL file
             MR.MeshSave.toAnySupportedFormat(res.mesh, "out_boolean.stl");
         }

--- a/examples/cpp-examples/MeshBoolean.dox.cpp
+++ b/examples/cpp-examples/MeshBoolean.dox.cpp
@@ -16,13 +16,28 @@ int main()
     MR::AffineXf3f xf = MR::AffineXf3f::translation( MR::Vector3f( 0.7f, 0.0f, 0.0f ) );
     sphere2.transform( xf );
 
+    // optional mapper relating the primitives of the input meshes to the primitives of the result
+    MR::BooleanResultMapper mapper;
+
     // perform boolean operation
-    MR::BooleanResult result = MR::boolean( sphere1, sphere2, MR::BooleanOperation::Intersection );
+    MR::BooleanResult result = MR::boolean( sphere1, sphere2, MR::BooleanOperation::Intersection, { .mapper = &mapper } );
     if ( !result.valid() )
         std::cerr << result.errorString << std::endl;
 
     MR::Mesh resultMesh = *result;
 //! [0]
+
+//! [1]
+    // find the faces of the result produced by each input sphere, and the faces the cut created
+    using MapObject = MR::BooleanResultMapper::MapObject;
+    MR::FaceBitSet facesOfSphere1 = mapper.map( sphere1.topology.getValidFaces(), MapObject::A );
+    MR::FaceBitSet facesOfSphere2 = mapper.map( sphere2.topology.getValidFaces(), MapObject::B );
+    MR::FaceBitSet newFaces = mapper.newFaces();
+
+    std::cout << "faces from sphere1: " << facesOfSphere1.count() << "\n"
+              << "faces from sphere2: " << facesOfSphere2.count() << "\n"
+              << "faces created by the cut: " << newFaces.count() << std::endl;
+//! [1]
 
     // save result to STL file
     if ( auto saveRes = MR::MeshSave::toAnySupportedFormat( resultMesh, "out_boolean.stl" ); !saveRes )

--- a/examples/cpp-examples/MeshBoolean.dox.cpp
+++ b/examples/cpp-examples/MeshBoolean.dox.cpp
@@ -39,6 +39,25 @@ int main()
               << "faces created by the cut: " << newFaces.count() << std::endl;
 //! [1]
 
+//! [2]
+    // map one particular face of sphere1 forward: the cut can split it in several faces of the
+    // result, or drop it completely if that part of sphere1 is not in the result
+    MR::FaceId faceOfSphere1( 793 );
+    MR::FaceBitSet oneFace;
+    oneFace.autoResizeSet( faceOfSphere1 );
+    MR::FaceBitSet producedFaces = mapper.map( oneFace, MapObject::A );
+    std::cout << "face " << faceOfSphere1 << " of sphere1 produced " << producedFaces.count() << " faces of the result:";
+    for ( MR::FaceId f : producedFaces )
+        std::cout << ' ' << f;
+    std::cout << std::endl;
+
+    // and backward: the face of sphere1 each face of the result came from
+    // (invalid id for the faces that came from sphere2)
+    MR::FaceMap new2OldFaces = mapper.getNew2OldFaceMap( MapObject::A );
+    MR::FaceId resultFace = producedFaces.find_first();
+    std::cout << "face " << resultFace << " of the result came from face " << new2OldFaces[resultFace] << " of sphere1" << std::endl;
+//! [2]
+
     // save result to STL file
     if ( auto saveRes = MR::MeshSave::toAnySupportedFormat( resultMesh, "out_boolean.stl" ); !saveRes )
     {

--- a/examples/js-examples/MeshBoolean.dox.js
+++ b/examples/js-examples/MeshBoolean.dox.js
@@ -31,6 +31,20 @@ console.log(`faces from sphere1: ${facesOfSphere1.count()}`);
 console.log(`faces from sphere2: ${facesOfSphere2.count()}`);
 console.log(`faces created by the cut: ${newFaces.count()}`);
 
+// map one particular face of sphere1 forward: the cut can split it in several faces of the
+// result, or drop it completely if that part of sphere1 is not in the result
+const faceOfSphere1 = 793;
+using oneFace = ml.FaceBitSet.fromIndices([faceOfSphere1]);
+using producedFaces = mapper.mapFaces(oneFace, ml.BooleanMapObject.A);
+console.log(`face ${faceOfSphere1} of sphere1 produced ${producedFaces.count()} faces of the result`);
+
+// and backward: the face of sphere1 each face of the result came from
+// (4294967295, i.e. an invalid id, for the faces that came from sphere2)
+using new2OldFaces = mapper.getNew2OldFaceMap(ml.BooleanMapObject.A);
+const new2OldFacesArray = new2OldFaces.toArray();
+const resultFace = producedFaces.find_first();
+console.log(`face ${resultFace} of the result came from face ${new2OldFacesArray[resultFace]} of sphere1`);
+
 // save result to STL file
 using resultMesh = result.mesh;
 ml.MeshSave.toAnySupportedFormat(resultMesh, 'out_boolean.stl');

--- a/examples/js-examples/MeshBoolean.dox.js
+++ b/examples/js-examples/MeshBoolean.dox.js
@@ -11,10 +11,25 @@ using sphere2 = ml.makeUVSphere(1.0, 64, 64);
 using xf = ml.AffineXf3f.translation({ x: 0.7, y: 0.0, z: 0.0 });
 sphere2.transform(xf);
 
+// optional mapper relating the primitives of the input meshes to the primitives of the result
+using mapper = new ml.BooleanResultMapper();
+
 // perform boolean operation
-using result = ml.boolean(sphere1, sphere2, ml.BooleanOperation.Intersection);
+using result = ml.boolean(sphere1, sphere2, ml.BooleanOperation.Intersection, mapper);
 if (!result.valid())
   throw new Error(result.errorString);
+
+// find the faces of the result produced by each input sphere, and the faces the cut created
+using topology1 = sphere1.topology;
+using topology2 = sphere2.topology;
+using validFaces1 = topology1.getValidFaces();
+using validFaces2 = topology2.getValidFaces();
+using facesOfSphere1 = mapper.mapFaces(validFaces1, ml.BooleanMapObject.A);
+using facesOfSphere2 = mapper.mapFaces(validFaces2, ml.BooleanMapObject.B);
+using newFaces = mapper.newFaces();
+console.log(`faces from sphere1: ${facesOfSphere1.count()}`);
+console.log(`faces from sphere2: ${facesOfSphere2.count()}`);
+console.log(`faces created by the cut: ${newFaces.count()}`);
 
 // save result to STL file
 using resultMesh = result.mesh;

--- a/examples/python-examples/MeshBoolean.dox.py
+++ b/examples/python-examples/MeshBoolean.dox.py
@@ -8,10 +8,22 @@ sphere2 = mrmeshpy.copyMesh(sphere1)
 xf = mrmeshpy.AffineXf3f.translation(mrmeshpy.Vector3f(0.7, 0.0, 0.0))
 sphere2.transform(xf)
 
+# optional mapper relating the primitives of the input meshes to the primitives of the result
+mapper = mrmeshpy.BooleanResultMapper()
+
 # perform boolean operation
-result = mrmeshpy.boolean(sphere1, sphere2, mrmeshpy.BooleanOperation.Intersection)
+result = mrmeshpy.boolean(sphere1, sphere2, mrmeshpy.BooleanOperation.Intersection, None, mapper)
 if not result.valid():
     print(result.errorString)
 else:
+    # find the faces of the result produced by each input sphere, and the faces the cut created
+    map_object = mrmeshpy.BooleanResultMapper.MapObject
+    faces_of_sphere1 = mapper.map(sphere1.topology.getValidFaces(), map_object.A)
+    faces_of_sphere2 = mapper.map(sphere2.topology.getValidFaces(), map_object.B)
+    new_faces = mapper.newFaces()
+    print(f"faces from sphere1: {faces_of_sphere1.count()}")
+    print(f"faces from sphere2: {faces_of_sphere2.count()}")
+    print(f"faces created by the cut: {new_faces.count()}")
+
     # save result to STL file
     mrmeshpy.saveMesh(result.mesh, "out_boolean.stl")

--- a/examples/python-examples/MeshBoolean.dox.py
+++ b/examples/python-examples/MeshBoolean.dox.py
@@ -25,5 +25,19 @@ else:
     print(f"faces from sphere2: {faces_of_sphere2.count()}")
     print(f"faces created by the cut: {new_faces.count()}")
 
+    # map one particular face of sphere1 forward: the cut can split it in several faces of the
+    # result, or drop it completely if that part of sphere1 is not in the result
+    face_of_sphere1 = mrmeshpy.FaceId(793)
+    one_face = mrmeshpy.FaceBitSet()
+    one_face.autoResizeSet(face_of_sphere1)
+    produced_faces = mapper.map(one_face, map_object.A)
+    print(f"face {face_of_sphere1.get()} of sphere1 produced {produced_faces.count()} faces of the result")
+
+    # and backward: the face of sphere1 each face of the result came from
+    # (invalid id for the faces that came from sphere2)
+    new2old_faces = mapper.getNew2OldFaceMap(map_object.A)
+    result_face = produced_faces.find_first()
+    print(f"face {result_face.get()} of the result came from face {new2old_faces[result_face].get()} of sphere1")
+
     # save result to STL file
     mrmeshpy.saveMesh(result.mesh, "out_boolean.stl")

--- a/source/MRMesh/MRBooleanOperation.cpp
+++ b/source/MRMesh/MRBooleanOperation.cpp
@@ -397,7 +397,7 @@ FaceMap BooleanResultMapper::getNew2OldFaceMap( MapObject obj ) const
     } );
 
     // fill map in parallel
-    FaceMap outMap( maxNewFace );
+    FaceMap outMap( maxNewFace + 1 );
     ParallelFor( map.cut2origin, [&] ( FaceId cf )
     {
         auto of = map.cut2origin[cf];

--- a/source/MRMesh/MRBooleanOperation.h
+++ b/source/MRMesh/MRBooleanOperation.h
@@ -51,6 +51,7 @@ enum class BooleanOperation
   * \details Structure to easily map topology of MR::boolean input meshes to result mesh
   *
   * This structure allows to map faces, vertices and edges of mesh `A` and mesh `B` input of MR::boolean to result mesh topology primitives
+  * \snippet cpp-examples/MeshBoolean.dox.cpp 1
   * \sa \ref MR::boolean
   */
 struct BooleanResultMapper

--- a/source/MRMesh/MRBooleanOperation.h
+++ b/source/MRMesh/MRBooleanOperation.h
@@ -52,6 +52,7 @@ enum class BooleanOperation
   *
   * This structure allows to map faces, vertices and edges of mesh `A` and mesh `B` input of MR::boolean to result mesh topology primitives
   * \snippet cpp-examples/MeshBoolean.dox.cpp 1
+  * \snippet cpp-examples/MeshBoolean.dox.cpp 2
   * \sa \ref MR::boolean
   */
 struct BooleanResultMapper


### PR DESCRIPTION
Nothing in the examples demonstrated `BooleanResultMapper` — the way to relate faces, vertices and edges of the input meshes to the primitives of the boolean result.

All five language variants (C++, C, Python, C#, JavaScript) now pass a mapper to the operation and use it to report:

- the faces of the result produced by each input mesh, and the faces the cut itself created (`map` over the inputs' valid faces, `newFaces`);
- one particular face of the first input mesh mapped **forward** to the faces of the result it produced — the cut can split one input face into several, or drop it entirely;
- a face of the result mapped **back** to the input face it came from, via `getNew2OldFaceMap`.

For the two spheres in the examples that prints:

```
faces from sphere1: 2670
faces from sphere2: 2670
faces created by the cut: 1344
face 793 of sphere1 produced 4 faces of the result: 8542 8543 8544 8545
face 8542 of the result came from face 793 of sphere1
```

### Fix in `getNew2OldFaceMap`

Writing the reverse example surfaced an off-by-one: the map was sized `maxNewFace` (the largest new face id) rather than `maxNewFace + 1`, so `outMap[nf] = of` for that largest id wrote one element past the end of the vector — an assert in a Debug build, an out-of-bounds write in Release — and the returned map never contained the entry for the last mapped face. For the spheres above, the last face of the result coming from `A` is 8863 while the map's size was 8863; it is now 8864 and that face resolves to its origin, 7199.

No test asserted on the size of the returned map, so nothing else changes.

### Docs

- `doxygen/examples/MeshBoolean.dox` mentions the mapper and the reverse map above the tabs.
- `MR::BooleanResultMapper`'s doc comment now shows the two new C++ snippets (markers `1` and `2`), the same way `MR::boolean` shows marker `0`.

### Verification

- The C++ example compiles and links against a locally built `MRMesh` (with the fix) and prints the output above; the reverse lookup of the last `A` face was checked separately against both the old and the new sizing.
- The Python example prints the same numbers with the installed `meshlib` wheel.
- The C example compiles clean (`cl /W3`) against the generated `MeshLibC2` headers.
- The C# and JS variants mirror API usage already covered by `MRDotNet2Test/src/BooleanTests.cs`, `MRWasmTest/booleanMapper.test.mjs` and the neighbouring examples (`FaceBitSet.fromIndices`, `FaceMap.toArray`, the `using` disposal style).

CI: ubuntu-x64 (C++ and C examples, MRTest) and windows (C# examples) are enabled; the other platforms are disabled.
