### PR TITLE
Drop the Python bindings from the .deb and the Windows archive

### DIFF
--- a/.github/workflows/test-distribution.yml
+++ b/.github/workflows/test-distribution.yml
@@ -141,12 +141,6 @@ jobs:
           cmake --build build
           ./build/MeshModification
 
-      - name: Ubuntu python test
-        env:
-          PYTHONPATH: /usr/local/lib/MeshLib/
-        working-directory: test_python
-        run: xvfb-run -a python3 -m pytest -s -v
-
   linux-arm64-test:
     if: ${{ inputs.test_ubuntu_arm64 }}
     timeout-minutes: 30
@@ -243,12 +237,6 @@ jobs:
           cmake -S . -B build -DCMAKE_C_COMPILER=${{matrix.c-compiler}} && \
           cmake --build build
           ./build/MeshModification
-
-      - name: Ubuntu python test
-        env:
-          PYTHONPATH: /usr/local/lib/MeshLib/
-        working-directory: test_python
-        run: xvfb-run -a python3 -m pytest -s -v
 
   macos-test:
     if: ${{ inputs.test_macos }}

--- a/scripts/distribution.sh
+++ b/scripts/distribution.sh
@@ -30,23 +30,6 @@ MR_INSTALL_LIB_DIR="/usr/local/lib/MeshLib"
 MR_INSTALL_INCLUDE_DIR="/usr/local/include/MeshLib"
 MR_INSTALL_RES_DIR="/usr/local/share/MeshLib"
 
-# Install the generated bindings, if needed.
-if [ ! -f "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib/mrmeshpy.so" ] && [ -f "build/Release/bin/meshlib/mrmeshpy.so" ]; then
-  echo "Installing the generated bindings..."
-  install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/__init__.py
-  install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/{mrmeshpy.so,mrmeshnumpy.so}
-  install -Dt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"         build/Release/bin/meshlib/__init__.py
-  install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"        build/Release/bin/meshlib/{mrmeshpy.so,mrmeshnumpy.so}
-  patchelf --set-rpath '' "distr/meshlib-dev$MR_INSTALL_LIB_DIR/"{,meshlib/}mrmeshpy.so
-
-  if [ -f "build/Release/bin/meshlib/mrcudapy.so" ]; then
-    echo "CUDA bindings found, installing with mrcudapy.so..."
-    install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR/meshlib" build/Release/bin/meshlib/mrcudapy.so
-    install -sDt "distr/meshlib-dev$MR_INSTALL_LIB_DIR"        build/Release/bin/meshlib/mrcudapy.so
-    patchelf --set-rpath '' "distr/meshlib-dev$MR_INSTALL_LIB_DIR/"{,meshlib/}mrcudapy.so
-  fi
-fi
-
 MR_VERSION="0.0.0.0"
 if [ "${1}" ]; then
   MR_VERSION="${1:1}"

--- a/scripts/make_install_folder.py
+++ b/scripts/make_install_folder.py
@@ -116,6 +116,15 @@ def copy_lib():
 	for f in glob.glob(os.path.join(it.path_to_app, "*/*pybind11nonlimitedapi_meshlib_*")):
 		os.remove(f)
 
+	# The mrbind-generated modules are not part of the distribution, matching the
+	# macOS .pkg and the vcpkg archive, which are built from `cmake --install` alone.
+	for pattern in ("*/meshlib/mrmeshpy.pyd", "*/meshlib/mrcudapy.pyd",
+	                "*/meshlib/__init__.py", "*/__init__.py"):
+		for f in glob.glob(os.path.join(it.path_to_app, pattern)):
+			os.remove(f)
+	for d in glob.glob(os.path.join(it.path_to_app, "*/meshlib/__pycache__")):
+		shutil.rmtree(d, ignore_errors=True)
+
 def copy_licenses():
 	src = os.path.join(it.base_path, 'thirdparty', 'licenses', 'THIRD-PARTY-NOTICES.txt')
 	shutil.copyfile(src, os.path.join(it.path_to_install_folder, 'THIRD-PARTY-NOTICES.txt'))


### PR DESCRIPTION
The mirror image of #6827: instead of teaching the macOS `.pkg` and the vcpkg `.tar.xz` to carry the bindings, this makes the `.deb` and the Windows archive stop carrying them, so all four distributions agree. **Merge one or the other, not both.**

Today only two packagers ship the mrbind modules, and both do it by accident of how they are built:

* `scripts/distribution.sh` has a hand-written block that `install -s`'s `mrmeshpy.so`, `mrmeshnumpy.so` and `mrcudapy.so` out of `build/Release/bin/meshlib/`, outside `cmake --install`;
* Windows never had a decision at all — its archive step is `tar --format zip -c -f MREDist_… ./source/<arch>/<config>`, the whole output tree, and `make_install_folder.py` only pruned the *duplicate* top-level `.pyd`s while keeping the ones under `meshlib/`.

`distribution_apple.sh` and `distribution_vcpkg.sh` build from `cmake --install` alone, and mrbind's output has no install rule, so those two have never shipped `mrmeshpy`.

### Changes

* **`scripts/distribution.sh`** — the bindings block is gone. What `cmake --install` provides (`mrmeshnumpy.so`, `mrviewerpy.so`, the pybind shim) still ships, exactly as on macOS and vcpkg.
* **`scripts/make_install_folder.py`** — prunes `mrmeshpy.pyd`, `mrcudapy.pyd`, the mrbind `__init__.py` and its `__pycache__` from the install folder, leaving the CMake-built `mrmeshnumpy.pyd` / `mrviewerpy.pyd` / shim in place. Same end state as the other three.
* **`test-distribution.yml`** — the two `Ubuntu python test` steps are removed. They run `pytest test_python` with `PYTHONPATH=/usr/local/lib/MeshLib/` against the installed `.deb`, which no longer provides `meshlib.mrmeshpy`. macOS and Windows have no equivalent step.

Wheels are untouched and remain the supported way to get the bindings.

### Size

Measured on the released `MeshLibDistVS22_v3.1.3.429.zip` by reading its central directory over range requests, so these are exact compressed bytes that carry over into the repack:

| entry | compressed | uncompressed |
|---|---|---|
| `install/app/Release/meshlib/mrmeshpy.pyd` | 30 425 126 | 123 060 736 |
| `install/app/Debug/meshlib/mrmeshpy.pyd` | 30 449 594 | 123 128 832 |
| `install/app/Release/meshlib/mrcudapy.pyd` | 537 162 | 1 853 952 |
| `install/app/Debug/meshlib/mrcudapy.pyd` | 541 340 | 1 869 312 |

About **62 MB off a 550 MB zip**, and both configs ship a copy today.

### One concern, stated once

Those two `Ubuntu python test` steps are the *only* place any Python binding is exercised from an installed distribution rather than from a build tree — the wheels are verified by `Verify meshlib.mrmeshpy import` inside `pip-build`, but no test installs a released package and imports from it afterwards. Removing them is unavoidable if the `.deb` no longer carries the module, but it is a real coverage loss worth being aware of, and it is the strongest argument for #6827 over this PR.
