### PR TITLE
Scene tree: groups open by default, collapse only on file load

### DIFF
--- a/source/MRViewer/MRRibbonSceneObjectsListDrawer.cpp
+++ b/source/MRViewer/MRRibbonSceneObjectsListDrawer.cpp
@@ -217,7 +217,7 @@ bool RibbonSceneObjectsListDrawer::drawTreeOpenedState_( Object& object, bool le
 
     const ImGuiTreeNodeFlags flags =
         ImGuiTreeNodeFlags_AllowOverlap |
-        ( !leaf ? ImGuiTreeNodeFlags_DefaultOpen : ImGuiTreeNodeFlags_Bullet );
+        ( !leaf ? sDefaultGroupState : ImGuiTreeNodeFlags_Bullet );
 
 
     auto startScreenPos = ImGui::GetCursorScreenPos();

--- a/source/MRViewer/MRRibbonSceneObjectsListDrawer.cpp
+++ b/source/MRViewer/MRRibbonSceneObjectsListDrawer.cpp
@@ -217,7 +217,7 @@ bool RibbonSceneObjectsListDrawer::drawTreeOpenedState_( Object& object, bool le
 
     const ImGuiTreeNodeFlags flags =
         ImGuiTreeNodeFlags_AllowOverlap |
-        ( !leaf ? sDefaultGroupState : ImGuiTreeNodeFlags_Bullet );
+        ( !leaf ? ImGuiTreeNodeFlags_DefaultOpen : ImGuiTreeNodeFlags_Bullet );
 
 
     auto startScreenPos = ImGui::GetCursorScreenPos();

--- a/source/MRViewer/MRSceneObjectsListDrawer.cpp
+++ b/source/MRViewer/MRSceneObjectsListDrawer.cpp
@@ -2,6 +2,7 @@
 #include "MRSceneCache.h"
 #include "MRViewer.h"
 #include "MRViewerInstance.h"
+#include "MRViewerSignals.h"
 #include "MRViewport.h"
 #include "MRUIStyle.h"
 #include "MRShowModal.h"
@@ -79,9 +80,19 @@ private:
 
 ////////////////////////////////////////////////////
 
+SceneObjectsListDrawer::SceneObjectsListDrawer()
+{
+    objectsLoadedConnection_ = getViewerInstance().signals().objectsLoadedSignal.connect(
+        [this] ( const std::vector<std::shared_ptr<Object>>& objs, const std::string&, const std::string& )
+    {
+        collapseObjectSubtrees( objs );
+    } );
+}
+
 void SceneObjectsListDrawer::draw( float height )
 {
     ImGui::BeginChild( "SceneObjectsList", ImVec2( -1, height ), ImGuiChildFlags_None );
+    applyCollapseRequests_();
     updateSceneWindowScrollIfNeeded_();
     drawObjectsList_();
     // any click on empty space below Scene Tree removes object selection
@@ -250,6 +261,35 @@ void SceneObjectsListDrawer::expandObjectTreeAndScroll( const Object* obj )
     const auto itAll = std::find( all.begin(), all.end(), obj->getSharedPtr() );
     nextVisible_.index = int( std::distance( all.begin(), itAll ) );
     setNextFrameFixScroll( 2 );
+}
+
+void SceneObjectsListDrawer::collapseObjectSubtrees( const std::vector<std::shared_ptr<Object>>& objs )
+{
+    collapseRequests_.insert( collapseRequests_.end(), objs.begin(), objs.end() );
+}
+
+void SceneObjectsListDrawer::applyCollapseRequests_()
+{
+    if ( collapseRequests_.empty() )
+        return;
+
+    auto* window = ImGui::GetCurrentWindow();
+    const auto collapse = [this, window] ( const Object& obj )
+    {
+        const auto uniqueStr = std::to_string( intptr_t( &obj ) );
+        ImGui::TreeNodeSetOpen( window->GetID( objectLineStrId_( obj, uniqueStr ).c_str() ), false );
+    };
+    for ( const auto& obj : collapseRequests_ )
+    {
+        if ( !obj )
+            continue;
+        collapse( *obj );
+        // the descendants are collapsed as well, since they are not necessarily drawn this frame,
+        // and would appear expanded when the user opens their parent
+        for ( const auto& child : getAllObjectsInTree( *obj, ObjectSelectivityType::Any ) )
+            collapse( *child );
+    }
+    collapseRequests_.clear();
 }
 
 void SceneObjectsListDrawer::allowSceneReorder( bool allow )
@@ -438,13 +478,13 @@ bool SceneObjectsListDrawer::drawSkippedObject_( Object& object, const std::stri
         ImGui::SetNextItemOpen( openCommandIt->second );
     }
     auto res = ImGui::TreeNodeUpdateNextOpen( ImGui::GetCurrentWindow()->GetID( objectLineStrId_( object, uniqueStr ).c_str() ),
-                    ( hasRealChildren ? sDefaultGroupState : 0 ) );
+                    ( hasRealChildren ? ImGuiTreeNodeFlags_DefaultOpen : 0 ) );
     if ( resetOpenFlag )
     {
         // as far as `TreeNodeUpdateNextOpen` uses `SetNextItemOpen` but does not clear it, we clear it manually
         auto ctx = ImGui::GetCurrentContext();
         ctx->NextItemData.HasFlags &= ~ImGuiNextItemDataFlags_HasOpen;
-        ctx->NextItemData.OpenVal = sDefaultGroupState;
+        ctx->NextItemData.OpenVal = false;
         ctx->NextItemData.OpenCond = ImGuiCond_None;
     }
     return res;
@@ -493,7 +533,7 @@ bool SceneObjectsListDrawer::drawObjectCollapsingHeader_( Object& object, const 
     const ImGuiTreeNodeFlags flags =
         ImGuiTreeNodeFlags_SpanAvailWidth |
         ImGuiTreeNodeFlags_Framed |
-        ( hasRealChildren ? ImGuiTreeNodeFlags_OpenOnArrow | sDefaultGroupState : ImGuiTreeNodeFlags_Bullet ) |
+        ( hasRealChildren ? ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_DefaultOpen : ImGuiTreeNodeFlags_Bullet ) |
         ( isSelected ? ImGuiTreeNodeFlags_Selected : 0 );
 
     const bool isOpen = collapsingHeader_( objectLineStrId_( object, uniqueStr ).c_str(), flags );

--- a/source/MRViewer/MRSceneObjectsListDrawer.cpp
+++ b/source/MRViewer/MRSceneObjectsListDrawer.cpp
@@ -24,6 +24,8 @@
 namespace MR
 {
 
+static_assert( sDefaultGroupState == ImGuiTreeNodeFlags_DefaultOpen );
+
 // helper class to optimaze render (skip elements outside draw area)
 class SkippableRenderer
 {
@@ -460,7 +462,7 @@ bool SceneObjectsListDrawer::drawSkippedObject_( Object& object, const std::stri
         ImGui::SetNextItemOpen( openCommandIt->second );
     }
     auto res = ImGui::TreeNodeUpdateNextOpen( ImGui::GetCurrentWindow()->GetID( objectLineStrId_( object, uniqueStr ).c_str() ),
-                    ( hasRealChildren ? ImGuiTreeNodeFlags_DefaultOpen : 0 ) );
+                    ( hasRealChildren ? sDefaultGroupState : 0 ) );
     if ( resetOpenFlag )
     {
         // as far as `TreeNodeUpdateNextOpen` uses `SetNextItemOpen` but does not clear it, we clear it manually
@@ -515,7 +517,7 @@ bool SceneObjectsListDrawer::drawObjectCollapsingHeader_( Object& object, const 
     const ImGuiTreeNodeFlags flags =
         ImGuiTreeNodeFlags_SpanAvailWidth |
         ImGuiTreeNodeFlags_Framed |
-        ( hasRealChildren ? ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_DefaultOpen : ImGuiTreeNodeFlags_Bullet ) |
+        ( hasRealChildren ? ImGuiTreeNodeFlags_OpenOnArrow | sDefaultGroupState : ImGuiTreeNodeFlags_Bullet ) |
         ( isSelected ? ImGuiTreeNodeFlags_Selected : 0 );
 
     const bool isOpen = collapsingHeader_( objectLineStrId_( object, uniqueStr ).c_str(), flags );

--- a/source/MRViewer/MRSceneObjectsListDrawer.cpp
+++ b/source/MRViewer/MRSceneObjectsListDrawer.cpp
@@ -2,7 +2,6 @@
 #include "MRSceneCache.h"
 #include "MRViewer.h"
 #include "MRViewerInstance.h"
-#include "MRViewerSignals.h"
 #include "MRViewport.h"
 #include "MRUIStyle.h"
 #include "MRShowModal.h"
@@ -80,19 +79,10 @@ private:
 
 ////////////////////////////////////////////////////
 
-SceneObjectsListDrawer::SceneObjectsListDrawer()
-{
-    objectsLoadedConnection_ = getViewerInstance().signals().objectsLoadedSignal.connect(
-        [this] ( const std::vector<std::shared_ptr<Object>>& objs, const std::string&, const std::string& )
-    {
-        collapseObjectSubtrees( objs );
-    } );
-}
-
 void SceneObjectsListDrawer::draw( float height )
 {
     ImGui::BeginChild( "SceneObjectsList", ImVec2( -1, height ), ImGuiChildFlags_None );
-    applyCollapseRequests_();
+    applyCollapseSceneTree_();
     updateSceneWindowScrollIfNeeded_();
     drawObjectsList_();
     // any click on empty space below Scene Tree removes object selection
@@ -263,33 +253,25 @@ void SceneObjectsListDrawer::expandObjectTreeAndScroll( const Object* obj )
     setNextFrameFixScroll( 2 );
 }
 
-void SceneObjectsListDrawer::collapseObjectSubtrees( const std::vector<std::shared_ptr<Object>>& objs )
+void SceneObjectsListDrawer::collapseSceneTree()
 {
-    collapseRequests_.insert( collapseRequests_.end(), objs.begin(), objs.end() );
+    collapseSceneTreeRequested_ = true;
 }
 
-void SceneObjectsListDrawer::applyCollapseRequests_()
+void SceneObjectsListDrawer::applyCollapseSceneTree_()
 {
-    if ( collapseRequests_.empty() )
+    if ( !collapseSceneTreeRequested_ )
         return;
+    collapseSceneTreeRequested_ = false;
 
     auto* window = ImGui::GetCurrentWindow();
-    const auto collapse = [this, window] ( const Object& obj )
+    // every object is collapsed, not only the visible ones: objects below a closed header are not drawn at all,
+    // and would open by default flag once the user expands their parent
+    for ( const auto& obj : getAllObjectsInTree( SceneRoot::get(), ObjectSelectivityType::Any ) )
     {
-        const auto uniqueStr = std::to_string( intptr_t( &obj ) );
-        ImGui::TreeNodeSetOpen( window->GetID( objectLineStrId_( obj, uniqueStr ).c_str() ), false );
-    };
-    for ( const auto& obj : collapseRequests_ )
-    {
-        if ( !obj )
-            continue;
-        collapse( *obj );
-        // the descendants are collapsed as well, since they are not necessarily drawn this frame,
-        // and would appear expanded when the user opens their parent
-        for ( const auto& child : getAllObjectsInTree( *obj, ObjectSelectivityType::Any ) )
-            collapse( *child );
+        const auto uniqueStr = std::to_string( intptr_t( obj.get() ) );
+        ImGui::TreeNodeSetOpen( window->GetID( objectLineStrId_( *obj, uniqueStr ).c_str() ), false );
     }
-    collapseRequests_.clear();
 }
 
 void SceneObjectsListDrawer::allowSceneReorder( bool allow )

--- a/source/MRViewer/MRSceneObjectsListDrawer.h
+++ b/source/MRViewer/MRSceneObjectsListDrawer.h
@@ -2,9 +2,11 @@
 
 #include "exports.h"
 #include "MRSceneReorder.h"
+#include <boost/signals2/connection.hpp>
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace MR
 {
@@ -15,6 +17,7 @@ class Object;
 class MRVIEWER_CLASS SceneObjectsListDrawer
 {
 public:
+    MRVIEWER_API SceneObjectsListDrawer();
     virtual ~SceneObjectsListDrawer() = default;
 
     /// Main method for drawing all
@@ -50,6 +53,10 @@ public:
 
     /// expands all `obj`s parents in tree and scroll scene tree window so selection becomes visible
     MRVIEWER_API void expandObjectTreeAndScroll( const Object* obj );
+
+    /// collapses given objects and all their descendants, the tree is updated during the next draw;
+    /// this is called on file loading, where deep hierarchies (e.g. of STEP files) would otherwise flood the tree
+    MRVIEWER_API void collapseObjectSubtrees( const std::vector<std::shared_ptr<Object>>& objs );
 
     /// set possibility change object order
     MRVIEWER_API void allowSceneReorder( bool allow );
@@ -149,10 +156,15 @@ private:
     // dragging either just started, or just stopped
     bool dragModeTrigger_{ false };
 
+    /// applies and clears collapseRequests_; must be called inside the scene tree window
+    void applyCollapseRequests_();
+
+    // subtrees to collapse on the next draw, see collapseObjectSubtrees()
+    std::vector<std::shared_ptr<Object>> collapseRequests_;
+    boost::signals2::scoped_connection objectsLoadedConnection_;
+
 protected:
     std::unordered_map<const Object*, bool> sceneOpenCommands_;
 };
-
-constexpr inline int sDefaultGroupState = 0; // 0 means closed; the other option is ImGuiTreeNodeFlags_DefaultOpen
 
 } //namespace MR

--- a/source/MRViewer/MRSceneObjectsListDrawer.h
+++ b/source/MRViewer/MRSceneObjectsListDrawer.h
@@ -2,11 +2,9 @@
 
 #include "exports.h"
 #include "MRSceneReorder.h"
-#include <boost/signals2/connection.hpp>
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 namespace MR
 {
@@ -17,7 +15,6 @@ class Object;
 class MRVIEWER_CLASS SceneObjectsListDrawer
 {
 public:
-    MRVIEWER_API SceneObjectsListDrawer();
     virtual ~SceneObjectsListDrawer() = default;
 
     /// Main method for drawing all
@@ -54,9 +51,9 @@ public:
     /// expands all `obj`s parents in tree and scroll scene tree window so selection becomes visible
     MRVIEWER_API void expandObjectTreeAndScroll( const Object* obj );
 
-    /// collapses given objects and all their descendants, the tree is updated during the next draw;
-    /// this is called on file loading, where deep hierarchies (e.g. of STEP files) would otherwise flood the tree
-    MRVIEWER_API void collapseObjectSubtrees( const std::vector<std::shared_ptr<Object>>& objs );
+    /// collapses every group of the scene tree during the next draw;
+    /// this is called when a scene is opened from a file, where deep hierarchies (e.g. of STEP files) would otherwise flood the tree
+    MRVIEWER_API void collapseSceneTree();
 
     /// set possibility change object order
     MRVIEWER_API void allowSceneReorder( bool allow );
@@ -156,12 +153,11 @@ private:
     // dragging either just started, or just stopped
     bool dragModeTrigger_{ false };
 
-    /// applies and clears collapseRequests_; must be called inside the scene tree window
-    void applyCollapseRequests_();
+    /// applies and resets collapseSceneTreeRequested_; must be called inside the scene tree window
+    void applyCollapseSceneTree_();
 
-    // subtrees to collapse on the next draw, see collapseObjectSubtrees()
-    std::vector<std::shared_ptr<Object>> collapseRequests_;
-    boost::signals2::scoped_connection objectsLoadedConnection_;
+    // see collapseSceneTree()
+    bool collapseSceneTreeRequested_ = false;
 
 protected:
     std::unordered_map<const Object*, bool> sceneOpenCommands_;

--- a/source/MRViewer/MRSceneObjectsListDrawer.h
+++ b/source/MRViewer/MRSceneObjectsListDrawer.h
@@ -163,4 +163,7 @@ protected:
     std::unordered_map<const Object*, bool> sceneOpenCommands_;
 };
 
+// ImGuiTreeNodeFlags_DefaultOpen; the value is spelled out not to include imgui.h here, see the static_assert in the .cpp
+constexpr inline int sDefaultGroupState = 1 << 5;
+
 } //namespace MR

--- a/source/MRViewer/MRViewer.cpp
+++ b/source/MRViewer/MRViewer.cpp
@@ -13,6 +13,7 @@
 #include "MRViewerSettingsManager.h"
 #include "MRGladGlfw.h"
 #include "MRRibbonMenu.h"
+#include "MRSceneObjectsListDrawer.h"
 #include "MRGetSystemInfoJson.h"
 #include "MRSpaceMouseHandler.h"
 #include "MRDragDropHandler.h"
@@ -1320,6 +1321,9 @@ bool Viewer::loadFiles( const std::vector<std::filesystem::path>& filesList, con
                     setSceneDirty();
                     onSceneSaved( result.loadedFiles.front() );
                 }
+                if ( menuPlugin_ )
+                    if ( const auto & sceneList = menuPlugin_->getSceneObjectsList() )
+                        sceneList->collapseSceneTree();
                 if ( options.loadedCallback ) // strictly after history is added
                     options.loadedCallback( SceneRoot::get().children(), result.errorSummary, result.warningSummary );
                 signals_->objectsLoadedSignal( SceneRoot::get().children(), result.errorSummary, result.warningSummary );


### PR DESCRIPTION
Scene tree groups are expanded by default again, and the auto-collapse happens only when a scene is opened from a file.

Since #5262 `sDefaultGroupState` was 0 (closed), so *every* group that appeared in the tree for the first time was collapsed — not only the ones coming from an import. Any object created by a tool, and every subfolder revealed by expanding its parent, came in closed, which made working with an existing scene tedious. The collapse-on-import behaviour, originally asked for to keep deep STEP hierarchies readable, is kept, but is now triggered explicitly by the load path.

- `sDefaultGroupState` is now `ImGuiTreeNodeFlags_DefaultOpen`. The value is spelled out as `1 << 5` because that header deliberately avoids including imgui.h; a `static_assert` in the .cpp guards it.
- `SceneObjectsListDrawer::collapseSceneTree()` raises a flag that the next `draw()` applies inside the scene tree child window with `ImGui::TreeNodeSetOpen`.
- `Viewer::loadFiles` calls it in the branch that replaces the scene with the one taken from the file, right after the root swap.

All objects of the scene are collapsed, not just the ones drawn in that frame: objects below a closed header are never drawn, so seeding their state only when they become visible would be too late — they would already be expanded by the default flag.

Verified with `cl /Zs /W4` on the three changed translation units.
