### PR TITLE
Do not dereference an unfound projection in distanceMapFromContours

### DIFF
--- a/source/MRMesh/MRDistanceMap.cpp
+++ b/source/MRMesh/MRDistanceMap.cpp
@@ -398,7 +398,9 @@ void distanceMapFromContours( DistanceMap & distMap, const Polyline2& polyline, 
         if ( params.withSign && ( !options.offsetParameters || options.offsetParameters->type != ContoursDistanceMapOffset::OffsetType::Shell ) )
         {
             bool positive = true;
-            if ( options.signMethod == ContoursDistanceMapOptions::SignedDetectionMethod::ContourOrientation )
+            // res.line stays invalid when maxDist/minDist rejected every candidate
+            if ( options.signMethod == ContoursDistanceMapOptions::SignedDetectionMethod::ContourOrientation
+                && res.line.valid() )
             {
                 const EdgeId e = res.line;
                 const auto& v0 = polyline.points[polyline.topology.org( e )];

--- a/source/MRMesh/MRDistanceMap.cpp
+++ b/source/MRMesh/MRDistanceMap.cpp
@@ -398,61 +398,64 @@ void distanceMapFromContours( DistanceMap & distMap, const Polyline2& polyline, 
         if ( params.withSign && ( !options.offsetParameters || options.offsetParameters->type != ContoursDistanceMapOffset::OffsetType::Shell ) )
         {
             bool positive = true;
-            // res.line stays invalid when maxDist/minDist rejected every candidate
-            if ( options.signMethod == ContoursDistanceMapOptions::SignedDetectionMethod::ContourOrientation
-                && res.line.valid() )
+            if ( options.signMethod == ContoursDistanceMapOptions::SignedDetectionMethod::ContourOrientation )
             {
-                const EdgeId e = res.line;
-                const auto& v0 = polyline.points[polyline.topology.org( e )];
-                const auto& v1 = polyline.points[polyline.topology.dest( e )];
-                auto vecA = v1 - v0;
-                auto ray = res.point - p;
-
-                // get next that is not zero for sign calculation
-                auto findNextNonZero = [&] ( EdgeId e, bool next )
+                // no closest edge means no sign to determine; res.line stays
+                // invalid when maxDist/minDist rejected every candidate
+                if ( res.line.valid() )
                 {
-                    float lengthSq = 0.0f;
-                    EdgeId prev = e;
-                    EdgeId res;
-                    do
-                    {
-                        res = next ?
-                            polyline.topology.next( prev.sym() ) :
-                            polyline.topology.next( prev ).sym();
-                        if ( res == prev.sym() || res == e )
-                            return e.sym();
-                        lengthSq = polyline.edgeLengthSq( res );
-                        prev = res;
-                    } while ( lengthSq <= 0.0f );
-                    return res;
-                };
+                    const EdgeId e = res.line;
+                    const auto& v0 = polyline.points[polyline.topology.org( e )];
+                    const auto& v1 = polyline.points[polyline.topology.dest( e )];
+                    auto vecA = v1 - v0;
+                    auto ray = res.point - p;
 
-                auto lengthSq = vecA.lengthSq();
-                float ratio = 0.0f;
-                if ( lengthSq > 0.0f )
-                    ratio = dot( res.point - v0, vecA ) / lengthSq;
-                if ( ratio <= 0.0f || ratio >= 1.0f || lengthSq <= 0.0f )
-                {
-                    Vector2f vecB;
-                    const EdgeId prevEdge = findNextNonZero( e, false );
-                    const EdgeId nextEdge = findNextNonZero( e, true );
-                    if ( ( ratio <= 0.0f || lengthSq <= 0.0f ) && e.sym() != prevEdge )
+                    // get next that is not zero for sign calculation
+                    auto findNextNonZero = [&] ( EdgeId e, bool next )
                     {
-                        const auto& v2 = polyline.points[polyline.topology.org( prevEdge )];
-                        vecB = v0 - v2;
-                    }
-                    if ( ( ratio >= 1.0f || lengthSq <= 0.0f ) && e.sym() != nextEdge )
+                        float lengthSq = 0.0f;
+                        EdgeId prev = e;
+                        EdgeId res;
+                        do
+                        {
+                            res = next ?
+                                polyline.topology.next( prev.sym() ) :
+                                polyline.topology.next( prev ).sym();
+                            if ( res == prev.sym() || res == e )
+                                return e.sym();
+                            lengthSq = polyline.edgeLengthSq( res );
+                            prev = res;
+                        } while ( lengthSq <= 0.0f );
+                        return res;
+                    };
+
+                    auto lengthSq = vecA.lengthSq();
+                    float ratio = 0.0f;
+                    if ( lengthSq > 0.0f )
+                        ratio = dot( res.point - v0, vecA ) / lengthSq;
+                    if ( ratio <= 0.0f || ratio >= 1.0f || lengthSq <= 0.0f )
                     {
-                        const auto& v2 = polyline.points[polyline.topology.dest( nextEdge )];
-                        if ( lengthSq <= 0.0f )
-                            vecA = v2 - v1; // degenerated edge, replace with neighbor
-                        else
-                            vecB = v2 - v1;
+                        Vector2f vecB;
+                        const EdgeId prevEdge = findNextNonZero( e, false );
+                        const EdgeId nextEdge = findNextNonZero( e, true );
+                        if ( ( ratio <= 0.0f || lengthSq <= 0.0f ) && e.sym() != prevEdge )
+                        {
+                            const auto& v2 = polyline.points[polyline.topology.org( prevEdge )];
+                            vecB = v0 - v2;
+                        }
+                        if ( ( ratio >= 1.0f || lengthSq <= 0.0f ) && e.sym() != nextEdge )
+                        {
+                            const auto& v2 = polyline.points[polyline.topology.dest( nextEdge )];
+                            if ( lengthSq <= 0.0f )
+                                vecA = v2 - v1; // degenerated edge, replace with neighbor
+                            else
+                                vecB = v2 - v1;
+                        }
+                        vecA = ( vecA.normalized() + vecB.normalized() ) * 0.5f;
                     }
-                    vecA = ( vecA.normalized() + vecB.normalized() ) * 0.5f;
+                    if ( cross( vecA, ray ) > 0.0f )
+                        positive = false;
                 }
-                if ( cross( vecA, ray ) > 0.0f )
-                    positive = false;
             }
             else if ( options.signMethod == ContoursDistanceMapOptions::SignedDetectionMethod::WindingRule )
             {

--- a/source/MRTest/MRDistanceMapTests.cpp
+++ b/source/MRTest/MRDistanceMapTests.cpp
@@ -65,6 +65,20 @@ TEST( MRMesh, DistanceMapBoolean2D )
     EXPECT_EQ( subContours.size(), 2 );
 }
 
+TEST( MRMesh, DistanceMapFromContoursNoProjection )
+{
+    // maxDist below the pixel-to-contour distance leaves every projection
+    // unfound, so the signed branch must not dereference res.line
+    const Contours2f c{ { {2.f,1.f},{2.f,4.f},{3.f,4.f},{3.f,1.f},{2.f,1.f} } };
+    const ContourToDistanceMapParams params( { 16,16 }, Vector2f( 0.5f, 0.5f ), Vector2f( 4.f, 4.f ), true );
+
+    ContoursDistanceMapOptions options;
+    options.maxDist = 1e-6f;
+    const auto dm = distanceMapFromContours( Polyline2( c ), params, options );
+    EXPECT_EQ( dm.resX(), 16 );
+    EXPECT_EQ( dm.resY(), 16 );
+}
+
 TEST( MRMesh, DistanceMapContours )
 {
     Contours2f conts;


### PR DESCRIPTION
`distanceMapFromContours` dereferences the closest edge returned by `findProjectionOnPolyline2` without checking that one was found:

```cpp
const EdgeId e = res.line;
const auto& v0 = polyline.points[polyline.topology.org( e )];
const auto& v1 = polyline.points[polyline.topology.dest( e )];
```

`findProjectionCore` begins with a default-constructed `PolylineProjectionResult`, whose `line` is `-1`, and sets `res.distSq = upDistLimitSq` before searching. It only ever assigns `line` when an edge beats that limit. So whenever `ContoursDistanceMapOptions::maxDist` (or `minDist`) rejects every candidate, the result comes back with `line` invalid - and `polyline.points[...]` is then indexed at `-1`.

That is an out-of-bounds read inside a `ParallelFor`, which on Windows surfaces as an access violation at an arbitrary address rather than as anything that points at this code.

## Fix

Skip the sign-detection branch when no edge was found:

```cpp
if ( options.signMethod == ...::ContourOrientation && res.line.valid() )
```

Sign is meaningless without a closest edge, so the pixel keeps its unsigned distance - which is already `maxDist`, the sentinel the search returns when nothing is in range.

Deliberately narrow:

- `WindingRule` does not touch `res.line` and is untouched.
- Every case where a projection *is* found behaves exactly as before, so no existing output changes.
- The `perEdgeOffset[res.line]` index further down is only reachable when the sign branch set `positive = false`, which now cannot happen with an invalid line.

## Test

`MRMesh.DistanceMapFromContoursNoProjection` pins `maxDist` below the smallest pixel-to-contour distance, so every pixel hits the not-found path with `withSign` on and the default `ContourOrientation` method - the exact state that used to read out of bounds.

## Provenance

Found while investigating a one-off `MRMesh.DistanceMapBoolean2D` crash on a Windows arm64 CI leg (access violation inside a TBB `parallel_for`). Re-running that commit passed, so this is **not** established as the cause of that flake - the defaults there are `minDist 0` / `maxDist FLT_MAX`, which should always find a projection. It is a real reachable defect on its own merits for any caller that sets `maxDist`, and worth closing regardless of whether it explains that crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
