### PR TITLE
DO NOT MERGE: shrink the wasm stall repro to one std::filesystem::copy loop

### DIFF
--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -329,9 +329,11 @@ jobs:
         timeout-minutes: 20
         working-directory: mrtest-bundle
         run: |
+          mkdir -p /tmp/ffprof
+          echo 'user_pref("dom.maxHardwareConcurrency", 2);' > /tmp/ffprof/user.js
           taskset -c 0,1 python3 emrun.py \
             --browser=/usr/bin/firefox \
-            --browser-args="--headless" \
-            --safe-firefox-profile \
+            --browser-args="--headless --profile /tmp/ffprof" \
+            --kill-start \
             --kill-exit \
             ./MRTest.html -- --gtest_filter=MRMesh.MemfsCopyStress

--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -306,15 +306,15 @@ jobs:
   emscripten-test:
     if: ${{ !inputs.definitions_only }}
     needs: emscripten-build
-    timeout-minutes: 10
+    timeout-minutes: 25
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
         package_name:
-          - emscripten-singlethreaded
-          - emscripten-multithreaded
           - emscripten-multithreaded-64bit
+          - emscripten-multithreaded
+        shard: [1, 2, 3, 4]
 
     steps:
       - name: Download MRTest bundle
@@ -326,12 +326,12 @@ jobs:
           run-id: ${{ github.run_id }}
 
       - name: Unit Tests
-        timeout-minutes: 5
+        timeout-minutes: 20
         working-directory: mrtest-bundle
         run: |
-          python3 emrun.py \
+          taskset -c 0,1 python3 emrun.py \
             --browser=/usr/bin/firefox \
             --browser-args="--headless" \
             --safe-firefox-profile \
             --kill-exit \
-            ./MRTest.html
+            ./MRTest.html -- --gtest_filter=MRMesh.MemfsCopyStress

--- a/source/MRTest/MRMemfsCopyTests.cpp
+++ b/source/MRTest/MRMemfsCopyTests.cpp
@@ -1,0 +1,145 @@
+#include "MRMesh/MRUniqueTemporaryFolder.h"
+#include "MRPch/MRSpdlog.h"
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+
+#if defined( __EMSCRIPTEN__ ) && defined( __EMSCRIPTEN_PTHREADS__ )
+#include <emscripten/emscripten.h>
+#include <emscripten/threading.h>
+#endif
+
+namespace MR
+{
+
+namespace
+{
+
+#ifdef __EMSCRIPTEN__
+constexpr int cSeconds = 480;
+#else
+constexpr int cSeconds = 2;
+#endif
+
+constexpr int cFileKiB = 100;
+
+#if !defined( __EMSCRIPTEN__ ) || defined( __EMSCRIPTEN_PTHREADS__ )
+
+constexpr int cStallSeconds = 60;
+
+/// keeps this thread awake without parking it on a futex; on the emscripten main thread it
+/// also drains the proxying queue, which is what the app does between frames
+void stayAwake( int ms )
+{
+#if defined( __EMSCRIPTEN__ ) && defined( __EMSCRIPTEN_PTHREADS__ )
+    emscripten_thread_sleep( ms );
+#else
+    std::this_thread::sleep_for( std::chrono::milliseconds( ms ) );
+#endif
+}
+
+/// a wedged thread cannot be joined, so the process has to leave without it
+[[noreturn]] void leaveNow( int code )
+{
+#ifdef __EMSCRIPTEN__
+    emscripten_force_exit( code );
+#endif
+    std::_Exit( code );
+}
+
+#endif
+
+} // namespace
+
+// Reduced from the application-level reproducer, where a worker doing nothing but
+// std::filesystem::copy wedged 3 of 8 CI shards within 8 minutes: the copy stops returning and
+// the main thread stops answering with it, while the compositor keeps painting. Everything else
+// - zip, scene loading, the converter - turned out to be irrelevant, so this is the whole
+// mechanism in one call.
+TEST( MRMesh, MemfsCopyStress )
+{
+    UniqueTemporaryFolder folder;
+    ASSERT_TRUE( bool( folder ) );
+    const std::filesystem::path dir = folder;
+
+    const auto src = dir / "src.bin";
+    {
+        std::ofstream ofs( src, std::ios::binary );
+        ASSERT_TRUE( bool( ofs ) );
+        const std::string chunk( 1024, 'x' );
+        for ( int i = 0; i < cFileKiB; ++i )
+            ofs << chunk;
+    }
+
+#if !defined( __EMSCRIPTEN__ ) || defined( __EMSCRIPTEN_PTHREADS__ )
+    std::atomic<long long> copies{ 0 };
+    std::atomic<bool> finished{ false };
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds( cSeconds );
+    std::thread worker( [&]
+    {
+        std::error_code ec;
+        const auto dst = dir / "dst.bin";
+        while ( std::chrono::steady_clock::now() < deadline )
+        {
+            std::filesystem::remove( dst, ec );
+            std::filesystem::copy( src, dst, ec );
+            copies.fetch_add( 1, std::memory_order_relaxed );
+        }
+        finished.store( true, std::memory_order_release );
+    } );
+
+    long long seen = 0;
+    int ticks = 0;
+    auto lastProgress = std::chrono::steady_clock::now();
+    while ( !finished.load( std::memory_order_acquire ) )
+    {
+        stayAwake( 250 );
+
+        const long long now = copies.load( std::memory_order_relaxed );
+        if ( now != seen )
+        {
+            seen = now;
+            lastProgress = std::chrono::steady_clock::now();
+        }
+        else
+        {
+            const auto idle = std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - lastProgress ).count();
+            if ( idle >= cStallSeconds )
+            {
+                spdlog::error( "STALLED: no copy finished for {} s after {} copies", idle, seen );
+                leaveNow( 3 );
+            }
+        }
+
+        if ( ++ticks % 20 == 0 )
+            spdlog::info( "{} copies", seen );
+    }
+
+    worker.join();
+    spdlog::info( "done: {} copies in {} s", seen, cSeconds );
+    EXPECT_GT( seen, 0 );
+#else
+    std::error_code ec;
+    const auto dst = dir / "dst.bin";
+    long long copies = 0;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds( cSeconds );
+    while ( std::chrono::steady_clock::now() < deadline )
+    {
+        std::filesystem::remove( dst, ec );
+        std::filesystem::copy( src, dst, ec );
+        ++copies;
+    }
+    spdlog::info( "done: {} single-threaded copies", copies );
+    EXPECT_GT( copies, 0 );
+#endif
+}
+
+} // namespace MR

--- a/source/MRTest/MRMemfsCopyTests.cpp
+++ b/source/MRTest/MRMemfsCopyTests.cpp
@@ -68,6 +68,8 @@ TEST( MRMesh, MemfsCopyStress )
     ASSERT_TRUE( bool( folder ) );
     const std::filesystem::path dir = folder;
 
+    spdlog::info( "hardware_concurrency {}", std::thread::hardware_concurrency() );
+
     const auto src = dir / "src.bin";
     {
         std::ofstream ofs( src, std::ios::binary );

--- a/source/MRTest/MRTest.vcxproj
+++ b/source/MRTest/MRTest.vcxproj
@@ -47,6 +47,7 @@
     <ClCompile Include="MRGridSamplingTests.cpp" />
     <ClCompile Include="MRICPTests.cpp" />
     <ClCompile Include="MRLaplacianTests.cpp" />
+    <ClCompile Include="MRMemfsCopyTests.cpp" />
     <ClCompile Include="MRMarchingCubesTests.cpp" />
     <ClCompile Include="MRMeshBooleanTests.cpp" />
     <ClCompile Include="MRMeshComponentsTests.cpp" />


### PR DESCRIPTION
**Throwaway experiment -- do not merge, do not review.** Deleted once it has answered.

An application-level reproducer just wedged **3 of 8 CI shards within 8 minutes** with a worker thread doing nothing but `std::filesystem::copy` in a loop -- no zip, no scene loading, no converter. A healthy shard managed 48,709 copies in 8 minutes, so roughly one wedge per 20,000 copies.

This strips the app and Playwright away: one worker copying a 100 KB file in a loop, the test thread polling a counter with `emscripten_thread_sleep` (which drains the proxying queue, unlike a futex sleep) and leaving with code 3 if no copy finishes for 60 s.

`emrun` runs under `taskset -c 0,1`, because every real stall has been on a 2-core runner while every clean MRTest attempt so far ran on 4 cores. Both multithreaded configs, 4 shards each, 480 s per shard. The singlethreaded build is excluded -- it has no worker to stall.

What the failure looks like in the application version, for comparison: the copy stops returning and **the main thread stops answering with it** -- a `page.evaluate` that only reads an atomic never resolves -- while the compositor keeps painting, which is why earlier reports in this investigation wrongly concluded the main thread was healthy.

If this bites, it is a standalone testcase worth taking upstream: a dozen lines, no MeshLib domain code, no application.

Refs MeshInspector/MeshInspectorCode#7724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
