### PR TITLE
Add const raw pointer model getters, deprecate the UB shared_ptr ones

### DIFF
--- a/scripts/mrbind/aliases.cpp
+++ b/scripts/mrbind/aliases.cpp
@@ -27,9 +27,9 @@ static const char MRBIND_UNIQUE_VAR = []
     MR_ALIAS( MeshBuilderSettings,                  MeshBuilder.BuildSettings                           );
     MR_ALIAS( MeshToVolumeParamsType,               MeshToVolumeParams.Type                             );
     MR_ALIAS( ObjectDistanceMap.extractDistanceMap, ObjectDistanceMap.getDistanceMap                    );
-    MR_ALIAS( ObjectLines.extractLines,             ObjectLines.polyline                                );
-    MR_ALIAS( ObjectMesh.extractMesh,               ObjectMesh.mesh                                     );
-    MR_ALIAS( ObjectPoints.extractPoints,           ObjectPoints.pointCloud                             );
+    MR_ALIAS( ObjectLines.extractLines,             ObjectLines.polylineConstPtr                        );
+    MR_ALIAS( ObjectMesh.extractMesh,               ObjectMesh.meshConstPtr                             );
+    MR_ALIAS( ObjectPoints.extractPoints,           ObjectPoints.pointCloudConstPtr                     );
     MR_ALIAS( objectSave,                           ObjectSave.toAnySupportedFormat                     );
     MR_ALIAS( ObjectVoxels.extractVoxels,           ObjectVoxels.vdbVolume                              );
     MR_ALIAS( saveAllSlicesToImage,                 VoxelsSave.saveAllSlicesToImage                     );

--- a/scripts/mrbind/aliases.cpp
+++ b/scripts/mrbind/aliases.cpp
@@ -27,9 +27,9 @@ static const char MRBIND_UNIQUE_VAR = []
     MR_ALIAS( MeshBuilderSettings,                  MeshBuilder.BuildSettings                           );
     MR_ALIAS( MeshToVolumeParamsType,               MeshToVolumeParams.Type                             );
     MR_ALIAS( ObjectDistanceMap.extractDistanceMap, ObjectDistanceMap.getDistanceMap                    );
-    MR_ALIAS( ObjectLines.extractLines,             ObjectLines.polylineConstPtr                        );
-    MR_ALIAS( ObjectMesh.extractMesh,               ObjectMesh.meshConstPtr                             );
-    MR_ALIAS( ObjectPoints.extractPoints,           ObjectPoints.pointCloudConstPtr                     );
+    MR_ALIAS( ObjectLines.extractLines,             ObjectLines.polylinePtr                             );
+    MR_ALIAS( ObjectMesh.extractMesh,               ObjectMesh.meshPtr                                  );
+    MR_ALIAS( ObjectPoints.extractPoints,           ObjectPoints.pointCloudPtr                          );
     MR_ALIAS( objectSave,                           ObjectSave.toAnySupportedFormat                     );
     MR_ALIAS( ObjectVoxels.extractVoxels,           ObjectVoxels.vdbVolume                              );
     MR_ALIAS( saveAllSlicesToImage,                 VoxelsSave.saveAllSlicesToImage                     );

--- a/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
@@ -778,7 +778,7 @@ bool SaveSelectedMenuItem::action()
     {
         std::vector<MeshSave::NamedXfMesh> objs;
         for ( auto obj : selectedMeshes )
-            objs.push_back( MeshSave::NamedXfMesh{ obj->name(),obj->worldXf(),obj->mesh() } );
+            objs.push_back( MeshSave::NamedXfMesh{ obj->name(),obj->worldXf(),obj->varMesh() } );
 
         ProgressBar::orderWithMainThreadPostProcessing( "Saving selected", [savePath, objs] ()->std::function<void()>
         {

--- a/source/MRCommonPlugins/ViewerButtons/MRSceneControlMenuItems.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRSceneControlMenuItems.cpp
@@ -172,7 +172,7 @@ std::string FitSelectedPrimitivesMenuItem::isAvailable( const std::vector<std::s
 {
     auto allObjs = getAllObjectsInTree<ObjectMesh>( &SceneRoot::get(), ObjectSelectivityType::Any );
     for ( const auto& obj : allObjs )
-        if ( obj->globalVisibility() && obj->meshConstPtr() && ( obj->getSelectedEdges().any() || obj->getSelectedFaces().any() ) )
+        if ( obj->globalVisibility() && obj->meshPtr() && ( obj->getSelectedEdges().any() || obj->getSelectedFaces().any() ) )
             return "";
 
     return _tr( "There are no visible selected primitives." );

--- a/source/MRCommonPlugins/ViewerButtons/MRSceneControlMenuItems.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRSceneControlMenuItems.cpp
@@ -172,7 +172,7 @@ std::string FitSelectedPrimitivesMenuItem::isAvailable( const std::vector<std::s
 {
     auto allObjs = getAllObjectsInTree<ObjectMesh>( &SceneRoot::get(), ObjectSelectivityType::Any );
     for ( const auto& obj : allObjs )
-        if ( obj->globalVisibility() && obj->mesh() && ( obj->getSelectedEdges().any() || obj->getSelectedFaces().any() ) )
+        if ( obj->globalVisibility() && obj->meshConstPtr() && ( obj->getSelectedEdges().any() || obj->getSelectedFaces().any() ) )
             return "";
 
     return _tr( "There are no visible selected primitives." );

--- a/source/MRIOExtras/MRGltf.cpp
+++ b/source/MRIOExtras/MRGltf.cpp
@@ -639,7 +639,7 @@ Expected<void> serializeObjectTreeToGltf( const Object& root, const std::filesys
                                b[0], b[1], b[2], 1 };
 
             auto curObjectMesh = curObj->asType<ObjectMesh>();
-            if ( curObjectMesh && curObjectMesh->mesh() )
+            if ( curObjectMesh && curObjectMesh->meshConstPtr() )
             {
                 Material material;
                 material.baseColor = curObjectMesh->getFrontColor( false );
@@ -675,7 +675,7 @@ Expected<void> serializeObjectTreeToGltf( const Object& root, const std::filesys
                     materialIndex = materialIt->second;
                 }
 
-                const auto mesh = curObjectMesh->mesh();
+                const auto mesh = curObjectMesh->meshConstPtr();
                 const auto points = mesh->points;
                 const auto triangles = mesh->topology.getAllTriVerts();
 

--- a/source/MRIOExtras/MRGltf.cpp
+++ b/source/MRIOExtras/MRGltf.cpp
@@ -639,7 +639,7 @@ Expected<void> serializeObjectTreeToGltf( const Object& root, const std::filesys
                                b[0], b[1], b[2], 1 };
 
             auto curObjectMesh = curObj->asType<ObjectMesh>();
-            if ( curObjectMesh && curObjectMesh->meshConstPtr() )
+            if ( curObjectMesh && curObjectMesh->meshPtr() )
             {
                 Material material;
                 material.baseColor = curObjectMesh->getFrontColor( false );
@@ -675,7 +675,7 @@ Expected<void> serializeObjectTreeToGltf( const Object& root, const std::filesys
                     materialIndex = materialIt->second;
                 }
 
-                const auto mesh = curObjectMesh->meshConstPtr();
+                const auto mesh = curObjectMesh->meshPtr();
                 const auto points = mesh->points;
                 const auto triangles = mesh->topology.getAllTriVerts();
 

--- a/source/MRIOExtras/MRStep.cpp
+++ b/source/MRIOExtras/MRStep.cpp
@@ -560,7 +560,7 @@ private:
             {
                 objMesh = std::dynamic_pointer_cast<ObjectMesh>( objStack_.top() );
                 assert( objMesh );
-                assert( objMesh->mesh() );
+                assert( objMesh->meshConstPtr() );
             }
             else
             {

--- a/source/MRIOExtras/MRStep.cpp
+++ b/source/MRIOExtras/MRStep.cpp
@@ -560,7 +560,7 @@ private:
             {
                 objMesh = std::dynamic_pointer_cast<ObjectMesh>( objStack_.top() );
                 assert( objMesh );
-                assert( objMesh->meshConstPtr() );
+                assert( objMesh->meshPtr() );
             }
             else
             {

--- a/source/MRMesh/MRChangeMeshAction.h
+++ b/source/MRMesh/MRChangeMeshAction.h
@@ -25,7 +25,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->meshConstPtr() )
+            if ( auto m = obj->meshPtr() )
                 cloneMesh_ = std::make_shared<Mesh>( *m );
         }
     }
@@ -199,7 +199,7 @@ public:
     {
         if ( !objMesh_ )
             return;
-        if ( auto m = objMesh_->meshConstPtr() )
+        if ( auto m = objMesh_->meshPtr() )
             clonePoints_ = m->points;
     }
 
@@ -263,7 +263,7 @@ public:
     {
         if ( !objMesh_ )
             return;
-        if ( auto m = objMesh_->meshConstPtr() )
+        if ( auto m = objMesh_->meshPtr() )
             cloneTopology_ = m->topology;
     }
 

--- a/source/MRMesh/MRChangeMeshAction.h
+++ b/source/MRMesh/MRChangeMeshAction.h
@@ -25,7 +25,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->mesh() )
+            if ( auto m = obj->meshConstPtr() )
                 cloneMesh_ = std::make_shared<Mesh>( *m );
         }
     }
@@ -199,7 +199,7 @@ public:
     {
         if ( !objMesh_ )
             return;
-        if ( auto m = objMesh_->mesh() )
+        if ( auto m = objMesh_->meshConstPtr() )
             clonePoints_ = m->points;
     }
 
@@ -263,7 +263,7 @@ public:
     {
         if ( !objMesh_ )
             return;
-        if ( auto m = objMesh_->mesh() )
+        if ( auto m = objMesh_->meshConstPtr() )
             cloneTopology_ = m->topology;
     }
 

--- a/source/MRMesh/MRChangePointCloudAction.h
+++ b/source/MRMesh/MRChangePointCloudAction.h
@@ -23,7 +23,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->pointCloudConstPtr() )
+            if ( auto m = obj->pointCloudPtr() )
                 clonePointCloud_ = std::make_shared<PointCloud>( *m );
         }
     }
@@ -80,7 +80,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->pointCloudConstPtr() )
+            if ( auto m = obj->pointCloudPtr() )
                 clonePoints_ = m->points;
         }
     }
@@ -144,7 +144,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->pointCloudConstPtr() )
+            if ( auto m = obj->pointCloudPtr() )
                 if ( m->points.size() > pointId_ )
                     safeCoords_ = m->points[pointId_];
         }

--- a/source/MRMesh/MRChangePointCloudAction.h
+++ b/source/MRMesh/MRChangePointCloudAction.h
@@ -23,7 +23,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->pointCloud() )
+            if ( auto m = obj->pointCloudConstPtr() )
                 clonePointCloud_ = std::make_shared<PointCloud>( *m );
         }
     }
@@ -80,7 +80,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->pointCloud() )
+            if ( auto m = obj->pointCloudConstPtr() )
                 clonePoints_ = m->points;
         }
     }
@@ -144,7 +144,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->pointCloud() )
+            if ( auto m = obj->pointCloudConstPtr() )
                 if ( m->points.size() > pointId_ )
                     safeCoords_ = m->points[pointId_];
         }

--- a/source/MRMesh/MRChangePointCloudNormalsAction.h
+++ b/source/MRMesh/MRChangePointCloudNormalsAction.h
@@ -23,7 +23,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto pc = obj->pointCloudConstPtr() )
+            if ( auto pc = obj->pointCloudPtr() )
                 backupNormals_ = pc->normals;
         }
     }
@@ -84,7 +84,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->pointCloudConstPtr() )
+            if ( auto m = obj->pointCloudPtr() )
                 if ( m->normals.size() > pointId_ )
                     safeNormal_ = m->normals[pointId_];
         }

--- a/source/MRMesh/MRChangePointCloudNormalsAction.h
+++ b/source/MRMesh/MRChangePointCloudNormalsAction.h
@@ -23,7 +23,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto pc = obj->pointCloud() )
+            if ( auto pc = obj->pointCloudConstPtr() )
                 backupNormals_ = pc->normals;
         }
     }
@@ -84,7 +84,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->pointCloud() )
+            if ( auto m = obj->pointCloudConstPtr() )
                 if ( m->normals.size() > pointId_ )
                     safeNormal_ = m->normals[pointId_];
         }

--- a/source/MRMesh/MRChangePolylineAction.h
+++ b/source/MRMesh/MRChangePolylineAction.h
@@ -24,7 +24,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto p = obj->polyline() )
+            if ( auto p = obj->polylineConstPtr() )
                 clonePolyline_ = std::make_shared<Polyline3>( *p );
         }
     }
@@ -82,7 +82,7 @@ public:
     {
         if ( !objLines_ )
             return;
-        if ( auto p = objLines_->polyline() )
+        if ( auto p = objLines_->polylineConstPtr() )
             clonePoints_ = p->points;
     }
 
@@ -143,7 +143,7 @@ public:
     {
         if ( !objLines_ )
             return;
-        if ( auto p = objLines_->polyline() )
+        if ( auto p = objLines_->polylineConstPtr() )
             cloneTopology_ = p->topology;
     }
 
@@ -198,7 +198,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->polyline() )
+            if ( auto m = obj->polylineConstPtr() )
                 if ( m->points.size() > pointId_ )
                     safeCoords_ = m->points[pointId_];
         }

--- a/source/MRMesh/MRChangePolylineAction.h
+++ b/source/MRMesh/MRChangePolylineAction.h
@@ -24,7 +24,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto p = obj->polylineConstPtr() )
+            if ( auto p = obj->polylinePtr() )
                 clonePolyline_ = std::make_shared<Polyline3>( *p );
         }
     }
@@ -82,7 +82,7 @@ public:
     {
         if ( !objLines_ )
             return;
-        if ( auto p = objLines_->polylineConstPtr() )
+        if ( auto p = objLines_->polylinePtr() )
             clonePoints_ = p->points;
     }
 
@@ -143,7 +143,7 @@ public:
     {
         if ( !objLines_ )
             return;
-        if ( auto p = objLines_->polylineConstPtr() )
+        if ( auto p = objLines_->polylinePtr() )
             cloneTopology_ = p->topology;
     }
 
@@ -198,7 +198,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->polylineConstPtr() )
+            if ( auto m = obj->polylinePtr() )
                 if ( m->points.size() > pointId_ )
                     safeCoords_ = m->points[pointId_];
         }

--- a/source/MRMesh/MRMeshBooleanFacade.cpp
+++ b/source/MRMesh/MRMeshBooleanFacade.cpp
@@ -7,7 +7,7 @@ namespace MR
 
 TransformedMesh MeshMeshConverter::operator() ( const ObjectMesh & obj ) const
 {
-    return TransformedMesh( *obj.mesh(), obj.xf() );
+    return TransformedMesh( *obj.meshConstPtr(), obj.xf() );
 }
 
 TransformedMesh & operator += ( TransformedMesh & a, const TransformedMesh& b )

--- a/source/MRMesh/MRMeshBooleanFacade.cpp
+++ b/source/MRMesh/MRMeshBooleanFacade.cpp
@@ -7,7 +7,7 @@ namespace MR
 
 TransformedMesh MeshMeshConverter::operator() ( const ObjectMesh & obj ) const
 {
-    return TransformedMesh( *obj.meshConstPtr(), obj.xf() );
+    return TransformedMesh( *obj.meshPtr(), obj.xf() );
 }
 
 TransformedMesh & operator += ( TransformedMesh & a, const TransformedMesh& b )

--- a/source/MRMesh/MRObject.h
+++ b/source/MRMesh/MRObject.h
@@ -251,7 +251,7 @@ public:
     [[nodiscard]] virtual bool hasVisualRepresentation() const { return false; }
 
     /// does the object have any model available (but possibly empty),
-    /// e.g. ObjectMesh has valid mesh() or ObjectPoints has valid pointCloud()
+    /// e.g. ObjectMesh has valid meshConstPtr() or ObjectPoints has valid pointCloudConstPtr()
     [[nodiscard]] virtual bool hasModel() const { return false; }
 
     /// provides read-only access to the tag storage

--- a/source/MRMesh/MRObject.h
+++ b/source/MRMesh/MRObject.h
@@ -251,7 +251,7 @@ public:
     [[nodiscard]] virtual bool hasVisualRepresentation() const { return false; }
 
     /// does the object have any model available (but possibly empty),
-    /// e.g. ObjectMesh has valid meshConstPtr() or ObjectPoints has valid pointCloudConstPtr()
+    /// e.g. ObjectMesh has valid meshPtr() or ObjectPoints has valid pointCloudPtr()
     [[nodiscard]] virtual bool hasModel() const { return false; }
 
     /// provides read-only access to the tag storage

--- a/source/MRMesh/MRObjectLines.cpp
+++ b/source/MRMesh/MRObjectLines.cpp
@@ -100,9 +100,9 @@ std::shared_ptr<ObjectLines> merge( const std::vector<std::shared_ptr<ObjectLine
     bool hasVertColorMap = false; // least one input line has
     for ( const auto& obj : objsLines )
     {
-        if ( !obj->polylineConstPtr() )
+        if ( !obj->polylinePtr() )
             continue;
-        totalVerts += obj->polylineConstPtr()->topology.numValidVerts();
+        totalVerts += obj->polylinePtr()->topology.numValidVerts();
         if ( !obj->getVertsColorMap().empty() )
             hasVertColorMap = true;
     }
@@ -118,13 +118,13 @@ std::shared_ptr<ObjectLines> merge( const std::vector<std::shared_ptr<ObjectLine
 
     for ( const auto& obj : objsLines )
     {
-        if ( !obj->polylineConstPtr() )
+        if ( !obj->polylinePtr() )
             continue;
 
         VertMap srcToMergeVmap;
         UndirectedEdgeBitSet validPoints;
-        validPoints.resize( obj->polylineConstPtr()->topology.undirectedEdgeSize(), true );
-        line->addPartByMask( *obj->polylineConstPtr(), validPoints, &srcToMergeVmap );
+        validPoints.resize( obj->polylinePtr()->topology.undirectedEdgeSize(), true );
+        line->addPartByMask( *obj->polylinePtr(), validPoints, &srcToMergeVmap );
 
         auto worldXf = obj->worldXf();
         for ( const auto& vInd : srcToMergeVmap )
@@ -160,7 +160,7 @@ std::shared_ptr<ObjectLines> cloneRegion( const std::shared_ptr<ObjectLines>& ob
     MR_TIMER;
     std::shared_ptr<Polyline3> newPolyline = std::make_shared<Polyline3>();
     VertMap src2clone;
-    newPolyline->addPartByMask( *objLines->polylineConstPtr(), region, &src2clone );
+    newPolyline->addPartByMask( *objLines->polylinePtr(), region, &src2clone );
     std::shared_ptr<ObjectLines> newObj = std::make_shared<ObjectLines>();
     newObj->setFrontColor( objLines->getFrontColor( true ), true );
     newObj->setFrontColor( objLines->getFrontColor( false ), false );

--- a/source/MRMesh/MRObjectLines.cpp
+++ b/source/MRMesh/MRObjectLines.cpp
@@ -100,9 +100,9 @@ std::shared_ptr<ObjectLines> merge( const std::vector<std::shared_ptr<ObjectLine
     bool hasVertColorMap = false; // least one input line has
     for ( const auto& obj : objsLines )
     {
-        if ( !obj->polyline() )
+        if ( !obj->polylineConstPtr() )
             continue;
-        totalVerts += obj->polyline()->topology.numValidVerts();
+        totalVerts += obj->polylineConstPtr()->topology.numValidVerts();
         if ( !obj->getVertsColorMap().empty() )
             hasVertColorMap = true;
     }
@@ -118,13 +118,13 @@ std::shared_ptr<ObjectLines> merge( const std::vector<std::shared_ptr<ObjectLine
 
     for ( const auto& obj : objsLines )
     {
-        if ( !obj->polyline() )
+        if ( !obj->polylineConstPtr() )
             continue;
 
         VertMap srcToMergeVmap;
         UndirectedEdgeBitSet validPoints;
-        validPoints.resize( obj->polyline()->topology.undirectedEdgeSize(), true );
-        line->addPartByMask( *obj->polyline(), validPoints, &srcToMergeVmap );
+        validPoints.resize( obj->polylineConstPtr()->topology.undirectedEdgeSize(), true );
+        line->addPartByMask( *obj->polylineConstPtr(), validPoints, &srcToMergeVmap );
 
         auto worldXf = obj->worldXf();
         for ( const auto& vInd : srcToMergeVmap )
@@ -160,7 +160,7 @@ std::shared_ptr<ObjectLines> cloneRegion( const std::shared_ptr<ObjectLines>& ob
     MR_TIMER;
     std::shared_ptr<Polyline3> newPolyline = std::make_shared<Polyline3>();
     VertMap src2clone;
-    newPolyline->addPartByMask( *objLines->polyline(), region, &src2clone );
+    newPolyline->addPartByMask( *objLines->polylineConstPtr(), region, &src2clone );
     std::shared_ptr<ObjectLines> newObj = std::make_shared<ObjectLines>();
     newObj->setFrontColor( objLines->getFrontColor( true ), true );
     newObj->setFrontColor( objLines->getFrontColor( false ), false );

--- a/source/MRMesh/MRObjectLinesHolder.h
+++ b/source/MRMesh/MRObjectLinesHolder.h
@@ -44,10 +44,15 @@ public:
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;
 
+    /// returns the polyline of this object, or nullptr if it is not set
+    [[nodiscard]] const Polyline3* polylineConstPtr() const { return polyline_.get(); }
+
     #ifdef __GNUC__
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
+    /// \deprecated the cast inside is undefined behaviour, use polylineConstPtr() instead
+    [[deprecated( "use polylineConstPtr() instead" )]]
     const std::shared_ptr<const Polyline3>& polyline() const
     { return reinterpret_cast< const std::shared_ptr<const Polyline3>& >( polyline_ ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectLinesHolder.h
+++ b/source/MRMesh/MRObjectLinesHolder.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "MRPch/MRBindingMacros.h"
 #include "MRVisualObject.h"
 #include "MRXfBasedCache.h"
 #include "MRHeapBytes.h"
@@ -53,7 +52,7 @@ public:
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
     /// \deprecated the cast inside is undefined behaviour, use polylineConstPtr() instead
-    [[deprecated( "use polylineConstPtr() instead" )]] MR_BIND_IGNORE
+    [[deprecated( "use polylineConstPtr() instead" )]]
     const std::shared_ptr<const Polyline3>& polyline() const
     { return reinterpret_cast< const std::shared_ptr<const Polyline3>& >( polyline_ ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectLinesHolder.h
+++ b/source/MRMesh/MRObjectLinesHolder.h
@@ -44,15 +44,18 @@ public:
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;
     MRMESH_API virtual std::shared_ptr<Object> shallowClone() const override;
 
+    /// returns the polyline of this object for modification, or nullptr if it is not set
+    [[nodiscard]]       Polyline3* varPolylinePtr() { return polyline_.get(); }
+
     /// returns the polyline of this object, or nullptr if it is not set
-    [[nodiscard]] const Polyline3* polylineConstPtr() const { return polyline_.get(); }
+    [[nodiscard]] const Polyline3* polylinePtr() const { return polyline_.get(); }
 
     #ifdef __GNUC__
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
-    /// \deprecated the cast inside is undefined behaviour, use polylineConstPtr() instead
-    [[deprecated( "use polylineConstPtr() instead" )]]
+    /// \deprecated the cast inside is undefined behaviour, use polylinePtr() instead
+    [[deprecated( "use polylinePtr() instead" )]]
     const std::shared_ptr<const Polyline3>& polyline() const
     { return reinterpret_cast< const std::shared_ptr<const Polyline3>& >( polyline_ ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectLinesHolder.h
+++ b/source/MRMesh/MRObjectLinesHolder.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "MRPch/MRBindingMacros.h"
 #include "MRVisualObject.h"
 #include "MRXfBasedCache.h"
 #include "MRHeapBytes.h"
@@ -52,7 +53,7 @@ public:
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
     /// \deprecated the cast inside is undefined behaviour, use polylineConstPtr() instead
-    [[deprecated( "use polylineConstPtr() instead" )]]
+    [[deprecated( "use polylineConstPtr() instead" )]] MR_BIND_IGNORE
     const std::shared_ptr<const Polyline3>& polyline() const
     { return reinterpret_cast< const std::shared_ptr<const Polyline3>& >( polyline_ ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectLoad.cpp
+++ b/source/MRMesh/MRObjectLoad.cpp
@@ -95,7 +95,7 @@ void postImportObject( const std::shared_ptr<Object> &o, const std::filesystem::
         bool flat;
         if ( SceneSettings::getDefaultShadingMode() == SceneSettings::ShadingMode::AutoDetect )
             flat = extension == ".step" || extension == ".stp" ||
-                   ( mesh->mesh() && detectFlatShading( *mesh->mesh().get() ) );
+                   ( mesh->meshConstPtr() && detectFlatShading( *mesh->meshConstPtr() ) );
         else
             flat = SceneSettings::getDefaultShadingMode() == SceneSettings::ShadingMode::Flat;
         mesh->setVisualizeProperty( flat, MeshVisualizePropertyType::FlatShading, ViewportMask::all() );
@@ -480,7 +480,7 @@ Expected<LoadedObjects> loadObjectFromFile( const std::filesystem::path& filenam
             postImportObject( o, filename );
             if ( auto objectPoints = o->asType<ObjectPoints>(); objectPoints )
             {
-                if ( !objectPoints->pointCloud()->hasNormals() )
+                if ( !objectPoints->pointCloudConstPtr()->hasNormals() )
                     result->warnings += "Point cloud " + o->name() + " has no normals.\n";
                 if ( objectPoints->getRenderDiscretization() > 1 )
                     result->warnings += "Point cloud " + o->name() + " has too many points in PointCloud:\n"

--- a/source/MRMesh/MRObjectLoad.cpp
+++ b/source/MRMesh/MRObjectLoad.cpp
@@ -95,7 +95,7 @@ void postImportObject( const std::shared_ptr<Object> &o, const std::filesystem::
         bool flat;
         if ( SceneSettings::getDefaultShadingMode() == SceneSettings::ShadingMode::AutoDetect )
             flat = extension == ".step" || extension == ".stp" ||
-                   ( mesh->meshConstPtr() && detectFlatShading( *mesh->meshConstPtr() ) );
+                   ( mesh->meshPtr() && detectFlatShading( *mesh->meshPtr() ) );
         else
             flat = SceneSettings::getDefaultShadingMode() == SceneSettings::ShadingMode::Flat;
         mesh->setVisualizeProperty( flat, MeshVisualizePropertyType::FlatShading, ViewportMask::all() );
@@ -480,7 +480,7 @@ Expected<LoadedObjects> loadObjectFromFile( const std::filesystem::path& filenam
             postImportObject( o, filename );
             if ( auto objectPoints = o->asType<ObjectPoints>(); objectPoints )
             {
-                if ( !objectPoints->pointCloudConstPtr()->hasNormals() )
+                if ( !objectPoints->pointCloudPtr()->hasNormals() )
                     result->warnings += "Point cloud " + o->name() + " has no normals.\n";
                 if ( objectPoints->getRenderDiscretization() > 1 )
                     result->warnings += "Point cloud " + o->name() + " has too many points in PointCloud:\n"

--- a/source/MRMesh/MRObjectMesh.cpp
+++ b/source/MRMesh/MRObjectMesh.cpp
@@ -176,7 +176,7 @@ std::shared_ptr<ObjectMesh> merge( const std::vector<std::shared_ptr<ObjectMesh>
 {
     MR_TIMER;
     std::shared_ptr<ObjectMesh> res;
-    const auto firstNotEmptyIt = std::find_if( objsMesh.begin(), objsMesh.end(), []( const auto & p ) { return p && p->meshConstPtr(); } );
+    const auto firstNotEmptyIt = std::find_if( objsMesh.begin(), objsMesh.end(), []( const auto & p ) { return p && p->meshPtr(); } );
     if ( firstNotEmptyIt == objsMesh.end() )
         return res; // if no input object, then no output
     res = std::make_shared<ObjectMesh>();
@@ -198,7 +198,7 @@ std::shared_ptr<ObjectMesh> merge( const std::vector<std::shared_ptr<ObjectMesh>
     size_t numObject = 0;
     for ( const auto& obj : objsMesh )
     {
-        if ( auto curMesh = obj->meshConstPtr() )
+        if ( auto curMesh = obj->meshPtr() )
         {
             totalVerts += curMesh->topology.numValidVerts();
             totalFaces += curMesh->topology.numValidFaces();
@@ -277,12 +277,12 @@ std::shared_ptr<ObjectMesh> merge( const std::vector<std::shared_ptr<ObjectMesh>
     for ( int i = 0; i < objsMesh.size(); ++i )
     {
         const auto& obj = objsMesh[i];
-        if ( !obj->meshConstPtr() )
+        if ( !obj->meshPtr() )
             continue;
 
         VertMap vertMap;
         FaceMap faceMap;
-        mesh->addMesh( *obj->meshConstPtr(), hasFaceColorMap || needTexturePerFace ? &faceMap : nullptr, &vertMap );
+        mesh->addMesh( *obj->meshPtr(), hasFaceColorMap || needTexturePerFace ? &faceMap : nullptr, &vertMap );
 
         auto worldXf = options.overrideXfs && i < options.overrideXfs->size() ? ( *options.overrideXfs )[i] : obj->worldXf();
         for ( const auto& vInd : vertMap )
@@ -413,7 +413,7 @@ std::shared_ptr<MR::ObjectMesh> cloneRegion( const std::shared_ptr<ObjectMesh>& 
         partMapping.tgt2srcVerts = &vertMap;
     if ( !objMesh->getFacesColorMap().empty() || !objMesh->getTexturePerFace().empty() )
         partMapping.tgt2srcFaces = &faceMap;
-    std::shared_ptr<Mesh> newMesh = std::make_shared<Mesh>( objMesh->meshConstPtr()->cloneRegion( region, false, partMapping ) );
+    std::shared_ptr<Mesh> newMesh = std::make_shared<Mesh>( objMesh->meshPtr()->cloneRegion( region, false, partMapping ) );
     std::shared_ptr<ObjectMesh> newObj = std::make_shared<ObjectMesh>();
     newObj->setFrontColor( objMesh->getFrontColor( true ), true );
     newObj->setFrontColor( objMesh->getFrontColor( false ), false );

--- a/source/MRMesh/MRObjectMesh.cpp
+++ b/source/MRMesh/MRObjectMesh.cpp
@@ -176,7 +176,7 @@ std::shared_ptr<ObjectMesh> merge( const std::vector<std::shared_ptr<ObjectMesh>
 {
     MR_TIMER;
     std::shared_ptr<ObjectMesh> res;
-    const auto firstNotEmptyIt = std::find_if( objsMesh.begin(), objsMesh.end(), []( const auto & p ) { return p && p->mesh(); } );
+    const auto firstNotEmptyIt = std::find_if( objsMesh.begin(), objsMesh.end(), []( const auto & p ) { return p && p->meshConstPtr(); } );
     if ( firstNotEmptyIt == objsMesh.end() )
         return res; // if no input object, then no output
     res = std::make_shared<ObjectMesh>();
@@ -198,7 +198,7 @@ std::shared_ptr<ObjectMesh> merge( const std::vector<std::shared_ptr<ObjectMesh>
     size_t numObject = 0;
     for ( const auto& obj : objsMesh )
     {
-        if ( auto curMesh = obj->mesh() )
+        if ( auto curMesh = obj->meshConstPtr() )
         {
             totalVerts += curMesh->topology.numValidVerts();
             totalFaces += curMesh->topology.numValidFaces();
@@ -277,12 +277,12 @@ std::shared_ptr<ObjectMesh> merge( const std::vector<std::shared_ptr<ObjectMesh>
     for ( int i = 0; i < objsMesh.size(); ++i )
     {
         const auto& obj = objsMesh[i];
-        if ( !obj->mesh() )
+        if ( !obj->meshConstPtr() )
             continue;
 
         VertMap vertMap;
         FaceMap faceMap;
-        mesh->addMesh( *obj->mesh(), hasFaceColorMap || needTexturePerFace ? &faceMap : nullptr, &vertMap );
+        mesh->addMesh( *obj->meshConstPtr(), hasFaceColorMap || needTexturePerFace ? &faceMap : nullptr, &vertMap );
 
         auto worldXf = options.overrideXfs && i < options.overrideXfs->size() ? ( *options.overrideXfs )[i] : obj->worldXf();
         for ( const auto& vInd : vertMap )
@@ -413,7 +413,7 @@ std::shared_ptr<MR::ObjectMesh> cloneRegion( const std::shared_ptr<ObjectMesh>& 
         partMapping.tgt2srcVerts = &vertMap;
     if ( !objMesh->getFacesColorMap().empty() || !objMesh->getTexturePerFace().empty() )
         partMapping.tgt2srcFaces = &faceMap;
-    std::shared_ptr<Mesh> newMesh = std::make_shared<Mesh>( objMesh->mesh()->cloneRegion( region, false, partMapping ) );
+    std::shared_ptr<Mesh> newMesh = std::make_shared<Mesh>( objMesh->meshConstPtr()->cloneRegion( region, false, partMapping ) );
     std::shared_ptr<ObjectMesh> newObj = std::make_shared<ObjectMesh>();
     newObj->setFrontColor( objMesh->getFrontColor( true ), true );
     newObj->setFrontColor( objMesh->getFrontColor( false ), false );

--- a/source/MRMesh/MRObjectMesh.h
+++ b/source/MRMesh/MRObjectMesh.h
@@ -24,7 +24,7 @@ public:
     constexpr static const char* StaticClassNameInPlural() noexcept { return "Meshes"; }
     virtual std::string classNameInPlural() const override { return StaticClassNameInPlural(); }
 
-    /// returns variable mesh, if const mesh is needed use `meshConstPtr()` instead
+    /// returns variable mesh, if const mesh is needed use `meshPtr()` instead
     virtual const std::shared_ptr< Mesh > & varMesh() { return data_.mesh; }
 
     /// sets given mesh to this, resets selection and creases

--- a/source/MRMesh/MRObjectMesh.h
+++ b/source/MRMesh/MRObjectMesh.h
@@ -24,7 +24,7 @@ public:
     constexpr static const char* StaticClassNameInPlural() noexcept { return "Meshes"; }
     virtual std::string classNameInPlural() const override { return StaticClassNameInPlural(); }
 
-    /// returns variable mesh, if const mesh is needed use `mesh()` instead
+    /// returns variable mesh, if const mesh is needed use `meshConstPtr()` instead
     virtual const std::shared_ptr< Mesh > & varMesh() { return data_.mesh; }
 
     /// sets given mesh to this, resets selection and creases

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -442,7 +442,7 @@ void ObjectMeshHolder::copyTextureAndColors( const ObjectMeshHolder & src, const
     }
 
     const auto& srcUVCoords = src.getUVCoords();
-    const auto lastVert = src.mesh()->topology.lastValidVert();
+    const auto lastVert = src.meshConstPtr()->topology.lastValidVert();
     const bool updateUV = lastVert < srcUVCoords.size();
 
     if ( !updateUV )

--- a/source/MRMesh/MRObjectMeshHolder.cpp
+++ b/source/MRMesh/MRObjectMeshHolder.cpp
@@ -442,7 +442,7 @@ void ObjectMeshHolder::copyTextureAndColors( const ObjectMeshHolder & src, const
     }
 
     const auto& srcUVCoords = src.getUVCoords();
-    const auto lastVert = src.meshConstPtr()->topology.lastValidVert();
+    const auto lastVert = src.meshPtr()->topology.lastValidVert();
     const bool updateUV = lastVert < srcUVCoords.size();
 
     if ( !updateUV )

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -48,10 +48,15 @@ public:
 
     [[nodiscard]] virtual bool hasModel() const override { return bool( data_.mesh ); }
 
+    /// returns the mesh of this object, or nullptr if it is not set
+    [[nodiscard]] const Mesh* meshConstPtr() const { return data_.mesh.get(); }
+
     #ifdef __GNUC__
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
+    /// \deprecated the cast inside is undefined behaviour, use meshConstPtr() instead
+    [[deprecated( "use meshConstPtr() instead" )]]
     const std::shared_ptr< const Mesh >& mesh() const
     { return reinterpret_cast< const std::shared_ptr<const Mesh>& >( data_.mesh ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -48,15 +48,18 @@ public:
 
     [[nodiscard]] virtual bool hasModel() const override { return bool( data_.mesh ); }
 
+    /// returns the mesh of this object for modification, or nullptr if it is not set
+    [[nodiscard]]       Mesh* varMeshPtr() { return data_.mesh.get(); }
+
     /// returns the mesh of this object, or nullptr if it is not set
-    [[nodiscard]] const Mesh* meshConstPtr() const { return data_.mesh.get(); }
+    [[nodiscard]] const Mesh* meshPtr() const { return data_.mesh.get(); }
 
     #ifdef __GNUC__
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
-    /// \deprecated the cast inside is undefined behaviour, use meshConstPtr() instead
-    [[deprecated( "use meshConstPtr() instead" )]]
+    /// \deprecated the cast inside is undefined behaviour, use meshPtr() instead
+    [[deprecated( "use meshPtr() instead" )]]
     const std::shared_ptr< const Mesh >& mesh() const
     { return reinterpret_cast< const std::shared_ptr<const Mesh>& >( data_.mesh ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -56,7 +56,7 @@ public:
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
     /// \deprecated the cast inside is undefined behaviour, use meshConstPtr() instead
-    [[deprecated( "use meshConstPtr() instead" )]]
+    [[deprecated( "use meshConstPtr() instead" )]] MR_BIND_IGNORE
     const std::shared_ptr< const Mesh >& mesh() const
     { return reinterpret_cast< const std::shared_ptr<const Mesh>& >( data_.mesh ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectMeshHolder.h
+++ b/source/MRMesh/MRObjectMeshHolder.h
@@ -56,7 +56,7 @@ public:
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
     /// \deprecated the cast inside is undefined behaviour, use meshConstPtr() instead
-    [[deprecated( "use meshConstPtr() instead" )]] MR_BIND_IGNORE
+    [[deprecated( "use meshConstPtr() instead" )]]
     const std::shared_ptr< const Mesh >& mesh() const
     { return reinterpret_cast< const std::shared_ptr<const Mesh>& >( data_.mesh ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectPoints.cpp
+++ b/source/MRMesh/MRObjectPoints.cpp
@@ -16,11 +16,11 @@ MR_ADD_CLASS_FACTORY( ObjectPoints )
 
 ObjectPoints::ObjectPoints( const ObjectMesh& objMesh, bool saveNormals/*=true*/ )
 {
-    if ( !objMesh.meshConstPtr() )
+    if ( !objMesh.meshPtr() )
         return;
 
-    const auto verts = getInnerVerts( objMesh.meshConstPtr()->topology, objMesh.getSelectedFaces() );
-    setPointCloud( std::make_shared<PointCloud>( meshToPointCloud( *objMesh.meshConstPtr(), saveNormals, verts.any() ? &verts : nullptr) ) );
+    const auto verts = getInnerVerts( objMesh.meshPtr()->topology, objMesh.getSelectedFaces() );
+    setPointCloud( std::make_shared<PointCloud>( meshToPointCloud( *objMesh.meshPtr(), saveNormals, verts.any() ? &verts : nullptr) ) );
     setName( objMesh.name() + " Points" );
     setVertsColorMap( objMesh.getVertsColorMap() );
     setFrontColor( objMesh.getFrontColor( true ), true );
@@ -120,13 +120,13 @@ std::shared_ptr<ObjectPoints> merge( const std::vector<std::shared_ptr<ObjectPoi
     bool anyWithColors = false;
     for ( const auto& obj : objsPoints )
     {
-        const auto * pc = obj->pointCloudConstPtr();
+        const auto * pc = obj->pointCloudPtr();
         if ( !pc || !pc->validPoints.any() )
             continue;
         if ( !pc->hasNormals() )
             allWithNormals = false;
         if ( ( obj->getColoringType() == ColoringType::VertsColorMap ) &&
-             ( obj->getVertsColorMap().size() > int( obj->pointCloudConstPtr()->validPoints.find_last() ) ) )
+             ( obj->getVertsColorMap().size() > int( obj->pointCloudPtr()->validPoints.find_last() ) ) )
             anyWithColors = true;
     }
     const VertNormals emptyNormals;
@@ -134,15 +134,15 @@ std::shared_ptr<ObjectPoints> merge( const std::vector<std::shared_ptr<ObjectPoi
     VertColors colors;
     for ( const auto& obj : objsPoints )
     {
-        if ( !obj->pointCloudConstPtr() )
+        if ( !obj->pointCloudPtr() )
             continue;
 
         VertMap vertMap{};
-        pointCloud->addPartByMask( *obj->pointCloudConstPtr(), obj->pointCloudConstPtr()->validPoints, { .src2tgtVerts = &vertMap },
+        pointCloud->addPartByMask( *obj->pointCloudPtr(), obj->pointCloudPtr()->validPoints, { .src2tgtVerts = &vertMap },
             allWithNormals ? nullptr : &emptyNormals );
 
         const bool withColors = ( obj->getColoringType() == ColoringType::VertsColorMap ) &&
-            ( obj->getVertsColorMap().size() > int( obj->pointCloudConstPtr()->validPoints.find_last() ) ) ;
+            ( obj->getVertsColorMap().size() > int( obj->pointCloudPtr()->validPoints.find_last() ) ) ;
         const auto& objColors = obj->getVertsColorMap();
         if ( anyWithColors )
             colors.resize( size_t( vertMap.back() ) + 1, obj->getFrontColor( true ) );
@@ -178,7 +178,7 @@ std::shared_ptr<MR::ObjectPoints> cloneRegion( const std::shared_ptr<ObjectPoint
     if ( !objPoints->getVertsColorMap().empty() )
         partMapping.tgt2srcVerts = &vertMap;
     std::shared_ptr<PointCloud> newCloud = std::make_shared<PointCloud>();
-    newCloud->addPartByMask( *objPoints->pointCloudConstPtr(), region, partMapping );
+    newCloud->addPartByMask( *objPoints->pointCloudPtr(), region, partMapping );
 
     std::shared_ptr<ObjectPoints> newObj = std::make_shared<ObjectPoints>();
     newObj->setFrontColor( objPoints->getFrontColor( true ), true );
@@ -194,7 +194,7 @@ std::shared_ptr<MR::ObjectPoints> cloneRegion( const std::shared_ptr<ObjectPoint
 std::shared_ptr<ObjectPoints> pack( const ObjectPoints& pts, Reorder reorder, VertBitSet* newValidVerts, const ProgressCallback & cb )
 {
     MR_TIMER;
-    if ( !pts.pointCloudConstPtr() )
+    if ( !pts.pointCloudPtr() )
     {
         assert( false );
         return {};
@@ -204,7 +204,7 @@ std::shared_ptr<ObjectPoints> pack( const ObjectPoints& pts, Reorder reorder, Ve
     if ( !reportProgress( cb, 0.0f ) )
         return {};
 
-    res->setPointCloud( std::make_shared<PointCloud>( *pts.pointCloudConstPtr() ) );
+    res->setPointCloud( std::make_shared<PointCloud>( *pts.pointCloudPtr() ) );
     if ( newValidVerts )
         res->varPointCloud()->validPoints = std::move( *newValidVerts );
     if ( !reportProgress( cb, 0.05f ) )

--- a/source/MRMesh/MRObjectPoints.cpp
+++ b/source/MRMesh/MRObjectPoints.cpp
@@ -16,11 +16,11 @@ MR_ADD_CLASS_FACTORY( ObjectPoints )
 
 ObjectPoints::ObjectPoints( const ObjectMesh& objMesh, bool saveNormals/*=true*/ )
 {
-    if ( !objMesh.mesh() )
+    if ( !objMesh.meshConstPtr() )
         return;
 
-    const auto verts = getInnerVerts( objMesh.mesh()->topology, objMesh.getSelectedFaces() );
-    setPointCloud( std::make_shared<PointCloud>( meshToPointCloud( *objMesh.mesh(), saveNormals, verts.any() ? &verts : nullptr) ) );
+    const auto verts = getInnerVerts( objMesh.meshConstPtr()->topology, objMesh.getSelectedFaces() );
+    setPointCloud( std::make_shared<PointCloud>( meshToPointCloud( *objMesh.meshConstPtr(), saveNormals, verts.any() ? &verts : nullptr) ) );
     setName( objMesh.name() + " Points" );
     setVertsColorMap( objMesh.getVertsColorMap() );
     setFrontColor( objMesh.getFrontColor( true ), true );
@@ -120,13 +120,13 @@ std::shared_ptr<ObjectPoints> merge( const std::vector<std::shared_ptr<ObjectPoi
     bool anyWithColors = false;
     for ( const auto& obj : objsPoints )
     {
-        const auto & pc = obj->pointCloud();
+        const auto * pc = obj->pointCloudConstPtr();
         if ( !pc || !pc->validPoints.any() )
             continue;
         if ( !pc->hasNormals() )
             allWithNormals = false;
         if ( ( obj->getColoringType() == ColoringType::VertsColorMap ) &&
-             ( obj->getVertsColorMap().size() > int( obj->pointCloud()->validPoints.find_last() ) ) )
+             ( obj->getVertsColorMap().size() > int( obj->pointCloudConstPtr()->validPoints.find_last() ) ) )
             anyWithColors = true;
     }
     const VertNormals emptyNormals;
@@ -134,15 +134,15 @@ std::shared_ptr<ObjectPoints> merge( const std::vector<std::shared_ptr<ObjectPoi
     VertColors colors;
     for ( const auto& obj : objsPoints )
     {
-        if ( !obj->pointCloud() )
+        if ( !obj->pointCloudConstPtr() )
             continue;
 
         VertMap vertMap{};
-        pointCloud->addPartByMask( *obj->pointCloud(), obj->pointCloud()->validPoints, { .src2tgtVerts = &vertMap },
+        pointCloud->addPartByMask( *obj->pointCloudConstPtr(), obj->pointCloudConstPtr()->validPoints, { .src2tgtVerts = &vertMap },
             allWithNormals ? nullptr : &emptyNormals );
 
         const bool withColors = ( obj->getColoringType() == ColoringType::VertsColorMap ) &&
-            ( obj->getVertsColorMap().size() > int( obj->pointCloud()->validPoints.find_last() ) ) ;
+            ( obj->getVertsColorMap().size() > int( obj->pointCloudConstPtr()->validPoints.find_last() ) ) ;
         const auto& objColors = obj->getVertsColorMap();
         if ( anyWithColors )
             colors.resize( size_t( vertMap.back() ) + 1, obj->getFrontColor( true ) );
@@ -178,7 +178,7 @@ std::shared_ptr<MR::ObjectPoints> cloneRegion( const std::shared_ptr<ObjectPoint
     if ( !objPoints->getVertsColorMap().empty() )
         partMapping.tgt2srcVerts = &vertMap;
     std::shared_ptr<PointCloud> newCloud = std::make_shared<PointCloud>();
-    newCloud->addPartByMask( *objPoints->pointCloud(), region, partMapping );
+    newCloud->addPartByMask( *objPoints->pointCloudConstPtr(), region, partMapping );
 
     std::shared_ptr<ObjectPoints> newObj = std::make_shared<ObjectPoints>();
     newObj->setFrontColor( objPoints->getFrontColor( true ), true );
@@ -194,7 +194,7 @@ std::shared_ptr<MR::ObjectPoints> cloneRegion( const std::shared_ptr<ObjectPoint
 std::shared_ptr<ObjectPoints> pack( const ObjectPoints& pts, Reorder reorder, VertBitSet* newValidVerts, const ProgressCallback & cb )
 {
     MR_TIMER;
-    if ( !pts.pointCloud() )
+    if ( !pts.pointCloudConstPtr() )
     {
         assert( false );
         return {};
@@ -204,7 +204,7 @@ std::shared_ptr<ObjectPoints> pack( const ObjectPoints& pts, Reorder reorder, Ve
     if ( !reportProgress( cb, 0.0f ) )
         return {};
 
-    res->setPointCloud( std::make_shared<PointCloud>( *pts.pointCloud() ) );
+    res->setPointCloud( std::make_shared<PointCloud>( *pts.pointCloudConstPtr() ) );
     if ( newValidVerts )
         res->varPointCloud()->validPoints = std::move( *newValidVerts );
     if ( !reportProgress( cb, 0.05f ) )

--- a/source/MRMesh/MRObjectPoints.h
+++ b/source/MRMesh/MRObjectPoints.h
@@ -24,7 +24,7 @@ public:
     constexpr static const char* StaticClassNameInPlural() noexcept { return "Point Clouds"; }
     virtual std::string classNameInPlural() const override { return StaticClassNameInPlural(); }
 
-    /// returns variable point cloud, if const point cloud is needed use `pointCloud()` instead
+    /// returns variable point cloud, if const point cloud is needed use `pointCloudConstPtr()` instead
     virtual const std::shared_ptr<PointCloud>& varPointCloud() { return points_; }
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;

--- a/source/MRMesh/MRObjectPoints.h
+++ b/source/MRMesh/MRObjectPoints.h
@@ -24,7 +24,7 @@ public:
     constexpr static const char* StaticClassNameInPlural() noexcept { return "Point Clouds"; }
     virtual std::string classNameInPlural() const override { return StaticClassNameInPlural(); }
 
-    /// returns variable point cloud, if const point cloud is needed use `pointCloudConstPtr()` instead
+    /// returns variable point cloud, if const point cloud is needed use `pointCloudPtr()` instead
     virtual const std::shared_ptr<PointCloud>& varPointCloud() { return points_; }
 
     MRMESH_API virtual std::shared_ptr<Object> clone() const override;

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -44,7 +44,7 @@ public:
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
     /// \deprecated the cast inside is undefined behaviour, use pointCloudConstPtr() instead
-    [[deprecated( "use pointCloudConstPtr() instead" )]] MR_BIND_IGNORE
+    [[deprecated( "use pointCloudConstPtr() instead" )]]
     const std::shared_ptr<const PointCloud>& pointCloud() const
     { return reinterpret_cast< const std::shared_ptr<const PointCloud>& >( points_ ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -44,7 +44,7 @@ public:
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
     /// \deprecated the cast inside is undefined behaviour, use pointCloudConstPtr() instead
-    [[deprecated( "use pointCloudConstPtr() instead" )]]
+    [[deprecated( "use pointCloudConstPtr() instead" )]] MR_BIND_IGNORE
     const std::shared_ptr<const PointCloud>& pointCloud() const
     { return reinterpret_cast< const std::shared_ptr<const PointCloud>& >( points_ ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -36,10 +36,15 @@ public:
 
     [[nodiscard]] virtual bool hasModel() const override { return bool( points_ ); }
 
+    /// returns the point cloud of this object, or nullptr if it is not set
+    [[nodiscard]] const PointCloud* pointCloudConstPtr() const { return points_.get(); }
+
     #ifdef __GNUC__
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
+    /// \deprecated the cast inside is undefined behaviour, use pointCloudConstPtr() instead
+    [[deprecated( "use pointCloudConstPtr() instead" )]]
     const std::shared_ptr<const PointCloud>& pointCloud() const
     { return reinterpret_cast< const std::shared_ptr<const PointCloud>& >( points_ ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectPointsHolder.h
+++ b/source/MRMesh/MRObjectPointsHolder.h
@@ -36,15 +36,18 @@ public:
 
     [[nodiscard]] virtual bool hasModel() const override { return bool( points_ ); }
 
+    /// returns the point cloud of this object for modification, or nullptr if it is not set
+    [[nodiscard]]       PointCloud* varPointCloudPtr() { return points_.get(); }
+
     /// returns the point cloud of this object, or nullptr if it is not set
-    [[nodiscard]] const PointCloud* pointCloudConstPtr() const { return points_.get(); }
+    [[nodiscard]] const PointCloud* pointCloudPtr() const { return points_.get(); }
 
     #ifdef __GNUC__
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
-    /// \deprecated the cast inside is undefined behaviour, use pointCloudConstPtr() instead
-    [[deprecated( "use pointCloudConstPtr() instead" )]]
+    /// \deprecated the cast inside is undefined behaviour, use pointCloudPtr() instead
+    [[deprecated( "use pointCloudPtr() instead" )]]
     const std::shared_ptr<const PointCloud>& pointCloud() const
     { return reinterpret_cast< const std::shared_ptr<const PointCloud>& >( points_ ); } // reinterpret_cast to avoid making a copy of shared_ptr
     #ifdef __GNUC__

--- a/source/MRMesh/MRObjectSave.cpp
+++ b/source/MRMesh/MRObjectSave.cpp
@@ -29,7 +29,7 @@ Mesh mergeToMesh( const Object& object )
     Mesh result;
     if ( const auto* objMesh = dynamic_cast<const ObjectMesh*>( &object ) )
     {
-        if ( const auto* mesh = objMesh->meshConstPtr() )
+        if ( const auto* mesh = objMesh->meshPtr() )
         {
             result = *mesh;
             result.transform( objMesh->worldXf() );
@@ -37,11 +37,11 @@ Mesh mergeToMesh( const Object& object )
     }
     for ( const auto& objMesh : getAllObjectsInTree<ObjectMesh>( const_cast<Object*>( &object ), ObjectSelectivityType::Selectable ) )
     {
-        if ( !objMesh || !objMesh->meshConstPtr() )
+        if ( !objMesh || !objMesh->meshPtr() )
             continue;
 
         VertMap vmap;
-        result.addMesh( *objMesh->meshConstPtr(), nullptr, &vmap );
+        result.addMesh( *objMesh->meshPtr(), nullptr, &vmap );
 
         const auto xf = objMesh->worldXf();
         for ( const auto v : vmap )
@@ -57,7 +57,7 @@ PointCloud mergeToPoints( const Object& object )
     PointCloud result;
     if ( const auto* objPoints = dynamic_cast<const ObjectPoints*>( &object ) )
     {
-        if ( const auto* pointCloud = objPoints->pointCloudConstPtr() )
+        if ( const auto* pointCloud = objPoints->pointCloudPtr() )
         {
             result = *pointCloud;
             const auto xf = objPoints->worldXf();
@@ -70,11 +70,11 @@ PointCloud mergeToPoints( const Object& object )
     }
     for ( const auto& objPoints : getAllObjectsInTree<ObjectPoints>( const_cast<Object*>( &object ), ObjectSelectivityType::Selectable ) )
     {
-        if ( !objPoints || !objPoints->pointCloudConstPtr() )
+        if ( !objPoints || !objPoints->pointCloudPtr() )
             continue;
 
         VertMap vmap;
-        result.addPartByMask( result, objPoints->pointCloudConstPtr()->validPoints, { .src2tgtVerts = &vmap } );
+        result.addPartByMask( result, objPoints->pointCloudPtr()->validPoints, { .src2tgtVerts = &vmap } );
 
         const auto xf = objPoints->worldXf();
         for ( const auto v : vmap )
@@ -90,7 +90,7 @@ Polyline3 mergeToLines( const Object& object )
     Polyline3 result;
     if ( const auto* objLines = dynamic_cast<const ObjectLines*>( &object ) )
     {
-        if ( const auto* polyline = objLines->polylineConstPtr() )
+        if ( const auto* polyline = objLines->polylinePtr() )
         {
             result = *polyline;
             result.transform( objLines->worldXf() );
@@ -98,11 +98,11 @@ Polyline3 mergeToLines( const Object& object )
     }
     for ( const auto& objLines : getAllObjectsInTree<ObjectLines>( const_cast<Object*>( &object ), ObjectSelectivityType::Selectable ) )
     {
-        if ( !objLines || !objLines->polylineConstPtr() )
+        if ( !objLines || !objLines->polylinePtr() )
             continue;
 
         VertMap vmap;
-        result.addPart( *objLines->polylineConstPtr(), &vmap );
+        result.addPart( *objLines->polylinePtr(), &vmap );
 
         const auto xf = objLines->worldXf();
         for ( const auto& v : vmap )

--- a/source/MRMesh/MRObjectSave.cpp
+++ b/source/MRMesh/MRObjectSave.cpp
@@ -29,7 +29,7 @@ Mesh mergeToMesh( const Object& object )
     Mesh result;
     if ( const auto* objMesh = dynamic_cast<const ObjectMesh*>( &object ) )
     {
-        if ( const auto& mesh = objMesh->mesh() )
+        if ( const auto* mesh = objMesh->meshConstPtr() )
         {
             result = *mesh;
             result.transform( objMesh->worldXf() );
@@ -37,11 +37,11 @@ Mesh mergeToMesh( const Object& object )
     }
     for ( const auto& objMesh : getAllObjectsInTree<ObjectMesh>( const_cast<Object*>( &object ), ObjectSelectivityType::Selectable ) )
     {
-        if ( !objMesh || !objMesh->mesh() )
+        if ( !objMesh || !objMesh->meshConstPtr() )
             continue;
 
         VertMap vmap;
-        result.addMesh( *objMesh->mesh(), nullptr, &vmap );
+        result.addMesh( *objMesh->meshConstPtr(), nullptr, &vmap );
 
         const auto xf = objMesh->worldXf();
         for ( const auto v : vmap )
@@ -57,7 +57,7 @@ PointCloud mergeToPoints( const Object& object )
     PointCloud result;
     if ( const auto* objPoints = dynamic_cast<const ObjectPoints*>( &object ) )
     {
-        if ( const auto& pointCloud = objPoints->pointCloud() )
+        if ( const auto* pointCloud = objPoints->pointCloudConstPtr() )
         {
             result = *pointCloud;
             const auto xf = objPoints->worldXf();
@@ -70,11 +70,11 @@ PointCloud mergeToPoints( const Object& object )
     }
     for ( const auto& objPoints : getAllObjectsInTree<ObjectPoints>( const_cast<Object*>( &object ), ObjectSelectivityType::Selectable ) )
     {
-        if ( !objPoints || !objPoints->pointCloud() )
+        if ( !objPoints || !objPoints->pointCloudConstPtr() )
             continue;
 
         VertMap vmap;
-        result.addPartByMask( result, objPoints->pointCloud()->validPoints, { .src2tgtVerts = &vmap } );
+        result.addPartByMask( result, objPoints->pointCloudConstPtr()->validPoints, { .src2tgtVerts = &vmap } );
 
         const auto xf = objPoints->worldXf();
         for ( const auto v : vmap )
@@ -90,7 +90,7 @@ Polyline3 mergeToLines( const Object& object )
     Polyline3 result;
     if ( const auto* objLines = dynamic_cast<const ObjectLines*>( &object ) )
     {
-        if ( const auto& polyline = objLines->polyline() )
+        if ( const auto* polyline = objLines->polylineConstPtr() )
         {
             result = *polyline;
             result.transform( objLines->worldXf() );
@@ -98,11 +98,11 @@ Polyline3 mergeToLines( const Object& object )
     }
     for ( const auto& objLines : getAllObjectsInTree<ObjectLines>( const_cast<Object*>( &object ), ObjectSelectivityType::Selectable ) )
     {
-        if ( !objLines || !objLines->polyline() )
+        if ( !objLines || !objLines->polylineConstPtr() )
             continue;
 
         VertMap vmap;
-        result.addPart( *objLines->polyline(), &vmap );
+        result.addPart( *objLines->polylineConstPtr(), &vmap );
 
         const auto xf = objLines->worldXf();
         for ( const auto& v : vmap )

--- a/source/MRMesh/MRPartialChangeMeshAction.h
+++ b/source/MRMesh/MRPartialChangeMeshAction.h
@@ -32,8 +32,8 @@ public:
         name_{ std::move( name ) }
     {
         assert( objMesh_ );
-        if ( objMesh_ && objMesh_->meshConstPtr() )
-            meshDiff_ = MeshDiff( *objMesh_->meshConstPtr(), oldMesh );
+        if ( objMesh_ && objMesh_->meshPtr() )
+            meshDiff_ = MeshDiff( *objMesh_->meshPtr(), oldMesh );
     }
 
     /// use this constructor to set new object's mesh and remember its difference from existed mesh for future undoing
@@ -45,8 +45,8 @@ public:
         if ( objMesh_ )
         {
             auto oldMesh = objMesh_->updateMesh( std::move( newMesh ) );
-            if ( oldMesh && objMesh_->meshConstPtr() )
-                meshDiff_ = MeshDiff( *objMesh_->meshConstPtr(), *oldMesh );
+            if ( oldMesh && objMesh_->meshPtr() )
+                meshDiff_ = MeshDiff( *objMesh_->meshPtr(), *oldMesh );
         }
     }
 

--- a/source/MRMesh/MRPartialChangeMeshAction.h
+++ b/source/MRMesh/MRPartialChangeMeshAction.h
@@ -32,8 +32,8 @@ public:
         name_{ std::move( name ) }
     {
         assert( objMesh_ );
-        if ( objMesh_ && objMesh_->mesh() )
-            meshDiff_ = MeshDiff( *objMesh_->mesh(), oldMesh );
+        if ( objMesh_ && objMesh_->meshConstPtr() )
+            meshDiff_ = MeshDiff( *objMesh_->meshConstPtr(), oldMesh );
     }
 
     /// use this constructor to set new object's mesh and remember its difference from existed mesh for future undoing
@@ -45,8 +45,8 @@ public:
         if ( objMesh_ )
         {
             auto oldMesh = objMesh_->updateMesh( std::move( newMesh ) );
-            if ( oldMesh && objMesh_->mesh() )
-                meshDiff_ = MeshDiff( *objMesh_->mesh(), *oldMesh );
+            if ( oldMesh && objMesh_->meshConstPtr() )
+                meshDiff_ = MeshDiff( *objMesh_->meshConstPtr(), *oldMesh );
         }
     }
 

--- a/source/MRMesh/MRPointOnObject.cpp
+++ b/source/MRMesh/MRPointOnObject.cpp
@@ -16,7 +16,7 @@ PickedPoint pointOnObjectToPickedPoint( const VisualObject* object, const PointO
 {
     if ( auto* objMesh = dynamic_cast< const ObjectMeshHolder* >( object ) )
     {
-        const auto * mesh = objMesh->meshConstPtr();
+        const auto * mesh = objMesh->meshPtr();
         // toTriPoint() indexes edgePerFace_ by the face, so an out-of-range one reads out of bounds
         if ( !mesh || !pos.face.valid() || !mesh->topology.hasFace( pos.face ) )
         {
@@ -30,7 +30,7 @@ PickedPoint pointOnObjectToPickedPoint( const VisualObject* object, const PointO
 
     if ( auto* objPoints = dynamic_cast< const ObjectPointsHolder* >( object ) )
     {
-        const auto * cloud = objPoints->pointCloudConstPtr();
+        const auto * cloud = objPoints->pointCloudPtr();
         if ( !cloud || !pos.vert.valid() || !cloud->validPoints.test( pos.vert ) )
         {
             spdlog::warn( "pointOnObjectToPickedPoint: not a valid point pick: vert={}, numPoints={}",
@@ -43,7 +43,7 @@ PickedPoint pointOnObjectToPickedPoint( const VisualObject* object, const PointO
 
     if ( auto* objLines  = dynamic_cast< const ObjectLinesHolder* >( object ) )
     {
-        const auto * polyline = objLines->polylineConstPtr();
+        const auto * polyline = objLines->polylinePtr();
         const EdgeId e( pos.uedge );
         if ( !polyline || !e.valid() || !polyline->topology.hasEdge( e ) )
         {
@@ -70,7 +70,7 @@ std::optional<Vector3f> getPickedPointPosition( const VisualObject& object, cons
         {
             if ( auto objMesh = dynamic_cast< const ObjectMeshHolder* >( &object ) )
             {
-                if ( const auto* mesh = objMesh->meshConstPtr() )
+                if ( const auto* mesh = objMesh->meshPtr() )
                 {
                     const auto & topology = mesh->topology;
                     if ( topology.hasEdge( triPoint.e ) )
@@ -86,11 +86,11 @@ std::optional<Vector3f> getPickedPointPosition( const VisualObject& object, cons
         {
             if ( auto objLines = dynamic_cast< const ObjectLinesHolder* >( &object ) )
             {
-                if ( const auto* polyline = objLines->polylineConstPtr() )
+                if ( const auto* polyline = objLines->polylinePtr() )
                 {
                     const auto & topology = polyline->topology;
                     if ( topology.hasEdge( edgePoint.e ) )
-                        return objLines->polylineConstPtr()->edgePoint( edgePoint );
+                        return objLines->polylinePtr()->edgePoint( edgePoint );
                 }
             }
             return {};
@@ -99,7 +99,7 @@ std::optional<Vector3f> getPickedPointPosition( const VisualObject& object, cons
         {
             if ( auto objPoints = dynamic_cast< const ObjectPointsHolder* >( &object ) )
             {
-                if ( const auto* pointCloud = objPoints->pointCloudConstPtr() )
+                if ( const auto* pointCloud = objPoints->pointCloudPtr() )
                 {
                     if ( pointCloud->validPoints.test( vertId ) )
                         return pointCloud->points[vertId];
@@ -121,7 +121,7 @@ std::optional<Vector3f> getPickedPointNormal( const VisualObject& object, const 
         {
             if ( auto objMesh = dynamic_cast< const ObjectMeshHolder* >( &object ) )
             {
-                if ( const auto* mesh = objMesh->meshConstPtr() )
+                if ( const auto* mesh = objMesh->meshPtr() )
                 {
                     const auto & topology = mesh->topology;
                     if ( topology.hasEdge( triPoint.e ) )
@@ -141,7 +141,7 @@ std::optional<Vector3f> getPickedPointNormal( const VisualObject& object, const 
         {
             if ( auto objPoints = dynamic_cast< const ObjectPointsHolder* >( &object ) )
             {
-                if ( const auto* pointCloud = objPoints->pointCloudConstPtr() )
+                if ( const auto* pointCloud = objPoints->pointCloudPtr() )
                 {
                     if ( vertId < pointCloud->normals.size() && pointCloud->validPoints.test( vertId ) )
                         return pointCloud->normals[vertId];

--- a/source/MRMesh/MRPointOnObject.cpp
+++ b/source/MRMesh/MRPointOnObject.cpp
@@ -16,7 +16,7 @@ PickedPoint pointOnObjectToPickedPoint( const VisualObject* object, const PointO
 {
     if ( auto* objMesh = dynamic_cast< const ObjectMeshHolder* >( object ) )
     {
-        const auto & mesh = objMesh->mesh();
+        const auto * mesh = objMesh->meshConstPtr();
         // toTriPoint() indexes edgePerFace_ by the face, so an out-of-range one reads out of bounds
         if ( !mesh || !pos.face.valid() || !mesh->topology.hasFace( pos.face ) )
         {
@@ -30,7 +30,7 @@ PickedPoint pointOnObjectToPickedPoint( const VisualObject* object, const PointO
 
     if ( auto* objPoints = dynamic_cast< const ObjectPointsHolder* >( object ) )
     {
-        const auto & cloud = objPoints->pointCloud();
+        const auto * cloud = objPoints->pointCloudConstPtr();
         if ( !cloud || !pos.vert.valid() || !cloud->validPoints.test( pos.vert ) )
         {
             spdlog::warn( "pointOnObjectToPickedPoint: not a valid point pick: vert={}, numPoints={}",
@@ -43,7 +43,7 @@ PickedPoint pointOnObjectToPickedPoint( const VisualObject* object, const PointO
 
     if ( auto* objLines  = dynamic_cast< const ObjectLinesHolder* >( object ) )
     {
-        const auto & polyline = objLines->polyline();
+        const auto * polyline = objLines->polylineConstPtr();
         const EdgeId e( pos.uedge );
         if ( !polyline || !e.valid() || !polyline->topology.hasEdge( e ) )
         {
@@ -70,7 +70,7 @@ std::optional<Vector3f> getPickedPointPosition( const VisualObject& object, cons
         {
             if ( auto objMesh = dynamic_cast< const ObjectMeshHolder* >( &object ) )
             {
-                if ( const auto& mesh = objMesh->mesh() )
+                if ( const auto* mesh = objMesh->meshConstPtr() )
                 {
                     const auto & topology = mesh->topology;
                     if ( topology.hasEdge( triPoint.e ) )
@@ -86,11 +86,11 @@ std::optional<Vector3f> getPickedPointPosition( const VisualObject& object, cons
         {
             if ( auto objLines = dynamic_cast< const ObjectLinesHolder* >( &object ) )
             {
-                if ( const auto& polyline = objLines->polyline() )
+                if ( const auto* polyline = objLines->polylineConstPtr() )
                 {
                     const auto & topology = polyline->topology;
                     if ( topology.hasEdge( edgePoint.e ) )
-                        return objLines->polyline()->edgePoint( edgePoint );
+                        return objLines->polylineConstPtr()->edgePoint( edgePoint );
                 }
             }
             return {};
@@ -99,7 +99,7 @@ std::optional<Vector3f> getPickedPointPosition( const VisualObject& object, cons
         {
             if ( auto objPoints = dynamic_cast< const ObjectPointsHolder* >( &object ) )
             {
-                if ( const auto& pointCloud = objPoints->pointCloud() )
+                if ( const auto* pointCloud = objPoints->pointCloudConstPtr() )
                 {
                     if ( pointCloud->validPoints.test( vertId ) )
                         return pointCloud->points[vertId];
@@ -121,7 +121,7 @@ std::optional<Vector3f> getPickedPointNormal( const VisualObject& object, const 
         {
             if ( auto objMesh = dynamic_cast< const ObjectMeshHolder* >( &object ) )
             {
-                if ( const auto& mesh = objMesh->mesh() )
+                if ( const auto* mesh = objMesh->meshConstPtr() )
                 {
                     const auto & topology = mesh->topology;
                     if ( topology.hasEdge( triPoint.e ) )
@@ -141,7 +141,7 @@ std::optional<Vector3f> getPickedPointNormal( const VisualObject& object, const 
         {
             if ( auto objPoints = dynamic_cast< const ObjectPointsHolder* >( &object ) )
             {
-                if ( const auto& pointCloud = objPoints->pointCloud() )
+                if ( const auto* pointCloud = objPoints->pointCloudConstPtr() )
                 {
                     if ( vertId < pointCloud->normals.size() && pointCloud->validPoints.test( vertId ) )
                         return pointCloud->normals[vertId];

--- a/source/MRTest/MRSerializeTests.cpp
+++ b/source/MRTest/MRSerializeTests.cpp
@@ -52,15 +52,15 @@ TEST( MRMesh, SerializeObjectMesh )
     EXPECT_EQ( l->obj->children().size(), 2 );
     auto m0 = dynamic_cast<const ObjectMesh*>( l->obj->children()[0].get() );
     EXPECT_TRUE( m0 );
-    EXPECT_TRUE( m0->mesh() );
-    EXPECT_EQ( m0->mesh()->topology.numValidFaces(), 12 );
+    EXPECT_TRUE( m0->meshConstPtr() );
+    EXPECT_EQ( m0->meshConstPtr()->topology.numValidFaces(), 12 );
     auto m1 = dynamic_cast<const ObjectMesh*>( l->obj->children()[1].get() );
     EXPECT_TRUE( m1 );
-    EXPECT_TRUE( m1->mesh() );
-    EXPECT_EQ( m1->mesh()->topology.numValidFaces(), 12 );
+    EXPECT_TRUE( m1->meshConstPtr() );
+    EXPECT_EQ( m1->meshConstPtr()->topology.numValidFaces(), 12 );
     // meshes are equal but not shared
-    EXPECT_EQ( *m0->mesh(), *m1->mesh() );
-    EXPECT_NE( m0->mesh(), m1->mesh() );
+    EXPECT_EQ( *m0->meshConstPtr(), *m1->meshConstPtr() );
+    EXPECT_NE( m0->meshConstPtr(), m1->meshConstPtr() );
 }
 
 // writing a scene in .mru file must not report any telemetry about the models saved inside it
@@ -72,7 +72,7 @@ TEST( MRMesh, SerializeNoTelemetry )
     om->setName( "mesh" );
     om->setMesh( std::make_shared<Mesh>( makeCube() ) );
     o.addChild( om );
-    auto cloud = std::make_shared<PointCloud>( meshToPointCloud( *om->mesh() ) );
+    auto cloud = std::make_shared<PointCloud>( meshToPointCloud( *om->meshConstPtr() ) );
     auto op = std::make_shared<ObjectPoints>();
     op->setName( "points" );
     op->setPointCloud( cloud );
@@ -95,7 +95,7 @@ TEST( MRMesh, SerializeNoTelemetry )
 
     // in contrast, ordinary saving of the same models is reported
     signals.clear();
-    EXPECT_TRUE( MeshSave::toAnySupportedFormat( *om->mesh(), f / "cube.ply" ).has_value() );
+    EXPECT_TRUE( MeshSave::toAnySupportedFormat( *om->meshConstPtr(), f / "cube.ply" ).has_value() );
     EXPECT_EQ( signals, std::vector<std::string>( { "Save *.ply VP TRI", "Save Mesh Log Tris 4" } ) );
 
     signals.clear();
@@ -128,8 +128,8 @@ TEST( MRMesh, SerializeObjectNameCutOnSpace )
     ASSERT_EQ( l->obj->children()[0]->children().size(), 1 );
     auto m = dynamic_cast<const ObjectMesh*>( l->obj->children()[0]->children()[0].get() );
     ASSERT_TRUE( m );
-    ASSERT_TRUE( m->mesh() );
-    EXPECT_EQ( m->mesh()->topology.numValidFaces(), 12 );
+    ASSERT_TRUE( m->meshConstPtr() );
+    EXPECT_EQ( m->meshConstPtr()->topology.numValidFaces(), 12 );
 }
 
 TEST( MRMesh, SerializeSharedObjectMesh )
@@ -156,14 +156,14 @@ TEST( MRMesh, SerializeSharedObjectMesh )
     EXPECT_EQ( l->obj->children().size(), 2 );
     auto m0 = dynamic_cast<const ObjectMesh*>( l->obj->children()[0].get() );
     EXPECT_TRUE( m0 );
-    EXPECT_TRUE( m0->mesh() );
-    EXPECT_EQ( m0->mesh()->topology.numValidFaces(), 12 );
+    EXPECT_TRUE( m0->meshConstPtr() );
+    EXPECT_EQ( m0->meshConstPtr()->topology.numValidFaces(), 12 );
     auto m1 = dynamic_cast<const ObjectMesh*>( l->obj->children()[1].get() );
     EXPECT_TRUE( m1 );
-    EXPECT_TRUE( m1->mesh() );
-    EXPECT_EQ( m1->mesh()->topology.numValidFaces(), 12 );
+    EXPECT_TRUE( m1->meshConstPtr() );
+    EXPECT_EQ( m1->meshConstPtr()->topology.numValidFaces(), 12 );
     // meshes are shared among two objects
-    EXPECT_EQ( m0->mesh(), m1->mesh() );
+    EXPECT_EQ( m0->meshConstPtr(), m1->meshConstPtr() );
 }
 
 } //namespace MR

--- a/source/MRTest/MRSerializeTests.cpp
+++ b/source/MRTest/MRSerializeTests.cpp
@@ -52,15 +52,15 @@ TEST( MRMesh, SerializeObjectMesh )
     EXPECT_EQ( l->obj->children().size(), 2 );
     auto m0 = dynamic_cast<const ObjectMesh*>( l->obj->children()[0].get() );
     EXPECT_TRUE( m0 );
-    EXPECT_TRUE( m0->meshConstPtr() );
-    EXPECT_EQ( m0->meshConstPtr()->topology.numValidFaces(), 12 );
+    EXPECT_TRUE( m0->meshPtr() );
+    EXPECT_EQ( m0->meshPtr()->topology.numValidFaces(), 12 );
     auto m1 = dynamic_cast<const ObjectMesh*>( l->obj->children()[1].get() );
     EXPECT_TRUE( m1 );
-    EXPECT_TRUE( m1->meshConstPtr() );
-    EXPECT_EQ( m1->meshConstPtr()->topology.numValidFaces(), 12 );
+    EXPECT_TRUE( m1->meshPtr() );
+    EXPECT_EQ( m1->meshPtr()->topology.numValidFaces(), 12 );
     // meshes are equal but not shared
-    EXPECT_EQ( *m0->meshConstPtr(), *m1->meshConstPtr() );
-    EXPECT_NE( m0->meshConstPtr(), m1->meshConstPtr() );
+    EXPECT_EQ( *m0->meshPtr(), *m1->meshPtr() );
+    EXPECT_NE( m0->meshPtr(), m1->meshPtr() );
 }
 
 // writing a scene in .mru file must not report any telemetry about the models saved inside it
@@ -72,7 +72,7 @@ TEST( MRMesh, SerializeNoTelemetry )
     om->setName( "mesh" );
     om->setMesh( std::make_shared<Mesh>( makeCube() ) );
     o.addChild( om );
-    auto cloud = std::make_shared<PointCloud>( meshToPointCloud( *om->meshConstPtr() ) );
+    auto cloud = std::make_shared<PointCloud>( meshToPointCloud( *om->meshPtr() ) );
     auto op = std::make_shared<ObjectPoints>();
     op->setName( "points" );
     op->setPointCloud( cloud );
@@ -95,7 +95,7 @@ TEST( MRMesh, SerializeNoTelemetry )
 
     // in contrast, ordinary saving of the same models is reported
     signals.clear();
-    EXPECT_TRUE( MeshSave::toAnySupportedFormat( *om->meshConstPtr(), f / "cube.ply" ).has_value() );
+    EXPECT_TRUE( MeshSave::toAnySupportedFormat( *om->meshPtr(), f / "cube.ply" ).has_value() );
     EXPECT_EQ( signals, std::vector<std::string>( { "Save *.ply VP TRI", "Save Mesh Log Tris 4" } ) );
 
     signals.clear();
@@ -128,8 +128,8 @@ TEST( MRMesh, SerializeObjectNameCutOnSpace )
     ASSERT_EQ( l->obj->children()[0]->children().size(), 1 );
     auto m = dynamic_cast<const ObjectMesh*>( l->obj->children()[0]->children()[0].get() );
     ASSERT_TRUE( m );
-    ASSERT_TRUE( m->meshConstPtr() );
-    EXPECT_EQ( m->meshConstPtr()->topology.numValidFaces(), 12 );
+    ASSERT_TRUE( m->meshPtr() );
+    EXPECT_EQ( m->meshPtr()->topology.numValidFaces(), 12 );
 }
 
 TEST( MRMesh, SerializeSharedObjectMesh )
@@ -156,14 +156,14 @@ TEST( MRMesh, SerializeSharedObjectMesh )
     EXPECT_EQ( l->obj->children().size(), 2 );
     auto m0 = dynamic_cast<const ObjectMesh*>( l->obj->children()[0].get() );
     EXPECT_TRUE( m0 );
-    EXPECT_TRUE( m0->meshConstPtr() );
-    EXPECT_EQ( m0->meshConstPtr()->topology.numValidFaces(), 12 );
+    EXPECT_TRUE( m0->meshPtr() );
+    EXPECT_EQ( m0->meshPtr()->topology.numValidFaces(), 12 );
     auto m1 = dynamic_cast<const ObjectMesh*>( l->obj->children()[1].get() );
     EXPECT_TRUE( m1 );
-    EXPECT_TRUE( m1->meshConstPtr() );
-    EXPECT_EQ( m1->meshConstPtr()->topology.numValidFaces(), 12 );
+    EXPECT_TRUE( m1->meshPtr() );
+    EXPECT_EQ( m1->meshPtr()->topology.numValidFaces(), 12 );
     // meshes are shared among two objects
-    EXPECT_EQ( m0->meshConstPtr(), m1->meshConstPtr() );
+    EXPECT_EQ( m0->meshPtr(), m1->meshPtr() );
 }
 
 } //namespace MR

--- a/source/MRViewer/ImGuiMenu.cpp
+++ b/source/MRViewer/ImGuiMenu.cpp
@@ -1249,13 +1249,13 @@ void ImGuiMenu::draw_selection_properties_content( const std::vector<std::shared
         if ( !obj )
             return false;
         auto objMesh = obj->asType<ObjectMesh>();
-        if ( objMesh && objMesh->mesh() )
+        if ( objMesh && objMesh->meshConstPtr() )
             return true;
         auto objPoints = obj->asType<ObjectPoints>();
-        if ( objPoints && objPoints->pointCloud() )
+        if ( objPoints && objPoints->pointCloudConstPtr() )
             return true;
         auto objLines = obj->asType<ObjectLines>();
-        if ( objLines && objLines->polyline() )
+        if ( objLines && objLines->polylineConstPtr() )
             return true;
         return false;
     } );
@@ -1465,12 +1465,12 @@ float ImGuiMenu::drawSelectionInformation_()
         {
             totalPoints += pObj->numValidPoints();
             totalSelectedPoints += pObj->numSelectedPoints();
-            if ( auto pointCloud = pObj->pointCloud() )
+            if ( auto pointCloud = pObj->pointCloudConstPtr() )
                 pointsHaveNormals |= pointCloud->hasNormals();
         }
         else if ( auto mObj = obj->asType<ObjectMesh>() )
         {
-            if ( auto mesh = mObj->mesh() )
+            if ( auto mesh = mObj->meshConstPtr() )
             {
                 totalFaces += mesh->topology.numValidFaces();
                 totalSelectedFaces += mObj->numSelectedFaces();
@@ -1487,7 +1487,7 @@ float ImGuiMenu::drawSelectionInformation_()
         }
         else if ( auto lObj = obj->asType<ObjectLines>() )
         {
-            if ( auto polyline = lObj->polyline() )
+            if ( auto polyline = lObj->polylineConstPtr() )
             {
                 totalVerts += polyline->topology.numValidVerts();
                 totalEdges += lObj->numUndirectedEdges();

--- a/source/MRViewer/ImGuiMenu.cpp
+++ b/source/MRViewer/ImGuiMenu.cpp
@@ -1249,13 +1249,13 @@ void ImGuiMenu::draw_selection_properties_content( const std::vector<std::shared
         if ( !obj )
             return false;
         auto objMesh = obj->asType<ObjectMesh>();
-        if ( objMesh && objMesh->meshConstPtr() )
+        if ( objMesh && objMesh->meshPtr() )
             return true;
         auto objPoints = obj->asType<ObjectPoints>();
-        if ( objPoints && objPoints->pointCloudConstPtr() )
+        if ( objPoints && objPoints->pointCloudPtr() )
             return true;
         auto objLines = obj->asType<ObjectLines>();
-        if ( objLines && objLines->polylineConstPtr() )
+        if ( objLines && objLines->polylinePtr() )
             return true;
         return false;
     } );
@@ -1465,12 +1465,12 @@ float ImGuiMenu::drawSelectionInformation_()
         {
             totalPoints += pObj->numValidPoints();
             totalSelectedPoints += pObj->numSelectedPoints();
-            if ( auto pointCloud = pObj->pointCloudConstPtr() )
+            if ( auto pointCloud = pObj->pointCloudPtr() )
                 pointsHaveNormals |= pointCloud->hasNormals();
         }
         else if ( auto mObj = obj->asType<ObjectMesh>() )
         {
-            if ( auto mesh = mObj->meshConstPtr() )
+            if ( auto mesh = mObj->meshPtr() )
             {
                 totalFaces += mesh->topology.numValidFaces();
                 totalSelectedFaces += mObj->numSelectedFaces();
@@ -1487,7 +1487,7 @@ float ImGuiMenu::drawSelectionInformation_()
         }
         else if ( auto lObj = obj->asType<ObjectLines>() )
         {
-            if ( auto polyline = lObj->polylineConstPtr() )
+            if ( auto polyline = lObj->polylinePtr() )
             {
                 totalVerts += polyline->topology.numValidVerts();
                 totalEdges += lObj->numUndirectedEdges();

--- a/source/MRViewer/MRAncillaryLines.cpp
+++ b/source/MRViewer/MRAncillaryLines.cpp
@@ -33,10 +33,10 @@ void AncillaryLines::make( Object &parent, const Contours3f& contours )
 
 void AncillaryLines::colorizeAxes()
 {
-    if ( !obj || !obj->polyline() )
+    if ( !obj || !obj->polylineConstPtr() )
         return;
 
-    const auto& polyline = *obj->polyline();
+    const auto& polyline = *obj->polylineConstPtr();
     const auto ueCount = polyline.topology.lastNotLoneUndirectedEdge() + 1;
     UndirectedEdgeColors colorMap( ueCount, Color::black() );
     for ( auto ue = 0_ue; ue < ueCount; ++ue )

--- a/source/MRViewer/MRAncillaryLines.cpp
+++ b/source/MRViewer/MRAncillaryLines.cpp
@@ -33,10 +33,10 @@ void AncillaryLines::make( Object &parent, const Contours3f& contours )
 
 void AncillaryLines::colorizeAxes()
 {
-    if ( !obj || !obj->polylineConstPtr() )
+    if ( !obj || !obj->polylinePtr() )
         return;
 
-    const auto& polyline = *obj->polylineConstPtr();
+    const auto& polyline = *obj->polylinePtr();
     const auto ueCount = polyline.topology.lastNotLoneUndirectedEdge() + 1;
     UndirectedEdgeColors colorMap( ueCount, Color::black() );
     for ( auto ue = 0_ue; ue < ueCount; ++ue )

--- a/source/MRViewer/MRAncillaryPoints.cpp
+++ b/source/MRViewer/MRAncillaryPoints.cpp
@@ -33,7 +33,7 @@ void AncillaryPoints::addPoint( const Vector3f& point )
 void AncillaryPoints::addPoint( const Vector3f& point, const Color& color )
 {
     auto colorMap = obj->getVertsColorMap();
-    assert( colorMap.size() == obj->pointCloud()->points.size() );
+    assert( colorMap.size() == obj->pointCloudConstPtr()->points.size() );
     obj->varPointCloud()->addPoint( point );
     colorMap.push_back( color );
     obj->setVertsColorMap( colorMap );
@@ -52,7 +52,7 @@ void AncillaryPoints::addPoints( const std::vector<Vector3f>& points, const std:
     assert( points.size() == colors.size() );
 
     auto colorMap = obj->getVertsColorMap();
-    assert( colorMap.size() == obj->pointCloud()->points.size() );
+    assert( colorMap.size() == obj->pointCloudConstPtr()->points.size() );
     colorMap.reserve( colorMap.size() + points.size() );
     auto& oldPoints = obj->varPointCloud()->points;
     oldPoints.reserve( oldPoints.size() + points.size() );

--- a/source/MRViewer/MRAncillaryPoints.cpp
+++ b/source/MRViewer/MRAncillaryPoints.cpp
@@ -33,7 +33,7 @@ void AncillaryPoints::addPoint( const Vector3f& point )
 void AncillaryPoints::addPoint( const Vector3f& point, const Color& color )
 {
     auto colorMap = obj->getVertsColorMap();
-    assert( colorMap.size() == obj->pointCloudConstPtr()->points.size() );
+    assert( colorMap.size() == obj->pointCloudPtr()->points.size() );
     obj->varPointCloud()->addPoint( point );
     colorMap.push_back( color );
     obj->setVertsColorMap( colorMap );
@@ -52,7 +52,7 @@ void AncillaryPoints::addPoints( const std::vector<Vector3f>& points, const std:
     assert( points.size() == colors.size() );
 
     auto colorMap = obj->getVertsColorMap();
-    assert( colorMap.size() == obj->pointCloudConstPtr()->points.size() );
+    assert( colorMap.size() == obj->pointCloudPtr()->points.size() );
     colorMap.reserve( colorMap.size() + points.size() );
     auto& oldPoints = obj->varPointCloud()->points;
     oldPoints.reserve( oldPoints.size() + points.size() );

--- a/source/MRViewer/MRMeshBoundarySelectionWidget.cpp
+++ b/source/MRViewer/MRMeshBoundarySelectionWidget.cpp
@@ -53,7 +53,7 @@ std::shared_ptr<MR::Polyline3> BoundarySelectionWidget::getHoleBorder_( const st
         return {};
 
     EdgePath path;
-    const auto& mesh = *obj->meshConstPtr();
+    const auto& mesh = *obj->meshPtr();
     for ( auto e : leftRing( mesh.topology, initEdge ) )
     {
         path.push_back( e );
@@ -195,7 +195,7 @@ std::vector<MR::Vector3f> BoundarySelectionWidget::getPointsForSelectedHole() co
 
     std::vector<MR::Vector3f> result;
     const auto hole = holes[selectedHoleIndex_];
-    auto& mesh = *selectedHoleObject_->meshConstPtr();
+    auto& mesh = *selectedHoleObject_->meshPtr();
     for ( auto e : leftRing( mesh.topology, hole ) )
     {
         auto v = mesh.topology.org( e );
@@ -278,7 +278,7 @@ void BoundarySelectionWidget::calculateHoles_()
             auto& holes = holes_[object];
             auto& polylines = holeLines_[object];
 
-            holes = object->meshConstPtr()->topology.findHoleRepresentiveEdges();
+            holes = object->meshPtr()->topology.findHoleRepresentiveEdges();
             polylines.reserve( holes.size() );
             for ( auto hole : holes )
                 polylines.push_back( createAncillaryLines_( object, hole ) );

--- a/source/MRViewer/MRMeshBoundarySelectionWidget.cpp
+++ b/source/MRViewer/MRMeshBoundarySelectionWidget.cpp
@@ -53,7 +53,7 @@ std::shared_ptr<MR::Polyline3> BoundarySelectionWidget::getHoleBorder_( const st
         return {};
 
     EdgePath path;
-    const auto& mesh = *obj->mesh();
+    const auto& mesh = *obj->meshConstPtr();
     for ( auto e : leftRing( mesh.topology, initEdge ) )
     {
         path.push_back( e );
@@ -195,7 +195,7 @@ std::vector<MR::Vector3f> BoundarySelectionWidget::getPointsForSelectedHole() co
 
     std::vector<MR::Vector3f> result;
     const auto hole = holes[selectedHoleIndex_];
-    auto& mesh = *selectedHoleObject_->mesh();
+    auto& mesh = *selectedHoleObject_->meshConstPtr();
     for ( auto e : leftRing( mesh.topology, hole ) )
     {
         auto v = mesh.topology.org( e );
@@ -278,7 +278,7 @@ void BoundarySelectionWidget::calculateHoles_()
             auto& holes = holes_[object];
             auto& polylines = holeLines_[object];
 
-            holes = object->mesh()->topology.findHoleRepresentiveEdges();
+            holes = object->meshConstPtr()->topology.findHoleRepresentiveEdges();
             polylines.reserve( holes.size() );
             for ( auto hole : holes )
                 polylines.push_back( createAncillaryLines_( object, hole ) );

--- a/source/MRViewer/MRObjectMeshHistory.cpp
+++ b/source/MRViewer/MRObjectMeshHistory.cpp
@@ -13,9 +13,9 @@ namespace MR
 void excludeLoneEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh )
 {
     MR_TIMER;
-    if ( !objMesh || !objMesh->meshConstPtr() )
+    if ( !objMesh || !objMesh->meshPtr() )
         return;
-    const auto & topology = objMesh->meshConstPtr()->topology;
+    const auto & topology = objMesh->meshPtr()->topology;
 
     // remove deleted edges from the selection
     auto selEdges = objMesh->getSelectedEdges();

--- a/source/MRViewer/MRObjectMeshHistory.cpp
+++ b/source/MRViewer/MRObjectMeshHistory.cpp
@@ -13,9 +13,9 @@ namespace MR
 void excludeLoneEdgesWithHistory( const std::shared_ptr<ObjectMesh>& objMesh )
 {
     MR_TIMER;
-    if ( !objMesh || !objMesh->mesh() )
+    if ( !objMesh || !objMesh->meshConstPtr() )
         return;
-    const auto & topology = objMesh->mesh()->topology;
+    const auto & topology = objMesh->meshConstPtr()->topology;
 
     // remove deleted edges from the selection
     auto selEdges = objMesh->getSelectedEdges();

--- a/source/MRViewer/MRObjectPointsHistory.cpp
+++ b/source/MRViewer/MRObjectPointsHistory.cpp
@@ -14,7 +14,7 @@ static void packPointsWithHistoryCore( const std::shared_ptr<ObjectPoints>& objP
 {
     MR_TIMER;
 
-    if ( !objPoints || !objPoints->pointCloudConstPtr() )
+    if ( !objPoints || !objPoints->pointCloudPtr() )
         return;
 
     auto packed = pack( *objPoints, reorder, newValidVerts );

--- a/source/MRViewer/MRObjectPointsHistory.cpp
+++ b/source/MRViewer/MRObjectPointsHistory.cpp
@@ -14,7 +14,7 @@ static void packPointsWithHistoryCore( const std::shared_ptr<ObjectPoints>& objP
 {
     MR_TIMER;
 
-    if ( !objPoints || !objPoints->pointCloud() )
+    if ( !objPoints || !objPoints->pointCloudConstPtr() )
         return;
 
     auto packed = pack( *objPoints, reorder, newValidVerts );

--- a/source/MRViewer/MRObjectTransformWidget.cpp
+++ b/source/MRViewer/MRObjectTransformWidget.cpp
@@ -842,7 +842,7 @@ void TransformControls::updateRotation( Axis ax, const AffineXf3f& xf, float sta
     if ( ( endAngle - startAngle ) < 0.0f )
         step = -1;
 
-    auto radius = ( rotateControls_[int( ax )]->xf( vpId ).A * ( rotateLines_[0]->polylineConstPtr()->points.vec_[0] - getCenter() ) ).length();
+    auto radius = ( rotateControls_[int( ax )]->xf( vpId ).A * ( rotateLines_[0]->polylinePtr()->points.vec_[0] - getCenter() ) ).length();
     Vector3f basisXTransfomed = xf.A * baseAxis[( int( ax ) + 1 ) % 3];
     Vector3f basisYTransfomed = xf.A * baseAxis[( int( ax ) + 2 ) % 3];
 

--- a/source/MRViewer/MRObjectTransformWidget.cpp
+++ b/source/MRViewer/MRObjectTransformWidget.cpp
@@ -842,7 +842,7 @@ void TransformControls::updateRotation( Axis ax, const AffineXf3f& xf, float sta
     if ( ( endAngle - startAngle ) < 0.0f )
         step = -1;
 
-    auto radius = ( rotateControls_[int( ax )]->xf( vpId ).A * ( rotateLines_[0]->polyline()->points.vec_[0] - getCenter() ) ).length();
+    auto radius = ( rotateControls_[int( ax )]->xf( vpId ).A * ( rotateLines_[0]->polylineConstPtr()->points.vec_[0] - getCenter() ) ).length();
     Vector3f basisXTransfomed = xf.A * baseAxis[( int( ax ) + 1 ) % 3];
     Vector3f basisYTransfomed = xf.A * baseAxis[( int( ax ) + 2 ) % 3];
 

--- a/source/MRViewer/MRPickHoleBorderElement.cpp
+++ b/source/MRViewer/MRPickHoleBorderElement.cpp
@@ -56,7 +56,7 @@ HoleEdgePoint findClosestToMouseHoleEdge( const Vector2i& mousePos, const std::s
                                           const std::vector<EdgeId>& holeRepresentativeEdges,
                                           float accuracy /*= 5.5f*/, bool attractToVert /*= false*/, float cornerAccuracy /*= 10.5f*/ )
 {
-    const Mesh& mesh = *objMesh->mesh();
+    const Mesh& mesh = *objMesh->meshConstPtr();
     HoleEdgePoint result;
     Viewer& viewerRef = Viewer::instanceRef();
     Viewport& viewport = viewerRef.viewport();
@@ -136,7 +136,7 @@ HoleEdgePoint findClosestToMouseEdge( const Vector2i& mousePos, const std::vecto
     for ( int i = 0; i < objsLines.size(); ++i )
     {
         const auto& objLines = objsLines[i];
-        const Polyline3& polyline = *objLines->polyline();
+        const Polyline3& polyline = *objLines->polylineConstPtr();
         auto xf = objLines->worldXf();
         for ( auto ue : undirectedEdges( polyline.topology ) )
         {

--- a/source/MRViewer/MRPickHoleBorderElement.cpp
+++ b/source/MRViewer/MRPickHoleBorderElement.cpp
@@ -56,7 +56,7 @@ HoleEdgePoint findClosestToMouseHoleEdge( const Vector2i& mousePos, const std::s
                                           const std::vector<EdgeId>& holeRepresentativeEdges,
                                           float accuracy /*= 5.5f*/, bool attractToVert /*= false*/, float cornerAccuracy /*= 10.5f*/ )
 {
-    const Mesh& mesh = *objMesh->meshConstPtr();
+    const Mesh& mesh = *objMesh->meshPtr();
     HoleEdgePoint result;
     Viewer& viewerRef = Viewer::instanceRef();
     Viewport& viewport = viewerRef.viewport();
@@ -136,7 +136,7 @@ HoleEdgePoint findClosestToMouseEdge( const Vector2i& mousePos, const std::vecto
     for ( int i = 0; i < objsLines.size(); ++i )
     {
         const auto& objLines = objsLines[i];
-        const Polyline3& polyline = *objLines->polylineConstPtr();
+        const Polyline3& polyline = *objLines->polylinePtr();
         auto xf = objLines->worldXf();
         for ( auto ue : undirectedEdges( polyline.topology ) )
         {

--- a/source/MRViewer/MRRenderLinesObject.cpp
+++ b/source/MRViewer/MRRenderLinesObject.cpp
@@ -246,9 +246,9 @@ void RenderLinesObject::bindPositions_( GLuint shaderId )
         assert( maxTexSize > 0 );
         RenderBufferRef<Vector3f> positions;
         Vector2i res;
-        if ( objLines_->polyline() )
+        if ( objLines_->polylineConstPtr() )
         {
-            const auto& polyline = objLines_->polyline();
+            const auto* polyline = objLines_->polylineConstPtr();
             const auto& topology = polyline->topology;
             auto lastValid = topology.lastNotLoneEdge();
             auto numL = lastValid.valid() ? lastValid.undirected() + 1 : 0;
@@ -295,9 +295,9 @@ void RenderLinesObject::calcAndBindLength_( const ModelRenderParams& params, GLu
         assert( maxTexSize > 0 );
         RenderBufferRef<float> accumScreenLength;
         Vector2i res;
-        if ( objLines_->polyline() )
+        if ( objLines_->polylineConstPtr() )
         {
-            const auto& polyline = objLines_->polyline();
+            const auto* polyline = objLines_->polylineConstPtr();
             const auto& topology = polyline->topology;
             auto lastValid = topology.lastNotLoneEdge();
             auto numL = lastValid.valid() ? lastValid.undirected() + 1 : 0;
@@ -365,10 +365,10 @@ void RenderLinesObject::bindLines_( GLStaticHolder::ShaderType shaderType )
         bool useColorMap = objLines_->getColoringType() == ColoringType::VertsColorMap && !objLines_->getVertsColorMap().empty();
         RenderBufferRef<Color> textVertColorMap;
         Vector2i res;
-        if ( useColorMap && objLines_->polyline() )
+        if ( useColorMap && objLines_->polylineConstPtr() )
         {
             auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-            const auto& polyline = objLines_->polyline();
+            const auto* polyline = objLines_->polylineConstPtr();
             const auto& topology = polyline->topology;
             res = calcTextureRes( (int)topology.edgeSize(), maxTexSize );
             textVertColorMap = glBuffer.prepareBuffer<Color>( res.x * res.y );

--- a/source/MRViewer/MRRenderLinesObject.cpp
+++ b/source/MRViewer/MRRenderLinesObject.cpp
@@ -246,9 +246,9 @@ void RenderLinesObject::bindPositions_( GLuint shaderId )
         assert( maxTexSize > 0 );
         RenderBufferRef<Vector3f> positions;
         Vector2i res;
-        if ( objLines_->polylineConstPtr() )
+        if ( objLines_->polylinePtr() )
         {
-            const auto* polyline = objLines_->polylineConstPtr();
+            const auto* polyline = objLines_->polylinePtr();
             const auto& topology = polyline->topology;
             auto lastValid = topology.lastNotLoneEdge();
             auto numL = lastValid.valid() ? lastValid.undirected() + 1 : 0;
@@ -295,9 +295,9 @@ void RenderLinesObject::calcAndBindLength_( const ModelRenderParams& params, GLu
         assert( maxTexSize > 0 );
         RenderBufferRef<float> accumScreenLength;
         Vector2i res;
-        if ( objLines_->polylineConstPtr() )
+        if ( objLines_->polylinePtr() )
         {
-            const auto* polyline = objLines_->polylineConstPtr();
+            const auto* polyline = objLines_->polylinePtr();
             const auto& topology = polyline->topology;
             auto lastValid = topology.lastNotLoneEdge();
             auto numL = lastValid.valid() ? lastValid.undirected() + 1 : 0;
@@ -365,10 +365,10 @@ void RenderLinesObject::bindLines_( GLStaticHolder::ShaderType shaderType )
         bool useColorMap = objLines_->getColoringType() == ColoringType::VertsColorMap && !objLines_->getVertsColorMap().empty();
         RenderBufferRef<Color> textVertColorMap;
         Vector2i res;
-        if ( useColorMap && objLines_->polylineConstPtr() )
+        if ( useColorMap && objLines_->polylinePtr() )
         {
             auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-            const auto* polyline = objLines_->polylineConstPtr();
+            const auto* polyline = objLines_->polylinePtr();
             const auto& topology = polyline->topology;
             res = calcTextureRes( (int)topology.edgeSize(), maxTexSize );
             textVertColorMap = glBuffer.prepareBuffer<Color>( res.x * res.y );

--- a/source/MRViewer/MRRenderMeshObject.cpp
+++ b/source/MRViewer/MRRenderMeshObject.cpp
@@ -526,13 +526,13 @@ void RenderMeshObject::bindMeshPicker_()
 
 void RenderMeshObject::bindEdges_()
 {
-    if ( !dirtyEdges_ || !objMesh_->mesh() )
+    if ( !dirtyEdges_ || !objMesh_->meshConstPtr() )
     {
         edgesTexture_.bind();
         return;
     }
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    const auto& mesh = *objMesh_->mesh();
+    const auto& mesh = *objMesh_->meshConstPtr();
     const auto& topology = mesh.topology;
     auto lastValid = topology.lastNotLoneEdge();
     edgeSize_ = lastValid.valid() ? lastValid.undirected() + 1 : 0;
@@ -560,7 +560,7 @@ void RenderMeshObject::bindEdges_()
 
 void RenderMeshObject::bindBorders_()
 {
-    if ( !( dirty_ & DIRTY_BORDER_LINES ) || !objMesh_->mesh() )
+    if ( !( dirty_ & DIRTY_BORDER_LINES ) || !objMesh_->meshConstPtr() )
     {
         borderTexture_.bind();
         return;
@@ -568,7 +568,7 @@ void RenderMeshObject::bindBorders_()
     MR_TIMER;
     dirty_ &= ~DIRTY_BORDER_LINES;
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    const auto& mesh = objMesh_->mesh();
+    const auto* mesh = objMesh_->meshConstPtr();
     const auto& topology = mesh->topology;
     auto boundary = findRightBoundary( topology );
     bordersSize_ = 0;
@@ -593,7 +593,7 @@ void RenderMeshObject::bindBorders_()
 
 void RenderMeshObject::bindSelectedEdges_()
 {
-    if ( !( dirty_ & DIRTY_EDGES_SELECTION ) || !objMesh_->mesh() )
+    if ( !( dirty_ & DIRTY_EDGES_SELECTION ) || !objMesh_->meshConstPtr() )
     {
         if ( !selEdgesTexture_.valid() )
             selEdgesTexture_.gen();
@@ -603,7 +603,7 @@ void RenderMeshObject::bindSelectedEdges_()
     MR_TIMER;
     dirty_ &= ~DIRTY_EDGES_SELECTION;
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    const auto& mesh = objMesh_->mesh();
+    const auto* mesh = objMesh_->meshConstPtr();
     const auto& topology = mesh->topology;
     auto selectedEdges = objMesh_->getSelectedEdges();
     for ( auto e : selectedEdges )
@@ -794,13 +794,13 @@ void RenderMeshObject::update_( ViewportMask )
 RenderBufferRef<Vector3f> RenderMeshObject::loadVertPosBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_POSITION ) || !objMesh_->mesh() )
+    if ( !( dirty_ & DIRTY_POSITION ) || !objMesh_->meshConstPtr() )
         return glBuffer.prepareBuffer<Vector3f>( vertPosSize_, false );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_POSITION;
 
-    const auto& mesh = objMesh_->mesh();
+    const auto* mesh = objMesh_->meshConstPtr();
     const auto& topology = mesh->topology;
     if ( cornerMode_ )
     {
@@ -837,13 +837,13 @@ RenderBufferRef<Vector3f> RenderMeshObject::loadVertPosBuffer_()
 RenderBufferRef<Vector3f> RenderMeshObject::loadVertNormalsBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_VERTS_RENDER_NORMAL ) || !objMesh_->mesh() )
+    if ( !( dirty_ & DIRTY_VERTS_RENDER_NORMAL ) || !objMesh_->meshConstPtr() )
         return glBuffer.prepareBuffer<Vector3f>( vertNormalsSize_, false );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_VERTS_RENDER_NORMAL;
 
-    const auto& mesh = objMesh_->mesh();
+    const auto* mesh = objMesh_->meshConstPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
     const auto& creases = objMesh_->creases();
@@ -907,14 +907,14 @@ RenderBufferRef<Vector3f> RenderMeshObject::loadVertNormalsBuffer_()
 RenderBufferRef<Color> RenderMeshObject::loadVertColorsBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_VERTS_COLORMAP ) || !objMesh_->mesh() )
+    if ( !( dirty_ & DIRTY_VERTS_COLORMAP ) || !objMesh_->meshConstPtr() )
         return glBuffer.prepareBuffer<Color>( vertColorsSize_, false ); // use updated color map
     if ( objMesh_->getColoringType() != ColoringType::VertsColorMap )
         return glBuffer.prepareBuffer<Color>( vertColorsSize_ = 0 ); // clear color map if not used
 
     MR_TIMER;
     dirty_ &= ~DIRTY_VERTS_COLORMAP;
-    const auto& mesh = objMesh_->mesh();
+    const auto* mesh = objMesh_->meshConstPtr();
     const auto& topology = mesh->topology;
     const auto& vertsColorMap = objMesh_->getVertsColorMap();
 
@@ -953,12 +953,12 @@ RenderBufferRef<Color> RenderMeshObject::loadVertColorsBuffer_()
 RenderBufferRef<UVCoord> RenderMeshObject::loadVertUVBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_UV ) || !objMesh_->mesh() )
+    if ( !( dirty_ & DIRTY_UV ) || !objMesh_->meshConstPtr() )
         return glBuffer.prepareBuffer<UVCoord>( vertUVSize_, false );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_UV;
-    const auto& mesh = objMesh_->mesh();
+    const auto* mesh = objMesh_->meshConstPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
     auto numV = topology.lastValidVert() + 1;
@@ -1003,14 +1003,14 @@ RenderBufferRef<UVCoord> RenderMeshObject::loadVertUVBuffer_()
 RenderBufferRef<Vector3i> RenderMeshObject::loadFaceIndicesBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_FACE ) || !objMesh_->mesh() )
+    if ( !( dirty_ & DIRTY_FACE ) || !objMesh_->meshConstPtr() )
         return glBuffer.prepareBuffer<Vector3i>( faceIndicesSize_, !facesIndicesBuffer_.valid() );
 
     // CORNDER BASED
     MR_TIMER;
     dirty_ &= ~DIRTY_FACE;
 
-    const auto& mesh = objMesh_->mesh();
+    const auto* mesh = objMesh_->meshConstPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
     auto buffer = glBuffer.prepareBuffer<Vector3i>( faceIndicesSize_ = numF );
@@ -1039,13 +1039,13 @@ RenderBufferRef<Vector3i> RenderMeshObject::loadFaceIndicesBuffer_()
 RenderBufferRef<unsigned> RenderMeshObject::loadFaceSelectionTextureBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_SELECTION ) || !objMesh_->mesh() )
+    if ( !( dirty_ & DIRTY_SELECTION ) || !objMesh_->meshConstPtr() )
         return glBuffer.prepareBuffer<unsigned>( faceSelectionTextureSize_.x * faceSelectionTextureSize_.y, !faceSelectionTex_.valid() );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_SELECTION;
 
-    const auto& mesh = objMesh_->mesh();
+    const auto* mesh = objMesh_->meshConstPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
 
@@ -1073,13 +1073,13 @@ RenderBufferRef<unsigned> RenderMeshObject::loadFaceSelectionTextureBuffer_()
 RenderBufferRef<Vector4f> RenderMeshObject::loadFaceNormalsTextureBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_FACES_RENDER_NORMAL ) || !objMesh_->mesh() )
+    if ( !( dirty_ & DIRTY_FACES_RENDER_NORMAL ) || !objMesh_->meshConstPtr() )
         return glBuffer.prepareBuffer<Vector4f>( faceNormalsTextureSize_.x * faceNormalsTextureSize_.y, !facesNormalsTex_.valid() );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_FACES_RENDER_NORMAL;
 
-    const auto& mesh = objMesh_->mesh();
+    const auto* mesh = objMesh_->meshConstPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
 
@@ -1095,13 +1095,13 @@ RenderBufferRef<Vector4f> RenderMeshObject::loadFaceNormalsTextureBuffer_()
 RenderBufferRef<uint8_t> RenderMeshObject::loadTexturePerFaceTextureBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_TEXTURE_PER_FACE ) || !objMesh_->mesh() )
+    if ( !( dirty_ & DIRTY_TEXTURE_PER_FACE ) || !objMesh_->meshConstPtr() )
         return glBuffer.prepareBuffer<uint8_t>( texturePerFaceSize_.x * texturePerFaceSize_.y, !texturePerFace_.valid() );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_TEXTURE_PER_FACE;
 
-    const auto& mesh = objMesh_->mesh();
+    const auto* mesh = objMesh_->meshConstPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
 
@@ -1125,12 +1125,12 @@ RenderBufferRef<uint8_t> RenderMeshObject::loadTexturePerFaceTextureBuffer_()
 RenderBufferRef<VertId> RenderMeshObject::loadPointValidIndicesBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !dirtyPointPos_ || !objMesh_->mesh() )
+    if ( !dirtyPointPos_ || !objMesh_->meshConstPtr() )
         return glBuffer.prepareBuffer<VertId>( pointValidSize_, !pointValidBuffer_.valid() );
 
     MR_NAMED_TIMER( "mesh_points_dirty_valid_indices" );
 
-    const auto& topology = objMesh_->mesh()->topology;
+    const auto& topology = objMesh_->meshConstPtr()->topology;
     const auto& validPoints = topology.getValidVerts();
     pointValidSize_ = int( validPoints.count() );
     auto buffer = glBuffer.prepareBuffer<VertId>( pointValidSize_ );

--- a/source/MRViewer/MRRenderMeshObject.cpp
+++ b/source/MRViewer/MRRenderMeshObject.cpp
@@ -526,13 +526,13 @@ void RenderMeshObject::bindMeshPicker_()
 
 void RenderMeshObject::bindEdges_()
 {
-    if ( !dirtyEdges_ || !objMesh_->meshConstPtr() )
+    if ( !dirtyEdges_ || !objMesh_->meshPtr() )
     {
         edgesTexture_.bind();
         return;
     }
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    const auto& mesh = *objMesh_->meshConstPtr();
+    const auto& mesh = *objMesh_->meshPtr();
     const auto& topology = mesh.topology;
     auto lastValid = topology.lastNotLoneEdge();
     edgeSize_ = lastValid.valid() ? lastValid.undirected() + 1 : 0;
@@ -560,7 +560,7 @@ void RenderMeshObject::bindEdges_()
 
 void RenderMeshObject::bindBorders_()
 {
-    if ( !( dirty_ & DIRTY_BORDER_LINES ) || !objMesh_->meshConstPtr() )
+    if ( !( dirty_ & DIRTY_BORDER_LINES ) || !objMesh_->meshPtr() )
     {
         borderTexture_.bind();
         return;
@@ -568,7 +568,7 @@ void RenderMeshObject::bindBorders_()
     MR_TIMER;
     dirty_ &= ~DIRTY_BORDER_LINES;
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    const auto* mesh = objMesh_->meshConstPtr();
+    const auto* mesh = objMesh_->meshPtr();
     const auto& topology = mesh->topology;
     auto boundary = findRightBoundary( topology );
     bordersSize_ = 0;
@@ -593,7 +593,7 @@ void RenderMeshObject::bindBorders_()
 
 void RenderMeshObject::bindSelectedEdges_()
 {
-    if ( !( dirty_ & DIRTY_EDGES_SELECTION ) || !objMesh_->meshConstPtr() )
+    if ( !( dirty_ & DIRTY_EDGES_SELECTION ) || !objMesh_->meshPtr() )
     {
         if ( !selEdgesTexture_.valid() )
             selEdgesTexture_.gen();
@@ -603,7 +603,7 @@ void RenderMeshObject::bindSelectedEdges_()
     MR_TIMER;
     dirty_ &= ~DIRTY_EDGES_SELECTION;
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    const auto* mesh = objMesh_->meshConstPtr();
+    const auto* mesh = objMesh_->meshPtr();
     const auto& topology = mesh->topology;
     auto selectedEdges = objMesh_->getSelectedEdges();
     for ( auto e : selectedEdges )
@@ -794,13 +794,13 @@ void RenderMeshObject::update_( ViewportMask )
 RenderBufferRef<Vector3f> RenderMeshObject::loadVertPosBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_POSITION ) || !objMesh_->meshConstPtr() )
+    if ( !( dirty_ & DIRTY_POSITION ) || !objMesh_->meshPtr() )
         return glBuffer.prepareBuffer<Vector3f>( vertPosSize_, false );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_POSITION;
 
-    const auto* mesh = objMesh_->meshConstPtr();
+    const auto* mesh = objMesh_->meshPtr();
     const auto& topology = mesh->topology;
     if ( cornerMode_ )
     {
@@ -837,13 +837,13 @@ RenderBufferRef<Vector3f> RenderMeshObject::loadVertPosBuffer_()
 RenderBufferRef<Vector3f> RenderMeshObject::loadVertNormalsBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_VERTS_RENDER_NORMAL ) || !objMesh_->meshConstPtr() )
+    if ( !( dirty_ & DIRTY_VERTS_RENDER_NORMAL ) || !objMesh_->meshPtr() )
         return glBuffer.prepareBuffer<Vector3f>( vertNormalsSize_, false );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_VERTS_RENDER_NORMAL;
 
-    const auto* mesh = objMesh_->meshConstPtr();
+    const auto* mesh = objMesh_->meshPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
     const auto& creases = objMesh_->creases();
@@ -907,14 +907,14 @@ RenderBufferRef<Vector3f> RenderMeshObject::loadVertNormalsBuffer_()
 RenderBufferRef<Color> RenderMeshObject::loadVertColorsBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_VERTS_COLORMAP ) || !objMesh_->meshConstPtr() )
+    if ( !( dirty_ & DIRTY_VERTS_COLORMAP ) || !objMesh_->meshPtr() )
         return glBuffer.prepareBuffer<Color>( vertColorsSize_, false ); // use updated color map
     if ( objMesh_->getColoringType() != ColoringType::VertsColorMap )
         return glBuffer.prepareBuffer<Color>( vertColorsSize_ = 0 ); // clear color map if not used
 
     MR_TIMER;
     dirty_ &= ~DIRTY_VERTS_COLORMAP;
-    const auto* mesh = objMesh_->meshConstPtr();
+    const auto* mesh = objMesh_->meshPtr();
     const auto& topology = mesh->topology;
     const auto& vertsColorMap = objMesh_->getVertsColorMap();
 
@@ -953,12 +953,12 @@ RenderBufferRef<Color> RenderMeshObject::loadVertColorsBuffer_()
 RenderBufferRef<UVCoord> RenderMeshObject::loadVertUVBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_UV ) || !objMesh_->meshConstPtr() )
+    if ( !( dirty_ & DIRTY_UV ) || !objMesh_->meshPtr() )
         return glBuffer.prepareBuffer<UVCoord>( vertUVSize_, false );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_UV;
-    const auto* mesh = objMesh_->meshConstPtr();
+    const auto* mesh = objMesh_->meshPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
     auto numV = topology.lastValidVert() + 1;
@@ -1003,14 +1003,14 @@ RenderBufferRef<UVCoord> RenderMeshObject::loadVertUVBuffer_()
 RenderBufferRef<Vector3i> RenderMeshObject::loadFaceIndicesBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_FACE ) || !objMesh_->meshConstPtr() )
+    if ( !( dirty_ & DIRTY_FACE ) || !objMesh_->meshPtr() )
         return glBuffer.prepareBuffer<Vector3i>( faceIndicesSize_, !facesIndicesBuffer_.valid() );
 
     // CORNDER BASED
     MR_TIMER;
     dirty_ &= ~DIRTY_FACE;
 
-    const auto* mesh = objMesh_->meshConstPtr();
+    const auto* mesh = objMesh_->meshPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
     auto buffer = glBuffer.prepareBuffer<Vector3i>( faceIndicesSize_ = numF );
@@ -1039,13 +1039,13 @@ RenderBufferRef<Vector3i> RenderMeshObject::loadFaceIndicesBuffer_()
 RenderBufferRef<unsigned> RenderMeshObject::loadFaceSelectionTextureBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_SELECTION ) || !objMesh_->meshConstPtr() )
+    if ( !( dirty_ & DIRTY_SELECTION ) || !objMesh_->meshPtr() )
         return glBuffer.prepareBuffer<unsigned>( faceSelectionTextureSize_.x * faceSelectionTextureSize_.y, !faceSelectionTex_.valid() );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_SELECTION;
 
-    const auto* mesh = objMesh_->meshConstPtr();
+    const auto* mesh = objMesh_->meshPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
 
@@ -1073,13 +1073,13 @@ RenderBufferRef<unsigned> RenderMeshObject::loadFaceSelectionTextureBuffer_()
 RenderBufferRef<Vector4f> RenderMeshObject::loadFaceNormalsTextureBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_FACES_RENDER_NORMAL ) || !objMesh_->meshConstPtr() )
+    if ( !( dirty_ & DIRTY_FACES_RENDER_NORMAL ) || !objMesh_->meshPtr() )
         return glBuffer.prepareBuffer<Vector4f>( faceNormalsTextureSize_.x * faceNormalsTextureSize_.y, !facesNormalsTex_.valid() );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_FACES_RENDER_NORMAL;
 
-    const auto* mesh = objMesh_->meshConstPtr();
+    const auto* mesh = objMesh_->meshPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
 
@@ -1095,13 +1095,13 @@ RenderBufferRef<Vector4f> RenderMeshObject::loadFaceNormalsTextureBuffer_()
 RenderBufferRef<uint8_t> RenderMeshObject::loadTexturePerFaceTextureBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_TEXTURE_PER_FACE ) || !objMesh_->meshConstPtr() )
+    if ( !( dirty_ & DIRTY_TEXTURE_PER_FACE ) || !objMesh_->meshPtr() )
         return glBuffer.prepareBuffer<uint8_t>( texturePerFaceSize_.x * texturePerFaceSize_.y, !texturePerFace_.valid() );
 
     MR_TIMER;
     dirty_ &= ~DIRTY_TEXTURE_PER_FACE;
 
-    const auto* mesh = objMesh_->meshConstPtr();
+    const auto* mesh = objMesh_->meshPtr();
     const auto& topology = mesh->topology;
     auto numF = topology.lastValidFace() + 1;
 
@@ -1125,12 +1125,12 @@ RenderBufferRef<uint8_t> RenderMeshObject::loadTexturePerFaceTextureBuffer_()
 RenderBufferRef<VertId> RenderMeshObject::loadPointValidIndicesBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !dirtyPointPos_ || !objMesh_->meshConstPtr() )
+    if ( !dirtyPointPos_ || !objMesh_->meshPtr() )
         return glBuffer.prepareBuffer<VertId>( pointValidSize_, !pointValidBuffer_.valid() );
 
     MR_NAMED_TIMER( "mesh_points_dirty_valid_indices" );
 
-    const auto& topology = objMesh_->meshConstPtr()->topology;
+    const auto& topology = objMesh_->meshPtr()->topology;
     const auto& validPoints = topology.getValidVerts();
     pointValidSize_ = int( validPoints.count() );
     auto buffer = glBuffer.prepareBuffer<VertId>( pointValidSize_ );

--- a/source/MRViewer/MRRenderPointsObject.cpp
+++ b/source/MRViewer/MRRenderPointsObject.cpp
@@ -36,7 +36,7 @@ bool RenderPointsObject::render( const ModelRenderParams& renderParams )
 {
     MR_TIMER;
     bool isColorTransparent = objPoints_->getFrontColor( objPoints_->isSelected(), renderParams.viewportId ).a < 255;
-    if ( !isColorTransparent && objPoints_->pointCloud() && objPoints_->pointCloud()->hasNormals() )
+    if ( !isColorTransparent && objPoints_->pointCloudConstPtr() && objPoints_->pointCloudConstPtr()->hasNormals() )
     {
         isColorTransparent = objPoints_->getBackColor( renderParams.viewportId ).a < 255;
     }
@@ -192,12 +192,12 @@ void RenderPointsObject::forceBindAll()
 RenderBufferRef<Vector3f> RenderPointsObject::loadVertPosBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_POSITION ) || !objPoints_->pointCloud() )
+    if ( !( dirty_ & DIRTY_POSITION ) || !objPoints_->pointCloudConstPtr() )
         return glBuffer.prepareBuffer<Vector3f>( vertPosSize_, false );
 
     const auto step = objPoints_->getRenderDiscretization();
-    const auto& points = objPoints_->pointCloud()->points;
-    const auto num = objPoints_->pointCloud()->validPoints.find_last() + 1;
+    const auto& points = objPoints_->pointCloudConstPtr()->points;
+    const auto num = objPoints_->pointCloudConstPtr()->validPoints.find_last() + 1;
     if ( step == 1 )
         // we are sure that points will not be changed, so can do const_cast
         return RenderBufferRef<Vector3f>( const_cast< Vector3f* >( points.data() ), vertPosSize_ = num, !points.empty() );
@@ -215,11 +215,11 @@ RenderBufferRef<Vector3f> RenderPointsObject::loadVertPosBuffer_()
 RenderBufferRef<Vector3f> RenderPointsObject::loadVertNormalsBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_RENDER_NORMALS ) || !objPoints_->pointCloud() )
+    if ( !( dirty_ & DIRTY_RENDER_NORMALS ) || !objPoints_->pointCloudConstPtr() )
         return glBuffer.prepareBuffer<Vector3f>( vertNormalsSize_, false );
 
-    const auto& normals = objPoints_->pointCloud()->normals;
-    int num = int( objPoints_->pointCloud()->validPoints.find_last() ) + 1;
+    const auto& normals = objPoints_->pointCloudConstPtr()->normals;
+    int num = int( objPoints_->pointCloudConstPtr()->validPoints.find_last() ) + 1;
     if ( normals.size() < num )
         num = 0;
     const auto step = objPoints_->getRenderDiscretization();
@@ -240,11 +240,11 @@ RenderBufferRef<Vector3f> RenderPointsObject::loadVertNormalsBuffer_()
 RenderBufferRef<Color> RenderPointsObject::loadVertColorsBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_VERTS_COLORMAP ) || !objPoints_->pointCloud() || objPoints_->getVertsColorMap().empty() )
+    if ( !( dirty_ & DIRTY_VERTS_COLORMAP ) || !objPoints_->pointCloudConstPtr() || objPoints_->getVertsColorMap().empty() )
         return glBuffer.prepareBuffer<Color>( vertColorsSize_, false );
 
     const auto& colors = objPoints_->getVertsColorMap();
-    const auto num = objPoints_->pointCloud()->validPoints.find_last() + 1;
+    const auto num = objPoints_->pointCloudConstPtr()->validPoints.find_last() + 1;
     const auto step = objPoints_->getRenderDiscretization();
     if ( step == 1 )
         // we are sure that colors will not be changed, so can do const_cast
@@ -269,7 +269,7 @@ void RenderPointsObject::bindPoints_( GLStaticHolder::ShaderType shaderType )
     GL_EXEC( glUseProgram( shader ) );
     if ( objPoints_->hasVisualRepresentation() )
     {
-        auto pointCloud = objPoints_->pointCloud();
+        auto pointCloud = objPoints_->pointCloudConstPtr();
 
         const auto positions = loadVertPosBuffer_();
         bindVertexAttribArray( shader, "position", vertPosBuffer_, positions, 3, positions.dirty(), positions.glSize() != 0 );
@@ -368,9 +368,9 @@ RenderBufferRef<VertId> RenderPointsObject::loadValidIndicesBuffer_()
     if ( !( dirty_ & DIRTY_POSITION ) || !objPoints_->hasVisualRepresentation() )
         return glBuffer.prepareBuffer<VertId>( validIndicesSize_, !validIndicesBuffer_.valid() );
 
-    const auto& points = objPoints_->pointCloud();
+    const auto* points = objPoints_->pointCloudConstPtr();
     const auto step = objPoints_->getRenderDiscretization();
-    const auto num = objPoints_->pointCloud()->validPoints.find_last() + 1;    
+    const auto num = objPoints_->pointCloudConstPtr()->validPoints.find_last() + 1;    
 
     const auto& validPoints = points->validPoints;
     auto firstValid = validPoints.find_first();
@@ -423,7 +423,7 @@ RenderBufferRef<unsigned> RenderPointsObject::loadVertSelectionTextureBuffer_()
         return glBuffer.prepareBuffer<unsigned>( vertSelectionTextureSize_.x * vertSelectionTextureSize_.y,
             ( dirty_ & DIRTY_SELECTION ) && vertSelectionTextureSize_.x * vertSelectionTextureSize_.y == 0 );
 
-    const auto& points = objPoints_->pointCloud();
+    const auto* points = objPoints_->pointCloudConstPtr();
     const auto step = objPoints_->getRenderDiscretization();
     const int num = points->validPoints.find_last() + 1;
     const auto numV = num / int( step );

--- a/source/MRViewer/MRRenderPointsObject.cpp
+++ b/source/MRViewer/MRRenderPointsObject.cpp
@@ -36,7 +36,7 @@ bool RenderPointsObject::render( const ModelRenderParams& renderParams )
 {
     MR_TIMER;
     bool isColorTransparent = objPoints_->getFrontColor( objPoints_->isSelected(), renderParams.viewportId ).a < 255;
-    if ( !isColorTransparent && objPoints_->pointCloudConstPtr() && objPoints_->pointCloudConstPtr()->hasNormals() )
+    if ( !isColorTransparent && objPoints_->pointCloudPtr() && objPoints_->pointCloudPtr()->hasNormals() )
     {
         isColorTransparent = objPoints_->getBackColor( renderParams.viewportId ).a < 255;
     }
@@ -192,12 +192,12 @@ void RenderPointsObject::forceBindAll()
 RenderBufferRef<Vector3f> RenderPointsObject::loadVertPosBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_POSITION ) || !objPoints_->pointCloudConstPtr() )
+    if ( !( dirty_ & DIRTY_POSITION ) || !objPoints_->pointCloudPtr() )
         return glBuffer.prepareBuffer<Vector3f>( vertPosSize_, false );
 
     const auto step = objPoints_->getRenderDiscretization();
-    const auto& points = objPoints_->pointCloudConstPtr()->points;
-    const auto num = objPoints_->pointCloudConstPtr()->validPoints.find_last() + 1;
+    const auto& points = objPoints_->pointCloudPtr()->points;
+    const auto num = objPoints_->pointCloudPtr()->validPoints.find_last() + 1;
     if ( step == 1 )
         // we are sure that points will not be changed, so can do const_cast
         return RenderBufferRef<Vector3f>( const_cast< Vector3f* >( points.data() ), vertPosSize_ = num, !points.empty() );
@@ -215,11 +215,11 @@ RenderBufferRef<Vector3f> RenderPointsObject::loadVertPosBuffer_()
 RenderBufferRef<Vector3f> RenderPointsObject::loadVertNormalsBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_RENDER_NORMALS ) || !objPoints_->pointCloudConstPtr() )
+    if ( !( dirty_ & DIRTY_RENDER_NORMALS ) || !objPoints_->pointCloudPtr() )
         return glBuffer.prepareBuffer<Vector3f>( vertNormalsSize_, false );
 
-    const auto& normals = objPoints_->pointCloudConstPtr()->normals;
-    int num = int( objPoints_->pointCloudConstPtr()->validPoints.find_last() ) + 1;
+    const auto& normals = objPoints_->pointCloudPtr()->normals;
+    int num = int( objPoints_->pointCloudPtr()->validPoints.find_last() ) + 1;
     if ( normals.size() < num )
         num = 0;
     const auto step = objPoints_->getRenderDiscretization();
@@ -240,11 +240,11 @@ RenderBufferRef<Vector3f> RenderPointsObject::loadVertNormalsBuffer_()
 RenderBufferRef<Color> RenderPointsObject::loadVertColorsBuffer_()
 {
     auto& glBuffer = GLStaticHolder::getStaticGLBuffer();
-    if ( !( dirty_ & DIRTY_VERTS_COLORMAP ) || !objPoints_->pointCloudConstPtr() || objPoints_->getVertsColorMap().empty() )
+    if ( !( dirty_ & DIRTY_VERTS_COLORMAP ) || !objPoints_->pointCloudPtr() || objPoints_->getVertsColorMap().empty() )
         return glBuffer.prepareBuffer<Color>( vertColorsSize_, false );
 
     const auto& colors = objPoints_->getVertsColorMap();
-    const auto num = objPoints_->pointCloudConstPtr()->validPoints.find_last() + 1;
+    const auto num = objPoints_->pointCloudPtr()->validPoints.find_last() + 1;
     const auto step = objPoints_->getRenderDiscretization();
     if ( step == 1 )
         // we are sure that colors will not be changed, so can do const_cast
@@ -269,7 +269,7 @@ void RenderPointsObject::bindPoints_( GLStaticHolder::ShaderType shaderType )
     GL_EXEC( glUseProgram( shader ) );
     if ( objPoints_->hasVisualRepresentation() )
     {
-        auto pointCloud = objPoints_->pointCloudConstPtr();
+        auto pointCloud = objPoints_->pointCloudPtr();
 
         const auto positions = loadVertPosBuffer_();
         bindVertexAttribArray( shader, "position", vertPosBuffer_, positions, 3, positions.dirty(), positions.glSize() != 0 );
@@ -368,9 +368,9 @@ RenderBufferRef<VertId> RenderPointsObject::loadValidIndicesBuffer_()
     if ( !( dirty_ & DIRTY_POSITION ) || !objPoints_->hasVisualRepresentation() )
         return glBuffer.prepareBuffer<VertId>( validIndicesSize_, !validIndicesBuffer_.valid() );
 
-    const auto* points = objPoints_->pointCloudConstPtr();
+    const auto* points = objPoints_->pointCloudPtr();
     const auto step = objPoints_->getRenderDiscretization();
-    const auto num = objPoints_->pointCloudConstPtr()->validPoints.find_last() + 1;    
+    const auto num = objPoints_->pointCloudPtr()->validPoints.find_last() + 1;    
 
     const auto& validPoints = points->validPoints;
     auto firstValid = validPoints.find_first();
@@ -423,7 +423,7 @@ RenderBufferRef<unsigned> RenderPointsObject::loadVertSelectionTextureBuffer_()
         return glBuffer.prepareBuffer<unsigned>( vertSelectionTextureSize_.x * vertSelectionTextureSize_.y,
             ( dirty_ & DIRTY_SELECTION ) && vertSelectionTextureSize_.x * vertSelectionTextureSize_.y == 0 );
 
-    const auto* points = objPoints_->pointCloudConstPtr();
+    const auto* points = objPoints_->pointCloudPtr();
     const auto step = objPoints_->getRenderDiscretization();
     const int num = points->validPoints.find_last() + 1;
     const auto numV = num / int( step );

--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -1151,14 +1151,14 @@ void RibbonMenu::cloneSelectedPart( const std::shared_ptr<Object>& object )
     std::string name;
     if ( auto selectedMesh = std::dynamic_pointer_cast< ObjectMesh >( object ) )
     {
-        if ( !selectedMesh->meshConstPtr() )
+        if ( !selectedMesh->meshPtr() )
             return;
         newObj = cloneRegion( selectedMesh, selectedMesh->getSelectedFaces() );
         name = "ObjectMesh";
     }
     else if ( auto selectedPoints = std::dynamic_pointer_cast< ObjectPoints >( object ) )
     {
-        if ( !selectedPoints->pointCloudConstPtr() )
+        if ( !selectedPoints->pointCloudPtr() )
             return;
         newObj = cloneRegion( selectedPoints, selectedPoints->getSelectedPoints() );
         name = "ObjectPoints";

--- a/source/MRViewer/MRRibbonMenu.cpp
+++ b/source/MRViewer/MRRibbonMenu.cpp
@@ -1151,14 +1151,14 @@ void RibbonMenu::cloneSelectedPart( const std::shared_ptr<Object>& object )
     std::string name;
     if ( auto selectedMesh = std::dynamic_pointer_cast< ObjectMesh >( object ) )
     {
-        if ( !selectedMesh->mesh() )
+        if ( !selectedMesh->meshConstPtr() )
             return;
         newObj = cloneRegion( selectedMesh, selectedMesh->getSelectedFaces() );
         name = "ObjectMesh";
     }
     else if ( auto selectedPoints = std::dynamic_pointer_cast< ObjectPoints >( object ) )
     {
-        if ( !selectedPoints->pointCloud() )
+        if ( !selectedPoints->pointCloudConstPtr() )
             return;
         newObj = cloneRegion( selectedPoints, selectedPoints->getSelectedPoints() );
         name = "ObjectPoints";

--- a/source/MRViewer/MRSaveObjects.cpp
+++ b/source/MRViewer/MRSaveObjects.cpp
@@ -63,42 +63,42 @@ Expected<void> saveObjectToFile( const Object& obj, const std::filesystem::path&
     Expected<void> result;
     if ( auto objPoints = obj.asType<ObjectPoints>() )
     {
-        if ( objPoints->pointCloud() )
+        if ( objPoints->pointCloudConstPtr() )
         {
             const auto& colors = objPoints->getVertsColorMap();
             if ( !colors.empty() )
                 saveSettings.colors = &colors;
-            result = PointsSave::toAnySupportedFormat( *objPoints->pointCloud(), filename, { saveSettings } );
+            result = PointsSave::toAnySupportedFormat( *objPoints->pointCloudConstPtr(), filename, { saveSettings } );
         }
         else
             result = unexpected( std::string( "ObjectPoints has no PointCloud in it" ) );
     }
     else if ( auto objLines = obj.asType<ObjectLines>() )
     {
-        if ( objLines->polyline() )
+        if ( objLines->polylineConstPtr() )
         {
             const auto& colors = objLines->getVertsColorMap();
             if ( !colors.empty() )
                 saveSettings.colors = &colors;
-            result = LinesSave::toAnySupportedFormat( *objLines->polyline(), filename, saveSettings );
+            result = LinesSave::toAnySupportedFormat( *objLines->polylineConstPtr(), filename, saveSettings );
         }
         else
             result = unexpected( std::string( "ObjectLines has no Polyline in it" ) );
     }
     else if ( auto objMesh = obj.asType<ObjectMesh>() )
     {
-        if ( objMesh->mesh() )
+        if ( objMesh->meshConstPtr() )
         {
             if ( objMesh->getColoringType() == ColoringType::VertsColorMap )
                 saveSettings.colors = &objMesh->getVertsColorMap();
             else if ( objMesh->getColoringType() == ColoringType::PrimitivesColorMap )
                 saveSettings.primitiveColors = &objMesh->getFacesColorMap().vec_;
-            if ( objMesh->getUVCoords().size() >= objMesh->mesh()->topology.lastValidVert() )
+            if ( objMesh->getUVCoords().size() >= objMesh->meshConstPtr()->topology.lastValidVert() )
                 saveSettings.uvMap = &objMesh->getUVCoords();
             if ( !objMesh->getTexture().pixels.empty() )
                 saveSettings.texture = &objMesh->getTexture();
             saveSettings.materialName = utf8string( filename.stem() );
-            result = MeshSave::toAnySupportedFormat( *objMesh->mesh(), filename, saveSettings );
+            result = MeshSave::toAnySupportedFormat( *objMesh->meshConstPtr(), filename, saveSettings );
         }
         else
             result = unexpected( std::string( "ObjectMesh has no Mesh in it" ) );

--- a/source/MRViewer/MRSaveObjects.cpp
+++ b/source/MRViewer/MRSaveObjects.cpp
@@ -63,42 +63,42 @@ Expected<void> saveObjectToFile( const Object& obj, const std::filesystem::path&
     Expected<void> result;
     if ( auto objPoints = obj.asType<ObjectPoints>() )
     {
-        if ( objPoints->pointCloudConstPtr() )
+        if ( objPoints->pointCloudPtr() )
         {
             const auto& colors = objPoints->getVertsColorMap();
             if ( !colors.empty() )
                 saveSettings.colors = &colors;
-            result = PointsSave::toAnySupportedFormat( *objPoints->pointCloudConstPtr(), filename, { saveSettings } );
+            result = PointsSave::toAnySupportedFormat( *objPoints->pointCloudPtr(), filename, { saveSettings } );
         }
         else
             result = unexpected( std::string( "ObjectPoints has no PointCloud in it" ) );
     }
     else if ( auto objLines = obj.asType<ObjectLines>() )
     {
-        if ( objLines->polylineConstPtr() )
+        if ( objLines->polylinePtr() )
         {
             const auto& colors = objLines->getVertsColorMap();
             if ( !colors.empty() )
                 saveSettings.colors = &colors;
-            result = LinesSave::toAnySupportedFormat( *objLines->polylineConstPtr(), filename, saveSettings );
+            result = LinesSave::toAnySupportedFormat( *objLines->polylinePtr(), filename, saveSettings );
         }
         else
             result = unexpected( std::string( "ObjectLines has no Polyline in it" ) );
     }
     else if ( auto objMesh = obj.asType<ObjectMesh>() )
     {
-        if ( objMesh->meshConstPtr() )
+        if ( objMesh->meshPtr() )
         {
             if ( objMesh->getColoringType() == ColoringType::VertsColorMap )
                 saveSettings.colors = &objMesh->getVertsColorMap();
             else if ( objMesh->getColoringType() == ColoringType::PrimitivesColorMap )
                 saveSettings.primitiveColors = &objMesh->getFacesColorMap().vec_;
-            if ( objMesh->getUVCoords().size() >= objMesh->meshConstPtr()->topology.lastValidVert() )
+            if ( objMesh->getUVCoords().size() >= objMesh->meshPtr()->topology.lastValidVert() )
                 saveSettings.uvMap = &objMesh->getUVCoords();
             if ( !objMesh->getTexture().pixels.empty() )
                 saveSettings.texture = &objMesh->getTexture();
             saveSettings.materialName = utf8string( filename.stem() );
-            result = MeshSave::toAnySupportedFormat( *objMesh->meshConstPtr(), filename, saveSettings );
+            result = MeshSave::toAnySupportedFormat( *objMesh->meshPtr(), filename, saveSettings );
         }
         else
             result = unexpected( std::string( "ObjectMesh has no Mesh in it" ) );

--- a/source/MRViewer/MRSceneOperations.cpp
+++ b/source/MRViewer/MRSceneOperations.cpp
@@ -150,11 +150,11 @@ void mergeSubtree( TypedFlatTree subtree )
         const auto hadNormals = std::any_of( objsPoints.begin(), objsPoints.end(), [] ( auto&& objPoints )
         {
             assert( objPoints );
-            assert( objPoints->pointCloud() );
-            return objPoints->pointCloud()->hasNormals();
+            assert( objPoints->pointCloudConstPtr() );
+            return objPoints->pointCloudConstPtr()->hasNormals();
         } );
-        assert( newObjPoints->pointCloud() );
-        if ( !newObjPoints->pointCloud()->hasNormals() && hadNormals )
+        assert( newObjPoints->pointCloudConstPtr() );
+        if ( !newObjPoints->pointCloudConstPtr()->hasNormals() && hadNormals )
         {
             pushNotification( {
                 .text = "Some input point have normals and some others do not, all normals are lost",

--- a/source/MRViewer/MRSceneOperations.cpp
+++ b/source/MRViewer/MRSceneOperations.cpp
@@ -150,11 +150,11 @@ void mergeSubtree( TypedFlatTree subtree )
         const auto hadNormals = std::any_of( objsPoints.begin(), objsPoints.end(), [] ( auto&& objPoints )
         {
             assert( objPoints );
-            assert( objPoints->pointCloudConstPtr() );
-            return objPoints->pointCloudConstPtr()->hasNormals();
+            assert( objPoints->pointCloudPtr() );
+            return objPoints->pointCloudPtr()->hasNormals();
         } );
-        assert( newObjPoints->pointCloudConstPtr() );
-        if ( !newObjPoints->pointCloudConstPtr()->hasNormals() && hadNormals )
+        assert( newObjPoints->pointCloudPtr() );
+        if ( !newObjPoints->pointCloudPtr()->hasNormals() && hadNormals )
         {
             pushNotification( {
                 .text = "Some input point have normals and some others do not, all normals are lost",

--- a/source/MRViewer/MRSelectScreenLasso.cpp
+++ b/source/MRViewer/MRSelectScreenLasso.cpp
@@ -112,7 +112,7 @@ FaceBitSet findIncidentFaces( const Viewport& viewport, const BitSet& pixBs, con
     if ( pixBs.none() )
         return {};
 
-    const auto* mesh = obj.meshConstPtr();
+    const auto* mesh = obj.meshPtr();
     const auto& vpRect = viewport.getViewportRect();
     const auto xf = obj.worldXf();
 
@@ -220,7 +220,7 @@ FaceBitSet findIncidentFaces( const Viewport& viewport, const BitSet& pixBs, con
                 const auto worldToOccMesh = occ->worldXf().inverse();
                 xfMeshToOccMesh.push_back( worldToOccMesh * xf );
                 cameraEyes.push_back( worldToOccMesh( viewport.getCameraPoint() ) );
-                const auto * occmesh = occ->meshConstPtr();
+                const auto * occmesh = occ->meshPtr();
                 lineMeshes.push_back( Line3fMesh{ .mesh = occmesh, .tree = &occmesh->getAABBTree() } );
             }
         }
@@ -297,12 +297,12 @@ void appendGPUVisibleFaces( const Viewport& viewport, const BitSet& pixBs,
             const auto xf = selMesh->worldXf();
             BitSetParallelFor( it->second, [&] ( FaceId f )
             {
-                auto n = selMesh->meshConstPtr()->dirDblArea( f );
+                auto n = selMesh->meshPtr()->dirDblArea( f );
                 Vector3f cameraDir;
                 if ( viewport.getParameters().orthographic )
                     cameraDir = orthoBackwards;
                 else
-                    cameraDir = -viewport.unprojectPixelRay( to2dim( viewport.projectToViewportSpace( selMesh->meshConstPtr()->triCenter( f ) ) ) ).d;
+                    cameraDir = -viewport.unprojectPixelRay( to2dim( viewport.projectToViewportSpace( selMesh->meshPtr()->triCenter( f ) ) ) ).d;
                 if ( dot( xf.A * n, cameraDir ) < 0 )
                     it->second.set( f, false );
             } );
@@ -317,7 +317,7 @@ VertBitSet findVertsInViewportArea( const Viewport& viewport, const BitSet& pixB
     if ( pixBs.none() )
         return {};
 
-    const auto* pointCloud = obj.pointCloudConstPtr();
+    const auto* pointCloud = obj.pointCloudPtr();
     const auto& vpRect = viewport.getViewportRect();
     const auto xf = obj.worldXf();
 

--- a/source/MRViewer/MRSelectScreenLasso.cpp
+++ b/source/MRViewer/MRSelectScreenLasso.cpp
@@ -210,7 +210,7 @@ FaceBitSet findIncidentFaces( const Viewport& viewport, const BitSet& pixBs, con
         std::vector<Line3fMesh> lineMeshes;
         xfMeshToOccMesh.emplace_back();
         cameraEyes.push_back( xf.inverse()( viewport.getCameraPoint() ) );
-        lineMeshes.push_back( Line3fMesh{ .mesh = mesh.get(), .tree = &mesh->getAABBTree() } );
+        lineMeshes.push_back( Line3fMesh{ .mesh = mesh, .tree = &mesh->getAABBTree() } );
         if ( occludingMeshes )
         {
             for ( const auto * occ : *occludingMeshes )

--- a/source/MRViewer/MRSelectScreenLasso.cpp
+++ b/source/MRViewer/MRSelectScreenLasso.cpp
@@ -112,7 +112,7 @@ FaceBitSet findIncidentFaces( const Viewport& viewport, const BitSet& pixBs, con
     if ( pixBs.none() )
         return {};
 
-    const auto& mesh = obj.mesh();
+    const auto* mesh = obj.meshConstPtr();
     const auto& vpRect = viewport.getViewportRect();
     const auto xf = obj.worldXf();
 
@@ -220,7 +220,7 @@ FaceBitSet findIncidentFaces( const Viewport& viewport, const BitSet& pixBs, con
                 const auto worldToOccMesh = occ->worldXf().inverse();
                 xfMeshToOccMesh.push_back( worldToOccMesh * xf );
                 cameraEyes.push_back( worldToOccMesh( viewport.getCameraPoint() ) );
-                const auto * occmesh = occ->mesh().get();
+                const auto * occmesh = occ->meshConstPtr();
                 lineMeshes.push_back( Line3fMesh{ .mesh = occmesh, .tree = &occmesh->getAABBTree() } );
             }
         }
@@ -297,12 +297,12 @@ void appendGPUVisibleFaces( const Viewport& viewport, const BitSet& pixBs,
             const auto xf = selMesh->worldXf();
             BitSetParallelFor( it->second, [&] ( FaceId f )
             {
-                auto n = selMesh->mesh()->dirDblArea( f );
+                auto n = selMesh->meshConstPtr()->dirDblArea( f );
                 Vector3f cameraDir;
                 if ( viewport.getParameters().orthographic )
                     cameraDir = orthoBackwards;
                 else
-                    cameraDir = -viewport.unprojectPixelRay( to2dim( viewport.projectToViewportSpace( selMesh->mesh()->triCenter( f ) ) ) ).d;
+                    cameraDir = -viewport.unprojectPixelRay( to2dim( viewport.projectToViewportSpace( selMesh->meshConstPtr()->triCenter( f ) ) ) ).d;
                 if ( dot( xf.A * n, cameraDir ) < 0 )
                     it->second.set( f, false );
             } );
@@ -317,7 +317,7 @@ VertBitSet findVertsInViewportArea( const Viewport& viewport, const BitSet& pixB
     if ( pixBs.none() )
         return {};
 
-    const auto& pointCloud = obj.pointCloud();
+    const auto* pointCloud = obj.pointCloudConstPtr();
     const auto& vpRect = viewport.getViewportRect();
     const auto xf = obj.worldXf();
 

--- a/source/MRViewer/MRSurfaceManipulationWidget.cpp
+++ b/source/MRViewer/MRSurfaceManipulationWidget.cpp
@@ -106,11 +106,11 @@ void SurfaceManipulationWidget::init( const std::shared_ptr<ObjectMesh>& objectM
         palette_->setFilterType( FilterType::Linear );
     }
 
-    size_t numV = obj_->meshConstPtr()->topology.lastValidVert() + 1;
+    size_t numV = obj_->meshPtr()->topology.lastValidVert() + 1;
 
     if ( !originalMesh_ )
     {
-        originalMesh_ = std::make_shared<Mesh>( *obj_->meshConstPtr() );
+        originalMesh_ = std::make_shared<Mesh>( *obj_->meshPtr() );
 
         const float rangeLength = settings_.editForce * ( Palette::DefaultColors.size() - 1 );
         palette_->setRangeMinMax( rangeLength * -0.5f, rangeLength * 0.5f );
@@ -151,7 +151,7 @@ void SurfaceManipulationWidget::reset()
 
 void SurfaceManipulationWidget::setFixedRegion( const FaceBitSet& region )
 {
-    unchangeableVerts_ = getIncidentVerts( obj_->meshConstPtr()->topology, region ) ;
+    unchangeableVerts_ = getIncidentVerts( obj_->meshPtr()->topology, region ) ;
 }
 
 void SurfaceManipulationWidget::setSettings( const Settings& settings )
@@ -217,7 +217,7 @@ void SurfaceManipulationWidget::updateTexture()
 
 void SurfaceManipulationWidget::updateUVs()
 {
-    updateRegionUVs_( obj_->meshConstPtr()->topology.getValidVerts() );
+    updateRegionUVs_( obj_->meshPtr()->topology.getValidVerts() );
 }
 
 void SurfaceManipulationWidget::enableDeviationVisualization( bool enable )
@@ -235,7 +235,7 @@ void SurfaceManipulationWidget::setDeviationCalculationMethod( DeviationCalculat
         deviationCalculationMethod_ = method;
     else
         deviationCalculationMethod_ = DeviationCalculationMethod::ExactDistance;
-    updateValueChanges_( obj_->meshConstPtr()->topology.getValidVerts() );
+    updateValueChanges_( obj_->meshPtr()->topology.getValidVerts() );
 }
 
 Vector2f SurfaceManipulationWidget::getMinMax()
@@ -311,7 +311,7 @@ bool SurfaceManipulationWidget::onMouseDown_( MouseButton button, int modifiers 
                 && ( settings_.workMode == WorkMode::Add || settings_.workMode == WorkMode::Remove ) )
             {
                 pickedVerts_.clear();
-                pickedVerts_.resize( obj_->meshConstPtr()->points.size() );
+                pickedVerts_.resize( obj_->meshPtr()->points.size() );
                 pickedVertsToData_.clear();
             }
 
@@ -336,7 +336,7 @@ void SurfaceManipulationWidget::subdivideAfterAddRemove_()
 {
     MR_TIMER;
     auto subdivData = obj_->data().clone();
-    auto fs = getIncidentFaces( obj_->meshConstPtr()->topology, generalEditingRegion_ );
+    auto fs = getIncidentFaces( obj_->meshPtr()->topology, generalEditingRegion_ );
     if ( subdivideMesh( subdivData, SubdivideSettings
         {
             .maxEdgeLen = settings_.radius,
@@ -350,7 +350,7 @@ void SurfaceManipulationWidget::subdivideAfterAddRemove_()
     {
         ownMeshChangedSignal_ = true;
         AppendHistory<PartialChangeMeshDataAction>( _t( "Subdivide Ridges/Grooves" ), obj_, std::move( subdivData ) );
-        reallocData_( obj_->meshConstPtr()->topology.lastValidVert() + 1 );
+        reallocData_( obj_->meshPtr()->topology.lastValidVert() + 1 );
         sameOriginalMeshTopology_ = false;
         setDeviationCalculationMethod( deviationCalculationMethod_ );
         obj_->setDirtyFlags( DIRTY_ALL );
@@ -376,7 +376,7 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
         return true;
     }
 
-    size_t numV = obj_->meshConstPtr()->topology.lastValidVert() + 1;
+    size_t numV = obj_->meshPtr()->topology.lastValidVert() + 1;
     pointsShift_.clear();
     pointsShift_.resize( numV, 0.f );
 
@@ -464,7 +464,7 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
                 assert( false );
             }
 
-            reallocData_( obj_->meshConstPtr()->topology.lastValidVert() + 1 );
+            reallocData_( obj_->meshPtr()->topology.lastValidVert() + 1 );
             sameOriginalMeshTopology_ = false;
             setDeviationCalculationMethod( deviationCalculationMethod_ );
             obj_->setDirtyFlags( DIRTY_ALL );
@@ -577,10 +577,10 @@ void SurfaceManipulationWidget::initConnections_()
             return;
         }
         abortEdit_();
-        reallocData_( obj_->meshConstPtr()->topology.lastValidVert() + 1 );
+        reallocData_( obj_->meshPtr()->topology.lastValidVert() + 1 );
         if ( settings_.workMode == WorkMode::Patch )
             updateUVmap_( false, true );
-        sameOriginalMeshTopology_ = originalMesh_->topology == obj_->meshConstPtr()->topology;
+        sameOriginalMeshTopology_ = originalMesh_->topology == obj_->meshPtr()->topology;
         setDeviationCalculationMethod( deviationCalculationMethod_ );
         updateRegion_( Vector2f( getViewerInstance().mouseController().getMousePos() ) );
     } );
@@ -627,7 +627,7 @@ void SurfaceManipulationWidget::changeSurface_()
 
     Vector3f normal;
     auto objMeshPtr = lastStableObjMesh_ ? lastStableObjMesh_ : obj_;
-    const auto& mesh = *objMeshPtr->meshConstPtr();
+    const auto& mesh = *objMeshPtr->meshPtr();
     for ( auto v : singleEditingRegion_ )
         normal += mesh.dirDblArea( v );
     normal = normal.normalized();
@@ -716,9 +716,9 @@ void SurfaceManipulationWidget::updateUVmap_( bool set, bool wholeMesh )
 {
     VertUVCoords uvs;
     obj_->updateAncillaryUVCoords( uvs );
-    uvs.resizeWithReserve( obj_->meshConstPtr()->points.size(), UVCoord{ 0.5f, 1 } );
+    uvs.resizeWithReserve( obj_->meshPtr()->points.size(), UVCoord{ 0.5f, 1 } );
     const float normalize = 0.5f / settings_.radius;
-    BitSetParallelFor( wholeMesh ? obj_->meshConstPtr()->topology.getValidVerts() : visualizationRegion_, [&] ( VertId v )
+    BitSetParallelFor( wholeMesh ? obj_->meshPtr()->topology.getValidVerts() : visualizationRegion_, [&] ( VertId v )
     {
         if ( set )
             uvs[v] = UVCoord( palette_->getUVcoord( valueChanges_[v], true ).x, ( visualizationDistanceMap_[v] * normalize - 0.5f ) * 100 + 0.5f );
@@ -773,7 +773,7 @@ void SurfaceManipulationWidget::updateRegion_( const Vector2f& mousePos )
         movedPosPick = getViewerInstance().viewport().multiPickObjects( visualObjectsP, viewportPoints );
     }
 
-    const auto& mesh = *objMeshPtr->meshConstPtr();
+    const auto& mesh = *objMeshPtr->meshPtr();
     pointsUnderMouse_.clear();
     for ( const auto& [obj,pick] : movedPosPick )
     {
@@ -842,7 +842,7 @@ void SurfaceManipulationWidget::initLaplacian_( RememberShape rs )
     else
         laplacian_ = std::make_unique<Laplacian>( *obj_->varMesh() );
 
-    laplacian_->initFromPoints( lastStableObjMesh_ ? lastStableObjMesh_->meshConstPtr()->points : obj_->meshConstPtr()->points,
+    laplacian_->initFromPoints( lastStableObjMesh_ ? lastStableObjMesh_->meshPtr()->points : obj_->meshPtr()->points,
         singleEditingRegion_, settings_.edgeWeights, settings_.vmass, rs );
 }
 
@@ -850,7 +850,7 @@ void SurfaceManipulationWidget::laplacianPickVert_( const PointOnFace& pick )
 {
     appendHistoryAction_ = true;
     storedDown_ = getViewerInstance().mouseController().getMousePos();
-    const auto& mesh = *obj_->meshConstPtr();
+    const auto& mesh = *obj_->meshPtr();
     touchVertId_ = mesh.getClosestVertex( pick );
     touchVertIniPos_ = mesh.points[touchVertId_];
     initLaplacian_( RememberShape::Yes );
@@ -884,7 +884,7 @@ void SurfaceManipulationWidget::updateVizualizeSelection_()
     updateUVmap_( false );
     visualizationRegion_.reset();
     auto objMeshPtr = lastStableObjMesh_ ? lastStableObjMesh_ : obj_;
-    const auto& mesh = *objMeshPtr->meshConstPtr();
+    const auto& mesh = *objMeshPtr->meshPtr();
     badRegion_ = false;
     if ( pointsUnderMouse_.empty() )
         return;
@@ -920,7 +920,7 @@ void SurfaceManipulationWidget::updateRegionUVs_( const VertBitSet& region )
     MR_TIMER;
     VertUVCoords uvs;
     obj_->updateAncillaryUVCoords( uvs );
-    uvs.resizeWithReserve( obj_->meshConstPtr()->points.size(), UVCoord{ 0.5f, 1 } );
+    uvs.resizeWithReserve( obj_->meshPtr()->points.size(), UVCoord{ 0.5f, 1 } );
     BitSetParallelFor( region, [&] ( VertId v )
     {
         uvs[v].x = palette_->getUVcoord( valueChanges_[v], true ).x;
@@ -948,7 +948,7 @@ void SurfaceManipulationWidget::updateValueChangesPointToPoint_( const VertBitSe
 {
     MR_TIMER;
     const auto& oldPoints = originalMesh_->points;
-    const auto& mesh = *obj_->meshConstPtr();
+    const auto& mesh = *obj_->meshPtr();
     const auto& points = mesh.points;
     BitSetParallelFor( region, [&] ( VertId v )
     {
@@ -965,7 +965,7 @@ void SurfaceManipulationWidget::updateValueChangesPointToPlane_( const VertBitSe
     MR_TIMER;
     const auto& oldMesh = *originalMesh_;
     const auto& oldPoints = oldMesh.points;
-    const auto& mesh = *obj_->meshConstPtr();
+    const auto& mesh = *obj_->meshPtr();
     const auto& points = mesh.points;
     BitSetParallelFor( region, [&] ( VertId v )
     {
@@ -980,7 +980,7 @@ void SurfaceManipulationWidget::updateValueChangesPointToPlane_( const VertBitSe
 void SurfaceManipulationWidget::updateValueChangesExactDistance_( const VertBitSet& region )
 {
     MR_TIMER;
-    const auto& mesh = *obj_->meshConstPtr();
+    const auto& mesh = *obj_->meshPtr();
     const auto& meshVerts = mesh.points;
 
     std::vector<MeshProjectionResult> projResults( meshVerts.size() );

--- a/source/MRViewer/MRSurfaceManipulationWidget.cpp
+++ b/source/MRViewer/MRSurfaceManipulationWidget.cpp
@@ -106,11 +106,11 @@ void SurfaceManipulationWidget::init( const std::shared_ptr<ObjectMesh>& objectM
         palette_->setFilterType( FilterType::Linear );
     }
 
-    size_t numV = obj_->mesh()->topology.lastValidVert() + 1;
+    size_t numV = obj_->meshConstPtr()->topology.lastValidVert() + 1;
 
     if ( !originalMesh_ )
     {
-        originalMesh_ = std::make_shared<Mesh>( *obj_->mesh() );
+        originalMesh_ = std::make_shared<Mesh>( *obj_->meshConstPtr() );
 
         const float rangeLength = settings_.editForce * ( Palette::DefaultColors.size() - 1 );
         palette_->setRangeMinMax( rangeLength * -0.5f, rangeLength * 0.5f );
@@ -151,7 +151,7 @@ void SurfaceManipulationWidget::reset()
 
 void SurfaceManipulationWidget::setFixedRegion( const FaceBitSet& region )
 {
-    unchangeableVerts_ = getIncidentVerts( obj_->mesh()->topology, region ) ;
+    unchangeableVerts_ = getIncidentVerts( obj_->meshConstPtr()->topology, region ) ;
 }
 
 void SurfaceManipulationWidget::setSettings( const Settings& settings )
@@ -217,7 +217,7 @@ void SurfaceManipulationWidget::updateTexture()
 
 void SurfaceManipulationWidget::updateUVs()
 {
-    updateRegionUVs_( obj_->mesh()->topology.getValidVerts() );
+    updateRegionUVs_( obj_->meshConstPtr()->topology.getValidVerts() );
 }
 
 void SurfaceManipulationWidget::enableDeviationVisualization( bool enable )
@@ -235,7 +235,7 @@ void SurfaceManipulationWidget::setDeviationCalculationMethod( DeviationCalculat
         deviationCalculationMethod_ = method;
     else
         deviationCalculationMethod_ = DeviationCalculationMethod::ExactDistance;
-    updateValueChanges_( obj_->mesh()->topology.getValidVerts() );
+    updateValueChanges_( obj_->meshConstPtr()->topology.getValidVerts() );
 }
 
 Vector2f SurfaceManipulationWidget::getMinMax()
@@ -311,7 +311,7 @@ bool SurfaceManipulationWidget::onMouseDown_( MouseButton button, int modifiers 
                 && ( settings_.workMode == WorkMode::Add || settings_.workMode == WorkMode::Remove ) )
             {
                 pickedVerts_.clear();
-                pickedVerts_.resize( obj_->mesh()->points.size() );
+                pickedVerts_.resize( obj_->meshConstPtr()->points.size() );
                 pickedVertsToData_.clear();
             }
 
@@ -336,7 +336,7 @@ void SurfaceManipulationWidget::subdivideAfterAddRemove_()
 {
     MR_TIMER;
     auto subdivData = obj_->data().clone();
-    auto fs = getIncidentFaces( obj_->mesh()->topology, generalEditingRegion_ );
+    auto fs = getIncidentFaces( obj_->meshConstPtr()->topology, generalEditingRegion_ );
     if ( subdivideMesh( subdivData, SubdivideSettings
         {
             .maxEdgeLen = settings_.radius,
@@ -350,7 +350,7 @@ void SurfaceManipulationWidget::subdivideAfterAddRemove_()
     {
         ownMeshChangedSignal_ = true;
         AppendHistory<PartialChangeMeshDataAction>( _t( "Subdivide Ridges/Grooves" ), obj_, std::move( subdivData ) );
-        reallocData_( obj_->mesh()->topology.lastValidVert() + 1 );
+        reallocData_( obj_->meshConstPtr()->topology.lastValidVert() + 1 );
         sameOriginalMeshTopology_ = false;
         setDeviationCalculationMethod( deviationCalculationMethod_ );
         obj_->setDirtyFlags( DIRTY_ALL );
@@ -376,7 +376,7 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
         return true;
     }
 
-    size_t numV = obj_->mesh()->topology.lastValidVert() + 1;
+    size_t numV = obj_->meshConstPtr()->topology.lastValidVert() + 1;
     pointsShift_.clear();
     pointsShift_.resize( numV, 0.f );
 
@@ -464,7 +464,7 @@ bool SurfaceManipulationWidget::onMouseUp_( Viewer::MouseButton button, int /*mo
                 assert( false );
             }
 
-            reallocData_( obj_->mesh()->topology.lastValidVert() + 1 );
+            reallocData_( obj_->meshConstPtr()->topology.lastValidVert() + 1 );
             sameOriginalMeshTopology_ = false;
             setDeviationCalculationMethod( deviationCalculationMethod_ );
             obj_->setDirtyFlags( DIRTY_ALL );
@@ -577,10 +577,10 @@ void SurfaceManipulationWidget::initConnections_()
             return;
         }
         abortEdit_();
-        reallocData_( obj_->mesh()->topology.lastValidVert() + 1 );
+        reallocData_( obj_->meshConstPtr()->topology.lastValidVert() + 1 );
         if ( settings_.workMode == WorkMode::Patch )
             updateUVmap_( false, true );
-        sameOriginalMeshTopology_ = originalMesh_->topology == obj_->mesh()->topology;
+        sameOriginalMeshTopology_ = originalMesh_->topology == obj_->meshConstPtr()->topology;
         setDeviationCalculationMethod( deviationCalculationMethod_ );
         updateRegion_( Vector2f( getViewerInstance().mouseController().getMousePos() ) );
     } );
@@ -627,7 +627,7 @@ void SurfaceManipulationWidget::changeSurface_()
 
     Vector3f normal;
     auto objMeshPtr = lastStableObjMesh_ ? lastStableObjMesh_ : obj_;
-    const auto& mesh = *objMeshPtr->mesh();
+    const auto& mesh = *objMeshPtr->meshConstPtr();
     for ( auto v : singleEditingRegion_ )
         normal += mesh.dirDblArea( v );
     normal = normal.normalized();
@@ -716,9 +716,9 @@ void SurfaceManipulationWidget::updateUVmap_( bool set, bool wholeMesh )
 {
     VertUVCoords uvs;
     obj_->updateAncillaryUVCoords( uvs );
-    uvs.resizeWithReserve( obj_->mesh()->points.size(), UVCoord{ 0.5f, 1 } );
+    uvs.resizeWithReserve( obj_->meshConstPtr()->points.size(), UVCoord{ 0.5f, 1 } );
     const float normalize = 0.5f / settings_.radius;
-    BitSetParallelFor( wholeMesh ? obj_->mesh()->topology.getValidVerts() : visualizationRegion_, [&] ( VertId v )
+    BitSetParallelFor( wholeMesh ? obj_->meshConstPtr()->topology.getValidVerts() : visualizationRegion_, [&] ( VertId v )
     {
         if ( set )
             uvs[v] = UVCoord( palette_->getUVcoord( valueChanges_[v], true ).x, ( visualizationDistanceMap_[v] * normalize - 0.5f ) * 100 + 0.5f );
@@ -773,7 +773,7 @@ void SurfaceManipulationWidget::updateRegion_( const Vector2f& mousePos )
         movedPosPick = getViewerInstance().viewport().multiPickObjects( visualObjectsP, viewportPoints );
     }
 
-    const auto& mesh = *objMeshPtr->mesh();
+    const auto& mesh = *objMeshPtr->meshConstPtr();
     pointsUnderMouse_.clear();
     for ( const auto& [obj,pick] : movedPosPick )
     {
@@ -842,7 +842,7 @@ void SurfaceManipulationWidget::initLaplacian_( RememberShape rs )
     else
         laplacian_ = std::make_unique<Laplacian>( *obj_->varMesh() );
 
-    laplacian_->initFromPoints( lastStableObjMesh_ ? lastStableObjMesh_->mesh()->points : obj_->mesh()->points,
+    laplacian_->initFromPoints( lastStableObjMesh_ ? lastStableObjMesh_->meshConstPtr()->points : obj_->meshConstPtr()->points,
         singleEditingRegion_, settings_.edgeWeights, settings_.vmass, rs );
 }
 
@@ -850,7 +850,7 @@ void SurfaceManipulationWidget::laplacianPickVert_( const PointOnFace& pick )
 {
     appendHistoryAction_ = true;
     storedDown_ = getViewerInstance().mouseController().getMousePos();
-    const auto& mesh = *obj_->mesh();
+    const auto& mesh = *obj_->meshConstPtr();
     touchVertId_ = mesh.getClosestVertex( pick );
     touchVertIniPos_ = mesh.points[touchVertId_];
     initLaplacian_( RememberShape::Yes );
@@ -884,7 +884,7 @@ void SurfaceManipulationWidget::updateVizualizeSelection_()
     updateUVmap_( false );
     visualizationRegion_.reset();
     auto objMeshPtr = lastStableObjMesh_ ? lastStableObjMesh_ : obj_;
-    const auto& mesh = *objMeshPtr->mesh();
+    const auto& mesh = *objMeshPtr->meshConstPtr();
     badRegion_ = false;
     if ( pointsUnderMouse_.empty() )
         return;
@@ -920,7 +920,7 @@ void SurfaceManipulationWidget::updateRegionUVs_( const VertBitSet& region )
     MR_TIMER;
     VertUVCoords uvs;
     obj_->updateAncillaryUVCoords( uvs );
-    uvs.resizeWithReserve( obj_->mesh()->points.size(), UVCoord{ 0.5f, 1 } );
+    uvs.resizeWithReserve( obj_->meshConstPtr()->points.size(), UVCoord{ 0.5f, 1 } );
     BitSetParallelFor( region, [&] ( VertId v )
     {
         uvs[v].x = palette_->getUVcoord( valueChanges_[v], true ).x;
@@ -948,7 +948,7 @@ void SurfaceManipulationWidget::updateValueChangesPointToPoint_( const VertBitSe
 {
     MR_TIMER;
     const auto& oldPoints = originalMesh_->points;
-    const auto& mesh = *obj_->mesh();
+    const auto& mesh = *obj_->meshConstPtr();
     const auto& points = mesh.points;
     BitSetParallelFor( region, [&] ( VertId v )
     {
@@ -965,7 +965,7 @@ void SurfaceManipulationWidget::updateValueChangesPointToPlane_( const VertBitSe
     MR_TIMER;
     const auto& oldMesh = *originalMesh_;
     const auto& oldPoints = oldMesh.points;
-    const auto& mesh = *obj_->mesh();
+    const auto& mesh = *obj_->meshConstPtr();
     const auto& points = mesh.points;
     BitSetParallelFor( region, [&] ( VertId v )
     {
@@ -980,7 +980,7 @@ void SurfaceManipulationWidget::updateValueChangesPointToPlane_( const VertBitSe
 void SurfaceManipulationWidget::updateValueChangesExactDistance_( const VertBitSet& region )
 {
     MR_TIMER;
-    const auto& mesh = *obj_->mesh();
+    const auto& mesh = *obj_->meshConstPtr();
     const auto& meshVerts = mesh.points;
 
     std::vector<MeshProjectionResult> projResults( meshVerts.size() );

--- a/source/MRViewer/MRSurfacePointPicker.cpp
+++ b/source/MRViewer/MRSurfacePointPicker.cpp
@@ -215,8 +215,8 @@ void SurfacePointWidget::updatePositionAndRadiusMesh_( MeshTriPoint mtp )
     assert( pickSphere_ );
     auto baseSurface = std::dynamic_pointer_cast<ObjectMeshHolder>( baseObject_ );
     assert( baseSurface );
-    assert( baseSurface->mesh() );
-    const auto& mesh = *baseSurface->mesh();
+    assert( baseSurface->meshConstPtr() );
+    const auto& mesh = *baseSurface->meshConstPtr();
 
     const auto f = mesh.topology.left( mtp.e );
     switch ( params_.positionType )
@@ -349,7 +349,7 @@ bool SurfacePointWidget::isPickIntoBackFace( const std::shared_ptr<MR::VisualObj
 
     if ( auto objMesh = std::dynamic_pointer_cast< const ObjectMeshHolder >( obj ) )
     {
-        const auto& n = objMesh->mesh()->dirDblArea( pick.face );
+        const auto& n = objMesh->meshConstPtr()->dirDblArea( pick.face );
         if ( dot( xf.A * n, cameraEye ) < 0 )
             return true;
         else
@@ -359,9 +359,9 @@ bool SurfacePointWidget::isPickIntoBackFace( const std::shared_ptr<MR::VisualObj
 
     if ( auto objPoints = std::dynamic_pointer_cast< const ObjectPointsHolder >( obj ) )
     {
-        if ( objPoints->pointCloud()->normals.size() > static_cast< int > ( pick.vert ) )
+        if ( objPoints->pointCloudConstPtr()->normals.size() > static_cast< int > ( pick.vert ) )
         {
-            const auto& n = objPoints->pointCloud()->normals[pick.vert];
+            const auto& n = objPoints->pointCloudConstPtr()->normals[pick.vert];
             auto dt = dot( xf.A * n, cameraEye );
             if ( dt < 0 )
                 return true;

--- a/source/MRViewer/MRSurfacePointPicker.cpp
+++ b/source/MRViewer/MRSurfacePointPicker.cpp
@@ -215,8 +215,8 @@ void SurfacePointWidget::updatePositionAndRadiusMesh_( MeshTriPoint mtp )
     assert( pickSphere_ );
     auto baseSurface = std::dynamic_pointer_cast<ObjectMeshHolder>( baseObject_ );
     assert( baseSurface );
-    assert( baseSurface->meshConstPtr() );
-    const auto& mesh = *baseSurface->meshConstPtr();
+    assert( baseSurface->meshPtr() );
+    const auto& mesh = *baseSurface->meshPtr();
 
     const auto f = mesh.topology.left( mtp.e );
     switch ( params_.positionType )
@@ -349,7 +349,7 @@ bool SurfacePointWidget::isPickIntoBackFace( const std::shared_ptr<MR::VisualObj
 
     if ( auto objMesh = std::dynamic_pointer_cast< const ObjectMeshHolder >( obj ) )
     {
-        const auto& n = objMesh->meshConstPtr()->dirDblArea( pick.face );
+        const auto& n = objMesh->meshPtr()->dirDblArea( pick.face );
         if ( dot( xf.A * n, cameraEye ) < 0 )
             return true;
         else
@@ -359,9 +359,9 @@ bool SurfacePointWidget::isPickIntoBackFace( const std::shared_ptr<MR::VisualObj
 
     if ( auto objPoints = std::dynamic_pointer_cast< const ObjectPointsHolder >( obj ) )
     {
-        if ( objPoints->pointCloudConstPtr()->normals.size() > static_cast< int > ( pick.vert ) )
+        if ( objPoints->pointCloudPtr()->normals.size() > static_cast< int > ( pick.vert ) )
         {
-            const auto& n = objPoints->pointCloudConstPtr()->normals[pick.vert];
+            const auto& n = objPoints->pointCloudPtr()->normals[pick.vert];
             auto dt = dot( xf.A * n, cameraEye );
             if ( dt < 0 )
                 return true;

--- a/source/MRViewer/MRToolsLibrary.cpp
+++ b/source/MRViewer/MRToolsLibrary.cpp
@@ -275,7 +275,7 @@ void GcodeToolsLibrary::addNewToolFromMesh_( const std::shared_ptr<ObjectMesh>& 
         return;
 
     toolMesh_ = std::dynamic_pointer_cast< ObjectMesh >( objMesh->clone() );
-    (void)MeshSave::toMrmesh( *toolMesh_->meshConstPtr(), folderPath / ( toolMesh_->name() + ".mrmesh" ) ); //TODO: process potential error
+    (void)MeshSave::toMrmesh( *toolMesh_->meshPtr(), folderPath / ( toolMesh_->name() + ".mrmesh" ) ); //TODO: process potential error
     endMillTool_.reset();
     selectedFileName_ = toolMesh_->name();
 }

--- a/source/MRViewer/MRToolsLibrary.cpp
+++ b/source/MRViewer/MRToolsLibrary.cpp
@@ -275,7 +275,7 @@ void GcodeToolsLibrary::addNewToolFromMesh_( const std::shared_ptr<ObjectMesh>& 
         return;
 
     toolMesh_ = std::dynamic_pointer_cast< ObjectMesh >( objMesh->clone() );
-    (void)MeshSave::toMrmesh( *toolMesh_->mesh(), folderPath / ( toolMesh_->name() + ".mrmesh" ) ); //TODO: process potential error
+    (void)MeshSave::toMrmesh( *toolMesh_->meshConstPtr(), folderPath / ( toolMesh_->name() + ".mrmesh" ) ); //TODO: process potential error
     endMillTool_.reset();
     selectedFileName_ = toolMesh_->name();
 }

--- a/source/MRViewer/MRViewport.cpp
+++ b/source/MRViewer/MRViewport.cpp
@@ -285,7 +285,7 @@ std::vector<ObjAndPick> Viewport::multiPickObjects( std::span<VisualObject* cons
         if ( auto pointObj = renderVector[pickRes.geomId]->asType<ObjectPointsHolder>() )
         {
             res.primId = int( pickRes.primId ) * pointObj->getRenderDiscretization();
-            if ( auto pc = pointObj->pointCloudConstPtr() )
+            if ( auto pc = pointObj->pointCloudPtr() )
             {
                 VertId vid( res.primId );
                 if ( pc->validPoints.test( vid ) )
@@ -302,14 +302,14 @@ std::vector<ObjAndPick> Viewport::multiPickObjects( std::span<VisualObject* cons
         {
             res.point = renderVector[pickRes.geomId]->worldXf( id ).inverse()( unprojectFromViewportSpace( Vector3f( viewportPoints[i].x, viewportPoints[i].y, pickRes.zBuffer ) ) );
             UndirectedEdgeId ue{ int( pickRes.primId ) };
-            if ( auto pl = linesObj->polylineConstPtr() )
+            if ( auto pl = linesObj->polylinePtr() )
                 res.point = closestPointOnLineSegm( res.point, pl->edgeSegment( ue ) );
         }
         else if ( auto meshObj = renderVector[pickRes.geomId]->asType<ObjectMeshHolder>() )
         {
             if ( res.face.valid() )
             {
-                const auto* mesh = meshObj->meshConstPtr();
+                const auto* mesh = meshObj->meshPtr();
                 if ( mesh && !mesh->topology.hasFace( res.face ) )
                 {
                     assert( false );
@@ -426,7 +426,7 @@ std::unordered_map<std::shared_ptr<MR::ObjectMesh>, MR::FaceBitSet> Viewport::fi
 
         auto& fbs = resMap[meshObj];
         if ( fbs.empty() )
-            fbs.resize( meshObj->meshConstPtr()->topology.lastValidFace() + 1 );
+            fbs.resize( meshObj->meshPtr()->topology.lastValidFace() + 1 );
         fbs.set( FaceId( int( pId ) ) );
     }
     return resMap;

--- a/source/MRViewer/MRViewport.cpp
+++ b/source/MRViewer/MRViewport.cpp
@@ -285,7 +285,7 @@ std::vector<ObjAndPick> Viewport::multiPickObjects( std::span<VisualObject* cons
         if ( auto pointObj = renderVector[pickRes.geomId]->asType<ObjectPointsHolder>() )
         {
             res.primId = int( pickRes.primId ) * pointObj->getRenderDiscretization();
-            if ( auto pc = pointObj->pointCloud() )
+            if ( auto pc = pointObj->pointCloudConstPtr() )
             {
                 VertId vid( res.primId );
                 if ( pc->validPoints.test( vid ) )
@@ -302,14 +302,14 @@ std::vector<ObjAndPick> Viewport::multiPickObjects( std::span<VisualObject* cons
         {
             res.point = renderVector[pickRes.geomId]->worldXf( id ).inverse()( unprojectFromViewportSpace( Vector3f( viewportPoints[i].x, viewportPoints[i].y, pickRes.zBuffer ) ) );
             UndirectedEdgeId ue{ int( pickRes.primId ) };
-            if ( auto pl = linesObj->polyline() )
+            if ( auto pl = linesObj->polylineConstPtr() )
                 res.point = closestPointOnLineSegm( res.point, pl->edgeSegment( ue ) );
         }
         else if ( auto meshObj = renderVector[pickRes.geomId]->asType<ObjectMeshHolder>() )
         {
             if ( res.face.valid() )
             {
-                const auto& mesh = meshObj->mesh();
+                const auto* mesh = meshObj->meshConstPtr();
                 if ( mesh && !mesh->topology.hasFace( res.face ) )
                 {
                     assert( false );
@@ -426,7 +426,7 @@ std::unordered_map<std::shared_ptr<MR::ObjectMesh>, MR::FaceBitSet> Viewport::fi
 
         auto& fbs = resMap[meshObj];
         if ( fbs.empty() )
-            fbs.resize( meshObj->mesh()->topology.lastValidFace() + 1 );
+            fbs.resize( meshObj->meshConstPtr()->topology.lastValidFace() + 1 );
         fbs.set( FaceId( int( pId ) ) );
     }
     return resMap;

--- a/source/MRViewer/MRViewportCamera.cpp
+++ b/source/MRViewer/MRViewportCamera.cpp
@@ -605,10 +605,10 @@ Box3f Viewport::calcBox_( const std::vector<std::shared_ptr<VisualObject>>& objs
         {
             if ( auto* objMesh = obj->asType<ObjectMeshHolder>() )
             {
-                if ( !objMesh->meshConstPtr() )
+                if ( !objMesh->meshPtr() )
                     continue;
 
-                const auto& mesh = *objMesh->meshConstPtr();
+                const auto& mesh = *objMesh->meshPtr();
                 const auto region =
                     getIncidentVerts( mesh.topology, objMesh->getSelectedEdges() )
                     | getIncidentVerts( mesh.topology, objMesh->getSelectedFaces() );
@@ -638,26 +638,26 @@ Box3f Viewport::calcBox_( const std::vector<std::shared_ptr<VisualObject>>& objs
 #endif
         if ( auto* objMesh = obj->asType<ObjectMeshHolder>() )
         {
-            if ( !objMesh->meshConstPtr() )
+            if ( !objMesh->meshPtr() )
                 continue;
 
-            const auto& mesh = *objMesh->meshConstPtr();
+            const auto& mesh = *objMesh->meshPtr();
             expandBox( mesh.points, mesh.topology.getValidVerts(), obj2cam );
         }
         else if ( auto* objLines = obj->asType<ObjectLinesHolder>() )
         {
-            if ( !objLines->polylineConstPtr() )
+            if ( !objLines->polylinePtr() )
                 continue;
 
-            const auto& polyline = *objLines->polylineConstPtr();
+            const auto& polyline = *objLines->polylinePtr();
             expandBox( polyline.points, polyline.topology.getValidVerts(), obj2cam );
         }
         else if ( auto objPoints = obj->asType<ObjectPointsHolder>() )
         {
-            if ( !objPoints->pointCloudConstPtr() )
+            if ( !objPoints->pointCloudPtr() )
                 continue;
 
-            const auto& pointCloud = *objPoints->pointCloudConstPtr();
+            const auto& pointCloud = *objPoints->pointCloudPtr();
             expandBox( pointCloud.points, pointCloud.validPoints, obj2cam );
         }
         else if ( const auto objBox = obj->getBoundingBox(); objBox.valid() )

--- a/source/MRViewer/MRViewportCamera.cpp
+++ b/source/MRViewer/MRViewportCamera.cpp
@@ -605,10 +605,10 @@ Box3f Viewport::calcBox_( const std::vector<std::shared_ptr<VisualObject>>& objs
         {
             if ( auto* objMesh = obj->asType<ObjectMeshHolder>() )
             {
-                if ( !objMesh->mesh() )
+                if ( !objMesh->meshConstPtr() )
                     continue;
 
-                const auto& mesh = *objMesh->mesh();
+                const auto& mesh = *objMesh->meshConstPtr();
                 const auto region =
                     getIncidentVerts( mesh.topology, objMesh->getSelectedEdges() )
                     | getIncidentVerts( mesh.topology, objMesh->getSelectedFaces() );
@@ -638,26 +638,26 @@ Box3f Viewport::calcBox_( const std::vector<std::shared_ptr<VisualObject>>& objs
 #endif
         if ( auto* objMesh = obj->asType<ObjectMeshHolder>() )
         {
-            if ( !objMesh->mesh() )
+            if ( !objMesh->meshConstPtr() )
                 continue;
 
-            const auto& mesh = *objMesh->mesh();
+            const auto& mesh = *objMesh->meshConstPtr();
             expandBox( mesh.points, mesh.topology.getValidVerts(), obj2cam );
         }
         else if ( auto* objLines = obj->asType<ObjectLinesHolder>() )
         {
-            if ( !objLines->polyline() )
+            if ( !objLines->polylineConstPtr() )
                 continue;
 
-            const auto& polyline = *objLines->polyline();
+            const auto& polyline = *objLines->polylineConstPtr();
             expandBox( polyline.points, polyline.topology.getValidVerts(), obj2cam );
         }
         else if ( auto objPoints = obj->asType<ObjectPointsHolder>() )
         {
-            if ( !objPoints->pointCloud() )
+            if ( !objPoints->pointCloudConstPtr() )
                 continue;
 
-            const auto& pointCloud = *objPoints->pointCloud();
+            const auto& pointCloud = *objPoints->pointCloudConstPtr();
             expandBox( pointCloud.points, pointCloud.validPoints, obj2cam );
         }
         else if ( const auto objBox = obj->getBoundingBox(); objBox.valid() )

--- a/source/MRVoxels/MRBoolean.cpp
+++ b/source/MRVoxels/MRBoolean.cpp
@@ -8,7 +8,7 @@ namespace MR
 
 FloatGrid MeshVoxelsConverter::operator() ( const ObjectMesh & obj ) const
 { 
-    return meshToLevelSet( *obj.meshConstPtr(), obj.xf(), Vector3f::diagonal( voxelSize ), surfaceOffset, callBack );
+    return meshToLevelSet( *obj.meshPtr(), obj.xf(), Vector3f::diagonal( voxelSize ), surfaceOffset, callBack );
 }
 
 Mesh MeshVoxelsConverter::operator() ( const FloatGrid & grid ) const

--- a/source/MRVoxels/MRBoolean.cpp
+++ b/source/MRVoxels/MRBoolean.cpp
@@ -8,7 +8,7 @@ namespace MR
 
 FloatGrid MeshVoxelsConverter::operator() ( const ObjectMesh & obj ) const
 { 
-    return meshToLevelSet( *obj.mesh(), obj.xf(), Vector3f::diagonal( voxelSize ), surfaceOffset, callBack );
+    return meshToLevelSet( *obj.meshConstPtr(), obj.xf(), Vector3f::diagonal( voxelSize ), surfaceOffset, callBack );
 }
 
 Mesh MeshVoxelsConverter::operator() ( const FloatGrid & grid ) const

--- a/source/MRVoxels/MRChangeVoxelsAction.h
+++ b/source/MRVoxels/MRChangeVoxelsAction.h
@@ -175,7 +175,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->mesh() )
+            if ( auto m = obj->meshConstPtr() )
                 cloneSurface_ = std::make_shared<Mesh>( *m );
         }
     }

--- a/source/MRVoxels/MRChangeVoxelsAction.h
+++ b/source/MRVoxels/MRChangeVoxelsAction.h
@@ -175,7 +175,7 @@ public:
     {
         if ( obj )
         {
-            if ( auto m = obj->meshConstPtr() )
+            if ( auto m = obj->meshPtr() )
                 cloneSurface_ = std::make_shared<Mesh>( *m );
         }
     }

--- a/source/MeshLibC2/CMakeLists.txt
+++ b/source/MeshLibC2/CMakeLists.txt
@@ -14,8 +14,9 @@ IF(MSVC)
   #   warning C4574: '__has_feature' is defined to be '0': did you mean to use '#if __has_feature'?
   #   warning C4800: Implicit conversion from '_Ty *' to bool. Possible information loss
   #   warning C4804: '+=': unsafe use of type 'bool' in operation
+  #   warning C4996: 'MR::ObjectMeshHolder::mesh': was declared deprecated
   #   warning C5204: class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4242 /wd4244 /wd4297 /wd4305 /wd4355 /wd4574 /wd4800 /wd4804 /wd5204")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4242 /wd4244 /wd4297 /wd4305 /wd4355 /wd4574 /wd4800 /wd4804 /wd4996 /wd5204")
 ELSE()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-int-in-bool-context -Wno-deprecated-declarations")
 ENDIF()

--- a/source/MeshLibC2/CMakeLists.txt
+++ b/source/MeshLibC2/CMakeLists.txt
@@ -14,9 +14,8 @@ IF(MSVC)
   #   warning C4574: '__has_feature' is defined to be '0': did you mean to use '#if __has_feature'?
   #   warning C4800: Implicit conversion from '_Ty *' to bool. Possible information loss
   #   warning C4804: '+=': unsafe use of type 'bool' in operation
-  #   warning C4996: 'MR::ObjectMeshHolder::mesh': was declared deprecated
   #   warning C5204: class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4242 /wd4244 /wd4297 /wd4305 /wd4355 /wd4574 /wd4800 /wd4804 /wd4996 /wd5204")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4242 /wd4244 /wd4297 /wd4305 /wd4355 /wd4574 /wd4800 /wd4804 /wd5204")
 ELSE()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-int-in-bool-context -Wno-deprecated-declarations")
 ENDIF()

--- a/source/MeshLibC2/MeshLibC2.vcxproj
+++ b/source/MeshLibC2/MeshLibC2.vcxproj
@@ -108,7 +108,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>SyncCThrow</ExceptionHandling>
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
-      <DisableSpecificWarnings>4242;4244;4297;4305;4355;4800;4804;5204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4242;4244;4297;4305;4355;4800;4804;4996;5204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)src;$(ProjectDir)..\..;%(AdditionalIncludeDirectories);$(ProjectDir)..\..\thirdparty</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -127,7 +127,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>SyncCThrow</ExceptionHandling>
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
-      <DisableSpecificWarnings>4242;4244;4297;4305;4355;4800;4804;5204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4242;4244;4297;4305;4355;4800;4804;4996;5204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)src;$(ProjectDir)..\..;%(AdditionalIncludeDirectories);$(ProjectDir)..\..\thirdparty</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/source/MeshLibC2/MeshLibC2.vcxproj
+++ b/source/MeshLibC2/MeshLibC2.vcxproj
@@ -108,7 +108,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>SyncCThrow</ExceptionHandling>
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
-      <DisableSpecificWarnings>4242;4244;4297;4305;4355;4800;4804;4996;5204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4242;4244;4297;4305;4355;4800;4804;5204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)src;$(ProjectDir)..\..;%(AdditionalIncludeDirectories);$(ProjectDir)..\..\thirdparty</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -127,7 +127,7 @@
       <ConformanceMode>true</ConformanceMode>
       <ExceptionHandling>SyncCThrow</ExceptionHandling>
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
-      <DisableSpecificWarnings>4242;4244;4297;4305;4355;4800;4804;4996;5204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4242;4244;4297;4305;4355;4800;4804;5204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)src;$(ProjectDir)..\..;%(AdditionalIncludeDirectories);$(ProjectDir)..\..\thirdparty</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/source/meshconv/meshconv.cpp
+++ b/source/meshconv/meshconv.cpp
@@ -145,11 +145,11 @@ MR::Expected<MR::ObjectPtr> combineObjs( const std::vector<std::shared_ptr<MR::O
             else if ( resType != Type::Mesh )
                 return MR::unexpected( "Error: File contains objects of different types!" );
             
-            if ( !objMesh->meshConstPtr() )
+            if ( !objMesh->meshPtr() )
                 continue;
 
             MR::VertMap vmap;
-            resMeshPtr->addMesh( *objMesh->meshConstPtr(), nullptr, &vmap );
+            resMeshPtr->addMesh( *objMesh->meshPtr(), nullptr, &vmap );
 
             auto& points = resMeshPtr->points;
             const auto xf = objMesh->worldXf();
@@ -164,11 +164,11 @@ MR::Expected<MR::ObjectPtr> combineObjs( const std::vector<std::shared_ptr<MR::O
             else if ( resType != Type::Lines )
                 return MR::unexpected( "Error: File contains objects of different types!" );
 
-            if ( !objLines->polylineConstPtr() )
+            if ( !objLines->polylinePtr() )
                 continue;
 
             MR::VertMap vmap;
-            resLinesPtr->addPart( *objLines->polylineConstPtr(), &vmap );
+            resLinesPtr->addPart( *objLines->polylinePtr(), &vmap );
 
             auto& points = resLinesPtr->points;
             const auto xf = objLines->worldXf();
@@ -183,11 +183,11 @@ MR::Expected<MR::ObjectPtr> combineObjs( const std::vector<std::shared_ptr<MR::O
             else if ( resType != Type::Points )
                 return MR::unexpected( "Error: File contains objects of different types!" );
 
-            if ( !objPoints->pointCloudConstPtr() )
+            if ( !objPoints->pointCloudPtr() )
                 continue;
 
             MR::VertMap vmap;
-            resPointsPtr->addPartByMask( *objPoints->pointCloudConstPtr(), objPoints->pointCloudConstPtr()->validPoints, { .src2tgtVerts = &vmap } );
+            resPointsPtr->addPartByMask( *objPoints->pointCloudPtr(), objPoints->pointCloudPtr()->validPoints, { .src2tgtVerts = &vmap } );
 
             auto& points = resPointsPtr->points;
             const auto xf = objPoints->worldXf();
@@ -372,7 +372,7 @@ static int mainInternal( int argc, char **argv )
     else if ( auto tryObjLinesPtr = std::dynamic_pointer_cast<MR::ObjectLines>( firstObjPtr ) )
     {
         objLinesPtr = tryObjLinesPtr;
-        if ( !objLinesPtr->polylineConstPtr() )
+        if ( !objLinesPtr->polylinePtr() )
         {
             std::cerr << "Error: polyline not found!\n";
             MC_EXIT( 1 );
@@ -381,7 +381,7 @@ static int mainInternal( int argc, char **argv )
     else if ( auto tryObjPointsPtr = std::dynamic_pointer_cast<MR::ObjectPoints>( firstObjPtr ) )
     {
         objPointsPtr = tryObjPointsPtr;
-        if ( !objPointsPtr->pointCloudConstPtr() )
+        if ( !objPointsPtr->pointCloudPtr() )
         {
             std::cerr << "Error: point cloud not found!\n";
             MC_EXIT( 1 );
@@ -405,11 +405,11 @@ static int mainInternal( int argc, char **argv )
         t.restart( "SaveFile" );
         MR::Expected<void> saveRes;
         if ( objMeshPtr )
-            saveRes = MR::MeshSave::toAnySupportedFormat( *objMeshPtr->meshConstPtr(), outFilePath);
+            saveRes = MR::MeshSave::toAnySupportedFormat( *objMeshPtr->meshPtr(), outFilePath);
         else if ( objLinesPtr )
-            saveRes = MR::LinesSave::toAnySupportedFormat( *objLinesPtr->polylineConstPtr(), outFilePath );
+            saveRes = MR::LinesSave::toAnySupportedFormat( *objLinesPtr->polylinePtr(), outFilePath );
         else if ( objPointsPtr )
-            saveRes = MR::PointsSave::toAnySupportedFormat( *objPointsPtr->pointCloudConstPtr(), outFilePath );
+            saveRes = MR::PointsSave::toAnySupportedFormat( *objPointsPtr->pointCloudPtr(), outFilePath );
         if ( !saveRes.has_value() )
         {
             std::cerr << "File save error: " << saveRes.error() << "\n";

--- a/source/meshconv/meshconv.cpp
+++ b/source/meshconv/meshconv.cpp
@@ -145,11 +145,11 @@ MR::Expected<MR::ObjectPtr> combineObjs( const std::vector<std::shared_ptr<MR::O
             else if ( resType != Type::Mesh )
                 return MR::unexpected( "Error: File contains objects of different types!" );
             
-            if ( !objMesh->mesh() )
+            if ( !objMesh->meshConstPtr() )
                 continue;
 
             MR::VertMap vmap;
-            resMeshPtr->addMesh( *objMesh->mesh(), nullptr, &vmap );
+            resMeshPtr->addMesh( *objMesh->meshConstPtr(), nullptr, &vmap );
 
             auto& points = resMeshPtr->points;
             const auto xf = objMesh->worldXf();
@@ -164,11 +164,11 @@ MR::Expected<MR::ObjectPtr> combineObjs( const std::vector<std::shared_ptr<MR::O
             else if ( resType != Type::Lines )
                 return MR::unexpected( "Error: File contains objects of different types!" );
 
-            if ( !objLines->polyline() )
+            if ( !objLines->polylineConstPtr() )
                 continue;
 
             MR::VertMap vmap;
-            resLinesPtr->addPart( *objLines->polyline(), &vmap );
+            resLinesPtr->addPart( *objLines->polylineConstPtr(), &vmap );
 
             auto& points = resLinesPtr->points;
             const auto xf = objLines->worldXf();
@@ -183,11 +183,11 @@ MR::Expected<MR::ObjectPtr> combineObjs( const std::vector<std::shared_ptr<MR::O
             else if ( resType != Type::Points )
                 return MR::unexpected( "Error: File contains objects of different types!" );
 
-            if ( !objPoints->pointCloud() )
+            if ( !objPoints->pointCloudConstPtr() )
                 continue;
 
             MR::VertMap vmap;
-            resPointsPtr->addPartByMask( *objPoints->pointCloud(), objPoints->pointCloud()->validPoints, { .src2tgtVerts = &vmap } );
+            resPointsPtr->addPartByMask( *objPoints->pointCloudConstPtr(), objPoints->pointCloudConstPtr()->validPoints, { .src2tgtVerts = &vmap } );
 
             auto& points = resPointsPtr->points;
             const auto xf = objPoints->worldXf();
@@ -372,7 +372,7 @@ static int mainInternal( int argc, char **argv )
     else if ( auto tryObjLinesPtr = std::dynamic_pointer_cast<MR::ObjectLines>( firstObjPtr ) )
     {
         objLinesPtr = tryObjLinesPtr;
-        if ( !objLinesPtr->polyline() )
+        if ( !objLinesPtr->polylineConstPtr() )
         {
             std::cerr << "Error: polyline not found!\n";
             MC_EXIT( 1 );
@@ -381,7 +381,7 @@ static int mainInternal( int argc, char **argv )
     else if ( auto tryObjPointsPtr = std::dynamic_pointer_cast<MR::ObjectPoints>( firstObjPtr ) )
     {
         objPointsPtr = tryObjPointsPtr;
-        if ( !objPointsPtr->pointCloud() )
+        if ( !objPointsPtr->pointCloudConstPtr() )
         {
             std::cerr << "Error: point cloud not found!\n";
             MC_EXIT( 1 );
@@ -405,11 +405,11 @@ static int mainInternal( int argc, char **argv )
         t.restart( "SaveFile" );
         MR::Expected<void> saveRes;
         if ( objMeshPtr )
-            saveRes = MR::MeshSave::toAnySupportedFormat( *objMeshPtr->mesh(), outFilePath);
+            saveRes = MR::MeshSave::toAnySupportedFormat( *objMeshPtr->meshConstPtr(), outFilePath);
         else if ( objLinesPtr )
-            saveRes = MR::LinesSave::toAnySupportedFormat( *objLinesPtr->polyline(), outFilePath );
+            saveRes = MR::LinesSave::toAnySupportedFormat( *objLinesPtr->polylineConstPtr(), outFilePath );
         else if ( objPointsPtr )
-            saveRes = MR::PointsSave::toAnySupportedFormat( *objPointsPtr->pointCloud(), outFilePath );
+            saveRes = MR::PointsSave::toAnySupportedFormat( *objPointsPtr->pointCloudConstPtr(), outFilePath );
         if ( !saveRes.has_value() )
         {
             std::cerr << "File save error: " << saveRes.error() << "\n";

--- a/source/mrviewerpy/MRPythonScene.cpp
+++ b/source/mrviewerpy/MRPythonScene.cpp
@@ -245,9 +245,9 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrviewerpy, Scene, [] ( pybind11::module_& m )
     m.def( "unselectAll", &pythonUnselect, "unselect all objects in scene tree" );
 
     m.def( "getSelectedObjects", []{ return MR::getAllObjectsInTree( &MR::SceneRoot::get(), MR::ObjectSelectivityType::Selected ); } );
-    m.def( "getSelectedMeshes", &pythonGetSelectedModels<MR::ObjectMeshHolder, &MR::ObjectMeshHolder::meshConstPtr>, "Get copies of all selected meshes in the scene." );
-    m.def( "getSelectedPointClouds", &pythonGetSelectedModels<MR::ObjectPointsHolder, &MR::ObjectPointsHolder::pointCloudConstPtr>, "Get copies of all selected point clouds in the scene." );
-    m.def( "getSelectedPolylines", &pythonGetSelectedModels<MR::ObjectLinesHolder, &MR::ObjectLinesHolder::polylineConstPtr>, "Get copies of all selected polylines in the scene." );
+    m.def( "getSelectedMeshes", &pythonGetSelectedModels<MR::ObjectMeshHolder, &MR::ObjectMeshHolder::meshPtr>, "Get copies of all selected meshes in the scene." );
+    m.def( "getSelectedPointClouds", &pythonGetSelectedModels<MR::ObjectPointsHolder, &MR::ObjectPointsHolder::pointCloudPtr>, "Get copies of all selected point clouds in the scene." );
+    m.def( "getSelectedPolylines", &pythonGetSelectedModels<MR::ObjectLinesHolder, &MR::ObjectLinesHolder::polylinePtr>, "Get copies of all selected polylines in the scene." );
     m.def( "getSelectedDistanceMaps", &pythonGetSelectedModels<MR::ObjectDistanceMap, &MR::ObjectDistanceMap::getDistanceMap>, "Get copies of all selected voxel grids in the scene." );
 } )
 

--- a/source/mrviewerpy/MRPythonScene.cpp
+++ b/source/mrviewerpy/MRPythonScene.cpp
@@ -146,7 +146,10 @@ template <typename ObjectType, auto MemberPtr>
 auto pythonGetSelectedModels()
 {
     using ReturnedElemType = std::remove_cvref_t<decltype((std::declval<ObjectType>().*MemberPtr)())>;
-    using ReturnedVecType = std::vector<std::remove_cvref_t<typename MR::Meta::SharedPtrTraits<ReturnedElemType>::elemType>>;
+    constexpr bool indirect = std::is_pointer_v<ReturnedElemType> || MR::Meta::SharedPtrTraits<ReturnedElemType>::isSharedPtr;
+    using ElemType = std::conditional_t<std::is_pointer_v<ReturnedElemType>,
+        std::remove_pointer_t<ReturnedElemType>, typename MR::Meta::SharedPtrTraits<ReturnedElemType>::elemType>;
+    using ReturnedVecType = std::vector<std::remove_cvref_t<ElemType>>;
 
     ReturnedVecType ret;
 
@@ -157,7 +160,7 @@ auto pythonGetSelectedModels()
 
         for ( const auto& object : objects )
         {
-            if constexpr ( MR::Meta::SharedPtrTraits<ReturnedElemType>::isSharedPtr )
+            if constexpr ( indirect )
                 ret.push_back( *( ( *object ).*MemberPtr)() );
             else
                 ret.push_back( ( ( *object ).*MemberPtr)() );
@@ -242,9 +245,9 @@ MR_ADD_PYTHON_CUSTOM_DEF( mrviewerpy, Scene, [] ( pybind11::module_& m )
     m.def( "unselectAll", &pythonUnselect, "unselect all objects in scene tree" );
 
     m.def( "getSelectedObjects", []{ return MR::getAllObjectsInTree( &MR::SceneRoot::get(), MR::ObjectSelectivityType::Selected ); } );
-    m.def( "getSelectedMeshes", &pythonGetSelectedModels<MR::ObjectMeshHolder, &MR::ObjectMeshHolder::mesh>, "Get copies of all selected meshes in the scene." );
-    m.def( "getSelectedPointClouds", &pythonGetSelectedModels<MR::ObjectPointsHolder, &MR::ObjectPointsHolder::pointCloud>, "Get copies of all selected point clouds in the scene." );
-    m.def( "getSelectedPolylines", &pythonGetSelectedModels<MR::ObjectLinesHolder, &MR::ObjectLinesHolder::polyline>, "Get copies of all selected polylines in the scene." );
+    m.def( "getSelectedMeshes", &pythonGetSelectedModels<MR::ObjectMeshHolder, &MR::ObjectMeshHolder::meshConstPtr>, "Get copies of all selected meshes in the scene." );
+    m.def( "getSelectedPointClouds", &pythonGetSelectedModels<MR::ObjectPointsHolder, &MR::ObjectPointsHolder::pointCloudConstPtr>, "Get copies of all selected point clouds in the scene." );
+    m.def( "getSelectedPolylines", &pythonGetSelectedModels<MR::ObjectLinesHolder, &MR::ObjectLinesHolder::polylineConstPtr>, "Get copies of all selected polylines in the scene." );
     m.def( "getSelectedDistanceMaps", &pythonGetSelectedModels<MR::ObjectDistanceMap, &MR::ObjectDistanceMap::getDistanceMap>, "Get copies of all selected voxel grids in the scene." );
 } )
 

--- a/test_regression/test_conversion/test_step_multibody.py
+++ b/test_regression/test_conversion/test_step_multibody.py
@@ -6,7 +6,7 @@ from constants import test_files_path
 
 
 def _collect_meshes(obj, out):
-    if isinstance(obj, mrmeshpy.ObjectMesh) and obj.mesh() is not None:
+    if isinstance(obj, mrmeshpy.ObjectMesh) and obj.meshConstPtr() is not None:
         out.append(obj)
     for child in obj.children():
         _collect_meshes(child, out)
@@ -31,7 +31,7 @@ def test_step_multibody_split():
     assert len(meshes) == 2
 
     # geometry is preserved, nothing lost or duplicated: two tetrahedra, 4 triangles each
-    assert sum(m.mesh().topology.numValidFaces() for m in meshes) == 8
+    assert sum(m.meshConstPtr().topology.numValidFaces() for m in meshes) == 8
 
     # placement is preserved: the bodies are not collapsed onto each other
     max_x = max(m.getWorldBox().max.x for m in meshes)

--- a/test_regression/test_conversion/test_step_multibody.py
+++ b/test_regression/test_conversion/test_step_multibody.py
@@ -6,7 +6,7 @@ from constants import test_files_path
 
 
 def _collect_meshes(obj, out):
-    if isinstance(obj, mrmeshpy.ObjectMesh) and obj.meshConstPtr() is not None:
+    if isinstance(obj, mrmeshpy.ObjectMesh) and obj.meshPtr() is not None:
         out.append(obj)
     for child in obj.children():
         _collect_meshes(child, out)
@@ -31,7 +31,7 @@ def test_step_multibody_split():
     assert len(meshes) == 2
 
     # geometry is preserved, nothing lost or duplicated: two tetrahedra, 4 triangles each
-    assert sum(m.meshConstPtr().topology.numValidFaces() for m in meshes) == 8
+    assert sum(m.meshPtr().topology.numValidFaces() for m in meshes) == 8
 
     # placement is preserved: the bodies are not collapsed onto each other
     max_x = max(m.getWorldBox().max.x for m in meshes)


### PR DESCRIPTION
`ObjectMeshHolder::mesh()`, `ObjectLinesHolder::polyline()` and `ObjectPointsHolder::pointCloud()` return

```cpp
return reinterpret_cast< const std::shared_ptr<const Mesh>& >( data_.mesh );
```

`std::shared_ptr<T>` and `std::shared_ptr<const T>` are unrelated types, so this is a strict-aliasing violation - undefined behaviour that every implementation happens to get away with only because the two have identical layout. GCC sees through it and each of the three functions needs its own `#pragma GCC diagnostic ignored "-Wstrict-aliasing"` block, commented "Fingers crossed."

Almost every caller only dereferences the result, so this PR:

* adds a raw pointer getter pair - const and mutable - next to each of the three, named after the existing `varMesh()` / `mesh()` pair: `meshPtr()` / `varMeshPtr()`, `polylinePtr()` / `varPolylinePtr()`, `pointCloudPtr()` / `varPointCloudPtr()`;
* switches all 222 call sites in the repository to the const one;
* marks the three casting functions `[[deprecated]]`, so nothing new starts using them and they can be removed later.

The only caller that really needs shared ownership is `SaveSelectedMenuItem::action()`, which fills `MeshSave::NamedXfMesh` and captures it in a `ProgressBar` lambda; it now takes the `shared_ptr` from `varMesh()` instead.

Two knock-on changes outside the call sites:

* the deprecated three stay exposed to Python, C and C#; mrbind wraps every call to a deprecated entity in `MRBINDC_IGNORE_DEPRECATION`, so the generated bindings need nothing from us. `scripts/mrbind/aliases.cpp` resolves `extractMesh` / `extractLines` / `extractPoints` by name at import time, and those now point at the new getters so they keep working once the deprecated ones are removed.
* `pythonGetSelectedModels` in `mrviewerpy` takes the getter as a member pointer, so it decided whether to dereference from `MR::Meta::SharedPtrTraits`; it now unwraps a raw pointer as well as a `shared_ptr`.

Verified locally with MSVC `cl /Zs` and `/we4996`, i.e. any remaining use of a deprecated getter is a compile error: MRMesh (305 TUs), MRViewer (153), MRVoxels (37), mrviewerpy (3) and the remaining 166 TUs under `source/` are clean apart from the sweep's own known artifacts (`MRSparsePolynomial`'s missing `<iterator>` without the project PCH, the win32 TUs that need `/FI windows.h`, and dllimport errors from not passing each library's `<Lib>_EXPORTS`).
