### PR TITLE
DO NOT MERGE: standalone emscripten reproducer, no MeshLib code at all

### DIFF
--- a/.github/repro/memfs_copy_repro.cpp
+++ b/.github/repro/memfs_copy_repro.cpp
@@ -108,6 +108,17 @@ int main()
             ofs << chunk;
     }
 
+    std::thread( [dir]
+    {
+        std::ofstream log( dir / "log.txt", std::ios::binary | std::ios::app );
+        while ( log )
+        {
+            log << "[info] a line of about the length the application writes";
+            log.put( char( 10 ) );
+            log.flush();
+        }
+    } ).detach();
+
     std::thread( [src, dir]
     {
         std::error_code workerEc;

--- a/.github/repro/memfs_copy_repro.cpp
+++ b/.github/repro/memfs_copy_repro.cpp
@@ -3,15 +3,11 @@
 // it. No application code, no framework -- the main thread only has to be in a real browser
 // event loop, which emscripten_set_main_loop gives it.
 #include <emscripten.h>
-#include <emscripten/html5_webgl.h>
-
-#include <GLES2/gl2.h>
 
 #include <atomic>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -23,8 +19,6 @@ namespace
 constexpr int cSeconds = 480;
 constexpr int cStallSeconds = 60;
 constexpr int cFileKiB = 100;
-/// the application stalls with a heap around this size
-constexpr size_t cBallastMiB = 600;
 
 std::atomic<long long> gCopies{ 0 };
 std::atomic<bool> gStop{ false };
@@ -39,16 +33,8 @@ int secondsSince( std::chrono::steady_clock::time_point t )
         std::chrono::steady_clock::now() - t ).count() );
 }
 
-EMSCRIPTEN_WEBGL_CONTEXT_HANDLE gGl = 0;
-
 void frame()
 {
-    if ( gGl )
-    {
-        glClearColor( 0.1f, 0.1f, 0.1f, 1.0f );
-        glClear( GL_COLOR_BUFFER_BIT );
-    }
-
     const long long now = gCopies.load( std::memory_order_relaxed );
     if ( now != gSeen )
     {
@@ -86,24 +72,6 @@ void frame()
 int main()
 {
     std::printf( "hardware_concurrency %u", std::thread::hardware_concurrency() );
-    std::putchar( 10 );
-    std::fflush( stdout );
-
-    // a WebGL context and a heap the size of the application's, the two things the
-    // application still has that this program did not
-    EmscriptenWebGLContextAttributes attrs;
-    emscripten_webgl_init_context_attributes( &attrs );
-    attrs.majorVersion = 2;
-    gGl = emscripten_webgl_create_context( "#canvas", &attrs );
-    if ( gGl )
-        emscripten_webgl_make_context_current( gGl );
-    std::printf( "webgl context %d", int( gGl ) );
-    std::putchar( 10 );
-
-    auto ballast = static_cast<char*>( std::malloc( cBallastMiB << 20 ) );
-    if ( ballast )
-        std::memset( ballast, 1, cBallastMiB << 20 );
-    std::printf( "ballast %s", ballast ? "allocated" : "FAILED" );
     std::putchar( 10 );
     std::fflush( stdout );
 

--- a/.github/repro/memfs_copy_repro.cpp
+++ b/.github/repro/memfs_copy_repro.cpp
@@ -3,10 +3,15 @@
 // it. No application code, no framework -- the main thread only has to be in a real browser
 // event loop, which emscripten_set_main_loop gives it.
 #include <emscripten.h>
+#include <emscripten/html5_webgl.h>
+
+#include <GLES2/gl2.h>
 
 #include <atomic>
 #include <chrono>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -18,6 +23,8 @@ namespace
 constexpr int cSeconds = 480;
 constexpr int cStallSeconds = 60;
 constexpr int cFileKiB = 100;
+/// the application stalls with a heap around this size
+constexpr size_t cBallastMiB = 600;
 
 std::atomic<long long> gCopies{ 0 };
 std::chrono::steady_clock::time_point gStart;
@@ -30,8 +37,16 @@ int secondsSince( std::chrono::steady_clock::time_point t )
         std::chrono::steady_clock::now() - t ).count() );
 }
 
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE gGl = 0;
+
 void frame()
 {
+    if ( gGl )
+    {
+        glClearColor( 0.1f, 0.1f, 0.1f, 1.0f );
+        glClear( GL_COLOR_BUFFER_BIT );
+    }
+
     const long long now = gCopies.load( std::memory_order_relaxed );
     if ( now != gSeen )
     {
@@ -60,6 +75,24 @@ void frame()
 int main()
 {
     std::printf( "hardware_concurrency %u", std::thread::hardware_concurrency() );
+    std::putchar( 10 );
+    std::fflush( stdout );
+
+    // a WebGL context and a heap the size of the application's, the two things the
+    // application still has that this program did not
+    EmscriptenWebGLContextAttributes attrs;
+    emscripten_webgl_init_context_attributes( &attrs );
+    attrs.majorVersion = 2;
+    gGl = emscripten_webgl_create_context( "#canvas", &attrs );
+    if ( gGl )
+        emscripten_webgl_make_context_current( gGl );
+    std::printf( "webgl context %d", int( gGl ) );
+    std::putchar( 10 );
+
+    auto ballast = static_cast<char*>( std::malloc( cBallastMiB << 20 ) );
+    if ( ballast )
+        std::memset( ballast, 1, cBallastMiB << 20 );
+    std::printf( "ballast %s", ballast ? "allocated" : "FAILED" );
     std::putchar( 10 );
     std::fflush( stdout );
 

--- a/.github/repro/memfs_copy_repro.cpp
+++ b/.github/repro/memfs_copy_repro.cpp
@@ -1,0 +1,96 @@
+// Standalone reproducer for a wasm stall seen in a large application: a worker thread doing
+// nothing but std::filesystem::copy eventually stops returning, and the main thread stops with
+// it. No application code, no framework -- the main thread only has to be in a real browser
+// event loop, which emscripten_set_main_loop gives it.
+#include <emscripten.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+
+namespace
+{
+
+constexpr int cSeconds = 480;
+constexpr int cStallSeconds = 60;
+constexpr int cFileKiB = 100;
+
+std::atomic<long long> gCopies{ 0 };
+std::chrono::steady_clock::time_point gStart;
+std::chrono::steady_clock::time_point gLastProgress;
+long long gSeen = 0;
+
+int secondsSince( std::chrono::steady_clock::time_point t )
+{
+    return int( std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - t ).count() );
+}
+
+void frame()
+{
+    const long long now = gCopies.load( std::memory_order_relaxed );
+    if ( now != gSeen )
+    {
+        gSeen = now;
+        gLastProgress = std::chrono::steady_clock::now();
+    }
+    else if ( secondsSince( gLastProgress ) >= cStallSeconds )
+    {
+        std::printf( "STALLED: no copy finished for %d s after %lld copies", cStallSeconds, gSeen );
+        std::putchar( 10 );
+        std::fflush( stdout );
+        emscripten_force_exit( 3 );
+    }
+
+    if ( secondsSince( gStart ) >= cSeconds )
+    {
+        std::printf( "done: %lld copies in %d s", gSeen, cSeconds );
+        std::putchar( 10 );
+        std::fflush( stdout );
+        emscripten_force_exit( 0 );
+    }
+}
+
+} // namespace
+
+int main()
+{
+    std::printf( "hardware_concurrency %u", std::thread::hardware_concurrency() );
+    std::putchar( 10 );
+    std::fflush( stdout );
+
+    std::error_code ec;
+    const std::filesystem::path dir = "/tmp/repro";
+    std::filesystem::create_directories( dir, ec );
+
+    const auto src = dir / "src.bin";
+    {
+        std::ofstream ofs( src, std::ios::binary );
+        const std::string chunk( 1024, 'x' );
+        for ( int i = 0; i < cFileKiB; ++i )
+            ofs << chunk;
+    }
+
+    std::thread( [src, dir]
+    {
+        std::error_code workerEc;
+        const auto dst = dir / "dst.bin";
+        for ( ;; )
+        {
+            std::filesystem::remove( dst, workerEc );
+            std::filesystem::copy( src, dst, workerEc );
+            gCopies.fetch_add( 1, std::memory_order_relaxed );
+        }
+    } ).detach();
+
+    gStart = gLastProgress = std::chrono::steady_clock::now();
+
+    // 0 fps means requestAnimationFrame, and the final 0 means main() returns instead of
+    // blocking -- so the main thread really is back in the browser's event loop between frames
+    emscripten_set_main_loop( frame, 0, 0 );
+    return 0;
+}

--- a/.github/repro/memfs_copy_repro.cpp
+++ b/.github/repro/memfs_copy_repro.cpp
@@ -27,6 +27,8 @@ constexpr int cFileKiB = 100;
 constexpr size_t cBallastMiB = 600;
 
 std::atomic<long long> gCopies{ 0 };
+std::atomic<bool> gStop{ false };
+int gExitCountdown = -1;
 std::chrono::steady_clock::time_point gStart;
 std::chrono::steady_clock::time_point gLastProgress;
 long long gSeen = 0;
@@ -61,12 +63,21 @@ void frame()
         emscripten_force_exit( 3 );
     }
 
+    if ( gExitCountdown > 0 )
+    {
+        if ( --gExitCountdown == 0 )
+            emscripten_force_exit( 0 );
+        return;
+    }
+
     if ( secondsSince( gStart ) >= cSeconds )
     {
         std::printf( "done: %lld copies in %d s", gSeen, cSeconds );
         std::putchar( 10 );
         std::fflush( stdout );
-        emscripten_force_exit( 0 );
+        // let both threads leave their loops first: exiting with one still running hangs
+        gStop.store( true, std::memory_order_release );
+        gExitCountdown = 60;
     }
 }
 
@@ -111,7 +122,7 @@ int main()
     std::thread( [dir]
     {
         std::ofstream log( dir / "log.txt", std::ios::binary | std::ios::app );
-        while ( log )
+        while ( log && !gStop.load( std::memory_order_acquire ) )
         {
             log << "[info] a line of about the length the application writes";
             log.put( char( 10 ) );
@@ -123,7 +134,7 @@ int main()
     {
         std::error_code workerEc;
         const auto dst = dir / "dst.bin";
-        for ( ;; )
+        while ( !gStop.load( std::memory_order_acquire ) )
         {
             std::filesystem::remove( dst, workerEc );
             std::filesystem::copy( src, dst, workerEc );

--- a/.github/repro/memfs_copy_repro.cpp
+++ b/.github/repro/memfs_copy_repro.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -19,6 +20,8 @@ namespace
 constexpr int cSeconds = 480;
 constexpr int cStallSeconds = 60;
 constexpr int cFileKiB = 100;
+/// the application stalls with a heap around this size
+constexpr size_t cBallastMiB = 600;
 
 std::atomic<long long> gCopies{ 0 };
 std::atomic<bool> gStop{ false };
@@ -72,6 +75,15 @@ void frame()
 int main()
 {
     std::printf( "hardware_concurrency %u", std::thread::hardware_concurrency() );
+    std::putchar( 10 );
+    std::fflush( stdout );
+
+    // a heap the size of the application's: with it and the log writer the stall
+    // appears, with either one alone it does not
+    auto ballast = static_cast<char*>( std::malloc( cBallastMiB << 20 ) );
+    if ( ballast )
+        std::memset( ballast, 1, cBallastMiB << 20 );
+    std::printf( "ballast %s", ballast ? "allocated" : "FAILED" );
     std::putchar( 10 );
     std::fflush( stdout );
 

--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           mkdir mrtest-bundle
           cp build/Release/bin/MRTest* /emsdk/upstream/emscripten/emrun.py mrtest-bundle/
+          em++ -std=c++20 -O2 -pthread ../MeshLib/.github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1             -o mrtest-bundle/repro.html ||           em++ -std=c++20 -O2 -pthread .github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1             -o mrtest-bundle/repro.html
 
       - name: Upload MRTest bundle
         uses: actions/upload-artifact@v7
@@ -306,15 +307,14 @@ jobs:
   emscripten-test:
     if: ${{ !inputs.definitions_only }}
     needs: emscripten-build
-    timeout-minutes: 10
+    timeout-minutes: 25
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
         package_name:
-          - emscripten-singlethreaded
           - emscripten-multithreaded
-          - emscripten-multithreaded-64bit
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
 
     steps:
       - name: Download MRTest bundle
@@ -326,12 +326,14 @@ jobs:
           run-id: ${{ github.run_id }}
 
       - name: Unit Tests
-        timeout-minutes: 5
+        timeout-minutes: 20
         working-directory: mrtest-bundle
         run: |
-          python3 emrun.py \
+          mkdir -p /tmp/ffprof
+          echo 'user_pref("dom.maxHardwareConcurrency", 2);' > /tmp/ffprof/user.js
+          taskset -c 0,1 python3 emrun.py \
             --browser=/usr/bin/firefox \
-            --browser-args="--headless" \
-            --safe-firefox-profile \
+            --browser-args="--headless --profile /tmp/ffprof" \
+            --kill-start \
             --kill-exit \
-            ./MRTest.html
+            ./repro.html

--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           mkdir mrtest-bundle
           cp build/Release/bin/MRTest* /emsdk/upstream/emscripten/emrun.py mrtest-bundle/
-          em++ -std=c++20 -O2 -pthread ../MeshLib/.github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1 --emrun             -o mrtest-bundle/repro.html ||           em++ -std=c++20 -O2 -pthread .github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1 --emrun             -o mrtest-bundle/repro.html
+          em++ -std=c++20 -O2 -pthread ../MeshLib/.github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1 --emrun -lGL -s MAX_WEBGL_VERSION=2             -o mrtest-bundle/repro.html ||           em++ -std=c++20 -O2 -pthread .github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1 --emrun -lGL -s MAX_WEBGL_VERSION=2             -o mrtest-bundle/repro.html
 
       - name: Upload MRTest bundle
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -331,6 +331,8 @@ jobs:
         run: |
           mkdir -p /tmp/ffprof
           echo 'user_pref("dom.maxHardwareConcurrency", 2);' > /tmp/ffprof/user.js
+          echo 'user_pref("webgl.force-enabled", true);' >> /tmp/ffprof/user.js
+          echo 'user_pref("webgl.disable-fail-if-major-performance-caveat", true);' >> /tmp/ffprof/user.js
           taskset -c 0,1 python3 emrun.py \
             --browser=/usr/bin/firefox \
             --browser-args="--headless --profile /tmp/ffprof" \

--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           mkdir mrtest-bundle
           cp build/Release/bin/MRTest* /emsdk/upstream/emscripten/emrun.py mrtest-bundle/
-          em++ -std=c++20 -O2 -pthread ../MeshLib/.github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1             -o mrtest-bundle/repro.html ||           em++ -std=c++20 -O2 -pthread .github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1             -o mrtest-bundle/repro.html
+          em++ -std=c++20 -O2 -pthread ../MeshLib/.github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1 --emrun             -o mrtest-bundle/repro.html ||           em++ -std=c++20 -O2 -pthread .github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1 --emrun             -o mrtest-bundle/repro.html
 
       - name: Upload MRTest bundle
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-test-emscripten.yml
+++ b/.github/workflows/build-test-emscripten.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           mkdir mrtest-bundle
           cp build/Release/bin/MRTest* /emsdk/upstream/emscripten/emrun.py mrtest-bundle/
-          em++ -std=c++20 -O2 -pthread ../MeshLib/.github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1 --emrun -lGL -s MAX_WEBGL_VERSION=2             -o mrtest-bundle/repro.html ||           em++ -std=c++20 -O2 -pthread .github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1 --emrun -lGL -s MAX_WEBGL_VERSION=2             -o mrtest-bundle/repro.html
+          em++ -std=c++20 -O2 -pthread ../MeshLib/.github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1 --emrun             -o mrtest-bundle/repro.html ||           em++ -std=c++20 -O2 -pthread .github/repro/memfs_copy_repro.cpp             -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency             -s PTHREAD_POOL_SIZE_STRICT=0             -s ALLOW_MEMORY_GROWTH=1             -s EXIT_RUNTIME=1 --emrun             -o mrtest-bundle/repro.html
 
       - name: Upload MRTest bundle
         uses: actions/upload-artifact@v7
@@ -331,8 +331,6 @@ jobs:
         run: |
           mkdir -p /tmp/ffprof
           echo 'user_pref("dom.maxHardwareConcurrency", 2);' > /tmp/ffprof/user.js
-          echo 'user_pref("webgl.force-enabled", true);' >> /tmp/ffprof/user.js
-          echo 'user_pref("webgl.disable-fail-if-major-performance-caveat", true);' >> /tmp/ffprof/user.js
           taskset -c 0,1 python3 emrun.py \
             --browser=/usr/bin/firefox \
             --browser-args="--headless --profile /tmp/ffprof" \


### PR DESCRIPTION
**Throwaway experiment -- do not merge, do not review.** Deleted once it has answered.

Final shrink. The application-level reproducer wedges about every 20,000 copies; the same `std::filesystem::copy` loop inside `MRTest` stayed clean at 2.2 M copies, even after capping the pool to 2 and pinning to 2 CPUs. The remaining difference is **what the main thread is doing**: the app returns to the browser event loop between frames, while `MRTest` sits inside `emscripten_thread_sleep` in gtest and never does.

So this drops MeshLib entirely -- about 40 lines, no framework, no domain code:

* one pthread looping `remove` + `copy` of a 100 KB file
* `main()` installing `emscripten_set_main_loop( frame, 0, 0 )`, so it **returns** and the main thread is genuinely back in the browser's event loop between frames
* the frame callback watching a counter and calling `emscripten_force_exit( 3 )` if no copy finishes for 60 s

`em++` builds it in the job that already has emsdk, it ships alongside `MRTest` in the same artifact, and emrun runs it with `dom.maxHardwareConcurrency` capped to 2 under `taskset -c 0,1`. Eight shards, 480 s each, on `emscripten-multithreaded`. The test prints `hardware_concurrency` on entry so the run states what it actually got.

If this wedges, it is a complete upstream testcase: one source file, one `em++` command line, no dependencies.

If it stays clean while the application version keeps wedging, the difference is narrowed to what is left -- a WebGL context and a much larger module and heap -- and the application-level reproducer becomes the artifact to report instead.

Refs MeshInspector/MeshInspectorCode#7724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
