### PR TITLE
CI: move the GCC 16 jobs from ubuntu24 to ubuntu26

### DIFF
--- a/.github/workflows/build-test-ubuntu-arm64.yml
+++ b/.github/workflows/build-test-ubuntu-arm64.yml
@@ -182,9 +182,9 @@ jobs:
           # `-fpch-codegen` hits clang defect llvm/llvm-project#203691 on libstdc++-12 (a `<filesystem>`
           # internal homed into the PCH object but never emitted, surfaces at import time). Disable on ubuntu22.
           PCH_CODEGEN: ${{ matrix.os == 'ubuntu22' && '0' || '1' }}
-          # The bindings always compile with clang++, which takes the newest GCC in the image (16 since
-          # #6717) and so needs GLIBCXX_3.4.35 - absent from stock Ubuntu 24.04. Pin the deb's own GCC 13.
-          CLANG_GCC_PIN: ${{ matrix.os == 'ubuntu24' && '--gcc-install-dir=/usr/lib/gcc/aarch64-linux-gnu/13' || '' }}
+          # The bindings always compile with clang++, which takes the newest GCC in the image - 16 on
+          # ubuntu26 - while the deb is built with GCC 15. Pin clang to that same 15.
+          CLANG_GCC_PIN: ${{ matrix.os == 'ubuntu26' && '--gcc-install-dir=/usr/lib/gcc/aarch64-linux-gnu/15' || '' }}
         run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin PCH_CODEGEN=${{env.PCH_CODEGEN}} EXTRA_CFLAGS="${{env.CLANG_GCC_PIN}}" EXTRA_LDFLAGS="${{env.CLANG_GCC_PIN}}"
 
       - name: Create Python Stubs

--- a/.github/workflows/build-test-ubuntu-x64.yml
+++ b/.github/workflows/build-test-ubuntu-x64.yml
@@ -172,9 +172,9 @@ jobs:
           # `-fpch-codegen` hits clang defect llvm/llvm-project#203691 on libstdc++-12 (a `<filesystem>`
           # internal homed into the PCH object but never emitted, surfaces at import time). Disable on ubuntu22.
           PCH_CODEGEN: ${{ matrix.os == 'ubuntu22' && '0' || '1' }}
-          # The bindings always compile with clang++, which takes the newest GCC in the image (16 since
-          # #6717) and so needs GLIBCXX_3.4.35 - absent from stock Ubuntu 24.04. Pin the deb's own GCC 13.
-          CLANG_GCC_PIN: ${{ matrix.os == 'ubuntu24' && '--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/13' || '' }}
+          # The bindings always compile with clang++, which takes the newest GCC in the image - 16 on
+          # ubuntu26 - while the deb is built with GCC 15. Pin clang to that same 15.
+          CLANG_GCC_PIN: ${{ matrix.os == 'ubuntu26' && '--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/15' || '' }}
         run: make -f scripts/mrbind/generate.mk MODE=none -B --trace MESHLIB_SHLIB_DIR=build/${{matrix.config}}/bin ENABLE_CUDA=${{env.ENABLE_CUDA}} PCH_CODEGEN=${{env.PCH_CODEGEN}} EXTRA_CFLAGS="${{env.CLANG_GCC_PIN}}" EXTRA_LDFLAGS="${{env.CLANG_GCC_PIN}}"
 
       - name: Collect Timings

--- a/.github/workflows/matrix/ubuntu-x64-full-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-full-config.json
@@ -81,26 +81,6 @@
       "upload_release": "OFF"
     },
     {
-      "os": "ubuntu24",
-      "config": "Release",
-      "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-16",
-      "c-compiler": "/usr/bin/gcc-16",
-      "cxx-standard": 23,
-      "build_mrcuda": "OFF",
-      "upload_release": "OFF"
-    },
-    {
-      "os": "ubuntu24",
-      "config": "Debug",
-      "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-16",
-      "c-compiler": "/usr/bin/gcc-16",
-      "cxx-standard": 23,
-      "build_mrcuda": "OFF",
-      "upload_release": "OFF"
-    },
-    {
       "os": "ubuntu26",
       "config": "Release",
       "compiler": "Clang",
@@ -138,6 +118,26 @@
       "c-compiler": "/usr/bin/gcc-15",
       "cxx-standard": 23,
       "build_mrcuda": "ON",
+      "upload_release": "OFF"
+    },
+    {
+      "os": "ubuntu26",
+      "config": "Release",
+      "compiler": "GCC",
+      "cxx-compiler": "/usr/bin/g++-16",
+      "c-compiler": "/usr/bin/gcc-16",
+      "cxx-standard": 23,
+      "build_mrcuda": "OFF",
+      "upload_release": "OFF"
+    },
+    {
+      "os": "ubuntu26",
+      "config": "Debug",
+      "compiler": "GCC",
+      "cxx-compiler": "/usr/bin/g++-16",
+      "c-compiler": "/usr/bin/gcc-16",
+      "cxx-standard": 23,
+      "build_mrcuda": "OFF",
       "upload_release": "OFF"
     }
   ]

--- a/.github/workflows/matrix/ubuntu-x64-minimal-config.json
+++ b/.github/workflows/matrix/ubuntu-x64-minimal-config.json
@@ -21,16 +21,6 @@
       "upload_release": "ON"
     },
     {
-      "os": "ubuntu24",
-      "config": "Release",
-      "compiler": "GCC",
-      "cxx-compiler": "/usr/bin/g++-16",
-      "c-compiler": "/usr/bin/gcc-16",
-      "cxx-standard": 23,
-      "build_mrcuda": "OFF",
-      "upload_release": "OFF"
-    },
-    {
       "os": "ubuntu26",
       "config": "Release",
       "compiler": "GCC",
@@ -39,6 +29,16 @@
       "cxx-standard": 23,
       "build_mrcuda": "ON",
       "upload_release": "ON"
+    },
+    {
+      "os": "ubuntu26",
+      "config": "Release",
+      "compiler": "GCC",
+      "cxx-compiler": "/usr/bin/g++-16",
+      "c-compiler": "/usr/bin/gcc-16",
+      "cxx-standard": 23,
+      "build_mrcuda": "OFF",
+      "upload_release": "OFF"
     }
   ]
 }

--- a/docker/ubuntu24Dockerfile
+++ b/docker/ubuntu24Dockerfile
@@ -49,16 +49,12 @@ RUN <<EOF
     wget "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/$ARCH/cuda-keyring_1.1-1_all.deb"
     dpkg -i cuda-keyring_1.1-1_all.deb
     rm cuda-keyring_1.1-1_all.deb
-    # configure Ubuntu Toolchain repo
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh gcc-13 g++-13 gcc-16 g++-16 \
+        gh gcc-13 g++-13 \
         cuda-minimal-build-12-6 \
         tzdata git sudo time xvfb curl unzip ninja-build patchelf gettext gawk procps
-    # the GCC 16 snapshot ships cc1/cc1plus/lto1 unstripped so ICEs get symbolized backtraces; costs ~640 MB
-    bash -c 'strip --strip-debug /usr/libexec/gcc/*/16/{cc1,cc1plus,lto1}'
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     # install toolchain

--- a/docker/ubuntu26Dockerfile
+++ b/docker/ubuntu26Dockerfile
@@ -52,10 +52,12 @@ RUN <<EOF
     # install packages
     apt-get update -qqy
     apt-get install -qqy --no-install-recommends \
-        gh gcc-15 g++-15 \
-        gfortran-15 $(: prevents libopenmpi-dev from installing GCC 16 ) \
+        gh gcc-15 g++-15 gcc-16 g++-16 \
+        gfortran-15 $(: prevents libopenmpi-dev from installing gfortran-16 too ) \
         cuda-minimal-build-13-3 \
         tzdata git sudo time xvfb curl unzip ninja-build patchelf gettext gawk procps
+    # the GCC 16 snapshot ships cc1/cc1plus/lto1 unstripped so ICEs get symbolized backtraces; costs ~640 MB
+    bash -c 'strip --strip-debug /usr/libexec/gcc/*/16/{cc1,cc1plus,lto1}'
     ./scripts/install_apt_requirements.sh
     bash -c 'touch /usr/bin/gdcm{anon,clean,conv,diff,dump,gendir,img,info,pap3,pdf,raw,scanner,scu,tar,xml}'
     # install toolchain


### PR DESCRIPTION
Ubuntu 26.04 (resolute) ships `gcc-16`/`g++-16` (`16-20260322-1ubuntu1`) in **universe**, so the GCC 16 coverage no longer has to come from an `ubuntu-toolchain-r/test` PPA snapshot on 24.04.

**Matrix** — the three GCC 16 cells (Release + Debug in the full config, Release in the minimal one) move from `ubuntu24` to `ubuntu26`. They keep `build_mrcuda: OFF`; CUDA 13.3's nvcc does not take GCC 16 as a host compiler.

**`docker/ubuntu26Dockerfile`** — `gcc-16 g++-16` added to the apt list. The distro package is a snapshot built the same way the PPA one was, so `cpp-16-x86-64-linux-gnu` is 248 MB installed against 37 MB for 15; the `strip --strip-debug` of `cc1`/`cc1plus`/`lto1` moves over with it.

**`docker/ubuntu24Dockerfile`** — `gcc-16 g++-16`, the strip line, and the `add-apt-repository ppa:ubuntu-toolchain-r/test` that existed only to supply them are all gone. The image is back to stock noble plus `gcc-13`, which also puts its `libstdc++6` back on the stock 24.04 one.

**`CLANG_GCC_PIN`** (both the x64 and arm64 build workflows) moves with the compiler. mrbind always compiles with `clang++`, which picks the newest GCC install dir in the image:

* `ubuntu24` now has only GCC 13, so the pin there is a no-op and is dropped.
* `ubuntu26` now has 16 alongside the 15 the deb is built with, so it gets the pin instead - `--gcc-install-dir=/usr/lib/gcc/<triple>/15`. This keeps the ubuntu26 bindings byte-for-byte in the same configuration they are in today.

Labelled `full-ci` so the Debug GCC 16 cell runs too, and the platforms this cannot affect are disabled. Note that touching `docker/` rebuilds every Linux image, so the first run is slow.
