### PR TITLE
Add Object::constChildren(), deprecate the UB children() const

### DIFF
--- a/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
+++ b/source/MRCommonPlugins/ViewerButtons/MRIOFilesMenuItems.cpp
@@ -134,7 +134,7 @@ Json::Value prepareJsonObjHierarchyRecursive( const MR::Object& obj )
 {
     Json::Value root;
     root["Name"] = obj.name();
-    for (const auto& child : obj.children())
+    for (const auto& child : obj.constChildren())
     {
         root["Children"].append( prepareJsonObjHierarchyRecursive( *child ) );
     }

--- a/source/MRIOExtras/MRGltf.cpp
+++ b/source/MRIOExtras/MRGltf.cpp
@@ -608,12 +608,12 @@ Expected<void> serializeObjectTreeToGltf( const Object& root, const std::filesys
     if ( !reportProgress( settings.progress, 0.1f ) )
         return unexpectedOperationCanceled();
 
-    for ( size_t childIndex = 0; childIndex < root.children().size(); ++childIndex )
+    for ( size_t childIndex = 0; childIndex < root.constChildren().size(); ++childIndex )
     {
-        if ( root.children()[childIndex]->isAncillary() )
+        if ( root.constChildren()[childIndex]->isAncillary() )
             continue;
 
-        objectStack.push( root.children()[childIndex] );
+        objectStack.push( root.constChildren()[childIndex] );
         size_t lastIndex = model.nodes.size();
         indexStack.push( lastIndex );
         model.scenes[0].nodes.push_back( int( lastIndex ) );
@@ -731,7 +731,7 @@ Expected<void> serializeObjectTreeToGltf( const Object& root, const std::filesys
                 }
             }
 
-            for ( auto child : curObj->children() )
+            for ( auto child : curObj->constChildren() )
             {
                 if ( child->isAncillary() )
                     continue;
@@ -742,7 +742,7 @@ Expected<void> serializeObjectTreeToGltf( const Object& root, const std::filesys
             }
         }
 
-        if ( !reportProgress( settings.progress, 0.1f + 0.7f * childIndex / root.children().size() ) )
+        if ( !reportProgress( settings.progress, 0.1f + 0.7f * childIndex / root.constChildren().size() ) )
             return unexpectedOperationCanceled();
     }
 

--- a/source/MRMesh/MRConstChildren.h
+++ b/source/MRMesh/MRConstChildren.h
@@ -37,20 +37,23 @@ public:
     class MR_BIND_IGNORE_PY Iterator
     {
     public:
+        /// dereference produces a prvalue, so the C++17 category can only be input,
+        /// but the iterator is multi-pass and models std::forward_iterator
+        using iterator_concept = std::forward_iterator_tag;
         using iterator_category = std::input_iterator_tag;
         using value_type = std::shared_ptr<const Object>;
         using difference_type = std::ptrdiff_t;
 
-        Iterator() = default;
+        Iterator() {}
         explicit Iterator( Storage::const_iterator it ) : it_( it ) {}
 
         [[nodiscard]] value_type operator *() const { return *it_; }
         Iterator & operator ++() { ++it_; return *this; }
         Iterator operator ++( int ) { auto res = *this; ++it_; return res; }
-        [[nodiscard]] friend bool operator ==( const Iterator & a, const Iterator & b ) { return a.it_ == b.it_; }
+        [[nodiscard]] bool operator ==( const Iterator & ) const = default;
 
     private:
-        Storage::const_iterator it_;
+        Storage::const_iterator it_{};
     };
 
     explicit ConstChildren( const Storage & children ) : children_( children ) {}

--- a/source/MRMesh/MRConstChildren.h
+++ b/source/MRMesh/MRConstChildren.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "MRPch/MRBindingMacros.h"
+#include "MRMeshFwd.h"
+
+#include <iterator>
+#include <memory>
+#include <vector>
+
+namespace MR
+{
+
+/// read-only access to the children of an Object, as returned by Object::constChildren()
+///
+/// Object stores its children as std::shared_ptr<Object>, and a const Object cannot hand
+/// them out directly without either dropping constness or copying the whole vector.
+/// This class solves that: it is a lightweight non-owning view on the object's children,
+/// which produces std::shared_ptr<const Object> on the fly. Typical use:
+///
+///     for ( const auto & child : obj.constChildren() )
+///         processRecursively( *child );
+///
+/// It is also indexable, so a plain loop works too:
+///
+///     for ( size_t i = 0; i < obj.constChildren().size(); ++i )
+///         process( *obj.constChildren()[i] );
+///
+/// The view refers to the object's own storage, so use it as a temporary and do not store
+/// it: it is invalidated by anything that adds, removes or reorders the object's children,
+/// exactly like an iterator of the underlying vector.
+class ConstChildren
+{
+public:
+    using Storage = std::vector<std::shared_ptr<Object>>;
+
+    /// dereferences to std::shared_ptr<const Object>, constructed on each dereference
+    class MR_BIND_IGNORE_PY Iterator
+    {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = std::shared_ptr<const Object>;
+        using difference_type = std::ptrdiff_t;
+
+        Iterator() = default;
+        explicit Iterator( Storage::const_iterator it ) : it_( it ) {}
+
+        [[nodiscard]] value_type operator *() const { return *it_; }
+        Iterator & operator ++() { ++it_; return *this; }
+        Iterator operator ++( int ) { auto res = *this; ++it_; return res; }
+        [[nodiscard]] friend bool operator ==( const Iterator & a, const Iterator & b ) { return a.it_ == b.it_; }
+
+    private:
+        Storage::const_iterator it_;
+    };
+
+    explicit ConstChildren( const Storage & children ) : children_( children ) {}
+
+    [[nodiscard]] MR_BIND_IGNORE_PY Iterator begin() const { return Iterator( children_.begin() ); }
+    [[nodiscard]] MR_BIND_IGNORE_PY Iterator end() const { return Iterator( children_.end() ); }
+
+    [[nodiscard]] bool empty() const { return children_.empty(); }
+    [[nodiscard]] size_t size() const { return children_.size(); }
+    [[nodiscard]] std::shared_ptr<const Object> operator []( size_t i ) const { return children_[i]; }
+
+private:
+    const Storage & children_;
+};
+
+} //namespace MR

--- a/source/MRMesh/MRMesh.vcxproj
+++ b/source/MRMesh/MRMesh.vcxproj
@@ -463,6 +463,7 @@
     <ClInclude Include="MRPointsLoadSettings.h" />
     <ClInclude Include="MRScopedValue.h" />
     <ClInclude Include="MRChunkIterator.h" />
+    <ClInclude Include="MRConstChildren.h" />
     <ClInclude Include="MRTbbThreadMutex.h" />
     <ClInclude Include="MRInplaceStack.h" />
     <ClInclude Include="MROffsetVerts.h" />

--- a/source/MRMesh/MRMeshOrPoints.cpp
+++ b/source/MRMesh/MRMeshOrPoints.cpp
@@ -275,7 +275,7 @@ MeshOrPoints::ProjectionResult projectWorldPointOntoObjectsRecursive(
 
         if ( !recursePred || recursePred( cur ) )
         {
-            for ( const auto& child : cur.children() )
+            for ( const auto& child : cur.constChildren() )
                 lambda( lambda, *child );
         }
     };

--- a/source/MRMesh/MRObject.cpp
+++ b/source/MRMesh/MRObject.cpp
@@ -95,7 +95,7 @@ int collectLinks( const Object& rootObject, Obj2FirstSharedObj& links )
             // map current object to first met object
             links.insert( { node, { it->object, numFile } } );
         }
-        auto children = node->children();
+        auto children = node->constChildren();
         for ( int i = int( children.size() ) - 1; i >= 0; --i )
         {
             sceneGraphVisitedList.push( children[i].get() );

--- a/source/MRMesh/MRObject.cpp
+++ b/source/MRMesh/MRObject.cpp
@@ -12,6 +12,8 @@
 namespace MR
 {
 
+static_assert( std::forward_iterator<ConstChildren::Iterator> );
+
 namespace
 {
 

--- a/source/MRMesh/MRObject.h
+++ b/source/MRMesh/MRObject.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "MRPch/MRBindingMacros.h"
 #include "MRAffineXf3.h"
+#include "MRConstChildren.h"
 #include "MRExpected.h"
 #include "MRProgressCallback.h"
 #include "MRSignal.h"
@@ -10,7 +10,6 @@
 #include <array>
 #include <filesystem>
 #include <future>
-#include <iterator>
 #include <memory>
 #include <set>
 #include <vector>
@@ -28,44 +27,6 @@ namespace MR
  * \brief This chapter represents documentation about data models
  * \{
  */
-
-/// read-only access to the children of an Object, see Object::constChildren()
-class ConstChildren
-{
-public:
-    using Storage = std::vector<std::shared_ptr<Object>>;
-
-    class MR_BIND_IGNORE_PY Iterator
-    {
-    public:
-        using iterator_category = std::input_iterator_tag;
-        using value_type = std::shared_ptr<const Object>;
-        using difference_type = std::ptrdiff_t;
-
-        Iterator() = default;
-        explicit Iterator( Storage::const_iterator it ) : it_( it ) {}
-
-        [[nodiscard]] value_type operator *() const { return *it_; }
-        Iterator & operator ++() { ++it_; return *this; }
-        Iterator operator ++( int ) { auto res = *this; ++it_; return res; }
-        [[nodiscard]] friend bool operator ==( const Iterator & a, const Iterator & b ) { return a.it_ == b.it_; }
-
-    private:
-        Storage::const_iterator it_;
-    };
-
-    explicit ConstChildren( const Storage & children ) : children_( children ) {}
-
-    [[nodiscard]] MR_BIND_IGNORE_PY Iterator begin() const { return Iterator( children_.begin() ); }
-    [[nodiscard]] MR_BIND_IGNORE_PY Iterator end() const { return Iterator( children_.end() ); }
-
-    [[nodiscard]] bool empty() const { return children_.empty(); }
-    [[nodiscard]] size_t size() const { return children_.size(); }
-    [[nodiscard]] std::shared_ptr<const Object> operator []( size_t i ) const { return children_[i]; }
-
-private:
-    const Storage & children_;
-};
 
 /// the main purpose of this class is to avoid copy and move constructor and assignment operator
 /// implementation in Object class, which has too many fields for that;

--- a/source/MRMesh/MRObject.h
+++ b/source/MRMesh/MRObject.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "MRPch/MRBindingMacros.h"
 #include "MRAffineXf3.h"
 #include "MRExpected.h"
 #include "MRProgressCallback.h"
@@ -9,6 +10,7 @@
 #include <array>
 #include <filesystem>
 #include <future>
+#include <iterator>
 #include <memory>
 #include <set>
 #include <vector>
@@ -26,6 +28,44 @@ namespace MR
  * \brief This chapter represents documentation about data models
  * \{
  */
+
+/// read-only access to the children of an Object, see Object::constChildren()
+class ConstChildren
+{
+public:
+    using Storage = std::vector<std::shared_ptr<Object>>;
+
+    class MR_BIND_IGNORE_PY Iterator
+    {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = std::shared_ptr<const Object>;
+        using difference_type = std::ptrdiff_t;
+
+        Iterator() = default;
+        explicit Iterator( Storage::const_iterator it ) : it_( it ) {}
+
+        [[nodiscard]] value_type operator *() const { return *it_; }
+        Iterator & operator ++() { ++it_; return *this; }
+        Iterator operator ++( int ) { auto res = *this; ++it_; return res; }
+        [[nodiscard]] friend bool operator ==( const Iterator & a, const Iterator & b ) { return a.it_ == b.it_; }
+
+    private:
+        Storage::const_iterator it_;
+    };
+
+    explicit ConstChildren( const Storage & children ) : children_( children ) {}
+
+    [[nodiscard]] MR_BIND_IGNORE_PY Iterator begin() const { return Iterator( children_.begin() ); }
+    [[nodiscard]] MR_BIND_IGNORE_PY Iterator end() const { return Iterator( children_.end() ); }
+
+    [[nodiscard]] bool empty() const { return children_.empty(); }
+    [[nodiscard]] size_t size() const { return children_.size(); }
+    [[nodiscard]] std::shared_ptr<const Object> operator []( size_t i ) const { return children_[i]; }
+
+private:
+    const Storage & children_;
+};
 
 /// the main purpose of this class is to avoid copy and move constructor and assignment operator
 /// implementation in Object class, which has too many fields for that;
@@ -158,10 +198,16 @@ public:
     /// an object can hold other sub-objects
     const std::vector<std::shared_ptr<Object>>& children() { return children_; }
 
+    /// the same sub-objects without the ability to modify them; the returned view is
+    /// invalidated by anything that changes the children of this object
+    [[nodiscard]] ConstChildren constChildren() const { return ConstChildren( children_ ); }
+
     #ifdef __GNUC__
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wstrict-aliasing" // Fingers crossed.
     #endif
+    /// \deprecated the cast inside is undefined behaviour, use constChildren() instead
+    [[deprecated( "use constChildren() instead" )]]
     const std::vector<std::shared_ptr<const Object>>& children() const { return reinterpret_cast<const std::vector< std::shared_ptr< const Object > > &>( children_ ); }
     #ifdef __GNUC__
     #pragma GCC diagnostic pop

--- a/source/MRMesh/MRObjectsAccess.h
+++ b/source/MRMesh/MRObjectsAccess.h
@@ -62,7 +62,7 @@ MR_BIND_IGNORE inline std::shared_ptr<ObjectT> getDepthFirstObject( Object& root
 /// \param recurse - if true, look up for selectable children at any depth
 inline bool objectHasSelectableChildren( const MR::Object& object, bool recurse = false )
 {
-    for ( const auto& child : object.children() )
+    for ( const auto& child : object.constChildren() )
     {
         if ( !child->isAncillary() || ( recurse && objectHasSelectableChildren( *child, recurse ) ) )
             return true;

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -1663,7 +1663,7 @@ static bool getRedrawFlagRecursive( const Object& obj, ViewportMask mask )
         return true;
     if ( !obj.isVisible( mask ) )
         return false;
-    for ( const auto& child : obj.children() )
+    for ( const auto& child : obj.constChildren() )
     {
         if ( getRedrawFlagRecursive( *child, mask ) )
             return true;
@@ -1674,7 +1674,7 @@ static bool getRedrawFlagRecursive( const Object& obj, ViewportMask mask )
 static void resetRedrawFlagRecursive( const Object& obj )
 {
     obj.resetRedrawFlag();
-    for ( const auto& child : obj.children() )
+    for ( const auto& child : obj.constChildren() )
         resetRedrawFlagRecursive( *child );
 }
 

--- a/source/MRViewer/MRViewportDraw.cpp
+++ b/source/MRViewer/MRViewportDraw.cpp
@@ -24,7 +24,7 @@ void Viewport::recursiveDraw( const Object& obj, DepthFunction depthFunc, const 
                 ++( *numDraws );
         }
     }
-    for ( const auto& child : obj.children() )
+    for ( const auto& child : obj.constChildren() )
         recursiveDraw( *child, depthFunc, xfCopy, renderType, transparentMode, numDraws );
 }
 


### PR DESCRIPTION
`Object::children() const` returns

```cpp
return reinterpret_cast<const std::vector< std::shared_ptr< const Object > > &>( children_ );
```

`std::vector<std::shared_ptr<Object>>` and `std::vector<std::shared_ptr<const Object>>` are unrelated types, so this is a strict-aliasing violation - undefined behaviour that happens to work only because the two have identical layout - and it needs a `#pragma GCC diagnostic ignored "-Wstrict-aliasing"` block, commented "Fingers crossed." This is the same pattern as the model getters removed in #6820, one level up.

This PR marks it `[[deprecated]]` and adds

```cpp
[[nodiscard]] ConstChildren constChildren() const { return ConstChildren( children_ ); }
```

`ConstChildren` lives in the new `MRConstChildren.h` and is a small non-owning view over the same `children_` vector, documented there with its intended use and its lifetime rule. It has `begin()` / `end()` yielding `std::shared_ptr<const Object>` by value, plus `size()`, `empty()` and `operator[]` so that the existing call sites port over unchanged in shape. The iterator follows the `SetBitIteratorT` precedent in `MRBitSet.h` and is `MR_BIND_IGNORE_PY`.

Naming: the description suggested `childrenConst()`. I went with `constChildren()` because MeshLib already marks the variant with a prefix rather than a suffix - `varMesh()` / `mesh()`, `varPointCloud()` / `pointCloud()` - and because it reads as English at the call site. Happy to rename.

All eleven internal users of the const overload are switched. The only behaviour change is in `collectLinks()`, where `auto children = node->children()` used to copy the whole vector and now takes the view instead; nothing there mutates the tree while iterating.

Verified locally with MSVC `cl /Zs` and `/we4996`, i.e. any remaining use of the deprecated overload is a compile error: MRMesh (305 TUs), MRViewer (153), MRVoxels (37), mrviewerpy (3) and the remaining 166 TUs under `source/` are clean apart from the sweep's own known artifacts.
