### PR TITLE
collect-stats: check out only the script the job runs

### DIFF
--- a/.github/workflows/collect-stats.yml
+++ b/.github/workflows/collect-stats.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          sparse-checkout: scripts/devops/collect_ci_stats.py
+          sparse-checkout-cone-mode: false
+          filter: blob:none
 
       - name: Download runners' system stats
         uses: actions/download-artifact@v8


### PR DESCRIPTION
The `collect-stats` job runs `scripts/devops/collect_ci_stats.py` and uses nothing else from the repository, but checks out the entire working tree. Three lines make the checkout fetch only that file:

```yaml
      - name: Checkout
        uses: actions/checkout@v7
        with:
          sparse-checkout: scripts/devops/collect_ci_stats.py
          sparse-checkout-cone-mode: false
          filter: blob:none
```

## How much this actually saves

**1-2 s, and it would be wrong to sell it as more.** Over the 10 runs this workflow has had so far, `Checkout` averages **2.3 s** (median 2, max 3) out of a **29.7 s** job. The dominant terms are elsewhere - `Install dependencies` and the API round trip.

The same change in the MeshInspector CI was worth far more, because there the job pulled a whole submodule rather than one repository's tree. Here it is a tidiness and consistency change with a small bonus, not a speedup worth arguing for. Easy to decline.

## Why both options

`filter: blob:none` is the one that does work - a sparse pattern controls what git *writes*, not what it *fetches*, so without the filter the checkout still downloads every blob of the commit. Measured against this repository, shallow clone plus the same single-file pattern, 3 runs each:

| | time | `.git` |
|---|---|---|
| `--filter=blob:none` | 2.8 / 2.9 / 3.1 s | 1 MB |
| without | 17.1 / 14.7 / 18.4 s | 39 MB |

`sparse-checkout-cone-mode: false` is not a speed option: cone mode matches only directories, so it is required for a file path to match anything at all.
