### PR TITLE
VisualObject: do not include MRVector.h, MRMeshTexture.h and MRIRenderObject.h

### DIFF
--- a/source/MRMesh/MRAngleMeasurementObject.cpp
+++ b/source/MRMesh/MRAngleMeasurementObject.cpp
@@ -3,6 +3,7 @@
 #include "MRMesh/MRObjectFactory.h"
 #include "MRPch/MRJson.h"
 #include "MRPch/MRFmt.h"
+#include "MRIRenderObject.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRChangeColoringActions.h
+++ b/source/MRMesh/MRChangeColoringActions.h
@@ -4,6 +4,7 @@
 #include "MRObjectLinesHolder.h"
 #include <memory>
 #include "MRChangeVertsColorMapAction.h"
+#include "MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRChangeColoringType.h
+++ b/source/MRMesh/MRChangeColoringType.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "MRHistoryAction.h"
 #include "MRVisualObject.h"
+#include "MRHeapBytes.h"
 #include <memory>
 
 namespace MR

--- a/source/MRMesh/MRChangeMeshAction.h
+++ b/source/MRMesh/MRChangeMeshAction.h
@@ -3,6 +3,7 @@
 #include "MRObjectMesh.h"
 #include "MRMesh.h"
 #include "MRHeapBytes.h"
+#include "MRMeshTexture.h"
 #include <memory>
 
 namespace MR

--- a/source/MRMesh/MRChangeMeshDataAction.h
+++ b/source/MRMesh/MRChangeMeshDataAction.h
@@ -2,6 +2,7 @@
 
 #include "MRCombinedHistoryAction.h"
 #include "MRObjectMesh.h"
+#include "MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRChangeObjectFields.h
+++ b/source/MRMesh/MRChangeObjectFields.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "MRHistoryAction.h"
 #include "MRVisualObject.h"
+#include "MRHeapBytes.h"
 #include <memory>
 
 namespace MR

--- a/source/MRMesh/MRChangeSelectionAction.h
+++ b/source/MRMesh/MRChangeSelectionAction.h
@@ -2,6 +2,7 @@
 #include "MRHistoryAction.h"
 #include "MRObjectMesh.h"
 #include "MRObjectPoints.h"
+#include "MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRChangeVertsColorMapAction.h
+++ b/source/MRMesh/MRChangeVertsColorMapAction.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "MRHistoryAction.h"
 #include "MRVisualObject.h" //Color and DIRTY_VERTS_COLORMAP
+#include "MRHeapBytes.h"
+#include "MRVector.h"
 #include <memory>
 
 namespace MR

--- a/source/MRMesh/MRCircleObject.cpp
+++ b/source/MRMesh/MRCircleObject.cpp
@@ -5,6 +5,7 @@
 #include "MRPch/MRJson.h"
 #include "MRConstants.h"
 #include "MRBestFit.h"
+#include "MRIRenderObject.h"
 #include <MRPch/MREigenCore.h>
 #include <Eigen/QR>
 

--- a/source/MRMesh/MRConeObject.cpp
+++ b/source/MRMesh/MRConeObject.cpp
@@ -9,6 +9,7 @@
 #include "MRLine.h"
 
 #include "MRArrow.h"
+#include "MRIRenderObject.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRCylinderObject.cpp
+++ b/source/MRMesh/MRCylinderObject.cpp
@@ -9,6 +9,7 @@
 #include "MRLine.h"
 #include "MRPch/MRSpdlog.h"
 #include "MRPch/MRJson.h"
+#include "MRIRenderObject.h"
 #include <iostream>
 
 namespace MR

--- a/source/MRMesh/MRDistanceMeasurementObject.cpp
+++ b/source/MRMesh/MRDistanceMeasurementObject.cpp
@@ -3,6 +3,7 @@
 #include "MRMesh/MRObjectFactory.h"
 #include "MRPch/MRJson.h"
 #include "MRPch/MRFmt.h"
+#include "MRIRenderObject.h"
 
 #include <cassert>
 

--- a/source/MRMesh/MRLineObject.cpp
+++ b/source/MRMesh/MRLineObject.cpp
@@ -6,6 +6,7 @@
 #include "MRPch/MRJson.h"
 #include "MRMatrix3.h"
 #include "MRVector3.h"
+#include "MRIRenderObject.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRMeshFwd.h
+++ b/source/MRMesh/MRMeshFwd.h
@@ -681,6 +681,11 @@ struct SignedDistanceToMeshOptions;
 
 using GcodeSource = std::vector<std::string>;
 
+class IRenderObject;
+struct BaseRenderParams;
+struct ModelBaseRenderParams;
+struct ModelRenderParams;
+struct UiRenderParams;
 class Object;
 class SceneRootObject;
 class VisualObject;

--- a/source/MRMesh/MRObjectDistanceMap.h
+++ b/source/MRMesh/MRObjectDistanceMap.h
@@ -2,6 +2,7 @@
 #include "MRMeshFwd.h"
 #include "MRObjectMeshHolder.h"
 #include "MRDistanceMapParams.h"
+#include "MRHeapBytes.h"
 
 
 namespace MR

--- a/source/MRMesh/MRObjectGcode.cpp
+++ b/source/MRMesh/MRObjectGcode.cpp
@@ -5,6 +5,7 @@
 #include "MRSerializer.h"
 #include "MRSceneSettings.h"
 #include "MRTimer.h"
+#include "MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRObjectGcode.h
+++ b/source/MRMesh/MRObjectGcode.h
@@ -2,6 +2,7 @@
 #include "MRObjectLinesHolder.h"
 #include "MRGcodeProcessor.h"
 #include "MRColor.h"
+#include "MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRObjectLinesHolder.cpp
+++ b/source/MRMesh/MRObjectLinesHolder.cpp
@@ -9,6 +9,7 @@
 #include "MRDirectory.h"
 #include "MRLinesLoad.h"
 #include "MRPch/MRJson.h"
+#include "MRIRenderObject.h"
 #include <filesystem>
 
 namespace MR

--- a/source/MRMesh/MRObjectLinesHolder.h
+++ b/source/MRMesh/MRObjectLinesHolder.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "MRVisualObject.h"
 #include "MRXfBasedCache.h"
+#include "MRHeapBytes.h"
+#include "MRVector.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRObjectLoad.cpp
+++ b/source/MRMesh/MRObjectLoad.cpp
@@ -384,7 +384,8 @@ Expected<LoadedObjects> loadObjectFromFile( const std::filesystem::path& filenam
 
     bool loadedFromSceneFile = false;
 
-    auto ext = std::string( "*" ) + utf8string( filename.extension().u8string() );
+    std::string ext = "*";
+    ext += utf8string( filename.extension().u8string() );
     for ( auto& c : ext )
         c = ( char )tolower( c );
 
@@ -530,7 +531,8 @@ bool isSupportedFileInSubfolders( const std::filesystem::path& folder )
 
 Expected<LoadedObject> loadSceneFromAnySupportedFormat( const std::filesystem::path& path, const ProgressCallback& callback )
 {
-    auto ext = std::string( "*" ) + utf8string( path.extension().u8string() );
+    std::string ext = "*";
+    ext += utf8string( path.extension().u8string() );
     for ( auto& c : ext )
         c = ( char )tolower( c );
 

--- a/source/MRMesh/MRObjectMesh.cpp
+++ b/source/MRMesh/MRObjectMesh.cpp
@@ -13,6 +13,8 @@
 #include "MRPch/MRJson.h"
 #include "MRPch/MRTBB.h"
 #include "MRPch/MRFmt.h"
+#include "MRHeapBytes.h"
+#include "MRMeshTexture.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -16,6 +16,7 @@
 #include "MRDirectory.h"
 #include "MRPch/MRJson.h"
 #include "MRPch/MRAsyncLaunchType.h"
+#include "MRMeshTexture.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -5,6 +5,8 @@
 #include "MRXfBasedCache.h"
 #include "MRMeshPart.h"
 #include "MRObjectMeshData.h"
+#include "MRHeapBytes.h"
+#include "MRMeshTexture.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRObjectPointsHolder.cpp
+++ b/source/MRMesh/MRObjectPointsHolder.cpp
@@ -14,6 +14,7 @@
 #include "MRPch/MRJson.h"
 #include "MRPch/MRTBB.h"
 #include "MRPch/MRAsyncLaunchType.h"
+#include "MRIRenderObject.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -5,6 +5,7 @@
 #include "MRVisualObject.h"
 #include "MRXfBasedCache.h"
 #include "MRPointCloudPart.h"
+#include "MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRPartialChangeMeshAction.h
+++ b/source/MRMesh/MRPartialChangeMeshAction.h
@@ -4,6 +4,7 @@
 #include "MRMesh.h"
 #include "MRMeshDiff.h"
 #include "MRObjectMesh.h"
+#include "MRHeapBytes.h"
 #include <cassert>
 
 namespace MR

--- a/source/MRMesh/MRPlaneObject.cpp
+++ b/source/MRMesh/MRPlaneObject.cpp
@@ -6,6 +6,7 @@
 #include "MRPch/MRJson.h"
 #include "MRMatrix3.h"
 #include "MRVector3.h"
+#include "MRIRenderObject.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRPointMeasurementObject.cpp
+++ b/source/MRMesh/MRPointMeasurementObject.cpp
@@ -4,6 +4,7 @@
 #include "MRSerializer.h"
 
 #include "MRPch/MRJson.h"
+#include "MRIRenderObject.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRPointObject.cpp
+++ b/source/MRMesh/MRPointObject.cpp
@@ -2,6 +2,7 @@
 #include "MRObjectFactory.h"
 #include "MRPch/MRJson.h"
 #include "MRVector3.h"
+#include "MRIRenderObject.h"
 
 #include <cassert>
 

--- a/source/MRMesh/MRRadiusMeasurementObject.cpp
+++ b/source/MRMesh/MRRadiusMeasurementObject.cpp
@@ -3,6 +3,7 @@
 #include "MRMesh/MRObjectFactory.h"
 #include "MRPch/MRJson.h"
 #include "MRPch/MRFmt.h"
+#include "MRIRenderObject.h"
 
 namespace MR
 {

--- a/source/MRMesh/MRSphereObject.cpp
+++ b/source/MRMesh/MRSphereObject.cpp
@@ -2,6 +2,7 @@
 #include "MRMatrix3.h"
 #include "MRMesh.h"
 #include "MRObjectFactory.h"
+#include "MRIRenderObject.h"
 #include <MRPch/MREigenCore.h>
 #include <Eigen/QR>
 #include <MRPch/MRJson.h>

--- a/source/MRMesh/MRVisualObject.cpp
+++ b/source/MRMesh/MRVisualObject.cpp
@@ -1,4 +1,5 @@
 #include "MRVisualObject.h"
+#include "MRIRenderObject.h"
 #include "MRObjectFactory.h"
 #include "MRSerializer.h"
 #include "MRSceneColors.h"
@@ -385,6 +386,14 @@ Box3f VisualObject::getWorldBox( ViewportId id ) const
 {
     return transformed( getBoundingBox(), worldXf( id ) );
 }
+
+VisualObject::VisualObject( VisualObject&& ) = default;
+
+VisualObject::VisualObject( const VisualObject& ) = default;
+
+VisualObject& VisualObject::operator = ( VisualObject&& ) = default;
+
+VisualObject::~VisualObject() = default;
 
 size_t VisualObject::heapBytes() const
 {

--- a/source/MRMesh/MRVisualObject.h
+++ b/source/MRMesh/MRVisualObject.h
@@ -2,8 +2,6 @@
 
 #include "MRObject.h"
 #include "MRBox.h"
-#include "MRMeshTexture.h"
-#include "MRVector.h"
 #include "MRColor.h"
 #include "MRIRenderObject.h"
 #include "MRUniquePtr.h"

--- a/source/MRMesh/MRVisualObject.h
+++ b/source/MRMesh/MRVisualObject.h
@@ -3,11 +3,11 @@
 #include "MRObject.h"
 #include "MRBox.h"
 #include "MRColor.h"
-#include "MRIRenderObject.h"
 #include "MRUniquePtr.h"
 #include "MREnums.h"
 
 #include <optional>
+#include <typeindex>
 
 namespace MR
 {
@@ -117,9 +117,9 @@ class MRMESH_CLASS VisualObject : public Object
 public:
     MRMESH_API VisualObject();
 
-    VisualObject( VisualObject&& ) = default;
-    VisualObject& operator = ( VisualObject&& ) = default;
-    virtual ~VisualObject() = default;
+    MRMESH_API VisualObject( VisualObject&& );
+    MRMESH_API VisualObject& operator = ( VisualObject&& );
+    MRMESH_API virtual ~VisualObject();
 
     constexpr static const char* StaticTypeName() noexcept { return "VisualObject"; }
     virtual const char* typeName() const override { return StaticTypeName(); }
@@ -285,7 +285,7 @@ public:
     MRMESH_API virtual void resetColors();
 
 protected:
-    VisualObject( const VisualObject& obj ) = default;
+    MRMESH_API VisualObject( const VisualObject& obj );
 
     /// swaps this object with other
     MRMESH_API virtual void swapBase_( Object& other ) override;

--- a/source/MRSymbolMesh/MRChangeLabelAction.h
+++ b/source/MRSymbolMesh/MRChangeLabelAction.h
@@ -6,6 +6,7 @@
 #include "MRMesh/MRHistoryAction.h"
 #include "MRMesh/MRPositionedText.h"
 #include "MRMesh/MRVector2.h"
+#include "MRMesh/MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRSymbolMesh/MRObjectLabel.cpp
+++ b/source/MRSymbolMesh/MRObjectLabel.cpp
@@ -15,6 +15,7 @@
 #include "MRPch/MRAsyncLaunchType.h"
 #include "MRPch/MRJson.h"
 #include "MRMesh/MRHeapBytes.h"
+#include "MRMesh/MRIRenderObject.h"
 
 namespace MR
 {

--- a/source/MRSymbolMesh/MRObjectLabel.cpp
+++ b/source/MRSymbolMesh/MRObjectLabel.cpp
@@ -14,6 +14,7 @@
 #include "MRPch/MRSpdlog.h"
 #include "MRPch/MRAsyncLaunchType.h"
 #include "MRPch/MRJson.h"
+#include "MRMesh/MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRSymbolMesh/MRObjectLabel.h
+++ b/source/MRSymbolMesh/MRObjectLabel.h
@@ -5,6 +5,7 @@
 
 #include "MRMesh/MRVisualObject.h"
 #include "MRMesh/MRPositionedText.h"
+#include "MRMesh/MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRViewer/MRDirectionWidget.h
+++ b/source/MRViewer/MRDirectionWidget.h
@@ -7,6 +7,7 @@
 #include "MRMesh/MRChangeXfAction.h"
 #include "MRMesh/MRColor.h"
 #include "MRMesh/MRObjectMesh.h"
+#include "MRMesh/MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRViewer/MRMeshBoundarySelectionWidget.cpp
+++ b/source/MRViewer/MRMeshBoundarySelectionWidget.cpp
@@ -16,6 +16,7 @@
 
 #include <MRMesh/MRRingIterator.h>
 #include "MRMesh/MRPolyline.h"
+#include "MRMesh/MRHeapBytes.h"
 #include <MRMesh/MRObjectsAccess.h>
 #include <MRMesh/MRSceneRoot.h>
 

--- a/source/MRViewer/MRMeshBoundarySelectionWidget.h
+++ b/source/MRViewer/MRMeshBoundarySelectionWidget.h
@@ -10,6 +10,7 @@
 #include "MRViewer/MRAncillaryLines.h"
 #include "MRMesh/MRRingIterator.h"
 #include "MRMesh/MRMesh.h"
+#include "MRMesh/MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRViewer/MRObjectImGuiLabel.cpp
+++ b/source/MRViewer/MRObjectImGuiLabel.cpp
@@ -2,6 +2,7 @@
 
 #include "MRMesh/MRObjectFactory.h"
 #include "MRPch/MRJson.h"
+#include "MRMesh/MRIRenderObject.h"
 
 namespace MR
 {

--- a/source/MRViewer/MRRenderLabelObject.cpp
+++ b/source/MRViewer/MRRenderLabelObject.cpp
@@ -13,6 +13,7 @@
 #include "MRRenderHelpers.h"
 #include "MRViewer.h"
 #include "MRGladGlfw.h"
+#include "MRMesh/MRHeapBytes.h"
 
 namespace
 {

--- a/source/MRViewer/MRRenderPointsObject.cpp
+++ b/source/MRViewer/MRRenderPointsObject.cpp
@@ -14,6 +14,7 @@
 #include "MRGladGlfw.h"
 #include "MRMesh/MRParallelFor.h"
 #include "MRViewer/MRRenderDefaultObjects.h"
+#include "MRMesh/MRHeapBytes.h"
 
 namespace MR
 {

--- a/source/MRViewer/MRRenderWrapObject.h
+++ b/source/MRViewer/MRRenderWrapObject.h
@@ -2,6 +2,7 @@
 
 #include "MRMesh/MRMeshFwd.h"
 #include "MRMesh/MRVisualObject.h"
+#include "MRMesh/MRIRenderObject.h"
 
 namespace MR::RenderWrapObject
 {

--- a/source/MRVoxels/MRObjectVoxels.cpp
+++ b/source/MRVoxels/MRObjectVoxels.cpp
@@ -19,6 +19,7 @@
 #include "MRPch/MRJson.h"
 #include "MRPch/MRAsyncLaunchType.h"
 #include "MRPch/MRFmt.h"
+#include "MRMesh/MRIRenderObject.h"
 #include <filesystem>
 #include <thread>
 


### PR DESCRIPTION
`MRVisualObject.h` stops including `MRVector.h`, `MRMeshTexture.h` and `MRIRenderObject.h`. It mentions neither `Vector` nor `MeshTexture` at all, and needs `IRenderObject` and the render-param structs only for a member and for by-reference parameters, so those are forward-declared in `MRMeshFwd.h` instead.

`VisualObject`s move constructor, protected copy constructor, move assignment and destructor move out of line. This is what makes the incomplete `IRenderObject` acceptable: `MRMESH_CLASS` is `__declspec(dllexport)` while building MRMesh, and MSVC emits every defaulted special member of a dllexported class, which instantiates `unique_ptr<IRenderObject>::~unique_ptr` and static-asserts on the incomplete type. It is not specific to `MRUniquePtr.h` - a plain `std::unique_ptr<Incomplete>` member behaves identically; a 25-line repro compiles with `dllimport` and fails with `dllexport`, and passes again once the special members are declared out of line.

The files that were relying on the transitive includes now include what they use:

- `MRIRenderObject.h` in the 16 files calling `createRenderObject()` or dereferencing `renderObj_`, plus `MRRenderWrapObject.h`;
- `MRVector.h` in the two headers with a `VertColors` member;
- `MRMeshTexture.h` in the four files using `MeshTexture`;
- `MRHeapBytes.h` in 22 files that call `MR::heapBytes()` in inline bodies and were getting it via `MRMeshTexture.h` -> `MRImage.h`;
- `<typeindex>` in `MRVisualObject.h` itself, for the `std::type_index` member of `AnyVisualizeMaskEnum`.

Verified with a `cl /Zs` sweep of MRMesh, MRViewer, MRVoxels and MRSymbolMesh: failing-TU sets identical to the same sweep on master (4 known no-PCH artifacts in MRMesh, 82 in MRViewer, 0 elsewhere), and MRMesh.dll links, which exercises the four new out-of-line definitions. The include-graph pass reports no remaining user of the dropped headers and no std header lost.
