### PR TITLE
collect_ci_stats.py: drop the CI_STATS_AUTH_TOKEN header, it never went out

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -497,7 +497,6 @@ jobs:
 
       - name: Collect stats
         env:
-          CI_STATS_AUTH_TOKEN: ${{ secrets.CI_STATS_AUTH_TOKEN }}
           GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
           GIT_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/collect-stats.yml
+++ b/.github/workflows/collect-stats.yml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Collect stats
         env:
-          CI_STATS_AUTH_TOKEN: ${{ secrets.CI_STATS_AUTH_TOKEN }}
           RUN_ID: ${{ inputs.run_id }}
           GIT_REF: ${{ inputs.ref }}
           GIT_BRANCH: ${{ inputs.branch }}

--- a/scripts/devops/collect_ci_stats.py
+++ b/scripts/devops/collect_ci_stats.py
@@ -166,9 +166,6 @@ if __name__ == "__main__":
         'Content-Type': 'application/json',
     }
 
-    if os.environ.get("CI_STATS_AUTH_TOKEN"):
-        headers['Authorization'] = f'Bearer {os.environ.get("CI_STATS_AUTH_TOKEN")}'
-
     signed_request = sign_api_request(
         API_URL,
         'POST',


### PR DESCRIPTION
`CI_STATS_AUTH_TOKEN` has never reached the stats API. The script builds its headers like this:

```python
if os.environ.get("CI_STATS_AUTH_TOKEN"):
    headers['Authorization'] = f'Bearer {os.environ.get("CI_STATS_AUTH_TOKEN")}'

signed_request = sign_api_request(API_URL, 'POST', headers, ...)
```

and `sign_api_request` passes those headers to botocore's `SigV4Auth.add_auth`. The first thing its `_modify_request_before_signing` does is delete any existing `Authorization` header, before installing the AWS one:

```python
if 'Authorization' in request.headers:
    del request.headers['Authorization']
```

So the bearer token is overwritten before the request goes out.

## Verification

Signed a request through botocore with the bearer header set and dumped the resulting headers. The bearer value is absent; the only `Authorization` present is `AWS4-HMAC-SHA256 Credential=.../execute-api/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-security-token, Signature=...`. The endpoint authenticates by IAM SigV4 alone and always has.

## Change

Removes the dead branch and the `env:` entries that fed it, in `build-test-distribute.yml` and `collect-stats.yml`. No behaviour change: the request on the wire is byte-for-byte what it was.

The repository secret itself is left alone - deleting it is not reversible from a PR. If that endpoint should check a bearer token in addition to IAM, that is an API-side change; this just stops pretending the current code sends one.
