### PR TITLE
Fail the Windows submodule clone instead of building without the sources

### DIFF
--- a/scripts/clone_submodules_windows.ps1
+++ b/scripts/clone_submodules_windows.ps1
@@ -6,6 +6,8 @@ git -C "$PSScriptRoot\.." submodule update --init --depth 1 `
     thirdparty/nlohmann-json `
     thirdparty/cpp-httplib `
     thirdparty/mrbind `
-    thirdparty/mrbind-pybind11 `
+    thirdparty/mrbind-pybind11
+if ( $LASTEXITCODE -ne 0 ) { exit $LASTEXITCODE }
 
 git -C "$PSScriptRoot\..\thirdparty\mrbind" submodule update --init --depth 1 deps/cppdecl
+if ( $LASTEXITCODE -ne 0 ) { exit $LASTEXITCODE }


### PR DESCRIPTION
## The problem

`scripts/clone_submodules_windows.ps1` never checked git's exit code, and PowerShell does not stop on a native command's failure — so **the script always exited 0**, however badly the clone went. The workflow already wraps it:

```yaml
bash scripts/retry.sh --timeout 300 -- powershell scripts/clone_submodules_windows.ps1 --skip-prebuilt-thirdparty
```

`retry.sh --times 3` is correct and would have retried, but it was never given anything to retry.

## What that looks like when it bites

On run [34598799537](https://github.com/MeshInspector/MeshLib/actions/runs/34598799537) the arm64 Windows leg could not reach github.com:

```
Cloning into '.../thirdparty/mrbind-pybind11'...
fatal: unable to access 'https://github.com/MeshInspector/mrbind-pybind11/':
       Failed to connect to github.com:443 after 21060 ms: Could not connect to server
Failed to clone 'thirdparty/mrbind-pybind11' a second time, aborting
```

`nlohmann-json` failed the same way and `imgui` was left unpopulated. The script exited 0, the job carried on for another **ten minutes**, and died in hundreds of

```
error C1083: Cannot open source file: '..\..\thirdparty\imgui\imgui.cpp'
```

which points at imgui rather than at the network failure that actually caused it. The `error: pathspec 'deps/cppdecl' did not match any file(s) known to git` a moment later is the same story — the second git call ran against a tree the first had failed to create.

## The fix

Check `$LASTEXITCODE` after each git call. The script then stops where the problem is, and `retry.sh` gets to do the retrying it was added for — a connection timeout is exactly the transient it exists to absorb.

The trailing line-continuation backtick after `mrbind-pybind11` is dropped: it continued the command into the blank line that now holds the check.

## Verification

With a stub `git` on PATH:

| | git fails | git succeeds |
|---|---|---|
| old script | **exit 0** | exit 0 |
| new script | **exit 1**, stops after the first call | exit 0, runs both calls |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
