### PR TITLE
Stop glfwInit changing the working directory on macOS

### DIFF
--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -858,6 +858,12 @@ int Viewer::launchInit_( const LaunchParams& params )
 #endif
 #endif
 
+#if defined( __APPLE__ )
+    // Otherwise glfwInit() chdirs into Contents/Resources of the .app bundle,
+    // and every relative path given on the command line resolves from there.
+    glfwInitHint( GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE );
+#endif
+
     if ( !glfwInit() )
     {
         spdlog::error( "glfwInit failed" );


### PR DESCRIPTION
## Summary

One line: `glfwInitHint( GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE )` before `glfwInit()`, so the viewer stops changing its own working directory on macOS.

## Why

`GLFW_COCOA_CHDIR_RESOURCES` defaults to `GLFW_TRUE`, which makes `glfwInit()` `chdir` into `Contents/Resources` of the `.app` bundle -- documented as happening "if present". It runs early in `Viewer::launchInit_`, before anything parses `argv`, so **every relative path the app is handed resolves from inside the bundle**: a mesh file, a `.py` script, a credentials file.

Nothing in MeshLib appears to want this. Resources are found through `SystemPath`, which derives its directories from the executable location, not from the working directory.

## How it was found

Chasing why `-creds ./scripts/creds.json` silently failed for a packaged MeshInspector while the same argument worked for a build tree one. Probed on a runner against the packaged `.app`:

| `-creds` | file actually at | read? |
|---|---|---|
| `./probe.json` | `<app>/Contents/Resources/probe.json` | **yes** |
| `./probe.json` | the shell's working directory | no |
| `./probe.json` | next to the executable in `Contents/MacOS` | no |
| `./../../../scripts/creds.json` | `<dir holding the .app>/scripts/creds.json` | **yes** |
| absolute | -- | **yes** |

So relative paths are not broken, they resolve from `Contents/Resources`. The first and fourth rows pin it exactly.

A bundle **without** `Contents/Resources` is unaffected, because the `chdir` fails and the inherited working directory survives. That is why this has gone unnoticed: build tree bundles have no `Contents/Resources`, so developers and CI see correct behaviour, and only the packaged app misbehaves.

## Risk

Behavioural for every macOS consumer of `MRViewer`: anything that has come to rely on the working directory being `Contents/Resources` after `launchInit_` would change. I found nothing that does -- no `current_path` or `chdir` call anywhere in MeshLib or MeshInspectorCode, and resource lookup goes through `SystemPath`. Worth a second opinion from someone who knows the macOS packaging history.

## Test plan

- [ ] macOS builds.
- [ ] Behaviour cannot be checked from this repo's CI: it needs a packaged `.app`, so it is verified downstream after the submodule bump. The check is that a relative path passed to `/Applications/MeshInspector.app/Contents/MacOS/MeshInspector` from a terminal resolves against the terminal's directory.

Other platforms are disabled: the change is inside `#if defined( __APPLE__ )`.
