### PR TITLE
macos_bundle_dylibs: do not require Python 3.9

### DIFF
--- a/scripts/macos_bundle_dylibs.py
+++ b/scripts/macos_bundle_dylibs.py
@@ -140,6 +140,15 @@ def is_macho(p: Path) -> bool:
         return False
 
 
+def is_under(p: Path, d: Path) -> bool:
+    # Path.is_relative_to needs Python 3.9; the macOS runners' python3 varies.
+    try:
+        p.relative_to(d)
+    except ValueError:
+        return False
+    return True
+
+
 def collect_machos(root: Path) -> list[Path]:
     if not root.exists():
         return []
@@ -212,7 +221,7 @@ def _rpath_for(p: Path, dest_dir: Path, exe_dirs: list[Path]) -> str:
     @loader_path for the dylibs, so they resolve whichever process loads them.
     """
     anchor = "@executable_path" if any(
-        p.is_relative_to(d) for d in exe_dirs
+        is_under(p, d) for d in exe_dirs
     ) else "@loader_path"
     rel = Path(os.path.relpath(dest_dir, p.parent)).as_posix()
     return f"{anchor}/{rel}"
@@ -320,7 +329,7 @@ def bundle(
     for p in all_files:
         make_writable(p)
         sp = str(p)
-        is_dylib = p.suffix == ".dylib" or p.is_relative_to(lib_dir)
+        is_dylib = p.suffix == ".dylib" or is_under(p, lib_dir)
         if is_dylib:
             set_install_id(sp, f"@rpath/{p.name}", ad_hoc_sign=False)
 
@@ -347,7 +356,7 @@ def bundle(
         # Signing a bundle's main executable signs the whole bundle and fails
         # on nested items it does not consider code; those callers sign the
         # bundle as a unit themselves.
-        if sign_exes or not any(p.is_relative_to(d) for d in exe_dirs):
+        if sign_exes or not any(is_under(p, d) for d in exe_dirs):
             codesign_adhoc(p)
 
     log(f"bundled {len(bundled)} dylibs into {lib_dir}")


### PR DESCRIPTION
## Summary

Replaces the three `Path.is_relative_to` calls with a small `is_under()` helper, so the script runs under any `python3` rather than requiring 3.9+.

## Why

The script is invoked as `python3 scripts/macos_bundle_dylibs.py ...`, so it runs under whatever `python3` the caller happens to have. That varies across the macOS runners: on the x64 one, `python3` predates 3.9 and the script dies with

```
is_dylib = p.suffix == ".dylib" or p.is_relative_to(lib_dir)
AttributeError: 'PosixPath' object has no attribute 'is_relative_to'
```

while arm64 passes. Both runners do have a 3.10 from Homebrew, just not as `python3`.

This has been latent since `is_relative_to` was introduced here; nothing hit it because MeshLib's own `distribution_apple.sh` runs on a runner whose `python3` is new enough. It surfaced in `MeshInspector/MeshInspectorCode#7789`, which calls this script to bundle a `.app`.

The alternative was to pin the caller to a specific interpreter, which pushes a version requirement onto everything that uses the script. `relative_to` plus `try/except ValueError` is the pre-3.9 idiom and requires nothing.

## Test plan

- [ ] macOS builds and the `.pkg` job pass — `scripts/distribution_apple.sh` runs this script, so the framework layout is covered here.
- [ ] The `.app` layout is verified downstream in `MeshInspector/MeshInspectorCode#7789`, which drops its interpreter workaround once this lands.

`_rpath_for` and `is_under` were exercised locally against both layouts, including the two framework cases whose rpaths must not change.
